### PR TITLE
RFC-060: uses as the authoritative component registry (Tiers 1-4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -641,6 +641,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "filetime"
 version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1914,7 +1920,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16ce3abbeba692c8b8441d036ef91aea6df8da2c6b6e21c7e14d3c18e526be45"
 dependencies = [
  "log",
- "phf",
+ "phf 0.11.3",
  "phf_codegen",
  "string_cache",
  "string_cache_codegen",
@@ -2147,7 +2153,18 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -2156,8 +2173,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -2166,8 +2183,31 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
  "rand 0.8.6",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.13.1",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2175,6 +2215,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -2278,6 +2327,7 @@ name = "pocopine"
 version = "0.1.0"
 dependencies = [
  "js-sys",
+ "phf 0.13.1",
  "pocopine-core",
  "pocopine-macros",
  "serde",
@@ -2307,6 +2357,7 @@ version = "0.1.0"
 dependencies = [
  "js-sys",
  "once_cell",
+ "phf 0.13.1",
  "pocopine-expr",
  "serde",
  "serde-wasm-bindgen 0.6.5",
@@ -3170,7 +3221,7 @@ checksum = "bf776ba3fa74f83bf4b63c3dcbbf82173db2632ed8452cb2d891d33f459de70f"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared",
+ "phf_shared 0.11.3",
  "precomputed-hash",
  "serde",
 ]
@@ -3181,8 +3232,8 @@ version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c711928715f1fe0fe509c53b43e993a9a557babc2d0a3567d0a3006f1ac931a0"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
 ]

--- a/crates/pine/src/calendar/grid.rs
+++ b/crates/pine/src/calendar/grid.rs
@@ -63,7 +63,8 @@ impl PineCalendarGridHead {}
 #[component(
     template = "PineCalendarGridBody.poco",
     role = "list",
-    display = "contents"
+    display = "contents",
+    uses = [crate::calendar::cell::PineCalendarCellTrigger],
 )]
 pub struct PineCalendarGridBody {
     #[observe(ROOT)]

--- a/crates/pine/src/date_picker/mod.rs
+++ b/crates/pine/src/date_picker/mod.rs
@@ -34,7 +34,21 @@ use serde::{Deserialize, Serialize};
 #[component(
     template = "PineDatePicker.poco",
     role = "interactive",
-    display = "contents"
+    display = "contents",
+    uses = [
+        crate::popover::PinePopoverRoot,
+        crate::popover::PinePopoverTrigger,
+        crate::popover::PinePopoverPortal,
+        crate::popover::PinePopoverContent,
+        crate::calendar::PineCalendarRoot,
+        crate::calendar::PineCalendarHeader,
+        crate::calendar::PineCalendarPrev,
+        crate::calendar::PineCalendarHeading,
+        crate::calendar::PineCalendarNext,
+        crate::calendar::PineCalendarGrid,
+        crate::calendar::PineCalendarGridHead,
+        crate::calendar::PineCalendarGridBody,
+    ],
 )]
 pub struct PineDatePicker {
     #[model]

--- a/crates/pine/src/date_range_field/mod.rs
+++ b/crates/pine/src/date_range_field/mod.rs
@@ -19,7 +19,8 @@ use web_sys::{Element, HtmlElement, KeyboardEvent};
 #[component(
     template = "PineDateRangeField.poco",
     role = "interactive",
-    display = "contents"
+    display = "contents",
+    uses = [crate::date_field::PineDateField],
 )]
 pub struct PineDateRangeField {
     #[model]

--- a/crates/pine/src/date_range_picker/mod.rs
+++ b/crates/pine/src/date_range_picker/mod.rs
@@ -30,7 +30,21 @@ use serde::{Deserialize, Serialize};
 #[component(
     template = "PineDateRangePicker.poco",
     role = "interactive",
-    display = "contents"
+    display = "contents",
+    uses = [
+        crate::popover::PinePopoverRoot,
+        crate::popover::PinePopoverTrigger,
+        crate::popover::PinePopoverPortal,
+        crate::popover::PinePopoverContent,
+        crate::range_calendar::PineRangeCalendarRoot,
+        crate::range_calendar::PineRangeCalendarHeader,
+        crate::range_calendar::PineRangeCalendarPrev,
+        crate::range_calendar::PineRangeCalendarHeading,
+        crate::range_calendar::PineRangeCalendarNext,
+        crate::range_calendar::PineRangeCalendarGrid,
+        crate::range_calendar::PineRangeCalendarGridHead,
+        crate::range_calendar::PineRangeCalendarGridBody,
+    ],
 )]
 pub struct PineDateRangePicker {
     #[model]

--- a/crates/pine/src/dialog/mod.rs
+++ b/crates/pine/src/dialog/mod.rs
@@ -279,3 +279,30 @@ impl PineDialogClose {
         }
     }
 }
+
+// ── Bundle marker ─────────────────────────────────────────────────
+
+/// RFC 060 Tier 3 — re-exports every Dialog part as a single
+/// `register()` target. `PineDialog::register()` registers the
+/// eight Dialog primitives (Root, Trigger, Portal, Overlay,
+/// Content, Title, Description, Close) transitively.
+///
+/// Bundle markers are tagless — `PineDialog` itself is never
+/// referenced in templates and does not appear in the runtime
+/// component registry. Authors instantiate the parts directly:
+///
+/// ```html
+/// <pine-dialog-root>…</pine-dialog-root>
+/// ```
+#[derive(Default)]
+#[component(extends = [
+    PineDialogRoot,
+    PineDialogTrigger,
+    PineDialogPortal,
+    PineDialogOverlay,
+    PineDialogContent,
+    PineDialogTitle,
+    PineDialogDescription,
+    PineDialogClose,
+])]
+pub struct PineDialog;

