### PR TITLE
RFC-058 Phase 6.5: compiled-only walker entry + Yew-class size profile + RFC 059 revision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,12 +183,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # RFC-058 Phase 6.5 — both walker tests and Pine
+          # depend on the runtime walker entry, which is gated
+          # behind `legacy-dom`. Without the feature flag the
+          # `walker.rs` test crate compiles to "no tests to
+          # run" (it's gated at file scope) and Pine's
+          # `mount()` helper fails to find `walker::start`.
           - name: pocopine-walker
             crate: crates/pocopine
-            args: --test walker
+            args: --features legacy-dom --test walker
           - name: pine
             crate: crates/pine
-            args: ""
+            args: --features legacy-dom
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,3 +56,17 @@ proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["full"] }
 strsim = "0.11"
+
+# RFC-058 Phase 6.5 — match Yew's release-profile knobs.
+# `opt-level = "z"` collapses size-vs-speed in favour of size;
+# `lto = true` lets the linker inline + dead-code-eliminate
+# across crate boundaries; `codegen-units = 1` removes the
+# parallelism-granularity barrier that prevents LTO from
+# seeing the whole tree; `panic = "abort"` is a no-op on
+# `wasm32-unknown-unknown` (the target already aborts) but
+# keeps the profile portable to other targets.
+[profile.release]
+lto = true
+codegen-units = 1
+panic = "abort"
+opt-level = "z"

--- a/crates/pine/Cargo.toml
+++ b/crates/pine/Cargo.toml
@@ -9,6 +9,16 @@ description = "Unstyled, accessible UI components for pocopine — headless prim
 [lib]
 crate-type = ["cdylib", "rlib"]
 
+[features]
+# Forwards `pocopine`'s `legacy-dom` feature so test runs of
+# Pine compounds (16 of which still need walker fallback for
+# their lifted-`pp-if`/`pp-teleport` body content — see the
+# Pine fallback audit) can opt into the runtime walker. Most
+# Pine compounds are walker-clean and don't need this; the
+# audit-tracked subset (portals, `*-content`, `*-indicator`,
+# `*-value`) does until the body-lift envelope expands.
+legacy-dom = ["pocopine/legacy-dom"]
+
 [dependencies]
 pocopine = { path = "../pocopine" }
 pocopine-core = { workspace = true }

--- a/crates/pine/tests/pine.rs
+++ b/crates/pine/tests/pine.rs
@@ -6140,24 +6140,14 @@ async fn pine_template_plan_fallback_audit() {
         .into(),
     );
 
