### PR TITLE
ci: enforce cargo fmt + clippy on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: ci
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-D warnings"
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fmt:
+    name: cargo fmt --check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
+  clippy-wasm:
+    name: clippy (wasm32)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: clippy-wasm
+      # Most workspace crates target wasm32; pocopine-cli is host-only so it
+      # gets its own clippy run below.
+      - run: cargo clippy --workspace --exclude pocopine-cli --target wasm32-unknown-unknown --all-targets -- -D warnings
+
+  clippy-host:
+    name: clippy (host — pocopine-cli)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: clippy-host
+      - run: cargo clippy -p pocopine-cli --all-targets -- -D warnings

--- a/crates/pine-icons/src/lib.rs
+++ b/crates/pine-icons/src/lib.rs
@@ -84,7 +84,7 @@ pub fn lookup(variant: &str, name: &str) -> Option<&'static str> {
 /// collide with: the algorithm seeds with a nonzero offset and
 /// multiplies by a nonzero prime, so every non-empty input
 /// produces a nonzero hash.
-pub const EMPTY_ICON: (&'static str, u64) = ("", 0u64);
+pub const EMPTY_ICON: (&str, u64) = ("", 0u64);
 
 /// Same as [`lookup`] but also returns the precomputed FNV-1a
 /// hash of the SVG bytes. Useful for O(1) change detection when

--- a/crates/pine-motion/src/easing.rs
+++ b/crates/pine-motion/src/easing.rs
@@ -16,7 +16,7 @@ use crate::spring::Spring;
 /// An animation's timing curve. Either a named browser-native easing
 /// (a single string lands on `Element.animate`'s `easing` option), or
 /// a spring/function that gets sampled into `linear(...)`.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 pub enum Easing {
     /// `linear`
     Linear,
@@ -25,6 +25,7 @@ pub enum Easing {
     /// `ease-in`
     EaseIn,
     /// `ease-out` — the default for most UI motion.
+    #[default]
     EaseOut,
     /// `ease-in-out`
     EaseInOut,
@@ -69,12 +70,6 @@ impl Easing {
             Easing::Spring(s) => Some(s.settle_duration_ms()),
             _ => None,
         }
-    }
-}
-
-impl Default for Easing {
-    fn default() -> Self {
-        Easing::EaseOut
     }
 }
 

--- a/crates/pine/src/date_field/mod.rs
+++ b/crates/pine/src/date_field/mod.rs
@@ -300,7 +300,7 @@ impl PineDateField {
         let next = s.to_date();
         if next != self.value {
             self.value = next;
-            emit_model_field("value", &self.value);
+            emit_model_field("value", self.value);
         }
     }
 

--- a/crates/pine/src/datetime/comparators.rs
+++ b/crates/pine/src/datetime/comparators.rs
@@ -154,9 +154,9 @@ pub fn are_all_days_between_valid(
         return true;
     }
     let bad = |d: &DateValue| -> bool {
-        let disabled = is_disabled.map_or(false, |f| f(d));
-        let unavailable = is_unavailable.map_or(false, |f| f(d));
-        let saved = is_highlightable.map_or(false, |f| f(d));
+        let disabled = is_disabled.is_some_and(|f| f(d));
+        let unavailable = is_unavailable.is_some_and(|f| f(d));
+        let saved = is_highlightable.is_some_and(|f| f(d));
         (disabled || unavailable) && !saved
     };
 