--- a/crates/pine/src/lib.rs
+++ b/crates/pine/src/lib.rs
@@ -107,8 +107,8 @@ pub use date_picker::PineDatePicker;
 pub use date_range_field::PineDateRangeField;
 pub use date_range_picker::PineDateRangePicker;
 pub use dialog::{
-    PineDialogClose, PineDialogContent, PineDialogDescription, PineDialogOverlay, PineDialogPortal,
-    PineDialogRoot, PineDialogTitle, PineDialogTrigger,
+    PineDialog, PineDialogClose, PineDialogContent, PineDialogDescription, PineDialogOverlay,
+    PineDialogPortal, PineDialogRoot, PineDialogTitle, PineDialogTrigger,
 };
 pub use dropdown_menu::{
     PineDropdownMenuArrow, PineDropdownMenuCheckboxItem, PineDropdownMenuContent,
@@ -227,14 +227,9 @@ pub fn register_all() {
     PineContextMenuContent::register();
     PineContextMenuItem::register();
     PineContextMenuSeparator::register();
-    PineDialogRoot::register();
-    PineDialogTrigger::register();
-    PineDialogPortal::register();
-    PineDialogOverlay::register();
-    PineDialogContent::register();
-    PineDialogTitle::register();
-    PineDialogDescription::register();
-    PineDialogClose::register();
+    // RFC 060 Tier 3 — bundle marker. `PineDialog::register()`
+    // transitively registers all eight Dialog parts.
+    PineDialog::register();
     PinePopoverRoot::register();
     PinePopoverTrigger::register();
     PinePopoverPortal::register();

--- a/crates/pine/src/range_calendar/grid.rs
+++ b/crates/pine/src/range_calendar/grid.rs
@@ -43,7 +43,8 @@ impl PineRangeCalendarGridHead {}
 #[component(
     template = "PineRangeCalendarGridBody.poco",
     role = "list",
-    display = "contents"
+    display = "contents",
+    uses = [crate::range_calendar::cell::PineRangeCalendarCellTrigger],
 )]
 pub struct PineRangeCalendarGridBody {
     #[observe(RANGE_ROOT)]

--- a/crates/pine/src/time_range_field/mod.rs
+++ b/crates/pine/src/time_range_field/mod.rs
@@ -11,7 +11,8 @@ use web_sys::{Element, HtmlElement, KeyboardEvent};
 #[component(
     template = "PineTimeRangeField.poco",
     role = "interactive",
-    display = "contents"
+    display = "contents",
+    uses = [crate::time_field::PineTimeField],
 )]
 pub struct PineTimeRangeField {
     #[model]

--- a/crates/pocopine-core/Cargo.toml
+++ b/crates/pocopine-core/Cargo.toml
@@ -29,6 +29,10 @@ serde_json = "1"
 serde-wasm-bindgen = { workspace = true }
 once_cell = { workspace = true }
 unicode-segmentation = "1"
+# RFC 060 Tier 4 — `&'static phf::Map<&'static str,
+# &'static ComponentVTable>` populated by the `app!{}` macro
+# at expansion time from an explicit `components: [...]` list.
+phf = { version = "0.13", features = ["macros"] }
 
 [dependencies.web-sys]
 version = "0.3"

--- a/crates/pocopine-core/src/app.rs
+++ b/crates/pocopine-core/src/app.rs
@@ -92,14 +92,14 @@ impl App {
         self
     }
 
-    /// RFC 060 Tier 4 — record a route without eagerly calling
-    /// `C::register()`. Used by the `app!{}` macro: the static
-    /// `&'static phf::Map` passed to [`Self::run_with_registry`]
-    /// is the authoritative registry, and this method keeps it
-    /// that way. If the macro called [`Self::route`] instead,
-    /// `C::register()` would fire unconditionally and the phf
-    /// map would no longer be the source of truth for which
-    /// components exist.
+    /// **Internal — invoked by the `app!{}` macro; do not call
+    /// directly.** Records a route without eagerly calling
+    /// `C::register()`. Safe only when paired with
+    /// [`Self::run_with_registry`]: the static `&'static phf::Map`
+    /// is the authoritative registry, and skipping the eager
+    /// `register()` keeps it that way. Direct user calls would
+    /// route to a component the registry never registered.
+    #[doc(hidden)]
     pub fn route_static<C: Component>(mut self, pattern: &'static str) -> Self {
         router::register_route(pattern.to_string(), C::NAME);
         self.routes.push(pattern);

--- a/crates/pocopine-core/src/app.rs
+++ b/crates/pocopine-core/src/app.rs
@@ -118,6 +118,25 @@ impl App {
         self
     }
 
+    /// RFC 060 Tier 4 — variant of [`Self::run`] that drives the
+    /// registry off an explicit `&'static phf::Map<&'static str,
+    /// &'static ComponentVTable>` produced by the `app!{}`
+    /// macro. Iterates the map's values and calls each vtable's
+    /// `register` fn (idempotent via the Tier 1
+    /// `mark_registered` guard) before mounting. The thread-local
+    /// runtime registries still back lookups; this method is
+    /// the bridge between the static phf surface and the
+    /// existing runtime data.
+    pub fn run_with_registry(
+        self,
+        registry: &'static phf::Map<&'static str, &'static crate::registry::ComponentVTable>,
+    ) {
+        for vtable in registry.values() {
+            (vtable.register)();
+        }
+        self.run();
+    }
+
     /// Fire pre-mount hooks, mount registered components on the body,
     /// initialise the router (if any routes were registered), then
     /// fire post-mount hooks.

--- a/crates/pocopine-core/src/app.rs
+++ b/crates/pocopine-core/src/app.rs
@@ -92,6 +92,20 @@ impl App {
         self
     }
 
+    /// RFC 060 Tier 4 — record a route without eagerly calling
+    /// `C::register()`. Used by the `app!{}` macro: the static
+    /// `&'static phf::Map` passed to [`Self::run_with_registry`]
+    /// is the authoritative registry, and this method keeps it
+    /// that way. If the macro called [`Self::route`] instead,
+    /// `C::register()` would fire unconditionally and the phf
+    /// map would no longer be the source of truth for which
+    /// components exist.
+    pub fn route_static<C: Component>(mut self, pattern: &'static str) -> Self {
+        router::register_route(pattern.to_string(), C::NAME);
+        self.routes.push(pattern);
+        self
+    }
+
     /// Run `f` before the initial DOM walk.
     pub fn before_mount(mut self, f: impl FnOnce() + 'static) -> Self {
         self.before_mount.push(Box::new(f));

--- a/crates/pocopine-core/src/lib.rs
+++ b/crates/pocopine-core/src/lib.rs
@@ -88,8 +88,8 @@ pub use reactive::{
 pub use registry::{
     assert_registry_clean, mark_registered, register_component, register_component_as,
     register_component_prefixed, registered_component_names, registry_errors, render_boot_error,
-    verify_registry, ComponentCtor, ComponentEntry, RegisteredComponent, RegistryError,
-    RegistryErrorKind, COMPONENT_ENTRIES,
+    verify_registry, ComponentCtor, ComponentEntry, ComponentVTable, RegisteredComponent,
+    RegistryError, RegistryErrorKind, COMPONENT_ENTRIES,
 };
 pub use router::{navigate, register_route};
 pub use scope::{

--- a/crates/pocopine-core/src/lib.rs
+++ b/crates/pocopine-core/src/lib.rs
@@ -86,9 +86,10 @@ pub use reactive::{
     SIGNAL_SCOPE,
 };
 pub use registry::{
-    assert_registry_clean, register_component, register_component_as, register_component_prefixed,
-    registered_component_names, registry_errors, render_boot_error, verify_registry, ComponentCtor,
-    ComponentEntry, RegisteredComponent, RegistryError, RegistryErrorKind, COMPONENT_ENTRIES,
+    assert_registry_clean, mark_registered, register_component, register_component_as,
+    register_component_prefixed, registered_component_names, registry_errors, render_boot_error,
+    verify_registry, ComponentCtor, ComponentEntry, RegisteredComponent, RegistryError,
+    RegistryErrorKind, COMPONENT_ENTRIES,
 };
 pub use router::{navigate, register_route};
 pub use scope::{

--- a/crates/pocopine-core/src/registry.rs
+++ b/crates/pocopine-core/src/registry.rs
@@ -112,6 +112,23 @@ thread_local! {
     static REGISTERED: RefCell<HashSet<TypeId>> = RefCell::new(HashSet::new());
 }
 
+/// RFC 060 Tier 4 — static vtable per `#[component]` type. The
+/// `app!{}` macro collects an explicit `components: [...]` list
+/// and emits a `&'static phf::Map<&'static str, &'static
+/// ComponentVTable>` that the runtime queries instead of (or in
+/// addition to) the legacy thread-local `HashMap`. Each entry
+/// lives in `.rodata` — no allocation, no init order.
+///
+/// The `plan` slot is reserved for the future hookup to
+/// `templates_plan::StaticTemplatePlan`; V1 leaves it `None`
+/// because the existing `register_template_plan` flow still
+/// owns plan lookup. RFC 061 / 062 will tighten this when the
+/// compiled-mount flow assumes the registry is exhaustive.
+pub struct ComponentVTable {
+    pub name: &'static str,
+    pub register: fn(),
+}
+
 /// Cycle/dedupe guard for the macro-emitted `Component::register()`
 /// body. Returns `true` the first time `T` is seen on this thread,
 /// `false` on every subsequent call. The `#[component]` macro emits

--- a/crates/pocopine-core/src/registry.rs
+++ b/crates/pocopine-core/src/registry.rs
@@ -13,8 +13,9 @@
 //! the first walk and refuse to mount when any are present (see
 //! [`verify_registry`] and [`render_boot_error`]).
 
+use std::any::TypeId;
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::scope::Scope;
 
@@ -104,6 +105,26 @@ struct Registry {
 
 thread_local! {
     static REGISTRY: RefCell<Registry> = RefCell::new(Registry::default());
+    /// RFC 060 Tier 1 — visited set of component types whose
+    /// `register()` body has already started executing on this thread.
+    /// Used by [`mark_registered`] to short-circuit transitive
+    /// `T::register()` calls emitted from `uses = [...]`.
+    static REGISTERED: RefCell<HashSet<TypeId>> = RefCell::new(HashSet::new());
+}
+
+/// Cycle/dedupe guard for the macro-emitted `Component::register()`
+/// body. Returns `true` the first time `T` is seen on this thread,
+/// `false` on every subsequent call. The `#[component]` macro emits
+/// `if !mark_registered::<Self>() { return; }` as the first statement
+/// of `register()`, so a cyclic `uses` graph (`A.uses=[B]`,
+/// `B.uses=[A]`) terminates and a converging graph short-circuits the
+/// redundant work.
+///
+/// TypeId-keyed (rather than NAME-keyed) so two distinct types sharing
+/// a NAME both reach [`register_component`] and surface
+/// [`RegistryErrorKind::DuplicateCanonicalTag`].
+pub fn mark_registered<T: 'static>() -> bool {
+    REGISTERED.with(|r| r.borrow_mut().insert(TypeId::of::<T>()))
 }
 
 /// Register `canonical` against `ctor`, attributing the entry to
@@ -282,6 +303,7 @@ pub fn __reset_for_test() {
         reg.aliases.clear();
         reg.errors.clear();
     });
+    REGISTERED.with(|r| r.borrow_mut().clear());
 }
 
 /// Render the boot-time error surface. Replaces `<body>` with a

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -697,6 +697,12 @@ struct ComponentArgs {
     /// case. Empty table means "declared but zero entries" —
     /// still opted-in for future use but no tags resolve.
     uses: Option<uses::UsesTable>,
+    /// RFC 060 Tier 3 — `extends = [...]` list. Marks this
+    /// component as a bundle: a tag-less type marker that
+    /// re-exports the registration of every type in the list
+    /// via its own `register()`. Mutually exclusive with
+    /// `template` / `template_inline`.
+    extends: Option<Vec<syn::Path>>,
 }
 
 impl Parse for ComponentArgs {
@@ -711,6 +717,10 @@ impl Parse for ComponentArgs {
                 let entries = uses::parse_uses_array(kv.value)?;
                 let table = uses::resolve_uses(entries)?;
                 args.uses = Some(table);
+                continue;
+            }
+            if kv.path.is_ident("extends") {
+                args.extends = Some(uses::parse_extends_array(kv.value)?);
                 continue;
             }
 
@@ -828,6 +838,66 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
         )
         .to_compile_error()
         .into();
+    }
+
+    // RFC 060 Tier 3 — bundle mode (`extends = [...]`) is a
+    // tagless re-export marker. It owns no template, no style,
+    // no constructor — all it does is forward `register()` to
+    // each member.
+    let is_bundle = args
+        .extends
+        .as_ref()
+        .map(|p| !p.is_empty())
+        .unwrap_or(false);
+    if is_bundle && (args.template.is_some() || args.template_inline.is_some()) {
+        return syn::Error::new_spanned(
+            &struct_ident,
+            "`extends = [...]` (bundle marker) is mutually exclusive with \
+             `template` / `template_inline` — bundles are tagless re-export \
+             markers and cannot carry their own template.",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    if is_bundle {
+        // RFC 060 Tier 3 — minimal bundle expansion. Skip every
+        // template / state / handler emission; the bundle is
+        // a tagless type marker whose `register()` just forwards
+        // to each `extends` entry. Cycle / dedupe protection
+        // comes from the Tier 1 `mark_registered` guard.
+        let extends_paths = args
+            .extends
+            .as_ref()
+            .expect("is_bundle implies extends.is_some()");
+        let extends_calls = extends_paths.iter().map(|path| {
+            quote! {
+                <#path as ::pocopine::__private::Component>::register();
+            }
+        });
+        let out = quote! {
+            #input
+
+            impl #struct_ident {
+                /// Bundle marker — registers every `extends` entry
+                /// transitively. Idempotent via the runtime
+                /// `mark_registered` guard.
+                pub fn register() {
+                    if !::pocopine::__private::mark_registered::<#struct_ident>() {
+                        return;
+                    }
+                    #(#extends_calls)*
+                }
+            }
+
+            impl ::pocopine::__private::Component for #struct_ident {
+                const NAME: &'static str = #name_str;
+                fn register() {
+                    <#struct_ident>::register();
+                }
+            }
+        };
+        return out.into();
     }
 
     let template_path: Option<LitStr> = if args.template_inline.is_some() {

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -1366,6 +1366,17 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
         _ => proc_macro2::TokenStream::new(),
     };
 
+    // RFC 060 Tier 2 — hard error on any custom-element tag in
+    // the template that isn't covered by the consumer's `uses`
+    // list. Opt-in: validation only runs when `uses = [...]` is
+    // declared.
+    let unknown_tag_diagnostics_tokens = match (&args.uses, &template_ast) {
+        (Some(uses_table), Some(ast)) => {
+            slot_assertions::emit_unknown_tag_diagnostics(ast, uses_table)
+        }
+        _ => proc_macro2::TokenStream::new(),
+    };
+
     // RFC 054 — compile row plans for eligible keyed `pp-for`
     // templates and stamp the source with `data-pp-row-plan`
     // anchors so the runtime can match the directive call back
@@ -1641,6 +1652,12 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
         // consumer didn't opt in or the template has no
         // recognised typed parents.
         #slot_assertions_tokens
+
+        // RFC 060 Tier 2 — hard `compile_error!` for every
+        // custom-element tag in the template that the consumer's
+        // `uses = [...]` doesn't cover. Opt-in: only fires when
+        // `uses` is declared.
+        #unknown_tag_diagnostics_tokens
 
         #observe_impl
 

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -1544,6 +1544,23 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
         None => quote! {},
     };
 
+    // RFC 060 Tier 1 — emit a transitive `T::register()` call per
+    // `uses = [...]` entry so the consumer's registration brings
+    // every reachable component along with it. The cycle/dedupe
+    // guard at the top of `register()` (see `mark_registered`)
+    // makes this safe for cyclic graphs.
+    let register_uses_stmts: proc_macro2::TokenStream = match args.uses.as_ref() {
+        Some(table) => {
+            let calls = table.entries.iter().map(|(_tag, type_path)| {
+                quote! {
+                    <#type_path as ::pocopine::__private::Component>::register();
+                }
+            });
+            quote! { #(#calls)* }
+        }
+        None => quote! {},
+    };
+
     // Give each registration function a distinct name so multiple components
     // in one module don't trip the `pub fn register()` duplicate.
     let _register_fn = format_ident!("__pocopine_register_{}", struct_ident);
@@ -1733,6 +1750,9 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
             /// with the pocopine runtime. Idempotent. Call directly or via
             /// [`pocopine::App::register`].
             pub fn register() {
+                if !::pocopine::__private::mark_registered::<#struct_ident>() {
+                    return;
+                }
                 ::pocopine::__private::register_component(
                     #name_str,
                     concat!(module_path!(), "::", stringify!(#struct_ident)),
@@ -1747,6 +1767,7 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
                 #register_template_stmt
                 #register_style_stmt
                 #register_display_stmt
+                #register_uses_stmts
             }
         }
 

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -843,21 +843,53 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
     // RFC 060 Tier 3 — bundle mode (`extends = [...]`) is a
     // tagless re-export marker. It owns no template, no style,
     // no constructor — all it does is forward `register()` to
-    // each member.
-    let is_bundle = args
-        .extends
-        .as_ref()
-        .map(|p| !p.is_empty())
-        .unwrap_or(false);
-    if is_bundle && (args.template.is_some() || args.template_inline.is_some()) {
-        return syn::Error::new_spanned(
-            &struct_ident,
-            "`extends = [...]` (bundle marker) is mutually exclusive with \
-             `template` / `template_inline` — bundles are tagless re-export \
-             markers and cannot carry their own template.",
-        )
-        .to_compile_error()
-        .into();
+    // each member. An empty `extends = []` is a degenerate
+    // bundle (registers nothing) and is rejected upfront so the
+    // author isn't routed into the non-bundle path with a
+    // missing-template diagnostic.
+    if let Some(paths) = args.extends.as_ref() {
+        if paths.is_empty() {
+            return syn::Error::new_spanned(
+                &struct_ident,
+                "`extends = []` is empty — bundle markers must list at least one member, \
+                 otherwise the type is a no-op. Drop the attribute or list the components.",
+            )
+            .to_compile_error()
+            .into();
+        }
+    }
+    let is_bundle = args.extends.is_some();
+    if is_bundle {
+        // Reject every component-body-only option in bundle
+        // mode. Silently dropping `style` / `role` / `display`
+        // / `transition*` / `animate` would mislead the author
+        // into thinking the bundle carries them.
+        let bundle_disallowed: &[(&str, bool)] = &[
+            ("template", args.template.is_some()),
+            ("template_inline", args.template_inline.is_some()),
+            ("style", args.style.is_some()),
+            ("role", args.role.is_some()),
+            ("display", args.display.is_some()),
+            ("transition", args.transition.is_some()),
+            ("transition_in", args.transition_in.is_some()),
+            ("transition_out", args.transition_out.is_some()),
+            ("animate", args.animate.is_some()),
+        ];
+        for (name, set) in bundle_disallowed {
+            if *set {
+                return syn::Error::new_spanned(
+                    &struct_ident,
+                    format!(
+                        "`{name} = ...` is not valid on a bundle marker \
+                         (`extends = [...]`) — bundles are tagless re-export \
+                         markers, they own no template, style, role, display, \
+                         transition, or animate metadata."
+                    ),
+                )
+                .to_compile_error()
+                .into();
+            }
+        }
     }
 
     if is_bundle {
@@ -3192,6 +3224,39 @@ fn parse_routes_array(value: Expr) -> syn::Result<Vec<AppRouteEntry>> {
 pub fn app(input: TokenStream) -> TokenStream {
     let parsed = parse_macro_input!(input as AppMacroInput);
 
+    // RFC 060 — every route target must appear in `components:`
+    // for the `&'static phf::Map` to be authoritative. Compare
+    // token strings — the user is expected to write the same
+    // path form in both lists. A `Home` route matched against a
+    // `crate::Home` component is a false negative we accept:
+    // both forms resolve to the same vtable at runtime, so the
+    // diagnostic just asks the user to align the paths.
+    let component_path_keys: std::collections::HashSet<String> = parsed
+        .components
+        .iter()
+        .map(|c| match c {
+            AppComponentEntry::Bare(p) => quote! { #p }.to_string(),
+            AppComponentEntry::Explicit(p, _) => quote! { #p }.to_string(),
+        })
+        .collect();
+    for r in &parsed.routes {
+        let path = &r.component;
+        let key = quote! { #path }.to_string();
+        if !component_path_keys.contains(&key) {
+            return syn::Error::new_spanned(
+                path,
+                format!(
+                    "route target `{key}` is not declared in `components: [...]` \
+                     — the static phf registry must be exhaustive (RFC 060 §4.3). \
+                     Add `{key}` to the `components:` list, or use the same path \
+                     form on both sides if you got an unexpected mismatch."
+                ),
+            )
+            .to_compile_error()
+            .into();
+        }
+    }
+
     // Resolve each component entry to (key, vtable_path).
     let entries = parsed.components.iter().map(|c| match c {
         AppComponentEntry::Bare(path) => {
@@ -3211,10 +3276,13 @@ pub fn app(input: TokenStream) -> TokenStream {
         quote! { #key => #vtable, }
     });
 
+    // Use `route_static` (record-only) so `C::register()` doesn't
+    // fire here — `run_with_registry` is the one and only
+    // registration path, keeping the phf map authoritative.
     let route_calls = parsed.routes.iter().map(|r| {
         let pattern = &r.pattern;
         let component = &r.component;
-        quote! { .route::<#component>(#pattern) }
+        quote! { .route_static::<#component>(#pattern) }
     });
 
     let out = quote! {

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -888,6 +888,19 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
                     }
                     #(#extends_calls)*
                 }
+
+                // RFC 060 Tier 4 — bundle vtables exist for
+                // symmetry with non-bundle components (so
+                // `app!{}`'s phf map can hold any type
+                // uniformly). The `name` is informational only —
+                // bundles aren't tag-resolvable.
+                #[doc(hidden)]
+                #[allow(non_upper_case_globals)]
+                pub const __POCO_VTABLE: &'static ::pocopine::__private::ComponentVTable =
+                    &::pocopine::__private::ComponentVTable {
+                        name: #name_str,
+                        register: <#struct_ident>::register,
+                    };
             }
 
             impl ::pocopine::__private::Component for #struct_ident {
@@ -1856,6 +1869,18 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
                 #register_display_stmt
                 #register_uses_stmts
             }
+
+            // RFC 060 Tier 4 — `&'static ComponentVTable` in
+            // `.rodata`. Consumed by the `app!{}` macro's
+            // `phf::Map` literal (vtable per component, keyed
+            // by NAME).
+            #[doc(hidden)]
+            #[allow(non_upper_case_globals)]
+            pub const __POCO_VTABLE: &'static ::pocopine::__private::ComponentVTable =
+                &::pocopine::__private::ComponentVTable {
+                    name: #name_str,
+                    register: <#struct_ident>::register,
+                };
         }
 
         impl ::pocopine::__private::Component for #struct_ident {
@@ -2954,6 +2979,256 @@ pub fn derive_emit(input: TokenStream) -> TokenStream {
                     _ => ::core::option::Option::None,
                 }
             }
+        }
+    };
+    out.into()
+}
+
+// ── RFC 060 Tier 4 — `app!{}` macro ───────────────────────────────
+
+/// One entry in the `components: [...]` list.
+enum AppComponentEntry {
+    /// `Home` — kebab-cased ident is the phf key.
+    Bare(syn::Path),
+    /// `(Home, "custom-tag")` — explicit override when the
+    /// component declared `#[component(name = "...")]`.
+    Explicit(syn::Path, LitStr),
+}
+
+/// One entry in the `routes: [...]` list — `("/path", Home)`.
+struct AppRouteEntry {
+    pattern: LitStr,
+    component: syn::Path,
+}
+
+/// Parsed body of the `app!{}` macro: explicit component list +
+/// route list. Per RFC 060 §8 Q1's chosen mechanism (Option b1):
+/// users list every reachable component explicitly so the macro
+/// can emit a `phf::phf_map!` literal at expansion time.
+struct AppMacroInput {
+    components: Vec<AppComponentEntry>,
+    routes: Vec<AppRouteEntry>,
+}
+
+impl Parse for AppMacroInput {
+    fn parse(input: ParseStream) -> syn::Result<Self> {
+        let mut components: Option<Vec<AppComponentEntry>> = None;
+        let mut routes: Option<Vec<AppRouteEntry>> = None;
+
+        while !input.is_empty() {
+            let key: syn::Ident = input.parse()?;
+            let _: Token![:] = input.parse()?;
+            let value: Expr = input.parse()?;
+            // optional trailing comma between sections
+            let _ = input.parse::<Token![,]>();
+
+            match key.to_string().as_str() {
+                "components" => {
+                    if components.is_some() {
+                        return Err(syn::Error::new(key.span(), "duplicate `components:`"));
+                    }
+                    components = Some(parse_components_array(value)?);
+                }
+                "routes" => {
+                    if routes.is_some() {
+                        return Err(syn::Error::new(key.span(), "duplicate `routes:`"));
+                    }
+                    routes = Some(parse_routes_array(value)?);
+                }
+                other => {
+                    return Err(syn::Error::new(
+                        key.span(),
+                        format!("unknown `app!{{}}` section `{other}` — expected `components:` or `routes:`"),
+                    ));
+                }
+            }
+        }
+
+        let components = components.ok_or_else(|| {
+            syn::Error::new(
+                proc_macro2::Span::call_site(),
+                "`app!{}` requires a `components: [...]` section",
+            )
+        })?;
+        let routes = routes.unwrap_or_default();
+
+        Ok(AppMacroInput { components, routes })
+    }
+}
+
+fn parse_components_array(value: Expr) -> syn::Result<Vec<AppComponentEntry>> {
+    let Expr::Array(arr) = value else {
+        return Err(syn::Error::new_spanned(
+            &value,
+            "`components` expects an array literal — \
+             `components: [Home, About, (CustomNamed, \"custom-tag\")]`",
+        ));
+    };
+    let mut out = Vec::with_capacity(arr.elems.len());
+    for elem in arr.elems {
+        match elem {
+            Expr::Path(syn::ExprPath { path, .. }) => out.push(AppComponentEntry::Bare(path)),
+            Expr::Tuple(tup) => {
+                if tup.elems.len() != 2 {
+                    return Err(syn::Error::new_spanned(
+                        &tup,
+                        "tuple `components` entries must be `(TypePath, \"tag\")` — exactly two elements",
+                    ));
+                }
+                let mut iter = tup.elems.into_iter();
+                let path = match iter.next().unwrap() {
+                    Expr::Path(p) => p.path,
+                    other => {
+                        return Err(syn::Error::new_spanned(
+                            other,
+                            "first tuple element must be a type path",
+                        ));
+                    }
+                };
+                let lit = match iter.next().unwrap() {
+                    Expr::Lit(ExprLit {
+                        lit: Lit::Str(s), ..
+                    }) => s,
+                    other => {
+                        return Err(syn::Error::new_spanned(
+                            other,
+                            "second tuple element must be a string literal tag",
+                        ));
+                    }
+                };
+                out.push(AppComponentEntry::Explicit(path, lit));
+            }
+            other => {
+                return Err(syn::Error::new_spanned(
+                    other,
+                    "components entries are either bare type paths or `(TypePath, \"tag\")` tuples",
+                ));
+            }
+        }
+    }
+    Ok(out)
+}
+
+fn parse_routes_array(value: Expr) -> syn::Result<Vec<AppRouteEntry>> {
+    let Expr::Array(arr) = value else {
+        return Err(syn::Error::new_spanned(
+            &value,
+            "`routes` expects an array literal — `routes: [(\"/\", Home), (\"/about\", About)]`",
+        ));
+    };
+    let mut out = Vec::with_capacity(arr.elems.len());
+    for elem in arr.elems {
+        let Expr::Tuple(tup) = elem else {
+            return Err(syn::Error::new_spanned(
+                &elem,
+                "route entries must be `(\"/path\", TypePath)` tuples",
+            ));
+        };
+        if tup.elems.len() != 2 {
+            return Err(syn::Error::new_spanned(
+                &tup,
+                "route entries must be `(\"/path\", TypePath)` — exactly two elements",
+            ));
+        }
+        let mut iter = tup.elems.into_iter();
+        let pattern = match iter.next().unwrap() {
+            Expr::Lit(ExprLit {
+                lit: Lit::Str(s), ..
+            }) => s,
+            other => {
+                return Err(syn::Error::new_spanned(
+                    other,
+                    "first route element must be a string literal pattern",
+                ));
+            }
+        };
+        let component = match iter.next().unwrap() {
+            Expr::Path(p) => p.path,
+            other => {
+                return Err(syn::Error::new_spanned(
+                    other,
+                    "second route element must be a component type path",
+                ));
+            }
+        };
+        out.push(AppRouteEntry { pattern, component });
+    }
+    Ok(out)
+}
+
+/// `app!{}` — single-site macro that emits a `&'static
+/// phf::Map<&'static str, &'static ComponentVTable>` from an
+/// explicit `components: [...]` list, then runs an
+/// `App::new()...route::<T>(...).run_with_registry(&REGISTRY)`
+/// chain.
+///
+/// Shape:
+///
+/// ```ignore
+/// fn main() {
+///     pocopine::app! {
+///         components: [
+///             Home,
+///             About,
+///             pine::PineButton,
+///             (CustomNamed, "custom-tag"),  // override for `#[component(name = "...")]`
+///         ],
+///         routes: [
+///             ("/", Home),
+///             ("/about", About),
+///         ],
+///     };
+/// }
+/// ```
+///
+/// Bundles (`#[component(extends = [...])]`) can appear in
+/// `components`, but their members must also be listed
+/// explicitly — proc-macros can't read const slices at
+/// expansion time, so transitive bundle expansion happens at
+/// runtime via `Bundle::register()` rather than statically in
+/// the phf map. Future work (RFC 061 / 062) may relax this if a
+/// type-level introspection mechanism becomes available.
+#[proc_macro]
+pub fn app(input: TokenStream) -> TokenStream {
+    let parsed = parse_macro_input!(input as AppMacroInput);
+
+    // Resolve each component entry to (key, vtable_path).
+    let entries = parsed.components.iter().map(|c| match c {
+        AppComponentEntry::Bare(path) => {
+            let last = path.segments.last().expect("path has at least one segment");
+            let kebab = kebab_case(&last.ident.to_string());
+            let vtable_path = quote! { #path::__POCO_VTABLE };
+            (kebab, vtable_path)
+        }
+        AppComponentEntry::Explicit(path, lit) => {
+            let kebab = lit.value();
+            let vtable_path = quote! { #path::__POCO_VTABLE };
+            (kebab, vtable_path)
+        }
+    });
+
+    let phf_arms = entries.map(|(key, vtable)| {
+        quote! { #key => #vtable, }
+    });
+
+    let route_calls = parsed.routes.iter().map(|r| {
+        let pattern = &r.pattern;
+        let component = &r.component;
+        quote! { .route::<#component>(#pattern) }
+    });
+
+    let out = quote! {
+        {
+            static REGISTRY: ::pocopine::__private::phf::Map<
+                &'static str,
+                &'static ::pocopine::__private::ComponentVTable,
+            > = ::pocopine::__private::phf::phf_map! {
+                #(#phf_arms)*
+            };
+
+            ::pocopine::App::new()
+                #(#route_calls)*
+                .run_with_registry(&REGISTRY);
         }
     };
     out.into()

--- a/crates/pocopine-macros/src/slot.rs
+++ b/crates/pocopine-macros/src/slot.rs
@@ -258,6 +258,30 @@ pub(crate) fn emit_slot_traits(
     slots: &[SlotDecl],
 ) -> TokenStream {
     let mut out = TokenStream::new();
+
+    // RFC 060 Tier 2 — emit a permissive fallback
+    // `__pocopine_assert_default_slot::<__T>()` on every
+    // component that doesn't declare a strict default slot, so
+    // RFC 049's consumer-side scan can fire on parent / child
+    // pairs where the parent is a leaf primitive (e.g.
+    // `<pine-dialog-trigger><pine-button>...`) that never
+    // opted into typed-slot validation. Strict defaults (when
+    // `#[slot(default, only = [...])]` is declared with a
+    // non-empty list) still emit their own bounded method
+    // below and shadow the fallback.
+    let has_strict_default = slots
+        .iter()
+        .any(|s| matches!(s.name, SlotName::Default) && !s.accepts.is_empty());
+    if !has_strict_default {
+        out.extend(quote! {
+            impl #struct_ident {
+                #[doc(hidden)]
+                #[allow(non_snake_case)]
+                pub fn __pocopine_assert_default_slot<__T>() {}
+            }
+        });
+    }
+
     for slot in slots {
         if slot.accepts.is_empty() {
             // Slot declared for future typed-yield use; no

--- a/crates/pocopine-macros/src/slot_assertions.rs
+++ b/crates/pocopine-macros/src/slot_assertions.rs
@@ -39,6 +39,8 @@
 //!   the trait half is proven. This commit establishes the
 //!   trait half.
 
+use std::collections::HashSet;
+
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::Path;
@@ -46,6 +48,7 @@ use syn::Path;
 use crate::slot::SlotName;
 use crate::template_parser::{Element, Node, TemplateAst};
 use crate::uses::UsesTable;
+use crate::HTML5_ELEMENTS;
 
 /// Walk `ast` alongside `uses` and emit slot-contract
 /// assertions for every typed-parent / direct-child pair.
@@ -184,6 +187,75 @@ fn emit_one_assertion(
     out.extend(assertion);
 }
 
+/// RFC 060 Tier 2 — emit `compile_error!` for every
+/// custom-element tag in `ast` not covered by `uses`. A custom
+/// element is any tag containing `-` that isn't an HTML5 native.
+/// Each unique unknown tag fires once (further occurrences in
+/// the same template are deduplicated).
+///
+/// Returns an empty `TokenStream` when every custom tag
+/// resolves. Validation only runs when the consumer declares
+/// `uses = [...]`; components without `uses` continue to
+/// compile unchecked (the brief's incremental rollout).
+pub(crate) fn emit_unknown_tag_diagnostics(ast: &TemplateAst, uses: &UsesTable) -> TokenStream {
+    let mut out = TokenStream::new();
+    let mut seen: HashSet<String> = HashSet::new();
+    for node in &ast.roots {
+        if let Node::Element(el) = node {
+            walk_for_unknown_tags(el, uses, &mut out, &mut seen);
+        }
+    }
+    out
+}
+
+fn walk_for_unknown_tags(
+    el: &Element,
+    uses: &UsesTable,
+    out: &mut TokenStream,
+    seen: &mut HashSet<String>,
+) {
+    if !el.synthetic
+        && is_custom_tag(&el.tag)
+        && uses.lookup(&el.tag).is_none()
+        && seen.insert(el.tag.clone())
+    {
+        let hint = pascal_case(&el.tag);
+        let msg = format!(
+            "tag `<{tag}>` is not declared in this component's `uses` list\n  \
+             help: add `uses = [{hint}]` to the #[component(...)] attribute,\n  \
+                   or re-export via a bundle (e.g. `uses = [pine::Dialog]`).",
+            tag = el.tag,
+        );
+        out.extend(quote! { ::core::compile_error!(#msg); });
+    }
+    for child in &el.children {
+        if let Node::Element(child_el) = child {
+            walk_for_unknown_tags(child_el, uses, out, seen);
+        }
+    }
+}
+
+/// `true` for any hyphenated tag that isn't an HTML5 native —
+/// the Custom Elements spec reserves hyphenation for custom
+/// elements, and `HTML5_ELEMENTS` is the canonical native list.
+fn is_custom_tag(tag: &str) -> bool {
+    tag.contains('-') && HTML5_ELEMENTS.binary_search(&tag).is_err()
+}
+
+fn pascal_case(kebab: &str) -> String {
+    kebab
+        .split('-')
+        .filter(|p| !p.is_empty())
+        .map(|p| {
+            let mut chars = p.chars();
+            match chars.next() {
+                Some(c) => c.to_ascii_uppercase().to_string() + chars.as_str(),
+                None => String::new(),
+            }
+        })
+        .collect()
+}
+
 /// Extract `pp-slot="NAME"` value from an element's
 /// attributes. Returns `None` if the attribute is missing or
 /// has an empty value.
@@ -314,6 +386,73 @@ mod tests {
         let uses = UsesTable::default();
         let tokens = emit_slot_assertions(&ast, &uses);
         assert!(tokens.is_empty());
+    }
+
+    // ── RFC 060 Tier 2 — unknown-tag diagnostics ──────────
+
+    #[test]
+    fn unknown_tag_emits_compile_error_with_help() {
+        let src = r#"<pine-foo><pine-bar></pine-bar></pine-foo>"#;
+        let (ast, _errors) = parse(src, "test.poco");
+        let uses = table(vec![bare("PineFoo")]);
+        let tokens = emit_unknown_tag_diagnostics(&ast, &uses);
+        let s = tokens.to_string();
+        assert!(
+            s.contains("compile_error"),
+            "expected compile_error! macro call, got:\n{s}"
+        );
+        assert!(s.contains("pine-bar"), "expected offending tag in message");
+        assert!(
+            s.contains("PineBar"),
+            "expected pascal-cased type hint, got:\n{s}"
+        );
+        assert!(
+            s.contains("uses ="),
+            "expected `uses = [...]` help text, got:\n{s}"
+        );
+    }
+
+    #[test]
+    fn known_tags_produce_no_diagnostics() {
+        let src = r#"<pine-foo><pine-bar></pine-bar></pine-foo>"#;
+        let (ast, _errors) = parse(src, "test.poco");
+        let uses = table(vec![bare("PineFoo"), bare("PineBar")]);
+        let tokens = emit_unknown_tag_diagnostics(&ast, &uses);
+        assert!(
+            tokens.is_empty(),
+            "every tag is in `uses`, expected empty diagnostics"
+        );
+    }
+
+    #[test]
+    fn html5_native_tags_are_not_flagged() {
+        // `<div>` and `<span>` are HTML5 native — never flagged
+        // even when no `uses` entry exists for them.
+        let src = r#"<div><span><pine-foo></pine-foo></span></div>"#;
+        let (ast, _errors) = parse(src, "test.poco");
+        let uses = table(vec![bare("PineFoo")]);
+        let tokens = emit_unknown_tag_diagnostics(&ast, &uses);
+        assert!(
+            tokens.is_empty(),
+            "HTML5 natives must not trigger validation, got:\n{tokens}"
+        );
+    }
+
+    #[test]
+    fn duplicate_unknown_tag_is_reported_once() {
+        let src = r#"<pine-foo><pine-bar></pine-bar><pine-bar></pine-bar></pine-foo>"#;
+        let (ast, _errors) = parse(src, "test.poco");
+        let uses = table(vec![bare("PineFoo")]);
+        let tokens = emit_unknown_tag_diagnostics(&ast, &uses);
+        let s = tokens.to_string();
+        let occurrences = s.matches("pine-bar").count();
+        // Single message — the `pine-bar` substring appears once
+        // in the format string. (If we ever change the message to
+        // include the tag twice, bump this expectation.)
+        assert_eq!(
+            occurrences, 1,
+            "the same unknown tag should fire one compile_error, got:\n{s}"
+        );
     }
 
     #[test]

--- a/crates/pocopine-macros/src/uses.rs
+++ b/crates/pocopine-macros/src/uses.rs
@@ -64,6 +64,35 @@ impl UsesTable {
     }
 }
 
+/// RFC 060 Tier 3 — parse the `extends = [...]` value of a
+/// bundle's `#[component]` attribute. Bundles re-export a fixed
+/// set of component types; the list is plain type paths only —
+/// no kebab strings, no tag overrides, no resolution table.
+/// Caller validates non-empty + mutual exclusion with
+/// `template` / `template_inline`.
+pub(crate) fn parse_extends_array(value: Expr) -> syn::Result<Vec<Path>> {
+    let Expr::Array(arr) = value else {
+        return Err(syn::Error::new(
+            value.span(),
+            "`extends` expects an array literal — `extends = [PineDialogRoot, PineDialogTrigger]`",
+        ));
+    };
+    let mut out = Vec::with_capacity(arr.elems.len());
+    for elem in arr.elems {
+        match elem {
+            Expr::Path(ExprPath { path, .. }) => out.push(path),
+            other => {
+                return Err(syn::Error::new(
+                    other.span(),
+                    "`extends` entries must be plain type paths — \
+                     `extends = [TypeA, TypeB]`",
+                ));
+            }
+        }
+    }
+    Ok(out)
+}
+
 /// Parse a `uses = [...]` value — specifically the `[...]`
 /// part — from an `Expr::Array`. Returns the raw entries; use
 /// [`resolve_uses`] to turn them into a `UsesTable`.

--- a/crates/pocopine/Cargo.toml
+++ b/crates/pocopine/Cargo.toml
@@ -23,6 +23,9 @@ js-sys = { workspace = true }
 serde = { workspace = true }
 serde-wasm-bindgen = { workspace = true }
 web-sys = { version = "0.3", features = ["Element"] }
+# RFC 060 Tier 4 — re-exported via `__private::phf` for the
+# `app!{}` macro's expansion site.
+phf = { version = "0.13", features = ["macros"] }
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/crates/pocopine/src/lib.rs
+++ b/crates/pocopine/src/lib.rs
@@ -20,18 +20,18 @@ pub use pocopine_core::{
     run_now, rw_signal, set_auto_flush, signal, spawn, spawn_latest, spawn_scoped, store,
     swap_list_indices_inline, this, trigger_scope, verify_registry, watch, watch_field,
     watch_field_scoped, watch_scope_field, watch_scope_field_now, watch_scope_field_scoped,
-    watch_scoped, App, Body, Component, ComponentState, Computed, ContextKey, ContextMarker, Doc,
-    DomEventName, EffectId, EffectOptions, El, Elapsed, Emit, Handle, HostEl, Inject, IsTeleported,
-    LifecycleContext, ListenerHandle, MountEpoch, NearestParent, Parent, ParentId, Refs,
-    RegisteredComponent, RegistryError, RegistryErrorKind, RwSignal, Scope, ScopeId, ScopePath,
-    ServerError, ServerResult, Setter, Signal, SignalId, Slots, Store, StoreHandle, TagName,
-    TaskHandle, TeleportHost, TypedEl, Win,
+    watch_scoped, App, Body, Component, ComponentState, ComponentVTable, Computed, ContextKey,
+    ContextMarker, Doc, DomEventName, EffectId, EffectOptions, El, Elapsed, Emit, Handle, HostEl,
+    Inject, IsTeleported, LifecycleContext, ListenerHandle, MountEpoch, NearestParent, Parent,
+    ParentId, Refs, RegisteredComponent, RegistryError, RegistryErrorKind, RwSignal, Scope,
+    ScopeId, ScopePath, ServerError, ServerResult, Setter, Signal, SignalId, Slots, Store,
+    StoreHandle, TagName, TaskHandle, TeleportHost, TypedEl, Win,
 };
 #[doc(inline)]
 pub use pocopine_core::{create_context, inject_key};
 // Note: `store` exists in both the value namespace (the accessor `fn store<T>()`)
 // and the macro namespace (the attribute `#[store]`). They don't collide.
-pub use pocopine_macros::{component, handlers, server, store, Emit};
+pub use pocopine_macros::{app, component, handlers, server, store, Emit};
 
 pub mod prelude {
     #[allow(deprecated)]
@@ -58,9 +58,11 @@ pub mod __private {
         register_store_scope, register_template, spawn as runtime_spawn,
         spawn_latest as runtime_spawn_latest, spawn_scoped as runtime_spawn_scoped, store_scope,
         task::TaskHandle, track, with_write_origin, BindingKind, Component, ComponentState,
-        FromHandlerArg, Handle, HandlerDispatch, LifecycleContext, Scope, StaticBinding,
-        StaticListener, StaticRowPlan, Store, WriteOrigin,
+        ComponentVTable, FromHandlerArg, Handle, HandlerDispatch, LifecycleContext, Scope,
+        StaticBinding, StaticListener, StaticRowPlan, Store, WriteOrigin,
     };
+    // RFC 060 Tier 4 — `phf` re-exported for `app!{}` macro use.
+    pub use phf;
     // RFC-058 Phase 2 — template-plan shape + registry. The
     // macro emits a `&'static StaticTemplatePlan` per component
     // and registers it via `register_template_plan` alongside the

--- a/crates/pocopine/src/lib.rs
+++ b/crates/pocopine/src/lib.rs
@@ -54,12 +54,12 @@ pub mod __private {
     pub use js_sys;
     pub use pocopine_core::{
         compile_template, component_computed, computed as runtime_computed, inject_pp_data,
-        inject_style, register_component, register_row_plans, register_store_scope,
-        register_template, spawn as runtime_spawn, spawn_latest as runtime_spawn_latest,
-        spawn_scoped as runtime_spawn_scoped, store_scope, task::TaskHandle, track,
-        with_write_origin, BindingKind, Component, ComponentState, FromHandlerArg, Handle,
-        HandlerDispatch, LifecycleContext, Scope, StaticBinding, StaticListener, StaticRowPlan,
-        Store, WriteOrigin,
+        inject_style, mark_registered, register_component, register_row_plans,
+        register_store_scope, register_template, spawn as runtime_spawn,
+        spawn_latest as runtime_spawn_latest, spawn_scoped as runtime_spawn_scoped, store_scope,
+        task::TaskHandle, track, with_write_origin, BindingKind, Component, ComponentState,
+        FromHandlerArg, Handle, HandlerDispatch, LifecycleContext, Scope, StaticBinding,
+        StaticListener, StaticRowPlan, Store, WriteOrigin,
     };
     // RFC-058 Phase 2 — template-plan shape + registry. The
     // macro emits a `&'static StaticTemplatePlan` per component

--- a/crates/pocopine/tests/adopted_dom_contract.rs
+++ b/crates/pocopine/tests/adopted_dom_contract.rs
@@ -65,12 +65,20 @@ impl AdtChild {}
 /// `materialize_adopted_slot`. Used by tests #1, #2, #3 as the
 /// boundary between "compiled host" and "adopted-DOM slot
 /// content."
+///
+/// `uses = [AdtChild]` (RFC 060 Tier 1) so registering the host
+/// transitively pulls the leaf along — historically a missed
+/// `AdtChild::register()` here silently broke case 1 (the leaf
+/// was invisible to discovery and never mounted).
 #[derive(Default, Serialize, Deserialize)]
-#[component(template_inline = r#"
+#[component(
+    template_inline = r#"
 <div class="adt-host">
   <slot></slot>
 </div>
-"#)]
+"#,
+    uses = [AdtChild],
+)]
 struct AdtHost {
     /// Backing storage for the case-2 `pp-for` items expression.
     /// Declared as a real field so the host's reactive proxy
@@ -118,7 +126,6 @@ fn doc() -> web_sys::Document {
 }
 
 fn register_all() {
-    AdtChild::register();
     AdtHost::register();
     AdtCompiledWrapper::register();
 }

--- a/crates/pocopine/tests/phf_registry.rs
+++ b/crates/pocopine/tests/phf_registry.rs
@@ -1,0 +1,124 @@
+//! RFC 060 Tier 4 — `app!{}` macro emits a `&'static
+//! phf::Map<&'static str, &'static ComponentVTable>` populated
+//! from an explicit `components: [...]` list. The phf map is
+//! the static surface; the existing thread-local runtime
+//! registries still back lookups so today's mount path keeps
+//! working unchanged.
+//!
+//! V1 scope: prove the plumbing — phf map literal compiles,
+//! `App::run_with_registry` walks each vtable's `register` fn
+//! (transitively idempotent via the Tier 1 guard), every
+//! reachable component lands in the runtime template registry.
+//!
+//! Run with:
+//!   `wasm-pack test --firefox --headless crates/pocopine --test phf_registry`
+
+#![cfg(target_arch = "wasm32")]
+
+use pocopine::prelude::*;
+use pocopine::ComponentVTable;
+use pocopine_core::templates::registered_template_names;
+use serde::{Deserialize, Serialize};
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+// ─── fixtures ───────────────────────────────────────────────────
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(name = "phf-home", template_inline = r#"<div class="phf-home"></div>"#)]
+struct PhfHome {}
+
+#[handlers]
+impl PhfHome {}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "phf-about",
+    template_inline = r#"<div class="phf-about"></div>"#
+)]
+struct PhfAbout {}
+
+#[handlers]
+impl PhfAbout {}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "phf-leaf",
+    template_inline = r#"<span class="phf-leaf"></span>"#
+)]
+struct PhfLeaf {}
+
+#[handlers]
+impl PhfLeaf {}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "phf-host",
+    template_inline = r#"<div class="phf-host"><phf-leaf></phf-leaf></div>"#,
+    uses = [PhfLeaf],
+)]
+struct PhfHost {}
+
+#[handlers]
+impl PhfHost {}
+
+// ─── tests ──────────────────────────────────────────────────────
+
+/// Each `#[component]` emits a `__POCO_VTABLE` const in
+/// `.rodata`. Confirm the static carries the right name + a
+/// callable `register` fn.
+#[wasm_bindgen_test]
+fn vtable_const_carries_name_and_register() {
+    let v: &'static ComponentVTable = PhfHome::__POCO_VTABLE;
+    assert_eq!(v.name, "phf-home");
+    (v.register)();
+    assert!(
+        registered_template_names().iter().any(|n| n == "phf-home"),
+        "vtable.register() must populate the runtime template registry",
+    );
+}
+
+/// `app!{}` emits a phf map that, when walked through
+/// `App::run_with_registry`, registers every entry. The map
+/// itself is `&'static` — proves the const surface compiles.
+#[wasm_bindgen_test]
+fn phf_map_keys_match_component_names() {
+    static REGISTRY: pocopine::__private::phf::Map<&'static str, &'static ComponentVTable> = pocopine::__private::phf::phf_map! {
+        "phf-home" => PhfHome::__POCO_VTABLE,
+        "phf-about" => PhfAbout::__POCO_VTABLE,
+    };
+
+    assert!(REGISTRY.contains_key("phf-home"));
+    assert!(REGISTRY.contains_key("phf-about"));
+    assert!(!REGISTRY.contains_key("not-registered"));
+
+    let home = REGISTRY.get("phf-home").expect("phf-home in map");
+    assert_eq!(home.name, "phf-home");
+}
+
+/// Walking the map and calling each vtable's `register` fn is
+/// what `App::run_with_registry` does. Confirm transitive
+/// closure works through the same path: registering the host
+/// also registers the leaf via the host's `uses = [PhfLeaf]`
+/// (Tier 1 transitivity).
+#[wasm_bindgen_test]
+fn run_with_registry_walks_vtables_and_transitive_uses() {
+    static REGISTRY: pocopine::__private::phf::Map<&'static str, &'static ComponentVTable> = pocopine::__private::phf::phf_map! {
+        "phf-host" => PhfHost::__POCO_VTABLE,
+    };
+
+    for vtable in REGISTRY.values() {
+        (vtable.register)();
+    }
+
+    let names = registered_template_names();
+    assert!(
+        names.iter().any(|n| n == "phf-host"),
+        "host registered via vtable",
+    );
+    assert!(
+        names.iter().any(|n| n == "phf-leaf"),
+        "leaf registered transitively through host's `uses` list (Tier 1 + Tier 4 compose)",
+    );
+}

--- a/crates/pocopine/tests/phf_registry.rs
+++ b/crates/pocopine/tests/phf_registry.rs
@@ -122,3 +122,50 @@ fn run_with_registry_walks_vtables_and_transitive_uses() {
         "leaf registered transitively through host's `uses` list (Tier 1 + Tier 4 compose)",
     );
 }
+
+// ─── route_static authority test ────────────────────────────────
+
+/// Component used only by [`route_static_does_not_eagerly_register`].
+/// The test asserts this component is NOT in the runtime registry
+/// after `route_static`, so it must never be registered anywhere
+/// else in the test suite.
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "phf-unregistered-by-route-static",
+    template_inline = r#"<div class="phf-unregistered-by-route-static"></div>"#
+)]
+struct PhfUnregisteredByRouteStatic {}
+
+#[handlers]
+impl PhfUnregisteredByRouteStatic {}
+
+/// **High-priority Codex fix.** `App::route_static::<C>` must
+/// record the route without eagerly calling `C::register()`. If
+/// it called `C::register()`, the `app!{}` macro could appear
+/// to work even when a route target is missing from the phf
+/// `components: [...]` list — silently breaking the
+/// authoritative-registry invariant. This test pins the
+/// non-registering behaviour.
+#[wasm_bindgen_test]
+fn route_static_does_not_eagerly_register_component() {
+    // Sanity: the component is NOT registered going in.
+    assert!(
+        !registered_template_names()
+            .iter()
+            .any(|n| n == "phf-unregistered-by-route-static"),
+        "fixture-unique tag must not have leaked from another test",
+    );
+
+    let _app = pocopine::App::new().route_static::<PhfUnregisteredByRouteStatic>("/never-mounted");
+
+    // After `route_static`, the component is STILL not
+    // registered. `run_with_registry` is the only registration
+    // path the macro emits — that path is exercised by the
+    // earlier tests in this file.
+    assert!(
+        !registered_template_names()
+            .iter()
+            .any(|n| n == "phf-unregistered-by-route-static"),
+        "route_static must NOT call C::register() — the static phf map is authoritative",
+    );
+}

--- a/crates/pocopine/tests/uses_bundles.rs
+++ b/crates/pocopine/tests/uses_bundles.rs
@@ -1,0 +1,148 @@
+//! RFC 060 Tier 3 — `#[component(extends = [...])]` bundle
+//! markers transitively register every member when the bundle's
+//! own `register()` runs.
+//!
+//! Locks three behaviours:
+//!
+//!   - **Single bundle**: `Bundle { extends = [A, B] }` →
+//!     `Bundle::register()` registers both A and B.
+//!   - **Nested bundle**: `Outer { extends = [Inner] }`,
+//!     `Inner { extends = [Leaf] }` → `Outer::register()`
+//!     registers Leaf.
+//!   - **Cyclic bundle**: `A { extends = [B] }`,
+//!     `B { extends = [A] }` → `A::register()` terminates and
+//!     both ends register (cycle is broken by the Tier 1
+//!     `mark_registered` guard, not compile-time detection).
+//!
+//! Run with:
+//!   `wasm-pack test --firefox --headless crates/pocopine --test uses_bundles`
+
+#![cfg(target_arch = "wasm32")]
+
+use pocopine::prelude::*;
+use pocopine_core::templates::registered_template_names;
+use serde::{Deserialize, Serialize};
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+// ─── single-bundle fixtures ─────────────────────────────────────
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "ub-leaf-a",
+    template_inline = r#"<span class="ub-leaf-a"></span>"#
+)]
+struct UbLeafA {}
+
+#[handlers]
+impl UbLeafA {}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "ub-leaf-b",
+    template_inline = r#"<span class="ub-leaf-b"></span>"#
+)]
+struct UbLeafB {}
+
+#[handlers]
+impl UbLeafB {}
+
+#[derive(Default)]
+#[component(extends = [UbLeafA, UbLeafB])]
+struct UbBundle;
+
+// ─── nested-bundle fixtures ─────────────────────────────────────
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "ub-nested-leaf",
+    template_inline = r#"<span class="ub-nested-leaf"></span>"#
+)]
+struct UbNestedLeaf {}
+
+#[handlers]
+impl UbNestedLeaf {}
+
+#[derive(Default)]
+#[component(extends = [UbNestedLeaf])]
+struct UbInner;
+
+#[derive(Default)]
+#[component(extends = [UbInner])]
+struct UbOuter;
+
+// ─── cycle fixtures ─────────────────────────────────────────────
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "ub-cycle-leaf-a",
+    template_inline = r#"<span class="ub-cycle-leaf-a"></span>"#
+)]
+struct UbCycleLeafA {}
+
+#[handlers]
+impl UbCycleLeafA {}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "ub-cycle-leaf-b",
+    template_inline = r#"<span class="ub-cycle-leaf-b"></span>"#
+)]
+struct UbCycleLeafB {}
+
+#[handlers]
+impl UbCycleLeafB {}
+
+// Two bundles whose `extends` lists reference each other.
+// Calling either one's `register()` must terminate.
+#[derive(Default)]
+#[component(extends = [UbCycleLeafA, UbCycleBundleB])]
+struct UbCycleBundleA;
+
+#[derive(Default)]
+#[component(extends = [UbCycleLeafB, UbCycleBundleA])]
+struct UbCycleBundleB;
+
+// ─── tests ──────────────────────────────────────────────────────
+
+#[wasm_bindgen_test]
+fn single_bundle_registers_every_member() {
+    UbBundle::register();
+
+    let names = registered_template_names();
+    assert!(
+        names.iter().any(|n| n == "ub-leaf-a"),
+        "UbBundle.register() must register UbLeafA",
+    );
+    assert!(
+        names.iter().any(|n| n == "ub-leaf-b"),
+        "UbBundle.register() must register UbLeafB",
+    );
+}
+
+#[wasm_bindgen_test]
+fn nested_bundle_resolves_through_intermediates() {
+    UbOuter::register();
+
+    let names = registered_template_names();
+    assert!(
+        names.iter().any(|n| n == "ub-nested-leaf"),
+        "UbOuter → UbInner → UbNestedLeaf chain must register the leaf",
+    );
+}
+
+#[wasm_bindgen_test]
+fn cyclic_bundle_terminates_via_runtime_guard() {
+    UbCycleBundleA::register();
+
+    let names = registered_template_names();
+    assert!(
+        names.iter().any(|n| n == "ub-cycle-leaf-a"),
+        "Cycle's leaf A must register",
+    );
+    assert!(
+        names.iter().any(|n| n == "ub-cycle-leaf-b"),
+        "Cycle's leaf B must register (reached via the back-edge)",
+    );
+}

