### PR TITLE
RFC-066 server-function auth + RFC-067 background jobs (Redis + memory)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,6 +297,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "bollard"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ccca1260af6a459d75994ad5acc1651bcabcbdbc41467cc9786519ab854c30"
+dependencies = [
+ "base64",
+ "bollard-stubs",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "home",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper",
+ "hyper-named-pipe",
+ "hyper-rustls",
+ "hyper-util",
+ "hyperlocal",
+ "log",
+ "pin-project-lite",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_repr",
+ "serde_urlencoded",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "winapi",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.47.1-rc.27.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f179cfbddb6e77a5472703d4b30436bff32929c0aa8a9008ecf23d1d3cdd0da"
+dependencies = [
+ "serde",
+ "serde_repr",
+ "serde_with",
+]
+
+[[package]]
 name = "boolinator"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +406,7 @@ checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "num-traits",
+ "serde",
  "windows-link",
 ]
 
@@ -535,6 +586,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -595,12 +656,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
 ]
 
 [[package]]
@@ -636,10 +732,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "docker_credential"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4564c274ebf369f501de192b02a0b81a5c4bda375abfe526aa70fc702fa6fa0"
+dependencies = [
+ "base64",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "drain_filter_polyfill"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "669a445ee724c5c69b1b06fe0b63e70a1c84bc9bb7d9696cd4f4e3ec45050408"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -677,6 +790,17 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1279,6 +1403,12 @@ checksum = "17e2ac29387b1aa07a1e448f7bb4f35b500787971e965b02842b900afa5c8f6f"
 
 [[package]]
 name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1305,6 +1435,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hn"
 version = "0.1.0"
 dependencies = [
@@ -1317,6 +1453,15 @@ dependencies = [
  "tokio",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1440,6 +1585,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-named-pipe"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
+dependencies = [
+ "hex",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+ "winapi",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1476,6 +1636,21 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1591,6 +1766,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1618,7 +1799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8a9aa791c7b5a71b636b7a68207fdebf171ddfc593d9c8506ec4cbc527b6a84"
 dependencies = [
  "implicit-clone-derive",
- "indexmap",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -1629,6 +1810,17 @@ checksum = "699c1b6d335e63d0ba5c1e1c7f647371ce989c3bcbe1f7ed2b85fa56e3bd1a21"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
 ]
 
 [[package]]
@@ -1881,7 +2073,7 @@ checksum = "9d2a0f220c8a5ef3c51199dfb9cdd702bc0eb80d52fbe70c7890adfaaae8a4b1"
 dependencies = [
  "anyhow",
  "camino",
- "indexmap",
+ "indexmap 2.14.0",
  "or_poisoned",
  "proc-macro2",
  "quote",
@@ -1958,6 +2150,12 @@ dependencies = [
  "plain",
  "redox_syscall 0.7.4",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -2232,6 +2430,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "or_poisoned"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2264,6 +2468,31 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "parse-display"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a1c2265c98e2446911282c6ac86d8524f495792c38c5bd884f80499c7538a"
+dependencies = [
+ "parse-display-derive",
+ "regex",
+ "regex-syntax",
+]
+
+[[package]]
+name = "parse-display-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ae7800a4c974efd12df917266338e79a7a74415173caf7e70aa0a0707345281"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "regex-syntax",
+ "structmeta",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2470,9 +2699,12 @@ dependencies = [
  "pocopine-jobs",
  "pocopine-macros",
  "pocopine-server",
+ "redis",
  "serde",
  "serde-wasm-bindgen 0.6.5",
  "serde_json",
+ "testcontainers",
+ "testcontainers-modules",
  "tokio",
  "tower",
  "wasm-bindgen",
@@ -2864,7 +3096,7 @@ dependencies = [
  "futures",
  "guardian",
  "hydration_context",
- "indexmap",
+ "indexmap 2.14.0",
  "or_poisoned",
  "paste",
  "pin-project-lite",
@@ -2884,7 +3116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c30fd35b7d299c591293bb69fed47a703eb2703b1cff0493e78b16ed007e5382"
 dependencies = [
  "guardian",
- "indexmap",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "or_poisoned",
  "paste",
@@ -2933,6 +3165,15 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
@@ -2947,6 +3188,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.1",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3063,6 +3324,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3074,6 +3348,27 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3119,10 +3414,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -3227,6 +3578,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3254,6 +3616,37 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_with"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5414fad8e6907dbdd5bc441a50ae8d6e26151a03b1de04d89a5576de61d01f"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3db8978e608f1fe7357e211969fd9abdcae80bac1ba7a3369bb7eb6b404eb65"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3452,6 +3845,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "structmeta"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e1575d8d40908d70f6fd05537266b90ae71b15dbbe7a8b7dffa2b759306d329"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "structmeta-derive",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "structmeta-derive"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "152a0b65a590ff6c3da95cabe2353ee04e6167c896b28e3b14478c2636c922fc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3524,7 +3940,7 @@ dependencies = [
  "erased",
  "futures",
  "html-escape",
- "indexmap",
+ "indexmap 2.14.0",
  "itertools 0.14.0",
  "js-sys",
  "next_tuple",
@@ -3570,6 +3986,44 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
+]
+
+[[package]]
+name = "testcontainers"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59a4f01f39bb10fc2a5ab23eb0d888b1e2bb168c157f61a1b98e6c501c639c74"
+dependencies = [
+ "async-trait",
+ "bollard",
+ "bollard-stubs",
+ "bytes",
+ "docker_credential",
+ "either",
+ "etcetera",
+ "futures",
+ "log",
+ "memchr",
+ "parse-display",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-tar",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "testcontainers-modules"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d43ed4e8f58424c3a2c6c56dbea6643c3c23e8666a34df13c54f0a184e6c707"
+dependencies = [
+ "testcontainers",
 ]
 
 [[package]]
@@ -3628,9 +4082,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "js-sys",
  "num-conv",
  "powerfmt",
+ "serde_core",
  "time-core",
  "time-macros",
 ]
@@ -3746,6 +4202,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tar"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5714c010ca3e5c27114c1cdeb9d14641ace49874aa5626d7149e47aedace75"
+dependencies = [
+ "filetime",
+ "futures-core",
+ "libc",
+ "redox_syscall 0.3.5",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3807,7 +4278,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "toml_datetime 0.6.11",
  "winnow 0.5.40",
 ]
@@ -3818,7 +4289,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -4007,6 +4478,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -4204,7 +4676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -4252,7 +4724,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -4300,6 +4772,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4307,6 +4795,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -4650,7 +5144,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -4681,7 +5175,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -4700,7 +5194,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -4715,6 +5209,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "xml5ever"
@@ -4749,7 +5253,7 @@ dependencies = [
  "futures",
  "gloo 0.10.0",
  "implicit-clone",
- "indexmap",
+ "indexmap 2.14.0",
  "js-sys",
  "prokio",
  "rustversion",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "annotate-snippets"
 version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -93,6 +102,15 @@ name = "anymap2"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
+
+[[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "ascii"
@@ -331,6 +349,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "windows-link",
+]
+
+[[package]]
 name = "chunked_transfer"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +427,20 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -492,6 +535,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "counter"
 version = "0.1.0"
 dependencies = [
@@ -507,6 +556,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "cron"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8c3e73077b4b4a6ab1ea5047c37c57aee77657bc8ecd6f29b0af082d0b0c07"
+dependencies = [
+ "chrono",
+ "nom",
+ "once_cell",
 ]
 
 [[package]]
@@ -1412,10 +1472,34 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1586,6 +1670,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
 
 [[package]]
+name = "inventory"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1606,6 +1699,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1800,7 +1902,7 @@ dependencies = [
  "convert_case 0.11.0",
  "convert_case_extras",
  "html-escape",
- "itertools",
+ "itertools 0.14.0",
  "leptos_hot_reload",
  "prettyplease",
  "proc-macro-error2",
@@ -1978,6 +2080,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "mio"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2013,6 +2121,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60993920e071b0c9b66f14e2b32740a4e27ffc82854dcd72035887f336a09a28"
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "notify"
 version = "6.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2041,10 +2159,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -2328,14 +2465,29 @@ version = "0.1.0"
 dependencies = [
  "js-sys",
  "phf 0.13.1",
+ "pocopine-auth",
  "pocopine-core",
+ "pocopine-jobs",
  "pocopine-macros",
+ "pocopine-server",
  "serde",
  "serde-wasm-bindgen 0.6.5",
+ "serde_json",
+ "tokio",
+ "tower",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
+]
+
+[[package]]
+name = "pocopine-auth"
+version = "0.1.0"
+dependencies = [
+ "http 1.4.0",
+ "pocopine-core",
+ "serde",
 ]
 
 [[package]]
@@ -2374,10 +2526,24 @@ name = "pocopine-expr"
 version = "0.1.0"
 
 [[package]]
+name = "pocopine-jobs"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "cron",
+ "inventory",
+ "redis",
+ "serde",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "pocopine-macros"
 version = "0.1.0"
 dependencies = [
  "annotate-snippets",
+ "cron",
  "html5ever",
  "markup5ever_rcdom",
  "pocopine-expr",
@@ -2391,6 +2557,7 @@ name = "pocopine-server"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "pocopine-auth",
  "serde",
  "serde_json",
  "tokio",
@@ -2557,7 +2724,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2594,7 +2761,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2718,7 +2885,7 @@ checksum = "c30fd35b7d299c591293bb69fed47a703eb2703b1cff0493e78b16ed007e5382"
 dependencies = [
  "guardian",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "or_poisoned",
  "paste",
  "reactive_graph",
@@ -2738,6 +2905,30 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "redis"
+version = "0.27.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d8f99a4090c89cc489a94833c901ead69bfbf3877b4867d5482e321ee875bc"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "combine",
+ "futures-util",
+ "itertools 0.13.0",
+ "itoa",
+ "num-bigint",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-util",
+ "url",
 ]
 
 [[package]]
@@ -3124,6 +3315,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3187,6 +3384,16 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "socket2"
@@ -3318,7 +3525,7 @@ dependencies = [
  "futures",
  "html-escape",
  "indexmap",
- "itertools",
+ "itertools 0.14.0",
  "js-sys",
  "next_tuple",
  "oco_ref",
@@ -3501,7 +3708,7 @@ dependencies = [
  "mio 1.2.0",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4102,10 +4309,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,11 @@ members = [
     "crates/pine-icons-macros",
     "crates/pine-motion",
     "crates/pocopine",
+    "crates/pocopine-auth",
     "crates/pocopine-cli",
     "crates/pocopine-core",
     "crates/pocopine-expr",
+    "crates/pocopine-jobs",
     "crates/pocopine-macros",
     "crates/pocopine-server",
     "examples/blog",
@@ -43,19 +45,24 @@ repository = "https://github.com/mambisi/pocopine"
 # of `pocopine` get devtools on by default via its own `default`
 # feature, which forwards `pocopine-core/devtools`.
 pocopine-core = { path = "crates/pocopine-core", version = "0.1.0", default-features = false }
+pocopine-auth = { path = "crates/pocopine-auth", version = "0.1.0" }
 pocopine-expr = { path = "crates/pocopine-expr", version = "0.1.0" }
+pocopine-jobs = { path = "crates/pocopine-jobs", version = "0.1.0" }
 pocopine-macros = { path = "crates/pocopine-macros", version = "0.1.0" }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
+http = "1"
+inventory = "0.3"
 linkme = "0.3"
 once_cell = "1"
 proc-macro2 = "1"
 quote = "1"
 syn = { version = "2", features = ["full"] }
 strsim = "0.11"
+cron = "0.12"
 
 # RFC-058 Phase 6.5 — match Yew's release-profile knobs.
 # `opt-level = "z"` collapses size-vs-speed in favour of size;

--- a/crates/pocopine-auth/Cargo.toml
+++ b/crates/pocopine-auth/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "pocopine-auth"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "First-party auth contracts and guards for pocopine server functions."
+
+[dependencies]
+pocopine-core = { workspace = true, default-features = false }
+serde = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+http = { workspace = true }

--- a/crates/pocopine-auth/src/lib.rs
+++ b/crates/pocopine-auth/src/lib.rs
@@ -81,14 +81,11 @@ impl From<&str> for Role {
 
 impl From<String> for Role {
     fn from(value: String) -> Self {
-        if value == "admin" {
-            Role::Admin
-        } else if value == "staff" {
-            Role::Staff
-        } else if value == "user" {
-            Role::User
-        } else {
-            Role::Named(value)
+        match value.as_str() {
+            "admin" => Role::Admin,
+            "staff" => Role::Staff,
+            "user" => Role::User,
+            _ => Role::Named(value),
         }
     }
 }

--- a/crates/pocopine-auth/src/lib.rs
+++ b/crates/pocopine-auth/src/lib.rs
@@ -1,0 +1,539 @@
+//! Native auth contracts for pocopine server functions.
+//!
+//! The crate stays provider-neutral. Pocopine's generated server routes
+//! build a host-only request context before decoding the server-function
+//! body; host middleware can validate a session/JWT/provider token and
+//! insert an [`AuthUser`] or [`Principal`] into request extensions.
+//! Guards then inspect that context through ordinary Rust functions.
+
+use std::fmt;
+#[cfg(not(target_arch = "wasm32"))]
+use std::future::Future;
+use std::hash::{Hash, Hasher};
+#[cfg(not(target_arch = "wasm32"))]
+use std::pin::Pin;
+
+#[cfg(not(target_arch = "wasm32"))]
+use http::{Extensions, HeaderMap, Method, Uri};
+use pocopine_core::{ServerError, ServerResult};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Default session cookie name used by the simple auth helpers.
+pub const SESSION_COOKIE: &str = "pocopine_session";
+
+/// Role attached to an authenticated user.
+///
+/// Built-ins cover the common Django-like roles. Use
+/// [`Role::named`] for app-specific roles.
+#[derive(Clone, Debug)]
+pub enum Role {
+    /// Administrative user.
+    Admin,
+    /// Staff/back-office user.
+    Staff,
+    /// Regular authenticated user.
+    User,
+    /// App-specific role name.
+    Named(String),
+}
+
+impl Role {
+    /// Build an app-specific role.
+    pub fn named(name: impl Into<String>) -> Self {
+        Self::Named(name.into())
+    }
+
+    /// Stable string representation.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Role::Admin => "admin",
+            Role::Staff => "staff",
+            Role::User => "user",
+            Role::Named(name) => name.as_str(),
+        }
+    }
+}
+
+impl PartialEq for Role {
+    fn eq(&self, other: &Self) -> bool {
+        self.as_str() == other.as_str()
+    }
+}
+
+impl Eq for Role {}
+
+impl Hash for Role {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_str().hash(state);
+    }
+}
+
+impl From<&str> for Role {
+    fn from(value: &str) -> Self {
+        match value {
+            "admin" => Role::Admin,
+            "staff" => Role::Staff,
+            "user" => Role::User,
+            other => Role::Named(other.to_string()),
+        }
+    }
+}
+
+impl From<String> for Role {
+    fn from(value: String) -> Self {
+        if value == "admin" {
+            Role::Admin
+        } else if value == "staff" {
+            Role::Staff
+        } else if value == "user" {
+            Role::User
+        } else {
+            Role::Named(value)
+        }
+    }
+}
+
+impl Serialize for Role {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for Role {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Ok(Role::from(value))
+    }
+}
+
+/// Permission attached to an authenticated user.
+#[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Permission(String);
+
+impl Permission {
+    /// Build a permission name.
+    pub fn new(name: impl Into<String>) -> Self {
+        Self(name.into())
+    }
+
+    /// Stable string representation.
+    pub fn as_str(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl From<&str> for Permission {
+    fn from(value: &str) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<String> for Permission {
+    fn from(value: String) -> Self {
+        Self::new(value)
+    }
+}
+
+/// Authenticated application user.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct AuthUser {
+    /// Stable application user id.
+    pub id: String,
+    /// Optional display/email fields for common apps.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    /// Roles granted to this user.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub roles: Vec<Role>,
+    /// Fine-grained permissions granted to this user.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub permissions: Vec<Permission>,
+}
+
+impl AuthUser {
+    /// Build a user from an application id.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            email: None,
+            name: None,
+            roles: Vec::new(),
+            permissions: Vec::new(),
+        }
+    }
+
+    /// Add an email address.
+    pub fn with_email(mut self, email: impl Into<String>) -> Self {
+        self.email = Some(email.into());
+        self
+    }
+
+    /// Add a display name.
+    pub fn with_name(mut self, name: impl Into<String>) -> Self {
+        self.name = Some(name.into());
+        self
+    }
+
+    /// Add a role.
+    pub fn with_role(mut self, role: impl Into<Role>) -> Self {
+        self.roles.push(role.into());
+        self
+    }
+
+    /// Add a permission.
+    pub fn with_permission(mut self, permission: impl Into<Permission>) -> Self {
+        self.permissions.push(permission.into());
+        self
+    }
+
+    /// Check whether the user has a role.
+    pub fn has_role(&self, role: impl Into<Role>) -> bool {
+        let role = role.into();
+        self.roles.iter().any(|candidate| candidate == &role)
+    }
+
+    /// Check whether the user has a permission.
+    pub fn has_permission(&self, permission: impl Into<Permission>) -> bool {
+        let permission = permission.into();
+        self.permissions
+            .iter()
+            .any(|candidate| candidate == &permission)
+    }
+}
+
+/// Request principal. Anonymous requests have no user, but the type still
+/// exposes role/permission probes so guard closures stay ergonomic.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Principal {
+    user: Option<AuthUser>,
+}
+
+impl Principal {
+    /// Anonymous principal.
+    pub fn anonymous() -> Self {
+        Self { user: None }
+    }
+
+    /// Authenticated principal.
+    pub fn from_user(user: AuthUser) -> Self {
+        Self { user: Some(user) }
+    }
+
+    /// Whether this request is authenticated.
+    pub fn is_authenticated(&self) -> bool {
+        self.user.is_some()
+    }
+
+    /// Authenticated user, if present.
+    pub fn user(&self) -> Option<&AuthUser> {
+        self.user.as_ref()
+    }
+
+    /// Require an authenticated user.
+    pub fn require_user(&self) -> ServerResult<&AuthUser> {
+        self.user
+            .as_ref()
+            .ok_or_else(|| ServerError::unauthorized("login required"))
+    }
+
+    /// Check whether the authenticated user has a role.
+    pub fn has_role(&self, role: impl Into<Role>) -> bool {
+        self.user
+            .as_ref()
+            .is_some_and(|user| user.has_role(role.into()))
+    }
+
+    /// Check whether the authenticated user has a permission.
+    pub fn has_permission(&self, permission: impl Into<Permission>) -> bool {
+        self.user
+            .as_ref()
+            .is_some_and(|user| user.has_permission(permission.into()))
+    }
+}
+
+impl From<AuthUser> for Principal {
+    fn from(user: AuthUser) -> Self {
+        Self::from_user(user)
+    }
+}
+
+/// Request metadata available to server-function auth guards.
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Clone, Debug)]
+pub struct RequestContext {
+    method: Method,
+    uri: Uri,
+    headers: HeaderMap,
+    /// Auth principal extracted from host middleware request extensions.
+    pub user: Principal,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl RequestContext {
+    /// Build an anonymous request context from HTTP request parts.
+    pub fn new(method: Method, uri: Uri, headers: HeaderMap) -> Self {
+        Self {
+            method,
+            uri,
+            headers,
+            user: Principal::anonymous(),
+        }
+    }
+
+    /// Build a request context and pull auth identity from extensions.
+    ///
+    /// Middleware may insert either [`Principal`] or [`AuthUser`]. If both
+    /// are present, [`Principal`] wins.
+    pub fn from_parts(
+        method: Method,
+        uri: Uri,
+        headers: HeaderMap,
+        extensions: Extensions,
+    ) -> Self {
+        let user = extensions
+            .get::<Principal>()
+            .cloned()
+            .or_else(|| {
+                extensions
+                    .get::<AuthUser>()
+                    .cloned()
+                    .map(Principal::from_user)
+            })
+            .unwrap_or_else(Principal::anonymous);
+
+        Self {
+            method,
+            uri,
+            headers,
+            user,
+        }
+    }
+
+    /// Attach an authenticated user.
+    pub fn with_user(mut self, user: AuthUser) -> Self {
+        self.user = Principal::from_user(user);
+        self
+    }
+
+    /// Attach a principal.
+    pub fn with_principal(mut self, principal: Principal) -> Self {
+        self.user = principal;
+        self
+    }
+
+    /// HTTP method used for the server-function call.
+    pub fn method(&self) -> &Method {
+        &self.method
+    }
+
+    /// Request URI used for the server-function call.
+    pub fn uri(&self) -> &Uri {
+        &self.uri
+    }
+
+    /// All request headers.
+    pub fn headers(&self) -> &HeaderMap {
+        &self.headers
+    }
+
+    /// Header value as UTF-8 text.
+    pub fn header(&self, name: &str) -> Option<&str> {
+        self.headers.get(name).and_then(|value| value.to_str().ok())
+    }
+
+    /// Bearer token from the `Authorization` header, if present.
+    pub fn bearer_token(&self) -> Option<&str> {
+        let value = self.header("authorization")?;
+        let (scheme, token) = value.split_once(' ')?;
+        if scheme.eq_ignore_ascii_case("bearer") && !token.trim().is_empty() {
+            Some(token.trim())
+        } else {
+            None
+        }
+    }
+
+    /// Cookie value by name from the `Cookie` header.
+    ///
+    /// This deliberately small parser is intended for simple session
+    /// cookies. It does not implement full RFC 6265 quoted-value parsing.
+    pub fn cookie(&self, name: &str) -> Option<&str> {
+        let cookies = self.header("cookie")?;
+        for part in cookies.split(';') {
+            if let Some((key, value)) = part.trim().split_once('=') {
+                if key.trim() == name {
+                    return Some(value.trim());
+                }
+            }
+        }
+        None
+    }
+
+    /// Session id from the default pocopine auth cookie.
+    pub fn session_id(&self) -> Option<&str> {
+        self.cookie(SESSION_COOKIE)
+    }
+
+    /// Require an authenticated user.
+    pub fn require_user(&self) -> ServerResult<&AuthUser> {
+        self.user.require_user()
+    }
+}
+
+/// Auth session metadata.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Session {
+    /// Stable session id.
+    pub id: String,
+    /// Authenticated user attached to this session.
+    pub user: AuthUser,
+    /// Optional Unix epoch expiry in milliseconds.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_at_ms: Option<u64>,
+}
+
+impl Session {
+    /// Build a session for a user.
+    pub fn new(id: impl Into<String>, user: AuthUser) -> Self {
+        Self {
+            id: id.into(),
+            user,
+            expires_at_ms: None,
+        }
+    }
+
+    /// Attach an expiry timestamp.
+    pub fn with_expires_at_ms(mut self, expires_at_ms: u64) -> Self {
+        self.expires_at_ms = Some(expires_at_ms);
+        self
+    }
+}
+
+/// Auth provider failure.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AuthError {
+    message: String,
+}
+
+impl AuthError {
+    /// Build an auth failure.
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for AuthError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for AuthError {}
+
+impl From<AuthError> for ServerError {
+    fn from(err: AuthError) -> Self {
+        ServerError::unauthorized(err.to_string())
+    }
+}
+
+/// Provider/session result type.
+pub type AuthResult<T> = Result<T, AuthError>;
+
+/// Boxed async result used by provider traits without choosing an
+/// async-trait dependency.
+#[cfg(not(target_arch = "wasm32"))]
+pub type AuthFuture<'a, T> = Pin<Box<dyn Future<Output = AuthResult<T>> + Send + 'a>>;
+
+/// Auth provider contract. Clerk/Auth0/Supabase adapters can implement
+/// this without changing the server-function guard ABI.
+#[cfg(not(target_arch = "wasm32"))]
+pub trait AuthProvider: Send + Sync {
+    /// Authenticate a request and return an optional user.
+    fn authenticate<'a>(&'a self, ctx: &'a RequestContext) -> AuthFuture<'a, Option<AuthUser>>;
+}
+
+/// Session persistence contract for first-party/simple auth.
+#[cfg(not(target_arch = "wasm32"))]
+pub trait SessionStore: Send + Sync {
+    /// Load a session by id.
+    fn load<'a>(&'a self, session_id: &'a str) -> AuthFuture<'a, Option<Session>>;
+
+    /// Save a session.
+    fn save<'a>(&'a self, session: Session) -> AuthFuture<'a, ()>;
+
+    /// Delete a session by id.
+    fn delete<'a>(&'a self, session_id: &'a str) -> AuthFuture<'a, ()>;
+}
+
+/// Ensure the request is authenticated.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn ensure_login(ctx: &RequestContext) -> ServerResult<()> {
+    ctx.require_user().map(|_| ())
+}
+
+/// Ensure the request has a role.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn ensure_role(ctx: &RequestContext, role: impl Into<Role>) -> ServerResult<()> {
+    if !ctx.user.is_authenticated() {
+        return Err(ServerError::unauthorized("login required"));
+    }
+
+    let role = role.into();
+    if ctx.user.has_role(role.clone()) {
+        Ok(())
+    } else {
+        Err(ServerError::forbidden(format!(
+            "missing role `{}`",
+            role.as_str()
+        )))
+    }
+}
+
+/// Ensure the request has a permission.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn ensure_permission(
+    ctx: &RequestContext,
+    permission: impl Into<Permission>,
+) -> ServerResult<()> {
+    if !ctx.user.is_authenticated() {
+        return Err(ServerError::unauthorized("login required"));
+    }
+
+    let permission = permission.into();
+    if ctx.user.has_permission(permission.clone()) {
+        Ok(())
+    } else {
+        Err(ServerError::forbidden(format!(
+            "missing permission `{}`",
+            permission.as_str()
+        )))
+    }
+}
+
+/// Built-in `#[server(guard = ...)]` guard requiring any logged-in user.
+#[cfg(not(target_arch = "wasm32"))]
+pub async fn require_login(ctx: RequestContext) -> ServerResult<()> {
+    ensure_login(&ctx)
+}
+
+/// Built-in `#[server(guard = ...)]` guard requiring [`Role::Admin`].
+#[cfg(not(target_arch = "wasm32"))]
+pub async fn require_admin(ctx: RequestContext) -> ServerResult<()> {
+    ensure_role(&ctx, Role::Admin)
+}
+
+/// Built-in `#[server(guard = ...)]` guard requiring [`Role::Staff`].
+#[cfg(not(target_arch = "wasm32"))]
+pub async fn require_staff(ctx: RequestContext) -> ServerResult<()> {
+    ensure_role(&ctx, Role::Staff)
+}

--- a/crates/pocopine-cli/src/main.rs
+++ b/crates/pocopine-cli/src/main.rs
@@ -513,7 +513,39 @@ fn ensure_redis_env(cmd: &mut Command) {
     }
 }
 
+fn validate_worker_backend_for_separate_process(default_redis_url: bool) -> Result<()> {
+    let backend = std::env::var("POCOPINE_JOB_BACKEND")
+        .ok()
+        .map(|value| value.trim().to_ascii_lowercase());
+    let redis_url = std::env::var("POCOPINE_REDIS_URL").ok();
+    let has_redis_url = redis_url
+        .as_deref()
+        .is_some_and(|value| !value.trim().is_empty());
+
+    match backend.as_deref() {
+        Some("memory") => bail!(
+            "`worker-bin` runs in a separate process, but POCOPINE_JOB_BACKEND=memory is process-local; use Redis for a separate worker binary or embed the worker in the server process"
+        ),
+        Some("redis") if has_redis_url => Ok(()),
+        Some("redis") if default_redis_url => Ok(()),
+        Some("redis") => bail!(
+            "`worker-bin` needs POCOPINE_REDIS_URL when POCOPINE_JOB_BACKEND=redis"
+        ),
+        Some("") => bail!("POCOPINE_JOB_BACKEND was set but empty; use `memory` or `redis`"),
+        Some(other) => bail!("unsupported POCOPINE_JOB_BACKEND `{other}`; use `memory` or `redis`"),
+        None if has_redis_url => Ok(()),
+        None if default_redis_url => Ok(()),
+        None => bail!(
+            "`worker-bin` runs in a separate process; set POCOPINE_REDIS_URL for Redis-backed jobs, or embed the worker in the server process to use the memory backend"
+        ),
+    }
+}
+
 fn run_project(path: &Path, cfg: &PocopineConfig, release: bool, port: u16) -> Result<()> {
+    if cfg.worker_bin.is_some() {
+        validate_worker_backend_for_separate_process(false)?;
+    }
+
     let worker = cfg
         .worker_bin
         .as_deref()
@@ -735,6 +767,7 @@ fn dev(args: &ServeArgs) -> Result<()> {
         }
     }
     if let Some(worker) = cfg.worker_bin.as_deref() {
+        validate_worker_backend_for_separate_process(true)?;
         bin_children.push(spawn_bin(
             &project,
             worker,

--- a/crates/pocopine-cli/src/main.rs
+++ b/crates/pocopine-cli/src/main.rs
@@ -78,6 +78,9 @@ struct PocopineConfig {
     /// Name of the server binary to spawn in `run` / `dev`. When set,
     /// `pocopine` delegates serving entirely to this bin.
     bin: Option<String>,
+    /// Name of the worker binary to spawn alongside the server/static
+    /// server in `run` / `dev`.
+    worker_bin: Option<String>,
     /// Advisory port shown in log output for server-bin mode. The bin
     /// binds whatever it wants; pocopine does not override it.
     #[allow(dead_code)]
@@ -146,6 +149,7 @@ fn main() -> Result<()> {
         Cmd::Build(a) => {
             let cfg = load_config(&a.path)?;
             build(&a.path, a.release)?;
+            build_configured_bins(&a.path, &cfg, a.release)?;
             if let Some(tw) = cfg.tailwind.as_ref() {
                 let project = a.path.canonicalize()?;
                 run_tailwind_once(&project, tw, a.release)?;
@@ -159,10 +163,7 @@ fn main() -> Result<()> {
                 let project = a.path.canonicalize()?;
                 run_tailwind_once(&project, tw, a.release)?;
             }
-            match cfg.bin.as_deref() {
-                Some(bin) => spawn_bin(&a.path, bin, a.release)?.wait_for_exit(),
-                None => serve_static(&a.path, a.port),
-            }
+            run_project(&a.path, &cfg, a.release, a.port)
         }
         Cmd::Dev(a) => dev(&a),
     }
@@ -408,29 +409,77 @@ fn build(path: &Path, release: bool) -> Result<()> {
     Ok(())
 }
 
+fn build_configured_bins(path: &Path, cfg: &PocopineConfig, release: bool) -> Result<()> {
+    for bin in configured_bins(cfg) {
+        build_bin(path, bin, release)?;
+    }
+    Ok(())
+}
+
+fn configured_bins(cfg: &PocopineConfig) -> Vec<&str> {
+    let mut bins = Vec::new();
+    if let Some(bin) = cfg.bin.as_deref() {
+        bins.push(bin);
+    }
+    if let Some(worker) = cfg.worker_bin.as_deref() {
+        if !bins.contains(&worker) {
+            bins.push(worker);
+        }
+    }
+    bins
+}
+
+fn build_bin(path: &Path, bin: &str, release: bool) -> Result<()> {
+    let project = path
+        .canonicalize()
+        .with_context(|| format!("resolve {}", path.display()))?;
+    let mut cmd = Command::new("cargo");
+    cmd.arg("build").arg("--bin").arg(bin);
+    if release {
+        cmd.arg("--release");
+    }
+    cmd.current_dir(&project);
+    println!(
+        "▶ building `{bin}` (cargo build --bin {bin} in {})",
+        project.display()
+    );
+    let status = cmd
+        .status()
+        .with_context(|| format!("failed to build configured bin `{bin}`"))?;
+    if !status.success() {
+        bail!("configured bin `{bin}` failed to build with {status}");
+    }
+    Ok(())
+}
+
 // ---------- server-bin spawn ----------
 
 struct BinChild {
     child: Child,
     bin: String,
+    role: BinRole,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BinRole {
+    Server,
+    Worker,
 }
 
 impl BinChild {
-    fn wait_for_exit(mut self) -> Result<()> {
-        let status = self.child.wait().context("waiting on server bin")?;
-        if !status.success() {
-            bail!("server bin `{}` exited with {status}", self.bin);
-        }
-        Ok(())
-    }
-
     fn kill(mut self) {
         let _ = self.child.kill();
         let _ = self.child.wait();
     }
 }
 
-fn spawn_bin(path: &Path, bin: &str, release: bool) -> Result<BinChild> {
+fn spawn_bin(
+    path: &Path,
+    bin: &str,
+    release: bool,
+    role: BinRole,
+    default_redis_url: bool,
+) -> Result<BinChild> {
     let project = path
         .canonicalize()
         .with_context(|| format!("resolve {}", path.display()))?;
@@ -440,6 +489,9 @@ fn spawn_bin(path: &Path, bin: &str, release: bool) -> Result<BinChild> {
         cmd.arg("--release");
     }
     cmd.current_dir(&project);
+    if default_redis_url {
+        ensure_redis_env(&mut cmd);
+    }
     cmd.stdout(Stdio::inherit()).stderr(Stdio::inherit());
     println!(
         "▶ spawning `{bin}` (cargo run --bin {bin} in {})",
@@ -451,7 +503,84 @@ fn spawn_bin(path: &Path, bin: &str, release: bool) -> Result<BinChild> {
     Ok(BinChild {
         child,
         bin: bin.into(),
+        role,
     })
+}
+
+fn ensure_redis_env(cmd: &mut Command) {
+    if std::env::var_os("POCOPINE_REDIS_URL").is_none() {
+        cmd.env("POCOPINE_REDIS_URL", "redis://127.0.0.1/");
+    }
+}
+
+fn run_project(path: &Path, cfg: &PocopineConfig, release: bool, port: u16) -> Result<()> {
+    let worker = cfg
+        .worker_bin
+        .as_deref()
+        .map(|bin| spawn_bin(path, bin, release, BinRole::Worker, false))
+        .transpose()?;
+
+    match cfg.bin.as_deref() {
+        Some(bin) => {
+            let server = spawn_bin(path, bin, release, BinRole::Server, false)?;
+            let mut children = Vec::new();
+            children.push(server);
+            if let Some(worker) = worker {
+                children.push(worker);
+            }
+            wait_for_children(children)
+        }
+        None => {
+            if let Some(worker) = worker {
+                let serve_path = path
+                    .canonicalize()
+                    .with_context(|| format!("bad serve dir: {}", path.display()))?;
+                thread::spawn(move || {
+                    if let Err(e) = serve_static(&serve_path, port) {
+                        eprintln!("server error: {e}");
+                    }
+                });
+                wait_for_children(vec![worker])
+            } else {
+                serve_static(path, port)
+            }
+        }
+    }
+}
+
+fn wait_for_children(mut children: Vec<BinChild>) -> Result<()> {
+    loop {
+        for index in 0..children.len() {
+            if let Some(status) = children[index]
+                .child
+                .try_wait()
+                .with_context(|| format!("poll `{}`", children[index].bin))?
+            {
+                let exited = children.swap_remove(index);
+                for child in children {
+                    child.kill();
+                }
+                if status.success() && exited.role == BinRole::Server {
+                    return Ok(());
+                }
+                bail!(
+                    "{} bin `{}` exited with {status}",
+                    exited.role.label(),
+                    exited.bin
+                );
+            }
+        }
+        thread::sleep(Duration::from_millis(250));
+    }
+}
+
+impl BinRole {
+    fn label(self) -> &'static str {
+        match self {
+            BinRole::Server => "server",
+            BinRole::Worker => "worker",
+        }
+    }
 }
 
 // ---------- static serving ----------
@@ -571,6 +700,7 @@ fn dev(args: &ServeArgs) -> Result<()> {
     let project = args.path.canonicalize()?;
     let cfg = load_config(&args.path)?;
     build(&project, args.release)?;
+    build_configured_bins(&project, &cfg, args.release)?;
 
     // Kick off Tailwind in watch mode *before* we start serving so
     // the first page load already sees compiled CSS.
@@ -585,8 +715,15 @@ fn dev(args: &ServeArgs) -> Result<()> {
 
     // Start the serving side. In bin mode the child owns its ports + routes.
     // In static mode the CLI owns the socket and runs on a background thread.
-    let bin_child = match cfg.bin.as_deref() {
-        Some(bin) => Some(spawn_bin(&project, bin, args.release)?),
+    let mut bin_children: Vec<BinChild> = Vec::new();
+    match cfg.bin.as_deref() {
+        Some(bin) => bin_children.push(spawn_bin(
+            &project,
+            bin,
+            args.release,
+            BinRole::Server,
+            true,
+        )?),
         None => {
             let serve_path = project.clone();
             let port = args.port;
@@ -595,9 +732,17 @@ fn dev(args: &ServeArgs) -> Result<()> {
                     eprintln!("server error: {e}");
                 }
             });
-            None
         }
-    };
+    }
+    if let Some(worker) = cfg.worker_bin.as_deref() {
+        bin_children.push(spawn_bin(
+            &project,
+            worker,
+            args.release,
+            BinRole::Worker,
+            true,
+        )?);
+    }
 
     let (tx, rx) = channel::<()>();
     let tx_w = tx.clone();
@@ -616,23 +761,46 @@ fn dev(args: &ServeArgs) -> Result<()> {
 
     // Handle Ctrl-C so the spawned server bin gets cleaned up.
     let result = loop {
-        if rx.recv().is_err() {
-            break Ok(());
+        if let Some(message) = poll_children(&mut bin_children)? {
+            break Err(anyhow!("{message}"));
         }
-        thread::sleep(Duration::from_millis(250));
-        while rx.try_recv().is_ok() {}
+        match rx.recv_timeout(Duration::from_millis(250)) {
+            Ok(()) => {
+                while rx.try_recv().is_ok() {}
 
-        println!("↻ rebuilding wasm…");
-        if let Err(e) = build(&project, args.release) {
-            eprintln!("build failed: {e:#}");
+                println!("↻ rebuilding wasm…");
+                if let Err(e) = build(&project, args.release) {
+                    eprintln!("build failed: {e:#}");
+                }
+            }
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break Ok(()),
         }
     };
 
-    if let Some(child) = bin_child {
+    for child in bin_children {
         child.kill();
     }
     if let Some(child) = tailwind_child {
         child.kill();
     }
     result
+}
+
+fn poll_children(children: &mut Vec<BinChild>) -> Result<Option<String>> {
+    for index in 0..children.len() {
+        if let Some(status) = children[index]
+            .child
+            .try_wait()
+            .with_context(|| format!("poll `{}`", children[index].bin))?
+        {
+            let exited = children.remove(index);
+            return Ok(Some(format!(
+                "{} bin `{}` exited with {status}",
+                exited.role.label(),
+                exited.bin
+            )));
+        }
+    }
+    Ok(None)
 }

--- a/crates/pocopine-core/src/server.rs
+++ b/crates/pocopine-core/src/server.rs
@@ -19,6 +19,12 @@ use serde::{Deserialize, Serialize};
 pub enum ServerError {
     /// An application-level error produced on the server side.
     App(String),
+    /// Authentication is required but missing or invalid.
+    Unauthorized(String),
+    /// Authentication succeeded, but this caller cannot perform the action.
+    Forbidden(String),
+    /// The request payload was malformed or exceeded the framework body limit.
+    BadRequest(String),
     /// Transport / deserialization failure on the client side.
     Network(String),
 }
@@ -27,12 +33,32 @@ impl fmt::Display for ServerError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             ServerError::App(msg) => write!(f, "server error: {msg}"),
+            ServerError::Unauthorized(msg) => write!(f, "unauthorized: {msg}"),
+            ServerError::Forbidden(msg) => write!(f, "forbidden: {msg}"),
+            ServerError::BadRequest(msg) => write!(f, "bad request: {msg}"),
             ServerError::Network(msg) => write!(f, "network error: {msg}"),
         }
     }
 }
 
 impl std::error::Error for ServerError {}
+
+impl ServerError {
+    /// Build an authentication failure.
+    pub fn unauthorized(msg: impl Into<String>) -> Self {
+        ServerError::Unauthorized(msg.into())
+    }
+
+    /// Build an authorization failure.
+    pub fn forbidden(msg: impl Into<String>) -> Self {
+        ServerError::Forbidden(msg.into())
+    }
+
+    /// Build a malformed request failure.
+    pub fn bad_request(msg: impl Into<String>) -> Self {
+        ServerError::BadRequest(msg.into())
+    }
+}
 
 impl From<String> for ServerError {
     fn from(s: String) -> Self {

--- a/crates/pocopine-jobs/Cargo.toml
+++ b/crates/pocopine-jobs/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "Redis-backed background jobs for pocopine apps."
+description = "Background jobs for pocopine apps."
 
 [dependencies]
 serde = { workspace = true }

--- a/crates/pocopine-jobs/Cargo.toml
+++ b/crates/pocopine-jobs/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "pocopine-jobs"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Redis-backed background jobs for pocopine apps."
+
+[dependencies]
+serde = { workspace = true }
+serde_json = "1"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
+cron = { workspace = true }
+inventory = { workspace = true }
+redis = { version = "0.27", features = ["tokio-comp"] }
+tokio = { version = "1", features = ["time"] }

--- a/crates/pocopine-jobs/src/lib.rs
+++ b/crates/pocopine-jobs/src/lib.rs
@@ -589,7 +589,12 @@ return redis.call(
         pub group: String,
         /// Consumer name inside the group.
         pub consumer: String,
-        /// Blocking read timeout.
+        /// Blocking read timeout for `XREADGROUP`. `0` means
+        /// "non-blocking poll" (the worker returns immediately when no
+        /// new entries are ready); a positive value caps the per-call
+        /// `BLOCK` argument. Note that Redis itself interprets
+        /// `BLOCK 0` as block forever, so this crate special-cases the
+        /// zero value rather than passing it through verbatim.
         pub block_ms: usize,
         /// Jobs idle longer than this may be reclaimed.
         pub visibility_timeout: Duration,
@@ -984,10 +989,17 @@ return redis.call(
                 .map(|queue| self.client.queue_key(queue))
                 .collect();
             let ids: Vec<&str> = streams.iter().map(|_| ">").collect();
-            let options = StreamReadOptions::default()
+            // Special-case `block_ms == 0`: don't send `BLOCK` at all,
+            // so XREADGROUP is a non-blocking poll. Redis treats
+            // `BLOCK 0` as "block forever," which is rarely what
+            // callers want and would deadlock `Worker::run_once` on
+            // an idle stream.
+            let mut options = StreamReadOptions::default()
                 .group(&self.config.group, &self.config.consumer)
-                .count(self.config.batch_size)
-                .block(self.config.block_ms);
+                .count(self.config.batch_size);
+            if self.config.block_ms > 0 {
+                options = options.block(self.config.block_ms);
+            }
             let reply: StreamReadReply = conn.xread_options(&streams, &ids, &options).await?;
 
             let mut handled = 0;

--- a/crates/pocopine-jobs/src/lib.rs
+++ b/crates/pocopine-jobs/src/lib.rs
@@ -391,6 +391,21 @@ return redis.call(
             T: Serialize,
         {
             let due_ms = epoch_ms(when)?;
+            self.schedule_json_at_ms(job_name, queue, max_attempts, payload, due_ms)
+                .await
+        }
+
+        async fn schedule_json_at_ms<T>(
+            &self,
+            job_name: &'static str,
+            queue: &'static str,
+            max_attempts: u32,
+            payload: &T,
+            due_ms: u64,
+        ) -> JobResult<JobId>
+        where
+            T: Serialize,
+        {
             let envelope = JobEnvelope::new(job_name, queue, max_attempts, payload, Some(due_ms))?;
             let id = JobId(envelope.job_id.clone());
             match &self.backend {
@@ -424,12 +439,19 @@ return redis.call(
         where
             T: Serialize,
         {
-            self.schedule_json_at(
+            let now_ms = match &self.backend {
+                JobBackend::Redis { .. } => {
+                    let mut conn = self.connection().await?;
+                    redis_time_ms(&mut conn).await?
+                }
+                JobBackend::Memory => epoch_ms(SystemTime::now())?,
+            };
+            self.schedule_json_at_ms(
                 job_name,
                 queue,
                 max_attempts,
                 payload,
-                SystemTime::now() + delay,
+                now_ms.saturating_add(duration_ms(delay)),
             )
             .await
         }
@@ -1480,6 +1502,10 @@ return redis.call(
             .duration_since(UNIX_EPOCH)
             .map_err(|err| JobError::Time(err.to_string()))?;
         Ok(duration.as_millis() as u64)
+    }
+
+    fn duration_ms(duration: Duration) -> u64 {
+        duration.as_millis().min(u128::from(u64::MAX)) as u64
     }
 
     fn default_consumer_name() -> String {

--- a/crates/pocopine-jobs/src/lib.rs
+++ b/crates/pocopine-jobs/src/lib.rs
@@ -534,6 +534,8 @@ return redis.call(
         pub visibility_timeout: Duration,
         /// Scheduler polling interval.
         pub scheduler_interval: Duration,
+        /// Maximum missed periodic slots to enqueue in one loop.
+        pub max_periodic_catch_up: usize,
         /// Max jobs read/promoted per loop.
         pub batch_size: usize,
     }
@@ -566,6 +568,10 @@ return redis.call(
                     DEFAULT_VISIBILITY_TIMEOUT_MS,
                 )?,
                 scheduler_interval: Duration::from_millis(DEFAULT_SCHEDULER_INTERVAL_MS),
+                max_periodic_catch_up: usize_env(
+                    "POCOPINE_JOB_PERIODIC_CATCH_UP_MAX",
+                    DEFAULT_MAX_PERIODIC_CATCH_UP,
+                )?,
                 batch_size: DEFAULT_BATCH_SIZE,
             })
         }
@@ -697,6 +703,7 @@ return redis.call(
                     now_ms,
                     self.config.scheduler_interval,
                     last_fired_ms,
+                    self.config.max_periodic_catch_up,
                 )? {
                     let lock_key = self.client.periodic_lock_key(descriptor.name, due_ms);
                     let expires_at_ms = now_ms.saturating_add(periodic_lock_ttl_ms(schedule));
@@ -762,6 +769,7 @@ return redis.call(
                     now_ms,
                     self.config.scheduler_interval,
                     last_fired_ms,
+                    self.config.max_periodic_catch_up,
                 )? {
                     let lock_key = self.client.periodic_lock_key(descriptor.name, due_ms);
                     let locked: Option<String> = redis::cmd("SET")
@@ -1405,11 +1413,30 @@ return redis.call(
         Ok(Duration::from_millis(value))
     }
 
+    fn usize_env(name: &str, default_value: usize) -> JobResult<usize> {
+        match std::env::var(name) {
+            Ok(raw) => parse_positive_usize(name, &raw),
+            Err(_) => Ok(default_value),
+        }
+    }
+
+    fn parse_positive_usize(name: &str, raw: &str) -> JobResult<usize> {
+        let value = raw
+            .trim()
+            .parse::<usize>()
+            .map_err(|err| JobError::Env(format!("{name} must be a positive integer: {err}")))?;
+        if value == 0 {
+            return Err(JobError::Env(format!("{name} must be greater than 0")));
+        }
+        Ok(value)
+    }
+
     fn due_periodic_slots(
         schedule: PeriodicSchedule,
         now_ms: u64,
         scheduler_interval: Duration,
         last_fired_ms: Option<u64>,
+        max_catch_up: usize,
     ) -> JobResult<Vec<u64>> {
         match schedule {
             PeriodicSchedule::Every { interval_ms } => {
@@ -1447,7 +1474,7 @@ return redis.call(
 
                 Ok(schedule
                     .after(&window_start)
-                    .take(DEFAULT_MAX_PERIODIC_CATCH_UP)
+                    .take(max_catch_up)
                     .filter_map(|due| {
                         let due_ms = due.timestamp_millis();
                         (due_ms >= 0 && due_ms as u64 <= now_ms).then_some(due_ms as u64)
@@ -1597,6 +1624,16 @@ return redis.call(
         }
 
         #[test]
+        fn positive_usize_env_parser_rejects_zero_and_invalid_values() {
+            assert_eq!(
+                parse_positive_usize("POCOPINE_JOB_PERIODIC_CATCH_UP_MAX", "32").unwrap(),
+                32
+            );
+            assert!(parse_positive_usize("POCOPINE_JOB_PERIODIC_CATCH_UP_MAX", "0").is_err());
+            assert!(parse_positive_usize("POCOPINE_JOB_PERIODIC_CATCH_UP_MAX", "banana").is_err());
+        }
+
+        #[test]
         fn cron_due_slots_catch_up_from_last_fired_time() {
             let last = chrono::DateTime::parse_from_rfc3339("2026-05-02T00:00:00Z")
                 .unwrap()
@@ -1612,6 +1649,7 @@ return redis.call(
                 now,
                 Duration::from_secs(1),
                 Some(last),
+                DEFAULT_MAX_PERIODIC_CATCH_UP,
             )
             .unwrap();
 
@@ -1622,12 +1660,38 @@ return redis.call(
         }
 
         #[test]
+        fn cron_due_slots_respect_catch_up_cap() {
+            let last = chrono::DateTime::parse_from_rfc3339("2026-05-02T00:00:00Z")
+                .unwrap()
+                .timestamp_millis() as u64;
+            let now = chrono::DateTime::parse_from_rfc3339("2026-05-02T00:00:15Z")
+                .unwrap()
+                .timestamp_millis() as u64;
+
+            let slots = due_periodic_slots(
+                PeriodicSchedule::Cron {
+                    expr: "0/5 * * * * * *",
+                },
+                now,
+                Duration::from_secs(1),
+                Some(last),
+                2,
+            )
+            .unwrap();
+
+            assert_eq!(slots.len(), 2);
+            assert_eq!(slots[0], last + 5_000);
+            assert_eq!(slots[1], last + 10_000);
+        }
+
+        #[test]
         fn every_due_slot_does_not_repeat_last_fired_slot() {
             let slots = due_periodic_slots(
                 PeriodicSchedule::Every { interval_ms: 5_000 },
                 12_000,
                 Duration::from_secs(1),
                 Some(10_000),
+                DEFAULT_MAX_PERIODIC_CATCH_UP,
             )
             .unwrap();
 
@@ -1684,6 +1748,7 @@ return redis.call(
                     block_ms: 0,
                     visibility_timeout: Duration::from_secs(60),
                     scheduler_interval: Duration::from_millis(1),
+                    max_periodic_catch_up: DEFAULT_MAX_PERIODIC_CATCH_UP,
                     batch_size: 10,
                 })
                 .unwrap();

--- a/crates/pocopine-jobs/src/lib.rs
+++ b/crates/pocopine-jobs/src/lib.rs
@@ -810,17 +810,9 @@ return redis.call(
                 .query_async(conn)
                 .await?;
             for raw in raw_jobs {
-                let removed: i32 = redis::cmd("ZREM")
-                    .arg(self.client.scheduled_key())
-                    .arg(&raw)
-                    .query_async(conn)
-                    .await?;
-                if removed == 0 {
-                    continue;
-                }
                 let mut envelope: JobEnvelope = serde_json::from_str(&raw)?;
                 envelope.scheduled_for_ms = None;
-                promote_scheduled_envelope(
+                let promoted = promote_scheduled_envelope(
                     conn,
                     &self.client.scheduled_key(),
                     &self.client.queue_key(&envelope.queue),
@@ -828,6 +820,9 @@ return redis.call(
                     &envelope,
                 )
                 .await?;
+                if !promoted {
+                    continue;
+                }
             }
             Ok(())
         }
@@ -1211,9 +1206,9 @@ return redis.call(
         queue_key: &str,
         raw_scheduled_envelope: &str,
         envelope: &JobEnvelope,
-    ) -> JobResult<()> {
+    ) -> JobResult<bool> {
         let payload = serde_json::to_string(&envelope.payload)?;
-        let _: Value = redis::cmd("EVAL")
+        let value: Value = redis::cmd("EVAL")
             .arg(PROMOTE_SCHEDULED_SCRIPT)
             .arg(2)
             .arg(scheduled_key)
@@ -1229,7 +1224,7 @@ return redis.call(
             .arg(0_u64)
             .query_async(conn)
             .await?;
-        Ok(())
+        Ok(!matches!(value, Value::Nil | Value::Int(0)))
     }
 
     async fn schedule_retry_and_ack(
@@ -1637,6 +1632,93 @@ return redis.call(
             .unwrap();
 
             assert!(slots.is_empty());
+        }
+
+        #[test]
+        fn redis_promotes_scheduled_jobs_when_redis_test_url_is_set() {
+            let Ok(redis_url) = std::env::var("REDIS_TEST_URL") else {
+                return;
+            };
+
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            rt.block_on(async {
+                const QUEUE: &str = "scheduled-smoke";
+                const JOB_NAME: &str = "redis_promotes_scheduled_jobs";
+
+                let app = format!(
+                    "pocopine-test-promote-{}-{}",
+                    std::process::id(),
+                    JOB_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+                );
+                let client = JobClient::new(redis_url.clone(), app.clone());
+                let scheduled_key = client.scheduled_key();
+                let queue_key = client.queue_key(QUEUE);
+                let mut conn = client.connection().await.unwrap();
+                let _: i64 = redis::cmd("DEL")
+                    .arg(&scheduled_key)
+                    .arg(&queue_key)
+                    .query_async(&mut conn)
+                    .await
+                    .unwrap();
+
+                client
+                    .schedule_json_at(
+                        JOB_NAME,
+                        QUEUE,
+                        1,
+                        &serde_json::json!({ "value": "ok" }),
+                        UNIX_EPOCH,
+                    )
+                    .await
+                    .unwrap();
+
+                let worker = Worker::new(WorkerConfig {
+                    backend: JobBackend::Redis { url: redis_url },
+                    app,
+                    queues: vec![QUEUE.to_string()],
+                    group: "test".to_string(),
+                    consumer: default_consumer_name(),
+                    block_ms: 0,
+                    visibility_timeout: Duration::from_secs(60),
+                    scheduler_interval: Duration::from_millis(1),
+                    batch_size: 10,
+                })
+                .unwrap();
+                let now_ms = redis_time_ms(&mut conn).await.unwrap();
+
+                worker.promote_due_jobs(&mut conn, now_ms).await.unwrap();
+
+                let scheduled_len: i64 = redis::cmd("ZCARD")
+                    .arg(&scheduled_key)
+                    .query_async(&mut conn)
+                    .await
+                    .unwrap();
+                let stream_len: i64 = redis::cmd("XLEN")
+                    .arg(&queue_key)
+                    .query_async(&mut conn)
+                    .await
+                    .unwrap();
+                assert_eq!(scheduled_len, 0);
+                assert_eq!(stream_len, 1);
+
+                worker.promote_due_jobs(&mut conn, now_ms).await.unwrap();
+                let stream_len_after_second_promote: i64 = redis::cmd("XLEN")
+                    .arg(&queue_key)
+                    .query_async(&mut conn)
+                    .await
+                    .unwrap();
+                assert_eq!(stream_len_after_second_promote, 1);
+
+                let _: i64 = redis::cmd("DEL")
+                    .arg(&scheduled_key)
+                    .arg(&queue_key)
+                    .query_async(&mut conn)
+                    .await
+                    .unwrap();
+            });
         }
     }
 }

--- a/crates/pocopine-jobs/src/lib.rs
+++ b/crates/pocopine-jobs/src/lib.rs
@@ -309,6 +309,7 @@ return redis.call(
     pub struct JobClient {
         backend: JobBackend,
         app: String,
+        redis_connection: Arc<Mutex<Option<MultiplexedConnection>>>,
     }
 
     impl JobClient {
@@ -319,6 +320,7 @@ return redis.call(
                 backend: job_backend_from_env()?,
                 app: std::env::var("POCOPINE_APP_NAME")
                     .unwrap_or_else(|_| DEFAULT_APP_NAME.to_string()),
+                redis_connection: Arc::new(Mutex::new(None)),
             })
         }
 
@@ -329,6 +331,7 @@ return redis.call(
                     url: redis_url.into(),
                 },
                 app: app.into(),
+                redis_connection: Arc::new(Mutex::new(None)),
             }
         }
 
@@ -337,6 +340,7 @@ return redis.call(
             Self {
                 backend: JobBackend::Memory,
                 app: app.into(),
+                redis_connection: Arc::new(Mutex::new(None)),
             }
         }
 
@@ -344,6 +348,7 @@ return redis.call(
             Self {
                 backend,
                 app: app.into(),
+                redis_connection: Arc::new(Mutex::new(None)),
             }
         }
 
@@ -435,8 +440,36 @@ return redis.call(
                     "the memory job backend does not have a Redis connection",
                 ));
             };
+            if let Some(conn) = self.cached_connection()? {
+                return Ok(conn);
+            }
+
             let client = redis::Client::open(url.as_str())?;
-            Ok(client.get_multiplexed_async_connection().await?)
+            let conn = client.get_multiplexed_async_connection().await?;
+            let mut cached = self.redis_connection.lock().map_err(|_| {
+                JobError::Env("cached Redis job connection mutex was poisoned".into())
+            })?;
+            if let Some(existing) = cached.as_ref() {
+                return Ok(existing.clone());
+            }
+            *cached = Some(conn.clone());
+            Ok(conn)
+        }
+
+        fn cached_connection(&self) -> JobResult<Option<MultiplexedConnection>> {
+            Ok(self
+                .redis_connection
+                .lock()
+                .map_err(|_| {
+                    JobError::Env("cached Redis job connection mutex was poisoned".into())
+                })?
+                .clone())
+        }
+
+        fn clear_connection(&self) {
+            if let Ok(mut cached) = self.redis_connection.lock() {
+                *cached = None;
+            }
         }
 
         fn queue_key(&self, queue: &str) -> String {
@@ -551,6 +584,7 @@ return redis.call(
                         backoff = Duration::from_millis(DEFAULT_WORKER_ERROR_BACKOFF_MS);
                     }
                     Err(err) => {
+                        self.client.clear_connection();
                         eprintln!("pocopine worker error: {err}; retrying in {backoff:?}");
                         tokio::time::sleep(backoff).await;
                         backoff = (backoff * 2)

--- a/crates/pocopine-jobs/src/lib.rs
+++ b/crates/pocopine-jobs/src/lib.rs
@@ -1,0 +1,921 @@
+//! Redis-backed background jobs for pocopine apps.
+//!
+//! The public authoring surface normally comes from `#[pocopine::job]`.
+//! This crate owns the host runtime: Redis enqueue/schedule helpers,
+//! `inventory`-backed job registration, and the worker loop.
+
+use std::fmt;
+
+/// Canonical result type for background jobs.
+pub type JobResult<T = ()> = Result<T, JobError>;
+
+/// Failures produced by job enqueueing, scheduling, decoding, and
+/// execution.
+#[derive(Debug)]
+pub enum JobError {
+    /// Redis command or connection failure.
+    #[cfg(not(target_arch = "wasm32"))]
+    Redis(redis::RedisError),
+    /// JSON payload/envelope serialization failure.
+    Json(serde_json::Error),
+    /// Required environment variable is missing or unusable.
+    Env(String),
+    /// A worker received a job name that has no linked descriptor.
+    UnknownJob(String),
+    /// System time moved before Unix epoch.
+    Time(String),
+    /// Background jobs are host-only.
+    Unsupported(String),
+}
+
+impl JobError {
+    /// Build a host-only unsupported failure.
+    pub fn unsupported(msg: impl Into<String>) -> Self {
+        JobError::Unsupported(msg.into())
+    }
+}
+
+impl fmt::Display for JobError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            #[cfg(not(target_arch = "wasm32"))]
+            JobError::Redis(err) => write!(f, "redis error: {err}"),
+            JobError::Json(err) => write!(f, "json error: {err}"),
+            JobError::Env(msg) => write!(f, "environment error: {msg}"),
+            JobError::UnknownJob(name) => write!(f, "unknown job: {name}"),
+            JobError::Time(msg) => write!(f, "time error: {msg}"),
+            JobError::Unsupported(msg) => write!(f, "unsupported: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for JobError {}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl From<redis::RedisError> for JobError {
+    fn from(err: redis::RedisError) -> Self {
+        JobError::Redis(err)
+    }
+}
+
+impl From<serde_json::Error> for JobError {
+    fn from(err: serde_json::Error) -> Self {
+        JobError::Json(err)
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+mod host {
+    use std::collections::{hash_map::DefaultHasher, BTreeSet, HashMap};
+    use std::future::Future;
+    use std::hash::{Hash, Hasher};
+    use std::pin::Pin;
+    use std::str::FromStr;
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+    use chrono::{Duration as ChronoDuration, Utc};
+    use cron::Schedule;
+    use redis::aio::MultiplexedConnection;
+    use redis::streams::{
+        StreamAutoClaimOptions, StreamAutoClaimReply, StreamReadOptions, StreamReadReply,
+    };
+    use redis::{AsyncCommands, FromRedisValue, Value};
+    use serde::{Deserialize, Serialize};
+
+    use crate::{JobError, JobResult};
+
+    const DEFAULT_APP_NAME: &str = "pocopine";
+    const DEFAULT_GROUP: &str = "pocopine-workers";
+    const DEFAULT_CONSUMER: &str = "worker-1";
+    const DEFAULT_BLOCK_MS: usize = 1_000;
+    const DEFAULT_BATCH_SIZE: usize = 10;
+    const DEFAULT_VISIBILITY_TIMEOUT_MS: u64 = 60_000;
+    const DEFAULT_SCHEDULER_INTERVAL_MS: u64 = 1_000;
+    const DEFAULT_MAX_PROMOTE: isize = 100;
+    const DEFAULT_WORKER_ERROR_BACKOFF_MS: u64 = 1_000;
+    const DEFAULT_WORKER_ERROR_BACKOFF_MAX_MS: u64 = 30_000;
+    const DEFAULT_RETRY_BASE_DELAY_MS: u64 = 1_000;
+    const DEFAULT_RETRY_MAX_DELAY_MS: u64 = 60_000;
+
+    static JOB_COUNTER: AtomicU64 = AtomicU64::new(1);
+
+    /// Unique id assigned to an enqueued job.
+    #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+    pub struct JobId(pub String);
+
+    impl JobId {
+        /// String value sent to Redis.
+        pub fn as_str(&self) -> &str {
+            &self.0
+        }
+    }
+
+    /// Retry behavior attached to generated job descriptors.
+    #[derive(Clone, Copy, Debug)]
+    pub struct RetryPolicy {
+        /// Maximum number of total attempts, including the first run.
+        pub max_attempts: u32,
+    }
+
+    /// Recurring schedule attached to a job descriptor.
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub enum PeriodicSchedule {
+        /// Run once per interval. The worker uses Redis locks keyed by
+        /// interval bucket so only one worker enqueues each due run.
+        Every { interval_ms: u64 },
+        /// Run from a cron expression parsed by the `cron` crate.
+        Cron { expr: &'static str },
+    }
+
+    impl PeriodicSchedule {
+        /// Build an interval schedule.
+        pub const fn every_millis(interval_ms: u64) -> Self {
+            Self::Every { interval_ms }
+        }
+
+        /// Build a cron-expression schedule.
+        pub const fn cron(expr: &'static str) -> Self {
+            Self::Cron { expr }
+        }
+    }
+
+    impl RetryPolicy {
+        /// Build a retry policy from a retry count.
+        pub const fn from_retries(retries: u32) -> Self {
+            Self {
+                max_attempts: retries.saturating_add(1),
+            }
+        }
+    }
+
+    /// Boxed async job handler produced by `#[pocopine::job]`.
+    pub type JobFuture = Pin<Box<dyn Future<Output = JobResult<()>> + Send + 'static>>;
+
+    /// Function pointer used to decode and execute one registered job.
+    pub type JobHandler = fn(Vec<u8>) -> JobFuture;
+
+    /// Metadata registered by every `#[pocopine::job]` function.
+    pub struct JobDescriptor {
+        /// Stable job name used in Redis envelopes.
+        pub name: &'static str,
+        /// Redis queue/stream suffix.
+        pub queue: &'static str,
+        /// Retry behavior.
+        pub retry_policy: RetryPolicy,
+        /// Optional recurring schedule. Periodic jobs are zero-arg jobs;
+        /// the worker enqueues `()` as the payload.
+        pub periodic: Option<PeriodicSchedule>,
+        /// Decode and run this job.
+        pub handler: JobHandler,
+    }
+
+    impl JobDescriptor {
+        /// Build a descriptor for `inventory::submit!`.
+        pub const fn new(
+            name: &'static str,
+            queue: &'static str,
+            retries: u32,
+            handler: JobHandler,
+        ) -> Self {
+            Self {
+                name,
+                queue,
+                retry_policy: RetryPolicy::from_retries(retries),
+                periodic: None,
+                handler,
+            }
+        }
+
+        /// Build a recurring descriptor for `inventory::submit!`.
+        pub const fn periodic(
+            name: &'static str,
+            queue: &'static str,
+            retries: u32,
+            periodic: PeriodicSchedule,
+            handler: JobHandler,
+        ) -> Self {
+            Self {
+                name,
+                queue,
+                retry_policy: RetryPolicy::from_retries(retries),
+                periodic: Some(periodic),
+                handler,
+            }
+        }
+    }
+
+    inventory::collect!(JobDescriptor);
+
+    /// Iterate over linked job descriptors.
+    pub fn registered_jobs() -> impl Iterator<Item = &'static JobDescriptor> {
+        inventory::iter::<JobDescriptor>.into_iter()
+    }
+
+    /// Redis client for enqueueing and scheduling background jobs.
+    #[derive(Clone, Debug)]
+    pub struct JobClient {
+        redis_url: String,
+        app: String,
+    }
+
+    impl JobClient {
+        /// Build from `POCOPINE_REDIS_URL` and optional
+        /// `POCOPINE_APP_NAME`.
+        pub fn from_env() -> JobResult<Self> {
+            Ok(Self {
+                redis_url: redis_url_from_env()?,
+                app: std::env::var("POCOPINE_APP_NAME")
+                    .unwrap_or_else(|_| DEFAULT_APP_NAME.to_string()),
+            })
+        }
+
+        /// Build a client with explicit Redis URL and app namespace.
+        pub fn new(redis_url: impl Into<String>, app: impl Into<String>) -> Self {
+            Self {
+                redis_url: redis_url.into(),
+                app: app.into(),
+            }
+        }
+
+        /// Enqueue a typed payload immediately.
+        pub async fn enqueue_json<T>(
+            &self,
+            job_name: &'static str,
+            queue: &'static str,
+            max_attempts: u32,
+            payload: &T,
+        ) -> JobResult<JobId>
+        where
+            T: Serialize,
+        {
+            let envelope = JobEnvelope::new(job_name, queue, max_attempts, payload, None)?;
+            let id = JobId(envelope.job_id.clone());
+            let mut conn = self.connection().await?;
+            xadd_envelope(&mut conn, &self.queue_key(queue), &envelope).await?;
+            Ok(id)
+        }
+
+        /// Schedule a typed payload for a future timestamp.
+        pub async fn schedule_json_at<T>(
+            &self,
+            job_name: &'static str,
+            queue: &'static str,
+            max_attempts: u32,
+            payload: &T,
+            when: SystemTime,
+        ) -> JobResult<JobId>
+        where
+            T: Serialize,
+        {
+            let due_ms = epoch_ms(when)?;
+            let envelope = JobEnvelope::new(job_name, queue, max_attempts, payload, Some(due_ms))?;
+            let id = JobId(envelope.job_id.clone());
+            let raw = serde_json::to_string(&envelope)?;
+            let mut conn = self.connection().await?;
+            let _: () = redis::cmd("ZADD")
+                .arg(self.scheduled_key())
+                .arg(due_ms)
+                .arg(raw)
+                .query_async(&mut conn)
+                .await?;
+            Ok(id)
+        }
+
+        /// Schedule a typed payload after a delay.
+        pub async fn schedule_json_in<T>(
+            &self,
+            job_name: &'static str,
+            queue: &'static str,
+            max_attempts: u32,
+            payload: &T,
+            delay: Duration,
+        ) -> JobResult<JobId>
+        where
+            T: Serialize,
+        {
+            self.schedule_json_at(
+                job_name,
+                queue,
+                max_attempts,
+                payload,
+                SystemTime::now() + delay,
+            )
+            .await
+        }
+
+        async fn connection(&self) -> JobResult<MultiplexedConnection> {
+            let client = redis::Client::open(self.redis_url.as_str())?;
+            Ok(client.get_multiplexed_async_connection().await?)
+        }
+
+        fn queue_key(&self, queue: &str) -> String {
+            format!("pocopine:{}:queue:{queue}", self.app)
+        }
+
+        fn scheduled_key(&self) -> String {
+            format!("pocopine:{}:scheduled", self.app)
+        }
+
+        fn dead_key(&self) -> String {
+            format!("pocopine:{}:dead", self.app)
+        }
+
+        fn periodic_lock_key(&self, job_name: &str, due_ms: u64) -> String {
+            format!("pocopine:{}:periodic:{job_name}:{due_ms}", self.app)
+        }
+    }
+
+    /// Worker configuration.
+    #[derive(Clone, Debug)]
+    pub struct WorkerConfig {
+        /// Redis connection URL.
+        pub redis_url: String,
+        /// Redis key namespace.
+        pub app: String,
+        /// Queues this worker should consume.
+        pub queues: Vec<String>,
+        /// Redis Streams consumer group.
+        pub group: String,
+        /// Consumer name inside the group.
+        pub consumer: String,
+        /// Blocking read timeout.
+        pub block_ms: usize,
+        /// Jobs idle longer than this may be reclaimed.
+        pub visibility_timeout: Duration,
+        /// Scheduler polling interval.
+        pub scheduler_interval: Duration,
+        /// Max jobs read/promoted per loop.
+        pub batch_size: usize,
+    }
+
+    impl WorkerConfig {
+        /// Build from environment variables and linked job descriptors.
+        pub fn from_env() -> JobResult<Self> {
+            let queues = match std::env::var("POCOPINE_JOB_QUEUES") {
+                Ok(raw) => raw
+                    .split(',')
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string)
+                    .collect(),
+                Err(_) => registered_queues(),
+            };
+
+            Ok(Self {
+                redis_url: redis_url_from_env()?,
+                app: std::env::var("POCOPINE_APP_NAME")
+                    .unwrap_or_else(|_| DEFAULT_APP_NAME.to_string()),
+                queues,
+                group: std::env::var("POCOPINE_JOB_GROUP")
+                    .unwrap_or_else(|_| DEFAULT_GROUP.to_string()),
+                consumer: std::env::var("POCOPINE_JOB_CONSUMER")
+                    .unwrap_or_else(|_| DEFAULT_CONSUMER.to_string()),
+                block_ms: DEFAULT_BLOCK_MS,
+                visibility_timeout: Duration::from_millis(DEFAULT_VISIBILITY_TIMEOUT_MS),
+                scheduler_interval: Duration::from_millis(DEFAULT_SCHEDULER_INTERVAL_MS),
+                batch_size: DEFAULT_BATCH_SIZE,
+            })
+        }
+    }
+
+    /// Redis-backed background worker.
+    pub struct Worker {
+        config: WorkerConfig,
+        client: JobClient,
+        descriptors: HashMap<&'static str, &'static JobDescriptor>,
+    }
+
+    impl Worker {
+        /// Build from environment.
+        pub fn from_env() -> JobResult<Self> {
+            Self::new(WorkerConfig::from_env()?)
+        }
+
+        /// Build from explicit config.
+        pub fn new(config: WorkerConfig) -> JobResult<Self> {
+            let client = JobClient::new(config.redis_url.clone(), config.app.clone());
+            let descriptors = registered_jobs()
+                .map(|descriptor| (descriptor.name, descriptor))
+                .collect();
+            Ok(Self {
+                config,
+                client,
+                descriptors,
+            })
+        }
+
+        /// Run until the process is stopped.
+        pub async fn run(&self) -> JobResult<()> {
+            let mut backoff = Duration::from_millis(DEFAULT_WORKER_ERROR_BACKOFF_MS);
+            loop {
+                match self.run_until_error().await {
+                    Ok(()) => {
+                        backoff = Duration::from_millis(DEFAULT_WORKER_ERROR_BACKOFF_MS);
+                    }
+                    Err(err) => {
+                        eprintln!("pocopine worker error: {err}; retrying in {backoff:?}");
+                        tokio::time::sleep(backoff).await;
+                        backoff = (backoff * 2)
+                            .min(Duration::from_millis(DEFAULT_WORKER_ERROR_BACKOFF_MAX_MS));
+                    }
+                }
+            }
+        }
+
+        async fn run_until_error(&self) -> JobResult<()> {
+            let mut conn = self.client.connection().await?;
+            self.ensure_groups(&mut conn).await?;
+            loop {
+                self.enqueue_due_periodic_jobs(&mut conn).await?;
+                self.promote_due_jobs(&mut conn).await?;
+                self.reclaim_stale_jobs(&mut conn).await?;
+                let handled = self.read_ready_jobs(&mut conn).await?;
+                if handled == 0 {
+                    tokio::time::sleep(self.config.scheduler_interval).await;
+                }
+            }
+        }
+
+        async fn ensure_groups(&self, conn: &mut MultiplexedConnection) -> JobResult<()> {
+            for queue in &self.config.queues {
+                let stream = self.client.queue_key(queue);
+                let result: redis::RedisResult<()> = redis::cmd("XGROUP")
+                    .arg("CREATE")
+                    .arg(&stream)
+                    .arg(&self.config.group)
+                    .arg("0")
+                    .arg("MKSTREAM")
+                    .query_async(conn)
+                    .await;
+                if let Err(err) = result {
+                    if !err.to_string().contains("BUSYGROUP") {
+                        return Err(err.into());
+                    }
+                }
+            }
+            Ok(())
+        }
+
+        async fn enqueue_due_periodic_jobs(
+            &self,
+            conn: &mut MultiplexedConnection,
+        ) -> JobResult<()> {
+            let now_ms = epoch_ms(SystemTime::now())?;
+            for descriptor in self.descriptors.values() {
+                let Some(schedule) = descriptor.periodic else {
+                    continue;
+                };
+                if !self.config.queues.iter().any(|q| q == descriptor.queue) {
+                    continue;
+                }
+                let Some(due_ms) =
+                    due_periodic_slot(schedule, now_ms, self.config.scheduler_interval)?
+                else {
+                    continue;
+                };
+                let lock_key = self.client.periodic_lock_key(descriptor.name, due_ms);
+                let locked: Option<String> = redis::cmd("SET")
+                    .arg(lock_key)
+                    .arg("1")
+                    .arg("NX")
+                    .arg("PX")
+                    .arg(periodic_lock_ttl_ms(schedule))
+                    .query_async(conn)
+                    .await?;
+                if locked.is_none() {
+                    continue;
+                }
+
+                let envelope = JobEnvelope::new(
+                    descriptor.name,
+                    descriptor.queue,
+                    descriptor.retry_policy.max_attempts,
+                    &(),
+                    None,
+                )?;
+                xadd_envelope(conn, &self.client.queue_key(descriptor.queue), &envelope).await?;
+            }
+            Ok(())
+        }
+
+        async fn promote_due_jobs(&self, conn: &mut MultiplexedConnection) -> JobResult<()> {
+            let now = epoch_ms(SystemTime::now())?;
+            let raw_jobs: Vec<String> = redis::cmd("ZRANGEBYSCORE")
+                .arg(self.client.scheduled_key())
+                .arg("-inf")
+                .arg(now)
+                .arg("LIMIT")
+                .arg(0)
+                .arg(DEFAULT_MAX_PROMOTE)
+                .query_async(conn)
+                .await?;
+            for raw in raw_jobs {
+                let removed: i32 = redis::cmd("ZREM")
+                    .arg(self.client.scheduled_key())
+                    .arg(&raw)
+                    .query_async(conn)
+                    .await?;
+                if removed == 0 {
+                    continue;
+                }
+                let mut envelope: JobEnvelope = serde_json::from_str(&raw)?;
+                envelope.scheduled_for_ms = None;
+                xadd_envelope(conn, &self.client.queue_key(&envelope.queue), &envelope).await?;
+            }
+            Ok(())
+        }
+
+        async fn reclaim_stale_jobs(&self, conn: &mut MultiplexedConnection) -> JobResult<()> {
+            let idle_ms = self.config.visibility_timeout.as_millis() as u64;
+            for queue in &self.config.queues {
+                let stream = self.client.queue_key(queue);
+                let reply: StreamAutoClaimReply = conn
+                    .xautoclaim_options(
+                        &stream,
+                        &self.config.group,
+                        &self.config.consumer,
+                        idle_ms,
+                        "0-0",
+                        StreamAutoClaimOptions::default().count(self.config.batch_size),
+                    )
+                    .await?;
+                for id in reply.claimed {
+                    let envelope = match envelope_from_stream(&id.map) {
+                        Ok(envelope) => envelope,
+                        Err(err) => {
+                            self.ack(conn, &stream, &id.id).await?;
+                            return Err(err);
+                        }
+                    };
+                    if envelope.attempt >= envelope.max_attempts {
+                        self.move_to_dead(conn, &envelope, "job reclaimed after max attempts")
+                            .await?;
+                        self.ack(conn, &stream, &id.id).await?;
+                        continue;
+                    }
+                    let mut envelope = envelope;
+                    envelope.attempt += 1;
+                    self.run_envelope(conn, &stream, &id.id, envelope).await?;
+                }
+            }
+            Ok(())
+        }
+
+        async fn read_ready_jobs(&self, conn: &mut MultiplexedConnection) -> JobResult<usize> {
+            if self.config.queues.is_empty() {
+                return Ok(0);
+            }
+
+            let streams: Vec<String> = self
+                .config
+                .queues
+                .iter()
+                .map(|queue| self.client.queue_key(queue))
+                .collect();
+            let ids: Vec<&str> = streams.iter().map(|_| ">").collect();
+            let options = StreamReadOptions::default()
+                .group(&self.config.group, &self.config.consumer)
+                .count(self.config.batch_size)
+                .block(self.config.block_ms);
+            let reply: StreamReadReply = conn.xread_options(&streams, &ids, &options).await?;
+
+            let mut handled = 0;
+            for key in reply.keys {
+                for id in key.ids {
+                    let envelope = match envelope_from_stream(&id.map) {
+                        Ok(envelope) => envelope,
+                        Err(err) => {
+                            self.ack(conn, &key.key, &id.id).await?;
+                            return Err(err);
+                        }
+                    };
+                    self.run_envelope(conn, &key.key, &id.id, envelope).await?;
+                    handled += 1;
+                }
+            }
+            Ok(handled)
+        }
+
+        async fn run_envelope(
+            &self,
+            conn: &mut MultiplexedConnection,
+            stream: &str,
+            stream_id: &str,
+            envelope: JobEnvelope,
+        ) -> JobResult<()> {
+            let Some(descriptor) = self.descriptors.get(envelope.job_name.as_str()) else {
+                self.move_to_dead(conn, &envelope, "unknown job").await?;
+                self.ack(conn, stream, stream_id).await?;
+                return Ok(());
+            };
+
+            let payload = serde_json::to_vec(&envelope.payload)?;
+            match (descriptor.handler)(payload).await {
+                Ok(()) => self.ack(conn, stream, stream_id).await,
+                Err(err) => {
+                    if envelope.attempt < envelope.max_attempts {
+                        let mut retry = envelope.clone();
+                        retry.attempt += 1;
+                        let due_ms = epoch_ms(SystemTime::now())?
+                            .saturating_add(retry_delay_ms(retry.attempt, &retry.job_id));
+                        retry.scheduled_for_ms = Some(due_ms);
+                        schedule_envelope(conn, &self.client.scheduled_key(), &retry, due_ms)
+                            .await?;
+                    } else {
+                        self.move_to_dead(conn, &envelope, &err.to_string()).await?;
+                    }
+                    self.ack(conn, stream, stream_id).await
+                }
+            }
+        }
+
+        async fn move_to_dead(
+            &self,
+            conn: &mut MultiplexedConnection,
+            envelope: &JobEnvelope,
+            error: &str,
+        ) -> JobResult<()> {
+            let raw = serde_json::to_string(envelope)?;
+            let _: String = redis::cmd("XADD")
+                .arg(self.client.dead_key())
+                .arg("*")
+                .arg("job_id")
+                .arg(&envelope.job_id)
+                .arg("job_name")
+                .arg(&envelope.job_name)
+                .arg("queue")
+                .arg(&envelope.queue)
+                .arg("attempt")
+                .arg(envelope.attempt)
+                .arg("max_attempts")
+                .arg(envelope.max_attempts)
+                .arg("error")
+                .arg(error)
+                .arg("envelope")
+                .arg(raw)
+                .query_async(conn)
+                .await?;
+            Ok(())
+        }
+
+        async fn ack(
+            &self,
+            conn: &mut MultiplexedConnection,
+            stream: &str,
+            stream_id: &str,
+        ) -> JobResult<()> {
+            let _: i32 = redis::cmd("XACK")
+                .arg(stream)
+                .arg(&self.config.group)
+                .arg(stream_id)
+                .query_async(conn)
+                .await?;
+            Ok(())
+        }
+    }
+
+    #[derive(Clone, Debug, Serialize, Deserialize)]
+    struct JobEnvelope {
+        job_id: String,
+        job_name: String,
+        queue: String,
+        payload: serde_json::Value,
+        attempt: u32,
+        max_attempts: u32,
+        created_at_ms: u64,
+        scheduled_for_ms: Option<u64>,
+    }
+
+    impl JobEnvelope {
+        fn new<T>(
+            job_name: &'static str,
+            queue: &'static str,
+            max_attempts: u32,
+            payload: &T,
+            scheduled_for_ms: Option<u64>,
+        ) -> JobResult<Self>
+        where
+            T: Serialize,
+        {
+            Ok(Self {
+                job_id: new_job_id()?,
+                job_name: job_name.to_string(),
+                queue: queue.to_string(),
+                payload: serde_json::to_value(payload)?,
+                attempt: 1,
+                max_attempts: max_attempts.max(1),
+                created_at_ms: epoch_ms(SystemTime::now())?,
+                scheduled_for_ms,
+            })
+        }
+    }
+
+    async fn xadd_envelope(
+        conn: &mut MultiplexedConnection,
+        stream: &str,
+        envelope: &JobEnvelope,
+    ) -> JobResult<()> {
+        let payload = serde_json::to_string(&envelope.payload)?;
+        let _: String = redis::cmd("XADD")
+            .arg(stream)
+            .arg("*")
+            .arg("job_id")
+            .arg(&envelope.job_id)
+            .arg("job_name")
+            .arg(&envelope.job_name)
+            .arg("queue")
+            .arg(&envelope.queue)
+            .arg("payload")
+            .arg(payload)
+            .arg("attempt")
+            .arg(envelope.attempt)
+            .arg("max_attempts")
+            .arg(envelope.max_attempts)
+            .arg("created_at_ms")
+            .arg(envelope.created_at_ms)
+            .arg("scheduled_for_ms")
+            .arg(envelope.scheduled_for_ms.unwrap_or(0))
+            .query_async(conn)
+            .await?;
+        Ok(())
+    }
+
+    async fn schedule_envelope(
+        conn: &mut MultiplexedConnection,
+        scheduled_key: &str,
+        envelope: &JobEnvelope,
+        due_ms: u64,
+    ) -> JobResult<()> {
+        let raw = serde_json::to_string(envelope)?;
+        let _: () = redis::cmd("ZADD")
+            .arg(scheduled_key)
+            .arg(due_ms)
+            .arg(raw)
+            .query_async(conn)
+            .await?;
+        Ok(())
+    }
+
+    fn envelope_from_stream(map: &HashMap<String, Value>) -> JobResult<JobEnvelope> {
+        let job_id = field::<String>(map, "job_id")?;
+        let job_name = field::<String>(map, "job_name")?;
+        let queue = field::<String>(map, "queue")?;
+        let payload_raw = field::<String>(map, "payload")?;
+        let payload = serde_json::from_str(&payload_raw)?;
+        Ok(JobEnvelope {
+            job_id,
+            job_name,
+            queue,
+            payload,
+            attempt: field::<u32>(map, "attempt")?,
+            max_attempts: field::<u32>(map, "max_attempts")?,
+            created_at_ms: field::<u64>(map, "created_at_ms")?,
+            scheduled_for_ms: match field::<u64>(map, "scheduled_for_ms")? {
+                0 => None,
+                value => Some(value),
+            },
+        })
+    }
+
+    fn field<T>(map: &HashMap<String, Value>, key: &str) -> JobResult<T>
+    where
+        T: FromRedisValue,
+    {
+        let value = map
+            .get(key)
+            .ok_or_else(|| JobError::Env(format!("job envelope missing `{key}`")))?;
+        Ok(T::from_redis_value(value)?)
+    }
+
+    fn registered_queues() -> Vec<String> {
+        let queues: BTreeSet<String> = registered_jobs()
+            .map(|descriptor| descriptor.queue.to_string())
+            .collect();
+        if queues.is_empty() {
+            vec!["default".to_string()]
+        } else {
+            queues.into_iter().collect()
+        }
+    }
+
+    fn redis_url_from_env() -> JobResult<String> {
+        std::env::var("POCOPINE_REDIS_URL").map_err(|_| {
+            JobError::Env(
+                "POCOPINE_REDIS_URL must be set for pocopine jobs; `pocopine dev` defaults it to redis://127.0.0.1/ for local development".into(),
+            )
+        })
+    }
+
+    fn due_periodic_slot(
+        schedule: PeriodicSchedule,
+        now_ms: u64,
+        scheduler_interval: Duration,
+    ) -> JobResult<Option<u64>> {
+        match schedule {
+            PeriodicSchedule::Every { interval_ms } => {
+                if interval_ms == 0 {
+                    return Ok(None);
+                }
+                Ok(Some((now_ms / interval_ms) * interval_ms))
+            }
+            PeriodicSchedule::Cron { expr } => {
+                let schedule = Schedule::from_str(expr).map_err(|err| {
+                    JobError::Env(format!("invalid cron expression `{expr}`: {err}"))
+                })?;
+                let interval = ChronoDuration::from_std(scheduler_interval)
+                    .unwrap_or_else(|_| ChronoDuration::seconds(1));
+                let window_start = Utc::now() - interval;
+                let Some(next) = schedule.after(&window_start).next() else {
+                    return Ok(None);
+                };
+                let due_ms = next.timestamp_millis();
+                if due_ms >= 0 && due_ms as u64 <= now_ms {
+                    Ok(Some(due_ms as u64))
+                } else {
+                    Ok(None)
+                }
+            }
+        }
+    }
+
+    fn periodic_lock_ttl_ms(schedule: PeriodicSchedule) -> u64 {
+        match schedule {
+            PeriodicSchedule::Every { interval_ms } => interval_ms
+                .saturating_mul(2)
+                .clamp(60_000, 7 * 24 * 60 * 60 * 1_000),
+            PeriodicSchedule::Cron { .. } => 7 * 24 * 60 * 60 * 1_000,
+        }
+    }
+
+    fn retry_delay_ms(attempt: u32, job_id: &str) -> u64 {
+        let exponent = attempt.saturating_sub(2).min(10);
+        let base = DEFAULT_RETRY_BASE_DELAY_MS
+            .saturating_mul(1_u64 << exponent)
+            .min(DEFAULT_RETRY_MAX_DELAY_MS);
+        let jitter_span = (base / 5).max(1);
+        base.saturating_add(jitter_ms(job_id, attempt, jitter_span))
+            .min(DEFAULT_RETRY_MAX_DELAY_MS)
+    }
+
+    fn jitter_ms(job_id: &str, attempt: u32, span: u64) -> u64 {
+        if span == 0 {
+            return 0;
+        }
+        let mut hasher = DefaultHasher::new();
+        job_id.hash(&mut hasher);
+        attempt.hash(&mut hasher);
+        hasher.finish() % span
+    }
+
+    fn new_job_id() -> JobResult<String> {
+        let now = epoch_ms(SystemTime::now())?;
+        let next = JOB_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let pid = std::process::id();
+        Ok(format!("{now:x}-{pid:x}-{next:x}"))
+    }
+
+    fn epoch_ms(time: SystemTime) -> JobResult<u64> {
+        let duration = time
+            .duration_since(UNIX_EPOCH)
+            .map_err(|err| JobError::Time(err.to_string()))?;
+        Ok(duration.as_millis() as u64)
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn retry_delay_uses_exponential_backoff_with_jitter_cap() {
+            let second = retry_delay_ms(2, "job-a");
+            let third = retry_delay_ms(3, "job-a");
+            let tenth = retry_delay_ms(10, "job-a");
+
+            assert!(second >= DEFAULT_RETRY_BASE_DELAY_MS);
+            assert!(third >= second);
+            assert!(tenth <= DEFAULT_RETRY_MAX_DELAY_MS);
+        }
+
+        #[test]
+        fn job_id_includes_process_identity() {
+            let id = new_job_id().unwrap();
+            let parts: Vec<_> = id.split('-').collect();
+
+            assert_eq!(parts.len(), 3);
+            assert_eq!(parts[1], format!("{:x}", std::process::id()));
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use host::{
+    registered_jobs, JobClient, JobDescriptor, JobFuture, JobHandler, JobId, PeriodicSchedule,
+    RetryPolicy, Worker, WorkerConfig,
+};
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use inventory;
+#[cfg(not(target_arch = "wasm32"))]
+pub use redis;
+pub use serde_json;

--- a/crates/pocopine-jobs/src/lib.rs
+++ b/crates/pocopine-jobs/src/lib.rs
@@ -367,8 +367,8 @@ return redis.call(
         /// Build from `POCOPINE_JOB_BACKEND`, `POCOPINE_REDIS_URL`, and
         /// optional `POCOPINE_APP_NAME`.
         pub fn from_env() -> JobResult<Self> {
-            let app = std::env::var("POCOPINE_APP_NAME")
-                .unwrap_or_else(|_| DEFAULT_APP_NAME.to_string());
+            let app =
+                std::env::var("POCOPINE_APP_NAME").unwrap_or_else(|_| DEFAULT_APP_NAME.to_string());
             Ok(Self::build(job_backend_from_env()?, app))
         }
 

--- a/crates/pocopine-jobs/src/lib.rs
+++ b/crates/pocopine-jobs/src/lib.rs
@@ -26,6 +26,10 @@ pub enum JobError {
     Time(String),
     /// Background jobs are host-only.
     Unsupported(String),
+    /// A job handler panicked or its task was cancelled. The worker
+    /// converts these into the same retry/dead-letter path as a normal
+    /// `Err(_)` return so panicking handlers do not silently lose jobs.
+    Handler(String),
 }
 
 impl JobError {
@@ -45,6 +49,7 @@ impl fmt::Display for JobError {
             JobError::UnknownJob(name) => write!(f, "unknown job: {name}"),
             JobError::Time(msg) => write!(f, "time error: {msg}"),
             JobError::Unsupported(msg) => write!(f, "unsupported: {msg}"),
+            JobError::Handler(msg) => write!(f, "handler failure: {msg}"),
         }
     }
 }
@@ -100,6 +105,12 @@ mod host {
     const DEFAULT_WORKER_ERROR_BACKOFF_MAX_MS: u64 = 30_000;
     const DEFAULT_RETRY_BASE_DELAY_MS: u64 = 1_000;
     const DEFAULT_RETRY_MAX_DELAY_MS: u64 = 60_000;
+    /// Cap on the in-memory dead-letter buffer. Keeps a long-running
+    /// embedded worker from leaking memory when a job is consistently
+    /// failing; oldest entries are dropped first. Operators that need
+    /// every dead-lettered job should call `Worker::drain_dead_letter`
+    /// periodically and persist the results.
+    const DEFAULT_MEMORY_DEAD_LETTER_CAP: usize = 1_024;
     const PROMOTE_SCHEDULED_SCRIPT_SRC: &str = r#"
 local removed = redis.call('ZREM', KEYS[1], ARGV[1])
 if removed == 0 then
@@ -216,7 +227,7 @@ return redis.call(
     struct MemoryState {
         ready: VecDeque<JobEnvelope>,
         scheduled: Vec<JobEnvelope>,
-        dead: Vec<(JobEnvelope, String)>,
+        dead: VecDeque<(JobEnvelope, String)>,
         periodic_locks: HashMap<String, u64>,
         periodic_last_fired: HashMap<String, u64>,
     }
@@ -653,8 +664,25 @@ return redis.call(
             })
         }
 
+        /// Take and clear the in-memory dead-letter buffer. Returns
+        /// `Unsupported` for the Redis backend; read the dead-letter
+        /// stream `pocopine:{app}:dead` directly there.
+        pub fn drain_dead_letter(&self) -> JobResult<Vec<DeadLetter>> {
+            match &self.config.backend {
+                JobBackend::Memory => {
+                    let store = self.client.cached_memory_store()?;
+                    memory_drain_dead_letter(&store)
+                }
+                JobBackend::Redis { .. } => Err(JobError::unsupported(
+                    "drain_dead_letter is memory-backend only; \
+                     read the Redis dead-letter stream directly",
+                )),
+            }
+        }
+
         /// Run until the process is stopped.
         pub async fn run(&self) -> JobResult<()> {
+            self.log_startup_backend();
             let mut backoff = Duration::from_millis(DEFAULT_WORKER_ERROR_BACKOFF_MS);
             loop {
                 match self.run_until_error().await {
@@ -691,6 +719,24 @@ return redis.call(
             match &self.config.backend {
                 JobBackend::Redis { .. } => self.run_redis_until_error().await,
                 JobBackend::Memory => self.run_memory_until_error().await,
+            }
+        }
+
+        // Print a one-line banner so operators can confirm which backend
+        // the worker bound to. Especially useful when no env is set and
+        // the backend silently defaults to Memory in a multi-process
+        // deployment where Redis was intended.
+        fn log_startup_backend(&self) {
+            match &self.config.backend {
+                JobBackend::Redis { .. } => eprintln!(
+                    "pocopine worker: backend = redis (durable, multi-process); app = {}",
+                    self.config.app
+                ),
+                JobBackend::Memory => eprintln!(
+                    "pocopine worker: backend = memory (process-local; \
+                     not shared across processes, lost on restart); app = {}",
+                    self.config.app
+                ),
             }
         }
 
@@ -975,7 +1021,7 @@ return redis.call(
             };
 
             let payload = serde_json::to_vec(&envelope.payload)?;
-            match (descriptor.handler)(payload).await {
+            match run_handler_safely(descriptor.handler, payload).await {
                 Ok(()) => self.ack(conn, stream, stream_id).await,
                 Err(err) => {
                     if envelope.attempt < envelope.max_attempts {
@@ -1017,7 +1063,7 @@ return redis.call(
             };
 
             let payload = serde_json::to_vec(&envelope.payload)?;
-            match (descriptor.handler)(payload).await {
+            match run_handler_safely(descriptor.handler, payload).await {
                 Ok(()) => Ok(()),
                 Err(err) => {
                     if envelope.attempt < envelope.max_attempts {
@@ -1074,6 +1120,40 @@ return redis.call(
                 .query_async(conn)
                 .await?;
             Ok(())
+        }
+    }
+
+    /// Snapshot of a dead-lettered job, returned by
+    /// [`Worker::drain_dead_letter`].
+    #[derive(Clone, Debug)]
+    pub struct DeadLetter {
+        /// Stable id assigned at enqueue time.
+        pub job_id: String,
+        /// Registered job name (`module::path::ident`).
+        pub job_name: String,
+        /// Queue the job lived on.
+        pub queue: String,
+        /// Final attempt count when the job was buried.
+        pub attempt: u32,
+        /// Configured retry budget.
+        pub max_attempts: u32,
+        /// Stringified terminal error (`Display` of `JobError`).
+        pub error: String,
+        /// Original enqueue time, milliseconds since the Unix epoch.
+        pub created_at_ms: u64,
+    }
+
+    impl DeadLetter {
+        fn from_envelope(envelope: JobEnvelope, error: String) -> Self {
+            Self {
+                job_id: envelope.job_id,
+                job_name: envelope.job_name,
+                queue: envelope.queue,
+                attempt: envelope.attempt,
+                max_attempts: envelope.max_attempts,
+                error,
+                created_at_ms: envelope.created_at_ms,
+            }
         }
     }
 
@@ -1222,10 +1302,21 @@ return redis.call(
         envelope: JobEnvelope,
         error: &str,
     ) -> JobResult<()> {
-        memory_state(store)?
-            .dead
-            .push((envelope, error.to_string()));
+        let mut state = memory_state(store)?;
+        state.dead.push_back((envelope, error.to_string()));
+        while state.dead.len() > DEFAULT_MEMORY_DEAD_LETTER_CAP {
+            state.dead.pop_front();
+        }
         Ok(())
+    }
+
+    fn memory_drain_dead_letter(store: &MemoryStore) -> JobResult<Vec<DeadLetter>> {
+        let mut state = memory_state(store)?;
+        Ok(state
+            .dead
+            .drain(..)
+            .map(|(envelope, error)| DeadLetter::from_envelope(envelope, error))
+            .collect())
     }
 
     async fn xadd_envelope(
@@ -1332,6 +1423,31 @@ return redis.call(
             .invoke_async(conn)
             .await?;
         Ok(())
+    }
+
+    /// Run a job handler future with panic-safety so a panicking
+    /// handler is converted into a regular `JobError::Handler` and
+    /// flows through the worker's normal retry/dead-letter path
+    /// instead of unwinding the worker task.
+    async fn run_handler_safely(handler: JobHandler, payload: Vec<u8>) -> JobResult<()> {
+        match tokio::spawn(handler(payload)).await {
+            Ok(result) => result,
+            Err(join_err) => {
+                let msg = match join_err.try_into_panic() {
+                    Ok(panic) => {
+                        if let Some(s) = panic.downcast_ref::<&'static str>() {
+                            format!("handler panicked: {s}")
+                        } else if let Some(s) = panic.downcast_ref::<String>() {
+                            format!("handler panicked: {s}")
+                        } else {
+                            "handler panicked".to_string()
+                        }
+                    }
+                    Err(_) => "handler task cancelled before completion".to_string(),
+                };
+                Err(JobError::Handler(msg))
+            }
+        }
     }
 
     async fn redis_time_ms(conn: &mut MultiplexedConnection) -> JobResult<u64> {
@@ -1834,8 +1950,8 @@ return redis.call(
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use host::{
-    registered_jobs, JobBackend, JobClient, JobDescriptor, JobFuture, JobHandler, JobId,
-    PeriodicSchedule, RetryPolicy, Worker, WorkerConfig,
+    registered_jobs, DeadLetter, JobBackend, JobClient, JobDescriptor, JobFuture, JobHandler,
+    JobId, PeriodicSchedule, RetryPolicy, Worker, WorkerConfig,
 };
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/pocopine-jobs/src/lib.rs
+++ b/crates/pocopine-jobs/src/lib.rs
@@ -67,6 +67,7 @@ impl From<serde_json::Error> for JobError {
 #[cfg(not(target_arch = "wasm32"))]
 mod host {
     use std::collections::{hash_map::DefaultHasher, BTreeSet, HashMap, VecDeque};
+    use std::fs;
     use std::future::Future;
     use std::hash::{Hash, Hasher};
     use std::pin::Pin;
@@ -88,7 +89,7 @@ mod host {
 
     const DEFAULT_APP_NAME: &str = "pocopine";
     const DEFAULT_GROUP: &str = "pocopine-workers";
-    const DEFAULT_CONSUMER: &str = "worker-1";
+    const DEFAULT_CONSUMER_PREFIX: &str = "worker";
     const DEFAULT_BLOCK_MS: usize = 1_000;
     const DEFAULT_BATCH_SIZE: usize = 10;
     const DEFAULT_VISIBILITY_TIMEOUT_MS: u64 = 60_000;
@@ -101,6 +102,7 @@ mod host {
 
     static JOB_COUNTER: AtomicU64 = AtomicU64::new(1);
     static MEMORY_STORES: OnceLock<Mutex<HashMap<String, Arc<MemoryStore>>>> = OnceLock::new();
+    static PROCESS_IDENTITY: OnceLock<String> = OnceLock::new();
 
     /// Unique id assigned to an enqueued job.
     #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
@@ -434,9 +436,12 @@ mod host {
                 group: std::env::var("POCOPINE_JOB_GROUP")
                     .unwrap_or_else(|_| DEFAULT_GROUP.to_string()),
                 consumer: std::env::var("POCOPINE_JOB_CONSUMER")
-                    .unwrap_or_else(|_| DEFAULT_CONSUMER.to_string()),
+                    .unwrap_or_else(|_| default_consumer_name()),
                 block_ms: DEFAULT_BLOCK_MS,
-                visibility_timeout: Duration::from_millis(DEFAULT_VISIBILITY_TIMEOUT_MS),
+                visibility_timeout: millis_env(
+                    "POCOPINE_JOB_VISIBILITY_MS",
+                    DEFAULT_VISIBILITY_TIMEOUT_MS,
+                )?,
                 scheduler_interval: Duration::from_millis(DEFAULT_SCHEDULER_INTERVAL_MS),
                 batch_size: DEFAULT_BATCH_SIZE,
             })
@@ -1117,6 +1122,25 @@ mod host {
         Ok(url)
     }
 
+    fn millis_env(name: &str, default_ms: u64) -> JobResult<Duration> {
+        match std::env::var(name) {
+            Ok(raw) => parse_positive_millis(name, &raw),
+            Err(_) => Ok(Duration::from_millis(default_ms)),
+        }
+    }
+
+    fn parse_positive_millis(name: &str, raw: &str) -> JobResult<Duration> {
+        let value = raw.trim().parse::<u64>().map_err(|err| {
+            JobError::Env(format!(
+                "{name} must be a positive integer number of milliseconds: {err}"
+            ))
+        })?;
+        if value == 0 {
+            return Err(JobError::Env(format!("{name} must be greater than 0")));
+        }
+        Ok(Duration::from_millis(value))
+    }
+
     fn due_periodic_slot(
         schedule: PeriodicSchedule,
         now_ms: u64,
@@ -1181,8 +1205,7 @@ mod host {
     fn new_job_id() -> JobResult<String> {
         let now = epoch_ms(SystemTime::now())?;
         let next = JOB_COUNTER.fetch_add(1, Ordering::Relaxed);
-        let pid = std::process::id();
-        Ok(format!("{now:x}-{pid:x}-{next:x}"))
+        Ok(format!("{now:x}:{}:{next:x}", process_identity()))
     }
 
     fn epoch_ms(time: SystemTime) -> JobResult<u64> {
@@ -1190,6 +1213,55 @@ mod host {
             .duration_since(UNIX_EPOCH)
             .map_err(|err| JobError::Time(err.to_string()))?;
         Ok(duration.as_millis() as u64)
+    }
+
+    fn default_consumer_name() -> String {
+        format!("{DEFAULT_CONSUMER_PREFIX}-{}", process_identity())
+    }
+
+    fn process_identity() -> &'static str {
+        PROCESS_IDENTITY.get_or_init(|| {
+            let host = sanitize_identity_part(&host_name_hint());
+            let pid = std::process::id();
+            let started_at = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .map(|duration| duration.as_nanos())
+                .unwrap_or_default();
+            format!("{host}_{pid:x}_{started_at:x}")
+        })
+    }
+
+    fn host_name_hint() -> String {
+        std::env::var("HOSTNAME")
+            .or_else(|_| std::env::var("COMPUTERNAME"))
+            .ok()
+            .filter(|value| !value.trim().is_empty())
+            .or_else(|| {
+                fs::read_to_string("/etc/hostname")
+                    .ok()
+                    .map(|value| value.trim().to_string())
+                    .filter(|value| !value.is_empty())
+            })
+            .unwrap_or_else(|| "host".to_string())
+    }
+
+    fn sanitize_identity_part(raw: &str) -> String {
+        let sanitized: String = raw
+            .chars()
+            .map(|ch| {
+                if ch.is_ascii_alphanumeric() || ch == '_' || ch == '.' {
+                    ch
+                } else {
+                    '_'
+                }
+            })
+            .collect();
+        let sanitized = sanitized.trim_matches('_');
+        if sanitized.is_empty() {
+            "host".to_string()
+        } else {
+            sanitized.to_string()
+        }
     }
 
     #[cfg(test)]
@@ -1210,10 +1282,30 @@ mod host {
         #[test]
         fn job_id_includes_process_identity() {
             let id = new_job_id().unwrap();
-            let parts: Vec<_> = id.split('-').collect();
+            let parts: Vec<_> = id.split(':').collect();
 
             assert_eq!(parts.len(), 3);
-            assert_eq!(parts[1], format!("{:x}", std::process::id()));
+            assert!(parts[1].contains(&format!("{:x}", std::process::id())));
+        }
+
+        #[test]
+        fn default_consumer_name_is_process_unique() {
+            let consumer = default_consumer_name();
+
+            assert!(consumer.starts_with("worker-"));
+            assert!(consumer.contains(&format!("{:x}", std::process::id())));
+        }
+
+        #[test]
+        fn visibility_timeout_parser_rejects_zero_and_invalid_values() {
+            assert_eq!(
+                parse_positive_millis("POCOPINE_JOB_VISIBILITY_MS", "1500")
+                    .unwrap()
+                    .as_millis(),
+                1500
+            );
+            assert!(parse_positive_millis("POCOPINE_JOB_VISIBILITY_MS", "0").is_err());
+            assert!(parse_positive_millis("POCOPINE_JOB_VISIBILITY_MS", "banana").is_err());
         }
     }
 }

--- a/crates/pocopine-jobs/src/lib.rs
+++ b/crates/pocopine-jobs/src/lib.rs
@@ -1,7 +1,7 @@
-//! Redis-backed background jobs for pocopine apps.
+//! Background jobs for pocopine apps.
 //!
 //! The public authoring surface normally comes from `#[pocopine::job]`.
-//! This crate owns the host runtime: Redis enqueue/schedule helpers,
+//! This crate owns the host runtime: enqueue/schedule helpers,
 //! `inventory`-backed job registration, and the worker loop.
 
 use std::fmt;
@@ -66,12 +66,13 @@ impl From<serde_json::Error> for JobError {
 
 #[cfg(not(target_arch = "wasm32"))]
 mod host {
-    use std::collections::{hash_map::DefaultHasher, BTreeSet, HashMap};
+    use std::collections::{hash_map::DefaultHasher, BTreeSet, HashMap, VecDeque};
     use std::future::Future;
     use std::hash::{Hash, Hasher};
     use std::pin::Pin;
     use std::str::FromStr;
     use std::sync::atomic::{AtomicU64, Ordering};
+    use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
     use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
     use chrono::{Duration as ChronoDuration, Utc};
@@ -99,6 +100,7 @@ mod host {
     const DEFAULT_RETRY_MAX_DELAY_MS: u64 = 60_000;
 
     static JOB_COUNTER: AtomicU64 = AtomicU64::new(1);
+    static MEMORY_STORES: OnceLock<Mutex<HashMap<String, Arc<MemoryStore>>>> = OnceLock::new();
 
     /// Unique id assigned to an enqueued job.
     #[derive(Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
@@ -109,6 +111,30 @@ mod host {
         pub fn as_str(&self) -> &str {
             &self.0
         }
+    }
+
+    /// Runtime storage backend for background jobs.
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub enum JobBackend {
+        /// Redis-backed, durable enough for multi-process workers.
+        Redis { url: String },
+        /// Process-local memory backend. This is useful for single-process
+        /// deployments and tests; it is not shared across server/worker
+        /// processes and is not durable across restarts.
+        Memory,
+    }
+
+    #[derive(Debug, Default)]
+    struct MemoryStore {
+        state: Mutex<MemoryState>,
+    }
+
+    #[derive(Debug, Default)]
+    struct MemoryState {
+        ready: VecDeque<JobEnvelope>,
+        scheduled: Vec<JobEnvelope>,
+        dead: Vec<(JobEnvelope, String)>,
+        periodic_locks: HashMap<String, u64>,
     }
 
     /// Retry behavior attached to generated job descriptors.
@@ -212,19 +238,19 @@ mod host {
         inventory::iter::<JobDescriptor>.into_iter()
     }
 
-    /// Redis client for enqueueing and scheduling background jobs.
+    /// Client for enqueueing and scheduling background jobs.
     #[derive(Clone, Debug)]
     pub struct JobClient {
-        redis_url: String,
+        backend: JobBackend,
         app: String,
     }
 
     impl JobClient {
-        /// Build from `POCOPINE_REDIS_URL` and optional
-        /// `POCOPINE_APP_NAME`.
+        /// Build from `POCOPINE_JOB_BACKEND`, `POCOPINE_REDIS_URL`, and
+        /// optional `POCOPINE_APP_NAME`.
         pub fn from_env() -> JobResult<Self> {
             Ok(Self {
-                redis_url: redis_url_from_env()?,
+                backend: job_backend_from_env()?,
                 app: std::env::var("POCOPINE_APP_NAME")
                     .unwrap_or_else(|_| DEFAULT_APP_NAME.to_string()),
             })
@@ -233,7 +259,24 @@ mod host {
         /// Build a client with explicit Redis URL and app namespace.
         pub fn new(redis_url: impl Into<String>, app: impl Into<String>) -> Self {
             Self {
-                redis_url: redis_url.into(),
+                backend: JobBackend::Redis {
+                    url: redis_url.into(),
+                },
+                app: app.into(),
+            }
+        }
+
+        /// Build a process-local memory client with an app namespace.
+        pub fn memory(app: impl Into<String>) -> Self {
+            Self {
+                backend: JobBackend::Memory,
+                app: app.into(),
+            }
+        }
+
+        fn for_backend(backend: JobBackend, app: impl Into<String>) -> Self {
+            Self {
+                backend,
                 app: app.into(),
             }
         }
@@ -251,8 +294,16 @@ mod host {
         {
             let envelope = JobEnvelope::new(job_name, queue, max_attempts, payload, None)?;
             let id = JobId(envelope.job_id.clone());
-            let mut conn = self.connection().await?;
-            xadd_envelope(&mut conn, &self.queue_key(queue), &envelope).await?;
+            match &self.backend {
+                JobBackend::Redis { .. } => {
+                    let mut conn = self.connection().await?;
+                    xadd_envelope(&mut conn, &self.queue_key(queue), &envelope).await?;
+                }
+                JobBackend::Memory => {
+                    let store = memory_store(&self.app)?;
+                    memory_enqueue_envelope(&store, envelope)?;
+                }
+            }
             Ok(id)
         }
 
@@ -271,14 +322,22 @@ mod host {
             let due_ms = epoch_ms(when)?;
             let envelope = JobEnvelope::new(job_name, queue, max_attempts, payload, Some(due_ms))?;
             let id = JobId(envelope.job_id.clone());
-            let raw = serde_json::to_string(&envelope)?;
-            let mut conn = self.connection().await?;
-            let _: () = redis::cmd("ZADD")
-                .arg(self.scheduled_key())
-                .arg(due_ms)
-                .arg(raw)
-                .query_async(&mut conn)
-                .await?;
+            match &self.backend {
+                JobBackend::Redis { .. } => {
+                    let raw = serde_json::to_string(&envelope)?;
+                    let mut conn = self.connection().await?;
+                    let _: () = redis::cmd("ZADD")
+                        .arg(self.scheduled_key())
+                        .arg(due_ms)
+                        .arg(raw)
+                        .query_async(&mut conn)
+                        .await?;
+                }
+                JobBackend::Memory => {
+                    let store = memory_store(&self.app)?;
+                    memory_schedule_envelope(&store, envelope)?;
+                }
+            }
             Ok(id)
         }
 
@@ -305,7 +364,12 @@ mod host {
         }
 
         async fn connection(&self) -> JobResult<MultiplexedConnection> {
-            let client = redis::Client::open(self.redis_url.as_str())?;
+            let JobBackend::Redis { url } = &self.backend else {
+                return Err(JobError::unsupported(
+                    "the memory job backend does not have a Redis connection",
+                ));
+            };
+            let client = redis::Client::open(url.as_str())?;
             Ok(client.get_multiplexed_async_connection().await?)
         }
 
@@ -329,9 +393,9 @@ mod host {
     /// Worker configuration.
     #[derive(Clone, Debug)]
     pub struct WorkerConfig {
-        /// Redis connection URL.
-        pub redis_url: String,
-        /// Redis key namespace.
+        /// Storage backend.
+        pub backend: JobBackend,
+        /// App namespace.
         pub app: String,
         /// Queues this worker should consume.
         pub queues: Vec<String>,
@@ -363,7 +427,7 @@ mod host {
             };
 
             Ok(Self {
-                redis_url: redis_url_from_env()?,
+                backend: job_backend_from_env()?,
                 app: std::env::var("POCOPINE_APP_NAME")
                     .unwrap_or_else(|_| DEFAULT_APP_NAME.to_string()),
                 queues,
@@ -379,7 +443,7 @@ mod host {
         }
     }
 
-    /// Redis-backed background worker.
+    /// Background worker.
     pub struct Worker {
         config: WorkerConfig,
         client: JobClient,
@@ -394,7 +458,7 @@ mod host {
 
         /// Build from explicit config.
         pub fn new(config: WorkerConfig) -> JobResult<Self> {
-            let client = JobClient::new(config.redis_url.clone(), config.app.clone());
+            let client = JobClient::for_backend(config.backend.clone(), config.app.clone());
             let descriptors = registered_jobs()
                 .map(|descriptor| (descriptor.name, descriptor))
                 .collect();
@@ -423,18 +487,105 @@ mod host {
             }
         }
 
+        /// Run one scheduler/read/execute pass.
+        ///
+        /// This is primarily useful for embedded workers, tests, and hosts that
+        /// want to own the outer loop.
+        pub async fn run_once(&self) -> JobResult<usize> {
+            match &self.config.backend {
+                JobBackend::Redis { .. } => {
+                    let mut conn = self.client.connection().await?;
+                    self.ensure_groups(&mut conn).await?;
+                    self.run_redis_once(&mut conn).await
+                }
+                JobBackend::Memory => self.run_memory_once().await,
+            }
+        }
+
         async fn run_until_error(&self) -> JobResult<()> {
+            match &self.config.backend {
+                JobBackend::Redis { .. } => self.run_redis_until_error().await,
+                JobBackend::Memory => self.run_memory_until_error().await,
+            }
+        }
+
+        async fn run_redis_until_error(&self) -> JobResult<()> {
             let mut conn = self.client.connection().await?;
             self.ensure_groups(&mut conn).await?;
             loop {
-                self.enqueue_due_periodic_jobs(&mut conn).await?;
-                self.promote_due_jobs(&mut conn).await?;
-                self.reclaim_stale_jobs(&mut conn).await?;
-                let handled = self.read_ready_jobs(&mut conn).await?;
+                let handled = self.run_redis_once(&mut conn).await?;
                 if handled == 0 {
                     tokio::time::sleep(self.config.scheduler_interval).await;
                 }
             }
+        }
+
+        async fn run_redis_once(&self, conn: &mut MultiplexedConnection) -> JobResult<usize> {
+            self.enqueue_due_periodic_jobs(&mut *conn).await?;
+            self.promote_due_jobs(&mut *conn).await?;
+            self.reclaim_stale_jobs(&mut *conn).await?;
+            self.read_ready_jobs(conn).await
+        }
+
+        async fn run_memory_until_error(&self) -> JobResult<()> {
+            loop {
+                let handled = self.run_memory_once().await?;
+                if handled == 0 {
+                    tokio::time::sleep(self.config.scheduler_interval).await;
+                }
+            }
+        }
+
+        async fn run_memory_once(&self) -> JobResult<usize> {
+            self.enqueue_due_periodic_jobs_memory()?;
+            self.promote_due_jobs_memory()?;
+
+            let store = memory_store(&self.config.app)?;
+            let envelopes =
+                memory_pop_ready_envelopes(&store, &self.config.queues, self.config.batch_size)?;
+            let handled = envelopes.len();
+            for envelope in envelopes {
+                self.run_envelope_memory(envelope).await?;
+            }
+            Ok(handled)
+        }
+
+        fn enqueue_due_periodic_jobs_memory(&self) -> JobResult<()> {
+            let now_ms = epoch_ms(SystemTime::now())?;
+            let store = memory_store(&self.config.app)?;
+            for descriptor in self.descriptors.values() {
+                let Some(schedule) = descriptor.periodic else {
+                    continue;
+                };
+                if !self.config.queues.iter().any(|q| q == descriptor.queue) {
+                    continue;
+                }
+                let Some(due_ms) =
+                    due_periodic_slot(schedule, now_ms, self.config.scheduler_interval)?
+                else {
+                    continue;
+                };
+                let lock_key = self.client.periodic_lock_key(descriptor.name, due_ms);
+                let expires_at_ms = now_ms.saturating_add(periodic_lock_ttl_ms(schedule));
+                if !memory_try_periodic_lock(&store, lock_key, now_ms, expires_at_ms)? {
+                    continue;
+                }
+
+                let envelope = JobEnvelope::new(
+                    descriptor.name,
+                    descriptor.queue,
+                    descriptor.retry_policy.max_attempts,
+                    &(),
+                    None,
+                )?;
+                memory_enqueue_envelope(&store, envelope)?;
+            }
+            Ok(())
+        }
+
+        fn promote_due_jobs_memory(&self) -> JobResult<()> {
+            let store = memory_store(&self.config.app)?;
+            memory_promote_due_envelopes(&store, epoch_ms(SystemTime::now())?)
         }
 
         async fn ensure_groups(&self, conn: &mut MultiplexedConnection) -> JobResult<()> {
@@ -630,6 +781,37 @@ mod host {
             }
         }
 
+        async fn run_envelope_memory(&self, envelope: JobEnvelope) -> JobResult<()> {
+            let Some(descriptor) = self.descriptors.get(envelope.job_name.as_str()) else {
+                self.move_to_dead_memory(envelope, "unknown job")?;
+                return Ok(());
+            };
+
+            let payload = serde_json::to_vec(&envelope.payload)?;
+            match (descriptor.handler)(payload).await {
+                Ok(()) => Ok(()),
+                Err(err) => {
+                    if envelope.attempt < envelope.max_attempts {
+                        let mut retry = envelope.clone();
+                        retry.attempt += 1;
+                        let due_ms = epoch_ms(SystemTime::now())?
+                            .saturating_add(retry_delay_ms(retry.attempt, &retry.job_id));
+                        retry.scheduled_for_ms = Some(due_ms);
+                        let store = memory_store(&self.config.app)?;
+                        memory_schedule_envelope(&store, retry)?;
+                    } else {
+                        self.move_to_dead_memory(envelope, &err.to_string())?;
+                    }
+                    Ok(())
+                }
+            }
+        }
+
+        fn move_to_dead_memory(&self, envelope: JobEnvelope, error: &str) -> JobResult<()> {
+            let store = memory_store(&self.config.app)?;
+            memory_move_to_dead(&store, envelope, error)
+        }
+
         async fn move_to_dead(
             &self,
             conn: &mut MultiplexedConnection,
@@ -709,6 +891,108 @@ mod host {
                 scheduled_for_ms,
             })
         }
+    }
+
+    fn memory_store(app: &str) -> JobResult<Arc<MemoryStore>> {
+        let stores = MEMORY_STORES.get_or_init(|| Mutex::new(HashMap::new()));
+        let mut stores = stores
+            .lock()
+            .map_err(|_| JobError::Env("memory job store registry was poisoned".into()))?;
+        Ok(stores
+            .entry(app.to_string())
+            .or_insert_with(|| Arc::new(MemoryStore::default()))
+            .clone())
+    }
+
+    fn memory_state(store: &MemoryStore) -> JobResult<MutexGuard<'_, MemoryState>> {
+        store
+            .state
+            .lock()
+            .map_err(|_| JobError::Env("memory job store was poisoned".into()))
+    }
+
+    fn memory_enqueue_envelope(store: &MemoryStore, envelope: JobEnvelope) -> JobResult<()> {
+        memory_state(store)?.ready.push_back(envelope);
+        Ok(())
+    }
+
+    fn memory_schedule_envelope(store: &MemoryStore, envelope: JobEnvelope) -> JobResult<()> {
+        memory_state(store)?.scheduled.push(envelope);
+        Ok(())
+    }
+
+    fn memory_promote_due_envelopes(store: &MemoryStore, now_ms: u64) -> JobResult<()> {
+        let mut state = memory_state(store)?;
+        let max_promote = DEFAULT_MAX_PROMOTE.max(0) as usize;
+        let scheduled_count = state.scheduled.len();
+        let mut remaining = Vec::with_capacity(scheduled_count);
+        let mut promoted = VecDeque::new();
+
+        for mut envelope in state.scheduled.drain(..) {
+            let is_due = envelope.scheduled_for_ms.unwrap_or(0) <= now_ms;
+            if is_due && promoted.len() < max_promote {
+                envelope.scheduled_for_ms = None;
+                promoted.push_back(envelope);
+            } else {
+                remaining.push(envelope);
+            }
+        }
+
+        state.scheduled = remaining;
+        state.ready.extend(promoted);
+        Ok(())
+    }
+
+    fn memory_pop_ready_envelopes(
+        store: &MemoryStore,
+        queues: &[String],
+        batch_size: usize,
+    ) -> JobResult<Vec<JobEnvelope>> {
+        if queues.is_empty() || batch_size == 0 {
+            return Ok(Vec::new());
+        }
+
+        let allowed: BTreeSet<&str> = queues.iter().map(String::as_str).collect();
+        let mut state = memory_state(store)?;
+        let mut selected = Vec::new();
+        let mut remaining = VecDeque::with_capacity(state.ready.len());
+
+        while let Some(envelope) = state.ready.pop_front() {
+            if selected.len() < batch_size && allowed.contains(envelope.queue.as_str()) {
+                selected.push(envelope);
+            } else {
+                remaining.push_back(envelope);
+            }
+        }
+
+        state.ready = remaining;
+        Ok(selected)
+    }
+
+    fn memory_try_periodic_lock(
+        store: &MemoryStore,
+        lock_key: String,
+        now_ms: u64,
+        expires_at_ms: u64,
+    ) -> JobResult<bool> {
+        let mut state = memory_state(store)?;
+        state.periodic_locks.retain(|_, expires| *expires > now_ms);
+        if state.periodic_locks.contains_key(&lock_key) {
+            return Ok(false);
+        }
+        state.periodic_locks.insert(lock_key, expires_at_ms);
+        Ok(true)
+    }
+
+    fn memory_move_to_dead(
+        store: &MemoryStore,
+        envelope: JobEnvelope,
+        error: &str,
+    ) -> JobResult<()> {
+        memory_state(store)?
+            .dead
+            .push((envelope, error.to_string()));
+        Ok(())
     }
 
     async fn xadd_envelope(
@@ -799,12 +1083,38 @@ mod host {
         }
     }
 
+    fn job_backend_from_env() -> JobResult<JobBackend> {
+        match std::env::var("POCOPINE_JOB_BACKEND") {
+            Ok(raw) => match raw.trim().to_ascii_lowercase().as_str() {
+                "memory" => Ok(JobBackend::Memory),
+                "redis" => redis_url_from_env().map(|url| JobBackend::Redis { url }),
+                "" => Err(JobError::Env(
+                    "POCOPINE_JOB_BACKEND was set but empty; use `memory` or `redis`".into(),
+                )),
+                other => Err(JobError::Env(format!(
+                    "unsupported POCOPINE_JOB_BACKEND `{other}`; use `memory` or `redis`"
+                ))),
+            },
+            Err(_) => match std::env::var("POCOPINE_REDIS_URL") {
+                Ok(url) if !url.trim().is_empty() => Ok(JobBackend::Redis { url }),
+                Ok(_) => Err(JobError::Env(
+                    "POCOPINE_REDIS_URL was set but empty; unset it for memory jobs or set a Redis URL".into(),
+                )),
+                Err(_) => Ok(JobBackend::Memory),
+            },
+        }
+    }
+
     fn redis_url_from_env() -> JobResult<String> {
-        std::env::var("POCOPINE_REDIS_URL").map_err(|_| {
-            JobError::Env(
-                "POCOPINE_REDIS_URL must be set for pocopine jobs; `pocopine dev` defaults it to redis://127.0.0.1/ for local development".into(),
-            )
-        })
+        let url = std::env::var("POCOPINE_REDIS_URL").map_err(|_| {
+            JobError::Env("POCOPINE_REDIS_URL must be set when POCOPINE_JOB_BACKEND=redis".into())
+        })?;
+        if url.trim().is_empty() {
+            return Err(JobError::Env(
+                "POCOPINE_REDIS_URL must not be empty when POCOPINE_JOB_BACKEND=redis".into(),
+            ));
+        }
+        Ok(url)
     }
 
     fn due_periodic_slot(
@@ -910,8 +1220,8 @@ mod host {
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use host::{
-    registered_jobs, JobClient, JobDescriptor, JobFuture, JobHandler, JobId, PeriodicSchedule,
-    RetryPolicy, Worker, WorkerConfig,
+    registered_jobs, JobBackend, JobClient, JobDescriptor, JobFuture, JobHandler, JobId,
+    PeriodicSchedule, RetryPolicy, Worker, WorkerConfig,
 };
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/pocopine-jobs/src/lib.rs
+++ b/crates/pocopine-jobs/src/lib.rs
@@ -99,6 +99,68 @@ mod host {
     const DEFAULT_WORKER_ERROR_BACKOFF_MAX_MS: u64 = 30_000;
     const DEFAULT_RETRY_BASE_DELAY_MS: u64 = 1_000;
     const DEFAULT_RETRY_MAX_DELAY_MS: u64 = 60_000;
+    const PROMOTE_SCHEDULED_SCRIPT: &str = r#"
+local removed = redis.call('ZREM', KEYS[1], ARGV[1])
+if removed == 0 then
+  return 0
+end
+return redis.call(
+  'XADD',
+  KEYS[2],
+  '*',
+  'job_id',
+  ARGV[2],
+  'job_name',
+  ARGV[3],
+  'queue',
+  ARGV[4],
+  'payload',
+  ARGV[5],
+  'attempt',
+  ARGV[6],
+  'max_attempts',
+  ARGV[7],
+  'created_at_ms',
+  ARGV[8],
+  'scheduled_for_ms',
+  ARGV[9]
+)
+"#;
+    const SCHEDULE_RETRY_AND_ACK_SCRIPT: &str = r#"
+local acked = redis.call('XACK', KEYS[2], ARGV[3], ARGV[4])
+if acked == 0 then
+  return 0
+end
+redis.call('ZADD', KEYS[1], ARGV[1], ARGV[2])
+return acked
+"#;
+    const DEAD_LETTER_AND_ACK_SCRIPT: &str = r#"
+local acked = redis.call('XACK', KEYS[2], ARGV[9], ARGV[10])
+if acked == 0 then
+  return 0
+end
+return redis.call(
+  'XADD',
+  KEYS[1],
+  '*',
+  'job_id',
+  ARGV[1],
+  'job_name',
+  ARGV[2],
+  'queue',
+  ARGV[3],
+  'attempt',
+  ARGV[4],
+  'max_attempts',
+  ARGV[5],
+  'error',
+  ARGV[6],
+  'envelope',
+  ARGV[7],
+  'failed_at_ms',
+  ARGV[8]
+)
+"#;
 
     static JOB_COUNTER: AtomicU64 = AtomicU64::new(1);
     static MEMORY_STORES: OnceLock<Mutex<HashMap<String, Arc<MemoryStore>>>> = OnceLock::new();
@@ -526,8 +588,9 @@ mod host {
         }
 
         async fn run_redis_once(&self, conn: &mut MultiplexedConnection) -> JobResult<usize> {
-            self.enqueue_due_periodic_jobs(&mut *conn).await?;
-            self.promote_due_jobs(&mut *conn).await?;
+            let now_ms = redis_time_ms(&mut *conn).await?;
+            self.enqueue_due_periodic_jobs(&mut *conn, now_ms).await?;
+            self.promote_due_jobs(&mut *conn, now_ms).await?;
             self.reclaim_stale_jobs(&mut *conn).await?;
             self.read_ready_jobs(conn).await
         }
@@ -616,8 +679,8 @@ mod host {
         async fn enqueue_due_periodic_jobs(
             &self,
             conn: &mut MultiplexedConnection,
+            now_ms: u64,
         ) -> JobResult<()> {
-            let now_ms = epoch_ms(SystemTime::now())?;
             for descriptor in self.descriptors.values() {
                 let Some(schedule) = descriptor.periodic else {
                     continue;
@@ -655,12 +718,15 @@ mod host {
             Ok(())
         }
 
-        async fn promote_due_jobs(&self, conn: &mut MultiplexedConnection) -> JobResult<()> {
-            let now = epoch_ms(SystemTime::now())?;
+        async fn promote_due_jobs(
+            &self,
+            conn: &mut MultiplexedConnection,
+            now_ms: u64,
+        ) -> JobResult<()> {
             let raw_jobs: Vec<String> = redis::cmd("ZRANGEBYSCORE")
                 .arg(self.client.scheduled_key())
                 .arg("-inf")
-                .arg(now)
+                .arg(now_ms)
                 .arg("LIMIT")
                 .arg(0)
                 .arg(DEFAULT_MAX_PROMOTE)
@@ -677,7 +743,14 @@ mod host {
                 }
                 let mut envelope: JobEnvelope = serde_json::from_str(&raw)?;
                 envelope.scheduled_for_ms = None;
-                xadd_envelope(conn, &self.client.queue_key(&envelope.queue), &envelope).await?;
+                promote_scheduled_envelope(
+                    conn,
+                    &self.client.scheduled_key(),
+                    &self.client.queue_key(&envelope.queue),
+                    &raw,
+                    &envelope,
+                )
+                .await?;
             }
             Ok(())
         }
@@ -705,9 +778,14 @@ mod host {
                         }
                     };
                     if envelope.attempt >= envelope.max_attempts {
-                        self.move_to_dead(conn, &envelope, "job reclaimed after max attempts")
-                            .await?;
-                        self.ack(conn, &stream, &id.id).await?;
+                        self.move_to_dead_and_ack(
+                            conn,
+                            &stream,
+                            &id.id,
+                            &envelope,
+                            "job reclaimed after max attempts",
+                        )
+                        .await?;
                         continue;
                     }
                     let mut envelope = envelope;
@@ -761,8 +839,8 @@ mod host {
             envelope: JobEnvelope,
         ) -> JobResult<()> {
             let Some(descriptor) = self.descriptors.get(envelope.job_name.as_str()) else {
-                self.move_to_dead(conn, &envelope, "unknown job").await?;
-                self.ack(conn, stream, stream_id).await?;
+                self.move_to_dead_and_ack(conn, stream, stream_id, &envelope, "unknown job")
+                    .await?;
                 return Ok(());
             };
 
@@ -773,15 +851,31 @@ mod host {
                     if envelope.attempt < envelope.max_attempts {
                         let mut retry = envelope.clone();
                         retry.attempt += 1;
-                        let due_ms = epoch_ms(SystemTime::now())?
+                        let due_ms = redis_time_ms(&mut *conn)
+                            .await?
                             .saturating_add(retry_delay_ms(retry.attempt, &retry.job_id));
                         retry.scheduled_for_ms = Some(due_ms);
-                        schedule_envelope(conn, &self.client.scheduled_key(), &retry, due_ms)
-                            .await?;
+                        schedule_retry_and_ack(
+                            conn,
+                            &self.client.scheduled_key(),
+                            stream,
+                            &self.config.group,
+                            stream_id,
+                            &retry,
+                            due_ms,
+                        )
+                        .await?;
                     } else {
-                        self.move_to_dead(conn, &envelope, &err.to_string()).await?;
+                        self.move_to_dead_and_ack(
+                            conn,
+                            stream,
+                            stream_id,
+                            &envelope,
+                            &err.to_string(),
+                        )
+                        .await?;
                     }
-                    self.ack(conn, stream, stream_id).await
+                    Ok(())
                 }
             }
         }
@@ -817,33 +911,24 @@ mod host {
             memory_move_to_dead(&store, envelope, error)
         }
 
-        async fn move_to_dead(
+        async fn move_to_dead_and_ack(
             &self,
             conn: &mut MultiplexedConnection,
+            stream: &str,
+            stream_id: &str,
             envelope: &JobEnvelope,
             error: &str,
         ) -> JobResult<()> {
-            let raw = serde_json::to_string(envelope)?;
-            let _: String = redis::cmd("XADD")
-                .arg(self.client.dead_key())
-                .arg("*")
-                .arg("job_id")
-                .arg(&envelope.job_id)
-                .arg("job_name")
-                .arg(&envelope.job_name)
-                .arg("queue")
-                .arg(&envelope.queue)
-                .arg("attempt")
-                .arg(envelope.attempt)
-                .arg("max_attempts")
-                .arg(envelope.max_attempts)
-                .arg("error")
-                .arg(error)
-                .arg("envelope")
-                .arg(raw)
-                .query_async(conn)
-                .await?;
-            Ok(())
+            dead_letter_and_ack(
+                conn,
+                &self.client.dead_key(),
+                stream,
+                &self.config.group,
+                stream_id,
+                envelope,
+                error,
+            )
+            .await
         }
 
         async fn ack(
@@ -1030,20 +1115,91 @@ mod host {
         Ok(())
     }
 
-    async fn schedule_envelope(
+    async fn promote_scheduled_envelope(
         conn: &mut MultiplexedConnection,
         scheduled_key: &str,
+        queue_key: &str,
+        raw_scheduled_envelope: &str,
+        envelope: &JobEnvelope,
+    ) -> JobResult<()> {
+        let payload = serde_json::to_string(&envelope.payload)?;
+        let _: Value = redis::cmd("EVAL")
+            .arg(PROMOTE_SCHEDULED_SCRIPT)
+            .arg(2)
+            .arg(scheduled_key)
+            .arg(queue_key)
+            .arg(raw_scheduled_envelope)
+            .arg(&envelope.job_id)
+            .arg(&envelope.job_name)
+            .arg(&envelope.queue)
+            .arg(payload)
+            .arg(envelope.attempt)
+            .arg(envelope.max_attempts)
+            .arg(envelope.created_at_ms)
+            .arg(0_u64)
+            .query_async(conn)
+            .await?;
+        Ok(())
+    }
+
+    async fn schedule_retry_and_ack(
+        conn: &mut MultiplexedConnection,
+        scheduled_key: &str,
+        stream: &str,
+        group: &str,
+        stream_id: &str,
         envelope: &JobEnvelope,
         due_ms: u64,
     ) -> JobResult<()> {
         let raw = serde_json::to_string(envelope)?;
-        let _: () = redis::cmd("ZADD")
+        let _: i32 = redis::cmd("EVAL")
+            .arg(SCHEDULE_RETRY_AND_ACK_SCRIPT)
+            .arg(2)
             .arg(scheduled_key)
+            .arg(stream)
             .arg(due_ms)
             .arg(raw)
+            .arg(group)
+            .arg(stream_id)
             .query_async(conn)
             .await?;
         Ok(())
+    }
+
+    async fn dead_letter_and_ack(
+        conn: &mut MultiplexedConnection,
+        dead_key: &str,
+        stream: &str,
+        group: &str,
+        stream_id: &str,
+        envelope: &JobEnvelope,
+        error: &str,
+    ) -> JobResult<()> {
+        let raw = serde_json::to_string(envelope)?;
+        let failed_at_ms = redis_time_ms(&mut *conn).await?;
+        let _: Value = redis::cmd("EVAL")
+            .arg(DEAD_LETTER_AND_ACK_SCRIPT)
+            .arg(2)
+            .arg(dead_key)
+            .arg(stream)
+            .arg(&envelope.job_id)
+            .arg(&envelope.job_name)
+            .arg(&envelope.queue)
+            .arg(envelope.attempt)
+            .arg(envelope.max_attempts)
+            .arg(error)
+            .arg(raw)
+            .arg(failed_at_ms)
+            .arg(group)
+            .arg(stream_id)
+            .query_async(conn)
+            .await?;
+        Ok(())
+    }
+
+    async fn redis_time_ms(conn: &mut MultiplexedConnection) -> JobResult<u64> {
+        let (seconds, micros): (u64, u64) = redis::cmd("TIME").query_async(conn).await?;
+        Ok(seconds.saturating_mul(1_000).saturating_add(micros / 1_000))
     }
 
     fn envelope_from_stream(map: &HashMap<String, Value>) -> JobResult<JobEnvelope> {
@@ -1159,7 +1315,9 @@ mod host {
                 })?;
                 let interval = ChronoDuration::from_std(scheduler_interval)
                     .unwrap_or_else(|_| ChronoDuration::seconds(1));
-                let window_start = Utc::now() - interval;
+                let now = chrono::DateTime::<Utc>::from_timestamp_millis(now_ms as i64)
+                    .ok_or_else(|| JobError::Time(format!("invalid timestamp ms: {now_ms}")))?;
+                let window_start = now - interval;
                 let Some(next) = schedule.after(&window_start).next() else {
                     return Ok(None);
                 };

--- a/crates/pocopine-jobs/src/lib.rs
+++ b/crates/pocopine-jobs/src/lib.rs
@@ -95,6 +95,7 @@ mod host {
     const DEFAULT_VISIBILITY_TIMEOUT_MS: u64 = 60_000;
     const DEFAULT_SCHEDULER_INTERVAL_MS: u64 = 1_000;
     const DEFAULT_MAX_PROMOTE: isize = 100;
+    const DEFAULT_MAX_PERIODIC_CATCH_UP: usize = 16;
     const DEFAULT_WORKER_ERROR_BACKOFF_MS: u64 = 1_000;
     const DEFAULT_WORKER_ERROR_BACKOFF_MAX_MS: u64 = 30_000;
     const DEFAULT_RETRY_BASE_DELAY_MS: u64 = 1_000;
@@ -199,6 +200,7 @@ return redis.call(
         scheduled: Vec<JobEnvelope>,
         dead: Vec<(JobEnvelope, String)>,
         periodic_locks: HashMap<String, u64>,
+        periodic_last_fired: HashMap<String, u64>,
     }
 
     /// Retry behavior attached to generated job descriptors.
@@ -452,6 +454,10 @@ return redis.call(
         fn periodic_lock_key(&self, job_name: &str, due_ms: u64) -> String {
             format!("pocopine:{}:periodic:{job_name}:{due_ms}", self.app)
         }
+
+        fn periodic_last_key(&self, job_name: &str) -> String {
+            format!("pocopine:{}:periodic:last:{job_name}", self.app)
+        }
     }
 
     /// Worker configuration.
@@ -628,25 +634,30 @@ return redis.call(
                 if !self.config.queues.iter().any(|q| q == descriptor.queue) {
                     continue;
                 }
-                let Some(due_ms) =
-                    due_periodic_slot(schedule, now_ms, self.config.scheduler_interval)?
-                else {
-                    continue;
-                };
-                let lock_key = self.client.periodic_lock_key(descriptor.name, due_ms);
-                let expires_at_ms = now_ms.saturating_add(periodic_lock_ttl_ms(schedule));
-                if !memory_try_periodic_lock(&store, lock_key, now_ms, expires_at_ms)? {
-                    continue;
-                }
+                let last_key = self.client.periodic_last_key(descriptor.name);
+                let last_fired_ms = memory_periodic_last_fired(&store, &last_key)?;
+                for due_ms in due_periodic_slots(
+                    schedule,
+                    now_ms,
+                    self.config.scheduler_interval,
+                    last_fired_ms,
+                )? {
+                    let lock_key = self.client.periodic_lock_key(descriptor.name, due_ms);
+                    let expires_at_ms = now_ms.saturating_add(periodic_lock_ttl_ms(schedule));
+                    if !memory_try_periodic_lock(&store, lock_key, now_ms, expires_at_ms)? {
+                        continue;
+                    }
 
-                let envelope = JobEnvelope::new(
-                    descriptor.name,
-                    descriptor.queue,
-                    descriptor.retry_policy.max_attempts,
-                    &(),
-                    None,
-                )?;
-                memory_enqueue_envelope(&store, envelope)?;
+                    let envelope = JobEnvelope::new(
+                        descriptor.name,
+                        descriptor.queue,
+                        descriptor.retry_policy.max_attempts,
+                        &(),
+                        None,
+                    )?;
+                    memory_enqueue_envelope(&store, envelope)?;
+                    memory_set_periodic_last_fired(&store, last_key.clone(), due_ms)?;
+                }
             }
             Ok(())
         }
@@ -688,32 +699,42 @@ return redis.call(
                 if !self.config.queues.iter().any(|q| q == descriptor.queue) {
                     continue;
                 }
-                let Some(due_ms) =
-                    due_periodic_slot(schedule, now_ms, self.config.scheduler_interval)?
-                else {
-                    continue;
-                };
-                let lock_key = self.client.periodic_lock_key(descriptor.name, due_ms);
-                let locked: Option<String> = redis::cmd("SET")
-                    .arg(lock_key)
-                    .arg("1")
-                    .arg("NX")
-                    .arg("PX")
-                    .arg(periodic_lock_ttl_ms(schedule))
-                    .query_async(conn)
-                    .await?;
-                if locked.is_none() {
-                    continue;
-                }
+                let last_key = self.client.periodic_last_key(descriptor.name);
+                let last_fired_ms = redis_get_u64(conn, &last_key).await?;
+                for due_ms in due_periodic_slots(
+                    schedule,
+                    now_ms,
+                    self.config.scheduler_interval,
+                    last_fired_ms,
+                )? {
+                    let lock_key = self.client.periodic_lock_key(descriptor.name, due_ms);
+                    let locked: Option<String> = redis::cmd("SET")
+                        .arg(lock_key)
+                        .arg("1")
+                        .arg("NX")
+                        .arg("PX")
+                        .arg(periodic_lock_ttl_ms(schedule))
+                        .query_async(&mut *conn)
+                        .await?;
+                    if locked.is_none() {
+                        continue;
+                    }
 
-                let envelope = JobEnvelope::new(
-                    descriptor.name,
-                    descriptor.queue,
-                    descriptor.retry_policy.max_attempts,
-                    &(),
-                    None,
-                )?;
-                xadd_envelope(conn, &self.client.queue_key(descriptor.queue), &envelope).await?;
+                    let envelope = JobEnvelope::new(
+                        descriptor.name,
+                        descriptor.queue,
+                        descriptor.retry_policy.max_attempts,
+                        &(),
+                        None,
+                    )?;
+                    xadd_envelope(
+                        &mut *conn,
+                        &self.client.queue_key(descriptor.queue),
+                        &envelope,
+                    )
+                    .await?;
+                    redis_set_u64(&mut *conn, &last_key, due_ms).await?;
+                }
             }
             Ok(())
         }
@@ -1074,6 +1095,19 @@ return redis.call(
         Ok(true)
     }
 
+    fn memory_periodic_last_fired(store: &MemoryStore, key: &str) -> JobResult<Option<u64>> {
+        Ok(memory_state(store)?.periodic_last_fired.get(key).copied())
+    }
+
+    fn memory_set_periodic_last_fired(
+        store: &MemoryStore,
+        key: String,
+        due_ms: u64,
+    ) -> JobResult<()> {
+        memory_state(store)?.periodic_last_fired.insert(key, due_ms);
+        Ok(())
+    }
+
     fn memory_move_to_dead(
         store: &MemoryStore,
         envelope: JobEnvelope,
@@ -1202,6 +1236,29 @@ return redis.call(
         Ok(seconds.saturating_mul(1_000).saturating_add(micros / 1_000))
     }
 
+    async fn redis_get_u64(conn: &mut MultiplexedConnection, key: &str) -> JobResult<Option<u64>> {
+        let raw: Option<String> = redis::cmd("GET").arg(key).query_async(conn).await?;
+        raw.map(|value| {
+            value.parse::<u64>().map_err(|err| {
+                JobError::Env(format!("Redis key `{key}` should contain a u64: {err}"))
+            })
+        })
+        .transpose()
+    }
+
+    async fn redis_set_u64(
+        conn: &mut MultiplexedConnection,
+        key: &str,
+        value: u64,
+    ) -> JobResult<()> {
+        let _: () = redis::cmd("SET")
+            .arg(key)
+            .arg(value)
+            .query_async(conn)
+            .await?;
+        Ok(())
+    }
+
     fn envelope_from_stream(map: &HashMap<String, Value>) -> JobResult<JobEnvelope> {
         let job_id = field::<String>(map, "job_id")?;
         let job_name = field::<String>(map, "job_name")?;
@@ -1297,36 +1354,54 @@ return redis.call(
         Ok(Duration::from_millis(value))
     }
 
-    fn due_periodic_slot(
+    fn due_periodic_slots(
         schedule: PeriodicSchedule,
         now_ms: u64,
         scheduler_interval: Duration,
-    ) -> JobResult<Option<u64>> {
+        last_fired_ms: Option<u64>,
+    ) -> JobResult<Vec<u64>> {
         match schedule {
             PeriodicSchedule::Every { interval_ms } => {
                 if interval_ms == 0 {
-                    return Ok(None);
+                    return Ok(Vec::new());
                 }
-                Ok(Some((now_ms / interval_ms) * interval_ms))
+                let due_ms = (now_ms / interval_ms) * interval_ms;
+                if last_fired_ms.is_some_and(|last| last >= due_ms) {
+                    Ok(Vec::new())
+                } else {
+                    Ok(vec![due_ms])
+                }
             }
             PeriodicSchedule::Cron { expr } => {
                 let schedule = Schedule::from_str(expr).map_err(|err| {
                     JobError::Env(format!("invalid cron expression `{expr}`: {err}"))
                 })?;
-                let interval = ChronoDuration::from_std(scheduler_interval)
-                    .unwrap_or_else(|_| ChronoDuration::seconds(1));
                 let now = chrono::DateTime::<Utc>::from_timestamp_millis(now_ms as i64)
                     .ok_or_else(|| JobError::Time(format!("invalid timestamp ms: {now_ms}")))?;
-                let window_start = now - interval;
-                let Some(next) = schedule.after(&window_start).next() else {
-                    return Ok(None);
+                let window_start = match last_fired_ms {
+                    Some(last_fired_ms) => {
+                        chrono::DateTime::<Utc>::from_timestamp_millis(last_fired_ms as i64)
+                            .ok_or_else(|| {
+                                JobError::Time(format!(
+                                    "invalid last-fired timestamp ms: {last_fired_ms}"
+                                ))
+                            })?
+                    }
+                    None => {
+                        let interval = ChronoDuration::from_std(scheduler_interval)
+                            .unwrap_or_else(|_| ChronoDuration::seconds(1));
+                        now - interval
+                    }
                 };
-                let due_ms = next.timestamp_millis();
-                if due_ms >= 0 && due_ms as u64 <= now_ms {
-                    Ok(Some(due_ms as u64))
-                } else {
-                    Ok(None)
-                }
+
+                Ok(schedule
+                    .after(&window_start)
+                    .take(DEFAULT_MAX_PERIODIC_CATCH_UP)
+                    .filter_map(|due| {
+                        let due_ms = due.timestamp_millis();
+                        (due_ms >= 0 && due_ms as u64 <= now_ms).then_some(due_ms as u64)
+                    })
+                    .collect())
             }
         }
     }
@@ -1464,6 +1539,44 @@ return redis.call(
             );
             assert!(parse_positive_millis("POCOPINE_JOB_VISIBILITY_MS", "0").is_err());
             assert!(parse_positive_millis("POCOPINE_JOB_VISIBILITY_MS", "banana").is_err());
+        }
+
+        #[test]
+        fn cron_due_slots_catch_up_from_last_fired_time() {
+            let last = chrono::DateTime::parse_from_rfc3339("2026-05-02T00:00:00Z")
+                .unwrap()
+                .timestamp_millis() as u64;
+            let now = chrono::DateTime::parse_from_rfc3339("2026-05-02T00:00:15Z")
+                .unwrap()
+                .timestamp_millis() as u64;
+
+            let slots = due_periodic_slots(
+                PeriodicSchedule::Cron {
+                    expr: "0/5 * * * * * *",
+                },
+                now,
+                Duration::from_secs(1),
+                Some(last),
+            )
+            .unwrap();
+
+            assert_eq!(slots.len(), 3);
+            assert_eq!(slots[0], last + 5_000);
+            assert_eq!(slots[1], last + 10_000);
+            assert_eq!(slots[2], last + 15_000);
+        }
+
+        #[test]
+        fn every_due_slot_does_not_repeat_last_fired_slot() {
+            let slots = due_periodic_slots(
+                PeriodicSchedule::Every { interval_ms: 5_000 },
+                12_000,
+                Duration::from_secs(1),
+                Some(10_000),
+            )
+            .unwrap();
+
+            assert!(slots.is_empty());
         }
     }
 }

--- a/crates/pocopine-jobs/src/lib.rs
+++ b/crates/pocopine-jobs/src/lib.rs
@@ -100,7 +100,7 @@ mod host {
     const DEFAULT_WORKER_ERROR_BACKOFF_MAX_MS: u64 = 30_000;
     const DEFAULT_RETRY_BASE_DELAY_MS: u64 = 1_000;
     const DEFAULT_RETRY_MAX_DELAY_MS: u64 = 60_000;
-    const PROMOTE_SCHEDULED_SCRIPT: &str = r#"
+    const PROMOTE_SCHEDULED_SCRIPT_SRC: &str = r#"
 local removed = redis.call('ZREM', KEYS[1], ARGV[1])
 if removed == 0 then
   return 0
@@ -127,7 +127,7 @@ return redis.call(
   ARGV[9]
 )
 "#;
-    const SCHEDULE_RETRY_AND_ACK_SCRIPT: &str = r#"
+    const SCHEDULE_RETRY_AND_ACK_SCRIPT_SRC: &str = r#"
 local acked = redis.call('XACK', KEYS[2], ARGV[3], ARGV[4])
 if acked == 0 then
   return 0
@@ -135,7 +135,7 @@ end
 redis.call('ZADD', KEYS[1], ARGV[1], ARGV[2])
 return acked
 "#;
-    const DEAD_LETTER_AND_ACK_SCRIPT: &str = r#"
+    const DEAD_LETTER_AND_ACK_SCRIPT_SRC: &str = r#"
 local acked = redis.call('XACK', KEYS[2], ARGV[9], ARGV[10])
 if acked == 0 then
   return 0
@@ -162,6 +162,24 @@ return redis.call(
   ARGV[8]
 )
 "#;
+
+    /// Cached `EVALSHA`-able scripts. The `redis` crate's `Script` LOADs
+    /// the body once and uses `EVALSHA` thereafter, avoiding shipping the
+    /// Lua source over the wire on every promote/retry/dead-letter call.
+    fn promote_scheduled_script() -> &'static redis::Script {
+        static SCRIPT: OnceLock<redis::Script> = OnceLock::new();
+        SCRIPT.get_or_init(|| redis::Script::new(PROMOTE_SCHEDULED_SCRIPT_SRC))
+    }
+
+    fn schedule_retry_and_ack_script() -> &'static redis::Script {
+        static SCRIPT: OnceLock<redis::Script> = OnceLock::new();
+        SCRIPT.get_or_init(|| redis::Script::new(SCHEDULE_RETRY_AND_ACK_SCRIPT_SRC))
+    }
+
+    fn dead_letter_and_ack_script() -> &'static redis::Script {
+        static SCRIPT: OnceLock<redis::Script> = OnceLock::new();
+        SCRIPT.get_or_init(|| redis::Script::new(DEAD_LETTER_AND_ACK_SCRIPT_SRC))
+    }
 
     static JOB_COUNTER: AtomicU64 = AtomicU64::new(1);
     static MEMORY_STORES: OnceLock<Mutex<HashMap<String, Arc<MemoryStore>>>> = OnceLock::new();
@@ -304,11 +322,33 @@ return redis.call(
         inventory::iter::<JobDescriptor>.into_iter()
     }
 
+    /// Pre-formatted Redis keys for a given app namespace.
+    ///
+    /// `scheduled` and `dead` are constant per-app and are hit on every
+    /// promote, retry, and dead-letter; caching avoids re-formatting them
+    /// on the worker hot path.
+    #[derive(Debug)]
+    struct JobKeys {
+        scheduled: String,
+        dead: String,
+    }
+
+    impl JobKeys {
+        fn new(app: &str) -> Self {
+            Self {
+                scheduled: format!("pocopine:{app}:scheduled"),
+                dead: format!("pocopine:{app}:dead"),
+            }
+        }
+    }
+
     /// Client for enqueueing and scheduling background jobs.
     #[derive(Clone, Debug)]
     pub struct JobClient {
         backend: JobBackend,
         app: String,
+        keys: Arc<JobKeys>,
+        memory_store: Arc<OnceLock<Arc<MemoryStore>>>,
         redis_connection: Arc<Mutex<Option<MultiplexedConnection>>>,
     }
 
@@ -316,38 +356,37 @@ return redis.call(
         /// Build from `POCOPINE_JOB_BACKEND`, `POCOPINE_REDIS_URL`, and
         /// optional `POCOPINE_APP_NAME`.
         pub fn from_env() -> JobResult<Self> {
-            Ok(Self {
-                backend: job_backend_from_env()?,
-                app: std::env::var("POCOPINE_APP_NAME")
-                    .unwrap_or_else(|_| DEFAULT_APP_NAME.to_string()),
-                redis_connection: Arc::new(Mutex::new(None)),
-            })
+            let app = std::env::var("POCOPINE_APP_NAME")
+                .unwrap_or_else(|_| DEFAULT_APP_NAME.to_string());
+            Ok(Self::build(job_backend_from_env()?, app))
         }
 
         /// Build a client with explicit Redis URL and app namespace.
         pub fn new(redis_url: impl Into<String>, app: impl Into<String>) -> Self {
-            Self {
-                backend: JobBackend::Redis {
+            Self::build(
+                JobBackend::Redis {
                     url: redis_url.into(),
                 },
-                app: app.into(),
-                redis_connection: Arc::new(Mutex::new(None)),
-            }
+                app.into(),
+            )
         }
 
         /// Build a process-local memory client with an app namespace.
         pub fn memory(app: impl Into<String>) -> Self {
-            Self {
-                backend: JobBackend::Memory,
-                app: app.into(),
-                redis_connection: Arc::new(Mutex::new(None)),
-            }
+            Self::build(JobBackend::Memory, app.into())
         }
 
         fn for_backend(backend: JobBackend, app: impl Into<String>) -> Self {
+            Self::build(backend, app.into())
+        }
+
+        fn build(backend: JobBackend, app: String) -> Self {
+            let keys = Arc::new(JobKeys::new(&app));
             Self {
                 backend,
-                app: app.into(),
+                app,
+                keys,
+                memory_store: Arc::new(OnceLock::new()),
                 redis_connection: Arc::new(Mutex::new(None)),
             }
         }
@@ -371,7 +410,7 @@ return redis.call(
                     xadd_envelope(&mut conn, &self.queue_key(queue), &envelope).await?;
                 }
                 JobBackend::Memory => {
-                    let store = memory_store(&self.app)?;
+                    let store = self.cached_memory_store()?;
                     memory_enqueue_envelope(&store, envelope)?;
                 }
             }
@@ -420,7 +459,7 @@ return redis.call(
                         .await?;
                 }
                 JobBackend::Memory => {
-                    let store = memory_store(&self.app)?;
+                    let store = self.cached_memory_store()?;
                     memory_schedule_envelope(&store, envelope)?;
                 }
             }
@@ -498,12 +537,12 @@ return redis.call(
             format!("pocopine:{}:queue:{queue}", self.app)
         }
 
-        fn scheduled_key(&self) -> String {
-            format!("pocopine:{}:scheduled", self.app)
+        fn scheduled_key(&self) -> &str {
+            &self.keys.scheduled
         }
 
-        fn dead_key(&self) -> String {
-            format!("pocopine:{}:dead", self.app)
+        fn dead_key(&self) -> &str {
+            &self.keys.dead
         }
 
         fn periodic_lock_key(&self, job_name: &str, due_ms: u64) -> String {
@@ -512,6 +551,17 @@ return redis.call(
 
         fn periodic_last_key(&self, job_name: &str) -> String {
             format!("pocopine:{}:periodic:last:{job_name}", self.app)
+        }
+
+        /// Resolve and cache the per-app `MemoryStore` handle so worker
+        /// loops don't lock the global registry on every iteration.
+        fn cached_memory_store(&self) -> JobResult<Arc<MemoryStore>> {
+            if let Some(store) = self.memory_store.get() {
+                return Ok(store.clone());
+            }
+            let store = memory_store(&self.app)?;
+            let _ = self.memory_store.set(store.clone());
+            Ok(store)
         }
     }
 
@@ -676,7 +726,7 @@ return redis.call(
             self.enqueue_due_periodic_jobs_memory()?;
             self.promote_due_jobs_memory()?;
 
-            let store = memory_store(&self.config.app)?;
+            let store = self.client.cached_memory_store()?;
             let envelopes =
                 memory_pop_ready_envelopes(&store, &self.config.queues, self.config.batch_size)?;
             let handled = envelopes.len();
@@ -688,7 +738,7 @@ return redis.call(
 
         fn enqueue_due_periodic_jobs_memory(&self) -> JobResult<()> {
             let now_ms = epoch_ms(SystemTime::now())?;
-            let store = memory_store(&self.config.app)?;
+            let store = self.client.cached_memory_store()?;
             for descriptor in self.descriptors.values() {
                 let Some(schedule) = descriptor.periodic else {
                     continue;
@@ -726,7 +776,7 @@ return redis.call(
         }
 
         fn promote_due_jobs_memory(&self) -> JobResult<()> {
-            let store = memory_store(&self.config.app)?;
+            let store = self.client.cached_memory_store()?;
             memory_promote_due_envelopes(&store, epoch_ms(SystemTime::now())?)
         }
 
@@ -822,7 +872,7 @@ return redis.call(
                 envelope.scheduled_for_ms = None;
                 let promoted = promote_scheduled_envelope(
                     conn,
-                    &self.client.scheduled_key(),
+                    self.client.scheduled_key(),
                     &self.client.queue_key(&envelope.queue),
                     &raw,
                     &envelope,
@@ -937,7 +987,7 @@ return redis.call(
                         retry.scheduled_for_ms = Some(due_ms);
                         schedule_retry_and_ack(
                             conn,
-                            &self.client.scheduled_key(),
+                            self.client.scheduled_key(),
                             stream,
                             &self.config.group,
                             stream_id,
@@ -976,7 +1026,7 @@ return redis.call(
                         let due_ms = epoch_ms(SystemTime::now())?
                             .saturating_add(retry_delay_ms(retry.attempt, &retry.job_id));
                         retry.scheduled_for_ms = Some(due_ms);
-                        let store = memory_store(&self.config.app)?;
+                        let store = self.client.cached_memory_store()?;
                         memory_schedule_envelope(&store, retry)?;
                     } else {
                         self.move_to_dead_memory(envelope, &err.to_string())?;
@@ -987,7 +1037,7 @@ return redis.call(
         }
 
         fn move_to_dead_memory(&self, envelope: JobEnvelope, error: &str) -> JobResult<()> {
-            let store = memory_store(&self.config.app)?;
+            let store = self.client.cached_memory_store()?;
             memory_move_to_dead(&store, envelope, error)
         }
 
@@ -1001,7 +1051,7 @@ return redis.call(
         ) -> JobResult<()> {
             dead_letter_and_ack(
                 conn,
-                &self.client.dead_key(),
+                self.client.dead_key(),
                 stream,
                 &self.config.group,
                 stream_id,
@@ -1216,21 +1266,19 @@ return redis.call(
         envelope: &JobEnvelope,
     ) -> JobResult<bool> {
         let payload = serde_json::to_string(&envelope.payload)?;
-        let value: Value = redis::cmd("EVAL")
-            .arg(PROMOTE_SCHEDULED_SCRIPT)
-            .arg(2)
-            .arg(scheduled_key)
-            .arg(queue_key)
+        let value: Value = promote_scheduled_script()
+            .key(scheduled_key)
+            .key(queue_key)
             .arg(raw_scheduled_envelope)
-            .arg(&envelope.job_id)
-            .arg(&envelope.job_name)
-            .arg(&envelope.queue)
+            .arg(envelope.job_id.as_str())
+            .arg(envelope.job_name.as_str())
+            .arg(envelope.queue.as_str())
             .arg(payload)
             .arg(envelope.attempt)
             .arg(envelope.max_attempts)
             .arg(envelope.created_at_ms)
             .arg(0_u64)
-            .query_async(conn)
+            .invoke_async(conn)
             .await?;
         Ok(!matches!(value, Value::Nil | Value::Int(0)))
     }
@@ -1245,16 +1293,14 @@ return redis.call(
         due_ms: u64,
     ) -> JobResult<()> {
         let raw = serde_json::to_string(envelope)?;
-        let _: i32 = redis::cmd("EVAL")
-            .arg(SCHEDULE_RETRY_AND_ACK_SCRIPT)
-            .arg(2)
-            .arg(scheduled_key)
-            .arg(stream)
+        let _: i32 = schedule_retry_and_ack_script()
+            .key(scheduled_key)
+            .key(stream)
             .arg(due_ms)
             .arg(raw)
             .arg(group)
             .arg(stream_id)
-            .query_async(conn)
+            .invoke_async(conn)
             .await?;
         Ok(())
     }
@@ -1270,14 +1316,12 @@ return redis.call(
     ) -> JobResult<()> {
         let raw = serde_json::to_string(envelope)?;
         let failed_at_ms = redis_time_ms(&mut *conn).await?;
-        let _: Value = redis::cmd("EVAL")
-            .arg(DEAD_LETTER_AND_ACK_SCRIPT)
-            .arg(2)
-            .arg(dead_key)
-            .arg(stream)
-            .arg(&envelope.job_id)
-            .arg(&envelope.job_name)
-            .arg(&envelope.queue)
+        let _: Value = dead_letter_and_ack_script()
+            .key(dead_key)
+            .key(stream)
+            .arg(envelope.job_id.as_str())
+            .arg(envelope.job_name.as_str())
+            .arg(envelope.queue.as_str())
             .arg(envelope.attempt)
             .arg(envelope.max_attempts)
             .arg(error)
@@ -1285,7 +1329,7 @@ return redis.call(
             .arg(failed_at_ms)
             .arg(group)
             .arg(stream_id)
-            .query_async(conn)
+            .invoke_async(conn)
             .await?;
         Ok(())
     }

--- a/crates/pocopine-macros/Cargo.toml
+++ b/crates/pocopine-macros/Cargo.toml
@@ -23,3 +23,4 @@ markup5ever_rcdom = "0.3"
 # RFC 049 / RFC 050 §4.6 — rustc-flavoured diagnostic renderer.
 # Host-only, same as the parser crates above.
 annotate-snippets = "0.11"
+cron = { workspace = true }

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -35,8 +35,8 @@ use syn::{
     parse::{Parse, ParseStream, Parser},
     parse_macro_input,
     punctuated::Punctuated,
-    Data, DeriveInput, Expr, ExprLit, Fields, FnArg, ImplItem, ItemFn, ItemImpl, ItemStruct, Lit,
-    LitStr, Meta, MetaNameValue, Pat, PatType, Path, Token, Type,
+    Data, DeriveInput, Expr, ExprClosure, ExprLit, Fields, FnArg, ImplItem, ItemFn, ItemImpl,
+    ItemStruct, Lit, LitStr, Meta, MetaNameValue, Pat, PatType, Path, Token, Type,
 };
 
 // RFC 050 — compile-time `.poco` template parser + diagnostic
@@ -2986,17 +2986,99 @@ pub fn store(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///   this target.
 /// * **non-wasm32** — the original user body, plus a helper
 ///   `__<name>_route(router) -> axum::Router` that registers the POST
-///   route so a server binary can mount it.
+///   route so a server binary can mount it. `#[server(guard = path)]`
+///   runs the guard before the user body.
+///
+/// Access policy:
+///
+/// * `#[server(public)]` explicitly declares an open endpoint.
+/// * `#[server(guard = require_user)]` protects the endpoint. The guard
+///   must be an async function that accepts
+///   `pocopine_server::auth::RequestContext` and returns a `Result`.
+/// * `#[server]` without either marker still compiles, but emits a
+///   warning so authors do not accidentally ship unreviewed endpoints.
 ///
 /// The signature shape this milestone supports:
 ///
 /// * `async fn name(arg1: T1, ..., argN: TN) -> Result<R, ServerError>`
 /// * Every arg must be owned (`T`, not `&T` / `&mut T`). Args must
 ///   `Serialize + Deserialize`.
-/// * Return type is ignored by this macro; the user is responsible for
-///   having it round-trip through `serde_json`.
+/// * Return type must round-trip through `serde_json`; guarded routes
+///   expect the canonical `ServerError` for auth/body-decode failures.
+#[derive(Default)]
+struct ServerPolicy {
+    public: bool,
+    guard: Option<Path>,
+}
+
+impl ServerPolicy {
+    fn has_access_policy(&self) -> bool {
+        self.public || self.guard.is_some()
+    }
+}
+
+fn parse_server_policy(attr: TokenStream) -> syn::Result<ServerPolicy> {
+    let metas = Punctuated::<Meta, Token![,]>::parse_terminated.parse(attr)?;
+    let mut policy = ServerPolicy::default();
+
+    for meta in metas {
+        match meta {
+            Meta::Path(path) if path.is_ident("public") => {
+                if policy.public {
+                    return Err(syn::Error::new_spanned(path, "duplicate `public` policy"));
+                }
+                policy.public = true;
+            }
+            Meta::NameValue(MetaNameValue { path, value, .. }) if path.is_ident("guard") => {
+                if policy.guard.is_some() {
+                    return Err(syn::Error::new_spanned(path, "duplicate auth guard"));
+                }
+                policy.guard = Some(parse_server_guard_value(value)?);
+            }
+            Meta::List(list) if list.path.is_ident("guard") => {
+                if policy.guard.is_some() {
+                    return Err(syn::Error::new_spanned(list.path, "duplicate auth guard"));
+                }
+                policy.guard = Some(list.parse_args::<Path>()?);
+            }
+            other => {
+                return Err(syn::Error::new_spanned(
+                    other,
+                    "unsupported `#[server]` option; expected `public` or `guard = path`",
+                ));
+            }
+        }
+    }
+
+    if policy.public && policy.guard.is_some() {
+        return Err(syn::Error::new_spanned(
+            policy.guard.as_ref().expect("guard checked"),
+            "`public` server functions cannot also declare an auth guard",
+        ));
+    }
+
+    Ok(policy)
+}
+
+fn parse_server_guard_value(value: Expr) -> syn::Result<Path> {
+    match value {
+        Expr::Path(expr_path) => Ok(expr_path.path),
+        Expr::Lit(ExprLit {
+            lit: Lit::Str(lit), ..
+        }) => lit.parse::<Path>(),
+        other => Err(syn::Error::new_spanned(
+            other,
+            "`guard` must be a Rust path, for example `guard = require_user`",
+        )),
+    }
+}
+
 #[proc_macro_attribute]
-pub fn server(_attr: TokenStream, item: TokenStream) -> TokenStream {
+pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let policy = match parse_server_policy(attr) {
+        Ok(policy) => policy,
+        Err(err) => return err.to_compile_error().into(),
+    };
     let input = parse_macro_input!(item as ItemFn);
     let vis = &input.vis;
     let sig = &input.sig;
@@ -3089,10 +3171,107 @@ pub fn server(_attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     };
 
+    let policy_warning = if policy.has_access_policy() {
+        proc_macro2::TokenStream::new()
+    } else {
+        build_warning_tokens(&format!(
+            "pocopine #[server] function `{fn_name_str}` has no access policy. Write #[server(public)] for an intentional public endpoint or #[server(guard = path::to_guard)] to enforce auth. Missing server-function access policy is currently a warning and may become a hard error."
+        ))
+    };
+
+    let route_handler = if let Some(guard_path) = policy.guard.as_ref() {
+        quote! {
+            ::pocopine_server::axum::routing::post(
+                |request: ::pocopine_server::axum::extract::Request| async move {
+                    let (parts, body) = request.into_parts();
+                    let ctx = ::pocopine_server::auth::RequestContext::from_parts(
+                        parts.method,
+                        parts.uri,
+                        parts.headers,
+                        parts.extensions,
+                    );
+                    if let Err(err) = #guard_path(ctx).await {
+                        let result = ::core::result::Result::Err(
+                            ::core::convert::Into::into(err),
+                        );
+                        return ::pocopine_server::axum::Json(result);
+                    }
+
+                    let body_limit = ::pocopine_server::server_function_body_limit();
+                    let body_bytes = match ::pocopine_server::axum::body::to_bytes(
+                        body,
+                        body_limit,
+                    ).await {
+                        Ok(bytes) => bytes,
+                        Err(err) => {
+                            let result = ::core::result::Result::Err(
+                                ::pocopine::ServerError::BadRequest(
+                                    format!("read server-function request body: {err}"),
+                                ),
+                            );
+                            return ::pocopine_server::axum::Json(result);
+                        }
+                    };
+                    let #destructure: #args_tuple_type =
+                        match ::pocopine_server::serde_json::from_slice(&body_bytes) {
+                            Ok(args) => args,
+                            Err(err) => {
+                                let result = ::core::result::Result::Err(
+                                    ::pocopine::ServerError::BadRequest(
+                                        format!("parse server-function request body: {err}"),
+                                    ),
+                                );
+                                return ::pocopine_server::axum::Json(result);
+                            }
+                        };
+                    let result = #fn_ident( #(#arg_idents),* ).await;
+                    ::pocopine_server::axum::Json(result)
+                },
+            )
+        }
+    } else {
+        quote! {
+            ::pocopine_server::axum::routing::post(
+                |request: ::pocopine_server::axum::extract::Request| async move {
+                    let (_parts, body) = request.into_parts();
+                    let body_limit = ::pocopine_server::server_function_body_limit();
+                    let body_bytes = match ::pocopine_server::axum::body::to_bytes(
+                        body,
+                        body_limit,
+                    ).await {
+                        Ok(bytes) => bytes,
+                        Err(err) => {
+                            let result = ::core::result::Result::Err(
+                                ::pocopine::ServerError::BadRequest(
+                                    format!("read server-function request body: {err}"),
+                                ),
+                            );
+                            return ::pocopine_server::axum::Json(result);
+                        }
+                    };
+                    let #destructure: #args_tuple_type =
+                        match ::pocopine_server::serde_json::from_slice(&body_bytes) {
+                            Ok(args) => args,
+                            Err(err) => {
+                                let result = ::core::result::Result::Err(
+                                    ::pocopine::ServerError::BadRequest(
+                                        format!("parse server-function request body: {err}"),
+                                    ),
+                                );
+                                return ::pocopine_server::axum::Json(result);
+                            }
+                        };
+                    let result = #fn_ident( #(#arg_idents),* ).await;
+                    ::pocopine_server::axum::Json(result)
+                },
+            )
+        }
+    };
+
     // On the server we preserve the user's body, plus emit a route helper.
-    // The extractor destructures the JSON body into our ident tuple, then
-    // we call the original function by name — Rust method resolution picks
-    // the non-wasm32 definition.
+    // Generated routes take the raw request so the same explicit body
+    // limit applies to public and guarded endpoints. Guarded routes run
+    // auth before reading the body.
     let server = quote! {
         #[cfg(not(target_arch = "wasm32"))]
         #vis #sig #body
@@ -3102,24 +3281,566 @@ pub fn server(_attr: TokenStream, item: TokenStream) -> TokenStream {
         pub fn #route_ident(
             router: ::pocopine_server::axum::Router,
         ) -> ::pocopine_server::axum::Router {
-            router.route(
-                #route_path,
-                ::pocopine_server::axum::routing::post(
-                    |::pocopine_server::axum::Json(#destructure):
-                        ::pocopine_server::axum::Json<#args_tuple_type>| async move {
-                        let result = #fn_ident( #(#arg_idents),* ).await;
-                        ::pocopine_server::axum::Json(result)
-                    },
-                ),
-            )
+            router.route(#route_path, #route_handler)
         }
     };
 
     let out = quote! {
+        #policy_warning
         #client
         #server
     };
     out.into()
+}
+
+mod protected_kw {
+    syn::custom_keyword!(require);
+}
+
+struct ProtectedInput {
+    check: ExprClosure,
+    function: ItemFn,
+}
+
+impl Parse for ProtectedInput {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
+        input.parse::<protected_kw::require>()?;
+        let check = input.parse::<ExprClosure>()?;
+
+        if input.peek(Token![;]) {
+            input.parse::<Token![;]>()?;
+        } else if input.peek(Token![,]) {
+            input.parse::<Token![,]>()?;
+        } else {
+            return Err(input.error("expected `;` after `require |ctx| ...`"));
+        }
+
+        let function = input.parse::<ItemFn>()?;
+        Ok(Self { check, function })
+    }
+}
+
+/// `protected!` — declare a guarded server function with inline policy.
+///
+/// ```ignore
+/// pocopine::protected! {
+///     require |ctx| ctx.user.has_role(Role::Admin);
+///
+///     pub async fn create_post(title: String) -> ServerResult<Post> {
+///         /* protected body */
+///     }
+/// }
+/// ```
+///
+/// The require closure must be a synchronous boolean check. The macro
+/// emits a private guard function and feeds it through
+/// `#[pocopine::server(guard = ...)]`, so auth still runs before the
+/// JSON body is decoded.
+#[proc_macro]
+pub fn protected(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as ProtectedInput);
+    let check = input.check;
+    let function = input.function;
+    let fn_ident = function.sig.ident.clone();
+    let guard_ident = format_ident!("__pocopine_guard_{fn_ident}");
+    let mut check_inputs = check.inputs.into_iter();
+    let Some(ctx_pat) = check_inputs.next() else {
+        return syn::Error::new(
+            proc_macro2::Span::call_site(),
+            "`protected!` requires `require |ctx| condition;`",
+        )
+        .to_compile_error()
+        .into();
+    };
+    if let Some(extra) = check_inputs.next() {
+        return syn::Error::new_spanned(
+            extra,
+            "`protected!` require closures must accept exactly one request context argument",
+        )
+        .to_compile_error()
+        .into();
+    }
+    let check_body = check.body;
+
+    quote! {
+        #[cfg(not(target_arch = "wasm32"))]
+        async fn #guard_ident(
+            ctx: ::pocopine::auth::RequestContext,
+        ) -> ::pocopine::ServerResult<()> {
+            let __pocopine_guard_allows: bool = {
+                let #ctx_pat = ctx;
+                #check_body
+            };
+            if !__pocopine_guard_allows {
+                return ::core::result::Result::Err(
+                    ::pocopine::ServerError::forbidden("server function access denied"),
+                );
+            }
+            ::core::result::Result::Ok(())
+        }
+
+        #[pocopine::server(guard = #guard_ident)]
+        #function
+    }
+    .into()
+}
+
+#[derive(Clone)]
+struct JobConfig {
+    queue: String,
+    retries: u32,
+    periodic: Option<JobPeriodicConfig>,
+}
+
+#[derive(Clone)]
+enum JobPeriodicConfig {
+    Every { interval_ms: u64 },
+    Cron { expr: String },
+}
+
+impl Default for JobConfig {
+    fn default() -> Self {
+        Self {
+            queue: "default".to_string(),
+            retries: 3,
+            periodic: None,
+        }
+    }
+}
+
+fn parse_job_config(attr: TokenStream) -> syn::Result<JobConfig> {
+    let metas = Punctuated::<Meta, Token![,]>::parse_terminated.parse(attr)?;
+    let mut config = JobConfig::default();
+
+    for meta in metas {
+        match meta {
+            Meta::NameValue(MetaNameValue { path, value, .. }) if path.is_ident("queue") => {
+                let Expr::Lit(ExprLit {
+                    lit: Lit::Str(lit), ..
+                }) = value
+                else {
+                    return Err(syn::Error::new_spanned(
+                        value,
+                        "`queue` must be a string literal",
+                    ));
+                };
+                config.queue = lit.value();
+            }
+            Meta::NameValue(MetaNameValue { path, value, .. })
+                if path.is_ident("retries") || path.is_ident("max_retries") =>
+            {
+                let Expr::Lit(ExprLit {
+                    lit: Lit::Int(lit), ..
+                }) = value
+                else {
+                    return Err(syn::Error::new_spanned(
+                        value,
+                        "`retries` must be an integer literal",
+                    ));
+                };
+                config.retries = lit.base10_parse::<u32>()?;
+            }
+            Meta::NameValue(MetaNameValue { path, value, .. }) if path.is_ident("every") => {
+                let Expr::Lit(ExprLit {
+                    lit: Lit::Str(lit), ..
+                }) = value
+                else {
+                    return Err(syn::Error::new_spanned(
+                        value,
+                        "`every` must be a string literal like \"15m\"",
+                    ));
+                };
+                if config.periodic.is_some() {
+                    return Err(syn::Error::new_spanned(
+                        path,
+                        "`every` and `cron` are mutually exclusive",
+                    ));
+                }
+                let interval_ms = parse_job_duration_ms(&lit)?;
+                config.periodic = Some(JobPeriodicConfig::Every { interval_ms });
+            }
+            Meta::NameValue(MetaNameValue { path, value, .. }) if path.is_ident("cron") => {
+                let Expr::Lit(ExprLit {
+                    lit: Lit::Str(lit), ..
+                }) = value
+                else {
+                    return Err(syn::Error::new_spanned(
+                        value,
+                        "`cron` must be a string literal",
+                    ));
+                };
+                if config.periodic.is_some() {
+                    return Err(syn::Error::new_spanned(
+                        path,
+                        "`every` and `cron` are mutually exclusive",
+                    ));
+                }
+                let expr = lit.value();
+                expr.parse::<cron::Schedule>().map_err(|err| {
+                    syn::Error::new_spanned(
+                        &lit,
+                        format!("invalid `cron` expression for #[job]: {err}"),
+                    )
+                })?;
+                config.periodic = Some(JobPeriodicConfig::Cron { expr });
+            }
+            other => {
+                return Err(syn::Error::new_spanned(
+                    other,
+                    "unsupported `#[job]` option; expected `queue = \"name\"`, `retries = N`, `every = \"15m\"`, or `cron = \"...\"`",
+                ));
+            }
+        }
+    }
+
+    Ok(config)
+}
+
+fn parse_job_duration_ms(lit: &LitStr) -> syn::Result<u64> {
+    let value = lit.value();
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(syn::Error::new_spanned(lit, "`every` cannot be empty"));
+    }
+
+    let split_at = trimmed
+        .find(|ch: char| !ch.is_ascii_digit())
+        .unwrap_or(trimmed.len());
+    let (num, unit) = trimmed.split_at(split_at);
+    if num.is_empty() || unit.is_empty() {
+        return Err(syn::Error::new_spanned(
+            lit,
+            "`every` must include a number and unit, for example \"30s\", \"15m\", or \"2h\"",
+        ));
+    }
+    let value = num.parse::<u64>().map_err(|err| {
+        syn::Error::new_spanned(lit, format!("invalid `every` duration number: {err}"))
+    })?;
+    let multiplier = match unit {
+        "ms" => 1,
+        "s" => 1_000,
+        "m" => 60_000,
+        "h" => 60 * 60_000,
+        "d" => 24 * 60 * 60_000,
+        _ => {
+            return Err(syn::Error::new_spanned(
+                lit,
+                "`every` supports ms, s, m, h, and d units",
+            ));
+        }
+    };
+    let interval_ms = value.checked_mul(multiplier).ok_or_else(|| {
+        syn::Error::new_spanned(lit, "`every` duration is too large to represent")
+    })?;
+    if interval_ms == 0 {
+        return Err(syn::Error::new_spanned(
+            lit,
+            "`every` duration must be greater than zero",
+        ));
+    }
+    Ok(interval_ms)
+}
+
+/// `#[job]` — declare a host-side background job.
+///
+/// The function body compiles only for host targets. On wasm32 the macro
+/// emits a stub with the same signature that returns
+/// `JobError::Unsupported`, keeping client bundles free of Redis and worker
+/// runtime dependencies.
+#[proc_macro_attribute]
+pub fn job(attr: TokenStream, item: TokenStream) -> TokenStream {
+    let config = match parse_job_config(attr) {
+        Ok(config) => config,
+        Err(err) => return err.to_compile_error().into(),
+    };
+    let input = parse_macro_input!(item as ItemFn);
+    let vis = &input.vis;
+    let sig = &input.sig;
+    let body = &input.block;
+
+    if sig.asyncness.is_none() {
+        return syn::Error::new_spanned(sig.fn_token, "`#[job]` functions must be async")
+            .to_compile_error()
+            .into();
+    }
+
+    let fn_ident = sig.ident.clone();
+    let fn_name_str = fn_ident.to_string();
+    let queue = config.queue;
+    let retries = config.retries;
+    let periodic = config.periodic.clone();
+    let job_mod = format_ident!("{fn_name_str}_job");
+    let job_name_const = format_ident!("__pocopine_job_name_{fn_name_str}");
+    let dispatch_ident = format_ident!("__pocopine_dispatch_{fn_name_str}");
+
+    let mut inputs = sig.inputs.iter();
+    let payload = match inputs.next() {
+        Some(input_arg) => {
+            if inputs.next().is_some() {
+                return syn::Error::new_spanned(
+                    sig,
+                    "`#[job]` functions must take zero args for periodic jobs or one owned payload argument for manually enqueued jobs",
+                )
+                .to_compile_error()
+                .into();
+            }
+            if periodic.is_some() {
+                return syn::Error::new_spanned(
+                    sig,
+                    "`#[job(every = ...)]` and `#[job(cron = ...)]` jobs must not take a payload argument",
+                )
+                .to_compile_error()
+                .into();
+            }
+            match input_arg {
+                FnArg::Receiver(r) => {
+                    return syn::Error::new_spanned(
+                        r,
+                        "`#[job]` functions cannot take `self` — they are free functions",
+                    )
+                    .to_compile_error()
+                    .into();
+                }
+                FnArg::Typed(PatType { pat, ty, .. }) => {
+                    if matches!(**ty, syn::Type::Reference(_)) {
+                        return syn::Error::new_spanned(
+                            ty,
+                            "`#[job]` payloads must be owned — reference types are not supported",
+                        )
+                        .to_compile_error()
+                        .into();
+                    }
+                    let Pat::Ident(pat_ident) = &**pat else {
+                        return syn::Error::new_spanned(
+                            pat,
+                            "`#[job]` payload argument must be a simple identifier",
+                        )
+                        .to_compile_error()
+                        .into();
+                    };
+                    JobPayload::Typed {
+                        ident: pat_ident.ident.clone(),
+                        ty: (**ty).clone(),
+                    }
+                }
+            }
+        }
+        None if periodic.is_some() => JobPayload::Unit,
+        None => {
+            return syn::Error::new_spanned(
+                sig,
+                "`#[job]` functions without `every` or `cron` must take one owned payload argument",
+            )
+            .to_compile_error()
+            .into();
+        }
+    };
+
+    if matches!(sig.output, syn::ReturnType::Default) {
+        return syn::Error::new_spanned(sig, "`#[job]` functions must return `JobResult<()>`")
+            .to_compile_error()
+            .into();
+    }
+
+    let sig_without_body = quote! { #vis #sig };
+    let helper_arg_def = payload.helper_arg_def();
+    let helper_arg_call = payload.helper_arg_call();
+    let payload_ref_binding = payload.payload_ref_binding();
+    let payload_ref = payload.payload_ref();
+    let dispatch_body = payload.dispatch_body(&fn_ident);
+    let descriptor_ctor = match periodic {
+        Some(JobPeriodicConfig::Every { interval_ms }) => quote! {
+            ::pocopine::__private::jobs::JobDescriptor::periodic(
+                #job_name_const,
+                #queue,
+                #retries,
+                ::pocopine::__private::jobs::PeriodicSchedule::every_millis(#interval_ms),
+                #job_mod::#dispatch_ident,
+            )
+        },
+        Some(JobPeriodicConfig::Cron { expr }) => quote! {
+            ::pocopine::__private::jobs::JobDescriptor::periodic(
+                #job_name_const,
+                #queue,
+                #retries,
+                ::pocopine::__private::jobs::PeriodicSchedule::cron(#expr),
+                #job_mod::#dispatch_ident,
+            )
+        },
+        None => quote! {
+            ::pocopine::__private::jobs::JobDescriptor::new(
+                #job_name_const,
+                #queue,
+                #retries,
+                #job_mod::#dispatch_ident,
+            )
+        },
+    };
+
+    let host = quote! {
+        #[cfg(not(target_arch = "wasm32"))]
+        #vis #sig #body
+
+        #[cfg(not(target_arch = "wasm32"))]
+        #[allow(non_upper_case_globals)]
+        const #job_name_const: &'static str =
+            concat!(module_path!(), "::", stringify!(#fn_ident));
+
+        #[cfg(not(target_arch = "wasm32"))]
+        #vis mod #job_mod {
+            use super::*;
+
+            pub async fn enqueue(
+                #helper_arg_def
+            ) -> ::pocopine::JobResult<::pocopine::JobId> {
+                let client = ::pocopine::JobClient::from_env()?;
+                enqueue_with(&client, #helper_arg_call).await
+            }
+
+            pub async fn enqueue_with(
+                client: &::pocopine::JobClient,
+                #helper_arg_def
+            ) -> ::pocopine::JobResult<::pocopine::JobId> {
+                #payload_ref_binding
+                client
+                    .enqueue_json(
+                        super::#job_name_const,
+                        #queue,
+                        ::pocopine::__private::jobs::RetryPolicy::from_retries(#retries).max_attempts,
+                        #payload_ref,
+                    )
+                    .await
+            }
+
+            pub async fn schedule_in(
+                #helper_arg_def
+                delay: ::std::time::Duration,
+            ) -> ::pocopine::JobResult<::pocopine::JobId> {
+                let client = ::pocopine::JobClient::from_env()?;
+                schedule_in_with(&client, #helper_arg_call delay).await
+            }
+
+            pub async fn schedule_in_with(
+                client: &::pocopine::JobClient,
+                #helper_arg_def
+                delay: ::std::time::Duration,
+            ) -> ::pocopine::JobResult<::pocopine::JobId> {
+                #payload_ref_binding
+                client
+                    .schedule_json_in(
+                        super::#job_name_const,
+                        #queue,
+                        ::pocopine::__private::jobs::RetryPolicy::from_retries(#retries).max_attempts,
+                        #payload_ref,
+                        delay,
+                    )
+                    .await
+            }
+
+            pub async fn schedule_at(
+                #helper_arg_def
+                when: ::std::time::SystemTime,
+            ) -> ::pocopine::JobResult<::pocopine::JobId> {
+                let client = ::pocopine::JobClient::from_env()?;
+                schedule_at_with(&client, #helper_arg_call when).await
+            }
+
+            pub async fn schedule_at_with(
+                client: &::pocopine::JobClient,
+                #helper_arg_def
+                when: ::std::time::SystemTime,
+            ) -> ::pocopine::JobResult<::pocopine::JobId> {
+                #payload_ref_binding
+                client
+                    .schedule_json_at(
+                        super::#job_name_const,
+                        #queue,
+                        ::pocopine::__private::jobs::RetryPolicy::from_retries(#retries).max_attempts,
+                        #payload_ref,
+                        when,
+                    )
+                    .await
+            }
+
+            pub fn #dispatch_ident(
+                payload: ::std::vec::Vec<u8>,
+            ) -> ::pocopine::JobFuture {
+                ::std::boxed::Box::pin(async move {
+                    #dispatch_body
+                })
+            }
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        ::pocopine::__private::jobs::inventory::submit! {
+            #descriptor_ctor
+        }
+    };
+
+    let wasm = quote! {
+        #[cfg(target_arch = "wasm32")]
+        #[allow(unused_variables)]
+        #sig_without_body {
+            ::core::result::Result::Err(::pocopine::JobError::unsupported(
+                "background jobs run on the server worker, not in wasm",
+            ))
+        }
+    };
+
+    quote! {
+        #host
+        #wasm
+    }
+    .into()
+}
+
+enum JobPayload {
+    Unit,
+    Typed { ident: syn::Ident, ty: Type },
+}
+
+impl JobPayload {
+    fn helper_arg_def(&self) -> proc_macro2::TokenStream {
+        match self {
+            JobPayload::Unit => quote! {},
+            JobPayload::Typed { ident, ty } => quote! { #ident: #ty, },
+        }
+    }
+
+    fn helper_arg_call(&self) -> proc_macro2::TokenStream {
+        match self {
+            JobPayload::Unit => quote! {},
+            JobPayload::Typed { ident, .. } => quote! { #ident, },
+        }
+    }
+
+    fn payload_ref_binding(&self) -> proc_macro2::TokenStream {
+        match self {
+            JobPayload::Unit => quote! { let __pocopine_payload = (); },
+            JobPayload::Typed { .. } => quote! {},
+        }
+    }
+
+    fn payload_ref(&self) -> proc_macro2::TokenStream {
+        match self {
+            JobPayload::Unit => quote! { &__pocopine_payload },
+            JobPayload::Typed { ident, .. } => quote! { &#ident },
+        }
+    }
+
+    fn dispatch_body(&self, fn_ident: &syn::Ident) -> proc_macro2::TokenStream {
+        match self {
+            JobPayload::Unit => quote! {
+                let _: () = ::pocopine::__private::jobs::serde_json::from_slice(&payload)?;
+                super::#fn_ident().await
+            },
+            JobPayload::Typed { ident, ty } => quote! {
+                let #ident: #ty =
+                    ::pocopine::__private::jobs::serde_json::from_slice(&payload)?;
+                super::#fn_ident(#ident).await
+            },
+        }
+    }
 }
 
 /// `#[derive(Emit)]` — RFC 056 §6.8 typed event emission.

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -3050,9 +3050,12 @@ fn parse_server_policy(attr: TokenStream) -> syn::Result<ServerPolicy> {
         }
     }
 
-    if policy.public && policy.guard.is_some() {
+    if policy.public {
+        let Some(guard) = policy.guard.as_ref() else {
+            return Ok(policy);
+        };
         return Err(syn::Error::new_spanned(
-            policy.guard.as_ref().expect("guard checked"),
+            guard,
             "`public` server functions cannot also declare an auth guard",
         ));
     }
@@ -3620,7 +3623,7 @@ pub fn job(attr: TokenStream, item: TokenStream) -> TokenStream {
                     };
                     JobPayload::Typed {
                         ident: pat_ident.ident.clone(),
-                        ty: (**ty).clone(),
+                        ty: ty.clone(),
                     }
                 }
             }
@@ -3796,7 +3799,7 @@ pub fn job(attr: TokenStream, item: TokenStream) -> TokenStream {
 
 enum JobPayload {
     Unit,
-    Typed { ident: syn::Ident, ty: Type },
+    Typed { ident: syn::Ident, ty: Box<Type> },
 }
 
 impl JobPayload {

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -3182,99 +3182,70 @@ pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
         ))
     };
 
-    let route_handler = if let Some(guard_path) = policy.guard.as_ref() {
-        quote! {
-            ::pocopine_server::axum::routing::post(
-                |request: ::pocopine_server::axum::extract::Request| async move {
-                    let (parts, body) = request.into_parts();
-                    let ctx = ::pocopine_server::auth::RequestContext::from_parts(
-                        parts.method,
-                        parts.uri,
-                        parts.headers,
-                        parts.extensions,
-                    );
-                    if let Err(err) = #guard_path(ctx).await {
+    let parts_binding = if policy.guard.is_some() {
+        quote! { let (parts, body) = request.into_parts(); }
+    } else {
+        quote! { let (_parts, body) = request.into_parts(); }
+    };
+    let guard_prologue = match policy.guard.as_ref() {
+        Some(guard_path) => quote! {
+            let ctx = ::pocopine_server::auth::RequestContext::from_parts(
+                parts.method,
+                parts.uri,
+                parts.headers,
+                parts.extensions,
+            );
+            if let Err(err) = #guard_path(ctx).await {
+                let result = ::core::result::Result::Err(
+                    ::core::convert::Into::into(err),
+                );
+                return ::pocopine_server::axum::Json(result);
+            }
+        },
+        None => proc_macro2::TokenStream::new(),
+    };
+
+    // Generated routes take the raw request so the same explicit body
+    // limit applies to public and guarded endpoints; guarded routes run
+    // auth before the body is read.
+    let route_handler = quote! {
+        ::pocopine_server::axum::routing::post(
+            |request: ::pocopine_server::axum::extract::Request| async move {
+                #parts_binding
+                #guard_prologue
+                let body_limit = ::pocopine_server::server_function_body_limit();
+                let body_bytes = match ::pocopine_server::axum::body::to_bytes(
+                    body,
+                    body_limit,
+                ).await {
+                    Ok(bytes) => bytes,
+                    Err(err) => {
                         let result = ::core::result::Result::Err(
-                            ::core::convert::Into::into(err),
+                            ::pocopine::ServerError::BadRequest(
+                                format!("read server-function request body: {err}"),
+                            ),
                         );
                         return ::pocopine_server::axum::Json(result);
                     }
-
-                    let body_limit = ::pocopine_server::server_function_body_limit();
-                    let body_bytes = match ::pocopine_server::axum::body::to_bytes(
-                        body,
-                        body_limit,
-                    ).await {
-                        Ok(bytes) => bytes,
+                };
+                let #destructure: #args_tuple_type =
+                    match ::pocopine_server::serde_json::from_slice(&body_bytes) {
+                        Ok(args) => args,
                         Err(err) => {
                             let result = ::core::result::Result::Err(
                                 ::pocopine::ServerError::BadRequest(
-                                    format!("read server-function request body: {err}"),
+                                    format!("parse server-function request body: {err}"),
                                 ),
                             );
                             return ::pocopine_server::axum::Json(result);
                         }
                     };
-                    let #destructure: #args_tuple_type =
-                        match ::pocopine_server::serde_json::from_slice(&body_bytes) {
-                            Ok(args) => args,
-                            Err(err) => {
-                                let result = ::core::result::Result::Err(
-                                    ::pocopine::ServerError::BadRequest(
-                                        format!("parse server-function request body: {err}"),
-                                    ),
-                                );
-                                return ::pocopine_server::axum::Json(result);
-                            }
-                        };
-                    let result = #fn_ident( #(#arg_idents),* ).await;
-                    ::pocopine_server::axum::Json(result)
-                },
-            )
-        }
-    } else {
-        quote! {
-            ::pocopine_server::axum::routing::post(
-                |request: ::pocopine_server::axum::extract::Request| async move {
-                    let (_parts, body) = request.into_parts();
-                    let body_limit = ::pocopine_server::server_function_body_limit();
-                    let body_bytes = match ::pocopine_server::axum::body::to_bytes(
-                        body,
-                        body_limit,
-                    ).await {
-                        Ok(bytes) => bytes,
-                        Err(err) => {
-                            let result = ::core::result::Result::Err(
-                                ::pocopine::ServerError::BadRequest(
-                                    format!("read server-function request body: {err}"),
-                                ),
-                            );
-                            return ::pocopine_server::axum::Json(result);
-                        }
-                    };
-                    let #destructure: #args_tuple_type =
-                        match ::pocopine_server::serde_json::from_slice(&body_bytes) {
-                            Ok(args) => args,
-                            Err(err) => {
-                                let result = ::core::result::Result::Err(
-                                    ::pocopine::ServerError::BadRequest(
-                                        format!("parse server-function request body: {err}"),
-                                    ),
-                                );
-                                return ::pocopine_server::axum::Json(result);
-                            }
-                        };
-                    let result = #fn_ident( #(#arg_idents),* ).await;
-                    ::pocopine_server::axum::Json(result)
-                },
-            )
-        }
+                let result = #fn_ident( #(#arg_idents),* ).await;
+                ::pocopine_server::axum::Json(result)
+            },
+        )
     };
 
-    // On the server we preserve the user's body, plus emit a route helper.
-    // Generated routes take the raw request so the same explicit body
-    // limit applies to public and guarded endpoints. Guarded routes run
-    // auth before reading the body.
     let server = quote! {
         #[cfg(not(target_arch = "wasm32"))]
         #vis #sig #body

--- a/crates/pocopine-server/Cargo.toml
+++ b/crates/pocopine-server/Cargo.toml
@@ -17,4 +17,5 @@ tower-http = { version = "0.6", features = ["fs", "trace"] }
 serde_json = "1"
 
 [dependencies]
+pocopine-auth = { workspace = true }
 serde = { workspace = true }

--- a/crates/pocopine-server/src/lib.rs
+++ b/crates/pocopine-server/src/lib.rs
@@ -27,6 +27,7 @@ pub use tower;
 pub use tower_http;
 
 use std::net::SocketAddr;
+use std::sync::OnceLock;
 
 use axum::Router;
 use tower_http::services::ServeDir;
@@ -44,8 +45,10 @@ pub mod auth {
 ///
 /// Set `POCOPINE_SERVER_FUNCTION_BODY_LIMIT` to override the default.
 /// Values may be raw bytes or use `kb`, `kib`, `mb`, or `mib` suffixes.
+/// Resolved once on first access and reused for the lifetime of the process.
 pub fn server_function_body_limit() -> usize {
-    match std::env::var("POCOPINE_SERVER_FUNCTION_BODY_LIMIT") {
+    static LIMIT: OnceLock<usize> = OnceLock::new();
+    *LIMIT.get_or_init(|| match std::env::var("POCOPINE_SERVER_FUNCTION_BODY_LIMIT") {
         Ok(raw) => match parse_body_limit(&raw) {
             Some(limit) => limit,
             None => {
@@ -56,7 +59,7 @@ pub fn server_function_body_limit() -> usize {
             }
         },
         Err(_) => DEFAULT_SERVER_FUNCTION_BODY_LIMIT,
-    }
+    })
 }
 
 fn parse_body_limit(raw: &str) -> Option<usize> {

--- a/crates/pocopine-server/src/lib.rs
+++ b/crates/pocopine-server/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! # mod app { pub fn __get_post_route(r: pocopine_server::axum::Router) -> pocopine_server::axum::Router { r } }
 //! #[tokio::main]
-//! async fn main() -> anyhow::Result<()> {
+//! async fn main() -> std::io::Result<()> {
 //!     let router = Router::new()
 //!         .nest_service("/", static_files("pkg"))
 //!         .merge(Router::new());
@@ -31,6 +31,57 @@ use std::net::SocketAddr;
 use axum::Router;
 use tower_http::services::ServeDir;
 
+/// Default maximum JSON request body accepted by generated
+/// server-function routes.
+pub const DEFAULT_SERVER_FUNCTION_BODY_LIMIT: usize = 2 * 1024 * 1024;
+
+/// Auth contracts passed to `#[server(guard = ...)]` functions.
+pub mod auth {
+    pub use pocopine_auth::*;
+}
+
+/// Server-function body limit in bytes.
+///
+/// Set `POCOPINE_SERVER_FUNCTION_BODY_LIMIT` to override the default.
+/// Values may be raw bytes or use `kb`, `kib`, `mb`, or `mib` suffixes.
+pub fn server_function_body_limit() -> usize {
+    match std::env::var("POCOPINE_SERVER_FUNCTION_BODY_LIMIT") {
+        Ok(raw) => match parse_body_limit(&raw) {
+            Some(limit) => limit,
+            None => {
+                eprintln!(
+                    "invalid POCOPINE_SERVER_FUNCTION_BODY_LIMIT={raw:?}; using default {DEFAULT_SERVER_FUNCTION_BODY_LIMIT}"
+                );
+                DEFAULT_SERVER_FUNCTION_BODY_LIMIT
+            }
+        },
+        Err(_) => DEFAULT_SERVER_FUNCTION_BODY_LIMIT,
+    }
+}
+
+fn parse_body_limit(raw: &str) -> Option<usize> {
+    let value = raw.trim().to_ascii_lowercase();
+    if value.is_empty() {
+        return None;
+    }
+
+    let split_at = value
+        .find(|ch: char| !ch.is_ascii_digit())
+        .unwrap_or(value.len());
+    let (digits, unit) = value.split_at(split_at);
+    let number = digits.parse::<usize>().ok()?;
+    let multiplier = match unit.trim() {
+        "" | "b" => 1,
+        "kb" => 1_000,
+        "kib" => 1024,
+        "mb" => 1_000_000,
+        "mib" => 1024 * 1024,
+        _ => return None,
+    };
+    let limit = number.checked_mul(multiplier)?;
+    (limit > 0).then_some(limit)
+}
+
 /// Serve a directory of static files (typically the `pkg/` directory
 /// that `wasm-pack build --target web` produces, plus `index.html`).
 pub fn static_files(dir: impl AsRef<std::path::Path>) -> ServeDir {
@@ -44,4 +95,26 @@ pub async fn serve(router: Router, addr: &str) -> std::io::Result<()> {
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?;
     let listener = tokio::net::TcpListener::bind(addr).await?;
     axum::serve(listener, router).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_body_limit_accepts_bytes_and_units() {
+        assert_eq!(parse_body_limit("1024"), Some(1024));
+        assert_eq!(parse_body_limit("1mib"), Some(1024 * 1024));
+        assert_eq!(parse_body_limit("2mb"), Some(2_000_000));
+        assert_eq!(parse_body_limit(" 5kb "), Some(5_000));
+    }
+
+    #[test]
+    fn parse_body_limit_rejects_zero_and_invalid_values() {
+        assert_eq!(parse_body_limit("0"), None);
+        assert_eq!(parse_body_limit("0mib"), None);
+        assert_eq!(parse_body_limit("banana"), None);
+        assert_eq!(parse_body_limit("5gb"), None);
+        assert_eq!(parse_body_limit(""), None);
+    }
 }

--- a/crates/pocopine/Cargo.toml
+++ b/crates/pocopine/Cargo.toml
@@ -33,7 +33,7 @@ phf = { version = "0.13", features = ["macros"] }
 [dev-dependencies]
 pocopine-server = { path = "../pocopine-server" }
 serde_json = "1"
-tokio = { version = "1", features = ["macros", "rt"] }
+tokio = { version = "1", features = ["macros", "rt", "time"] }
 tower = { version = "0.5", features = ["util"] }
 wasm-bindgen-test = "0.3"
 web-sys = { version = "0.3", features = [
@@ -50,3 +50,13 @@ web-sys = { version = "0.3", features = [
     "NodeList",
     "Window",
 ] }
+
+# Redis-backed integration tests spin up a throwaway Redis container per
+# test binary via testcontainers; no external Redis dependency for CI.
+# Host-only — the wasm32 test build can't reach Docker, and tokio's
+# `rt-multi-thread` feature is incompatible with the wasm target.
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+testcontainers = "0.23"
+testcontainers-modules = { version = "0.11", features = ["redis"] }
+redis = { version = "0.27", features = ["tokio-comp"] }
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time"] }

--- a/crates/pocopine/Cargo.toml
+++ b/crates/pocopine/Cargo.toml
@@ -16,7 +16,9 @@ mount-profiler = ["pocopine-core/mount-profiler"]
 runtime-expr-fallback = ["pocopine-core/runtime-expr-fallback"]
 
 [dependencies]
+pocopine-auth = { workspace = true }
 pocopine-core = { workspace = true, default-features = false }
+pocopine-jobs = { workspace = true }
 pocopine-macros = { workspace = true }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
@@ -29,6 +31,10 @@ web-sys = { version = "0.3", features = ["Element"] }
 phf = { version = "0.13", features = ["macros"] }
 
 [dev-dependencies]
+pocopine-server = { path = "../pocopine-server" }
+serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt"] }
+tower = { version = "0.5", features = ["util"] }
 wasm-bindgen-test = "0.3"
 web-sys = { version = "0.3", features = [
     "CustomEvent",

--- a/crates/pocopine/src/lib.rs
+++ b/crates/pocopine/src/lib.rs
@@ -35,7 +35,8 @@ pub use pocopine_core::{
 pub use pocopine_core::{create_context, inject_key};
 #[cfg(not(target_arch = "wasm32"))]
 pub use pocopine_jobs::{
-    JobClient, JobDescriptor, JobFuture, JobHandler, JobId, PeriodicSchedule, Worker, WorkerConfig,
+    JobBackend, JobClient, JobDescriptor, JobFuture, JobHandler, JobId, PeriodicSchedule, Worker,
+    WorkerConfig,
 };
 pub use pocopine_jobs::{JobError, JobResult};
 // Note: `store` exists in both the value namespace (the accessor `fn store<T>()`)

--- a/crates/pocopine/src/lib.rs
+++ b/crates/pocopine/src/lib.rs
@@ -4,6 +4,9 @@
 //! `#[handlers]` attribute macros from `pocopine-macros`. App code should
 //! depend on `pocopine` and pull everything from `pocopine::prelude::*`.
 
+#[cfg(not(target_arch = "wasm32"))]
+pub use pocopine_auth::RequestContext;
+pub use pocopine_auth::{AuthUser, Permission, Principal, Role, Session};
 #[allow(deprecated)]
 pub use pocopine_core::InjectKey;
 pub use pocopine_core::{
@@ -30,9 +33,23 @@ pub use pocopine_core::{
 };
 #[doc(inline)]
 pub use pocopine_core::{create_context, inject_key};
+#[cfg(not(target_arch = "wasm32"))]
+pub use pocopine_jobs::{
+    JobClient, JobDescriptor, JobFuture, JobHandler, JobId, PeriodicSchedule, Worker, WorkerConfig,
+};
+pub use pocopine_jobs::{JobError, JobResult};
 // Note: `store` exists in both the value namespace (the accessor `fn store<T>()`)
 // and the macro namespace (the attribute `#[store]`). They don't collide.
-pub use pocopine_macros::{app, component, handlers, server, store, Emit};
+pub use pocopine_macros::{app, component, handlers, job, protected, server, store, Emit};
+
+pub mod auth {
+    pub use pocopine_auth::*;
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub mod jobs {
+    pub use pocopine_jobs::*;
+}
 
 pub mod prelude {
     #[allow(deprecated)]
@@ -41,10 +58,11 @@ pub mod prelude {
         batch, component, computed, create_context, cx, dispatch, dispatch_event, effect, emit,
         emit_cancelable, emit_cancelable_from, emit_event, emit_event_from, emit_from,
         emit_from_host, emit_model, emit_model_field, emit_raw, emit_raw_from, handlers,
-        inject_key, on, on_cleanup, on_emit, prepend_list_inline, remove_list_at_inline, rw_signal,
-        signal, spawn, spawn_latest, spawn_scoped, store, this, watch, App, Component,
-        ComponentState, Computed, ContextKey, ContextMarker, Emit, Handle, Inject, NearestParent,
-        Parent, RwSignal, Scope, ScopeId, ServerError, ServerResult, Setter, Signal, Store,
+        inject_key, job, on, on_cleanup, on_emit, prepend_list_inline, protected,
+        remove_list_at_inline, rw_signal, signal, spawn, spawn_latest, spawn_scoped, store, this,
+        watch, App, AuthUser, Component, ComponentState, Computed, ContextKey, ContextMarker, Emit,
+        Handle, Inject, JobError, JobResult, NearestParent, Parent, Permission, Principal, Role,
+        RwSignal, Scope, ScopeId, ServerError, ServerResult, Setter, Signal, Store,
     };
     pub use wasm_bindgen::prelude::*;
 }
@@ -66,6 +84,8 @@ pub mod __private {
         Scope, StaticBinOp, StaticBinding, StaticExpr, StaticListener, StaticLiteral,
         StaticRowPlan, Store, WriteOrigin,
     };
+    #[cfg(not(target_arch = "wasm32"))]
+    pub use pocopine_jobs as jobs;
     // RFC 060 Tier 4 — `phf` re-exported for `app!{}` macro use.
     pub use phf;
     // RFC-058 Phase 2 — template-plan shape + registry. The

--- a/crates/pocopine/src/lib.rs
+++ b/crates/pocopine/src/lib.rs
@@ -35,8 +35,8 @@ pub use pocopine_core::{
 pub use pocopine_core::{create_context, inject_key};
 #[cfg(not(target_arch = "wasm32"))]
 pub use pocopine_jobs::{
-    JobBackend, JobClient, JobDescriptor, JobFuture, JobHandler, JobId, PeriodicSchedule, Worker,
-    WorkerConfig,
+    DeadLetter, JobBackend, JobClient, JobDescriptor, JobFuture, JobHandler, JobId,
+    PeriodicSchedule, Worker, WorkerConfig,
 };
 pub use pocopine_jobs::{JobError, JobResult};
 // Note: `store` exists in both the value namespace (the accessor `fn store<T>()`)

--- a/crates/pocopine/tests/job_macro.rs
+++ b/crates/pocopine/tests/job_macro.rs
@@ -1,5 +1,11 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
 use pocopine::JobResult;
 use serde::{Deserialize, Serialize};
+
+static MEMORY_APP_COUNTER: AtomicUsize = AtomicUsize::new(1);
+static MEMORY_JOB_RUNS: AtomicUsize = AtomicUsize::new(0);
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct JobPayload {
@@ -9,6 +15,13 @@ struct JobPayload {
 #[pocopine::job(queue = "tests", retries = 2)]
 async fn macro_registered_job(input: JobPayload) -> JobResult<()> {
     assert_eq!(input.value, "ok");
+    Ok(())
+}
+
+#[pocopine::job(queue = "memory", retries = 0)]
+async fn memory_backend_job(input: JobPayload) -> JobResult<()> {
+    assert_eq!(input.value, "memory");
+    MEMORY_JOB_RUNS.fetch_add(1, Ordering::SeqCst);
     Ok(())
 }
 
@@ -79,4 +92,47 @@ fn generated_periodic_dispatch_decodes_unit_payload() {
         .build()
         .unwrap();
     rt.block_on(future).unwrap();
+}
+
+#[test]
+fn memory_backend_worker_runs_enqueued_job() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    rt.block_on(async {
+        MEMORY_JOB_RUNS.store(0, Ordering::SeqCst);
+        let app = format!(
+            "job-macro-memory-{}-{}",
+            std::process::id(),
+            MEMORY_APP_COUNTER.fetch_add(1, Ordering::SeqCst)
+        );
+        let client = pocopine::JobClient::memory(app.clone());
+        memory_backend_job_job::enqueue_with(
+            &client,
+            JobPayload {
+                value: "memory".into(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let worker = pocopine::Worker::new(pocopine::WorkerConfig {
+            backend: pocopine::JobBackend::Memory,
+            app,
+            queues: vec!["memory".to_string()],
+            group: "test".to_string(),
+            consumer: "test".to_string(),
+            block_ms: 0,
+            visibility_timeout: Duration::from_secs(60),
+            scheduler_interval: Duration::from_millis(1),
+            batch_size: 10,
+        })
+        .unwrap();
+
+        assert_eq!(worker.run_once().await.unwrap(), 1);
+        assert_eq!(worker.run_once().await.unwrap(), 0);
+        assert_eq!(MEMORY_JOB_RUNS.load(Ordering::SeqCst), 1);
+    });
 }

--- a/crates/pocopine/tests/job_macro.rs
+++ b/crates/pocopine/tests/job_macro.rs
@@ -25,6 +25,11 @@ async fn memory_backend_job(input: JobPayload) -> JobResult<()> {
     Ok(())
 }
 
+#[pocopine::job(queue = "panic", retries = 0)]
+async fn panicking_memory_job(_input: JobPayload) -> JobResult<()> {
+    panic!("intentional panic for memory backend test");
+}
+
 #[pocopine::job(queue = "periodic", every = "15m", retries = 1)]
 async fn refresh_periodic_cache() -> JobResult<()> {
     Ok(())
@@ -135,5 +140,62 @@ fn memory_backend_worker_runs_enqueued_job() {
         assert_eq!(worker.run_once().await.unwrap(), 1);
         assert_eq!(worker.run_once().await.unwrap(), 0);
         assert_eq!(MEMORY_JOB_RUNS.load(Ordering::SeqCst), 1);
+    });
+}
+
+#[test]
+fn memory_backend_routes_handler_panic_through_dead_letter() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    rt.block_on(async {
+        let app = format!(
+            "job-macro-panic-{}-{}",
+            std::process::id(),
+            MEMORY_APP_COUNTER.fetch_add(1, Ordering::SeqCst)
+        );
+        let client = pocopine::JobClient::memory(app.clone());
+        panicking_memory_job_job::enqueue_with(
+            &client,
+            JobPayload {
+                value: "panic".into(),
+            },
+        )
+        .await
+        .unwrap();
+
+        let worker = pocopine::Worker::new(pocopine::WorkerConfig {
+            backend: pocopine::JobBackend::Memory,
+            app,
+            queues: vec!["panic".to_string()],
+            group: "test".to_string(),
+            consumer: "test".to_string(),
+            block_ms: 0,
+            visibility_timeout: Duration::from_secs(60),
+            scheduler_interval: Duration::from_millis(1),
+            max_periodic_catch_up: 16,
+            batch_size: 10,
+        })
+        .unwrap();
+
+        // retries = 0 → max_attempts = 1, so a panic on the first attempt
+        // dead-letters immediately. The worker must NOT propagate the
+        // panic; if catch-unwind were broken, the spawned task would
+        // unwind through `run_once` and crash this test.
+        assert_eq!(worker.run_once().await.unwrap(), 1);
+        let dead = worker.drain_dead_letter().unwrap();
+        assert_eq!(dead.len(), 1);
+        assert!(
+            dead[0].error.contains("panic"),
+            "expected panic message, got `{}`",
+            dead[0].error
+        );
+        assert_eq!(dead[0].attempt, 1);
+        assert_eq!(dead[0].max_attempts, 1);
+
+        // Drain is single-shot.
+        assert!(worker.drain_dead_letter().unwrap().is_empty());
     });
 }

--- a/crates/pocopine/tests/job_macro.rs
+++ b/crates/pocopine/tests/job_macro.rs
@@ -127,6 +127,7 @@ fn memory_backend_worker_runs_enqueued_job() {
             block_ms: 0,
             visibility_timeout: Duration::from_secs(60),
             scheduler_interval: Duration::from_millis(1),
+            max_periodic_catch_up: 16,
             batch_size: 10,
         })
         .unwrap();

--- a/crates/pocopine/tests/job_macro.rs
+++ b/crates/pocopine/tests/job_macro.rs
@@ -1,0 +1,82 @@
+use pocopine::JobResult;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct JobPayload {
+    value: String,
+}
+
+#[pocopine::job(queue = "tests", retries = 2)]
+async fn macro_registered_job(input: JobPayload) -> JobResult<()> {
+    assert_eq!(input.value, "ok");
+    Ok(())
+}
+
+#[pocopine::job(queue = "periodic", every = "15m", retries = 1)]
+async fn refresh_periodic_cache() -> JobResult<()> {
+    Ok(())
+}
+
+#[pocopine::job(queue = "periodic", cron = "0 0 2 * * * *")]
+async fn nightly_periodic_cleanup() -> JobResult<()> {
+    Ok(())
+}
+
+#[test]
+fn job_descriptor_is_registered_by_inventory() {
+    let descriptor = pocopine::jobs::registered_jobs()
+        .find(|descriptor| descriptor.name.ends_with("::macro_registered_job"))
+        .expect("job descriptor should be registered");
+
+    assert_eq!(descriptor.queue, "tests");
+    assert_eq!(descriptor.retry_policy.max_attempts, 3);
+}
+
+#[test]
+fn periodic_job_descriptor_is_registered_by_inventory() {
+    let descriptor = pocopine::jobs::registered_jobs()
+        .find(|descriptor| descriptor.name.ends_with("::refresh_periodic_cache"))
+        .expect("periodic job descriptor should be registered");
+
+    assert_eq!(descriptor.queue, "periodic");
+    assert_eq!(descriptor.retry_policy.max_attempts, 2);
+    assert_eq!(
+        descriptor.periodic,
+        Some(pocopine::PeriodicSchedule::Every {
+            interval_ms: 15 * 60 * 1_000
+        })
+    );
+
+    let descriptor = pocopine::jobs::registered_jobs()
+        .find(|descriptor| descriptor.name.ends_with("::nightly_periodic_cleanup"))
+        .expect("cron job descriptor should be registered");
+
+    assert_eq!(
+        descriptor.periodic,
+        Some(pocopine::PeriodicSchedule::Cron {
+            expr: "0 0 2 * * * *"
+        })
+    );
+}
+
+#[test]
+fn generated_dispatch_decodes_payload() {
+    let payload = serde_json::to_vec(&JobPayload { value: "ok".into() }).unwrap();
+    let future = macro_registered_job_job::__pocopine_dispatch_macro_registered_job(payload);
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(future).unwrap();
+}
+
+#[test]
+fn generated_periodic_dispatch_decodes_unit_payload() {
+    let payload = serde_json::to_vec(&()).unwrap();
+    let future = refresh_periodic_cache_job::__pocopine_dispatch_refresh_periodic_cache(payload);
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    rt.block_on(future).unwrap();
+}

--- a/crates/pocopine/tests/job_macro.rs
+++ b/crates/pocopine/tests/job_macro.rs
@@ -1,3 +1,8 @@
+// `#[pocopine::job]` only generates the host-side worker, client, and
+// dispatch helpers; on `wasm32` the macro emits stubs and the
+// `<fn>_job` modules don't exist. Skip the whole file under wasm.
+#![cfg(not(target_arch = "wasm32"))]
+
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 

--- a/crates/pocopine/tests/jobs_redis.rs
+++ b/crates/pocopine/tests/jobs_redis.rs
@@ -13,28 +13,40 @@ use std::time::Duration;
 
 use pocopine::{JobBackend, JobClient, JobError, JobResult, Worker, WorkerConfig};
 use serde::{Deserialize, Serialize};
+use testcontainers::core::{ContainerPort, WaitFor};
 use testcontainers::runners::AsyncRunner;
-use testcontainers::ContainerAsync;
-use testcontainers_modules::redis::Redis;
+use testcontainers::{ContainerAsync, GenericImage};
 use tokio::sync::OnceCell;
+
+// `testcontainers-modules`'s default `Redis` image is pinned to 5.0,
+// which predates `XAUTOCLAIM` (Redis 6.2). The job worker uses
+// `XAUTOCLAIM` in its stale-job reclaim path, so we pin a modern tag
+// here via `GenericImage`.
+const REDIS_IMAGE: &str = "redis";
+const REDIS_TAG: &str = "7-alpine";
+const REDIS_PORT: u16 = 6379;
 
 // One Redis container is shared by every test in this binary. Tests
 // keep state isolated by using a unique `app` namespace, so all keys
 // live under `pocopine:{app}:*` and cannot collide across tests.
-static REDIS: OnceCell<ContainerAsync<Redis>> = OnceCell::const_new();
+static REDIS: OnceCell<ContainerAsync<GenericImage>> = OnceCell::const_new();
 static APP_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 async fn redis_url() -> String {
     let container = REDIS
         .get_or_init(|| async {
-            Redis::default()
+            GenericImage::new(REDIS_IMAGE, REDIS_TAG)
+                .with_exposed_port(ContainerPort::Tcp(REDIS_PORT))
+                .with_wait_for(WaitFor::message_on_stdout(
+                    "Ready to accept connections",
+                ))
                 .start()
                 .await
                 .expect("start redis testcontainer")
         })
         .await;
     let port = container
-        .get_host_port_ipv4(6379)
+        .get_host_port_ipv4(REDIS_PORT)
         .await
         .expect("redis container port");
     format!("redis://127.0.0.1:{port}/")

--- a/crates/pocopine/tests/jobs_redis.rs
+++ b/crates/pocopine/tests/jobs_redis.rs
@@ -37,9 +37,7 @@ async fn redis_url() -> String {
         .get_or_init(|| async {
             GenericImage::new(REDIS_IMAGE, REDIS_TAG)
                 .with_exposed_port(ContainerPort::Tcp(REDIS_PORT))
-                .with_wait_for(WaitFor::message_on_stdout(
-                    "Ready to accept connections",
-                ))
+                .with_wait_for(WaitFor::message_on_stdout("Ready to accept connections"))
                 .start()
                 .await
                 .expect("start redis testcontainer")
@@ -246,14 +244,7 @@ async fn flaky_handler_retries_through_backoff_and_succeeds() {
     // First attempt fails, retry scheduled with backoff (base 1s).
     // 200 iters * 100 ms = 20 s — comfortably above the 2-3 s the two
     // retries need.
-    drive_until_counter(
-        &worker,
-        &FLAKY_RUNS,
-        3,
-        200,
-        Duration::from_millis(100),
-    )
-    .await;
+    drive_until_counter(&worker, &FLAKY_RUNS, 3, 200, Duration::from_millis(100)).await;
 
     assert_eq!(
         FLAKY_RUNS.load(Ordering::SeqCst),
@@ -288,15 +279,7 @@ async fn permanently_failing_handler_lands_in_dead_letter_stream() {
 
     // retries=1 → max_attempts=2 → 2 attempts then dead-letter.
     let dead_key = format!("pocopine:{app}:dead");
-    drive_until_xlen(
-        &worker,
-        &url,
-        &dead_key,
-        1,
-        200,
-        Duration::from_millis(100),
-    )
-    .await;
+    drive_until_xlen(&worker, &url, &dead_key, 1, 200, Duration::from_millis(100)).await;
 
     assert_eq!(redis_xlen(&url, &dead_key).await, 1);
     assert!(
@@ -335,15 +318,7 @@ async fn handler_panic_is_caught_and_dead_lettered() {
 
     // retries=0 → max_attempts=1 → first panic dead-letters.
     let dead_key = format!("pocopine:{app}:dead");
-    drive_until_xlen(
-        &worker,
-        &url,
-        &dead_key,
-        1,
-        200,
-        Duration::from_millis(50),
-    )
-    .await;
+    drive_until_xlen(&worker, &url, &dead_key, 1, 200, Duration::from_millis(50)).await;
 
     assert_eq!(PANIC_RUNS.load(Ordering::SeqCst), baseline + 1);
     assert_eq!(redis_xlen(&url, &dead_key).await, 1);

--- a/crates/pocopine/tests/jobs_redis.rs
+++ b/crates/pocopine/tests/jobs_redis.rs
@@ -1,0 +1,338 @@
+// Redis-backed integration tests for `#[pocopine::job]`. Each test
+// targets a throwaway Redis container started by testcontainers, so CI
+// runs them without any external service.
+//
+// Requires a working Docker daemon. Local contributors without Docker
+// can skip these with `cargo test --workspace -- --skip jobs_redis`.
+//
+// Host-only.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use pocopine::{JobBackend, JobClient, JobError, JobResult, Worker, WorkerConfig};
+use serde::{Deserialize, Serialize};
+use testcontainers::runners::AsyncRunner;
+use testcontainers::ContainerAsync;
+use testcontainers_modules::redis::Redis;
+use tokio::sync::OnceCell;
+
+// One Redis container is shared by every test in this binary. Tests
+// keep state isolated by using a unique `app` namespace, so all keys
+// live under `pocopine:{app}:*` and cannot collide across tests.
+static REDIS: OnceCell<ContainerAsync<Redis>> = OnceCell::const_new();
+static APP_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+async fn redis_url() -> String {
+    let container = REDIS
+        .get_or_init(|| async {
+            Redis::default()
+                .start()
+                .await
+                .expect("start redis testcontainer")
+        })
+        .await;
+    let port = container
+        .get_host_port_ipv4(6379)
+        .await
+        .expect("redis container port");
+    format!("redis://127.0.0.1:{port}/")
+}
+
+fn unique_app(prefix: &str) -> String {
+    format!(
+        "pocopine-it-{prefix}-{}-{}",
+        std::process::id(),
+        APP_COUNTER.fetch_add(1, Ordering::SeqCst)
+    )
+}
+
+fn worker_config(backend: JobBackend, app: String, queue: &str) -> WorkerConfig {
+    WorkerConfig {
+        backend,
+        app,
+        queues: vec![queue.to_string()],
+        group: "test".to_string(),
+        consumer: format!("test-consumer-{}", std::process::id()),
+        block_ms: 0,
+        visibility_timeout: Duration::from_secs(60),
+        scheduler_interval: Duration::from_millis(1),
+        max_periodic_catch_up: 16,
+        batch_size: 10,
+    }
+}
+
+async fn redis_xlen(url: &str, key: &str) -> i64 {
+    let client = redis::Client::open(url).unwrap();
+    let mut conn = client.get_multiplexed_async_connection().await.unwrap();
+    redis::cmd("XLEN")
+        .arg(key)
+        .query_async(&mut conn)
+        .await
+        .unwrap()
+}
+
+async fn redis_zcard(url: &str, key: &str) -> i64 {
+    let client = redis::Client::open(url).unwrap();
+    let mut conn = client.get_multiplexed_async_connection().await.unwrap();
+    redis::cmd("ZCARD")
+        .arg(key)
+        .query_async(&mut conn)
+        .await
+        .unwrap()
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct Payload {
+    value: String,
+}
+
+// Run-counters are global because `inventory::submit!` registers
+// handlers crate-wide. Each test isolates its own counter via the
+// `app` namespace + a per-test atomic that the handler reads/writes.
+static HAPPY_RUNS: AtomicUsize = AtomicUsize::new(0);
+static FLAKY_RUNS: AtomicUsize = AtomicUsize::new(0);
+static FLAKY_FAIL_UNTIL: AtomicUsize = AtomicUsize::new(0);
+static ALWAYS_FAILING_RUNS: AtomicUsize = AtomicUsize::new(0);
+static PANIC_RUNS: AtomicUsize = AtomicUsize::new(0);
+
+#[pocopine::job(queue = "it-happy", retries = 0)]
+async fn it_happy_job(input: Payload) -> JobResult<()> {
+    assert_eq!(input.value, "hello");
+    HAPPY_RUNS.fetch_add(1, Ordering::SeqCst);
+    Ok(())
+}
+
+#[pocopine::job(queue = "it-flaky", retries = 3)]
+async fn it_flaky_job(_input: Payload) -> JobResult<()> {
+    let attempt = FLAKY_RUNS.fetch_add(1, Ordering::SeqCst) + 1;
+    if attempt <= FLAKY_FAIL_UNTIL.load(Ordering::SeqCst) {
+        return Err(JobError::Env(format!(
+            "simulated failure on attempt {attempt}"
+        )));
+    }
+    Ok(())
+}
+
+#[pocopine::job(queue = "it-dead", retries = 1)]
+async fn it_always_failing_job(_input: Payload) -> JobResult<()> {
+    ALWAYS_FAILING_RUNS.fetch_add(1, Ordering::SeqCst);
+    Err(JobError::Env("permanent failure".into()))
+}
+
+#[pocopine::job(queue = "it-panic", retries = 0)]
+async fn it_panicking_job(_input: Payload) -> JobResult<()> {
+    PANIC_RUNS.fetch_add(1, Ordering::SeqCst);
+    panic!("intentional integration-test panic");
+}
+
+async fn drive_until_counter(
+    worker: &Worker,
+    counter: &AtomicUsize,
+    target: usize,
+    iter_cap: usize,
+    sleep: Duration,
+) {
+    for _ in 0..iter_cap {
+        let _ = worker.run_once().await.unwrap();
+        if counter.load(Ordering::SeqCst) >= target {
+            return;
+        }
+        tokio::time::sleep(sleep).await;
+    }
+}
+
+async fn drive_until_xlen(
+    worker: &Worker,
+    url: &str,
+    key: &str,
+    target: i64,
+    iter_cap: usize,
+    sleep: Duration,
+) {
+    for _ in 0..iter_cap {
+        let _ = worker.run_once().await.unwrap();
+        if redis_xlen(url, key).await >= target {
+            return;
+        }
+        tokio::time::sleep(sleep).await;
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn schedule_in_promotes_consumes_and_acks() {
+    let url = redis_url().await;
+    let app = unique_app("happy");
+    let client = JobClient::new(url.clone(), app.clone());
+    let baseline = HAPPY_RUNS.load(Ordering::SeqCst);
+
+    it_happy_job_job::schedule_in_with(
+        &client,
+        Payload {
+            value: "hello".into(),
+        },
+        Duration::from_millis(0),
+    )
+    .await
+    .unwrap();
+
+    let scheduled_key = format!("pocopine:{app}:scheduled");
+    assert_eq!(redis_zcard(&url, &scheduled_key).await, 1);
+
+    let worker = Worker::new(worker_config(
+        JobBackend::Redis { url: url.clone() },
+        app.clone(),
+        "it-happy",
+    ))
+    .unwrap();
+
+    drive_until_counter(
+        &worker,
+        &HAPPY_RUNS,
+        baseline + 1,
+        20,
+        Duration::from_millis(50),
+    )
+    .await;
+
+    assert_eq!(HAPPY_RUNS.load(Ordering::SeqCst), baseline + 1);
+    assert_eq!(redis_zcard(&url, &scheduled_key).await, 0);
+    // The promote script atomically ZREMs from the sorted set and
+    // XADDs onto the ready stream. Earlier code did the ZREM outside
+    // the script and silently dropped XADD; this assertion is the
+    // regression check.
+    let queue_key = format!("pocopine:{app}:queue:it-happy");
+    assert_eq!(redis_xlen(&url, &queue_key).await, 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn flaky_handler_retries_through_backoff_and_succeeds() {
+    let url = redis_url().await;
+    let app = unique_app("flaky");
+    let client = JobClient::new(url.clone(), app.clone());
+
+    FLAKY_RUNS.store(0, Ordering::SeqCst);
+    FLAKY_FAIL_UNTIL.store(2, Ordering::SeqCst);
+
+    it_flaky_job_job::enqueue_with(
+        &client,
+        Payload {
+            value: "retry".into(),
+        },
+    )
+    .await
+    .unwrap();
+
+    let worker = Worker::new(worker_config(
+        JobBackend::Redis { url: url.clone() },
+        app,
+        "it-flaky",
+    ))
+    .unwrap();
+
+    // First attempt fails, retry scheduled with backoff (base 1s).
+    // 200 iters * 100 ms = 20 s — comfortably above the 2-3 s the two
+    // retries need.
+    drive_until_counter(
+        &worker,
+        &FLAKY_RUNS,
+        3,
+        200,
+        Duration::from_millis(100),
+    )
+    .await;
+
+    assert_eq!(
+        FLAKY_RUNS.load(Ordering::SeqCst),
+        3,
+        "expected exactly 3 attempts (2 fail + 1 success)"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn permanently_failing_handler_lands_in_dead_letter_stream() {
+    let url = redis_url().await;
+    let app = unique_app("dead");
+    let client = JobClient::new(url.clone(), app.clone());
+
+    let baseline = ALWAYS_FAILING_RUNS.load(Ordering::SeqCst);
+
+    it_always_failing_job_job::enqueue_with(
+        &client,
+        Payload {
+            value: "dead".into(),
+        },
+    )
+    .await
+    .unwrap();
+
+    let worker = Worker::new(worker_config(
+        JobBackend::Redis { url: url.clone() },
+        app.clone(),
+        "it-dead",
+    ))
+    .unwrap();
+
+    // retries=1 → max_attempts=2 → 2 attempts then dead-letter.
+    let dead_key = format!("pocopine:{app}:dead");
+    drive_until_xlen(
+        &worker,
+        &url,
+        &dead_key,
+        1,
+        200,
+        Duration::from_millis(100),
+    )
+    .await;
+
+    assert_eq!(redis_xlen(&url, &dead_key).await, 1);
+    assert!(
+        ALWAYS_FAILING_RUNS.load(Ordering::SeqCst) >= baseline + 2,
+        "handler should have run at least max_attempts=2 times"
+    );
+
+    assert!(matches!(
+        worker.drain_dead_letter(),
+        Err(JobError::Unsupported(_))
+    ));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn handler_panic_is_caught_and_dead_lettered() {
+    let url = redis_url().await;
+    let app = unique_app("panic");
+    let client = JobClient::new(url.clone(), app.clone());
+
+    let baseline = PANIC_RUNS.load(Ordering::SeqCst);
+    it_panicking_job_job::enqueue_with(
+        &client,
+        Payload {
+            value: "boom".into(),
+        },
+    )
+    .await
+    .unwrap();
+
+    let worker = Worker::new(worker_config(
+        JobBackend::Redis { url: url.clone() },
+        app.clone(),
+        "it-panic",
+    ))
+    .unwrap();
+
+    // retries=0 → max_attempts=1 → first panic dead-letters.
+    let dead_key = format!("pocopine:{app}:dead");
+    drive_until_xlen(
+        &worker,
+        &url,
+        &dead_key,
+        1,
+        200,
+        Duration::from_millis(50),
+    )
+    .await;
+
+    assert_eq!(PANIC_RUNS.load(Ordering::SeqCst), baseline + 1);
+    assert_eq!(redis_xlen(&url, &dead_key).await, 1);
+}

--- a/crates/pocopine/tests/server_auth.rs
+++ b/crates/pocopine/tests/server_auth.rs
@@ -1,0 +1,112 @@
+use pocopine::{AuthUser, Role, ServerError, ServerResult};
+use pocopine_server::axum::{
+    body::{to_bytes, Body},
+    http::{Extensions, HeaderMap, Method, Request, Uri},
+};
+use pocopine_server::tower::ServiceExt;
+
+async fn require_token(ctx: pocopine_server::auth::RequestContext) -> ServerResult<()> {
+    match ctx.bearer_token() {
+        Some("test-token") => Ok(()),
+        Some(_) => Err(ServerError::forbidden("invalid bearer token")),
+        None => Err(ServerError::unauthorized("missing bearer token")),
+    }
+}
+
+#[pocopine::server(guard = require_token)]
+async fn guarded_echo(value: String) -> ServerResult<String> {
+    Ok(value)
+}
+
+#[pocopine::server(public)]
+async fn public_echo(value: String) -> ServerResult<String> {
+    Ok(value)
+}
+
+pocopine::protected! {
+    require |ctx| ctx.user.has_role(Role::Admin);
+
+    async fn admin_echo(value: String) -> ServerResult<String> {
+        Ok(value)
+    }
+}
+
+#[test]
+fn guarded_and_public_route_helpers_typecheck() {
+    let router = pocopine_server::axum::Router::new();
+    let router = __guarded_echo_route(router);
+    let router = __public_echo_route(router);
+    let _router = __admin_echo_route(router);
+}
+
+#[test]
+fn request_context_extracts_user_from_extensions() {
+    let mut extensions = Extensions::new();
+    extensions.insert(AuthUser::new("user-1").with_role(Role::Admin));
+
+    let ctx = pocopine::auth::RequestContext::from_parts(
+        Method::GET,
+        Uri::from_static("/_pocopine/admin_echo"),
+        HeaderMap::new(),
+        extensions,
+    );
+
+    assert!(ctx.user.is_authenticated());
+    assert!(ctx.user.has_role(Role::Admin));
+}
+
+#[test]
+fn protected_macro_guard_checks_inline_policy() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    let allowed = pocopine::auth::RequestContext::new(
+        Method::POST,
+        Uri::from_static("/_pocopine/admin_echo"),
+        HeaderMap::new(),
+    )
+    .with_user(AuthUser::new("admin").with_role(Role::Admin));
+    rt.block_on(__pocopine_guard_admin_echo(allowed)).unwrap();
+
+    let denied = pocopine::auth::RequestContext::new(
+        Method::POST,
+        Uri::from_static("/_pocopine/admin_echo"),
+        HeaderMap::new(),
+    )
+    .with_user(AuthUser::new("user").with_role(Role::User));
+    let err = rt
+        .block_on(__pocopine_guard_admin_echo(denied))
+        .unwrap_err();
+    assert!(matches!(err, ServerError::Forbidden(_)));
+}
+
+#[test]
+fn oversized_body_returns_bad_request() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+
+    rt.block_on(async {
+        std::env::set_var("POCOPINE_SERVER_FUNCTION_BODY_LIMIT", "1");
+        let router = __public_echo_route(pocopine_server::axum::Router::new());
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/_pocopine/public_echo")
+                    .header("content-type", "application/json")
+                    .body(Body::from("[\"too large\"]"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        std::env::remove_var("POCOPINE_SERVER_FUNCTION_BODY_LIMIT");
+
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let result: ServerResult<String> = serde_json::from_slice(&bytes).unwrap();
+        assert!(matches!(result, Err(ServerError::BadRequest(_))));
+    });
+}

--- a/crates/pocopine/tests/server_auth.rs
+++ b/crates/pocopine/tests/server_auth.rs
@@ -1,3 +1,10 @@
+// `#[pocopine::server(guard = ...)]` and the `protected!` macro only
+// emit the route helper, guard function, and `RequestContext` plumbing
+// on the host target; the umbrella `pocopine` crate also gates the
+// `RequestContext` re-export to non-wasm. Skip the whole file under
+// wasm.
+#![cfg(not(target_arch = "wasm32"))]
+
 use pocopine::{AuthUser, Role, ServerError, ServerResult};
 use pocopine_server::axum::{
     body::{to_bytes, Body},

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,10 @@ looks the way it does — the code itself tells you *what*.
 - [`performance-strategy.md`](./performance-strategy.md) — current
   large-list performance strategy, including why Vue / Svelte are
   ahead and what pocopine should optimize next.
+- [`jobs.md`](./jobs.md) — background-job runtime: Redis Streams +
+  sorted-set scheduler + Lua-scripted state transitions, periodic
+  firings, reclaim, and the memory backend. Includes redis-cli
+  recipes for validating a live deployment.
 - [`postmortems/`](./postmortems/) — write-ups of subtle bugs + the
   invariants new code should preserve.
 

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -1,0 +1,588 @@
+# Background jobs — architecture
+
+Source of truth for how `pocopine-jobs` works. The code tells you what
+each function does; this doc tells you what the broker is doing,
+which invariants the algorithm preserves, and how to verify them
+against a live Redis.
+
+For the framing decision (why two backends, what's a non-goal), see
+[`rfcs/rfc-067-redis-background-jobs.md`](../rfcs/rfc-067-redis-background-jobs.md).
+For the auth surface server functions use, see
+[`rfcs/rfc-066-server-function-auth.md`](../rfcs/rfc-066-server-function-auth.md).
+
+## Mental model
+
+A `#[pocopine::job]` function compiles to two artifacts:
+
+1. **A static descriptor** registered through `inventory` at link
+   time. `Worker::new()` walks the registry to build a name →
+   handler dispatch map.
+2. **A typed enqueue/schedule helper module** (`<fn>_job::enqueue`,
+   `enqueue_with`, `schedule_in`, `schedule_at`, …) that produces a
+   JSON envelope and writes it to the chosen backend.
+
+The runtime has two backends behind the same enum:
+
+```
+JobBackend::Redis { url }   // durable, multi-process
+JobBackend::Memory          // process-local, in-memory
+```
+
+Both share the same envelope shape, retry math, and dead-letter
+contract. The Redis backend is the interesting one — the rest of this
+doc covers it. The memory backend is documented at the end.
+
+## Data model (Redis keys)
+
+All keys are namespaced by the configured `app` value. Curly braces
+in `{app}` are intentional — they double as a Redis Cluster hash tag
+so every pocopine key for one app lands on one slot, which makes the
+Lua scripts viable on cluster topologies.
+
+| Key | Type | What's in it |
+|---|---|---|
+| `pocopine:{app}:queue:{queue}` | Stream | Ready queue. Entries here are eligible for `XREADGROUP`. |
+| `pocopine:{app}:scheduled` | Sorted Set | Future-due envelopes. Score is `due_ms` (broker time, ms since epoch); member is the JSON envelope. |
+| `pocopine:{app}:dead` | Stream | Dead-letter — jobs that exhausted their retry budget, with the failure message and full envelope captured as fields. |
+| `pocopine:{app}:periodic:{job}:{due_ms}` | String + TTL | One-shot lock per (job, slot). `SET NX PX <ttl>` so only one worker enqueues each periodic firing. Auto-expires before the next slot. |
+| `pocopine:{app}:periodic:last:{job}` | String (`u64`) | Last fired slot for the periodic job, used for cron catch-up after worker downtime. |
+
+The envelope itself:
+
+```json
+{
+  "job_id":           "1a2b3c:hostname_pid_started:42",
+  "job_name":         "blog::record_post_view",
+  "queue":            "blog",
+  "payload":          { /* serde_json::Value */ },
+  "attempt":          1,
+  "max_attempts":     4,
+  "created_at_ms":    1714680000000,
+  "scheduled_for_ms": null
+}
+```
+
+`job_id` is `{ms:x}:{host}_{pid:x}_{started_at:x}:{counter:x}` so two
+workers on different hosts cannot collide even at the same wall-clock
+millisecond, and two restarts of the same process can't collide either
+(the `started_at` nanoseconds differ).
+
+## The worker loop
+
+```rust
+async fn run_redis_once(&self, conn) -> JobResult<usize> {
+    let now_ms = redis_time_ms(conn).await?;            // ① broker clock
+    self.enqueue_due_periodic_jobs(conn, now_ms).await?; // ②
+    self.promote_due_jobs(conn, now_ms).await?;          // ③
+    self.reclaim_stale_jobs(conn).await?;                 // ④
+    self.read_ready_jobs(conn).await                      // ⑤
+}
+```
+
+Order matters:
+
+- **① TIME comes from Redis, not `SystemTime::now()`.** All due-time
+  comparisons (`now_ms` vs scheduled score, vs cron next-fire, etc.)
+  use the broker's clock so worker clock skew doesn't cause premature
+  promotion or missed firings.
+- **② Periodic before promote** so a periodic firing this tick can be
+  consumed in the same iteration (no extra round-trip).
+- **③ Promote before reclaim** so retries scheduled in earlier
+  iterations land in the stream before reclaim/read look at it.
+- **④ Reclaim before read** so abandoned entries from dead workers are
+  picked up before the new-entry path. Reclaimed entries run
+  inline in step ④; step ⑤ only returns *new* entries.
+- **⑤ Read new** — `XREADGROUP ... >` skips PEL entirely.
+
+The outer `Worker::run()` loop wraps `run_redis_once` with capped
+exponential-backoff reconnect on transient errors and prints a
+one-line backend banner so operators can see at startup which backend
+is bound.
+
+## Lifecycle 1 — happy path
+
+```
+                ┌──────────────────────┐
+                │  app calls            │
+                │  enqueue_with(client, │
+                │     payload)          │
+                └──────────┬───────────┘
+                           ▼
+            XADD pocopine:{app}:queue:{queue} *
+                  job_id, job_name, queue, payload, attempt=1, …
+                           │
+        ─ ── ── ── ── ── ── ┼ ── ── ── ── ── ── ── ── ── ──
+                           ▼
+              ⑤ Worker XREADGROUP ... >
+                           │
+                           ▼
+              run_envelope(stream_id, envelope)
+                           │
+            run_handler_safely(handler, payload).await
+                           │
+                           ▼
+                   Ok(())  ──►  XACK stream group stream_id
+```
+
+Why `run_handler_safely`? It runs the handler future under
+`tokio::spawn` so a panic becomes `JoinError::is_panic()` →
+`JobError::Handler(...)`. Without that wrapper, a panic would unwind
+through `run_once` and crash the worker; with the wrapper it routes
+through the same retry/dead-letter path as a normal `Err`.
+
+The stream entry is **not** deleted by `XACK`. `XACK` only removes
+the entry from the consumer group's PEL ("Pending Entries List").
+The stream itself is append-only; pocopine doesn't `XTRIM` or `XDEL`.
+For high-throughput apps, configure Redis-side stream-trim (e.g.
+`XADD ... MAXLEN ~ 10000`) — that's a follow-up.
+
+### Verifying
+
+```sh
+# Before consume
+XLEN pocopine:my-app:queue:emails              # 1
+XPENDING pocopine:my-app:queue:emails group    # 0 pending
+
+# After XREADGROUP, before XACK
+XPENDING pocopine:my-app:queue:emails group    # 1, owner=consumer-name
+
+# After XACK
+XPENDING pocopine:my-app:queue:emails group    # 0
+XLEN pocopine:my-app:queue:emails              # still 1 — the entry is in the log
+```
+
+## Lifecycle 2 — failure → retry → success or dead-letter
+
+When `run_handler_safely` returns `Err(_)`:
+
+```rust
+if envelope.attempt < envelope.max_attempts {
+    retry.attempt += 1;
+    due_ms = redis_TIME() + retry_delay_ms(retry.attempt, retry.job_id);
+    schedule_retry_and_ack(conn, scheduled_key, stream, group,
+                            stream_id, retry, due_ms).await?;
+} else {
+    move_to_dead_and_ack(conn, stream, stream_id, envelope, err.to_string()).await?;
+}
+```
+
+`retry_delay_ms` is exponential with cap and hash-jittered span:
+
+```
+attempt    base       jitter span    delay range
+─────────  ─────────  ─────────────  ─────────────
+2          1000 ms    ≤ 200 ms       1.0 – 1.2 s
+3          2000 ms    ≤ 400 ms       2.0 – 2.4 s
+4          4000 ms    ≤ 800 ms       4.0 – 4.8 s
+5          8000 ms    ≤ 1600 ms      8.0 – 9.6 s
+…          …          …              capped at 60 s
+```
+
+The jitter is hashed from `(job_id, attempt)` so the same envelope
+gets the same delay on every replay, but different jobs spread out.
+Job-id hashing means cross-host collisions in the id were a real
+concern — the `host_pid_started` portion of the id makes it negligible.
+
+### `SCHEDULE_RETRY_AND_ACK_SCRIPT`
+
+```lua
+local acked = redis.call('XACK', KEYS[2], ARGV[3], ARGV[4])
+-- KEYS[2] = stream, ARGV[3] = group, ARGV[4] = stream_id
+if acked == 0 then return 0 end                -- already acked? skip
+redis.call('ZADD', KEYS[1], ARGV[1], ARGV[2])
+-- KEYS[1] = scheduled, ARGV[1] = due_ms (score), ARGV[2] = raw envelope JSON
+return acked
+```
+
+**Why Lua.** If the worker crashes between `XACK` and `ZADD` we'd
+have an acked entry with no retry — a silent loss. Redis runs Lua
+scripts to completion without interleaving, so either both writes
+land or neither does (broker-crash + AOF recovery still preserves the
+all-or-nothing property at fsync boundaries).
+
+**Why XACK first.** If we did ZADD first and the script aborted before
+XACK, the entry would be in PEL *and* in scheduled — eventually
+reclaim would re-run the same envelope a second time. Acking first +
+checking the result avoids that duplication; the worst case becomes
+"never run again," which is fine because `attempt` is preserved in the
+new envelope and reclaim doesn't fire on already-acked entries.
+
+The retry then waits in the sorted set until the next promote tick:
+
+```rust
+async fn promote_due_jobs(conn, now_ms):
+    let raw_jobs: Vec<String> = ZRANGEBYSCORE scheduled -inf now_ms LIMIT 0 100
+    for raw in raw_jobs:
+        promote_scheduled_envelope(conn, scheduled_key, queue_key, raw, envelope)
+```
+
+### `PROMOTE_SCHEDULED_SCRIPT`
+
+```lua
+local removed = redis.call('ZREM', KEYS[1], ARGV[1])
+if removed == 0 then return 0 end
+return redis.call('XADD', KEYS[2], '*',
+                  'job_id', ARGV[2],
+                  'job_name', ARGV[3],
+                  'queue', ARGV[4],
+                  'payload', ARGV[5],
+                  'attempt', ARGV[6],
+                  'max_attempts', ARGV[7],
+                  'created_at_ms', ARGV[8],
+                  'scheduled_for_ms', ARGV[9])
+```
+
+**Why Lua.** Two workers can both `ZRANGEBYSCORE` and see the same
+envelope simultaneously. The `ZREM` inside the script is the claim:
+the first worker gets `removed = 1` and proceeds to `XADD`, the
+second gets `removed = 0` and bails. Without atomicity here, a worker
+crash between ZREM and XADD silently drops the envelope.
+
+> **Regression we caught:** an earlier version did the `ZREM` in Rust
+> *before* calling the script. The script's own `ZREM` then always
+> returned `0` and skipped `XADD` — every promoted retry was silently
+> dropped. The integration test
+> `schedule_in_promotes_consumes_and_acks` is the regression check
+> for this. See `crates/pocopine/tests/jobs_redis.rs`.
+
+### `DEAD_LETTER_AND_ACK_SCRIPT`
+
+```lua
+local acked = redis.call('XACK', KEYS[2], ARGV[9], ARGV[10])
+if acked == 0 then return 0 end
+return redis.call('XADD', KEYS[1], '*',
+                  'job_id', ARGV[1], …, 'envelope', ARGV[7], 'failed_at_ms', ARGV[8])
+```
+
+Same shape as the retry script. Atomically: ack the original stream
+entry, then write a new entry to the dead-letter stream with the
+final attempt count, error message, and full envelope embedded as a
+field so an operator can inspect what was attempted.
+
+### `EVALSHA` caching
+
+All three scripts are wrapped in `redis::Script` statics
+(`promote_scheduled_script`, `schedule_retry_and_ack_script`,
+`dead_letter_and_ack_script`) so the redis crate `LOADs` the script
+on first call and uses `EVALSHA` thereafter. Without this wrapper,
+the worker would ship the full Lua source on every promote/retry/
+dead-letter call.
+
+### Verifying retry → dead-letter
+
+Enqueue with `retries = 3` (so `max_attempts = 4`), handler always
+returns `Err`:
+
+```
+T+0   XLEN queue        = 1, attempt = 1
+T+0   handler runs, fails
+T+0   ZCARD scheduled   = 1, score ≈ T+1s
+T+1s  promote runs
+T+1s  XLEN queue        = 1 (new entry, attempt = 2 in the fields)
+T+1s  ZCARD scheduled   = 0
+T+1s  handler runs, fails
+T+~3s ... (attempt=3, then 4) ...
+T+~15s XLEN dead        = 1
+T+~15s ZCARD scheduled  = 0
+```
+
+`crates/pocopine/tests/jobs_redis.rs::permanently_failing_handler_lands_in_dead_letter_stream`
+asserts the final state.
+
+## Lifecycle 3 — reclaim (worker died, or handler exceeded visibility)
+
+If a worker reads an entry and never `XACK`s — crashed, OOM-killed,
+network-partitioned, or just took longer than `visibility_timeout` —
+the entry sits in PEL forever from that consumer's perspective.
+`XAUTOCLAIM` is the recovery mechanism:
+
+```
+XREADGROUP ... >        # only delivers NEW entries; PEL is untouched
+XAUTOCLAIM stream group new_consumer min_idle_ms 0-0 COUNT N
+                                             ↑
+                                        visibility_timeout
+```
+
+`XAUTOCLAIM` walks the PEL and reassigns ownership of any entry idle
+≥ `min_idle_ms` to the calling consumer (not the original owner).
+The reassigned entries are returned and pocopine processes them
+through `run_envelope` with `attempt += 1` so chronically-stuck jobs
+eventually exhaust the retry budget and dead-letter.
+
+**At-least-once is the contract.** If your handler runs longer than
+`visibility_timeout` (default 60s, configurable via
+`POCOPINE_JOB_VISIBILITY_MS`), another worker will reclaim and
+re-execute the same job. Handlers must therefore be idempotent
+*or* finish well under the timeout. This is documented in
+RFC-067 §4 and in the doc comment on `WorkerConfig.visibility_timeout`.
+
+### Reclaim attempt accounting
+
+```rust
+async fn reclaim_stale_jobs(conn):
+    XAUTOCLAIM ... → claimed entries
+    for id in claimed:
+        envelope = parse(id.map)
+        if envelope.attempt >= envelope.max_attempts:
+            move_to_dead_and_ack(...)              // already exhausted
+        else:
+            envelope.attempt += 1
+            run_envelope(...)                       // run with bumped attempt
+```
+
+The `attempt += 1` is critical: a handler that hangs forever would
+otherwise loop reclaim → re-run → reclaim indefinitely. Bumping
+attempt on each reclaim consumes the retry budget like a normal
+failure.
+
+### Verifying reclaim
+
+In one shell, enqueue and have a worker pick up an entry but never
+ack it (e.g. handler that sleeps 70s with `visibility_timeout = 60s`).
+Watch `XPENDING`:
+
+```sh
+redis-cli XPENDING pocopine:my-app:queue:slow group
+# 1) "1"                                                # 1 entry pending
+# 2) "stream-id-of-entry"
+# 3) "stream-id-of-entry"
+# 4) 1) 1) "consumer-A"
+#       2) "1"
+```
+
+After 60s + the next worker's reclaim loop, the entry's owner flips
+to whatever consumer ran reclaim. If the handler still doesn't
+complete, eventually `attempt == max_attempts` and the entry moves to
+the dead stream.
+
+## Lifecycle 4 — periodic jobs
+
+`#[pocopine::job(every = "15m")]` and `#[pocopine::job(cron = "...")]`
+register a periodic descriptor. Periodic jobs are not executed by the
+scheduler loop directly — the scheduler computes due slots and
+enqueues them like normal jobs.
+
+```rust
+async fn enqueue_due_periodic_jobs(conn, now_ms):
+    for descriptor in periodic descriptors with matching queue:
+        last_fired_ms = GET pocopine:{app}:periodic:last:{job}
+        for due_ms in due_periodic_slots(schedule, now_ms,
+                                          scheduler_interval, last_fired_ms):
+            // Lock the slot. SET NX PX is atomic on the broker.
+            locked = SET pocopine:{app}:periodic:{job}:{due_ms}
+                          1 NX PX <ttl>
+            if locked:
+                XADD ready_stream (envelope payload = ())
+                SET pocopine:{app}:periodic:last:{job} {due_ms}
+```
+
+Two failure modes the lock defends against:
+
+1. **Multi-worker race in the same slot.** Workers A and B both
+   compute `due_ms = T`. Only one wins `SET NX PX` and enqueues; the
+   other gets `nil` and skips.
+2. **Catch-up after downtime.** If a worker was offline through 5
+   firings, `due_periodic_slots` returns up to
+   `max_periodic_catch_up` past slots (default 16). Each one needs
+   its own lock so multiple workers coming back online don't all
+   replay the backlog. The TTL is the inter-firing interval × 2 (or
+   7 days for cron) so old slots can't accidentally re-fire after
+   state is forgotten.
+
+### `due_periodic_slots`
+
+```rust
+match schedule {
+    Every { interval_ms } => {
+        let due_ms = (now_ms / interval_ms) * interval_ms;
+        if last_fired_ms.is_some_and(|last| last >= due_ms) {
+            vec![]                  // already fired this slot
+        } else {
+            vec![due_ms]
+        }
+    }
+    Cron { expr } => {
+        let window_start = match last_fired_ms {
+            Some(last) => from_ms(last),
+            None => now - scheduler_interval,
+        };
+        schedule.after(&window_start)
+                .take(MAX_CATCH_UP)         // cap on catch-up
+                .filter(|d| d as u64 <= now_ms)
+                .collect()
+    }
+}
+```
+
+For `every`, only one slot is returned per tick — the most recent
+boundary that hasn't fired. Cron fans out missed firings.
+
+### Verifying periodic firings
+
+```sh
+# With #[pocopine::job(every = "5s")]:
+redis-cli --scan --pattern 'pocopine:my-app:periodic:*'
+
+# pocopine:my-app:periodic:my::job::name:1714680000000   (slot lock, TTL ~10s)
+# pocopine:my-app:periodic:last:my::job::name             (last fired)
+```
+
+The slot lock keys come and go with TTL; the `:last:` key is updated
+in lockstep with each successful enqueue.
+
+## Atomicity guarantees, summarized
+
+| Transition | Mechanism | What breaks without it |
+|---|---|---|
+| Schedule retry + ack original | `SCHEDULE_RETRY_AND_ACK_SCRIPT` | Crash between XACK and ZADD = job lost. |
+| Promote scheduled → ready | `PROMOTE_SCHEDULED_SCRIPT` | Two workers double-promote, or crash between ZREM and XADD = lost. |
+| Dead-letter + ack original | `DEAD_LETTER_AND_ACK_SCRIPT` | Crash between XACK and dead XADD = no record of the failure. |
+| Periodic slot dedup | `SET NX PX` | All workers enqueue every slot independently → N×duplicate firings. |
+| Promote claim race | ZREM-as-claim inside the Lua script | Two workers both `XADD` the same envelope = duplicate run. |
+| Reclaim ownership transfer | `XAUTOCLAIM` (atomic broker-side) | Multiple workers think they own the same entry = duplicate run. |
+
+## Configuration knobs
+
+| Field / env var | Default | What it controls |
+|---|---|---|
+| `WorkerConfig.visibility_timeout` / `POCOPINE_JOB_VISIBILITY_MS` | 60 000 ms | `XAUTOCLAIM` `min_idle_ms`. Handlers must finish well under this or be idempotent under reclaim. |
+| `WorkerConfig.scheduler_interval` | 1 000 ms | Sleep when `run_redis_once` returns 0 work. Bounds the worst-case latency between "scheduled time reached" and "promoted to stream." |
+| `WorkerConfig.block_ms` | 1 000 ms | `XREADGROUP BLOCK` timeout. **Special case:** `0` means non-blocking poll, *not* "block forever" — the worker omits `BLOCK` from the command so callers using `run_once` against an idle stream don't deadlock. |
+| `WorkerConfig.batch_size` | 10 | `XREADGROUP COUNT` and reclaim/promote batch size. |
+| `WorkerConfig.max_periodic_catch_up` | 16 | Cap on missed cron firings backfilled per loop iteration. |
+| `POCOPINE_JOB_BACKEND` | (auto) | `memory` or `redis`. If unset and `POCOPINE_REDIS_URL` is set → redis; otherwise → memory. |
+| `POCOPINE_REDIS_URL` | — | Standard `redis://[user[:pass]]@host:port/[db]` connection string. |
+
+## Failure modes & invariants
+
+**No silent drops.** Every entry that enters the ready stream or the
+scheduled set leaves only via:
+
+- successful execution + `XACK`, or
+- exhaust attempts → `XADD` to dead + `XACK`, or
+- crash + `XAUTOCLAIM` reclaim (back to one of the above)
+
+**Idempotent acks.** `XACK` returns 0 for already-acked entries. The
+Lua scripts check this and short-circuit the next-state write, so a
+re-run of the same script doesn't double-write to scheduled or dead.
+
+**At-least-once.** Documented and enforced by the visibility-timeout
+contract.
+
+**At-most-one-per-slot for periodic.** Defended by `SET NX PX` and
+`pocopine:{app}:periodic:last:{job}`.
+
+**Retry budget honored.** `attempt < max_attempts` is checked in
+`run_envelope` for the normal path and in `reclaim_stale_jobs` for
+the timeout path. Both routes converge on the same dead-letter
+script.
+
+**Worker crashes are recoverable.** The worker's connection cache is
+cleared on errors, then `run()` retries with capped exponential
+backoff. PEL entries from the dead worker process are reclaimed by
+any other worker (or by the same worker after restart) via
+`XAUTOCLAIM`.
+
+## Out of scope (RFC-067 §4)
+
+- **Native Redis Cluster `MOVED`/`ASK` handling.** Pocopine targets a
+  single-instance Redis or an operator-managed proxy that preserves
+  a primary endpoint across failover.
+- **Sentinel auto-discovery.** Same — operators provide a stable URL.
+- **In-memory durability.** The memory backend is process-local;
+  state is lost on restart.
+
+## Memory backend
+
+Same envelope shape, retry math, periodic semantics, and dead-letter
+flow — implemented inside a `Mutex<MemoryState>` keyed by `app`
+namespace inside a process-global registry.
+
+```rust
+struct MemoryState {
+    ready: VecDeque<JobEnvelope>,                    // ready queue
+    scheduled: Vec<JobEnvelope>,                     // future-due
+    dead: VecDeque<(JobEnvelope, String)>,           // capped dead-letter
+    periodic_locks: HashMap<String, u64>,            // slot → expires_at
+    periodic_last_fired: HashMap<String, u64>,       // job → last fired
+}
+```
+
+Differences from the Redis backend:
+
+- **No consumer groups.** A handler runs directly inside the worker
+  task. There's no PEL and no reclaim path.
+- **Panic safety still routes through dead-letter.**
+  `run_handler_safely` uses `tokio::spawn` + `JoinError::is_panic()`
+  for both backends, so a panicking handler is captured and routed
+  through retry/dead-letter rather than unwinding the worker.
+- **Dead-letter is capped** at `DEFAULT_MEMORY_DEAD_LETTER_CAP = 1024`
+  entries (oldest evicted on overflow) and exposed via
+  `Worker::drain_dead_letter() -> Vec<DeadLetter>`. Operators using
+  the embedded worker should drain periodically and persist the
+  results.
+- **Process-local.** Two separately-launched processes both pick the
+  memory backend by default if neither env is set, and never share
+  state. The CLI rejects `worker-bin` + `POCOPINE_JOB_BACKEND=memory`
+  to defend against this in the official path; for direct
+  `cargo run`, the `Worker::run` startup banner names the backend so
+  the misconfiguration is loud at startup.
+
+When to pick which:
+
+- **Redis** for any deployment where server and worker are separate
+  processes, or where the queue must survive restarts, or where you
+  want to scale workers horizontally.
+- **Memory** for embedded workers, single-process production
+  deployments where losing in-flight jobs on restart is acceptable,
+  and tests.
+
+## Verifying a running deployment
+
+The shortest path is `redis-cli` against the broker. With a
+testcontainer:
+
+```sh
+docker ps                                         # find the container id
+docker exec -it <id> redis-cli
+
+> KEYS pocopine:*
+> XLEN pocopine:my-app:queue:emails
+> XPENDING pocopine:my-app:queue:emails group-name
+> ZRANGE pocopine:my-app:scheduled 0 -1 WITHSCORES
+> XRANGE pocopine:my-app:dead - +
+```
+
+Live tracing:
+
+```sh
+> MONITOR        # prints every command the worker issues
+```
+
+The `EVALSHA` script lookups, `XADD`/`XREADGROUP`/`XACK`/`ZADD`/
+`ZREM`/`XAUTOCLAIM` stream is exactly what `pocopine-jobs` is doing
+on the wire. If you see anything in `MONITOR` that doesn't match one
+of the lifecycle diagrams above, that's worth a bug report.
+
+## Code locations
+
+| Concern | Where |
+|---|---|
+| Lua script source | `crates/pocopine-jobs/src/lib.rs:108-164` |
+| `EVALSHA` wrappers | `crates/pocopine-jobs/src/lib.rs:182-198` |
+| `run_redis_once` (loop body) | `crates/pocopine-jobs/src/lib.rs:705-715` |
+| `enqueue_due_periodic_jobs` | `~:756-803` |
+| `promote_due_jobs` | `~:805-836` |
+| `reclaim_stale_jobs` | `~:838-880` |
+| `read_ready_jobs` (incl. `block_ms == 0` special case) | `~:884-918` |
+| `run_envelope` | `~:920-960` |
+| `run_handler_safely` (panic capture) | `~:1453-1473` |
+| `retry_delay_ms` (backoff math) | `~:1487-1495` |
+| `due_periodic_slots` | `~:1422-1471` |
+| `JobId` construction | `~:1500-1505` |
+| Memory backend state + helpers | `~:218-227, 1085-1140, 1175-1207` |
+| Integration tests | `crates/pocopine/tests/jobs_redis.rs` |
+| Unit tests (math, parsers, ids) | `crates/pocopine-jobs/src/lib.rs` `mod tests` |
+
+If a function on this page doesn't match what's in the file, the
+file is right and this page is stale — please open a PR.

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -32,6 +32,48 @@ Both share the same envelope shape, retry math, and dead-letter
 contract. The Redis backend is the interesting one — the rest of this
 doc covers it. The memory backend is documented at the end.
 
+### High-level topology
+
+```mermaid
+flowchart LR
+    App["app code<br/>(server fn / request handler)"]
+    Client["JobClient"]
+    Worker["Worker"]
+    Redis[("Redis<br/>broker")]
+    Handler["#[pocopine::job]<br/>handler fn"]
+
+    App -->|"enqueue_with / schedule_in"| Client
+    Client -->|"XADD / ZADD"| Redis
+    Worker -->|"TIME / XREADGROUP / XAUTOCLAIM /<br/>EVALSHA promote, retry, dead"| Redis
+    Worker --> Handler
+    Handler -.->|"Ok / Err / panic"| Worker
+```
+
+The client and worker are usually different processes — `bin = "server"`
+and `worker-bin = "worker"` in `[package.metadata.pocopine]`. They
+communicate only through Redis; there's no in-process queue or RPC.
+
+### Job state machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Ready: enqueue
+    [*] --> Scheduled: schedule_in / schedule_at
+    Scheduled --> Ready: promote (due_ms reached)
+    Ready --> Running: XREADGROUP delivers
+    Running --> Done: Ok + XACK
+    Running --> Scheduled: Err, attempt < max (retry)
+    Running --> Dead: Err, attempt >= max
+    Running --> Stale: idle > visibility_timeout
+    Stale --> Running: XAUTOCLAIM (attempt += 1)
+    Stale --> Dead: attempt >= max after bump
+    Done --> [*]
+    Dead --> [*]
+```
+
+Every transition is exercised by an integration test in
+`crates/pocopine/tests/jobs_redis.rs`.
+
 ## Data model (Redis keys)
 
 All keys are namespaced by the configured `app` value. Curly braces
@@ -69,9 +111,22 @@ millisecond, and two restarts of the same process can't collide either
 
 ## The worker loop
 
+```mermaid
+flowchart TD
+    Start(["run_redis_once"]) --> T["① now_ms = Redis TIME"]
+    T --> P["② enqueue_due_periodic_jobs"]
+    P --> M["③ promote_due_jobs"]
+    M --> R["④ reclaim_stale_jobs"]
+    R --> X["⑤ read_ready_jobs<br/>(XREADGROUP)"]
+    X --> Z(["return handled count"])
+    Z -->|"handled == 0"| Sleep["sleep scheduler_interval"]
+    Sleep --> Start
+    Z -->|"handled > 0"| Start
+```
+
 ```rust
 async fn run_redis_once(&self, conn) -> JobResult<usize> {
-    let now_ms = redis_time_ms(conn).await?;            // ① broker clock
+    let now_ms = redis_time_ms(conn).await?;             // ①
     self.enqueue_due_periodic_jobs(conn, now_ms).await?; // ②
     self.promote_due_jobs(conn, now_ms).await?;          // ③
     self.reclaim_stale_jobs(conn).await?;                 // ④
@@ -101,27 +156,29 @@ is bound.
 
 ## Lifecycle 1 — happy path
 
-```
-                ┌──────────────────────┐
-                │  app calls            │
-                │  enqueue_with(client, │
-                │     payload)          │
-                └──────────┬───────────┘
-                           ▼
-            XADD pocopine:{app}:queue:{queue} *
-                  job_id, job_name, queue, payload, attempt=1, …
-                           │
-        ─ ── ── ── ── ── ── ┼ ── ── ── ── ── ── ── ── ── ──
-                           ▼
-              ⑤ Worker XREADGROUP ... >
-                           │
-                           ▼
-              run_envelope(stream_id, envelope)
-                           │
-            run_handler_safely(handler, payload).await
-                           │
-                           ▼
-                   Ok(())  ──►  XACK stream group stream_id
+```mermaid
+sequenceDiagram
+    autonumber
+    participant App as App code
+    participant Cli as JobClient
+    participant R as Redis
+    participant W as Worker
+    participant H as Handler
+
+    App->>Cli: enqueue_with(payload)
+    Cli->>R: XADD pocopine:{app}:queue:Q *<br/>job_id, attempt=1, payload, …
+    R-->>Cli: stream-id
+
+    loop run loop
+        W->>R: TIME
+        R-->>W: now_ms
+        W->>R: XREADGROUP GROUP g c COUNT N STREAMS Q >
+        R-->>W: stream-id, envelope
+        W->>H: tokio::spawn(handler(payload))
+        H-->>W: Ok(())
+        W->>R: XACK Q g stream-id
+        R-->>W: 1
+    end
 ```
 
 Why `run_handler_safely`? It runs the handler future under
@@ -152,6 +209,44 @@ XLEN pocopine:my-app:queue:emails              # still 1 — the entry is in the
 ```
 
 ## Lifecycle 2 — failure → retry → success or dead-letter
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant W as Worker
+    participant R as Redis
+    participant H as Handler
+
+    Note over W: attempt 1, fails
+    W->>H: tokio::spawn(handler)
+    H-->>W: Err(_)
+    W->>R: TIME
+    R-->>W: now_ms
+    Note over W: due_ms = now + retry_delay(2)
+    W->>R: EVALSHA SCHEDULE_RETRY_AND_ACK<br/>XACK + ZADD scheduled
+    R-->>W: 1
+
+    Note over W,R: ...retry_delay later, next loop iter...
+
+    W->>R: ZRANGEBYSCORE scheduled -inf now_ms
+    R-->>W: [raw envelope (attempt=2)]
+    W->>R: EVALSHA PROMOTE_SCHEDULED<br/>ZREM + XADD ready
+    R-->>W: stream-id (or 0 if a peer won the race)
+    W->>R: XREADGROUP ... >
+    R-->>W: stream-id, envelope (attempt=2)
+    W->>H: tokio::spawn(handler)
+
+    alt handler succeeds
+        H-->>W: Ok(())
+        W->>R: XACK Q g stream-id
+    else attempt < max_attempts
+        H-->>W: Err(_)
+        Note over W: schedule attempt=3 …
+    else attempt >= max_attempts
+        H-->>W: Err(_)
+        W->>R: EVALSHA DEAD_LETTER_AND_ACK<br/>XACK + XADD dead
+    end
+```
 
 When `run_handler_safely` returns `Err(_)`:
 
@@ -291,6 +386,29 @@ asserts the final state.
 
 ## Lifecycle 3 — reclaim (worker died, or handler exceeded visibility)
 
+```mermaid
+sequenceDiagram
+    autonumber
+    participant A as Worker A (will die)
+    participant R as Redis
+    participant B as Worker B
+
+    A->>R: XREADGROUP ... >
+    R-->>A: stream-id, envelope (attempt=1)
+    Note over A: handler hangs<br/>or process is killed<br/>before XACK
+
+    Note over R: stream-id remains in PEL,<br/>owner = A's consumer name
+
+    Note over B: ...visibility_timeout (60s)...
+
+    B->>R: XAUTOCLAIM Q g B-consumer<br/>min_idle=60000 0-0 COUNT N
+    R-->>B: [stream-id, envelope]<br/>ownership transferred to B
+
+    Note over B: envelope.attempt += 1
+    B->>B: run_envelope (attempt=2)
+    Note over B: routes through normal Ok / retry / dead path
+```
+
 If a worker reads an entry and never `XACK`s — crashed, OOM-killed,
 network-partitioned, or just took longer than `visibility_timeout` —
 the entry sits in PEL forever from that consumer's perspective.
@@ -356,6 +474,37 @@ complete, eventually `attempt == max_attempts` and the entry moves to
 the dead stream.
 
 ## Lifecycle 4 — periodic jobs
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant A as Worker A
+    participant B as Worker B
+    participant R as Redis
+
+    Note over A,B: tick T+0: both compute the same due_ms
+
+    A->>R: GET pocopine:{app}:periodic:last:job
+    R-->>A: nil (never fired)
+    A->>R: SET pocopine:{app}:periodic:job:T 1 NX PX <ttl>
+    R-->>A: OK (locked)
+    A->>R: XADD ready stream (envelope, payload=())
+    A->>R: SET pocopine:{app}:periodic:last:job T
+
+    B->>R: GET pocopine:{app}:periodic:last:job
+    R-->>B: T (already fired)
+    Note over B: due_periodic_slots returns []<br/>(skip this slot)
+
+    Note over A,B: ...next due slot T'...
+
+    B->>R: GET periodic:last:job
+    R-->>B: T
+    Note over B: T' > T → due
+    B->>R: SET periodic:job:T' 1 NX PX <ttl>
+    R-->>B: OK (B wins this time)
+    B->>R: XADD ready stream
+    B->>R: SET periodic:last:job T'
+```
 
 `#[pocopine::job(every = "15m")]` and `#[pocopine::job(cron = "...")]`
 register a periodic descriptor. Periodic jobs are not executed by the

--- a/examples/blog/Cargo.toml
+++ b/examples/blog/Cargo.toml
@@ -10,6 +10,7 @@ publish = false
 # running the static-file server. The bin is expected to handle static +
 # `/_pocopine/*` routes itself (see `src/bin/server.rs`).
 bin = "server"
+worker-bin = "worker"
 port = 3000
 
 [lib]
@@ -19,6 +20,11 @@ crate-type = ["cdylib", "rlib"]
 name = "server"
 path = "src/bin/server.rs"
 # Server binary doesn't build on wasm32; only build it on the host.
+required-features = []
+
+[[bin]]
+name = "worker"
+path = "src/bin/worker.rs"
 required-features = []
 
 [dependencies]

--- a/examples/blog/src/bin/worker.rs
+++ b/examples/blog/src/bin/worker.rs
@@ -5,7 +5,7 @@
 async fn main() -> pocopine::JobResult<()> {
     use blog as _;
 
-    println!("▶ running blog worker (redis: POCOPINE_REDIS_URL)");
+    println!("▶ running blog worker (POCOPINE_JOB_BACKEND or POCOPINE_REDIS_URL)");
     pocopine::Worker::from_env()?.run().await
 }
 

--- a/examples/blog/src/bin/worker.rs
+++ b/examples/blog/src/bin/worker.rs
@@ -1,0 +1,13 @@
+//! Blog background worker — host-only.
+
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::main]
+async fn main() -> pocopine::JobResult<()> {
+    use blog as _;
+
+    println!("▶ running blog worker (redis: POCOPINE_REDIS_URL)");
+    pocopine::Worker::from_env()?.run().await
+}
+
+#[cfg(target_arch = "wasm32")]
+fn main() {}

--- a/examples/blog/src/lib.rs
+++ b/examples/blog/src/lib.rs
@@ -13,13 +13,35 @@ use serde::{Deserialize, Serialize};
 
 use shared::Post;
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct PostViewAudit {
+    pub post_id: u32,
+}
+
+#[pocopine::job(queue = "blog", retries = 2)]
+pub async fn record_post_view(input: PostViewAudit) -> JobResult<()> {
+    eprintln!("post view audit: {}", input.post_id);
+    Ok(())
+}
+
+#[pocopine::job(queue = "blog", every = "10m")]
+pub async fn refresh_blog_index() -> JobResult<()> {
+    eprintln!("refresh blog index");
+    Ok(())
+}
+
 /// `#[server]` generates:
 /// * on wasm32 — a client stub that POSTs `[post_id]` to
 ///   `/_pocopine/get_post` and deserializes the response.
 /// * on the host — this body is the real handler, plus a
 ///   `__get_post_route` helper used by `bin/server.rs`.
-#[pocopine::server]
+#[pocopine::server(public)]
 pub async fn get_post(post_id: u32) -> ServerResult<Post> {
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let _ = record_post_view_job::enqueue(PostViewAudit { post_id }).await;
+    }
+
     match post_id {
         1 => Ok(Post {
             id: 1,

--- a/examples/hn/src/lib.rs
+++ b/examples/hn/src/lib.rs
@@ -43,7 +43,7 @@ async fn fetch_json<T: serde::de::DeserializeOwned>(url: &str) -> Result<T, poco
 /// Search story titles / text. An empty query returns the front page
 /// (the same 30 stories news.ycombinator.com shows). Otherwise
 /// searches `tags=story` via the Algolia index, ordered by relevance.
-#[pocopine::server]
+#[pocopine::server(public)]
 pub async fn search_stories(query: String) -> pocopine::ServerResult<Vec<Story>> {
     let trimmed = query.trim();
     let url = if trimmed.is_empty() {
@@ -58,7 +58,7 @@ pub async fn search_stories(query: String) -> pocopine::ServerResult<Vec<Story>>
 
 /// Story + full comment subtree. Algolia pre-populates `children`, so
 /// there is no N+1 fan-out — one request, the whole thread.
-#[pocopine::server]
+#[pocopine::server(public)]
 pub async fn get_item_tree(id: u32) -> pocopine::ServerResult<ItemNode> {
     fetch_json(&format!("{ALGOLIA}/items/{id}")).await
 }

--- a/examples/site/src/lib.rs
+++ b/examples/site/src/lib.rs
@@ -26,7 +26,7 @@ use shared::{ContactMessage, ContactResponse};
 
 // ─── server functions ───────────────────────────────────────────
 
-#[pocopine::server]
+#[pocopine::server(public)]
 pub async fn submit_contact(msg: ContactMessage) -> ServerResult<ContactResponse> {
     eprintln!(
         "contact: {name} <{email}>: {msg}",

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -75,4 +75,4 @@ Conventions:
 | 064 | [Performance roadmap to community-credible benchmarks](./rfc-064-performance-roadmap.md) | Draft |
 | 065 | [Route-cluster bundling](./rfc-065-route-cluster-bundling.md) | Draft |
 | 066 | [Server-function auth and access policy](./rfc-066-server-function-auth.md) | Draft |
-| 067 | [Redis-backed background jobs](./rfc-067-redis-background-jobs.md) | Draft |
+| 067 | [Background jobs with Redis and memory backends](./rfc-067-redis-background-jobs.md) | Draft |

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -74,3 +74,5 @@ Conventions:
 | 063 | [Directive cleanup for Vue-3 alignment](./rfc-063-directive-cleanup-vue-alignment.md) | Draft |
 | 064 | [Performance roadmap to community-credible benchmarks](./rfc-064-performance-roadmap.md) | Draft |
 | 065 | [Route-cluster bundling](./rfc-065-route-cluster-bundling.md) | Draft |
+| 066 | [Server-function auth and access policy](./rfc-066-server-function-auth.md) | Draft |
+| 067 | [Redis-backed background jobs](./rfc-067-redis-background-jobs.md) | Draft |

--- a/rfcs/rfc-066-server-function-auth.md
+++ b/rfcs/rfc-066-server-function-auth.md
@@ -1,0 +1,289 @@
+# RFC 066 - Server-function auth and access policy
+
+| Field | Value |
+|---|---|
+| **Status** | Draft |
+| **Author** | pocopine team |
+| **Created** | 2026-05-02 |
+| **Related** | [`rfc-002-app-stores-servers.md`](./rfc-002-app-stores-servers.md), [`rfc-059-server-side-rendering-and-hydration.md`](./rfc-059-server-side-rendering-and-hydration.md) |
+| **Supersedes** | RFC 002's server-function auth non-goal |
+
+## 1. Summary
+
+Add a first-class access policy to `#[server]` functions:
+
+```rust
+#[pocopine::server(public)]
+pub async fn search(query: String) -> ServerResult<Vec<Row>> {
+    /* intentionally open */
+}
+
+#[pocopine::server(guard = require_user)]
+pub async fn save_profile(input: ProfileInput) -> ServerResult<Profile> {
+    /* only runs after require_user accepts the request */
+}
+
+pub async fn require_user(
+    ctx: pocopine::auth::RequestContext,
+) -> ServerResult<()> {
+    let Some(token) = ctx.bearer_token() else {
+        return Err(ServerError::unauthorized("missing bearer token"));
+    };
+    verify_token(token).await
+}
+```
+
+The framework motto for server functions is: "do not let users shoot
+themselves in the foot." A server function without an access policy is
+not invisible framework plumbing; it is a network endpoint. Pocopine
+therefore warns when an endpoint is neither explicitly public nor
+guarded.
+
+## 2. Motivation
+
+RFC 002 deliberately deferred authentication and session middleware so
+server functions could land as a small JSON-over-POST primitive. That
+was the right first step, but the current default is unsafe for real
+apps: adding `#[server]` creates a public route unless the author
+remembers to add checks inside the function body.
+
+That is a footgun in three ways:
+
+- The insecure state is silent.
+- The access rule is easy to miss during review.
+- Client-side route guards can be mistaken for server-side access
+  control.
+
+Pocopine should make the access boundary obvious at the function
+definition and enforce protected checks in the generated server route
+before the user body runs.
+
+## 3. Goals
+
+- Every server function has a visible access policy in source:
+  `public` or `guard = path`.
+- Missing policy emits a compile-time warning during migration.
+- Guarded functions run the guard before deserializing application
+  intent into side effects.
+- Guards receive request metadata needed for common auth/session
+  checks: method, URI, headers, bearer token, and cookies.
+- Auth failures use typed `ServerError` variants so clients can
+  distinguish unauthenticated, unauthorized, application, and network
+  failures.
+
+## 4. Non-goals
+
+- Pocopine does not choose a session store, OAuth provider, password
+  hashing scheme, or database model.
+- This RFC does not make client-side route guards authoritative.
+- This RFC does not add CSRF, CORS, SameSite, or rate-limit policy.
+  Those belong in the host server/middleware layer.
+- This RFC does not make missing policy a hard error immediately.
+  The migration starts as a warning so existing examples and apps can
+  opt in intentionally.
+
+## 5. Design
+
+### 5.1 Policy syntax
+
+`#[server]` accepts these policy forms:
+
+```rust
+#[pocopine::server(public)]
+#[pocopine::server(guard = require_user)]
+#[pocopine::server(guard = crate::auth::require_admin)]
+#[pocopine::server(guard = "crate::auth::require_admin")]
+```
+
+`public` means the route is intentionally open. It suppresses the
+missing-policy warning but does not install a guard.
+
+`guard = path` means the route is protected. The generated Axum route
+constructs a `pocopine_server::auth::RequestContext`, awaits the guard,
+and only calls the original function body if the guard returns `Ok(())`.
+
+`#[server]` with no policy still compiles in this phase, but emits:
+
+```text
+pocopine #[server] function `name` has no access policy. Write
+#[server(public)] for an intentional public endpoint or
+#[server(guard = path::to_guard)] to enforce auth.
+```
+
+Future phases may promote this warning to a hard error.
+
+### 5.2 Guard contract
+
+The initial guard contract is intentionally narrow:
+
+```rust
+pub async fn require_user(
+    ctx: pocopine::auth::RequestContext,
+) -> ServerResult<()> {
+    /* inspect ctx, return Ok or ServerError */
+}
+```
+
+The generated route accepts any guard error type that can convert into
+the server function's error type. In normal pocopine code, guards return
+`pocopine::ServerResult<()>`.
+
+### 5.3 Request context
+
+`pocopine::auth::RequestContext` and the re-exported
+`pocopine_server::auth::RequestContext` contain:
+
+- `method()`
+- `uri()`
+- `headers()`
+- `header(name)`
+- `bearer_token()`
+- `cookie(name)`
+- `session_id()`
+- `user: Principal`
+
+`RequestContext` and the HTTP-backed guard helpers are host-only. The
+cross-target auth value types remain available to client code:
+`AuthUser`, `Principal`, `Role`, `Permission`, and `Session`.
+
+`Principal` is anonymous by default. Host middleware may validate a
+session/JWT/provider token and insert either `AuthUser` or `Principal`
+into Axum request extensions. The generated server route copies that
+identity into `RequestContext` before running the guard.
+
+The context does not own the request body. This keeps auth guards from
+accidentally consuming the JSON payload before the server-function
+argument extractor runs.
+
+`cookie(name)` is intentionally small and meant for simple session
+cookies; it does not implement full RFC 6265 quoted-value parsing.
+
+### 5.4 Native auth core
+
+The `pocopine-auth` crate provides the provider-neutral auth surface:
+
+```rust
+pub struct AuthUser {
+    pub id: String,
+    pub roles: Vec<Role>,
+    pub permissions: Vec<Permission>,
+}
+
+pub enum Role {
+    Admin,
+    Staff,
+    User,
+    Named(String),
+}
+```
+
+It also provides built-in path guards:
+
+```rust
+#[pocopine::server(guard = pocopine::auth::require_login)]
+pub async fn dashboard() -> ServerResult<Dashboard> { /* ... */ }
+
+#[pocopine::server(guard = pocopine::auth::require_admin)]
+pub async fn admin_stats() -> ServerResult<Stats> { /* ... */ }
+```
+
+And reusable checks for custom guards:
+
+```rust
+pub async fn require_editor(ctx: pocopine::auth::RequestContext) -> ServerResult<()> {
+    pocopine::auth::ensure_role(&ctx, Role::named("editor"))
+}
+```
+
+Provider integrations such as Clerk/Auth0/Supabase should adapt into
+`AuthUser`/`Principal` instead of changing the server-function ABI.
+
+### 5.5 `protected!` sugar
+
+For concise inline role checks, `protected!` emits a private guard and
+then expands to `#[server(guard = generated_guard)]`:
+
+```rust
+pocopine::protected! {
+    require |ctx| ctx.user.has_role(Role::Admin);
+
+    pub async fn create_post(
+        title: String,
+        description: String,
+    ) -> ServerResult<Post> {
+        /* protected */
+    }
+}
+```
+
+This is syntax sugar only. The generated route still runs auth before
+reading or decoding the request body. The `require |ctx| ...` closure is
+a synchronous boolean check; async/provider work belongs in a named guard
+function passed to `#[server(guard = path)]`.
+
+### 5.6 Error vocabulary
+
+`ServerError` grows:
+
+```rust
+ServerError::Unauthorized(String)
+ServerError::Forbidden(String)
+ServerError::BadRequest(String)
+```
+
+Use `Unauthorized` when authentication is missing or invalid. Use
+`Forbidden` when the caller is authenticated but lacks permission. Use
+`BadRequest` when the JSON request body is malformed or exceeds the
+server-function body limit.
+
+### 5.7 Generated route shape
+
+For a guarded function:
+
+```rust
+router.route(
+    "/_pocopine/save_profile",
+    post(|request: Request| async move {
+        let (parts, body) = request.into_parts();
+        let ctx = RequestContext::from_parts(
+            parts.method,
+            parts.uri,
+            parts.headers,
+            parts.extensions,
+        );
+        if let Err(err) = require_user(ctx).await {
+            return Json(Err(err.into()));
+        }
+        let args = match decode_json_body_with_limit(body).await {
+            Ok(args) => args,
+            Err(err) => return Json(Err(err)),
+        };
+        Json(save_profile(args).await)
+    }),
+)
+```
+
+This matters: access control is installed by the server route helper,
+not by client code and not by convention inside the body.
+
+Generated routes use the same explicit body limit for public and guarded
+server functions. The default is 2 MiB and can be overridden with
+`POCOPINE_SERVER_FUNCTION_BODY_LIMIT` (`kb`, `kib`, `mb`, and `mib`
+suffixes are accepted). Zero and invalid values are rejected, log a
+warning, and fall back to the default.
+
+## 6. Migration
+
+1. Mark intentionally open endpoints as `#[server(public)]`.
+2. Add guard functions for protected endpoints and switch them to
+   `#[server(guard = path)]`.
+3. Keep CI warnings visible while apps migrate.
+4. After examples and downstream apps have moved, make missing policy a
+   hard macro error.
+
+## 7. Open Questions
+
+1. Should guard failures eventually return HTTP 401/403 statuses while
+   still preserving typed `ServerError` decoding in the wasm client?
+2. Do we need CSRF helpers in `pocopine-server`, or should those stay in
+   host-framework middleware?

--- a/rfcs/rfc-067-redis-background-jobs.md
+++ b/rfcs/rfc-067-redis-background-jobs.md
@@ -152,6 +152,22 @@ does not use consumer groups or stale pending reclaim because a handler is
 run directly by the worker task. If a handler hangs, the worker task is
 occupied; if the process restarts, queued memory jobs are lost.
 
+Job handlers run on a `tokio::spawn` task so a panicking handler is
+captured by the runtime, converted into a `JobError::Handler`, and routed
+through the same retry/dead-letter path as a normal `Err` return. This
+applies to both backends.
+
+The memory dead-letter buffer is capped (oldest entries dropped first) and
+exposed via `Worker::drain_dead_letter() -> Vec<DeadLetter>` so embedded
+operators can periodically scrape and persist failed jobs. The Redis
+backend does not implement `drain_dead_letter`; the dead-letter stream
+`pocopine:{app}:dead` is queryable directly.
+
+`Worker::run` prints a one-line backend banner at startup so operators can
+confirm whether the worker bound to Redis or to the process-local memory
+backend, defending against the silent-default footgun in multi-process
+deployments where Redis was intended.
+
 `visibility_timeout` is part of the worker contract and is configured by
 `POCOPINE_JOB_VISIBILITY_MS`: handlers should normally finish well under
 that timeout or be idempotent enough to handle reclaim/retry. Periodic jobs

--- a/rfcs/rfc-067-redis-background-jobs.md
+++ b/rfcs/rfc-067-redis-background-jobs.md
@@ -156,6 +156,10 @@ computes the due slot, acquires a backend-specific lock for that job/slot
 job with a unit payload. From that point on the job uses the same retry and
 dead-letter path as manually enqueued work.
 
+Workers persist the last fired periodic slot per job. Cron jobs evaluate the
+window `(last_fired_at_ms, now]`, capped per loop, so a slow scheduler
+iteration catches up missed firings instead of dropping them permanently.
+
 ## 5. Example Worker
 
 ```rust

--- a/rfcs/rfc-067-redis-background-jobs.md
+++ b/rfcs/rfc-067-redis-background-jobs.md
@@ -118,12 +118,21 @@ scheduled for retry, or is moved to the dead stream. Delayed jobs and
 retry jobs are promoted by polling the sorted set. Stale pending jobs are
 reclaimed via Redis stream claiming before each read loop.
 
+Redis workers use Redis `TIME` for scheduler and retry due-time
+comparisons. This keeps workers on different hosts from promoting jobs early
+because their local clocks disagree.
+
 Retries use exponential backoff with jitter and go through the sorted-set
 scheduler instead of being immediately re-added to the ready stream. A
 reclaimed stale job consumes another attempt before it is re-run; if it
 has already reached the max attempt count it is moved to the dead stream.
 The worker loop logs Redis/runtime errors, sleeps with capped backoff, and
 reconnects instead of exiting on a transient Redis failure.
+
+Redis state transitions that cross queue structures are Lua-scripted:
+scheduled promotion removes from the sorted set and writes to the ready
+stream atomically, and retry/dead-letter paths acknowledge the original
+stream entry in the same script that records the next state.
 
 The memory backend uses the same envelope, scheduled queue, retry backoff,
 dead-letter, and periodic slot semantics inside a process-local store. It

--- a/rfcs/rfc-067-redis-background-jobs.md
+++ b/rfcs/rfc-067-redis-background-jobs.md
@@ -84,6 +84,8 @@ worker-bin = "worker"
 - If neither variable is set, memory is selected.
 - `POCOPINE_JOB_VISIBILITY_MS` configures Redis pending-entry reclaim
   timeout and defaults to `60000`.
+- `POCOPINE_JOB_PERIODIC_CATCH_UP_MAX` configures the maximum missed
+  periodic slots a worker enqueues in one loop and defaults to `16`.
 - `POCOPINE_JOB_CONSUMER` overrides the Redis Streams consumer name. If it
   is unset, Pocopine derives a process-unique name from host, pid, and a
   process token.
@@ -158,7 +160,8 @@ firing creates a fresh envelope.
 
 Job IDs include timestamp, host/process identity, and process-local counter
 so multiple workers do not mint the same id during the same millisecond and
-retry jitter does not collapse across hosts.
+retry jitter does not collapse across hosts. The separator is `:` because
+the id is an internal metadata value, not a stable external format.
 
 Periodic jobs are not executed directly by the scheduler loop. The worker
 computes the due slot, acquires a backend-specific lock for that job/slot
@@ -169,6 +172,8 @@ dead-letter path as manually enqueued work.
 Workers persist the last fired periodic slot per job. Cron jobs evaluate the
 window `(last_fired_at_ms, now]`, capped per loop, so a slow scheduler
 iteration catches up missed firings instead of dropping them permanently.
+Operators can widen the per-loop cap with
+`POCOPINE_JOB_PERIODIC_CATCH_UP_MAX` for explicit backfill scenarios.
 
 ## 5. Example Worker
 

--- a/rfcs/rfc-067-redis-background-jobs.md
+++ b/rfcs/rfc-067-redis-background-jobs.md
@@ -1,4 +1,4 @@
-# RFC 067 - Redis-backed background jobs
+# RFC 067 - Background jobs with Redis and memory backends
 
 | Field | Value |
 |---|---|
@@ -20,8 +20,10 @@ pub async fn send_welcome_email(input: WelcomeEmail) -> JobResult<()> {
 ```
 
 The macro registers job metadata through `inventory`, generates typed
-enqueue/schedule helpers, and keeps Redis/worker code out of wasm
-bundles. A new `pocopine-jobs` crate owns the Redis runtime.
+enqueue/schedule helpers, and keeps host-only worker code out of wasm
+bundles. A new `pocopine-jobs` crate owns the runtime. Redis is the
+durable multi-process backend; a process-local memory backend is available
+for single-process production deployments and tests.
 
 Periodic jobs ship in the same slice:
 
@@ -39,6 +41,10 @@ pub async fn nightly_cleanup() -> JobResult<()> {
 
 ## 2. Design
 
+- The runtime has two storage backends:
+  - Redis for durable-enough queues shared by server and worker binaries.
+  - Memory for process-local queues when enqueueing and worker execution live
+    in the same process.
 - Redis Streams are the ready queue:
   `pocopine:{app}:queue:{queue}`.
 - Redis sorted sets hold delayed jobs:
@@ -69,15 +75,31 @@ bin = "server"
 worker-bin = "worker"
 ```
 
+`JobClient::from_env` and `Worker::from_env` select the backend with:
+
+- `POCOPINE_JOB_BACKEND=memory` for the process-local memory backend.
+- `POCOPINE_JOB_BACKEND=redis` plus `POCOPINE_REDIS_URL=...` for Redis.
+- If `POCOPINE_JOB_BACKEND` is unset and `POCOPINE_REDIS_URL` is set, Redis
+  is selected.
+- If neither variable is set, memory is selected.
+
 `pocopine dev` injects `POCOPINE_REDIS_URL=redis://127.0.0.1/` into
-spawned server and worker binaries when the variable is not already set.
-`pocopine run` and direct `cargo run` do not inject a production default;
-`JobClient::from_env` and `Worker::from_env` fail fast unless
-`POCOPINE_REDIS_URL` is set.
+spawned server and worker binaries when the variable is not already set so
+the default dev path exercises separate server/worker processes. It still
+rejects `POCOPINE_JOB_BACKEND=memory` when a `worker-bin` is configured.
+`pocopine run` and direct `cargo run` do not inject a production default.
+When `pocopine run` sees a configured `worker-bin`, it rejects the
+process-local memory backend and requires a Redis URL because the server
+and worker are separate processes.
+
+A configured `worker-bin` is a separate process. With the memory backend,
+server-to-worker enqueueing across binaries is impossible because the queue
+is not shared; use Redis for that shape. Memory is appropriate for embedded
+workers or periodic/background work owned inside one process.
 
 ## 3. Non-goals
 
-- No in-memory production fallback.
+- No durable in-memory broker or cross-process memory sharing.
 - No result storage API.
 - No dashboard or job inspection UI.
 
@@ -95,6 +117,12 @@ has already reached the max attempt count it is moved to the dead stream.
 The worker loop logs Redis/runtime errors, sleeps with capped backoff, and
 reconnects instead of exiting on a transient Redis failure.
 
+The memory backend uses the same envelope, scheduled queue, retry backoff,
+dead-letter, and periodic slot semantics inside a process-local store. It
+does not use consumer groups or stale pending reclaim because a handler is
+run directly by the worker task. If a handler hangs, the worker task is
+occupied; if the process restarts, queued memory jobs are lost.
+
 `visibility_timeout` is part of the worker contract: handlers should
 normally finish well under that timeout or be idempotent enough to handle
 reclaim/retry. Periodic jobs follow the same reclaim-attempt accounting as
@@ -105,9 +133,10 @@ multiple local workers do not mint the same id during the same
 millisecond.
 
 Periodic jobs are not executed directly by the scheduler loop. The worker
-computes the due slot, acquires a Redis `SET NX PX` lock for that job/slot,
-and enqueues the job with a unit payload. From that point on the job uses
-the same stream, retry, and dead-letter path as manually enqueued work.
+computes the due slot, acquires a backend-specific lock for that job/slot
+(`SET NX PX` in Redis, a process-local lock map in memory), and enqueues the
+job with a unit payload. From that point on the job uses the same retry and
+dead-letter path as manually enqueued work.
 
 ## 5. Example Worker
 

--- a/rfcs/rfc-067-redis-background-jobs.md
+++ b/rfcs/rfc-067-redis-background-jobs.md
@@ -134,6 +134,14 @@ scheduled promotion removes from the sorted set and writes to the ready
 stream atomically, and retry/dead-letter paths acknowledge the original
 stream entry in the same script that records the next state.
 
+`JobClient` caches a multiplexed Redis connection so burst enqueueing does
+not open a TCP connection per job. The worker clears that cache after a
+Redis loop error before reconnecting with backoff.
+
+This RFC targets single-instance Redis or an operator-managed proxy that
+preserves a primary endpoint across failover. Native Redis Cluster
+`MOVED`/`ASK` handling and Sentinel discovery are not part of this slice.
+
 The memory backend uses the same envelope, scheduled queue, retry backoff,
 dead-letter, and periodic slot semantics inside a process-local store. It
 does not use consumer groups or stale pending reclaim because a handler is

--- a/rfcs/rfc-067-redis-background-jobs.md
+++ b/rfcs/rfc-067-redis-background-jobs.md
@@ -120,7 +120,9 @@ reclaimed via Redis stream claiming before each read loop.
 
 Redis workers use Redis `TIME` for scheduler and retry due-time
 comparisons. This keeps workers on different hosts from promoting jobs early
-because their local clocks disagree.
+because their local clocks disagree. Redis-backed `schedule_in` also bases
+relative delays on Redis `TIME`; `schedule_at` remains an explicit absolute
+timestamp chosen by the caller.
 
 Retries use exponential backoff with jitter and go through the sorted-set
 scheduler instead of being immediately re-added to the ready stream. A

--- a/rfcs/rfc-067-redis-background-jobs.md
+++ b/rfcs/rfc-067-redis-background-jobs.md
@@ -1,0 +1,124 @@
+# RFC 067 - Redis-backed background jobs
+
+| Field | Value |
+|---|---|
+| **Status** | Draft |
+| **Author** | pocopine team |
+| **Created** | 2026-05-02 |
+| **Related** | [`rfc-002-app-stores-servers.md`](./rfc-002-app-stores-servers.md), [`rfc-066-server-function-auth.md`](./rfc-066-server-function-auth.md) |
+| **Supersedes** | - |
+
+## 1. Summary
+
+Add native background jobs for server-side Pocopine apps:
+
+```rust
+#[pocopine::job(queue = "mail", retries = 3)]
+pub async fn send_welcome_email(input: WelcomeEmail) -> JobResult<()> {
+    /* host-side work */
+}
+```
+
+The macro registers job metadata through `inventory`, generates typed
+enqueue/schedule helpers, and keeps Redis/worker code out of wasm
+bundles. A new `pocopine-jobs` crate owns the Redis runtime.
+
+Periodic jobs ship in the same slice:
+
+```rust
+#[pocopine::job(queue = "maintenance", every = "15m")]
+pub async fn refresh_indexes() -> JobResult<()> {
+    /* host-side work */
+}
+
+#[pocopine::job(queue = "maintenance", cron = "0 0 2 * * * *")]
+pub async fn nightly_cleanup() -> JobResult<()> {
+    /* host-side work */
+}
+```
+
+## 2. Design
+
+- Redis Streams are the ready queue:
+  `pocopine:{app}:queue:{queue}`.
+- Redis sorted sets hold delayed jobs:
+  `pocopine:{app}:scheduled`.
+- Redis locks coordinate periodic enqueue slots:
+  `pocopine:{app}:periodic:{job}:{due_ms}`.
+- Exhausted jobs move to:
+  `pocopine:{app}:dead`.
+- Worker coordination uses Streams consumer groups.
+- Manually enqueued `#[job]` functions take exactly one owned payload
+  argument and return `JobResult<()>`.
+- Periodic `#[job(every = "...")]` and `#[job(cron = "...")]`
+  functions take no payload argument and return `JobResult<()>`.
+- Generated one-time helpers:
+  `enqueue`, `enqueue_with`, `schedule_in`, `schedule_in_with`,
+  `schedule_at`, and `schedule_at_with`.
+- `every = "..."` supports `ms`, `s`, `m`, `h`, and `d` units.
+- `cron = "..."` uses the `cron` crate expression format
+  (`sec min hour day-of-month month day-of-week year`).
+- The macro rejects zero intervals, invalid duration strings, invalid
+  cron expressions, payload arguments on periodic jobs, and zero-arg
+  manually enqueued jobs at compile time.
+- `pocopine run` / `pocopine dev` can spawn a configured worker binary:
+
+```toml
+[package.metadata.pocopine]
+bin = "server"
+worker-bin = "worker"
+```
+
+`pocopine dev` injects `POCOPINE_REDIS_URL=redis://127.0.0.1/` into
+spawned server and worker binaries when the variable is not already set.
+`pocopine run` and direct `cargo run` do not inject a production default;
+`JobClient::from_env` and `Worker::from_env` fail fast unless
+`POCOPINE_REDIS_URL` is set.
+
+## 3. Non-goals
+
+- No in-memory production fallback.
+- No result storage API.
+- No dashboard or job inspection UI.
+
+## 4. Failure Model
+
+The worker acknowledges a stream entry only after the job succeeds, is
+scheduled for retry, or is moved to the dead stream. Delayed jobs and
+retry jobs are promoted by polling the sorted set. Stale pending jobs are
+reclaimed via Redis stream claiming before each read loop.
+
+Retries use exponential backoff with jitter and go through the sorted-set
+scheduler instead of being immediately re-added to the ready stream. A
+reclaimed stale job consumes another attempt before it is re-run; if it
+has already reached the max attempt count it is moved to the dead stream.
+The worker loop logs Redis/runtime errors, sleeps with capped backoff, and
+reconnects instead of exiting on a transient Redis failure.
+
+`visibility_timeout` is part of the worker contract: handlers should
+normally finish well under that timeout or be idempotent enough to handle
+reclaim/retry. Periodic jobs follow the same reclaim-attempt accounting as
+manual jobs; a later periodic firing creates a fresh envelope.
+
+Job IDs include timestamp, process id, and process-local counter so
+multiple local workers do not mint the same id during the same
+millisecond.
+
+Periodic jobs are not executed directly by the scheduler loop. The worker
+computes the due slot, acquires a Redis `SET NX PX` lock for that job/slot,
+and enqueues the job with a unit payload. From that point on the job uses
+the same stream, retry, and dead-letter path as manually enqueued work.
+
+## 5. Example Worker
+
+```rust
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::main]
+async fn main() -> pocopine::JobResult<()> {
+    use my_app as _;
+    pocopine::Worker::from_env()?.run().await
+}
+
+#[cfg(target_arch = "wasm32")]
+fn main() {}
+```

--- a/rfcs/rfc-067-redis-background-jobs.md
+++ b/rfcs/rfc-067-redis-background-jobs.md
@@ -82,6 +82,11 @@ worker-bin = "worker"
 - If `POCOPINE_JOB_BACKEND` is unset and `POCOPINE_REDIS_URL` is set, Redis
   is selected.
 - If neither variable is set, memory is selected.
+- `POCOPINE_JOB_VISIBILITY_MS` configures Redis pending-entry reclaim
+  timeout and defaults to `60000`.
+- `POCOPINE_JOB_CONSUMER` overrides the Redis Streams consumer name. If it
+  is unset, Pocopine derives a process-unique name from host, pid, and a
+  process token.
 
 `pocopine dev` injects `POCOPINE_REDIS_URL=redis://127.0.0.1/` into
 spawned server and worker binaries when the variable is not already set so
@@ -105,6 +110,9 @@ workers or periodic/background work owned inside one process.
 
 ## 4. Failure Model
 
+Jobs are at-least-once. Handlers must be idempotent for effects that cannot
+be safely repeated.
+
 The worker acknowledges a stream entry only after the job succeeds, is
 scheduled for retry, or is moved to the dead stream. Delayed jobs and
 retry jobs are promoted by polling the sorted set. Stale pending jobs are
@@ -123,14 +131,15 @@ does not use consumer groups or stale pending reclaim because a handler is
 run directly by the worker task. If a handler hangs, the worker task is
 occupied; if the process restarts, queued memory jobs are lost.
 
-`visibility_timeout` is part of the worker contract: handlers should
-normally finish well under that timeout or be idempotent enough to handle
-reclaim/retry. Periodic jobs follow the same reclaim-attempt accounting as
-manual jobs; a later periodic firing creates a fresh envelope.
+`visibility_timeout` is part of the worker contract and is configured by
+`POCOPINE_JOB_VISIBILITY_MS`: handlers should normally finish well under
+that timeout or be idempotent enough to handle reclaim/retry. Periodic jobs
+follow the same reclaim-attempt accounting as manual jobs; a later periodic
+firing creates a fresh envelope.
 
-Job IDs include timestamp, process id, and process-local counter so
-multiple local workers do not mint the same id during the same
-millisecond.
+Job IDs include timestamp, host/process identity, and process-local counter
+so multiple workers do not mint the same id during the same millisecond and
+retry jitter does not collapse across hosts.
 
 Periodic jobs are not executed directly by the scheduler loop. The worker
 computes the due slot, acquires a backend-specific lock for that job/slot


### PR DESCRIPTION
## Summary

- **RFC-066** — `#[server(public)]` / `#[server(guard = path)]` access policy with `pocopine-auth` providing `RequestContext`, `Principal`, `AuthUser`, `Role`, `Permission`, and built-in `require_login`/`require_admin`/`require_staff` guards. Generated guarded routes run the guard before reading the body and route auth/decoding failures through typed `ServerError::{Unauthorized, Forbidden, BadRequest}` variants. `protected!` macro provides inline sync-bool sugar.
- **RFC-067** — `#[pocopine::job]` macro + `pocopine-jobs` crate with two backends:
  - **Redis** (durable, multi-process): Streams ready queue, sorted-set scheduler with exponential-jittered retry backoff, `xautoclaim`-based reclamation, dead-letter stream, periodic `every`/`cron` jobs with per-slot `SET NX PX` locks, persisted `last_fired_ms` for cron catch-up. Multi-key transitions (promote, retry+ack, dead-letter+ack) run as Lua scripts cached via `EVALSHA`. Worker reads broker time via `TIME` to neutralize clock skew, uses process-unique consumer names, caches a multiplexed connection.
  - **Memory** (process-local): same envelope/retry/dead-letter semantics inside an in-process store, intended for single-process deployments and tests. Capped dead-letter buffer with `Worker::drain_dead_letter()`, panic-safe handler dispatch via `tokio::spawn`, startup banner naming the backend.
- CLI orchestrates `bin` (server) and `worker-bin` (worker) child processes; rejects `worker-bin` + `POCOPINE_JOB_BACKEND=memory` at startup.

## RFCs

- [`rfcs/rfc-066-server-function-auth.md`](./rfcs/rfc-066-server-function-auth.md)
- [`rfcs/rfc-067-redis-background-jobs.md`](./rfcs/rfc-067-redis-background-jobs.md)

## Scope

This PR targets single-instance Redis or an operator-managed proxy that preserves a primary endpoint across failover. Native Redis Cluster `MOVED`/`ASK` handling and Sentinel discovery are explicitly out of scope. Documented in RFC-067 §4.

## Test plan

- [x] `cargo build --workspace --exclude pocopine` clean
- [x] `cargo test -p pocopine-jobs --lib` — 9 unit tests pass (id uniqueness, consumer name, retry backoff, cron catch-up math, env parsers, body-limit parser, gated Redis integration test)
- [x] `cargo test -p pocopine --tests --target x86_64-unknown-linux-gnu` — auth + job-macro integration tests pass, including:
  - `request_context_extracts_user_from_extensions`
  - `protected_macro_guard_checks_inline_policy`
  - `oversized_body_returns_bad_request`
  - `memory_backend_worker_runs_enqueued_job`
  - `memory_backend_routes_handler_panic_through_dead_letter`
- [ ] Smoke test against a live Redis (set `REDIS_TEST_URL=redis://127.0.0.1/`): the gated `redis_promotes_scheduled_jobs_when_redis_test_url_is_set` test exercises the `schedule_in` → promote → consume → ack path
- [ ] Manually verify `pocopine dev` with the blog example spawns server + worker, jobs flow end-to-end against a local Redis

## Migration

- Existing `#[pocopine::server]` functions emit a compile warning until they are explicitly tagged `#[server(public)]` or `#[server(guard = path)]`. Migration phase only; future RFC may promote to a hard error.
- New env vars (with defaults):
  - `POCOPINE_JOB_BACKEND={memory,redis}` — default heuristic: `redis` if `POCOPINE_REDIS_URL` is set, else `memory`
  - `POCOPINE_REDIS_URL`
  - `POCOPINE_JOB_VISIBILITY_MS` (default 60000)
  - `POCOPINE_SERVER_FUNCTION_BODY_LIMIT` (default 2 MiB; accepts `kb`/`kib`/`mb`/`mib` suffixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)