-    let expected: &[&str] = &[
-        "pine-accordion-content",
-        "pine-alert-dialog-portal",
-        "pine-collapsible-content",
-        "pine-combobox-portal",
-        "pine-command-portal",
-        "pine-context-menu-portal",
-        "pine-dialog-portal",
-        "pine-dropdown-menu-item-indicator",
-        "pine-dropdown-menu-portal",
-        "pine-dropdown-menu-sub-content",
-        "pine-hover-card-portal",
-        "pine-popover-portal",
-        "pine-select-item-indicator",
-        "pine-select-portal",
-        "pine-select-value",
-        "pine-tooltip-portal",
-    ];
+    // RFC-058 Phase 6.5 — body-lift envelope expanded to include
+    // `<slot>` children. Every previously walker-required Pine
+    // compound (`*-portal`, `*-content`, `*-indicator`, `*-value`)
+    // now lifts cleanly — its pp-if/pp-teleport body becomes a
+    // fragment fn whose plan installs every directive + slot
+    // outlet via `apply_static_plan`. The audit baseline drops to
+    // **zero** walker-required plans across the entire Pine surface.
+    let expected: &[&str] = &[];
 
     assert_eq!(
         walker_owned,

--- a/crates/pine/tests/pine.rs
+++ b/crates/pine/tests/pine.rs
@@ -29,7 +29,16 @@ fn mount(host_html: &str) -> Element {
     let host = doc().create_element("div").unwrap();
     host.set_inner_html(host_html);
     body.append_child(&host).unwrap();
-    pocopine_core::start(&host);
+    // Pine compounds rely on the full runtime walker — 16
+    // compounds are still walker-required (the `*-portal` /
+    // `*-content` / `*-indicator` / `*-value` family per the
+    // Pine fallback audit) and the dialog/popover scroll-lock
+    // teardown chains through the walker's `MutationObserver`.
+    // Pine tests therefore opt into `legacy-dom` (the test
+    // command passes `--features legacy-dom`) and use the full
+    // legacy entry. Compiled-only consumers test through
+    // `pocopine`'s own test crate.
+    pocopine_core::walker::start(&host);
     host
 }
 

--- a/crates/pocopine-core/Cargo.toml
+++ b/crates/pocopine-core/Cargo.toml
@@ -10,32 +10,27 @@ description = "Client-side reactive runtime for pocopine — a Rust/WASM port of
 crate-type = ["cdylib", "rlib"]
 
 [features]
+# RFC-058 Phase 6.5 — defaults are opt-in. `cargo add pocopine-core`
+# now ships the smallest viable runtime; consumers opt into
+# `devtools` for the in-browser scope inspector and into
+# `legacy-dom` for runtime DOM auto-discovery. CI / test runs
+# pass `--features legacy-dom` when exercising the observer or
+# the runtime walker discovery path.
+default = []
 # Compile the devtools overlay (scope inspector + state panel).
-# Default-on: most users develop with it. Turn off with
-# `default-features = false` for minimal release bundles —
-# devtools.rs is ~1200 LOC of UI shell + MutationObserver glue
-# that's pure binary-size cost when unused.
-default = ["devtools", "legacy-dom"]
+# Opt-in — devtools.rs is ~1200 LOC of UI shell + MutationObserver
+# glue, pure binary-size cost when unused. Apps enable it via
+# `pocopine = { features = ["devtools"] }` and `App::with_devtools()`.
 devtools = []
 mount-profiler = []
-# RFC-058 Phase 6 v1 — runtime walker's MutationObserver-based
-# auto-discovery for adopted / externally-injected DOM. Default-on
-# today: every example still relies on it indirectly (the initial
-# `start_on_body` path uses `walker::walk` for the root tag, but
-# the observer is what catches dynamic insertions like router
-# page changes, markdown render output, server-rendered partials
-# that aren't compiled by pocopine).
-#
-# Apps that bootstrap entirely through compiled-view mounts and
-# never adopt external DOM can `default-features = false` to
-# drop the observer's ~200-line `MutationRecord` callback +
-# closure registration. The walker's `walk` / `bind` /
-# `mount_component` themselves stay always-on — controllers
-# call them for `pp-if` / `pp-for` / `pp-teleport` body content
-# and for slot materialisation. Phases 4.1d / 4.2c / 4.3
-# follow-ups (body fragment lifting) graduate those into
-# fragment fns, at which point more of the walker can move
-# behind this same flag.
+# Runtime walker's MutationObserver-based auto-discovery for
+# adopted / externally-injected DOM (router page changes,
+# markdown render output, server-rendered partials, anything
+# pocopine didn't compile itself). Opt-in: apps that bootstrap
+# entirely through compiled-view mounts and never adopt
+# external DOM stay walker-free. Phases 4.1d / 4.2c / 4.3
+# follow-ups graduate more of the walker behind this same
+# flag.
 legacy-dom = []
 
 [dependencies]

--- a/crates/pocopine-core/src/app.rs
+++ b/crates/pocopine-core/src/app.rs
@@ -150,6 +150,24 @@ impl App {
             crate::registry::render_boot_error(&errors);
             return;
         }
+        // RFC-058 Phase 6.5 — refuse to boot a compiled-only app
+        // with registered routes when `legacy-dom` is off. The
+        // router currently uses `walker::walk` to mount each
+        // route's component into the `<pp-outlet>`, and the walker
+        // is gated behind the feature; without it the page would
+        // silently render blank. The diagnostic points at the
+        // exact remediation so the failure mode isn't a black box.
+        #[cfg(not(feature = "legacy-dom"))]
+        if compiled_only && !self.routes.is_empty() {
+            web_sys::console::error_1(&JsValue::from_str(
+                "pocopine: `App::run_compiled` with `App::route` requires the \
+                 `legacy-dom` feature — the router mounts route components via the \
+                 runtime walker (`<pp-outlet>` discovery + `walker::walk`). Either \
+                 enable `pocopine = { features = [\"legacy-dom\"] }` or drop \
+                 `App::route` and mount your shell explicitly. Aborting boot.",
+            ));
+            return;
+        }
         // Inject the animate-preset atom stylesheet before any
         // component `register()` injects per-component styles, so
         // the preset atoms live earlier in the cascade and

--- a/crates/pocopine-core/src/app.rs
+++ b/crates/pocopine-core/src/app.rs
@@ -125,6 +125,21 @@ impl App {
     /// when collisions exist the boot error surface is rendered and
     /// no further mount work runs.
     pub fn run(self) {
+        self.boot(false);
+    }
+
+    /// RFC-058 Phase 6.5 — same lifecycle as [`run`] but mounts via
+    /// the compiled-only [`walker::start_compiled`] entry instead
+    /// of the recursive directive scan. Apps whose body contains
+    /// only registered component tags (the canonical compiled
+    /// shape) save the per-descendant `bind` cost; the
+    /// `MutationObserver` install and body-level `pp-*` discovery
+    /// are skipped.
+    pub fn run_compiled(self) {
+        self.boot(true);
+    }
+
+    fn boot(self, compiled_only: bool) {
         if let Err(errors) = crate::registry::verify_registry() {
             crate::registry::render_boot_error(&errors);
             return;
@@ -137,7 +152,16 @@ impl App {
         for f in self.before_mount {
             f();
         }
-        walker::start_on_body();
+        if compiled_only {
+            if let Some(body) = web_sys::window()
+                .and_then(|w| w.document())
+                .and_then(|d| d.body())
+            {
+                walker::start_compiled(&body.into());
+            }
+        } else {
+            walker::start_on_body();
+        }
         if !self.routes.is_empty() {
             router::init();
         }

--- a/crates/pocopine-core/src/app.rs
+++ b/crates/pocopine-core/src/app.rs
@@ -124,6 +124,10 @@ impl App {
     /// RFC 056 §6.2: before any walker work the registry is verified;
     /// when collisions exist the boot error surface is rendered and
     /// no further mount work runs.
+    ///
+    /// Gated behind `legacy-dom` (RFC-058 Phase 6.5). Apps that
+    /// don't enable the feature use [`Self::run_compiled`].
+    #[cfg(feature = "legacy-dom")]
     pub fn run(self) {
         self.boot(false);
     }
@@ -135,6 +139,8 @@ impl App {
     /// shape) save the per-descendant `bind` cost; the
     /// `MutationObserver` install and body-level `pp-*` discovery
     /// are skipped.
+    ///
+    /// Always available — does not require `legacy-dom`.
     pub fn run_compiled(self) {
         self.boot(true);
     }
@@ -160,7 +166,10 @@ impl App {
                 walker::start_compiled(&body.into());
             }
         } else {
+            #[cfg(feature = "legacy-dom")]
             walker::start_on_body();
+            #[cfg(not(feature = "legacy-dom"))]
+            unreachable!("non-compiled boot reached without `legacy-dom` feature");
         }
         if !self.routes.is_empty() {
             router::init();

--- a/crates/pocopine-core/src/directives/for_plan.rs
+++ b/crates/pocopine-core/src/directives/for_plan.rs
@@ -130,6 +130,25 @@ pub struct StaticRef {
     pub name: &'static str,
 }
 
+/// Static-lifetime descriptor for `pp-model[.modifier]="field"`
+/// on a native input/textarea/select. RFC-058 Phase 6.5 — lifts
+/// the previously walker-only directive into the static plan so
+/// compiled-only apps wire two-way input bindings without going
+/// through `walker::dispatch`. Component-target `pp-model` (with
+/// or without an arg) is a separate entry on `StaticChildMount`
+/// (see [`StaticChildHostModel`]); this type covers only native
+/// elements, the path that walker dispatch routed via
+/// `model::run_native`.
+#[doc(hidden)]
+pub struct StaticNativeModel {
+    pub node_path: &'static [u16],
+    pub expr_src: &'static str,
+    /// `.number` modifier — coerce input string to f64 on write.
+    pub number: bool,
+    /// `.lazy` modifier — listen on `change` instead of `input`.
+    pub lazy: bool,
+}
+
 /// Static-lifetime descriptor for a child-component mount site.
 ///
 /// RFC-058 Phase 3 — emitted by the macro for every non-HTML5

--- a/crates/pocopine-core/src/directives/init.rs
+++ b/crates/pocopine-core/src/directives/init.rs
@@ -1,15 +1,27 @@
 //! `pp-init="handler"` — run a handler once after the scope is bound.
 
 use js_sys::Array;
+use web_sys::Element;
 
 use super::DirectiveCall;
+use crate::reactive::ScopeId;
 use crate::scope::{invoke_handler, with_current_el};
 
 pub fn run(call: &DirectiveCall) {
-    let el = call.el.clone();
-    let handler = call.value.clone();
-    let scope_id = call.scope_id;
-    with_current_el(&el, || {
+    install(&call.el.clone(), call.scope_id, &call.value);
+}
+
+/// Compiled-path entry. Invokes `handler` against `scope_id` with
+/// the element bound as the current `with_current_el`. Used by
+/// `walker::fire_deferred_init` (the post-order drain that runs
+/// stashed `pp-init` values after descendants have bound) and
+/// `apply_static_plan`'s init step. Avoids the directive-registry
+/// `DirectiveCall` round-trip so compiled-only builds don't
+/// depend on `walker::dispatch`.
+pub fn install(el: &Element, scope_id: ScopeId, handler: &str) {
+    let el_owned = el.clone();
+    let handler = handler.to_string();
+    with_current_el(&el_owned, || {
         invoke_handler(scope_id, &handler, &Array::new());
     });
 }

--- a/crates/pocopine-core/src/directives/mod.rs
+++ b/crates/pocopine-core/src/directives/mod.rs
@@ -3,8 +3,6 @@
 //! A directive is a `fn(&DirectiveCall)`; the walker calls it once per
 //! matching attribute after resolving the enclosing scope.
 
-use once_cell::sync::OnceCell;
-use std::collections::HashMap;
 use wasm_bindgen::JsValue;
 use web_sys::Element;
 
@@ -46,50 +44,61 @@ pub struct DirectiveCall<'a> {
 
 pub type DirectiveFn = fn(&DirectiveCall);
 
-static REGISTRY: OnceCell<HashMap<&'static str, DirectiveFn>> = OnceCell::new();
-
-fn registry() -> &'static HashMap<&'static str, DirectiveFn> {
-    REGISTRY.get_or_init(|| {
-        let mut m: HashMap<&'static str, DirectiveFn> = HashMap::new();
-        // RFC-058 Phase 6.5 — opaque-directive lift allowlist. The
-        // compiled path's `apply_static_plan` looks these up by name
-        // for `StaticOpaqueDirective` entries; they're the only
-        // directives compiled-only apps need at runtime.
-        m.insert("resize", resize::run);
-        m.insert("intersect", intersect::run);
-        m.insert("anchor", anchor::run);
-        m.insert("roving", roving::run);
-        m.insert("flip", flip::run);
-        // RFC-058 Phase 6.5 — every other `run()` is a walker-only
-        // entry: the runtime walker's `dispatch` loop calls them
-        // when scanning `pp-*` attributes on user-authored DOM.
-        // Compiled apps install these directives via the typed
-        // `install_*` entries on `apply_static_plan` instead, so
-        // the registry stays bare without `legacy-dom`. With the
-        // feature off, the linker drops every `run()` body listed
-        // below (and their transitive `DirectiveCall` extraction
-        // helpers) — that's the bulk of the Phase 6.5 size win.
-        #[cfg(feature = "legacy-dom")]
-        {
-            m.insert("text", text::run);
-            m.insert("html", html::run);
-            m.insert("bind", bind::run);
-            m.insert("on", on::run);
-            m.insert("show", show::run);
-            m.insert("model", model::run);
-            m.insert("init", init::run);
-            m.insert("route", route::run);
-            m.insert("for", for_::run);
-            m.insert("if", if_::run);
-            m.insert("teleport", teleport::run);
-            m.insert("ref", ref_::run);
-        }
-        m
-    })
-}
+// RFC-058 Phase 6.5 size pass — registry was a
+// `OnceCell<HashMap<&'static str, DirectiveFn>>` for ~5 entries
+// without `legacy-dom` and ~17 with. Twiggy showed the
+// HashMap's `reserve_rehash` instantiation alone cost ~2.2 KB.
+// A `&'static [(&str, DirectiveFn)]` + linear scan is smaller,
+// faster (no hash, no allocation, no OnceCell), and the lookup
+// is only called from `apply_static_plan` for opaque directives
+// + `walker::dispatch` for legacy-dom — neither is a hot loop.
+const REGISTRY: &[(&str, DirectiveFn)] = &[
+    // RFC-058 Phase 6.5 opaque-directive lift allowlist. The
+    // compiled path's `apply_static_plan` looks these up by name
+    // for `StaticOpaqueDirective` entries; they're the only
+    // directives compiled-only apps need at runtime.
+    ("resize", resize::run),
+    ("intersect", intersect::run),
+    ("anchor", anchor::run),
+    ("roving", roving::run),
+    ("flip", flip::run),
+    // Every other `run()` is a walker-only entry: the runtime
+    // walker's `dispatch` loop calls them when scanning `pp-*`
+    // attributes on user-authored DOM. Compiled apps install
+    // these via the typed `install_*` entries on
+    // `apply_static_plan` instead, so the registry stays bare
+    // without `legacy-dom`. With the feature off, the linker
+    // drops every `run()` body listed below (and their
+    // transitive `DirectiveCall` extraction helpers) — that's
+    // the bulk of the Phase 6.5 size win.
+    #[cfg(feature = "legacy-dom")]
+    ("text", text::run),
+    #[cfg(feature = "legacy-dom")]
+    ("html", html::run),
+    #[cfg(feature = "legacy-dom")]
+    ("bind", bind::run),
+    #[cfg(feature = "legacy-dom")]
+    ("on", on::run),
+    #[cfg(feature = "legacy-dom")]
+    ("show", show::run),
+    #[cfg(feature = "legacy-dom")]
+    ("model", model::run),
+    #[cfg(feature = "legacy-dom")]
+    ("init", init::run),
+    #[cfg(feature = "legacy-dom")]
+    ("route", route::run),
+    #[cfg(feature = "legacy-dom")]
+    ("for", for_::run),
+    #[cfg(feature = "legacy-dom")]
+    ("if", if_::run),
+    #[cfg(feature = "legacy-dom")]
+    ("teleport", teleport::run),
+    #[cfg(feature = "legacy-dom")]
+    ("ref", ref_::run),
+];
 
 pub fn lookup(name: &str) -> Option<DirectiveFn> {
-    registry().get(name).copied()
+    REGISTRY.iter().find(|(n, _)| *n == name).map(|(_, f)| *f)
 }
 
 /// Parse an attribute name like `pp-bind:class.camel` into

--- a/crates/pocopine-core/src/directives/mod.rs
+++ b/crates/pocopine-core/src/directives/mod.rs
@@ -51,23 +51,39 @@ static REGISTRY: OnceCell<HashMap<&'static str, DirectiveFn>> = OnceCell::new();
 fn registry() -> &'static HashMap<&'static str, DirectiveFn> {
     REGISTRY.get_or_init(|| {
         let mut m: HashMap<&'static str, DirectiveFn> = HashMap::new();
-        m.insert("text", text::run);
-        m.insert("html", html::run);
-        m.insert("bind", bind::run);
-        m.insert("on", on::run);
-        m.insert("show", show::run);
-        m.insert("model", model::run);
-        m.insert("init", init::run);
-        m.insert("route", route::run);
-        m.insert("for", for_::run);
-        m.insert("if", if_::run);
-        m.insert("teleport", teleport::run);
-        m.insert("ref", ref_::run);
+        // RFC-058 Phase 6.5 — opaque-directive lift allowlist. The
+        // compiled path's `apply_static_plan` looks these up by name
+        // for `StaticOpaqueDirective` entries; they're the only
+        // directives compiled-only apps need at runtime.
         m.insert("resize", resize::run);
         m.insert("intersect", intersect::run);
         m.insert("anchor", anchor::run);
         m.insert("roving", roving::run);
         m.insert("flip", flip::run);
+        // RFC-058 Phase 6.5 — every other `run()` is a walker-only
+        // entry: the runtime walker's `dispatch` loop calls them
+        // when scanning `pp-*` attributes on user-authored DOM.
+        // Compiled apps install these directives via the typed
+        // `install_*` entries on `apply_static_plan` instead, so
+        // the registry stays bare without `legacy-dom`. With the
+        // feature off, the linker drops every `run()` body listed
+        // below (and their transitive `DirectiveCall` extraction
+        // helpers) — that's the bulk of the Phase 6.5 size win.
+        #[cfg(feature = "legacy-dom")]
+        {
+            m.insert("text", text::run);
+            m.insert("html", html::run);
+            m.insert("bind", bind::run);
+            m.insert("on", on::run);
+            m.insert("show", show::run);
+            m.insert("model", model::run);
+            m.insert("init", init::run);
+            m.insert("route", route::run);
+            m.insert("for", for_::run);
+            m.insert("if", if_::run);
+            m.insert("teleport", teleport::run);
+            m.insert("ref", ref_::run);
+        }
         m
     })
 }

--- a/crates/pocopine-core/src/directives/model.rs
+++ b/crates/pocopine-core/src/directives/model.rs
@@ -113,11 +113,29 @@ fn run_component(call: &DirectiveCall, child_proxy: JsValue) {
 // ─── native input path ────────────────────────────────────────────
 
 fn run_native(call: &DirectiveCall) {
-    let proxy = call.proxy.clone();
-    let key = call.value.clone();
-    let el = call.el.clone();
     let number = call.modifiers.iter().any(|m| m == "number");
     let lazy = call.modifiers.iter().any(|m| m == "lazy");
+    install_native(call.el, call.proxy, call.value.clone(), number, lazy);
+}
+
+/// RFC-058 Phase 6.5 — compiled-path entry for `pp-model` on a
+/// native input/textarea/select. Same effect + listener wiring
+/// as the runtime walker dispatch (`run_native`); extracted so
+/// `apply_static_plan` can install it directly without going
+/// through the directive registry. The macro emits one
+/// [`crate::directives::for_plan::StaticNativeModel`] per
+/// `<input pp-model="field">` site and the runtime applier
+/// routes through here, dropping the runtime walker dependency
+/// for native model bindings.
+pub fn install_native(
+    el: &web_sys::Element,
+    proxy: &JsValue,
+    key: String,
+    number: bool,
+    lazy: bool,
+) {
+    let proxy = proxy.clone();
+    let el = el.clone();
 
     // Read side: proxy[key] -> element value.
     let proxy_r = proxy.clone();
@@ -129,7 +147,7 @@ fn run_native(call: &DirectiveCall) {
             write_to_element(&el_r, &v);
         });
     });
-    track_effect_on(call.el, id);
+    track_effect_on(&el, id);
 
     // Write side: input event -> proxy[key] = element value.
     let proxy_w = proxy.clone();
@@ -142,7 +160,7 @@ fn run_native(call: &DirectiveCall) {
 
     let event_name = if lazy { "change" } else { "input" };
     let target: web_sys::EventTarget = el.clone().into();
-    track_listener_on(call.el, target, event_name, false, handler);
+    track_listener_on(&el, target, event_name, false, handler);
 }
 
 fn write_to_element(el: &web_sys::Element, v: &JsValue) {

--- a/crates/pocopine-core/src/directives/transition.rs
+++ b/crates/pocopine-core/src/directives/transition.rs
@@ -523,6 +523,17 @@ fn collect_animated(root: &Element) -> Vec<Element> {
 /// the longest enter completes; with no animated elements it's
 /// synchronous.
 pub fn enter_subtree<F: FnOnce() + 'static>(root: &Element, on_done: F) {
+    enter_subtree_dyn(root, Box::new(on_done));
+}
+
+// RFC-058 Phase 6.5 — type-erased implementation. The generic
+// shim above forwards into this single boxed instantiation so
+// the bulk of `enter_subtree`'s body collapses to one wasm
+// function regardless of how many distinct closure types call
+// it. Twiggy showed `transition::enter_subtree::<F>` totalling
+// ~7 KB across pp-for / pp-if / show / for_::run_keyed closure
+// types before this consolidation.
+fn enter_subtree_dyn(root: &Element, on_done: Box<dyn FnOnce() + 'static>) {
     let elems = collect_animated(root);
     if elems.is_empty() {
         on_done();
@@ -731,6 +742,12 @@ pub fn enter_subtree_staggered<F: FnOnce() + 'static>(root: &Element, stagger_ms
 /// plenty of time to land first — if they don't, we fire `on_done`
 /// anyway so the DOM doesn't leak.
 pub fn leave_subtree<F: FnOnce() + 'static>(root: &Element, on_done: F) {
+    leave_subtree_dyn(root, Box::new(on_done));
+}
+
+// RFC-058 Phase 6.5 — type-erased counterpart to
+// `enter_subtree_dyn`. Same monomorphization-collapse rationale.
+fn leave_subtree_dyn(root: &Element, on_done: Box<dyn FnOnce() + 'static>) {
     let elems = collect_animated(root);
     if elems.is_empty() {
         on_done();

--- a/crates/pocopine-core/src/lib.rs
+++ b/crates/pocopine-core/src/lib.rs
@@ -103,6 +103,7 @@ pub use task::{spawn, spawn_latest, spawn_scoped, TaskHandle};
 pub use templates::{
     compile_template, inject_pp_data, is_registered, register_template, template_for,
 };
+#[cfg(feature = "legacy-dom")]
 pub use walker::{start, start_on_body};
 pub use watch::{
     watch, watch_field, watch_field_scoped, watch_scope_field, watch_scope_field_now,
@@ -114,6 +115,9 @@ pub use watch::{
 /// Verifies the component registry first (RFC 056 §6.2). When any
 /// collision was recorded during `register()` calls, the boot error
 /// surface is rendered and the walker is *not* started.
+///
+/// Gated behind `legacy-dom` (RFC-058 Phase 6.5).
+#[cfg(feature = "legacy-dom")]
 pub fn run() {
     if let Err(errors) = registry::verify_registry() {
         registry::render_boot_error(&errors);

--- a/crates/pocopine-core/src/reactive.rs
+++ b/crates/pocopine-core/src/reactive.rs
@@ -171,8 +171,19 @@ pub fn effect_scoped(f: impl Fn() + 'static) {
 /// not run; a `scheduler` diverts `trigger` to user code instead of the
 /// default microtask flush.
 pub fn effect_with(f: impl Fn() + 'static, opts: EffectOptions) -> EffectId {
+    effect_with_dyn(Rc::new(f), opts)
+}
+
+// RFC-058 Phase 6.5 — type-erased body. The generic shim above
+// performs the `Rc::new(f)` coercion to `EffectFn` (one
+// monomorphization per call site, but each is just the
+// `Rc::new + forward` instructions). The body that does the
+// registry insertion + run lives here as a single instantiation.
+// Twiggy showed `effect_with::<F>` totalling ~7 KB across pp-for
+// / pp-if / pp-text / pp-bind closure types before this
+// consolidation.
+fn effect_with_dyn(f: EffectFn, opts: EffectOptions) -> EffectId {
     let id = next_effect_id();
-    let f: EffectFn = Rc::new(f);
     EFFECTS.with(|e| e.borrow_mut().insert(id, f.clone()));
     if let Some(sched) = opts.scheduler {
         SCHEDULERS.with(|s| s.borrow_mut().insert(id, sched));

--- a/crates/pocopine-core/src/templates_plan.rs
+++ b/crates/pocopine-core/src/templates_plan.rs
@@ -45,8 +45,8 @@ use web_sys::{console, Element};
 
 use crate::directives::for_plan::{
     BindingKind, StaticBinding, StaticChildMount, StaticForPlan, StaticIfPlan, StaticInit,
-    StaticInterp, StaticListener, StaticOpaqueDirective, StaticRef, StaticSlotOutlet,
-    StaticTeleportPlan,
+    StaticInterp, StaticListener, StaticNativeModel, StaticOpaqueDirective, StaticRef,
+    StaticSlotOutlet, StaticTeleportPlan,
 };
 use crate::directives::{self, DirectiveCall};
 use crate::expr;
@@ -131,6 +131,13 @@ pub struct StaticTemplatePlan {
     /// install effects per dynamic segment. Empty for templates
     /// with no interpolation.
     pub interps: &'static [StaticInterp],
+    /// `pp-model[.modifier]="field"` sites on native input /
+    /// textarea / select elements (RFC-058 Phase 6.5). Lifted
+    /// out of `walker::dispatch` so compiled-only apps wire
+    /// two-way input bindings without the runtime walker.
+    /// Component-target `pp-model` is on `StaticChildMount`
+    /// instead.
+    pub native_models: &'static [StaticNativeModel],
     /// True when the cleaned HTML still contains framework-owned
     /// attributes that this plan does not install. Compiled
     /// fragments can skip fallback only when their own plan and
@@ -506,6 +513,22 @@ pub fn apply_static_plan(
     }
     for (el, target, segments) in &interp_targets {
         directives::interp::install_planned_target(el, proxy, target, segments);
+    }
+    // RFC-058 Phase 6.5 — `pp-model` on native inputs lifted out
+    // of `walker::dispatch`. The macro already parsed the
+    // modifier list (`.number`, `.lazy`); the applier installs
+    // the read-side effect + write-side listener directly.
+    for nm in plan.native_models {
+        let Some(el) = resolve(root, nm.node_path) else {
+            fail(
+                "native pp-model",
+                template_name,
+                nm.node_path,
+                Some(nm.expr_src),
+            );
+            continue;
+        };
+        directives::model::install_native(&el, proxy, nm.expr_src.to_string(), nm.number, nm.lazy);
     }
 }
 

--- a/crates/pocopine-core/src/tick.rs
+++ b/crates/pocopine-core/src/tick.rs
@@ -46,7 +46,7 @@ fn next_dyn(f: Box<dyn FnOnce() + 'static>) {
     let Some(window) = web_sys::window() else {
         return;
     };
-    let js = Closure::once_into_js(move || f());
+    let js = Closure::once_into_js(f);
     window.queue_microtask(js.unchecked_ref());
 }
 
@@ -62,6 +62,6 @@ fn after_flush_dyn(f: Box<dyn FnOnce() + 'static>) {
     let Some(window) = web_sys::window() else {
         return;
     };
-    let js = Closure::once_into_js(move || f());
+    let js = Closure::once_into_js(f);
     let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(js.unchecked_ref(), 0);
 }

--- a/crates/pocopine-core/src/tick.rs
+++ b/crates/pocopine-core/src/tick.rs
@@ -17,20 +17,12 @@ use wasm_bindgen::JsCast;
 
 /// Schedule `f` on the next microtask.
 pub fn next<F: FnOnce() + 'static>(f: F) {
-    let Some(window) = web_sys::window() else {
-        return;
-    };
-    let js = Closure::once_into_js(f);
-    window.queue_microtask(js.unchecked_ref());
+    next_dyn(Box::new(f));
 }
 
 /// Schedule `f` on the next animation frame.
 pub fn next_frame<F: FnOnce() + 'static>(f: F) {
-    let Some(window) = web_sys::window() else {
-        return;
-    };
-    let js = Closure::once_into_js(move |_: JsValue| f());
-    let _ = window.request_animation_frame(js.unchecked_ref());
+    next_frame_dyn(Box::new(f));
 }
 
 /// Schedule `f` after the current reactive flush yields — a
@@ -38,9 +30,38 @@ pub fn next_frame<F: FnOnce() + 'static>(f: F) {
 /// DOM mutations like re-focusing an element that the reactive
 /// walk just blurred. Strictly later than [`next`] (microtask).
 pub fn after_flush<F: FnOnce() + 'static>(f: F) {
+    after_flush_dyn(Box::new(f));
+}
+
+// RFC-058 Phase 6.5 — type-erased helpers. The public generic
+// shims monomorphise once per call site (cheap — they just forward
+// to the boxed variant). The boxed variants are the only versions
+// that get instantiated for `Closure::once_into_js`, collapsing
+// N call sites' worth of `Closure` boilerplate into a single copy
+// in the wasm. Twiggy showed `tick::next_frame::<F>` totalling
+// ~5 KB of bloat across pp-for / pp-if / transition closure
+// types before this consolidation.
+
+fn next_dyn(f: Box<dyn FnOnce() + 'static>) {
     let Some(window) = web_sys::window() else {
         return;
     };
-    let js = Closure::once_into_js(f);
+    let js = Closure::once_into_js(move || f());
+    window.queue_microtask(js.unchecked_ref());
+}
+
+fn next_frame_dyn(f: Box<dyn FnOnce() + 'static>) {
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let js = Closure::once_into_js(move |_: JsValue| f());
+    let _ = window.request_animation_frame(js.unchecked_ref());
+}
+
+fn after_flush_dyn(f: Box<dyn FnOnce() + 'static>) {
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+    let js = Closure::once_into_js(move || f());
     let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(js.unchecked_ref(), 0);
 }

--- a/crates/pocopine-core/src/walker.rs
+++ b/crates/pocopine-core/src/walker.rs
@@ -133,7 +133,23 @@ pub fn start_compiled(root: &Element) {
             continue;
         }
         let tag = el.local_name();
+        let walker_clean = crate::templates_plan::template_plan_for(&tag)
+            .map(|p| !p.requires_walker)
+            .unwrap_or(false);
         mount_component(&el, &tag, None);
+        // Drive lifecycle for the freshly mounted subtree. For
+        // walker-clean plans the cheaper `finalize_compiled_subtree`
+        // skips the per-descendant `bind` and only fires
+        // `pp-init` + `on_mount` post-order. For plans that still
+        // need the walker (e.g. `pp-model` on a native input —
+        // RFC-058 §7 deferral), `walk_compiled_fallback` performs
+        // the legacy directive scan over the subtree to install
+        // any un-lifted attributes the macro left in place.
+        if walker_clean {
+            finalize_compiled_subtree(&el);
+        } else {
+            walk_compiled_fallback(&el);
+        }
     }
 }
 

--- a/crates/pocopine-core/src/walker.rs
+++ b/crates/pocopine-core/src/walker.rs
@@ -22,6 +22,7 @@ use web_sys::{DocumentFragment, Element, Event, EventTarget, HtmlTemplateElement
 #[cfg(feature = "legacy-dom")]
 use web_sys::{MutationObserver, MutationObserverInit, MutationRecord, NodeList};
 
+#[cfg(feature = "legacy-dom")]
 use crate::directives::{lookup, parse_attr, DirectiveCall};
 use crate::reactive::{release, EffectId, ScopeId};
 use crate::registry::instantiate;
@@ -264,10 +265,10 @@ fn fire_deferred_init(el: &Element) {
         return;
     };
     let _ = Reflect::delete_property(el.as_ref(), &INIT_PENDING_KEY.into());
-    let Some((scope_id, proxy)) = enclosing_scope(el) else {
+    let Some((scope_id, _proxy)) = enclosing_scope(el) else {
         return;
     };
-    dispatch(el, &proxy, scope_id, "pp-init", &value);
+    crate::directives::init::install(el, scope_id, &value);
 }
 
 /// Defer a `pp-init` handler invocation on `el` until the
@@ -416,6 +417,19 @@ fn bind(el: &Element) {
         mount_component(el, &tag, None);
     }
 
+    // RFC-058 Phase 6.5 — `pp-*` attribute scan + dispatch is
+    // walker-only. Compiled apps install every directive via
+    // `apply_static_plan`; the per-element scan only matters for
+    // user-authored `pp-*` outside compiled components (the
+    // `legacy-dom` envelope). With the feature off, `bind` ends
+    // here; `walk` still recurses into descendants to discover
+    // inner registered tags.
+    #[cfg(feature = "legacy-dom")]
+    bind_legacy_attrs(el);
+}
+
+#[cfg(feature = "legacy-dom")]
+fn bind_legacy_attrs(el: &Element) {
     // Snapshot all pp-* attributes — some directives mutate the element
     // (e.g. `set_attribute`) which would invalidate a live NamedNodeMap.
     //
@@ -1199,6 +1213,11 @@ fn first_element_child(el: &Element) -> Option<Element> {
 /// `@foo` → `pp-on:foo`. Anything else — including a bare `:` or
 /// `@` with no tail — is returned unchanged so the normal pp-*
 /// filter can drop it.
+///
+/// Walker-only — RFC-058 Phase 6.5: compiled apps don't scan
+/// `pp-*` attributes at runtime, so the shorthand normaliser is
+/// gated behind `legacy-dom`.
+#[cfg(feature = "legacy-dom")]
 fn normalise_shorthand_attr(name: &str) -> String {
     if let Some(rest) = name.strip_prefix(':') {
         if !rest.is_empty() {
@@ -1513,6 +1532,7 @@ pub fn child_component_scope(el: &Element) -> Option<(ScopeId, JsValue)> {
     scope_of_element(&root)
 }
 
+#[cfg(feature = "legacy-dom")]
 fn dispatch(el: &Element, proxy: &JsValue, scope_id: ScopeId, name: &str, value: &str) {
     let Some((dname, arg, modifiers)) = parse_attr(name) else {
         return;

--- a/crates/pocopine-core/src/walker.rs
+++ b/crates/pocopine-core/src/walker.rs
@@ -63,6 +63,15 @@ const BULK_RELEASE_KEY: &str = "__pp_bulk_release";
 pub(crate) const CTX_PARENT_KEY: &str = "__pp_ctx_parent";
 
 /// Convenience used by `#[wasm_bindgen(js_name=start)]`.
+///
+/// Gated behind `legacy-dom`: the legacy entry runs the
+/// recursive walker over `<body>` so user-authored `pp-*`
+/// directives outside compiled components get bound. Apps
+/// that bootstrap entirely through compiled views call
+/// [`crate::App::run_compiled`] (which delegates to
+/// [`start_compiled`]) and need neither this entry nor the
+/// `legacy-dom` feature.
+#[cfg(feature = "legacy-dom")]
 pub fn start_on_body() {
     let Some(win) = web_sys::window() else { return };
     let Some(doc) = win.document() else { return };
@@ -74,18 +83,14 @@ pub fn start_on_body() {
 /// install a `MutationObserver` so later DOM mutations are picked
 /// up too.
 ///
-/// The observer install is gated on the RFC-058 Phase 6
-/// `legacy-dom` feature. Without the feature the initial
-/// synchronous walk still runs (compiled views still need it for
-/// the root tag), but dynamically-inserted DOM (markdown render
-/// output, server-rendered partials, externally adopted nodes)
-/// won't be auto-discovered. Apps that bootstrap entirely through
-/// compiled-view mounts can `default-features = false` to drop
-/// the observer's binary cost.
+/// Gated behind `legacy-dom` (RFC-058 Phase 6.5). The recursive
+/// directive scan + the `MutationObserver` install both depend
+/// on this feature; compiled-only apps mount via
+/// [`start_compiled`] instead.
+#[cfg(feature = "legacy-dom")]
 pub fn start(root: &Element) {
     crate::styles::inject_style("__pp_cloak", "[pp-cloak] { display: none !important; }");
     walk(root);
-    #[cfg(feature = "legacy-dom")]
     install_observer(root);
 }
 

--- a/crates/pocopine-core/src/walker.rs
+++ b/crates/pocopine-core/src/walker.rs
@@ -215,6 +215,18 @@ pub fn bind_borrowed_scope_to(el: &Element, scope_id: ScopeId, proxy: &JsValue) 
 /// at walk time with either the user's captured content (via the
 /// slot store keyed by the owning component) or the slot's own
 /// default children, then the replacement is walked recursively.
+///
+/// RFC-058 Phase 6.5 — without `legacy-dom` this is a no-op stub.
+/// Compiled apps mount registered tags through `start_compiled` /
+/// `mount_component` and install every directive via
+/// `apply_static_plan`; the runtime walker has nothing to do.
+/// Callers that still funnel a clone through `walk` (pp-if /
+/// pp-for / pp-teleport's `body_fn = None` fallback,
+/// `walk_compiled_fallback`, the router's outlet walk, the
+/// MutationObserver callback) silently lose un-lifted directive
+/// bindings without the feature — the documented contract for
+/// the gate.
+#[cfg(feature = "legacy-dom")]
 pub fn walk(el: &Element) {
     if el.local_name() == "slot" {
         materialize_slot(el);
@@ -259,6 +271,9 @@ pub fn walk(el: &Element) {
     fire_mount_hook(el);
     set_private(el, WALKED_KEY, &JsValue::TRUE);
 }
+
+#[cfg(not(feature = "legacy-dom"))]
+pub fn walk(_el: &Element) {}
 
 fn fire_deferred_init(el: &Element) {
     let Some(value) = get_private(el, INIT_PENDING_KEY).and_then(|v| v.as_string()) else {
@@ -393,6 +408,7 @@ pub fn fire_ready_next_tick(el: &Element, scope_id: ScopeId) {
     });
 }
 
+#[cfg(feature = "legacy-dom")]
 fn bind(el: &Element) {
     BIND_CALLS.with(|c| c.set(c.get().saturating_add(1)));
     // Step 0: `<pp-outlet>` is the router's mount point. Hand the
@@ -1797,9 +1813,16 @@ thread_local! {
 /// still have preserved runtime-owned behavior inside a generated
 /// fragment. RFC-058 Phase 6 should drive this counter to zero,
 /// then remove this wrapper and the corresponding call sites.
+///
+/// Without `legacy-dom` this is a no-op (the underlying `walk`
+/// is also gated). The counter still increments so tests can
+/// detect attempted fallbacks even in compiled-only builds.
 pub fn walk_compiled_fallback(el: &Element) {
     COMPILED_FALLBACK_WALKS.with(|c| c.set(c.get().saturating_add(1)));
+    #[cfg(feature = "legacy-dom")]
     walk(el);
+    #[cfg(not(feature = "legacy-dom"))]
+    let _ = el;
 }
 
 /// Number of compiled-path fallback walks since the last reset.

--- a/crates/pocopine-core/src/walker.rs
+++ b/crates/pocopine-core/src/walker.rs
@@ -142,6 +142,24 @@ pub fn start_compiled(root: &Element) {
         let walker_clean = crate::templates_plan::template_plan_for(&tag)
             .map(|p| !p.requires_walker)
             .unwrap_or(false);
+        // RFC-058 Phase 6.5 — refuse to mount a walker-required
+        // plan in a compiled-only build. Without `legacy-dom`
+        // the fallback walk that would install the un-lifted
+        // directives is a no-op, so silently mounting would
+        // leave handlers / bindings inert. Hard-fail with a
+        // diagnostic before `mount_component` runs so the
+        // failure points at the plan, not at the missing
+        // behaviour later.
+        #[cfg(not(feature = "legacy-dom"))]
+        if !walker_clean {
+            web_sys::console::error_1(&wasm_bindgen::JsValue::from_str(&format!(
+                "pocopine: <{tag}>'s plan requires the runtime walker (`pp-*` directives \
+                 outside the compiled lift envelope). Enable the `legacy-dom` feature \
+                 (`pocopine = {{ features = [\"legacy-dom\"] }}`) or remove the offending \
+                 directives from the template. Skipping mount."
+            )));
+            continue;
+        }
         mount_component(&el, &tag, None);
         // Drive lifecycle for the freshly mounted subtree. For
         // walker-clean plans the cheaper `finalize_compiled_subtree`

--- a/crates/pocopine-core/src/walker.rs
+++ b/crates/pocopine-core/src/walker.rs
@@ -89,6 +89,54 @@ pub fn start(root: &Element) {
     install_observer(root);
 }
 
+/// RFC-058 Phase 6.5 — compiled-only mount entry. Skips the
+/// recursive directive scan over `root`'s subtree: only
+/// registered component tags get mounted, and each mount drives
+/// its template plan via [`crate::templates_plan::apply_static_plan`].
+/// Body-level `pp-*` attributes (e.g. `pp-data` on a
+/// server-rendered wrapper) are NOT bound by this entry — apps
+/// that need that path keep [`start`].
+///
+/// Discovers component tags via a single
+/// [`Element::query_selector_all`] call against the union of
+/// every registered plan tag, then mounts in document order.
+/// Inner component tags inside a parent's compiled subtree
+/// will already be mounted by the parent's `apply_static_plan`
+/// child_mounts pass before the iteration reaches them; the
+/// `__pp_mounted` guard short-circuits the duplicate mount.
+///
+/// The `MutationObserver` install is intentionally omitted —
+/// dynamically-inserted DOM is out of scope for compiled-only
+/// builds. Apps that need observation-based discovery for
+/// adopted DOM keep [`start`] and the `legacy-dom` feature.
+pub fn start_compiled(root: &Element) {
+    crate::styles::inject_style("__pp_cloak", "[pp-cloak] { display: none !important; }");
+    let tags = crate::templates_plan::registered_template_tags();
+    if tags.is_empty() {
+        return;
+    }
+    // Build a comma-separated tag selector. Tag names emitted by
+    // the macro are kebab-case ASCII identifiers — no escaping
+    // needed for `query_selector_all`.
+    let selector = tags.join(",");
+    let Ok(matches) = root.query_selector_all(&selector) else {
+        return;
+    };
+    for i in 0..matches.length() {
+        let Some(node) = matches.item(i) else {
+            continue;
+        };
+        let Ok(el) = node.dyn_into::<Element>() else {
+            continue;
+        };
+        if get_private(&el, "__pp_mounted").is_some() {
+            continue;
+        }
+        let tag = el.local_name();
+        mount_component(&el, &tag, None);
+    }
+}
+
 /// Pin a pre-built scope onto an element so [`enclosing_scope`] resolves
 /// through it. The element is assumed to **own** this scope — when the
 /// element unmounts, `release_subtree` removes the scope from the

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -1145,6 +1145,7 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
     // role is a compile-time error; an explicitly-omitted role
     // keeps the classic `inject_pp_data`-only path so non-primitive
     // components don't need a placeholder root.
+    let mut role_for_template_plan: Option<(String, String)> = None;
     let role_arg: proc_macro2::TokenStream = match args.role.as_ref() {
         Some(lit) => {
             let role_name = lit.value();
@@ -1160,6 +1161,14 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
                 .to_compile_error()
                 .into();
             };
+            // RFC-058 Phase 6.5 — body / slot fragments need the
+            // same `<root>` substitution `compile_template`
+            // applies at runtime. The runtime version stamps
+            // `data-pine-role="<role>"`; mirror that exact attr
+            // shape here so DOM / CSS selectors agree across the
+            // two paths.
+            role_for_template_plan =
+                Some((tag.to_string(), format!("data-pine-role=\"{}\"", role_name)));
             quote! { Some((#tag, #role_name)) }
         }
         None => quote! { None },
@@ -1245,7 +1254,13 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
     // (no eligible directive anywhere AND no row plans either).
     let template_plan = template_ast
         .as_ref()
-        .map(|ast| template_plan::analyze_template_plan(ast, &row_plans.assignments))
+        .map(|ast| {
+            template_plan::analyze_template_plan(
+                ast,
+                &row_plans.assignments,
+                role_for_template_plan.clone(),
+            )
+        })
         .unwrap_or_else(|| template_plan::EmittedTemplatePlan {
             plan_tokens: None,
             cleaned_html: None,

--- a/crates/pocopine-macros/src/template_plan.rs
+++ b/crates/pocopine-macros/src/template_plan.rs
@@ -199,6 +199,14 @@ struct AnalysisCtx {
     /// runtime walker's `interp::scan_children` skips the
     /// element via the `data-pp-interp-managed` marker.
     interps: Vec<InterpLite>,
+    /// RFC-058 Phase 6.5 — `pp-model[.modifier]="field"` on a
+    /// native input/textarea/select. The previously walker-only
+    /// directive lifts into a static plan entry the applier
+    /// installs via `directives::model::install_native`.
+    /// Component-target `pp-model` (registered tag, with or
+    /// without an arg) stays on `ChildHostModelLite`; this
+    /// vec covers only native targets.
+    native_models: Vec<NativeModelLite>,
     /// Set of (node_path, attr_name) entries the cleaned-HTML
     /// serializer should drop. Lookup is O(scan) per attribute
     /// — fine at typical template sizes.
@@ -427,6 +435,16 @@ enum InterpSegment {
     Dynamic(String),
 }
 
+/// RFC-058 Phase 6.5 — accumulated `pp-model[.modifier]="field"`
+/// site on a native input/textarea/select. Component-target
+/// `pp-model` (registered tag) keeps using `ChildHostModelLite`.
+struct NativeModelLite {
+    node_path: Vec<u16>,
+    expr_src: String,
+    number: bool,
+    lazy: bool,
+}
+
 struct ChildMountLite {
     node_path: Vec<u16>,
     tag: String,
@@ -541,6 +559,7 @@ fn emit_static_template_plan_literal(ctx: &AnalysisCtx) -> TokenStream {
     let slot_outlets_tokens = ctx.slot_outlets.iter().map(emit_slot_outlet);
     let opaque_tokens = ctx.opaque_directives.iter().map(emit_opaque_directive);
     let interp_tokens = ctx.interps.iter().map(emit_interp);
+    let native_model_tokens = ctx.native_models.iter().map(emit_native_model);
     let requires_walker = ctx.requires_walker;
     quote! {
         ::pocopine::__private::StaticTemplatePlan {
@@ -555,7 +574,23 @@ fn emit_static_template_plan_literal(ctx: &AnalysisCtx) -> TokenStream {
             slot_outlets: &[ #(#slot_outlets_tokens),* ],
             opaque_directives: &[ #(#opaque_tokens),* ],
             interps: &[ #(#interp_tokens),* ],
+            native_models: &[ #(#native_model_tokens),* ],
             requires_walker: #requires_walker,
+        }
+    }
+}
+
+fn emit_native_model(nm: &NativeModelLite) -> TokenStream {
+    let path_tokens = emit_node_path(&nm.node_path);
+    let expr_lit = proc_macro2::Literal::string(&nm.expr_src);
+    let number = nm.number;
+    let lazy = nm.lazy;
+    quote! {
+        ::pocopine::__private::StaticNativeModel {
+            node_path: #path_tokens,
+            expr_src: #expr_lit,
+            number: #number,
+            lazy: #lazy,
         }
     }
 }
@@ -1334,11 +1369,19 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
     }
     let mut listener_unsupported_modifier = false;
     let mut had_text = false;
+    let host_is_native = is_plan_native(&el.tag);
     for (name, value) in &el.attrs {
         if el.tag == "root" && name == "pp-as" {
             continue;
         }
-        match classify_attr(name, value, path, ctx, &mut listener_unsupported_modifier) {
+        match classify_attr(
+            name,
+            value,
+            path,
+            ctx,
+            host_is_native,
+            &mut listener_unsupported_modifier,
+        ) {
             ClassifyOutcome::Stripped { is_text } => {
                 if is_text {
                     had_text = true;
@@ -1485,6 +1528,7 @@ fn classify_attr(
     value: &str,
     path: &[u16],
     ctx: &mut AnalysisCtx,
+    host_is_native: bool,
     listener_unsupported_modifier: &mut bool,
 ) -> ClassifyOutcome {
     // RFC-020 listener shorthand: `@event[.mod]`.
@@ -1618,9 +1662,37 @@ fn classify_attr(
                 return ClassifyOutcome::Stripped { is_text: false };
             }
         }
+        // RFC-058 Phase 6.5 — `pp-model[.modifier]="field"` on a
+        // native input/textarea/select. Component-target
+        // `pp-model` (registered tag, with or without a `:arg`)
+        // stays on the runtime walker for now and is collected
+        // by `parse_child_host_model` on the parent
+        // `ChildMountLite`. Lifting only fires when host is
+        // native AND the directive has no `:arg` (the arg form
+        // is for component target prop selection, not native
+        // inputs).
+        if host_is_native && (rest == "model" || rest.starts_with("model.")) {
+            // Parse modifiers (`.number`, `.lazy`). Accept any
+            // unknown modifier silently — runtime currently does
+            // the same; surfacing is a future enhancement.
+            let modifiers: Vec<&str> = rest.split('.').skip(1).collect();
+            let number = modifiers.contains(&"number");
+            let lazy = modifiers.contains(&"lazy");
+            ctx.native_models.push(NativeModelLite {
+                node_path: path.to_vec(),
+                expr_src: value.to_string(),
+                number,
+                lazy,
+            });
+            ctx.stripped.push(StrippedAttr {
+                node_path: path.to_vec(),
+                name: name.to_string(),
+            });
+            return ClassifyOutcome::Stripped { is_text: false };
+        }
         // Every other pp-* attribute (pp-data, pp-cloak,
-        // pp-model, pp-route, pp-transition:*, pp-stagger, etc.)
-        // — preserved on the cleaned HTML and handled by the
+        // pp-route, pp-transition:*, pp-stagger, etc.) —
+        // preserved on the cleaned HTML and handled by the
         // runtime walker as today.
         return ClassifyOutcome::Preserved;
     }
@@ -2020,14 +2092,15 @@ fn if_body_subtree_is_eligible(el: &Element) -> bool {
     // body fragment's own static plan, and the runtime fallback
     // walk over the cleaned fragment binds any preserved
     // directives inside the mounted child template.
-    let is_custom = !is_plan_native(&el.tag);
+    let _ = is_plan_native(&el.tag); // kept for symmetry with slot eligibility
     for (name, _) in &el.attrs {
         if name == "pp-data" || name == "pp-route" {
             return false;
         }
-        if !is_custom && (name == "pp-model" || name.starts_with("pp-model:")) {
-            return false;
-        }
+        // RFC-058 Phase 6.5 — both branches of `pp-model` are
+        // compile-time handled now: native targets lift to
+        // `NativeModelLite`, component targets to
+        // `ChildHostModelLite`. No need to gate either form.
     }
     for child in &el.children {
         if let Node::Element(child_el) = child {
@@ -2164,14 +2237,14 @@ fn slot_node_is_lift_eligible(node: &Node) -> bool {
             // (which lands at the same `walk()` path that
             // emits child_mount entries + nested slot
             // fragments into the shared `Emissions` queue).
-            let is_custom = !is_plan_native(&el.tag);
+            let _ = is_plan_native(&el.tag); // kept for parity with body eligibility
             for (name, _) in &el.attrs {
                 if name == "pp-data" || name == "pp-route" {
                     return false;
                 }
-                if !is_custom && (name == "pp-model" || name.starts_with("pp-model:")) {
-                    return false;
-                }
+                // RFC-058 Phase 6.5 — `pp-model` lifts in both
+                // forms (native via `NativeModelLite`, component
+                // via `ChildHostModelLite`). No walker needed.
             }
             slot_subtree_is_lift_eligible(&el.children)
         }

--- a/crates/pocopine-macros/src/template_plan.rs
+++ b/crates/pocopine-macros/src/template_plan.rs
@@ -92,12 +92,16 @@ pub(crate) struct EmittedTemplatePlan {
 pub(crate) fn analyze_template_plan(
     ast: &TemplateAst,
     row_plan_assignments: &[(Vec<u16>, u32)],
+    role: Option<(String, String)>,
 ) -> EmittedTemplatePlan {
     let mut ctx = AnalysisCtx {
         row_plan_assignments: row_plan_assignments.to_vec(),
         ..AnalysisCtx::default()
     };
-    let mut emissions = Emissions::default();
+    let mut emissions = Emissions {
+        role: role.clone(),
+        ..Emissions::default()
+    };
     let mut path: Vec<u16> = Vec::new();
     for node in &ast.roots {
         if let Node::Element(el) = node {
@@ -263,6 +267,15 @@ struct Emissions {
     /// allocation (pp-if / pp-for / pp-teleport bodies share
     /// the same counter).
     next_if_body_id: usize,
+    /// RFC-058 Phase 6.5 — `(role_tag, role_attrs)` for the
+    /// component's `<root>` placeholder, copied from the
+    /// `#[component(role = "...")]` attribute. The runtime
+    /// `compile_template` substitutes `<root>` in the parent's
+    /// registered HTML; lifted body fragments + slot fragments
+    /// stamp their own cleaned HTML directly via `set_inner_html`
+    /// and need the substitution applied at compile time so the
+    /// fragment root materialises with the right tag.
+    role: Option<(String, String)>,
 }
 
 impl Emissions {
@@ -2067,9 +2080,16 @@ fn is_debounce_ms(m: &str) -> bool {
 /// envelope falls back to the legacy `clone_template_body` +
 /// `walker::walk` path the controller already drives.
 ///
+/// RFC-058 Phase 6.5 expansion: `<slot>` elements are now
+/// allowed. The macro records them in the body fragment's
+/// `slot_outlets`; the runtime applier materialises each via
+/// `walker::materialize_compiled_slot_outlet`, which falls
+/// through to the same `slot_fragment::lookup` path the parent
+/// template uses. The body's stamped `CTX_PARENT_KEY` carries
+/// the slot owner scope through to descendants so nested
+/// inject chains resolve correctly.
+///
 /// Excludes:
-///   * `<slot>` elements (would need slot capture/replay
-///     hooks inside a body fragment — Phase 3.5c+);
 ///   * `pp-data` / `pp-model` / `pp-route` (component scope
 ///     boundaries — the body fragment installs against the
 ///     enclosing scope only).
@@ -2083,9 +2103,6 @@ fn if_body_subtree_is_eligible(el: &Element) -> bool {
             }
         }
         return true;
-    }
-    if el.tag == "slot" {
-        return false;
     }
     // Phase 3.5d expansion: non-HTML5 tags are allowed here.
     // `walk()` emits child_mount entries for them into the
@@ -2149,7 +2166,23 @@ fn analyze_lift_body(
     let mut html = String::new();
     let mut sp: Vec<u16> = Vec::new();
     emit_element(root_el, &ctx, &mut html, &mut sp);
+    if let Some((tag, attrs)) = emissions.role.as_ref() {
+        html = apply_role_substitution(&html, tag, attrs);
+    }
     Some((html, ctx))
+}
+
+/// Compile-time mirror of `pocopine_core::templates::compile_template`'s
+/// `<root>` rewrite. Body fragments and dynamic slot fragments stamp
+/// their cleaned HTML directly via `set_inner_html` (no runtime
+/// `compile_template` pass), so the macro applies the same
+/// substitution before the literal lands in the fragment fn.
+fn apply_role_substitution(html: &str, tag: &str, attrs: &str) -> String {
+    let with_open_self_close = html
+        .replace("<root>", &format!("<{tag} {attrs}>"))
+        .replace("<root/>", &format!("<{tag} {attrs}/>"))
+        .replace("<root ", &format!("<{tag} {attrs} "));
+    with_open_self_close.replace("</root>", &format!("</{tag}>"))
 }
 
 // ─── slot subtree eligibility + emission ─────────────────────────
@@ -2187,6 +2220,11 @@ fn analyze_slot_subtree(nodes: &[Node], emissions: &mut Emissions) -> Option<Slo
         }
     }
     let html = serialize_slot_children_with(nodes, &ctx);
+    let html = if let Some((tag, attrs)) = emissions.role.as_ref() {
+        apply_role_substitution(&html, tag, attrs)
+    } else {
+        html
+    };
     let is_dynamic = !ctx.bindings.is_empty()
         || !ctx.listeners.is_empty()
         || !ctx.refs.is_empty()

--- a/crates/pocopine/Cargo.toml
+++ b/crates/pocopine/Cargo.toml
@@ -7,18 +7,18 @@ repository.workspace = true
 description = "Rust/WASM framework with an Alpine.js-style client runtime."
 
 [features]
-# Forwards the `devtools` feature of `pocopine-core`. Default-on so
-# `cargo add pocopine` keeps the in-browser scope inspector available.
-# Users who want minimum-binary release builds opt out with
-# `pocopine = { default-features = false }` in their Cargo.toml.
-default = ["devtools", "legacy-dom"]
+# RFC-058 Phase 6.5 — defaults are opt-in. `cargo add pocopine`
+# now ships the smallest viable runtime; consumers opt into
+# `devtools` (in-browser scope inspector) and `legacy-dom`
+# (MutationObserver auto-discovery for adopted DOM) explicitly.
+default = []
 devtools = ["pocopine-core/devtools"]
 mount-profiler = ["pocopine-core/mount-profiler"]
-# RFC-058 Phase 6 v1 — see `pocopine-core/Cargo.toml` for the
-# trade-off. Default-on; opt out with `default-features = false`
-# when the app bootstraps entirely through compiled-view mounts
-# and never adopts external DOM. Phases 4.1d / 4.2c / 4.3
-# follow-ups graduate more of the walker behind this same flag.
+# Runtime walker's MutationObserver-based auto-discovery for
+# adopted / externally-injected DOM. Opt-in — apps that boot
+# entirely through compiled-view mounts (`App::run_compiled`)
+# and never adopt external DOM stay walker-free. See
+# `pocopine-core/Cargo.toml` for the gate's current scope.
 legacy-dom = ["pocopine-core/legacy-dom"]
 
 [dependencies]

--- a/crates/pocopine/src/lib.rs
+++ b/crates/pocopine/src/lib.rs
@@ -75,7 +75,7 @@ pub mod __private {
     // existing `register_template` call.
     pub use pocopine_core::directives::for_plan::{
         IfBodyFn, StaticChildHostBinding, StaticChildHostListener, StaticChildHostModel,
-        StaticChildMount, StaticForPlan, StaticIfPlan, StaticInit, StaticInterp,
+        StaticChildMount, StaticForPlan, StaticIfPlan, StaticInit, StaticInterp, StaticNativeModel,
         StaticOpaqueDirective, StaticRef, StaticSlotFragment, StaticSlotOutlet, StaticTeleportPlan,
     };
     pub use pocopine_core::directives::interp::PlannedSegment;

--- a/crates/pocopine/src/lib.rs
+++ b/crates/pocopine/src/lib.rs
@@ -16,7 +16,7 @@ pub use pocopine_core::{
     emit_model_field, emit_raw, emit_raw_from, fetch, flush_sync, inject, invalidate_field,
     invalidate_field_cache, mount_profile_enabled, on_cleanup, on_scope_unmount,
     patch_list_at_inline, patch_list_indices_inline, provide, registered_component_names,
-    registry_errors, release, replace_field_inline, report_mount_profile, reset_mount_profile, run,
+    registry_errors, release, replace_field_inline, report_mount_profile, reset_mount_profile,
     run_now, rw_signal, set_auto_flush, signal, spawn, spawn_latest, spawn_scoped, store,
     swap_list_indices_inline, this, trigger_scope, verify_registry, watch, watch_field,
     watch_field_scoped, watch_scope_field, watch_scope_field_now, watch_scope_field_scoped,
@@ -33,17 +33,25 @@ pub use pocopine_core::{create_context, inject_key};
 // and the macro namespace (the attribute `#[store]`). They don't collide.
 pub use pocopine_macros::{component, handlers, server, store, Emit};
 
+/// Re-export of [`pocopine_core::run`]. Gated behind `legacy-dom`
+/// (RFC-058 Phase 6.5) — apps that don't enable the feature use
+/// [`App::run_compiled`] instead.
+#[cfg(feature = "legacy-dom")]
+pub use pocopine_core::run;
+
 pub mod prelude {
+    #[cfg(feature = "legacy-dom")]
+    pub use crate::run;
     #[allow(deprecated)]
     pub use crate::InjectKey;
     pub use crate::{
         batch, component, computed, create_context, cx, dispatch, dispatch_event, effect, emit,
         emit_cancelable, emit_cancelable_from, emit_event, emit_event_from, emit_from,
         emit_from_host, emit_model, emit_model_field, emit_raw, emit_raw_from, handlers,
-        inject_key, on, on_cleanup, on_emit, run, rw_signal, signal, spawn, spawn_latest,
-        spawn_scoped, store, this, watch, App, Component, ComponentState, Computed, ContextKey,
-        ContextMarker, Emit, Handle, Inject, NearestParent, Parent, RwSignal, Scope, ScopeId,
-        ServerError, ServerResult, Setter, Signal, Store,
+        inject_key, on, on_cleanup, on_emit, rw_signal, signal, spawn, spawn_latest, spawn_scoped,
+        store, this, watch, App, Component, ComponentState, Computed, ContextKey, ContextMarker,
+        Emit, Handle, Inject, NearestParent, Parent, RwSignal, Scope, ScopeId, ServerError,
+        ServerResult, Setter, Signal, Store,
     };
     pub use wasm_bindgen::prelude::*;
 }

--- a/crates/pocopine/tests/StartCompiledModelHost.html
+++ b/crates/pocopine/tests/StartCompiledModelHost.html
@@ -1,0 +1,4 @@
+<div class="scmh-root">
+  <span class="scmh-readout" pp-text="value"></span>
+  <input class="scmh-input" type="text" pp-model="value" />
+</div>

--- a/crates/pocopine/tests/template_plan.rs
+++ b/crates/pocopine/tests/template_plan.rs
@@ -716,7 +716,7 @@ fn mount(host_html: &str) -> Element {
     let host = doc().create_element("div").unwrap();
     host.set_inner_html(host_html);
     body.append_child(&host).unwrap();
-    pocopine_core::walker::start(&host);
+    pocopine_core::walker::start_compiled(&host);
     host
 }
 
@@ -1490,7 +1490,7 @@ async fn slot_fragment_runtime_hook_replaces_capture_path() {
         &JsValue::UNDEFINED,
     );
 
-    pocopine_core::walker::start(&host);
+    pocopine_core::walker::start_compiled(&host);
     tick().await;
 
     let marker = host
@@ -2189,15 +2189,15 @@ async fn start_compiled_skips_walker_recursion_for_registered_tags() {
     host.remove();
 }
 
-/// RFC-058 Phase 6.5 — `start_compiled` must drive the walker
-/// fallback for plans the macro flagged with
-/// `requires_walker = true` (e.g. `pp-model` on a native input,
-/// in the §7 deferred set). Mounts a host whose template has
-/// the model directive, asserts the input is reactive, and
-/// pins `compiled_fallback_walk_count` at 1 — proving the
-/// fallback path engaged exactly once for the single host.
+/// RFC-058 Phase 6.5 — `pp-model` on a native input now lifts
+/// into a [`StaticNativeModel`] entry on the template plan
+/// instead of forcing `requires_walker = true`. `start_compiled`
+/// installs the read-side effect + write-side listener directly
+/// via `directives::model::install_native`; no walker fallback
+/// runs. Pin `compiled_fallback_walk_count` at 0 + the input's
+/// reactive end-to-end behaviour to lock the lift.
 #[wasm_bindgen_test]
-async fn start_compiled_runs_walker_fallback_for_walker_required_plans() {
+async fn pp_model_on_native_input_lifts_without_walker_fallback() {
     register_all();
     reset_plan_failure_count();
     reset_compiled_fallback_walk_count();
@@ -2205,9 +2205,13 @@ async fn start_compiled_runs_walker_fallback_for_walker_required_plans() {
     let plan = template_plan_for("start-compiled-model-host")
         .expect("start-compiled-model-host registers a template plan");
     assert!(
-        plan.requires_walker,
-        "fixture relies on pp-model flipping requires_walker — if the macro starts \
-         lifting pp-model, swap the fixture for one that still trips the fallback",
+        !plan.requires_walker,
+        "lifted native pp-model must NOT flip requires_walker",
+    );
+    assert_eq!(
+        plan.native_models.len(),
+        1,
+        "the fixture's single <input pp-model> must produce one StaticNativeModel entry",
     );
 
     let body = doc().body().unwrap();
@@ -2220,8 +2224,8 @@ async fn start_compiled_runs_walker_fallback_for_walker_required_plans() {
     assert_eq!(read(&host, ".scmh-readout"), "seed");
     assert_eq!(
         compiled_fallback_walk_count(),
-        1,
-        "start_compiled must run walk_compiled_fallback once for the walker-required plan",
+        0,
+        "lifted native pp-model must not need walker fallback",
     );
     assert_eq!(plan_failure_count(), 0);
 
@@ -2239,7 +2243,7 @@ async fn start_compiled_runs_walker_fallback_for_walker_required_plans() {
     assert_eq!(
         read(&host, ".scmh-readout"),
         "typed",
-        "pp-model must wire input → scope after start_compiled mounts via fallback",
+        "lifted pp-model must wire input → scope through the compiled path",
     );
 
     host.remove();
@@ -2271,11 +2275,15 @@ async fn walker_skips_recursion_for_plan_clean_subtrees() {
 
     let after = bind_call_count();
     let delta = after - baseline;
+    // RFC-058 Phase 6.5 — `mount()` now uses `start_compiled`,
+    // which routes through `mount_component` directly without
+    // ever calling `bind`. The previous walker entry (`start`)
+    // bound the harness wrapper + the host element (delta=2);
+    // the compiled entry binds nothing (delta=0).
     assert_eq!(
-        delta, 2,
-        "plan-clean component must bind only its harness wrapper + the host element \
-         ({delta} bind calls — walker is re-entering descendants instead of routing \
-         through finalize_compiled_subtree)",
+        delta, 0,
+        "compiled entry mounts via apply_static_plan — no `bind` calls expected \
+         ({delta} bind calls observed)",
     );
 
     // The plan still applied correctly — sanity-check the

--- a/crates/pocopine/tests/template_plan.rs
+++ b/crates/pocopine/tests/template_plan.rs
@@ -559,6 +559,25 @@ impl PlanInterpMultiHost {
     }
 }
 
+/// RFC-058 Phase 6.5 — fixture for the `start_compiled` walker-
+/// required branch. `pp-model` on a native input is in the §7
+/// deferred set, so the macro flips `requires_walker = true` on
+/// the plan; the runtime applier installs the lifted plan
+/// entries, then the start path must run a fallback walker pass
+/// to wire up `pp-model`.
+#[derive(Default, Serialize, Deserialize)]
+#[component(template = "StartCompiledModelHost.html")]
+struct StartCompiledModelHost {
+    value: String,
+}
+
+#[handlers]
+impl StartCompiledModelHost {
+    pub fn on_setup(&mut self) {
+        self.value = "seed".into();
+    }
+}
+
 /// RFC-058 Phase 3 hardening — host with `pp-ref` on a
 /// custom child host. Drives the regression that without
 /// classifier coverage for `pp-ref` on a non-HTML5 tag the
@@ -688,6 +707,7 @@ fn register_all() {
     PlanChildHostRefHost::register();
     PlanInterpHost::register();
     PlanInterpMultiHost::register();
+    StartCompiledModelHost::register();
 }
 
 fn mount(host_html: &str) -> Element {
@@ -2164,6 +2184,62 @@ async fn start_compiled_skips_walker_recursion_for_registered_tags() {
         compiled_fallback_walk_count(),
         0,
         "compiled-only path must not trip walker fallback for a walker-clean plan",
+    );
+
+    host.remove();
+}
+
+/// RFC-058 Phase 6.5 — `start_compiled` must drive the walker
+/// fallback for plans the macro flagged with
+/// `requires_walker = true` (e.g. `pp-model` on a native input,
+/// in the §7 deferred set). Mounts a host whose template has
+/// the model directive, asserts the input is reactive, and
+/// pins `compiled_fallback_walk_count` at 1 — proving the
+/// fallback path engaged exactly once for the single host.
+#[wasm_bindgen_test]
+async fn start_compiled_runs_walker_fallback_for_walker_required_plans() {
+    register_all();
+    reset_plan_failure_count();
+    reset_compiled_fallback_walk_count();
+
+    let plan = template_plan_for("start-compiled-model-host")
+        .expect("start-compiled-model-host registers a template plan");
+    assert!(
+        plan.requires_walker,
+        "fixture relies on pp-model flipping requires_walker — if the macro starts \
+         lifting pp-model, swap the fixture for one that still trips the fallback",
+    );
+
+    let body = doc().body().unwrap();
+    let host = doc().create_element("div").unwrap();
+    host.set_inner_html("<start-compiled-model-host></start-compiled-model-host>");
+    body.append_child(&host).unwrap();
+    pocopine_core::walker::start_compiled(&host);
+    tick().await;
+
+    assert_eq!(read(&host, ".scmh-readout"), "seed");
+    assert_eq!(
+        compiled_fallback_walk_count(),
+        1,
+        "start_compiled must run walk_compiled_fallback once for the walker-required plan",
+    );
+    assert_eq!(plan_failure_count(), 0);
+
+    let input = host
+        .query_selector(".scmh-input")
+        .unwrap()
+        .unwrap()
+        .dyn_into::<web_sys::HtmlInputElement>()
+        .unwrap();
+    input.set_value("typed");
+    let event = web_sys::Event::new("input").unwrap();
+    input.dispatch_event(&event).unwrap();
+    tick().await;
+
+    assert_eq!(
+        read(&host, ".scmh-readout"),
+        "typed",
+        "pp-model must wire input → scope after start_compiled mounts via fallback",
     );
 
     host.remove();

--- a/crates/pocopine/tests/template_plan.rs
+++ b/crates/pocopine/tests/template_plan.rs
@@ -2115,6 +2115,60 @@ async fn planned_interp_keeps_text_indexes_valid_across_mutations() {
     host.remove();
 }
 
+/// RFC-058 Phase 6.5 — `walker::start_compiled` mounts every
+/// registered component tag inside `root` via the compiled
+/// path without binding the wrapper or any non-component
+/// descendant. Where the legacy `walker::start` recursively
+/// dispatches `bind` on every element below `root`,
+/// `start_compiled` resolves the registered tags via a single
+/// `query_selector_all`, then routes each through
+/// `mount_component` directly — `bind` itself is never invoked
+/// on the wrapper, the intermediate `<section>`, or the
+/// component tag. The plan applier handles every directive on
+/// every descendant via `apply_static_plan`.
+///
+/// Pin the bind-call delta of 0 so any regression that
+/// re-introduces a body-level recursive scan is loud.
+#[wasm_bindgen_test]
+async fn start_compiled_skips_walker_recursion_for_registered_tags() {
+    register_all();
+    reset_bind_call_count();
+    reset_plan_failure_count();
+    reset_compiled_fallback_walk_count();
+
+    let body = doc().body().unwrap();
+    let host = doc().create_element("div").unwrap();
+    host.set_attribute("class", "scsr-wrapper").unwrap();
+    host.set_inner_html(
+        r#"<section class="scsr-section">
+              <plan-interp-host></plan-interp-host>
+           </section>"#,
+    );
+    body.append_child(&host).unwrap();
+    let baseline = bind_call_count();
+    pocopine_core::walker::start_compiled(&host);
+    tick().await;
+
+    let post = bind_call_count() - baseline;
+    assert_eq!(
+        post, 0,
+        "start_compiled mounts via apply_static_plan directly — no bind call on the wrapper, section, or component tag",
+    );
+
+    assert_eq!(read(&host, ".pih-line"), "hello world, you have 3 items");
+    assert_eq!(read(&host, ".pih-bare"), "world");
+    assert_eq!(read(&host, ".pih-static"), "no interp here");
+
+    assert_eq!(plan_failure_count(), 0);
+    assert_eq!(
+        compiled_fallback_walk_count(),
+        0,
+        "compiled-only path must not trip walker fallback for a walker-clean plan",
+    );
+
+    host.remove();
+}
+
 /// RFC-058 Phase 6.3 — when a registered component plan has
 /// `requires_walker = false`, the walker invokes `bind` once on
 /// the host element, applies the entire plan, then descends via

--- a/crates/pocopine/tests/walker.rs
+++ b/crates/pocopine/tests/walker.rs
@@ -1,5 +1,13 @@
 //! Walker + `pp-for` integration tests. Covers the regressions that
-//! broke HN's recursive comment tree:
+//! broke HN's recursive comment tree.
+//!
+//! RFC-058 Phase 6.5 — gated behind `legacy-dom`: every test in this
+//! file exercises the runtime walker entry (`walker::start` →
+//! `walker::walk` recursion + `MutationObserver` install). Compiled-
+//! only consumers that don't enable the feature don't run these
+//! paths and don't compile this test crate.
+#![cfg(feature = "legacy-dom")]
+//!
 //!
 //! 1. Component tags mount even when they sit directly inside a
 //!    `pp-for` body (LoopScope `SCOPE_ID_KEY` no longer shadows the

--- a/crates/pocopine/tests/walker.rs
+++ b/crates/pocopine/tests/walker.rs
@@ -2911,6 +2911,12 @@ async fn delegated_listener_after_proxy_elision() {
 /// the handler. If the previous teardown was incorrectly skipped
 /// the new clone would inherit a stale scope id and the click
 /// would route to nowhere.
+///
+/// RFC-058 Phase 6.5 — gated behind `legacy-dom` because the
+/// mechanism under test (the `MutationObserver` callback that
+/// clears `BULK_RELEASE_KEY`) is only compiled with that
+/// feature. Compiled-only apps don't run this code path.
+#[cfg(feature = "legacy-dom")]
 #[wasm_bindgen_test]
 async fn lever5b_marker_clears_so_later_removes_teardown_normally() {
     let host = mount("<bulk-list></bulk-list>");

--- a/examples/blog/Cargo.toml
+++ b/examples/blog/Cargo.toml
@@ -22,7 +22,7 @@ path = "src/bin/server.rs"
 required-features = []
 
 [dependencies]
-pocopine = { path = "../../crates/pocopine" }
+pocopine = { path = "../../crates/pocopine", features = ["legacy-dom"] }
 wasm-bindgen = { workspace = true }
 serde = { workspace = true }
 

--- a/examples/counter/src/lib.rs
+++ b/examples/counter/src/lib.rs
@@ -33,5 +33,5 @@ impl Counter {
 
 #[wasm_bindgen(start)]
 pub fn main() {
-    App::new().register::<Counter>().run();
+    App::new().register::<Counter>().run_compiled();
 }

--- a/examples/hn/Cargo.toml
+++ b/examples/hn/Cargo.toml
@@ -17,7 +17,7 @@ name = "server"
 path = "src/bin/server.rs"
 
 [dependencies]
-pocopine = { path = "../../crates/pocopine" }
+pocopine = { path = "../../crates/pocopine", features = ["devtools", "legacy-dom"] }
 wasm-bindgen = { workspace = true }
 serde = { workspace = true }
 web-sys = { version = "0.3", features = ["Window", "Performance"] }

--- a/examples/site/Cargo.toml
+++ b/examples/site/Cargo.toml
@@ -17,7 +17,7 @@ name = "server"
 path = "src/bin/server.rs"
 
 [dependencies]
-pocopine = { path = "../../crates/pocopine" }
+pocopine = { path = "../../crates/pocopine", features = ["legacy-dom"] }
 wasm-bindgen = { workspace = true }
 serde = { workspace = true }
 

--- a/examples/spa/Cargo.toml
+++ b/examples/spa/Cargo.toml
@@ -9,6 +9,6 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-pocopine = { path = "../../crates/pocopine" }
+pocopine = { path = "../../crates/pocopine", features = ["legacy-dom"] }
 wasm-bindgen = { workspace = true }
 serde = { workspace = true }

--- a/examples/tailwind/Cargo.toml
+++ b/examples/tailwind/Cargo.toml
@@ -16,6 +16,6 @@ output = "pkg/tailwind.css"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-pocopine = { path = "../../crates/pocopine" }
+pocopine = { path = "../../crates/pocopine", features = ["legacy-dom"] }
 wasm-bindgen = { workspace = true }
 serde = { workspace = true }

--- a/examples/todo/Cargo.toml
+++ b/examples/todo/Cargo.toml
@@ -9,6 +9,6 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-pocopine = { path = "../../crates/pocopine" }
+pocopine = { path = "../../crates/pocopine", features = ["legacy-dom"] }
 wasm-bindgen = { workspace = true }
 serde = { workspace = true }

--- a/examples/website/Cargo.toml
+++ b/examples/website/Cargo.toml
@@ -12,7 +12,7 @@ crate-type = ["cdylib", "rlib"]
 pine = { path = "../../crates/pine" }
 pine-icons = { path = "../../crates/pine-icons" }
 pine-motion = { path = "../../crates/pine-motion" }
-pocopine = { path = "../../crates/pocopine" }
+pocopine = { path = "../../crates/pocopine", features = ["legacy-dom"] }
 wasm-bindgen = { workspace = true }
 js-sys = { workspace = true }
 serde = { workspace = true }

--- a/jsbench/pocopine/Cargo.toml
+++ b/jsbench/pocopine/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-pocopine = { path = "../../crates/pocopine" }
+pocopine = { path = "../../crates/pocopine", features = ["legacy-dom"] }
 wasm-bindgen = { workspace = true }
 serde = { workspace = true }
 web-sys = { version = "0.3", features = ["Performance", "Window"] }

--- a/jsbench/tags_input_repro/Cargo.toml
+++ b/jsbench/tags_input_repro/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-pocopine = { path = "../../crates/pocopine" }
+pocopine = { path = "../../crates/pocopine", features = ["legacy-dom"] }
 pine = { path = "../../crates/pine" }
 wasm-bindgen = { workspace = true }
 serde = { workspace = true }

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -66,4 +66,5 @@ Conventions:
 | 055 | [Typed context ergonomics on top of keyed `provide` / `inject`](./rfc-055-typed-context.md) | Deferred to 056 |
 | 056 | [Component interaction safety batch](./rfc-056-component-interaction-safety-batch.md) | Implemented (all phases + follow-on infrastructure) |
 | 057 | [Compile-time template plans](./rfc-057-compile-time-template-plans.md) | Superseded by 058 |
-| 058 | [Compiled views and walker removal](./rfc-058-compiled-views-walker-removal.md) | Draft |
+| 058 | [Compiled views and walker removal](./rfc-058-compiled-views-walker-removal.md) | Phases 1–6.5 implemented; 7–8 deferred |
+| 059 | [Server-side rendering and hydration](./rfc-059-server-side-rendering-and-hydration.md) | Draft (revised post-RFC-058 Phase 6.5) |

--- a/rfcs/rfc-059-server-side-rendering-and-hydration.md
+++ b/rfcs/rfc-059-server-side-rendering-and-hydration.md
@@ -1,0 +1,687 @@
+# RFC 059 — Server-Side Rendering and Hydration
+
+| Field | Value |
+|---|---|
+| **Status** | Draft (revised post-RFC-058 Phase 6.5) |
+| **Author** | pocopine team |
+| **Created** | 2026-04-26 |
+| **Revised** | 2026-04-27 |
+| **Related** | [RFC 058](./rfc-058-compiled-views-walker-removal.md), [issue #10](https://github.com/mambisi/pocopine/issues/10), [issue #13](https://github.com/mambisi/pocopine/issues/13) |
+| **Supersedes** | RFC 058 §6 Phase 5 (Hydration), which deferred specifics to this RFC |
+
+## 1. Summary
+
+Add server-side rendering (SSR) and client-side hydration on top of
+the RFC-058 compiled-views architecture. The compiler already
+generates a per-component `mount(host)` function; this RFC adds a
+peer `hydrate(host)` function and a server-side `render_to_string`
+mode.
+
+**Architectural commitments locked in by RFC 058 + Phase 6.5**:
+
+- Reactivity stays Vue-3-style **proxy + effect** (NOT fine-grained
+  signals). RFC 058 Phase 6.5 measured that signals would require a
+  full architectural rewrite for ~25 KB gzip; the council has
+  rejected that trade.
+- Animations stay **default-on** (`animate::*` + `transition::*` in
+  core, ~15 KB gzip). Hydration must coexist with `<Transition>`-
+  style enter/leave without flicker.
+- The runtime walker is gone for compiled apps (RFC 058 Phase 6.5);
+  hydration must drive the same compiled-mount machinery, not a
+  separate hydrate-via-walker path.
+- Templates are compiled to per-tag plans (`StaticTemplatePlan`)
+  with `child_mounts` / `for_plans` / `if_plans` / `teleport_plans`
+  / `slot_outlets` / `interps` / `native_models`. Hydration must
+  reuse these plans — no second hydration-only IR.
+
+## 2. Motivation
+
+Same as the original draft (TTI, SEO, slow connections), plus three
+forces specific to pocopine:
+
+1. **The compiled-views Phase 6.5 work makes hydration cheap.** The
+   per-component plan already records "this `node_path` carries an
+   `pp-on:click` listener for `expr_src`" — hydration is just
+   "install the listener on the existing element" instead of
+   "create the element + install the listener."
+2. **Vue 3 + Solid hybrid alignment.** Pocopine's current
+   architecture is closer to Vue 3 (proxy reactivity, runtime
+   templates, transitions in core) than to Solid (signals) or Yew
+   (vdom). The hydration design follows Vue 3 where Vue's choice
+   maps onto our model, and Solid where Vue's model doesn't (e.g.
+   event replay, which Vue doesn't ship).
+3. **Server-functions + stores need a transfer protocol.** RFC
+   056's server functions and the `#[store]` macro both need a way
+   to ship initial state to the hydrating client. Without an SSR
+   contract, server-rendered pages today silently re-fetch
+   everything on hydration.
+
+## 3. Goals
+
+- `render_to_string<C: Component>(...)` in `pocopine-server`,
+  framework-agnostic; returns the rendered HTML body and a side
+  channel for state to transfer.
+- `#[component]` macro generates a `hydrate(host, scope)` function
+  alongside `mount(host, scope)`. Both consume the same
+  `StaticTemplatePlan`; only the per-entry installer differs.
+- Non-destructive client hydration: walks the existing DOM via
+  `firstChild`/`nextSibling`, attaches listeners + effects without
+  recreating nodes.
+- A documented mismatch policy (warn + best-effort fix in
+  development; warn-once + leave attrs alone in production), with a
+  per-element `pp-allow-mismatch` opt-out.
+- A `<Transition>`-during-hydration story that doesn't flicker on
+  first paint (lift Vue 3's inert-`<template>` `appear` trick).
+- Adopt Solid's pre-hydration **event replay** — a tiny inline
+  capture script that queues clicks/inputs received before the wasm
+  bundle finishes downloading; the runtime drains the queue after
+  hydrate completes.
+- Per-server-function / per-`use_prepared_state` state serialization
+  rather than one global `__POCOPINE_STATE__` blob (Yew's model).
+- Streaming SSR for `<Suspense>` boundaries (Solid's
+  `renderToStream` + `<template id="pl-N">` placeholder protocol).
+
+## 4. Non-goals
+
+- A full server framework. `render_to_string` is a pure function
+  that plugs into Axum / Actix / Cloudflare Workers / etc.
+- Islands / partial hydration in v1. Full-page hydration first; the
+  RFC-058 Phase 8 cluster work is the right granularity for islands
+  later.
+- Replacing the SPA router. The SSR path renders the initial route;
+  subsequent navigations stay client-side.
+- A custom serialization format. We use `serde-json` for the wire,
+  but each `use_prepared_state` site picks its own
+  `serde::{Serialize, Deserialize}` types (see §5.5).
+
+## 5. Proposal
+
+### 5.1 Server-side rendering — `render_to_string`
+
+```rust
+// pocopine-server crate
+pub fn render_to_string<C: Component + Default>() -> RenderedPage {
+    /* ... */
+}
+
+pub struct RenderedPage {
+    /// Rendered HTML body (no `<html>` / `<head>` wrapping —
+    /// the caller composes the full document).
+    pub body: String,
+    /// `<script type="application/json" data-pp-state-id="...">`
+    /// fragments the caller injects into `<body>` after `body`.
+    /// One fragment per `use_prepared_state` / `register_store`
+    /// site that emitted a value.
+    pub state_fragments: Vec<String>,
+    /// The optional pre-hydration event-replay script
+    /// (see §5.6). Caller injects into `<head>` if event-replay
+    /// is enabled.
+    pub event_replay_script: Option<String>,
+}
+```
+
+Implementation runs the compiler's emitted `mount` against a
+**string backend** instead of `web_sys`. The trick that makes this
+small: the per-component `StaticTemplatePlan` already records every
+binding as `(node_path, BindingKind, expr_src)`. The string backend
+walks the cleaned HTML once, stamps interpolated text + attribute
+values from the plan, and emits comment markers at every dynamic
+boundary (§5.4).
+
+#### 5.1.1 Reactivity is disabled during SSR
+
+Vue 3 (`setupComponent(instance, isSSR=true)` →
+`setInSSRSetupState(true)`) disables reactive tracking server-side
+because there's nothing to subscribe to. Pocopine adopts the same
+pattern:
+
+```rust
+// pocopine-core
+pub fn with_ssr_disabled<R>(f: impl FnOnce() -> R) -> R { /* ... */ }
+```
+
+`Scope::into_proxy()` checks the flag and returns a proxy whose
+`get` doesn't `track()`. `effect()` becomes a no-op that runs the
+closure once and discards the dep set. `Scope::find` etc. still
+work — only the **subscription** half of reactivity is silenced.
+
+This lets the same `mount` code path execute on server and client
+without forking the macro emit. The string backend is a
+`RenderTarget` trait with a `Dom` impl (today) and a `String` impl
+(this RFC).
+
+### 5.2 Compiler changes — `hydrate` peer of `mount`
+
+The `#[component]` macro currently emits per-component:
+
+```rust
+pub fn __pp_mount_<COMPONENT>(host: &Element, scope: &Scope) { /* ... */ }
+pub static __POC_TEMPLATE_PLAN_<COMPONENT>: StaticTemplatePlan = /* ... */;
+```
+
+This RFC adds:
+
+```rust
+pub fn __pp_hydrate_<COMPONENT>(host: &Element, scope: &Scope) -> HydrateResult { /* ... */ }
+```
+
+`hydrate` and `mount` share the `StaticTemplatePlan`. They differ
+only in how they realize each plan entry:
+
+| Plan entry | `mount` action | `hydrate` action |
+|---|---|---|
+| `StaticBinding` | install effect that writes the attr/text | install effect (server already wrote initial value) — first run is suppressed |
+| `StaticListener` | `addEventListener` on the freshly-created element | `addEventListener` on the existing element looked up by `node_path` |
+| `StaticChildMount` | mount child component into the host element | call child's `__pp_hydrate_*` against the existing child DOM |
+| `StaticIfPlan` (truthy at SSR) | clone body + install effects | walk body via comment markers, install effects, no DOM changes |
+| `StaticIfPlan` (falsy at SSR) | install controller, no body | install controller anchored at `<!--pp-if-->` placeholder |
+| `StaticForPlan` | clone N rows | walk N row fragments delimited by `<!--pp-for-key:K-->` markers |
+| `StaticTeleportPlan` | clone body + insert at target | locate teleported clone via `<!--pp-teleport-out:N-->` back-reference, attach |
+| `StaticSlotOutlet` | materialize slot fragment | walk between `<!--pp-slot:NAME-->` markers, run installer |
+| `StaticInterp` | parse segments, install per-dynamic effect | install per-dynamic effect; static segments adopt existing text |
+| `StaticNativeModel` | install read-effect + write-listener | install read-effect (suppress first run) + write-listener |
+| `StaticOpaqueDirective` | dispatch via `directives::lookup` | dispatch via `directives::lookup` (these directives are `<Transition>`-style and idempotent) |
+
+The "first run is suppressed" pattern is critical (see §5.7): an
+effect installed during hydration must not fire during the
+hydration walk because that would mutate the DOM and risk overwriting
+SSR state. Vue 3's solution is to NOT have a global flag; instead,
+each render-effect entry checks `el && hydrateNode` and routes the
+*first* tick into `hydrate` instead of `patch`
+(`runtime-core/renderer.ts:1306-1342`). Pocopine adopts the same
+shape: effects' first invocation during hydration is a no-op
+(reactive subscription is established, but the side-effect is
+skipped).
+
+### 5.3 Client-side hydration entry — `App::hydrate()`
+
+```rust
+impl App {
+    /// Like `run_compiled` but expects the body to already
+    /// contain server-rendered HTML + state fragments.
+    pub fn hydrate(self) { /* ... */ }
+}
+```
+
+The runtime detects hydration mode by querying for any
+`<script data-pp-state-id="...">` tag. If absent, falls through to
+`run_compiled`'s normal mount.
+
+Steps:
+
+1. **Drain state fragments**: parse every
+   `<script type="application/json" data-pp-state-id="...">`,
+   index by id, hand them to the per-site loaders (§5.5).
+2. **Locate root component tags** via the same querySelectorAll
+   the Phase 6.5 `start_compiled` uses.
+3. **For each root**, instantiate the scope (priming with
+   transferred state if relevant), call `__pp_hydrate_*` instead
+   of `__pp_mount_*`.
+4. **Drain the event-replay queue** (§5.6) on the next microtask.
+
+Once `hydrate` returns, the app is fully interactive. The wire
+contract: from `<script id="__pp_state_index__">` parse-time to
+the queue drain takes one synchronous frame (the hydrate walk is
+allocation-free and DOM-mutation-free except for state-fragment
+removal).
+
+### 5.4 Comment marker scheme
+
+Inspired by Solid's `<!--$-->` / `<!--/-->` pairs and Vue 3's
+`<!--[-->` / `<!--]-->`. Pocopine uses a `pp-`-prefixed namespace
+to avoid confusing devtools with framework markers:
+
+| Boundary | Open marker | Close marker |
+|---|---|---|
+| Component fragment (multi-root) | `<!--pp-frag-->` | `<!--/pp-frag-->` |
+| `pp-if` (truthy) | `<!--pp-if-->` | `<!--/pp-if-->` |
+| `pp-if` (falsy) | `<!--pp-if-->` | (no close, just placeholder) |
+| `pp-for` block | `<!--pp-for-->` | `<!--/pp-for-->` |
+| `pp-for` keyed item | `<!--pp-for-key:KEY-->` | `<!--/pp-for-key-->` |
+| `pp-teleport` source anchor | `<!--pp-teleport-from:N-->` | (none) |
+| `pp-teleport` destination | `<!--pp-teleport-to:N-->` | `<!--/pp-teleport-to-->` |
+| `<slot>` outlet | `<!--pp-slot:NAME-->` | `<!--/pp-slot-->` |
+| `{{expr}}` text segment | `<!--pp-interp-->` | (no close, single text node) |
+| Suspense pending | `<template id="pp-pl:N"></template>` | `<!--pp-pl:N-->` |
+
+**Important**: every marker is at most ~25 chars; the gzip
+overhead is negligible. The component-level `<!--pp-frag-->`
+markers are emitted only for components whose root is a multi-
+node fragment; single-root components (the common case) skip them.
+
+The keyed `pp-for` marker carries the key string verbatim so the
+client hydration can reuse SSR-computed `LoopScope` instances
+without re-evaluating `pp-key`. Keys with special chars
+(`-->`, etc.) are URL-encoded.
+
+### 5.5 State serialization — per-prepared-site fragments
+
+Yew's `use_prepared_state` (per-hook bincode + base64) and Vue's
+Pinia (per-store JSON) share a key insight: **don't ship one global
+state blob**. A global blob couples every store / server-fn / async
+component to one serialization point and adds a "load order"
+problem on the client.
+
+Pocopine's mechanism:
+
+```rust
+// In a #[component] handler or async server function:
+let user = use_prepared_state!("user", async {
+    server_fn::fetch_user(id).await
+}).await;
+```
+
+Server side, the macro emits:
+
+```rust
+// One <script> per use_prepared_state! site
+RenderedPage::state_fragments.push(format!(
+    r#"<script type="application/json" data-pp-state-id="{}">{}</script>"#,
+    SITE_ID,
+    serde_json::to_string(&value).unwrap()
+));
+```
+
+Client side, `use_prepared_state!` checks the index built during
+`App::hydrate`'s step 1 and either takes the SSR value (decoding
+via `serde_json::from_str::<T>`) or runs the closure (the CSR
+fallback / SPA navigation case).
+
+Each `#[store]` registers itself as a prepared-state site with the
+store's struct name as the `SITE_ID`. Stores are
+serialized server-side after all `serverPrefetch`-style hooks run.
+
+**Cross-request pollution**. Vue 3's documented warning
+(`https://vuejs.org/guide/scaling-up/ssr.html#cross-request-state-pollution`)
+applies to pocopine too: module-level singletons shared between
+requests leak. Pocopine adopts Pinia's pattern: `App::new()`
+builds a per-request scope tree; stores live inside that tree, not
+in module statics. Existing `pocopine_core::store::*` thread-locals
+need to migrate to a per-request arena before SSR is enabled (§7,
+implementation phase 0).
+
+### 5.6 Pre-hydration event replay (Solid model)
+
+Adopted verbatim from Solid (`dom-expressions/src/server.js:541-543`
+and `client.js:308-327`). A small inline script runs in the page
+`<head>` before any wasm loads:
+
+```javascript
+// Approx. 250 bytes minified; emitted by RenderedPage.event_replay_script
+window._pp = window._pp || {events: [], done: false};
+['click', 'input', 'submit', 'change'].forEach(t => {
+  document.addEventListener(t, e => {
+    if (window._pp.done) return;
+    window._pp.events.push([e.type, e.target, e.timeStamp]);
+  }, true);
+});
+```
+
+After `hydrate` finishes, the runtime drains `_pp.events` in
+microtask order, dispatching synthetic events on the now-bound
+target chain. Events whose target is no longer in the DOM (the
+hydrate completed, but the user clicked something the SSR didn't
+include because of a `pp-if` mismatch) are silently dropped.
+
+Event types are configurable per-page via
+`render_to_string(opts)` so a server-rendered marketing page that
+doesn't expect form submissions can ship a smaller capture script.
+
+### 5.7 Mismatch policy
+
+**Categories** (cribbed from Vue 3 `hydration.ts:964-979`):
+TEXT, CHILDREN, CLASS, STYLE, ATTRIBUTE, NODE_TYPE, FRAGMENT_BOUNDS.
+
+**Behaviour**:
+
+| Category | Dev | Production |
+|---|---|---|
+| TEXT | `console.warn` with both values, overwrite to client value | overwrite to client value, no warn |
+| CHILDREN | `console.warn`, mount missing / remove excess | mount missing / remove excess |
+| CLASS, STYLE | `console.warn`, write client value | write client value |
+| ATTRIBUTE | `console.warn`, write client value | **no-op** (Vue's choice — round-tripping every attr in production is too expensive) |
+| NODE_TYPE | `console.error`, replace node | replace node |
+| FRAGMENT_BOUNDS | `console.error`, abandon hydration of this subtree, full client mount | same as dev |
+
+**Per-element opt-out**: `pp-allow-mismatch` attribute (Vue
+`data-allow-mismatch` rebrand). Comma-separated category list:
+
+```html
+<!-- this whole subtree's mismatches are silenced -->
+<div pp-allow-mismatch>{{server_only_value}}</div>
+
+<!-- only attribute mismatches silenced -->
+<input pp-allow-mismatch="attribute" :value="client_only">
+```
+
+Both `mount` and `hydrate` strip the attribute after consuming it
+so it doesn't reach the live DOM.
+
+### 5.8 `<Transition>` during hydration — the inert-template trick
+
+This is the single non-obvious Vue trick worth copying verbatim
+(`runtime-core/hydration.ts:391-552`). Without it, `<Transition>`
+elements with `appear` flicker on first paint: the SSR rendered the
+final state, the client adds `enter-from` classes, the browser
+paints both states.
+
+Vue's solution: the SSR compiler renders any `<Transition appear>`
+child wrapped in `<template>...</template>`. The browser parses
+`<template>` as inert `DocumentFragment` content — the inner DOM
+exists but is never painted. Hydration calls `transition.beforeEnter`
+on the inner content (applies `enter-from` classes), then
+`replaceNode` swaps the `<template>` for the real element, then
+queues `transition.enter(el)` post-flush. The browser sees the
+element appear with `enter-from` already applied → animates in
+naturally.
+
+Pocopine's animation runtime (`crate::animate::*`) has the same
+contract: `apply_preset(el, in_name, out_name)` stamps
+`pp-transition:enter-start` etc. before the element enters the
+live tree. The SSR macro detects components with `transition = "..."`
+or any `pp-transition:*` attribute on the rendered root and wraps
+the element in `<template data-pp-appear="N">`. The hydrate path
+unwraps and triggers the enter.
+
+For non-`appear` transitions (the default), enter is suppressed
+on first hydrate exactly as Vue does — the element is just adopted
+in its SSR-rendered final state.
+
+### 5.9 Streaming SSR (`render_to_stream`)
+
+Adopt Solid's shell-first model (`dom-expressions/src/server.js:75-302`):
+
+1. Render the synchronous shell into the response stream, emitting
+   `<template id="pp-pl:N"></template><fallback HTML><!--pp-pl:N-->`
+   for each suspended `<Suspense>` boundary.
+2. Hold the stream open while suspended futures resolve.
+3. As each resolves, emit `<template id="pp-pl:N">...resolved
+   HTML...</template>` followed by a tiny `<script>$pp_swap("N")</script>`
+   that splices the resolved fragment in over the placeholder.
+
+The runtime swap helper (`$pp_swap`) is ~120 bytes, inlined into
+the bootstrap script.
+
+`render_to_stream` returns `impl Stream<Item = Result<Bytes, Err>>`
+so it composes naturally with Axum's `body::Body::from_stream`.
+
+For v1, streaming is **opt-in** via
+`render_to_stream_with(opts)`; the basic `render_to_string` blocks
+until all pending futures resolve. Streaming has subtle
+interactions with event replay (events dispatched on a
+not-yet-streamed subtree need to land in the queue but not be
+dropped), and we want the simple path proven first.
+
+## 6. Lessons from prior art
+
+Concrete findings from research into Solid, Vue 3, and Yew (see
+issue #14 for the long-form research notes). Each numbered finding
+maps to a design decision above.
+
+### 6.1 Solid (`dom-expressions` runtime)
+
+- **Marker scheme**: `<!--$-->` / `<!--/-->` for dynamic boundaries,
+  `data-hk` attribute for hydration keys per element. Tracked via
+  `gatherHydratable` (`querySelectorAll('*[data-hk]')` once at
+  hydrate). **Pitfall**: `gatherHydratable` snapshots once; DOM
+  mutations by third-party scripts (analytics, ad blockers) after
+  that point are invisible. → Pocopine uses sequential
+  `firstChild`/`nextSibling` walk anchored at component roots, not
+  a global registry, so we don't take this snapshot at all.
+- **Resource serialization** uses `seroval` (cyclic refs, Promises,
+  Maps, FormData). One global `_$HY.r = {}`. → Pocopine prefers
+  `serde-json` per site; we don't need cyclic refs in initial
+  state, and a single global blob is the load-order hazard Vue
+  documented.
+- **Event replay** (`_$HY.events`, ~250 bytes) — adopted (§5.6).
+- **`createUniqueId` is the dominant mismatch source**
+  (solidjs/solid#2452): conditional rendering shifts every
+  subsequent ID. → Pocopine should expose `pp_unique_id()` only
+  for hydration-stable contexts, and document that it must be
+  invariant between SSR and hydrate.
+- **Browser HTML repair breaks hydration** (`<p>` in `<p>`,
+  `<td>` outside `<tr>`, block elements in `<a>`) silently
+  invalidates the registry. → Pocopine's macro should validate
+  template HTML at compile time against an HTML5 nesting allowlist
+  (RFC 050's `html5ever` is already in the workspace; this is one
+  more validation pass).
+
+### 6.2 Vue 3 (`runtime-core/hydration.ts`)
+
+- **Per-render-effect hydration entry** (`renderer.ts:1306-1342`)
+  — no global "hydrating" flag, instead the *first* tick of each
+  render-effect routes into `hydrateNode` instead of `patch`.
+  → Pocopine adopts this exactly: no global flag in `pocopine-core`,
+  per-effect first-run suppression.
+- **Reactivity disabled during SSR** (`setInSSRSetupState`).
+  → Pocopine adopts via `with_ssr_disabled` (§5.1.1).
+- **Mismatch policy** is the most thoughtfully-tuned of the three
+  frameworks: warn + best-effort fix in dev, warn-once + leave
+  attrs alone in production, opt-out via `data-allow-mismatch`.
+  → Adopted as `pp-allow-mismatch` (§5.7).
+- **`<Transition>` inert-`<template>` trick** for `appear`
+  animations (`hydration.ts:391-552`). → Adopted (§5.8). This
+  closes the single biggest "looks janky on first paint" hazard
+  pocopine inherits from shipping animations in core.
+- **Per-request store factory** is the answer to cross-request
+  state pollution. → Documented as a pre-SSR migration in §7
+  Phase 0.
+- **`compiler-ssr` is a separate compiler** (no `hoistStatic`, no
+  `cacheHandlers`, emits `_push(\`<div…\`)` template-literal
+  builders). → Pocopine's macro emit reuses the same
+  `StaticTemplatePlan`; the divergence is the per-entry installer
+  (string buffer vs `web_sys` calls), not the plan shape.
+- **Pinia's `serverPrefetch` lifecycle + `devalue` for state
+  serialization** — pocopine uses `serde-json` instead since we're
+  not crossing a JSON-string boundary inside JS (server emits the
+  value directly into the script tag).
+
+### 6.3 Yew
+
+- **`Renderer::hydrate` walks via `firstChild`/`nextSibling`**
+  on a per-component-tree `Fragment`, asserting the DOM matches
+  the VDOM. → Pocopine adopts the walk pattern but trades the
+  asserts for the Vue mismatch-policy gradient (panic is too
+  aggressive for a framework that ships to user devices).
+- **`use_prepared_state` per-hook serialization** (bincode +
+  base64 in script tag). → Pocopine adopts the per-site model
+  (§5.5) but uses JSON for inspectability — bincode is opaque,
+  which makes hydration debugging harder for a marginal size win.
+- **Yew panics on mismatch** — closed issues #2664, #2596, #2623,
+  #4002, #3913 all stem from this. The Suspense slot-ownership
+  bugs (`DomSlot` chain poisoning) in particular are a class
+  pocopine should design out by anchoring slots at explicit
+  comment markers rather than implicit "next sibling" relationships.
+- **No event replay**, no streamed Suspense placeholders, no
+  islands. The cumulative effect is that Yew apps with large wasm
+  bundles are visually present but inert until hydration finishes
+  — issue #3619 ("SSR + hydration results in a stalled request").
+  → Pocopine ships event replay in v1 (§5.6).
+
+## 7. Pitfalls catalog
+
+Cross-referenced from the three research reports. Each entry is a
+documented bug or footgun in one or more of Solid / Vue / Yew that
+pocopine must explicitly handle or document.
+
+| # | Pitfall | Prior art | Pocopine response |
+|---|---|---|---|
+| P1 | `Math.random` / `Date.now` in render → text mismatch | Vue (docs), Solid (silent) | Documented in §5.7 mismatch categories. `pp-allow-mismatch="text"` for unavoidable cases. |
+| P2 | Date/time formatting differences (server vs client locale/timezone) | Vue (docs), Solid (silent) | Same as P1. Recommend `chrono` with explicit timezones in component handlers. |
+| P3 | `localStorage` / `sessionStorage` reads in setup | Vue (community) | `with_ssr_disabled` skips effects, but `setup` still runs server-side. Document: gate browser-only reads behind `if cfg!(target_arch = "wasm32")` or move into `on_mount`. |
+| P4 | Browser HTML repair (`<p>` in `<p>`, `<td>` outside `<tr>`) breaks marker walk | Solid (#2400, #2274), Yew (#2684) | Compile-time HTML nesting validator (`html5ever`-backed). |
+| P5 | Adjacent text-node coalescing | Solid (`<!--!$-->` separator), Yew (BText explicit handling) | Pocopine emits `<!--pp-interp-->` between adjacent dynamic text segments to keep the browser from coalescing. |
+| P6 | Browser-extension DOM injection (analytics, ad-blockers, theme toggles) | Solid (snapshot-once registry breaks), Vue (warn) | Sequential walk + per-element mismatch tolerance handles this case; `pp-allow-mismatch` on app root for paranoia. |
+| P7 | Form-field state typed by user before hydrate gets stomped | Yew (always re-applies attrs), Solid (`assignProp` short-circuits during hydrate) | Per `directives::model::install_native` (RFC 058 Phase 6.5), suppress the **first** read-side effect during hydrate so user-typed values aren't overwritten. |
+| P8 | `<Transition>` enter classes apply post-paint → flicker | Vue (inert-`<template>` trick) | §5.8 adopts the trick. |
+| P9 | `createUniqueId` / scope-id-based stable refs shifting between SSR and hydrate | Solid (#2452) | `pp_unique_id()` documented as hydration-unsafe; provide `pp_stable_id(seed)` that's deterministic per call site + render index. |
+| P10 | Suspense boundary slot-ownership races | Yew (#4002, #3913) | Slots anchor at explicit `<!--pp-slot:NAME-->` markers — slot ownership is positional, not next-sibling-implicit. |
+| P11 | Cross-request state pollution (module singletons) | Vue (docs) | §7 Phase 0 migrates `store::*` thread-locals into per-request arena. |
+| P12 | HMR + SSR registry desync | Solid (#2219) | Document as v1 limitation; HMR mode falls back to client mount. |
+| P13 | Effects firing mid-hydration mutate the DOM | Vue (per-effect first-run gate) | Each effect installed during hydrate has its first run suppressed — subscription is established, but the side effect doesn't fire until the next reactive trigger. |
+| P14 | `web_sys` calls in component handlers crash SSR | Yew (universal pitfall in Rust/wasm SSR) | `pocopine-server`'s `RenderTarget::String` impl panics on any `web_sys::*` access; the panic message points at the offending call site. Encourage moving DOM access into `on_mount`. |
+| P15 | Wasm bundle download latency leaves page inert | Yew (#3619) | §5.6 event replay buffers user input across the gap. |
+
+## 8. Implementation phases
+
+### Phase 0 — Pre-SSR migration (must land before Phase 1)
+
+1. Migrate `pocopine_core::store::*` thread-locals to a per-`App`
+   arena so SSR can run multiple `render_to_string` calls in
+   parallel without cross-pollution. Touch surface: `crates/pocopine-core/src/store.rs`,
+   `crates/pocopine-macros/src/lib.rs::store!` macro emit.
+2. Add `with_ssr_disabled` scope (§5.1.1). Gate
+   `Scope::into_proxy`, `effect`, `effect_with` on the flag.
+3. Add `RenderTarget` trait (`Dom` + `String` impls) — refactor
+   `walker::mount_component` + `apply_static_plan` to write through
+   the trait instead of calling `web_sys` directly. Behaviour
+   preserved for the `Dom` impl; `String` impl panics on every
+   method until Phase 2.
+
+### Phase 1 — Client-side hydration (no server yet)
+
+1. `#[component]` macro emits `__pp_hydrate_*` alongside `__pp_mount_*`.
+2. `App::hydrate()` entry; state-fragment scanner; per-component
+   hydrate dispatch.
+3. Each plan entry's hydrate installer (per the table in §5.2).
+4. Comment marker emission in the macro — both `mount` and
+   `hydrate` walk through the same marker positions, so emission
+   lives in the cleaned-HTML serializer.
+5. Mismatch policy + `pp-allow-mismatch` attribute.
+6. **Testing**: hand-write static HTML files mimicking the SSR
+   output (markers + state script), call `App::hydrate()`, assert
+   listeners fire + reactive updates land. No server needed.
+
+Acceptance: a Counter-shaped component hand-hydrates to fully
+interactive state, with `bind_call_count == 0` (Phase 6.5 metric)
+verifying nothing leaks back to the legacy walker.
+
+### Phase 2 — Server-side rendering
+
+1. `render_to_string<C>()` — drives the Phase 0 `RenderTarget::String`
+   impl through every plan entry.
+2. State serialization — `use_prepared_state!` macro,
+   `#[store]` per-request hooks, fragment emission.
+3. Event-replay script generation.
+4. Streaming hooks (placeholder emission for `<Suspense>`; the
+   resolution-and-flush half ships in Phase 4).
+
+Acceptance: `cargo run -p hn` (or any example with a server)
+returns SSR HTML for the initial route; the page becomes
+interactive on hydrate without reissuing the per-route fetch.
+
+### Phase 3 — `<Transition>` integration
+
+1. SSR macro detects components with `transition = "..."` /
+   `pp-transition:*` and wraps the SSR root in
+   `<template data-pp-appear="N">`.
+2. Hydrate path unwraps + invokes `animate::apply_preset` +
+   `transition::enter` post-flush.
+3. Documentation + a Pine showcase regression test for every
+   compound that uses `appear`.
+
+Acceptance: the Pine `<Dialog>` / `<Popover>` showcase pages
+render server-side and animate in on hydrate without flicker.
+
+### Phase 4 — Streaming (`render_to_stream`)
+
+1. Build the resolution pipeline for `<Suspense>` boundaries.
+2. `<template id="pp-pl:N">` + `$pp_swap("N")` runtime helper.
+3. Update event-replay queue to handle targets that arrive
+   post-shell.
+4. Axum example end-to-end.
+
+Acceptance: a deliberately-slow server-fn renders its placeholder
+in the first chunk, the resolved HTML in a later chunk, the user
+sees both transitions cleanly.
+
+### Phase 5 — Cluster-aware shell rendering (depends on RFC 058 Phase 8)
+
+When RFC 058 Phase 8 (cluster split delivery) ships, the SSR
+output emits the shell-cluster manifest and the per-route cluster
+loader runs as the route resolves. v1 ignores cluster boundaries
+and ships one wasm.
+
+## 9. Testing requirements
+
+The RFC is not implemented until tests cover:
+
+- Pure hydrate (no SSR) for every directive in `StaticTemplatePlan`:
+  `pp-text`, `pp-html`, `pp-bind:*`, `pp-on:*`, `pp-show`,
+  `pp-init`, `pp-ref`, `pp-if`, `pp-for`, `pp-teleport`, `pp-model`,
+  `<slot>`, `{{interp}}`.
+- Mismatch policy: every category triggers the documented
+  warn/recover behaviour.
+- `pp-allow-mismatch` (whole-element + per-category list) silences
+  warnings + skips per-category recovery.
+- Event replay: capture script + drain ordering, with at least
+  click + input + submit verified end-to-end.
+- `with_ssr_disabled`: effects installed within the scope don't
+  fire; reactive proxies still get/set without tracking.
+- Per-request store isolation: two concurrent `render_to_string`
+  calls don't see each other's writes.
+- `<Transition>` `appear` doesn't flicker on first hydrate
+  (visual regression: pre-paint enter-from class is set).
+- Streaming: `render_to_stream` interleaves placeholder + resolved
+  + swap-script in the right order.
+- Per-pitfall (P1–P15): a regression test per documented
+  pitfall confirming the recommended response holds.
+
+## 10. Measurement requirements
+
+Report separately for the SSR + hydrate path:
+
+- TTFB for the hn / website examples (cold + warm).
+- TTI: time from server response received to event-replay queue
+  fully drained.
+- Bundle size of the event-replay script (target ≤ 300 bytes
+  inline).
+- SSR throughput (renders/sec) for hn home + a Pine showcase
+  page.
+- Hydration cost: ms from `App::hydrate()` start to first
+  user-event-replay drain, for hn (small page) and a 500-row
+  table (large page).
+
+Compare against the matching CSR-only `App::run_compiled()` numbers
+from RFC 058 Phase 6.5 to quantify what hydration buys vs costs.
+
+## 11. Open questions
+
+1. **Async server functions and reactive subscriptions**.
+   `use_prepared_state!` is sync-only as drafted. RFC 056 server
+   functions are async. We need a clean rule for which futures
+   block the SSR shell vs which suspend (Solid's
+   `deferStream: true` is the prior art).
+2. **Hydration vs RFC 058 Phase 8 clusters**. When the shell
+   cluster hydrates, the route cluster may not have downloaded
+   yet. Does hydration block on the route cluster, or do we
+   render a placeholder + hydrate that subtree later? Solid /
+   Vue don't have a clean answer because they don't split-by-
+   default.
+3. **Devtools support**. Solid's hydration integrates with the
+   devtools panel (showing per-component hydrate timings). RFC
+   059 v1 doesn't budget for this; deferred to a follow-up.
+4. **Server-side router**. The pocopine SPA router lives entirely
+   client-side; the SSR path picks the initial route via the URL
+   passed to `render_to_string`. Should the router move to a
+   shared crate so server + client see the same matcher?
+
+## 12. Council questions
+
+1. Is the `pp-`-prefixed comment-marker namespace OK, or should
+   we adopt the shorter Solid convention (`<!--$-->` /
+   `<!--/-->`) and accept the devtools confusion cost for the
+   ~10 KB of body savings on large pages?
+2. Are we comfortable with **panic on `web_sys` access during
+   SSR** (Yew's de-facto behaviour, though more graceful) as the
+   default? The alternative is a `Mock<Element>` that absorbs
+   calls silently — but that masks real bugs.
+3. Do we ship event replay (§5.6) in v1, or defer to v2 with the
+   simpler "page is inert during the wasm-load gap" UX?
+4. Is `serde-json` the right wire format for state, or do we
+   need binary encoding (Yew's bincode + base64) for large
+   payloads? Inspectability vs size.
+5. Should `pp-allow-mismatch` accept a Rust expression for
+   conditional opt-out, or stay as the static comma-list Vue
+   uses? Conditional opt-out enables "don't warn for these specific
+   reactive states" but adds parser complexity.


### PR DESCRIPTION
## Summary

Three layered deliverables on top of `main`:

1. **RFC-058 Phase 6.5** — compiled-only walker entry (`App::run_compiled` / `walker::start_compiled`), `legacy-dom` feature gate over the entire runtime walker (dispatch, registry, `walk`/`bind`/`start`/`MutationObserver`), Pine fallback audit driven from 16 → 0 walker-required compounds.
2. **Size research** — twiggy-driven cuts for monomorphization bloat (type-erased `tick`, `transition`, `effect_with`), `HashMap` registries → static slices, defaults flipped to opt-in. Workspace adopts Yew's release profile (`opt-level = "z"`, `lto = true`, `codegen-units = 1`, `panic = "abort"`).
3. **RFC 059 revision** — comprehensive rewrite of the SSR + hydration RFC (126 → 610 lines) cross-referenced against Solid `dom-expressions`, Vue 3 `runtime-core/hydration.ts`, and Yew `dom_bundle/*`. 15 documented pitfalls cataloged; 5 council questions queued.

## Cumulative size win (Counter, no features, `run_compiled`, release + `wasm-opt`)

| Slice | gzip | Δ |
|---|---:|---:|
| Pre-Phase 6.5 baseline (`run`, full defaults) | 271,439 | — |
| Defaults flipped to opt-in | 228,131 | −43.3 KB |
| `start*` / `App::run` gated | 227,371 | −0.7 KB |
| Native `pp-model` lifted | 227,817 | +0.4 KB |
| `<slot>` in body fragments lift + role substitution | 227,817 | 0 |
| Walker dispatch + registry gated | 220,068 | −7.7 KB |
| `walk`/`bind` body stubbed | 219,422 | −0.6 KB |
| Type-erase `tick`/`transition`/`effect_with` | 210,284 | −9.1 KB |
| Directive registry → static slice | 206,490 | −3.8 KB |
| Yew release profile | 177,439 | −29.1 KB |

**−94 KB gzip / −34.6% vs the pre-Phase-6.5 baseline.**

Cross-framework comparison (jsbench harness, same Yew profile applied):

| Framework | gzip | vs pocopine |
|---|---:|---:|
| jsbench-leptos | 68.6 KB | 0.35× |
| jsbench-yew | 82.5 KB | 0.42× |
| jsbench (pocopine) | 197.1 KB | 1.00× |
| counter (pocopine) | 177.4 KB | — |

The remaining gap is intrinsic to pocopine's architectural commitments (proxy reactivity + default-on animations + runtime template registry — see issue #13 for the realistic floor analysis).

## Walker quarantine — what shipped

Compiled-only apps (no `legacy-dom`) no longer link:
- Devtools panel + scope inspector
- `MutationObserver` install + adopted-DOM auto-discovery
- `walker::start` / `start_on_body` / `App::run`
- `walker::walk` recursion + `walker::bind`
- `pp-*` attribute scan + `dispatch` + `parse_attr` + `normalise_shorthand_attr`
- 12 directive `run()` registry entries (`text`, `html`, `bind`, `on`, `show`, `model`, `init`, `route`, `for`, `if`, `teleport`, `ref`)

What's still in core (intentionally kept):
- Animation runtime (~15 KB gzip — measured by stubbing). Stays default per architectural decision in issue #13.
- Reactive proxy + effect system. Stays per architectural decision (signals rejected in issue #13).
- Compiled-views infrastructure (`apply_static_plan`, slot fragments, child mounts, controllers).

## Codex findings addressed

Three High findings on the in-progress branch (commit 6da3a7c):
1. CI: pine + walker tests now pass `--features legacy-dom` so the walker test crate compiles and Pine's `mount()` helper finds `walker::start`.
2. `start_compiled` no longer silently drops walker fallback when `legacy-dom` is off — emits a `console.error` pointing at the remediation and refuses the mount.
3. `App::run_compiled` rejects route-using apps without `legacy-dom` (router uses `walker::walk` via `<pp-outlet>`).

## RFC 059 revision highlights

The original RFC was a 126-line sketch. Revision pins each design decision against prior-art source (paths cited inline):

- **Hydration uses the same `StaticTemplatePlan` as mount** — per-entry installer differs (table in §5.2). No second hydration-only IR.
- **Per-render-effect first-run suppression** (Vue 3 `renderer.ts:1306-1342`) instead of a global hydrating flag.
- **`with_ssr_disabled` scope** (Vue 3 `setInSSRSetupState`) silences subscription tracking server-side.
- **`<Transition>` inert-`<template>` `appear` trick** (Vue 3 `hydration.ts:391-552`) — critical for pocopine since animations are default-on.
- **Pre-hydration event replay** (Solid `_$HY.events`, ~250 B inline) — buffers user input across the wasm download gap.
- **Per-`use_prepared_state!` site state fragments** (Yew model, serde-json instead of bincode) instead of one global blob.
- **Mismatch policy gradient** (Vue 3 `hydration.ts:964-979`): warn + best-effort fix in dev, attribute mismatches no-op in prod, `pp-allow-mismatch` opt-out.
- **Comment markers in `pp-` namespace** for devtools clarity (vs Solid's `<!--$-->` / Vue's `<!--[-->`).
- **15 documented pitfalls** (P1–P15) cross-referenced from Solid / Vue / Yew issue trackers, each mapped to a pocopine response.
- **5-phase implementation plan**: Phase 0 (per-request store arena + `RenderTarget` trait + `with_ssr_disabled`) → 1 (client hydrate, no server) → 2 (`render_to_string`) → 3 (transitions) → 4 (streaming).

## Test plan

- [x] `wasm-pack test --firefox --headless crates/pocopine` — 31/31 (no features)
- [x] `wasm-pack test --firefox --headless crates/pocopine --features legacy-dom` — 31 + 50/50
- [x] `wasm-pack test --firefox --headless crates/pine --features legacy-dom` — 106/106
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --exclude pocopine-cli --target wasm32-unknown-unknown --all-targets -- -D warnings` clean (both with and without `legacy-dom`)
- [x] CI matrix updated to pass `--features legacy-dom` for walker + pine jobs

## What's NOT in this PR

- Animation feature gate (rejected in issue #13 — animations stay default)
- Signals / fine-grained reactivity (rejected in issue #13 — proxy stays)
- `no_std` migration (~80 sites; multi-day refactor, separate PR)
- Bake expr AST (separate RFC)
- RFC 059 implementation (this PR ships the design only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)