--- a/crates/pocopine/tests/uses_registry_transitive.rs
+++ b/crates/pocopine/tests/uses_registry_transitive.rs
@@ -1,0 +1,157 @@
+//! RFC 060 Tier 1 — `uses = [...]` is the authoritative
+//! component registry: registering a consumer transitively pulls
+//! every type in its `uses` list along.
+//!
+//! Mounts only the root and asserts that the leaf and mid both
+//! appear in the runtime template registry. Locks two
+//! correctness properties:
+//!
+//!   - **Transitivity**: nested `uses` chains close over the
+//!     full graph (Root → Mid → Leaf).
+//!   - **No global magic**: components NOT reachable from Root's
+//!     `uses` graph are absent from the registry.
+//!   - **Cycle safety**: `A.uses=[B]`, `B.uses=[A]` terminates
+//!     because the macro emits a cycle/dedupe guard at the top
+//!     of every `register()` body.
+//!
+//! Run with:
+//!   `wasm-pack test --firefox --headless crates/pocopine --test uses_registry_transitive`
+
+#![cfg(target_arch = "wasm32")]
+
+use pocopine::prelude::*;
+use pocopine_core::templates::registered_template_names;
+use serde::{Deserialize, Serialize};
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+// ─── transitive-closure fixtures ────────────────────────────────
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "urt-leaf",
+    template_inline = r#"<span class="urt-leaf"></span>"#
+)]
+struct UrtLeaf {}
+
+#[handlers]
+impl UrtLeaf {}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "urt-mid",
+    template_inline = r#"<div class="urt-mid"><urt-leaf></urt-leaf></div>"#,
+    uses = [UrtLeaf],
+)]
+struct UrtMid {}
+
+#[handlers]
+impl UrtMid {}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "urt-root",
+    template_inline = r#"<div class="urt-root"><urt-mid></urt-mid></div>"#,
+    uses = [UrtMid],
+)]
+struct UrtRoot {}
+
+#[handlers]
+impl UrtRoot {}
+
+/// Sibling component, NOT reachable from `UrtRoot`'s `uses`
+/// closure. Has its own `register()` body but the test never
+/// calls it — used to prove the registry has no global magic.
+#[allow(dead_code)]
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "urt-sibling",
+    template_inline = r#"<span class="urt-sibling"></span>"#
+)]
+struct UrtSibling {}
+
+#[handlers]
+impl UrtSibling {}
+
+// ─── cycle fixtures ─────────────────────────────────────────────
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "urt-cycle-a",
+    template_inline = r#"<span class="urt-cycle-a"></span>"#,
+    uses = [UrtCycleB],
+)]
+struct UrtCycleA {}
+
+#[handlers]
+impl UrtCycleA {}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "urt-cycle-b",
+    template_inline = r#"<span class="urt-cycle-b"></span>"#,
+    uses = [UrtCycleA],
+)]
+struct UrtCycleB {}
+
+#[handlers]
+impl UrtCycleB {}
+
+// ─── tests ──────────────────────────────────────────────────────
+
+/// Mounting only `UrtRoot::register()` registers the entire
+/// `uses` closure: Root → Mid → Leaf all appear in the runtime
+/// template registry.
+#[wasm_bindgen_test]
+fn root_register_brings_full_uses_closure() {
+    UrtRoot::register();
+
+    let names = registered_template_names();
+    assert!(
+        names.iter().any(|n| n == "urt-root"),
+        "UrtRoot self-registers (sanity)",
+    );
+    assert!(
+        names.iter().any(|n| n == "urt-mid"),
+        "UrtMid registered transitively via Root.uses=[Mid]",
+    );
+    assert!(
+        names.iter().any(|n| n == "urt-leaf"),
+        "UrtLeaf registered transitively via Mid.uses=[Leaf]",
+    );
+}
+
+/// `UrtSibling` is not reachable from `UrtRoot`'s `uses` closure
+/// and the test never calls `UrtSibling::register()`. The
+/// registry must NOT contain it — proves the macro doesn't
+/// silently auto-register every component the linker can see.
+#[wasm_bindgen_test]
+fn unreachable_sibling_is_not_registered() {
+    UrtRoot::register();
+
+    let names = registered_template_names();
+    assert!(
+        !names.iter().any(|n| n == "urt-sibling"),
+        "UrtSibling has no path from Root.uses; must not appear in the registry",
+    );
+}
+
+/// Cyclic `uses` graph (`A.uses=[B]`, `B.uses=[A]`) terminates
+/// thanks to the macro-emitted `mark_registered::<Self>()` guard
+/// at the top of every `register()` body. Both ends end up
+/// registered.
+#[wasm_bindgen_test]
+fn cyclic_uses_graph_terminates_and_registers_both() {
+    UrtCycleA::register();
+
+    let names = registered_template_names();
+    assert!(
+        names.iter().any(|n| n == "urt-cycle-a"),
+        "UrtCycleA registers itself",
+    );
+    assert!(
+        names.iter().any(|n| n == "urt-cycle-b"),
+        "UrtCycleB registers transitively even though the graph is cyclic",
+    );
+}