@@ -185,7 +185,7 @@ pub fn are_all_months_between_valid(
     let mut cur = start.set_day(1);
     let end_month = end.set_day(1);
     while compare_year_month(&cur, &end_month) <= 0 {
-        if is_disabled.map_or(false, |f| f(&cur)) || is_unavailable.map_or(false, |f| f(&cur)) {
+        if is_disabled.is_some_and(|f| f(&cur)) || is_unavailable.is_some_and(|f| f(&cur)) {
             return false;
         }
         cur = cur.add_months(1);
@@ -205,7 +205,7 @@ pub fn are_all_years_between_valid(
     let mut cur = start.set_day(1).set_month(1);
     let end_year = end.year();
     while cur.year() <= end_year {
-        if is_disabled.map_or(false, |f| f(&cur)) || is_unavailable.map_or(false, |f| f(&cur)) {
+        if is_disabled.is_some_and(|f| f(&cur)) || is_unavailable.is_some_and(|f| f(&cur)) {
             return false;
         }
         cur = cur.add_years(1);

--- a/crates/pine/src/datetime/types.rs
+++ b/crates/pine/src/datetime/types.rs
@@ -73,15 +73,10 @@ pub type WeekStartsOn = u8;
 /// Format spec for the weekday labels in a calendar header.
 /// Mirrors reka's `WeekDayFormat` union; renderers are free to
 /// ignore it for v1 and ship English short names.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum WeekDayFormat {
     Narrow,
+    #[default]
     Short,
     Long,
-}
-
-impl Default for WeekDayFormat {
-    fn default() -> Self {
-        WeekDayFormat::Short
-    }
 }

--- a/crates/pine/src/time_field/mod.rs
+++ b/crates/pine/src/time_field/mod.rs
@@ -103,13 +103,13 @@ impl Default for PineTimeField {
 impl PineTimeField {
     pub fn on_setup(&mut self) {
         self.has_seconds = seconds_visible(self.step);
-        let segs = TimeSegments::from_str(&self.value);
+        let segs = TimeSegments::parse(&self.value);
         self.sync_display(&segs);
     }
 
     #[watch(value)]
     fn on_value_change(&mut self, new: String, _prev: Option<String>) {
-        let segs = TimeSegments::from_str(&new);
+        let segs = TimeSegments::parse(&new);
         self.sync_display(&segs);
     }
 
@@ -117,7 +117,7 @@ impl PineTimeField {
     fn on_step_change(&mut self, new: f64, _prev: Option<f64>) {
         self.has_seconds = seconds_visible(new);
         // Re-derive filled/invalid for the new granularity.
-        let segs = TimeSegments::from_str(&self.value);
+        let segs = TimeSegments::parse(&self.value);
         self.sync_display(&segs);
     }
 
@@ -153,7 +153,7 @@ impl PineTimeField {
         }
 
         let key = ev.key();
-        let mut segs = TimeSegments::from_str(&self.value);
+        let mut segs = TimeSegments::parse(&self.value);
         // Preserve partial digits not yet committed to `value`.
         self.refill_from_display(&mut segs);
 

--- a/crates/pine/src/time_field/segments.rs
+++ b/crates/pine/src/time_field/segments.rs
@@ -79,7 +79,7 @@ pub struct TimeSegments {
 impl TimeSegments {
     /// Parse a native-input `HH:MM` or `HH:MM:SS` value. Empty
     /// or malformed input yields empty segments.
-    pub fn from_str(value: &str) -> Self {
+    pub fn parse(value: &str) -> Self {
         let mut s = Self::default();
         let mut parts = value.split(':');
         if let Some(h) = parts.next().and_then(|p| p.trim().parse::<u8>().ok()) {
@@ -237,7 +237,7 @@ mod tests {
 
     #[test]
     fn parse_hh_mm() {
-        let s = TimeSegments::from_str("09:30");
+        let s = TimeSegments::parse("09:30");
         assert_eq!(s.hour, Some(9));
         assert_eq!(s.minute, Some(30));
         assert_eq!(s.second, None);
@@ -245,7 +245,7 @@ mod tests {
 
     #[test]
     fn parse_hh_mm_ss() {
-        let s = TimeSegments::from_str("09:30:45");
+        let s = TimeSegments::parse("09:30:45");
         assert_eq!(s.hour, Some(9));
         assert_eq!(s.minute, Some(30));
         assert_eq!(s.second, Some(45));
@@ -253,7 +253,7 @@ mod tests {
 
     #[test]
     fn parse_garbage_is_empty() {
-        let s = TimeSegments::from_str("not a time");
+        let s = TimeSegments::parse("not a time");
         assert_eq!(s, TimeSegments::default());
     }
 

--- a/crates/pocopine-core/src/directives/for_.rs
+++ b/crates/pocopine-core/src/directives/for_.rs
@@ -88,9 +88,8 @@ fn remove_or_leave(root: &Element) {
 /// in `run_keyed` falls back to the per-row leave loop when
 /// this returns true, so transition keyframes still play.
 fn has_leavers_with_transition(pool: &HashMap<Rc<str>, PrevItem>) -> bool {
-    pool.values().any(|entry| {
-        crate::directives::transition::has_transition_in_subtree(&entry.element)
-    })
+    pool.values()
+        .any(|entry| crate::directives::transition::has_transition_in_subtree(&entry.element))
 }
 
 /// Predicate for the bulk-clear path. `replace_children_with_node_1`
@@ -373,6 +372,7 @@ fn item_signature(v: &JsValue) -> String {
 /// Keyed iteration. Reuses clones whose keys still appear, fires
 /// `trigger_scope` so their bindings re-evaluate against the updated
 /// `LoopScope`, and reorders the DOM to match the new order.
+#[allow(clippy::too_many_arguments)]
 fn run_keyed(
     item_name: String,
     items_expr: String,
@@ -702,7 +702,7 @@ fn run_keyed(
                     crate::directives::for_plan::unmount_rows_bulk(&scope_ids);
                     Scope::remove_compiled_rows(&scope_ids);
                     pool.clear();
-                    let _ = parent_el.replace_children_with_node_1(template_el.as_ref());
+                    parent_el.replace_children_with_node_1(template_el.as_ref());
                     prior.borrow_mut().clear();
                     crate::profiler::reconcile::record_leaver_drain(leaver_drain_start);
                     crate::profiler::reconcile::record_total(reconcile_total_start);
@@ -1086,7 +1086,6 @@ fn stringify_key(v: &JsValue) -> String {
         .and_then(|s| s.as_string())
         .unwrap_or_default()
 }
-
 
 /// Clone `<template>.content` deeply and return the first element
 /// child of the resulting fragment. Returns `None` when the body is

--- a/crates/pocopine-core/src/directives/for_plan.rs
+++ b/crates/pocopine-core/src/directives/for_plan.rs
@@ -109,7 +109,7 @@ pub(crate) struct CompiledBinding {
     /// `effect()` per row for this binding — the effect reads
     /// each named field through `parent_proxy` to subscribe via
     /// the parent proxy's `get` trap, then evaluates the binding
-    /// + patches DOM. Without this, RFC 054 M2's effect-less
+    /// and patches DOM. Without this, RFC 054 M2's effect-less
     /// per-row eval path silently drops parent-state reactivity:
     /// changes to `selected_id` (e.g. selection styling on
     /// `:class="selected_id == row.id ? 'danger' : ''"`) wouldn't
@@ -278,11 +278,7 @@ fn walk_collect(item_name: &str, expr: &Spanned<Expr>, out: &mut Vec<String>) {
             let Some(first) = segments.first() else {
                 return;
             };
-            if first == item_name
-                || first == "$index"
-                || first == "$first"
-                || first == "$last"
-            {
+            if first == item_name || first == "$index" || first == "$first" || first == "$last" {
                 return;
             }
             if !out.iter().any(|existing| existing == first) {
@@ -450,7 +446,7 @@ pub(crate) fn ensure_delegated_listeners(
 fn unique_listener_events(plan: &CompiledRowPlan) -> Vec<&'static str> {
     let mut events: Vec<&'static str> = Vec::new();
     for listener in &plan.listeners {
-        if !events.iter().any(|event| *event == listener.event) {
+        if !events.contains(&listener.event) {
             events.push(listener.event);
         }
     }
@@ -739,10 +735,9 @@ pub(crate) fn mount_row_compiled(
     let loop_state = Scope::find(scope_id).and_then(|scope| scope.typed::<LoopScope>());
     let binding_start = crate::profiler::mount::start();
     let binding_cache = {
-        let mut binding_cache: Vec<Option<Rc<str>>> =
-            vec![None; plan.bindings.len()];
+        let mut binding_cache: Vec<Option<Rc<str>>> = vec![None; plan.bindings.len()];
         let loop_borrow = loop_state.as_ref().map(|state| state.borrow());
-        let loop_ref = loop_borrow.as_ref().map(|state| &**state);
+        let loop_ref = loop_borrow.as_deref();
         let placeholder_proxy = JsValue::UNDEFINED;
         let proxy_for_eval = proxy.unwrap_or(&placeholder_proxy);
         for (i, b) in plan.bindings.iter().enumerate() {
@@ -949,11 +944,8 @@ fn refresh_parent_bindings(scope_id: ScopeId) {
         let proxy_value = instance.proxy.borrow().clone();
         let placeholder = JsValue::UNDEFINED;
         let proxy_ref = proxy_value.as_ref().unwrap_or(&placeholder);
-        let loop_borrow = instance
-            .loop_state
-            .as_ref()
-            .map(|state| state.borrow());
-        let loop_ref = loop_borrow.as_ref().map(|s| &**s);
+        let loop_borrow = instance.loop_state.as_ref().map(|state| state.borrow());
+        let loop_ref = loop_borrow.as_deref();
         for (i, binding) in plan.bindings.iter().enumerate() {
             if binding.parent_field_paths.is_empty() {
                 continue;
@@ -965,7 +957,6 @@ fn refresh_parent_bindings(scope_id: ScopeId) {
         }
     });
 }
-
 
 /// Re-run the row plan's bindings against the (mutated) loop
 /// scope. Evaluates each binding's AST, compares against the
@@ -991,7 +982,7 @@ pub(crate) fn reuse_row_compiled(scope_id: ScopeId) -> bool {
         let placeholder = JsValue::UNDEFINED;
         let proxy_ref = proxy_value.as_ref().unwrap_or(&placeholder);
         let loop_borrow = instance.loop_state.as_ref().map(|state| state.borrow());
-        let loop_ref = loop_borrow.as_ref().map(|state| &**state);
+        let loop_ref = loop_borrow.as_deref();
         for (i, b) in plan.bindings.iter().enumerate() {
             let v = evaluate_binding(b, proxy_ref, loop_ref);
             let prev = instance.binding_cache[i].as_deref();
@@ -1020,9 +1011,7 @@ pub fn unmount_row_compiled(scope_id: ScopeId) {
     };
     let dropped_effect = LIST_WATCHERS.with(|m| {
         let mut map = m.borrow_mut();
-        let Some(watcher) = map.get_mut(&list_key) else {
-            return None;
-        };
+        let watcher = map.get_mut(&list_key)?;
         watcher.members.retain(|id| *id != scope_id);
         if watcher.members.is_empty() {
             // Last row in this list — tear the watcher down so

--- a/crates/pocopine-core/src/directives/transition.rs
+++ b/crates/pocopine-core/src/directives/transition.rs
@@ -494,10 +494,7 @@ pub fn has_transition_in_subtree(root: &Element) -> bool {
     if has_any_transition_attr(root) {
         return true;
     }
-    root.query_selector(ATTR_SELECTOR)
-        .ok()
-        .flatten()
-        .is_some()
+    root.query_selector(ATTR_SELECTOR).ok().flatten().is_some()
 }
 
 fn collect_animated(root: &Element) -> Vec<Element> {

--- a/crates/pocopine-core/src/expr.rs
+++ b/crates/pocopine-core/src/expr.rs
@@ -18,7 +18,7 @@ use std::{cell::RefCell, collections::HashMap};
 use js_sys::Reflect;
 use wasm_bindgen::{JsCast, JsValue};
 
-pub use pocopine_expr::{BinOp, Expr, Literal, ParseError, Span, Spanned, parse};
+pub use pocopine_expr::{parse, BinOp, Expr, Literal, ParseError, Span, Spanned};
 
 thread_local! {
     static PARSE_CACHE: RefCell<HashMap<String, Result<Spanned<Expr>, ParseError>>> =

--- a/crates/pocopine-core/src/handle.rs
+++ b/crates/pocopine-core/src/handle.rs
@@ -33,9 +33,7 @@ use std::cell::{Ref, RefCell, RefMut};
 use std::rc::Rc;
 
 use crate::reactive::{trigger_scope, ScopeId};
-use crate::scope::{
-    current_scope_id, invalidate_field_cache, with_current_scope_id, Scope,
-};
+use crate::scope::{current_scope_id, invalidate_field_cache, with_current_scope_id, Scope};
 
 /// Typed handle onto a component or store scope.
 ///

--- a/crates/pocopine-core/src/scope.rs
+++ b/crates/pocopine-core/src/scope.rs
@@ -359,11 +359,7 @@ impl Scope {
     /// apply targeted patches against the live JS object that
     /// effects are reading.
     pub fn cached_field(&self, field: &str) -> Option<JsValue> {
-        FIELD_CACHE.with(|c| {
-            c.borrow()
-                .get(&self.id)
-                .and_then(|m| m.get(field).cloned())
-        })
+        FIELD_CACHE.with(|c| c.borrow().get(&self.id).and_then(|m| m.get(field).cloned()))
     }
 
     /// Replace the cached `JsValue` for `field`. Mostly used by
@@ -580,11 +576,7 @@ pub fn patch_list_at_inline<T: serde::Serialize>(field: &str, idx: usize, row: &
     let Some(sid) = current_scope_id() else {
         return;
     };
-    let cached = FIELD_CACHE.with(|c| {
-        c.borrow()
-            .get(&sid)
-            .and_then(|m| m.get(field).cloned())
-    });
+    let cached = FIELD_CACHE.with(|c| c.borrow().get(&sid).and_then(|m| m.get(field).cloned()));
     if let Some(arr) = cached {
         if arr.is_object() {
             if let Ok(new_js) = serde_wasm_bindgen::to_value(row) {

--- a/crates/pocopine-core/src/task.rs
+++ b/crates/pocopine-core/src/task.rs
@@ -88,7 +88,10 @@ pub fn spawn_latest(
     TASKS.with(|tasks| {
         let mut tasks = tasks.borrow_mut();
         let scope_tasks = tasks.entry(scope_id).or_default();
-        if let Some(prev) = scope_tasks.latest.insert(task_name.clone(), handle.inner.clone()) {
+        if let Some(prev) = scope_tasks
+            .latest
+            .insert(task_name.clone(), handle.inner.clone())
+        {
             prev.cancelled.set(true);
         }
         scope_tasks.tasks.push(handle.inner.clone());

--- a/crates/pocopine-core/src/templates.rs
+++ b/crates/pocopine-core/src/templates.rs
@@ -204,7 +204,6 @@ fn find_tag_end(bytes: &[u8], tag_start: usize) -> Option<usize> {
     None
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::{compile_template, inject_pp_data};
@@ -309,5 +308,4 @@ mod tests {
         assert!(out.contains(r#"pp-data="pine-avatar-image""#));
         assert!(out.ends_with("/>"));
     }
-
 }

--- a/crates/pocopine-core/src/walker.rs
+++ b/crates/pocopine-core/src/walker.rs
@@ -1560,16 +1560,17 @@ fn install_observer(root: &Element) {
             // state torn down synchronously. Skip the per-node
             // `release_subtree` walk + recursive `Reflect::get`
             // sweeps. Saves ~30-50ms on a 10K-row clear.
-            let bulk_skip = rec.target().and_then(|t| t.dyn_into::<Element>().ok()).and_then(
-                |parent_el| {
+            let bulk_skip = rec
+                .target()
+                .and_then(|t| t.dyn_into::<Element>().ok())
+                .and_then(|parent_el| {
                     if get_private(&parent_el, BULK_RELEASE_KEY).is_some() {
                         bulk_release_parents.push(parent_el);
                         Some(())
                     } else {
                         None
                     }
-                },
-            );
+                });
 
             // "Removed" records report nodes detached from *this*
             // parent. When we reparent an element (a keyed `pp-for`

--- a/crates/pocopine-core/tests/reactive.rs
+++ b/crates/pocopine-core/tests/reactive.rs
@@ -313,9 +313,8 @@ fn spawn_scoped_cancels_when_scope_is_removed() {
 
     let state = Rc::new(std::cell::RefCell::new(TestScopeState::default()));
     let scope = Scope::new(state);
-    let handle = pocopine_core::scope::with_current_scope_id(scope.id, || {
-        spawn_scoped(async move {})
-    });
+    let handle =
+        pocopine_core::scope::with_current_scope_id(scope.id, || spawn_scoped(async move {}));
 
     assert!(!handle.is_cancelled());
     Scope::remove(scope.id);
@@ -334,7 +333,10 @@ fn spawn_latest_cancels_previous_task_in_same_slot() {
         (first, second)
     });
 
-    assert!(first.is_cancelled(), "older latest-wins task should be cancelled");
+    assert!(
+        first.is_cancelled(),
+        "older latest-wins task should be cancelled"
+    );
     assert!(
         !second.is_cancelled(),
         "newest latest-wins task should stay active until scope teardown"

--- a/crates/pocopine-macros/src/diagnostics.rs
+++ b/crates/pocopine-macros/src/diagnostics.rs
@@ -57,15 +57,9 @@ pub(crate) fn render_template_error(
 /// back to a file-level message without a source snippet.
 /// Used when a `ParseError` surfaces without a range (e.g.
 /// inherited from html5ever without position info).
-pub(crate) fn render_fileless_error(
-    file_path: &str,
-    title: &str,
-    note: &str,
-) -> String {
+pub(crate) fn render_fileless_error(file_path: &str, title: &str, note: &str) -> String {
     let footer = format!("in {file_path}: {note}");
-    let message = Level::Error
-        .title(title)
-        .footer(Level::Note.title(&footer));
+    let message = Level::Error.title(title).footer(Level::Note.title(&footer));
     format!("{}", Renderer::styled().render(message))
 }
 
@@ -100,11 +94,7 @@ mod tests {
 
     #[test]
     fn fileless_render_includes_file_and_note() {
-        let rendered = render_fileless_error(
-            "test.poco",
-            "malformed template",
-            "unclosed tag",
-        );
+        let rendered = render_fileless_error("test.poco", "malformed template", "unclosed tag");
         assert!(rendered.contains("test.poco"));
         assert!(rendered.contains("unclosed tag"));
     }

--- a/crates/pocopine-macros/src/for_plan.rs
+++ b/crates/pocopine-macros/src/for_plan.rs
@@ -106,6 +106,7 @@ impl AnalysisCtx {
 /// not part of the surrounding component's template). Failure →
 /// continue descending so nested `pp-for`s still get their
 /// chance.
+#[allow(clippy::only_used_in_recursion)]
 fn walk(el: &Element, ast: &TemplateAst, ctx: &mut AnalysisCtx) {
     if el.synthetic {
         // Synthetic elements (html5ever's auto-inserted `<tbody>`)
@@ -149,10 +150,7 @@ fn walk(el: &Element, ast: &TemplateAst, ctx: &mut AnalysisCtx) {
 /// Try to compile one `<template pp-for>` element into a row
 /// plan. Returns `None` on any eligibility miss; the caller
 /// just leaves the template alone in that case.
-fn try_compile_row(
-    template_el: &Element,
-    plan_id: u32,
-) -> Option<(TokenStream, TemplateStamp)> {
+fn try_compile_row(template_el: &Element, plan_id: u32) -> Option<(TokenStream, TemplateStamp)> {
     // 1. Parse `pp-for="<v> in <items>"`. We don't need the
     //    items expression at the row-plan level — `pp-for`
     //    itself runs at runtime and handles the items lookup —
@@ -171,9 +169,7 @@ fn try_compile_row(
     //    Without `pp-key` the runtime falls into `run_naive`,
     //    which doesn't consult the plan anyway, so silently
     //    skipping here is fine.
-    if find_attr(template_el, "pp-key").is_none() {
-        return None;
-    }
+    find_attr(template_el, "pp-key")?;
 
     // 3. Reject other directives on the `<template>` itself
     //    that aren't part of the keyed `pp-for` envelope.
@@ -347,12 +343,7 @@ fn walk_row(el: &Element, ctx: &mut RowWalkCtx, path: &mut Vec<u16>) -> bool {
 /// node is in-envelope. Static attributes pass silently; known
 /// dynamic attributes record a binding/listener; anything else
 /// fails the row.
-fn classify_attribute(
-    name: &str,
-    value: &str,
-    path: &Vec<u16>,
-    ctx: &mut RowWalkCtx,
-) -> bool {
+fn classify_attribute(name: &str, value: &str, path: &[u16], ctx: &mut RowWalkCtx) -> bool {
     // Listener shorthand: `@<event>="<expr>"`. RFC-020.
     if let Some(event) = name.strip_prefix('@') {
         // No modifiers: reject if `event` contains a `.`.
@@ -364,7 +355,7 @@ fn classify_attribute(
             return false;
         }
         ctx.listeners.push(ListenerLite {
-            node_path: path.clone(),
+            node_path: path.to_vec(),
             event: event.to_string(),
             expr_src: value.to_string(),
         });
@@ -380,7 +371,7 @@ fn classify_attribute(
             return false;
         }
         ctx.bindings.push(BindingLite {
-            node_path: path.clone(),
+            node_path: path.to_vec(),
             kind: BindingKindLite::Class,
             expr_src: value.to_string(),
         });
@@ -394,7 +385,7 @@ fn classify_attribute(
                 return false;
             }
             ctx.bindings.push(BindingLite {
-                node_path: path.clone(),
+                node_path: path.to_vec(),
                 kind: BindingKindLite::Text,
                 expr_src: value.to_string(),
             });
@@ -415,7 +406,7 @@ fn classify_attribute(
                 return false;
             }
             ctx.bindings.push(BindingLite {
-                node_path: path.clone(),
+                node_path: path.to_vec(),
                 kind: BindingKindLite::Class,
                 expr_src: value.to_string(),
             });
@@ -434,7 +425,7 @@ fn classify_attribute(
                 return false;
             }
             ctx.listeners.push(ListenerLite {
-                node_path: path.clone(),
+                node_path: path.to_vec(),
                 event: rest.to_string(),
                 expr_src: value.to_string(),
             });
@@ -468,13 +459,9 @@ fn single_element_child(template_el: &Element) -> Option<&Element> {
 }
 
 fn find_attr<'a>(el: &'a Element, name: &str) -> Option<&'a String> {
-    el.attrs.iter().find_map(|(n, v)| {
-        if n == name {
-            Some(v)
-        } else {
-            None
-        }
-    })
+    el.attrs
+        .iter()
+        .find_map(|(n, v)| if n == name { Some(v) } else { None })
 }
 
 /// Parse `pp-for="<v> in <items>"` and return the loop
@@ -487,7 +474,10 @@ fn parse_for_item(value: &str) -> Option<String> {
     if var.is_empty() {
         return None;
     }
-    if !var.chars().all(|c| c.is_alphanumeric() || c == '_' || c == '$') {
+    if !var
+        .chars()
+        .all(|c| c.is_alphanumeric() || c == '_' || c == '$')
+    {
         return None;
     }
     Some(var.to_string())

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -41,8 +41,8 @@ use syn::{
 
 // RFC 050 — compile-time `.poco` template parser + diagnostic
 // renderer. Both host-only (proc-macro crate), invisible to wasm.
-mod template_parser;
 mod diagnostics;
+mod template_parser;
 // RFC 049 — `#[slot]` helper-attribute parsing + marker-trait
 // emission. Inert helper consumed by `#[component]`.
 mod slot;
@@ -81,7 +81,13 @@ mod for_plan;
 fn validate_template_or_emit_errors(
     template_path: &LitStr,
     component_name: &str,
-) -> Result<(Option<proc_macro2::TokenStream>, Option<template_parser::TemplateAst>), TokenStream> {
+) -> Result<
+    (
+        Option<proc_macro2::TokenStream>,
+        Option<template_parser::TemplateAst>,
+    ),
+    TokenStream,
+> {
     let lenient = is_lenient_mode();
 
     // Resolve the `.poco` file via a two-tier strategy.
@@ -120,9 +126,7 @@ fn validate_template_or_emit_errors(
         Err(e) => {
             let msg = diagnostics::render_fileless_error(
                 &display_path,
-                &format!(
-                    "pocopine: cannot read template for component `{component_name}`"
-                ),
+                &format!("pocopine: cannot read template for component `{component_name}`"),
                 &format!("{} ({})", e, file_path_str),
             );
             return surface_diagnostic(template_path, &msg, lenient, None);
@@ -134,9 +138,7 @@ fn validate_template_or_emit_errors(
         Err(parse_errors) => {
             let mut rendered_blocks: Vec<String> = Vec::new();
             for err in parse_errors {
-                if err.byte_range.end > err.byte_range.start
-                    && err.byte_range.end <= source.len()
-                {
+                if err.byte_range.end > err.byte_range.start && err.byte_range.end <= source.len() {
                     rendered_blocks.push(diagnostics::render_template_error(
                         &source,
                         &display_path,
@@ -150,9 +152,7 @@ fn validate_template_or_emit_errors(
                 } else {
                     rendered_blocks.push(diagnostics::render_fileless_error(
                         &display_path,
-                        &format!(
-                            "pocopine: invalid template for component `{component_name}`"
-                        ),
+                        &format!("pocopine: invalid template for component `{component_name}`"),
                         &err.message,
                     ));
                 }
@@ -171,9 +171,7 @@ fn validate_template_or_emit_errors(
         0 => {
             let msg = diagnostics::render_fileless_error(
                 &display_path,
-                &format!(
-                    "pocopine: template for component `{component_name}` has no root element"
-                ),
+                &format!("pocopine: template for component `{component_name}` has no root element"),
                 "pocopine templates require exactly one root",
             );
             drop(roots);
@@ -211,15 +209,19 @@ fn surface_diagnostic(
     rendered: &str,
     lenient: bool,
     ast: Option<template_parser::TemplateAst>,
-) -> Result<(Option<proc_macro2::TokenStream>, Option<template_parser::TemplateAst>), TokenStream> {
+) -> Result<
+    (
+        Option<proc_macro2::TokenStream>,
+        Option<template_parser::TemplateAst>,
+    ),
+    TokenStream,
+> {
     if lenient {
         Ok((Some(build_warning_tokens(rendered)), ast))
     } else {
-        Err(
-            syn::Error::new(anchor.span(), rendered)
-                .to_compile_error()
-                .into(),
-        )
+        Err(syn::Error::new(anchor.span(), rendered)
+            .to_compile_error()
+            .into())
     }
 }
 
@@ -283,7 +285,9 @@ fn manifest_relative(path: &std::path::Path) -> String {
 fn resolve_template_path(template_path: &LitStr) -> Option<std::path::PathBuf> {
     // Tier 1 — span-based (cargo + rust-analyzer file-backed).
     if let Some(caller_rs) = template_path.span().unwrap().local_file() {
-        let caller_dir = caller_rs.parent().unwrap_or_else(|| std::path::Path::new("."));
+        let caller_dir = caller_rs
+            .parent()
+            .unwrap_or_else(|| std::path::Path::new("."));
         let candidate = caller_dir.join(template_path.value());
         if candidate.is_file() {
             return Some(candidate);
@@ -712,11 +716,7 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
         Ok(s) => s,
         Err(e) => return e.to_compile_error().into(),
     };
-    let slot_traits_tokens = slot::emit_slot_traits(
-        &struct_ident,
-        &name_str,
-        &slot_decls,
-    );
+    let slot_traits_tokens = slot::emit_slot_traits(&struct_ident, &name_str, &slot_decls);
 
     // RFC-031 — `#[prop]` is the explicit "parent contract"
     // marker; everything else defaults to state (internal,
@@ -1199,25 +1199,18 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
     // Also keeps the parsed AST in scope for RFC 049's
     // consumer-side slot-contract scan, run below when the
     // consumer declared a `uses = [...]` list.
-    let (template_warnings, template_ast) = match validate_template_or_emit_errors(
-        &template_path,
-        &name_str,
-    ) {
-        Ok((warning, ast)) => (
-            warning.unwrap_or_else(proc_macro2::TokenStream::new),
-            ast,
-        ),
-        Err(token_stream) => return token_stream,
-    };
+    let (template_warnings, template_ast) =
+        match validate_template_or_emit_errors(&template_path, &name_str) {
+            Ok((warning, ast)) => (warning.unwrap_or_else(proc_macro2::TokenStream::new), ast),
+            Err(token_stream) => return token_stream,
+        };
 
     // RFC 049 consumer-side scan — emit trait-bound assertions
     // for each (parent, child) pair where both tags resolve
     // through the consumer's `uses` list. Empty when `uses` is
     // absent or the template has no recognised typed parents.
     let slot_assertions_tokens = match (&args.uses, &template_ast) {
-        (Some(uses_table), Some(ast)) => {
-            slot_assertions::emit_slot_assertions(ast, uses_table)
-        }
+        (Some(uses_table), Some(ast)) => slot_assertions::emit_slot_assertions(ast, uses_table),
         _ => proc_macro2::TokenStream::new(),
     };
 
@@ -1595,7 +1588,12 @@ pub fn handlers(_attr: TokenStream, item: TokenStream) -> TokenStream {
             methods_to_skip_in_arms.insert(method.sig.ident.to_string());
             computed_methods.push(ComputedMethod {
                 method_ident: method.sig.ident.clone(),
-                field_name: method.sig.ident.to_string().trim_start_matches("r#").to_string(),
+                field_name: method
+                    .sig
+                    .ident
+                    .to_string()
+                    .trim_start_matches("r#")
+                    .to_string(),
                 ret_ty,
                 params: Vec::new(),
             });
@@ -1627,7 +1625,11 @@ pub fn handlers(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 .to_compile_error()
                 .into();
             };
-            let dep_name = pat_ident.ident.to_string().trim_start_matches("r#").to_string();
+            let dep_name = pat_ident
+                .ident
+                .to_string()
+                .trim_start_matches("r#")
+                .to_string();
             entry.params.push(ComputedParam {
                 ident: pat_ident.ident.clone(),
                 ty: (**ty).clone(),
@@ -1875,12 +1877,9 @@ pub fn handlers(_attr: TokenStream, item: TokenStream) -> TokenStream {
             .enumerate()
             .find_map(|(idx, entry)| (indegree[idx] > 0).then_some(entry.method_ident.clone()))
             .unwrap_or_else(|| format_ident!("computed"));
-        return syn::Error::new_spanned(
-            offender,
-            "#[computed] dependency graph contains a cycle",
-        )
-        .to_compile_error()
-        .into();
+        return syn::Error::new_spanned(offender, "#[computed] dependency graph contains a cycle")
+            .to_compile_error()
+            .into();
     }
 
     let computed_install_stmts = topo.iter().map(|idx| {

--- a/crates/pocopine-macros/src/slot.rs
+++ b/crates/pocopine-macros/src/slot.rs
@@ -100,9 +100,7 @@ impl SlotName {
 /// Strip all `#[slot(...)]` attributes from `attrs`, parsing each
 /// into a [`SlotDecl`]. Mutates `attrs` in place — the remaining
 /// attributes are re-emitted on the struct as normal.
-pub(crate) fn parse_and_strip_slots(
-    attrs: &mut Vec<Attribute>,
-) -> syn::Result<Vec<SlotDecl>> {
+pub(crate) fn parse_and_strip_slots(attrs: &mut Vec<Attribute>) -> syn::Result<Vec<SlotDecl>> {
     let mut decls = Vec::new();
     let mut i = 0;
     while i < attrs.len() {
@@ -129,9 +127,7 @@ fn parse_slot_attr(attr: &Attribute) -> syn::Result<SlotDecl> {
 
     // Parse the parenthesised body. `Meta`-list parsing is
     // comma-separated; first entry is the selector.
-    let nested = attr.parse_args_with(
-        Punctuated::<SlotArg, Token![,]>::parse_terminated,
-    )?;
+    let nested = attr.parse_args_with(Punctuated::<SlotArg, Token![,]>::parse_terminated)?;
 
     for arg in nested {
         match arg {
@@ -268,11 +264,7 @@ pub(crate) fn emit_slot_traits(
             // compile-time child constraint means no trait.
             continue;
         }
-        let trait_ident = format_ident!(
-            "{}{}Child",
-            struct_ident,
-            slot.name.trait_suffix(),
-        );
+        let trait_ident = format_ident!("{}{}Child", struct_ident, slot.name.trait_suffix(),);
         let assert_method_ident = slot.name.assert_method_ident();
         let slot_display = slot.name.display();
         let mode_suffix = match slot.mode {
@@ -400,6 +392,7 @@ impl AttrSpanHelpers for Attribute {
 // Re-export for tests; kept as a free function so the test
 // module can call it without grabbing Path imports.
 #[cfg(test)]
+#[allow(dead_code)]
 pub(crate) fn parse_slot_for_test(attr: &Attribute) -> syn::Result<SlotDecl> {
     parse_slot_attr(attr)
 }

--- a/crates/pocopine-macros/src/slot_assertions.rs
+++ b/crates/pocopine-macros/src/slot_assertions.rs
@@ -52,10 +52,7 @@ use crate::uses::UsesTable;
 ///
 /// Returns an empty `TokenStream` when `uses` is empty or the
 /// template contains no recognised typed-parent tags.
-pub(crate) fn emit_slot_assertions(
-    ast: &TemplateAst,
-    uses: &UsesTable,
-) -> TokenStream {
+pub(crate) fn emit_slot_assertions(ast: &TemplateAst, uses: &UsesTable) -> TokenStream {
     if uses.entries.is_empty() {
         return TokenStream::new();
     }
@@ -145,13 +142,7 @@ fn emit_assertions_for_parent(
                 let site = SlotName::Named(slot_name);
                 for slotted in &child_el.children {
                     if let Node::Element(slotted_el) = slotted {
-                        emit_one_assertion(
-                            parent_path,
-                            &site,
-                            slotted_el,
-                            uses,
-                            out,
-                        );
+                        emit_one_assertion(parent_path, &site, slotted_el, uses, out);
                     }
                 }
                 continue;
@@ -159,13 +150,7 @@ fn emit_assertions_for_parent(
         }
 
         // Default slot — any non-template-wrapped direct child.
-        emit_one_assertion(
-            parent_path,
-            &SlotName::Default,
-            child_el,
-            uses,
-            out,
-        );
+        emit_one_assertion(parent_path, &SlotName::Default, child_el, uses, out);
     }
 }
 
@@ -287,11 +272,7 @@ mod tests {
             <pine-item></pine-item>
         </pine-foo>"#;
         let (ast, _errors) = parse(src, "test.poco");
-        let uses = table(vec![
-            bare("PineFoo"),
-            bare("PineItem"),
-            bare("PineTitle"),
-        ]);
+        let uses = table(vec![bare("PineFoo"), bare("PineItem"), bare("PineTitle")]);
         let tokens = emit_slot_assertions(&ast, &uses);
         let s = tokens.to_string();
         assert!(
@@ -314,11 +295,7 @@ mod tests {
             </pine-inner>
         </pine-outer>"#;
         let (ast, _errors) = parse(src, "test.poco");
-        let uses = table(vec![
-            bare("PineOuter"),
-            bare("PineInner"),
-            bare("PineItem"),
-        ]);
+        let uses = table(vec![bare("PineOuter"), bare("PineInner"), bare("PineItem")]);
         let tokens = emit_slot_assertions(&ast, &uses);
         let s = tokens.to_string();
         // Two assertion blocks — both via the default-slot

--- a/crates/pocopine-macros/src/template_parser.rs
+++ b/crates/pocopine-macros/src/template_parser.rs
@@ -438,16 +438,13 @@ impl<'a> Mapper<'a> {
     /// opening `<tagname` that corresponds to a real element.
     fn skip_insignificant_and_text(&mut self) {
         loop {
-            while self.cursor < self.source.len()
-                && self.source[self.cursor].is_ascii_whitespace()
+            while self.cursor < self.source.len() && self.source[self.cursor].is_ascii_whitespace()
             {
                 self.cursor += 1;
             }
             if !self.peek_seq(b"<") {
                 // Stray text content — advance until next `<`.
-                while self.cursor < self.source.len()
-                    && self.source[self.cursor] != b'<'
-                {
+                while self.cursor < self.source.len() && self.source[self.cursor] != b'<' {
                     self.cursor += 1;
                 }
                 if self.cursor >= self.source.len() {
@@ -506,8 +503,7 @@ fn find_seq(bytes: &[u8], start: usize, needle: &[u8]) -> Option<usize> {
     if needle.is_empty() || start + needle.len() > bytes.len() {
         return None;
     }
-    (start..=bytes.len() - needle.len())
-        .find(|&i| &bytes[i..i + needle.len()] == needle)
+    (start..=bytes.len() - needle.len()).find(|&i| &bytes[i..i + needle.len()] == needle)
 }
 
 /// Find the `>` that closes the opening tag starting at
@@ -547,9 +543,7 @@ fn find_close_tag(bytes: &[u8], start: usize, tag: &str) -> Option<Range<usize>>
             let name_start = i + 2;
             if name_start + tag_bytes.len() <= bytes.len() {
                 let candidate = &bytes[name_start..name_start + tag_bytes.len()];
-                let matches = candidate.iter().zip(tag_bytes).all(|(a, b)| {
-                    a.to_ascii_lowercase() == b.to_ascii_lowercase()
-                });
+                let matches = candidate.eq_ignore_ascii_case(tag_bytes);
                 if matches {
                     // Next byte should be whitespace or `>`.
                     let next = bytes.get(name_start + tag_bytes.len()).copied();
@@ -570,8 +564,8 @@ fn find_close_tag(bytes: &[u8], start: usize, tag: &str) -> Option<Range<usize>>
 /// never carry a `</tag>` close. Kept in sync with the list in
 /// `pocopine-core/src/templates.rs`.
 const VOID_ELEMENTS: &[&str] = &[
-    "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta",
-    "source", "track", "wbr",
+    "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "source", "track",
+    "wbr",
 ];
 
 fn is_void_element(tag: &str) -> bool {
@@ -585,7 +579,9 @@ fn is_void_element(tag: &str) -> bool {
 const FOREIGN_CONTENT_ROOTS: &[&str] = &["svg", "math"];
 
 fn is_foreign_content_root(tag: &str) -> bool {
-    FOREIGN_CONTENT_ROOTS.iter().any(|v| v.eq_ignore_ascii_case(tag))
+    FOREIGN_CONTENT_ROOTS
+        .iter()
+        .any(|v| v.eq_ignore_ascii_case(tag))
 }
 
 /// RFC 050 explicit rule: `<tagname/>` self-close is only valid
@@ -776,10 +772,7 @@ fn source_tag_matches(bytes: &[u8], open_lt: usize, tag: &str) -> bool {
         return false;
     }
     let tag_bytes = tag.as_bytes();
-    bytes[name_start..name_end]
-        .iter()
-        .zip(tag_bytes)
-        .all(|(a, b)| a.to_ascii_lowercase() == b.to_ascii_lowercase())
+    bytes[name_start..name_end].eq_ignore_ascii_case(tag_bytes)
 }
 
 /// RcDom's fragment parsing nests the user's content inside an
@@ -816,11 +809,8 @@ fn collect_fragment_roots(
     out
 }
 
-fn convert_node(
-    handle: &Handle,
-    source: &str,
-    errors: &mut Vec<ParseError>,
-) -> Option<Node> {
+#[allow(clippy::only_used_in_recursion)]
+fn convert_node(handle: &Handle, source: &str, errors: &mut Vec<ParseError>) -> Option<Node> {
     match &handle.data {
         NodeData::Element {
             name,
@@ -838,10 +828,12 @@ fn convert_node(
             let attrs: Vec<(String, String)> = attrs_ref
                 .borrow()
                 .iter()
-                .map(|a| (
-                    a.name.local.to_string().to_ascii_lowercase(),
-                    a.value.to_string(),
-                ))
+                .map(|a| {
+                    (
+                        a.name.local.to_string().to_ascii_lowercase(),
+                        a.value.to_string(),
+                    )
+                })
                 .collect();
 
             let mut children: Vec<Node> = Vec::new();
@@ -882,9 +874,7 @@ fn convert_node(
             let text = contents.borrow().to_string();
             Some(Node::Text(text, 0..0))
         }
-        NodeData::Comment { contents } => {
-            Some(Node::Comment(contents.to_string(), 0..0))
-        }
+        NodeData::Comment { contents } => Some(Node::Comment(contents.to_string(), 0..0)),
         // Doctype / ProcessingInstruction / Document are either
         // filtered by parse options (doctype) or don't occur
         // inside a fragment tree.
@@ -908,19 +898,12 @@ fn source_contains_tag_opener(source: &str, tag: &str) -> bool {
     let mut i = 0;
     while i + n <= src.len() {
         let candidate = &src[i..i + n];
-        if candidate
-            .iter()
-            .zip(needle)
-            .all(|(a, b)| a.to_ascii_lowercase() == b.to_ascii_lowercase())
-        {
+        if candidate.eq_ignore_ascii_case(needle) {
             // Confirm next byte is a tag delimiter.
             match src.get(i + n) {
                 None => return true,
                 Some(&b) => {
-                    if b.is_ascii_whitespace()
-                        || b == b'>'
-                        || b == b'/'
-                    {
+                    if b.is_ascii_whitespace() || b == b'>' || b == b'/' {
                         return true;
                     }
                 }
@@ -941,7 +924,7 @@ mod tests {
         ast
     }
 
-    fn elem<'a>(node: &'a Node) -> &'a Element {
+    fn elem(node: &Node) -> &Element {
         node.as_element().expect("expected element node")
     }
 
@@ -985,7 +968,10 @@ mod tests {
         // diagnostic will land with byte ranges; this test only
         // pins down that we *do* surface an error today.
         let (ast, errors) = parse(r#"<div a="1" a="2">x</div>"#, "test.poco");
-        assert!(!errors.is_empty(), "expected parser error for duplicate attr");
+        assert!(
+            !errors.is_empty(),
+            "expected parser error for duplicate attr"
+        );
         let root = elem(&ast.roots[0]);
         // html5ever retains the first occurrence; we don't
         // invent additional deduping on top.
@@ -1144,7 +1130,10 @@ mod tests {
         let src = "<div><span>inner</span></div>";
         let ast = parse_ok(src);
         let root = ast.element_roots().next().unwrap();
-        assert_eq!(slice(src, &root.byte_range), "<div><span>inner</span></div>");
+        assert_eq!(
+            slice(src, &root.byte_range),
+            "<div><span>inner</span></div>"
+        );
         let span = root.children[0].as_element().unwrap();
         assert_eq!(slice(src, &span.opening_tag_range), "<span>");
         assert_eq!(slice(src, &span.byte_range), "<span>inner</span>");
@@ -1155,7 +1144,10 @@ mod tests {
         let src = r#"<input type="text"/>"#;
         let ast = parse_ok(src);
         let root = ast.element_roots().next().unwrap();
-        assert_eq!(slice(src, &root.opening_tag_range), r#"<input type="text"/>"#);
+        assert_eq!(
+            slice(src, &root.opening_tag_range),
+            r#"<input type="text"/>"#
+        );
         // Self-closing: byte_range == opening_tag_range.
         assert_eq!(root.byte_range, root.opening_tag_range);
     }
@@ -1197,7 +1189,10 @@ mod tests {
         let src = "<div\n  class=\"x\"\n  id=\"y\"\n>\n  inside\n</div>";
         let ast = parse_ok(src);
         let root = ast.element_roots().next().unwrap();
-        assert_eq!(slice(src, &root.opening_tag_range), "<div\n  class=\"x\"\n  id=\"y\"\n>");
+        assert_eq!(
+            slice(src, &root.opening_tag_range),
+            "<div\n  class=\"x\"\n  id=\"y\"\n>"
+        );
         assert_eq!(slice(src, &root.byte_range), src);
     }
 
@@ -1383,9 +1378,7 @@ mod tests {
         let src = "<div><pine-foo/></div>";
         let (_ast, errors) = parse(src, "test.poco");
         assert!(
-            errors
-                .iter()
-                .any(|e| e.message.contains("`<pine-foo/>`")),
+            errors.iter().any(|e| e.message.contains("`<pine-foo/>`")),
             "expected self-close error on custom element, got: {errors:?}"
         );
     }
@@ -1438,7 +1431,10 @@ mod tests {
     fn parse_strict_rejects_forbidden_self_close() {
         let src = "<root><slot/></root>";
         let err = parse_strict(src, "test.poco").err();
-        assert!(err.is_some(), "parse_strict must reject forbidden self-close");
+        assert!(
+            err.is_some(),
+            "parse_strict must reject forbidden self-close"
+        );
     }
 
     // ── Table-rooted templates (Pine calendar regression) ───

--- a/crates/pocopine/tests/walker.rs
+++ b/crates/pocopine/tests/walker.rs
@@ -2643,20 +2643,14 @@ async fn computed_fields_render_and_update_reactively() {
     assert_eq!(summary.text_content().as_deref(), Some("Ada Lovelace"));
 
     let rename = host.query_selector("#rename").unwrap().unwrap();
-    rename
-        .dyn_ref::<HtmlElement>()
-        .unwrap()
-        .click();
+    rename.dyn_ref::<HtmlElement>().unwrap().click();
     tick().await;
 
     assert_eq!(full.text_content().as_deref(), Some("Grace Hopper"));
     assert_eq!(summary.text_content().as_deref(), Some("Grace Hopper"));
 
     let toggle = host.query_selector("#toggle").unwrap().unwrap();
-    toggle
-        .dyn_ref::<HtmlElement>()
-        .unwrap()
-        .click();
+    toggle.dyn_ref::<HtmlElement>().unwrap().click();
     tick().await;
 
     assert_eq!(
@@ -2736,11 +2730,26 @@ async fn empty_pool_compiled_mount_renders_all_rows() {
     seed_bulk_rows(
         &host,
         &[
-            Row { id: 1, label: "alpha".into() },
-            Row { id: 2, label: "bravo".into() },
-            Row { id: 3, label: "charlie".into() },
-            Row { id: 4, label: "delta".into() },
-            Row { id: 5, label: "echo".into() },
+            Row {
+                id: 1,
+                label: "alpha".into(),
+            },
+            Row {
+                id: 2,
+                label: "bravo".into(),
+            },
+            Row {
+                id: 3,
+                label: "charlie".into(),
+            },
+            Row {
+                id: 4,
+                label: "delta".into(),
+            },
+            Row {
+                id: 5,
+                label: "echo".into(),
+            },
         ],
     );
     tick().await;
@@ -2771,9 +2780,18 @@ async fn remount_after_bulk_clear() {
     seed_bulk_rows(
         &host,
         &[
-            Row { id: 1, label: "one".into() },
-            Row { id: 2, label: "two".into() },
-            Row { id: 3, label: "three".into() },
+            Row {
+                id: 1,
+                label: "one".into(),
+            },
+            Row {
+                id: 2,
+                label: "two".into(),
+            },
+            Row {
+                id: 3,
+                label: "three".into(),
+            },
         ],
     );
     tick().await;
@@ -2788,8 +2806,14 @@ async fn remount_after_bulk_clear() {
     seed_bulk_rows(
         &host,
         &[
-            Row { id: 10, label: "x".into() },
-            Row { id: 11, label: "y".into() },
+            Row {
+                id: 10,
+                label: "x".into(),
+            },
+            Row {
+                id: 11,
+                label: "y".into(),
+            },
         ],
     );
     tick().await;
@@ -2817,9 +2841,18 @@ async fn delegated_listener_after_proxy_elision() {
     seed_bulk_rows(
         &host,
         &[
-            Row { id: 1, label: "a".into() },
-            Row { id: 2, label: "b".into() },
-            Row { id: 3, label: "c".into() },
+            Row {
+                id: 1,
+                label: "a".into(),
+            },
+            Row {
+                id: 2,
+                label: "b".into(),
+            },
+            Row {
+                id: 3,
+                label: "c".into(),
+            },
         ],
     );
     tick().await;
@@ -2835,9 +2868,15 @@ async fn delegated_listener_after_proxy_elision() {
     tick().await;
 
     // Selected_id became 2 → row 2's :class must now be 'sel'.
-    let row1_class = bulk_li_at(&host, 0).get_attribute("class").unwrap_or_default();
-    let row2_class = bulk_li_at(&host, 1).get_attribute("class").unwrap_or_default();
-    let row3_class = bulk_li_at(&host, 2).get_attribute("class").unwrap_or_default();
+    let row1_class = bulk_li_at(&host, 0)
+        .get_attribute("class")
+        .unwrap_or_default();
+    let row2_class = bulk_li_at(&host, 1)
+        .get_attribute("class")
+        .unwrap_or_default();
+    let row3_class = bulk_li_at(&host, 2)
+        .get_attribute("class")
+        .unwrap_or_default();
     assert_eq!(row1_class, "", "row 1 not selected");
     assert_eq!(row2_class, "sel", "row 2 should carry .sel");
     assert_eq!(row3_class, "", "row 3 not selected");
@@ -2852,8 +2891,12 @@ async fn delegated_listener_after_proxy_elision() {
     btn3.click();
     tick().await;
 
-    let row2_class = bulk_li_at(&host, 1).get_attribute("class").unwrap_or_default();
-    let row3_class = bulk_li_at(&host, 2).get_attribute("class").unwrap_or_default();
+    let row2_class = bulk_li_at(&host, 1)
+        .get_attribute("class")
+        .unwrap_or_default();
+    let row3_class = bulk_li_at(&host, 2)
+        .get_attribute("class")
+        .unwrap_or_default();
     assert_eq!(row2_class, "", "row 2 should clear after row 3 picked");
     assert_eq!(row3_class, "sel", "row 3 should carry .sel");
 }
@@ -2874,8 +2917,14 @@ async fn lever5b_marker_clears_so_later_removes_teardown_normally() {
     seed_bulk_rows(
         &host,
         &[
-            Row { id: 1, label: "a".into() },
-            Row { id: 2, label: "b".into() },
+            Row {
+                id: 1,
+                label: "a".into(),
+            },
+            Row {
+                id: 2,
+                label: "b".into(),
+            },
         ],
     );
     tick().await;
@@ -2889,8 +2938,14 @@ async fn lever5b_marker_clears_so_later_removes_teardown_normally() {
     seed_bulk_rows(
         &host,
         &[
-            Row { id: 10, label: "x".into() },
-            Row { id: 11, label: "y".into() },
+            Row {
+                id: 10,
+                label: "x".into(),
+            },
+            Row {
+                id: 11,
+                label: "y".into(),
+            },
         ],
     );
     tick().await;
@@ -2903,7 +2958,10 @@ async fn lever5b_marker_clears_so_later_removes_teardown_normally() {
     // by the observer already.
     seed_bulk_rows(
         &host,
-        &[Row { id: 10, label: "x".into() }],
+        &[Row {
+            id: 10,
+            label: "x".into(),
+        }],
     );
     tick().await;
     assert_eq!(bulk_li_count(&host), 1);
@@ -2915,9 +2973,18 @@ async fn lever5b_marker_clears_so_later_removes_teardown_normally() {
     seed_bulk_rows(
         &host,
         &[
-            Row { id: 10, label: "x".into() },
-            Row { id: 11, label: "y2".into() },
-            Row { id: 12, label: "z".into() },
+            Row {
+                id: 10,
+                label: "x".into(),
+            },
+            Row {
+                id: 11,
+                label: "y2".into(),
+            },
+            Row {
+                id: 12,
+                label: "z".into(),
+            },
         ],
     );
     tick().await;
@@ -2968,8 +3035,14 @@ async fn lever5_watcher_reinstalls_after_bulk_clear() {
     seed_bulk_rows(
         &host,
         &[
-            Row { id: 1, label: "a".into() },
-            Row { id: 2, label: "b".into() },
+            Row {
+                id: 1,
+                label: "a".into(),
+            },
+            Row {
+                id: 2,
+                label: "b".into(),
+            },
         ],
     );
     tick().await;
@@ -2984,8 +3057,14 @@ async fn lever5_watcher_reinstalls_after_bulk_clear() {
     seed_bulk_rows(
         &host,
         &[
-            Row { id: 7, label: "g".into() },
-            Row { id: 8, label: "h".into() },
+            Row {
+                id: 7,
+                label: "g".into(),
+            },
+            Row {
+                id: 8,
+                label: "h".into(),
+            },
         ],
     );
     tick().await;
@@ -2999,7 +3078,9 @@ async fn lever5_watcher_reinstalls_after_bulk_clear() {
     btn.click();
     tick().await;
 
-    let cls = bulk_li_at(&host, 1).get_attribute("class").unwrap_or_default();
+    let cls = bulk_li_at(&host, 1)
+        .get_attribute("class")
+        .unwrap_or_default();
     assert_eq!(
         cls, "sel",
         "list-level watcher must re-install on the cold-pool re-mount"

--- a/examples/website/src/components/showcase/alert_dialog/mod.rs
+++ b/examples/website/src/components/showcase/alert_dialog/mod.rs
@@ -1,7 +1,7 @@
 use pine::{
     PineAlertDialogAction, PineAlertDialogCancel, PineAlertDialogContent,
-    PineAlertDialogDescription, PineAlertDialogOverlay, PineAlertDialogPortal,
-    PineAlertDialogRoot, PineAlertDialogTitle, PineAlertDialogTrigger,
+    PineAlertDialogDescription, PineAlertDialogOverlay, PineAlertDialogPortal, PineAlertDialogRoot,
+    PineAlertDialogTitle, PineAlertDialogTrigger,
 };
 use pocopine::prelude::*;
 use serde::{Deserialize, Serialize};

--- a/examples/website/src/components/showcase/calendar/mod.rs
+++ b/examples/website/src/components/showcase/calendar/mod.rs
@@ -70,8 +70,8 @@ impl CalendarDemo {
         {
             let js = js_sys::Date::new_0();
             let y = js.get_full_year() as i32;
-            let m = (js.get_month() + 1) as u32;
-            let d = js.get_date() as u32;
+            let m = js.get_month() + 1;
+            let d = js.get_date();
             self.placeholder = DateValue::new(y, m as u8, d as u8);
         }
     }

--- a/examples/website/src/components/showcase/dialog/mod.rs
+++ b/examples/website/src/components/showcase/dialog/mod.rs
@@ -1,6 +1,6 @@
 use pine::{
-    PineDialogClose, PineDialogContent, PineDialogDescription, PineDialogOverlay,
-    PineDialogPortal, PineDialogRoot, PineDialogTitle, PineDialogTrigger,
+    PineDialogClose, PineDialogContent, PineDialogDescription, PineDialogOverlay, PineDialogPortal,
+    PineDialogRoot, PineDialogTitle, PineDialogTrigger,
 };
 use pocopine::prelude::*;
 use serde::{Deserialize, Serialize};

--- a/examples/website/src/components/showcase/field/mod.rs
+++ b/examples/website/src/components/showcase/field/mod.rs
@@ -1,6 +1,4 @@
-use pine::{
-    PineFieldControl, PineFieldDescription, PineFieldError, PineFieldLabel, PineFieldRoot,
-};
+use pine::{PineFieldControl, PineFieldDescription, PineFieldError, PineFieldLabel, PineFieldRoot};
 use pocopine::prelude::*;
 use serde::{Deserialize, Serialize};
 

--- a/examples/website/src/components/showcase/hover_card/mod.rs
+++ b/examples/website/src/components/showcase/hover_card/mod.rs
@@ -1,6 +1,6 @@
 use pine::{
-    PineAvatarFallback, PineAvatarImage, PineAvatarRoot, PineHoverCardContent,
-    PineHoverCardPortal, PineHoverCardRoot, PineHoverCardTrigger,
+    PineAvatarFallback, PineAvatarImage, PineAvatarRoot, PineHoverCardContent, PineHoverCardPortal,
+    PineHoverCardRoot, PineHoverCardTrigger,
 };
 use pocopine::prelude::*;
 use serde::{Deserialize, Serialize};

--- a/examples/website/src/components/showcase/tooltip/mod.rs
+++ b/examples/website/src/components/showcase/tooltip/mod.rs
@@ -1,6 +1,5 @@
 use pine::{
-    PineTooltipContent, PineTooltipPortal, PineTooltipProvider, PineTooltipRoot,
-    PineTooltipTrigger,
+    PineTooltipContent, PineTooltipPortal, PineTooltipProvider, PineTooltipRoot, PineTooltipTrigger,
 };
 use pocopine::prelude::*;
 use serde::{Deserialize, Serialize};

--- a/examples/website/src/lib.rs
+++ b/examples/website/src/lib.rs
@@ -16,11 +16,11 @@ use serde::{Deserialize, Serialize};
 use components::showcase::{
     AccordionDemo, AlertDialogDemo, AnimationDemo, AspectRatioDemo, AvatarDemo, Basics, ButtonDemo,
     CalendarDemo, CmdPopoverDemo, CollapsibleDemo, ComboboxDemo, CommandDemo, ContextMenuDemo,
-    DatePickerDemo, DateRangePickerDemo, DatetimeFieldsDemo, DialogDemo, DropdownMenuDemo, FieldDemo, FieldsetDemo,
-    FormDemo, HoverCardDemo, InputDemo, OtpDemo, PinCardDemo, PopoverDemo, RadioGroupDemo,
-    RangeCalendarDemo, ScrollAreaDemo, SelectDemo, SignupDemo, SliderDemo, SplitterDemo,
-    StressDemo, SwitchCheckboxDemo, TabsDemo, TagsInputDemo, TagsMentionsDemo, TagsSkillsDemo,
-    TextDemo, ToggleDemo, ToolbarDemo, TooltipDemo, TreeDemo,
+    DatePickerDemo, DateRangePickerDemo, DatetimeFieldsDemo, DialogDemo, DropdownMenuDemo,
+    FieldDemo, FieldsetDemo, FormDemo, HoverCardDemo, InputDemo, OtpDemo, PinCardDemo, PopoverDemo,
+    RadioGroupDemo, RangeCalendarDemo, ScrollAreaDemo, SelectDemo, SignupDemo, SliderDemo,
+    SplitterDemo, StressDemo, SwitchCheckboxDemo, TabsDemo, TagsInputDemo, TagsMentionsDemo,
+    TagsSkillsDemo, TextDemo, ToggleDemo, ToolbarDemo, TooltipDemo, TreeDemo,
 };
 use components::{Hero, Showcase, ShowcaseCard, SiteHeader, Tutorial};
 

--- a/jsbench/leptos/src/lib.rs
+++ b/jsbench/leptos/src/lib.rs
@@ -3,19 +3,41 @@ use wasm_bindgen::prelude::*;
 use web_sys::window;
 
 const ADJECTIVES: &[&str] = &[
-    "pretty", "large", "big", "small", "tall", "short", "long", "handsome", "plain",
-    "quaint", "clean", "elegant", "easy", "angry", "crazy", "helpful", "mushy", "odd",
-    "unsightly", "adorable", "important", "inexpensive", "cheap", "expensive", "fancy",
+    "pretty",
+    "large",
+    "big",
+    "small",
+    "tall",
+    "short",
+    "long",
+    "handsome",
+    "plain",
+    "quaint",
+    "clean",
+    "elegant",
+    "easy",
+    "angry",
+    "crazy",
+    "helpful",
+    "mushy",
+    "odd",
+    "unsightly",
+    "adorable",
+    "important",
+    "inexpensive",
+    "cheap",
+    "expensive",
+    "fancy",
 ];
 
 const COLOURS: &[&str] = &[
-    "red", "yellow", "blue", "green", "pink", "brown", "purple", "brown", "white",
-    "black", "orange",
+    "red", "yellow", "blue", "green", "pink", "brown", "purple", "brown", "white", "black",
+    "orange",
 ];
 
 const NOUNS: &[&str] = &[
-    "table", "chair", "house", "bbq", "desk", "car", "pony", "cookie", "sandwich",
-    "burger", "pizza", "mouse", "keyboard",
+    "table", "chair", "house", "bbq", "desk", "car", "pony", "cookie", "sandwich", "burger",
+    "pizza", "mouse", "keyboard",
 ];
 
 #[derive(Clone, PartialEq)]

--- a/jsbench/yew/src/lib.rs
+++ b/jsbench/yew/src/lib.rs
@@ -3,19 +3,41 @@ use web_sys::window;
 use yew::prelude::*;
 
 const ADJECTIVES: &[&str] = &[
-    "pretty", "large", "big", "small", "tall", "short", "long", "handsome", "plain",
-    "quaint", "clean", "elegant", "easy", "angry", "crazy", "helpful", "mushy", "odd",
-    "unsightly", "adorable", "important", "inexpensive", "cheap", "expensive", "fancy",
+    "pretty",
+    "large",
+    "big",
+    "small",
+    "tall",
+    "short",
+    "long",
+    "handsome",
+    "plain",
+    "quaint",
+    "clean",
+    "elegant",
+    "easy",
+    "angry",
+    "crazy",
+    "helpful",
+    "mushy",
+    "odd",
+    "unsightly",
+    "adorable",
+    "important",
+    "inexpensive",
+    "cheap",
+    "expensive",
+    "fancy",
 ];
 
 const COLOURS: &[&str] = &[
-    "red", "yellow", "blue", "green", "pink", "brown", "purple", "brown", "white",
-    "black", "orange",
+    "red", "yellow", "blue", "green", "pink", "brown", "purple", "brown", "white", "black",
+    "orange",
 ];
 
 const NOUNS: &[&str] = &[
-    "table", "chair", "house", "bbq", "desk", "car", "pony", "cookie", "sandwich",
-    "burger", "pizza", "mouse", "keyboard",
+    "table", "chair", "house", "bbq", "desk", "car", "pony", "cookie", "sandwich", "burger",
+    "pizza", "mouse", "keyboard",
 ];
 
 #[derive(Clone, PartialEq)]


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` with three strict jobs (`-D warnings`): `cargo fmt --check`, wasm clippy (`--workspace --exclude pocopine-cli --target wasm32-unknown-unknown --all-targets`), host clippy (`-p pocopine-cli --all-targets`).
- Clears every existing clippy warning across the workspace so main lands green under the new gate.
- Folds in pre-existing rustfmt drift across ~20 unrelated files so `cargo fmt --check` passes workspace-wide.

## Test plan
- [x] `cargo fmt --all -- --check` clean locally
- [x] `cargo clippy --workspace --exclude pocopine-cli --target wasm32-unknown-unknown --all-targets -- -D warnings` clean
- [x] `cargo clippy -p pocopine-cli --all-targets -- -D warnings` clean
- [x] `cargo test --workspace --lib` green
- [ ] CI workflow runs green on this PR before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)