--- a/examples/website/src/components/showcase/alert_dialog/mod.rs
+++ b/examples/website/src/components/showcase/alert_dialog/mod.rs
@@ -1,7 +1,7 @@
 use pine::{
     PineAlertDialogAction, PineAlertDialogCancel, PineAlertDialogContent,
     PineAlertDialogDescription, PineAlertDialogOverlay, PineAlertDialogPortal, PineAlertDialogRoot,
-    PineAlertDialogTitle, PineAlertDialogTrigger,
+    PineAlertDialogTitle, PineAlertDialogTrigger, PineButton,
 };
 use pocopine::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -22,6 +22,7 @@ use serde::{Deserialize, Serialize};
         PineAlertDialogDescription,
         PineAlertDialogAction,
         PineAlertDialogCancel,
+        PineButton,
     ]
 )]
 pub struct AlertDialogDemo {

--- a/examples/website/src/components/showcase/calendar/mod.rs
+++ b/examples/website/src/components/showcase/calendar/mod.rs
@@ -1,7 +1,7 @@
 use pine::datetime::DateValue;
 use pine::{
     PineCalendarGrid, PineCalendarGridBody, PineCalendarGridHead, PineCalendarHeader,
-    PineCalendarHeading, PineCalendarNext, PineCalendarPrev, PineCalendarRoot,
+    PineCalendarHeading, PineCalendarNext, PineCalendarPrev, PineCalendarRoot, PineSwitch,
 };
 use pocopine::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -22,6 +22,7 @@ use serde::{Deserialize, Serialize};
         PineCalendarGrid,
         PineCalendarGridHead,
         PineCalendarGridBody,
+        PineSwitch,
     ]
 )]
 pub struct CalendarDemo {

--- a/examples/website/src/components/showcase/context_menu/mod.rs
+++ b/examples/website/src/components/showcase/context_menu/mod.rs
@@ -1,4 +1,7 @@
-use pine::{PineContextMenuContent, PineContextMenuItem, PineContextMenuSeparator};
+use pine::{
+    PineContextMenuContent, PineContextMenuItem, PineContextMenuPortal, PineContextMenuRoot,
+    PineContextMenuSeparator, PineContextMenuTrigger,
+};
 use pocopine::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -7,16 +10,14 @@ use serde::{Deserialize, Serialize};
     template = "ContextMenuDemo.poco",
     style = "context_menu.css",
     role = "panel",
-    // RFC 049 reference migration: list the one typed parent
-    // (`<pine-context-menu-content>` declared `#[slot(default,
-    // only = [...])]`) and its accepted children. Other
-    // pocopine components referenced in the template
-    // (`<pine-context-menu-root>` / -trigger / -portal) don't
-    // have typed slots, so they're intentionally NOT listed
-    // here — including them would make the scan expect a
-    // <ParentType>DefaultChild trait that those primitives
-    // don't emit.
+    // RFC 060 — every custom-element tag in the template must
+    // appear in `uses`. Root/Trigger/Portal don't expose typed
+    // slot contracts (RFC 049 §4.3 still treats their children
+    // as loose) but Tier 2 requires them as registry entries.
     uses = [
+        PineContextMenuRoot,
+        PineContextMenuTrigger,
+        PineContextMenuPortal,
         PineContextMenuContent,
         PineContextMenuItem,
         PineContextMenuSeparator,

--- a/examples/website/src/components/showcase/date_picker/mod.rs
+++ b/examples/website/src/components/showcase/date_picker/mod.rs
@@ -1,8 +1,8 @@
 use pine::datetime::DateValue;
 use pine::{
     PineCalendarGrid, PineCalendarGridBody, PineCalendarGridHead, PineCalendarHeader,
-    PineCalendarHeading, PineCalendarNext, PineCalendarPrev, PineCalendarRoot, PinePopoverContent,
-    PinePopoverPortal, PinePopoverRoot, PinePopoverTrigger,
+    PineCalendarHeading, PineCalendarNext, PineCalendarPrev, PineCalendarRoot, PineDatePicker,
+    PinePopoverContent, PinePopoverPortal, PinePopoverRoot, PinePopoverTrigger,
 };
 use pocopine::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -35,6 +35,7 @@ use serde::{Deserialize, Serialize};
     // own — so it doesn't appear here. Trigger's author
     // content (a custom button) is silently skipped.
     uses = [
+        PineDatePicker,
         PinePopoverRoot,
         PinePopoverTrigger,
         PinePopoverPortal,

--- a/examples/website/src/components/showcase/dialog/mod.rs
+++ b/examples/website/src/components/showcase/dialog/mod.rs
@@ -1,6 +1,6 @@
 use pine::{
-    PineDialogClose, PineDialogContent, PineDialogDescription, PineDialogOverlay, PineDialogPortal,
-    PineDialogRoot, PineDialogTitle, PineDialogTrigger,
+    PineButton, PineDialogClose, PineDialogContent, PineDialogDescription, PineDialogOverlay,
+    PineDialogPortal, PineDialogRoot, PineDialogTitle, PineDialogTrigger,
 };
 use pocopine::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -10,18 +10,13 @@ use serde::{Deserialize, Serialize};
     template = "DialogDemo.poco",
     style = "dialog.css",
     role = "panel",
-    // RFC 049 — opt into compile-time slot-contract validation.
-    // Listing Pine types here lets `#[component]` scan the
-    // template for parent/child shape violations. The Dialog
-    // compound enforces:
+    // RFC 060 Tier 2 — every custom-element tag in the template
+    // must be declared. The Dialog compound enforces (RFC 049):
     //   Root → [Trigger, Portal]
     //   Portal → [Overlay, Content]
     //   Content → accepts [Title, Description, Close, …]
-    //
-    // Only the Dialog parts participate in the slot contract.
-    // `<pine-button>` elsewhere in the template is treated as
-    // arbitrary author content (not listed here, silently
-    // skipped by the scan per RFC 049 §4.3).
+    // PineButton is loose author content but still has to be
+    // listed so the registry walk covers it.
     uses = [
         PineDialogRoot,
         PineDialogTrigger,
@@ -31,6 +26,7 @@ use serde::{Deserialize, Serialize};
         PineDialogTitle,
         PineDialogDescription,
         PineDialogClose,
+        PineButton,
     ]
 )]
 pub struct DialogDemo {

--- a/examples/website/src/components/showcase/fieldset/mod.rs
+++ b/examples/website/src/components/showcase/fieldset/mod.rs
@@ -1,4 +1,4 @@
-use pine::{PineFieldsetLegend, PineFieldsetRoot};
+use pine::{PineButton, PineFieldsetLegend, PineFieldsetRoot};
 use pocopine::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
     uses = [
         PineFieldsetRoot,
         PineFieldsetLegend,
+        PineButton,
     ]
 )]
 pub struct FieldsetDemo {

--- a/examples/website/src/components/showcase/tags_input/mod.rs
+++ b/examples/website/src/components/showcase/tags_input/mod.rs
@@ -1,5 +1,5 @@
 use pine::{
-    PineTagsInputClear, PineTagsInputInput, PineTagsInputItem, PineTagsInputItemDelete,
+    PineButton, PineTagsInputClear, PineTagsInputInput, PineTagsInputItem, PineTagsInputItemDelete,
     PineTagsInputItemText, PineTagsInputRoot,
 };
 use pocopine::prelude::*;
@@ -19,6 +19,7 @@ use serde::{Deserialize, Serialize};
         PineTagsInputItemDelete,
         PineTagsInputInput,
         PineTagsInputClear,
+        PineButton,
     ]
 )]
 pub struct TagsInputDemo {

--- a/examples/website/src/components/showcase/tags_mentions/mod.rs
+++ b/examples/website/src/components/showcase/tags_mentions/mod.rs
@@ -1,6 +1,7 @@
 use pine::{
-    PineAvatarFallback, PineAvatarImage, PineAvatarRoot, PineTagsInputClear, PineTagsInputInput,
-    PineTagsInputItem, PineTagsInputItemDelete, PineTagsInputItemText, PineTagsInputRoot,
+    PineAvatarFallback, PineAvatarImage, PineAvatarRoot, PineButton, PineTagsInputClear,
+    PineTagsInputInput, PineTagsInputItem, PineTagsInputItemDelete, PineTagsInputItemText,
+    PineTagsInputRoot,
 };
 use pocopine::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -22,6 +23,7 @@ use serde::{Deserialize, Serialize};
         PineAvatarRoot,
         PineAvatarImage,
         PineAvatarFallback,
+        PineButton,
     ]
 )]
 pub struct TagsMentionsDemo {

--- a/examples/website/src/components/showcase/tags_skills/mod.rs
+++ b/examples/website/src/components/showcase/tags_skills/mod.rs
@@ -1,5 +1,5 @@
 use pine::{
-    PineTagsInputClear, PineTagsInputInput, PineTagsInputItem, PineTagsInputItemDelete,
+    PineButton, PineTagsInputClear, PineTagsInputInput, PineTagsInputItem, PineTagsInputItemDelete,
     PineTagsInputItemText, PineTagsInputRoot,
 };
 use pocopine::prelude::*;
@@ -18,6 +18,7 @@ use serde::{Deserialize, Serialize};
         PineTagsInputItemDelete,
         PineTagsInputInput,
         PineTagsInputClear,
+        PineButton,
     ]
 )]
 pub struct TagsSkillsDemo {

--- a/examples/website/src/components/showcase/tooltip/mod.rs
+++ b/examples/website/src/components/showcase/tooltip/mod.rs
@@ -1,5 +1,6 @@
 use pine::{
-    PineTooltipContent, PineTooltipPortal, PineTooltipProvider, PineTooltipRoot, PineTooltipTrigger,
+    PineButton, PineTooltipContent, PineTooltipPortal, PineTooltipProvider, PineTooltipRoot,
+    PineTooltipTrigger,
 };
 use pocopine::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -17,6 +18,7 @@ use serde::{Deserialize, Serialize};
         PineTooltipTrigger,
         PineTooltipPortal,
         PineTooltipContent,
+        PineButton,
     ]
 )]
 pub struct TooltipDemo {}


### PR DESCRIPTION
## Summary

Implements all four tiers of [RFC 060](./rfcs/rfc-060-component-uses-registry.md) — promotes `#[component(uses = [...])]` from a local slot-contract validator (RFC 049) into the **authoritative source of which components exist in a pocopine application**.

- **Tier 1** (5617e8e): Transitive `register()` via `uses`. The macro-emitted `pub fn register()` now recursively calls `register()` on every entry in the consumer's `uses` list. Reaching `App::route::<HomePage>()` registers everything in HomePage's transitive closure. Eliminates the "I forgot to call `Foo::register()`" footgun (the case-1 trap from `adopted_dom_contract.rs`).

- **Tier 2** (6fa90f6): Compile-time tag validation. Templates that reference custom tags not declared in `uses` fail at `cargo check` with an actionable error message + bundle hint. `unused_imports`-style warning for declared-but-unused entries.

- **Tier 3** (41fa8c9): Bundle re-exports via `extends = [...]`. Marker types declare a flat list of additional tags that flatten into any consumer's `uses`. `uses = [pine::Dialog]` resolves to the six Dialog sub-components without authors typing each one.

- **Tier 4** (508d637 + 6b7524b + 8dba00f): Build-time `phf` registry from a closure walk seeded by `App::route::<C>()`. New `app!{}` macro emits the `&'static phf::Map<&'static str, &'static ComponentVTable>` and the `App::run_with_registry(...)` call site. `App::route_static` is `#[doc(hidden)]` and contracted as macro-internal (per Codex's non-blocking review note).

## Diff scale

33 files, +1395 / -75. Most lines land in `pocopine-macros/src/lib.rs` (the four-tier macro extensions) and the new `pocopine-core/src/registry.rs` (`ComponentVTable` + `verify_registry`). Pine + website examples updated to use `app!{}` and bundle re-exports as Tier 3 dogfooding.

## Test plan

- [x] `cargo check --workspace --exclude pocopine-cli --target wasm32-unknown-unknown` clean
- [x] `wasm-pack test --firefox --headless crates/pocopine` green (existing tests + new tier-1/2/3/4 coverage)
- [x] `wasm-pack test --firefox --headless crates/pine` 106/106 green
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --exclude pocopine-cli --target wasm32-unknown-unknown --all-targets -- -D warnings` clean
- [x] Codex review pass on 6b7524b — three issues addressed (`app!{}` uses `route_static`, route targets checked against `components: [...]`, `extends = []`/body-only bundles rejected pre-expansion); one non-blocking cleanup applied in 8dba00f

## Follow-ups (not in this PR)

- **RFC 061 Phase 2** (`App::run` flips to compiled-mount-only) — now unblocked.
- **RFC 058 Phase 7** (cluster algorithm) — consumes the `phf` map this PR introduces.
- **RFC 062** (per-component mount specialization) — sequenced after RFC 061 Phase 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)