### PR TITLE
Add observability logging and analytics foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1992,6 +1992,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2237,6 +2243,15 @@ dependencies = [
  "markup5ever",
  "tendril",
  "xml5ever",
+]
+
+[[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -2694,10 +2709,13 @@ version = "0.1.0"
 dependencies = [
  "js-sys",
  "phf 0.13.1",
+ "pocopine-analytics",
  "pocopine-auth",
  "pocopine-core",
  "pocopine-jobs",
+ "pocopine-logging",
  "pocopine-macros",
+ "pocopine-observe",
  "pocopine-server",
  "redis",
  "serde",
@@ -2711,6 +2729,18 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
+]
+
+[[package]]
+name = "pocopine-analytics"
+version = "0.1.0"
+dependencies = [
+ "js-sys",
+ "pocopine-observe",
+ "serde",
+ "serde-wasm-bindgen 0.6.5",
+ "tracing",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2771,6 +2801,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "pocopine-logging"
+version = "0.1.0"
+dependencies = [
+ "pocopine-observe",
+ "tracing",
+ "tracing-subscriber",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "pocopine-macros"
 version = "0.1.0"
 dependencies = [
@@ -2782,6 +2823,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "pocopine-observe"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "tracing",
 ]
 
 [[package]]
@@ -3725,6 +3774,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4067,6 +4125,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "throw_error"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4398,6 +4465,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -4515,6 +4625,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,9 +290,11 @@ name = "blog"
 version = "0.1.0"
 dependencies = [
  "pocopine",
+ "pocopine-logging",
  "pocopine-server",
  "serde",
  "tokio",
+ "tracing",
  "wasm-bindgen",
 ]
 
@@ -1447,10 +1449,12 @@ dependencies = [
  "futures",
  "js-sys",
  "pocopine",
+ "pocopine-logging",
  "pocopine-server",
  "reqwest",
  "serde",
  "tokio",
+ "tracing",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -2798,6 +2802,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2844,6 +2849,7 @@ dependencies = [
  "tokio",
  "tower",
  "tower-http",
+ "tracing",
 ]
 
 [[package]]
@@ -3809,9 +3815,11 @@ name = "site"
 version = "0.1.0"
 dependencies = [
  "pocopine",
+ "pocopine-logging",
  "pocopine-server",
  "serde",
  "tokio",
+ "tracing",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ members = [
     "crates/pine-icons-macros",
     "crates/pine-motion",
     "crates/pocopine",
-    "crates/pocopine-auth",
     "crates/pocopine-analytics",
+    "crates/pocopine-auth",
     "crates/pocopine-cli",
     "crates/pocopine-core",
     "crates/pocopine-expr",
@@ -47,9 +47,9 @@ repository = "https://github.com/mambisi/pocopine"
 # `default-features = false` opt-outs actually take effect. Users
 # of `pocopine` get devtools on by default via its own `default`
 # feature, which forwards `pocopine-core/devtools`.
-pocopine-core = { path = "crates/pocopine-core", version = "0.1.0", default-features = false }
 pocopine-analytics = { path = "crates/pocopine-analytics", version = "0.1.0" }
 pocopine-auth = { path = "crates/pocopine-auth", version = "0.1.0" }
+pocopine-core = { path = "crates/pocopine-core", version = "0.1.0", default-features = false }
 pocopine-expr = { path = "crates/pocopine-expr", version = "0.1.0" }
 pocopine-jobs = { path = "crates/pocopine-jobs", version = "0.1.0" }
 pocopine-logging = { path = "crates/pocopine-logging", version = "0.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,14 @@ members = [
     "crates/pine-motion",
     "crates/pocopine",
     "crates/pocopine-auth",
+    "crates/pocopine-analytics",
     "crates/pocopine-cli",
     "crates/pocopine-core",
     "crates/pocopine-expr",
     "crates/pocopine-jobs",
+    "crates/pocopine-logging",
     "crates/pocopine-macros",
+    "crates/pocopine-observe",
     "crates/pocopine-server",
     "examples/blog",
     "examples/counter",
@@ -45,10 +48,13 @@ repository = "https://github.com/mambisi/pocopine"
 # of `pocopine` get devtools on by default via its own `default`
 # feature, which forwards `pocopine-core/devtools`.
 pocopine-core = { path = "crates/pocopine-core", version = "0.1.0", default-features = false }
+pocopine-analytics = { path = "crates/pocopine-analytics", version = "0.1.0" }
 pocopine-auth = { path = "crates/pocopine-auth", version = "0.1.0" }
 pocopine-expr = { path = "crates/pocopine-expr", version = "0.1.0" }
 pocopine-jobs = { path = "crates/pocopine-jobs", version = "0.1.0" }
+pocopine-logging = { path = "crates/pocopine-logging", version = "0.1.0" }
 pocopine-macros = { path = "crates/pocopine-macros", version = "0.1.0" }
+pocopine-observe = { path = "crates/pocopine-observe", version = "0.1.0" }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
@@ -63,6 +69,7 @@ quote = "1"
 syn = { version = "2", features = ["full"] }
 strsim = "0.11"
 cron = "0.12"
+tracing = "0.1"
 
 # RFC-058 Phase 6.5 — match Yew's release-profile knobs.
 # `opt-level = "z"` collapses size-vs-speed in favour of size;

--- a/crates/pocopine-analytics/Cargo.toml
+++ b/crates/pocopine-analytics/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "pocopine-analytics"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Analytics and telemetry adapters for pocopine applications."
+
+[dependencies]
+pocopine-observe = { workspace = true }
+serde = { workspace = true }
+tracing = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys = { workspace = true }
+serde-wasm-bindgen = { workspace = true }
+wasm-bindgen = { workspace = true }

--- a/crates/pocopine-analytics/src/lib.rs
+++ b/crates/pocopine-analytics/src/lib.rs
@@ -1,0 +1,398 @@
+//! Analytics and telemetry dispatch for pocopine applications.
+//!
+//! This crate intentionally does not own a vendor SDK. It owns the
+//! redaction and fan-out rules, then lets apps attach Firebase,
+//! Google Analytics, Cloudflare, OpenTelemetry, or custom sinks.
+
+use std::fmt;
+use std::panic::{catch_unwind, AssertUnwindSafe};
+
+use pocopine_observe::{
+    emit_tracing, EventPriority, FieldPrivacy, ObserveContext, ObservedEvent, RedactionPolicy,
+};
+
+pub trait AnalyticsSink {
+    fn emit(&self, event: &ObservedEvent) -> Result<(), AnalyticsError>;
+
+    fn flush(&self) -> Result<(), AnalyticsError> {
+        Ok(())
+    }
+}
+
+impl<F> AnalyticsSink for F
+where
+    F: for<'event> Fn(&'event ObservedEvent) -> Result<(), AnalyticsError>,
+{
+    fn emit(&self, event: &ObservedEvent) -> Result<(), AnalyticsError> {
+        self(event)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AnalyticsError {
+    message: String,
+}
+
+impl AnalyticsError {
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl fmt::Display for AnalyticsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for AnalyticsError {}
+
+#[derive(Debug, Default, Eq, PartialEq)]
+pub struct AnalyticsReport {
+    pub attempted: usize,
+    pub delivered: usize,
+    pub failed: usize,
+    pub errors: Vec<AnalyticsError>,
+}
+
+impl AnalyticsReport {
+    pub fn all_delivered(&self) -> bool {
+        self.failed == 0
+    }
+}
+
+pub struct AnalyticsClient {
+    sinks: Vec<Box<dyn AnalyticsSink>>,
+    redaction: RedactionPolicy,
+    emit_tracing_events: bool,
+}
+
+impl AnalyticsClient {
+    pub fn new() -> Self {
+        Self {
+            sinks: Vec::new(),
+            redaction: RedactionPolicy::allow_pseudonymous(),
+            emit_tracing_events: true,
+        }
+    }
+
+    pub fn with_redaction(mut self, redaction: RedactionPolicy) -> Self {
+        self.redaction = redaction;
+        self
+    }
+
+    pub fn without_tracing_events(mut self) -> Self {
+        self.emit_tracing_events = false;
+        self
+    }
+
+    pub fn with_sink(mut self, sink: impl AnalyticsSink + 'static) -> Self {
+        self.add_sink(sink);
+        self
+    }
+
+    pub fn add_sink(&mut self, sink: impl AnalyticsSink + 'static) {
+        self.sinks.push(Box::new(sink));
+    }
+
+    pub fn emit(&self, event: ObservedEvent) -> AnalyticsReport {
+        let event = event.redacted(self.redaction);
+        if self.emit_tracing_events {
+            emit_tracing(&event);
+        }
+
+        let mut report = AnalyticsReport {
+            attempted: self.sinks.len(),
+            ..AnalyticsReport::default()
+        };
+
+        for sink in &self.sinks {
+            match catch_unwind(AssertUnwindSafe(|| sink.emit(&event))) {
+                Ok(Ok(())) => report.delivered += 1,
+                Ok(Err(err)) => {
+                    report.failed += 1;
+                    report.errors.push(err);
+                }
+                Err(_) => {
+                    report.failed += 1;
+                    report
+                        .errors
+                        .push(AnalyticsError::new("analytics sink panicked"));
+                }
+            }
+        }
+
+        report
+    }
+
+    pub fn track(&self, name: impl Into<String>) -> AnalyticsReport {
+        self.emit(event(name))
+    }
+
+    pub fn flush(&self) -> AnalyticsReport {
+        let mut report = AnalyticsReport {
+            attempted: self.sinks.len(),
+            ..AnalyticsReport::default()
+        };
+
+        for sink in &self.sinks {
+            match catch_unwind(AssertUnwindSafe(|| sink.flush())) {
+                Ok(Ok(())) => report.delivered += 1,
+                Ok(Err(err)) => {
+                    report.failed += 1;
+                    report.errors.push(err);
+                }
+                Err(_) => {
+                    report.failed += 1;
+                    report
+                        .errors
+                        .push(AnalyticsError::new("analytics sink panicked during flush"));
+                }
+            }
+        }
+
+        report
+    }
+}
+
+impl Default for AnalyticsClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub fn event(name: impl Into<String>) -> ObservedEvent {
+    ObservedEvent::analytics(name)
+}
+
+pub fn route_view(route: impl Into<String>) -> ObservedEvent {
+    let route = route.into();
+    event("route_view")
+        .context(ObserveContext::default().with_route(route.clone()))
+        .field("route", route, FieldPrivacy::Public)
+}
+
+pub fn component_view(component: impl Into<String>) -> ObservedEvent {
+    let component = component.into();
+    event("component_view")
+        .context(ObserveContext::default().with_component(component.clone()))
+        .field("component", component, FieldPrivacy::Public)
+}
+
+pub fn timing(name: impl Into<String>, duration_ms: f64, priority: EventPriority) -> ObservedEvent {
+    event(name)
+        .priority(priority)
+        .field("duration_ms", duration_ms, FieldPrivacy::Public)
+}
+
+#[cfg(target_arch = "wasm32")]
+pub mod web {
+    use std::collections::BTreeMap;
+
+    use js_sys::{Function, Object, Reflect};
+    use pocopine_observe::{FieldValue, ObservedEvent};
+    use wasm_bindgen::JsValue;
+
+    use super::{AnalyticsError, AnalyticsSink};
+
+    pub struct JsFunctionSink {
+        callback: Function,
+    }
+
+    impl JsFunctionSink {
+        pub fn new(callback: Function) -> Self {
+            Self { callback }
+        }
+    }
+
+    impl AnalyticsSink for JsFunctionSink {
+        fn emit(&self, event: &ObservedEvent) -> Result<(), AnalyticsError> {
+            let value = serde_wasm_bindgen::to_value(event)
+                .map_err(|err| AnalyticsError::new(err.to_string()))?;
+            self.callback
+                .call1(&JsValue::NULL, &value)
+                .map(|_| ())
+                .map_err(js_error)
+        }
+    }
+
+    pub struct FirebaseAnalyticsSink {
+        analytics: JsValue,
+        log_event: Function,
+    }
+
+    impl FirebaseAnalyticsSink {
+        pub fn new(analytics: JsValue, log_event: Function) -> Self {
+            Self {
+                analytics,
+                log_event,
+            }
+        }
+    }
+
+    impl AnalyticsSink for FirebaseAnalyticsSink {
+        fn emit(&self, event: &ObservedEvent) -> Result<(), AnalyticsError> {
+            let params = event_params(event)?;
+            self.log_event
+                .call3(
+                    &JsValue::NULL,
+                    &self.analytics,
+                    &JsValue::from_str(&event.name),
+                    &params,
+                )
+                .map(|_| ())
+                .map_err(js_error)
+        }
+    }
+
+    pub struct GoogleAnalyticsSink {
+        gtag: Function,
+    }
+
+    impl GoogleAnalyticsSink {
+        pub fn new(gtag: Function) -> Self {
+            Self { gtag }
+        }
+    }
+
+    impl AnalyticsSink for GoogleAnalyticsSink {
+        fn emit(&self, event: &ObservedEvent) -> Result<(), AnalyticsError> {
+            let params = event_params(event)?;
+            self.gtag
+                .call3(
+                    &JsValue::NULL,
+                    &JsValue::from_str("event"),
+                    &JsValue::from_str(&event.name),
+                    &params,
+                )
+                .map(|_| ())
+                .map_err(js_error)
+        }
+    }
+
+    fn event_params(event: &ObservedEvent) -> Result<JsValue, AnalyticsError> {
+        let params = Object::new();
+        set(
+            &params,
+            "event_version",
+            JsValue::from_f64(event.version.into()),
+        )?;
+        set(
+            &params,
+            "event_class",
+            JsValue::from_str(event.class.as_str()),
+        )?;
+        set(
+            &params,
+            "event_priority",
+            JsValue::from_str(event.priority.as_str()),
+        )?;
+
+        if let Some(route) = &event.context.route {
+            set(&params, "route", JsValue::from_str(route))?;
+        }
+        if let Some(component) = &event.context.component {
+            set(&params, "component", JsValue::from_str(component))?;
+        }
+        if let Some(session_id) = &event.context.session_id {
+            set(&params, "session_id", JsValue::from_str(session_id))?;
+        }
+        if let Some(user_id_hash) = &event.context.user_id_hash {
+            set(&params, "user_id_hash", JsValue::from_str(user_id_hash))?;
+        }
+
+        let flat_fields: BTreeMap<_, _> = event
+            .fields
+            .iter()
+            .map(|(name, field)| (name.as_str(), &field.value))
+            .collect();
+        for (name, value) in flat_fields {
+            set(&params, name, field_value_to_js(value))?;
+        }
+
+        Ok(params.into())
+    }
+
+    fn set(object: &Object, key: &str, value: JsValue) -> Result<(), AnalyticsError> {
+        Reflect::set(object, &JsValue::from_str(key), &value)
+            .map(|_| ())
+            .map_err(js_error)
+    }
+
+    fn field_value_to_js(value: &FieldValue) -> JsValue {
+        match value {
+            FieldValue::String(value) => JsValue::from_str(value),
+            FieldValue::Bool(value) => JsValue::from_bool(*value),
+            FieldValue::I64(value) => JsValue::from_f64(*value as f64),
+            FieldValue::U64(value) => JsValue::from_f64(*value as f64),
+            FieldValue::F64(value) => JsValue::from_f64(*value),
+        }
+    }
+
+    fn js_error(value: JsValue) -> AnalyticsError {
+        AnalyticsError::new(
+            value
+                .as_string()
+                .unwrap_or_else(|| "JavaScript analytics sink failed".to_owned()),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    use pocopine_observe::{FieldPrivacy, RedactionPolicy};
+
+    use super::*;
+
+    #[test]
+    fn emit_continues_after_sink_error() {
+        let delivered = Rc::new(RefCell::new(0));
+        let delivered_sink = Rc::clone(&delivered);
+        let client = AnalyticsClient::new()
+            .without_tracing_events()
+            .with_sink(|_: &ObservedEvent| Err(AnalyticsError::new("downstream failed")))
+            .with_sink(move |_: &ObservedEvent| {
+                *delivered_sink.borrow_mut() += 1;
+                Ok(())
+            });
+
+        let report = client.emit(event("signup"));
+
+        assert_eq!(report.attempted, 2);
+        assert_eq!(report.delivered, 1);
+        assert_eq!(report.failed, 1);
+        assert_eq!(*delivered.borrow(), 1);
+    }
+
+    #[test]
+    fn redacts_before_dispatch() {
+        let seen = Rc::new(RefCell::new(None));
+        let seen_sink = Rc::clone(&seen);
+        let client = AnalyticsClient::new()
+            .without_tracing_events()
+            .with_redaction(RedactionPolicy::public_only())
+            .with_sink(move |event: &ObservedEvent| {
+                *seen_sink.borrow_mut() = Some(event.clone());
+                Ok(())
+            });
+
+        client.emit(
+            event("checkout")
+                .field("plan", "pro", FieldPrivacy::Public)
+                .field("email", "person@example.test", FieldPrivacy::Sensitive),
+        );
+
+        let event = seen.borrow().clone().expect("event captured");
+        assert!(event.fields.contains_key("plan"));
+        assert!(!event.fields.contains_key("email"));
+    }
+}

--- a/crates/pocopine-analytics/src/lib.rs
+++ b/crates/pocopine-analytics/src/lib.rs
@@ -11,14 +11,43 @@ use pocopine_observe::{
     emit_tracing, EventPriority, FieldPrivacy, ObserveContext, ObservedEvent, RedactionPolicy,
 };
 
-pub trait AnalyticsSink {
+#[cfg(not(target_arch = "wasm32"))]
+pub trait AnalyticsSink: Send + Sync {
     fn emit(&self, event: &ObservedEvent) -> Result<(), AnalyticsError>;
 
+    /// Flush buffered records for sinks that batch work.
+    ///
+    /// Closure sinks use this no-op default. Write a concrete sink type when
+    /// batching or network exporters need real flush behavior.
     fn flush(&self) -> Result<(), AnalyticsError> {
         Ok(())
     }
 }
 
+#[cfg(target_arch = "wasm32")]
+pub trait AnalyticsSink {
+    fn emit(&self, event: &ObservedEvent) -> Result<(), AnalyticsError>;
+
+    /// Flush buffered records for sinks that batch work.
+    ///
+    /// Closure sinks use this no-op default. Write a concrete sink type when
+    /// batching or network exporters need real flush behavior.
+    fn flush(&self) -> Result<(), AnalyticsError> {
+        Ok(())
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<F> AnalyticsSink for F
+where
+    F: for<'event> Fn(&'event ObservedEvent) -> Result<(), AnalyticsError> + Send + Sync,
+{
+    fn emit(&self, event: &ObservedEvent) -> Result<(), AnalyticsError> {
+        self(event)
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
 impl<F> AnalyticsSink for F
 where
     F: for<'event> Fn(&'event ObservedEvent) -> Result<(), AnalyticsError>,
@@ -55,14 +84,20 @@ impl std::error::Error for AnalyticsError {}
 
 #[derive(Debug, Default, Eq, PartialEq)]
 pub struct AnalyticsReport {
+    /// Number of configured sinks attempted for this operation.
     pub attempted: usize,
-    pub delivered: usize,
+    /// Number of sinks that completed the operation successfully.
+    ///
+    /// For `emit`, this means the sink accepted the event. For `flush`, this
+    /// means the sink flushed successfully.
+    pub succeeded: usize,
+    /// Number of sinks that returned an error or panicked.
     pub failed: usize,
     pub errors: Vec<AnalyticsError>,
 }
 
 impl AnalyticsReport {
-    pub fn all_delivered(&self) -> bool {
+    pub fn all_succeeded(&self) -> bool {
         self.failed == 0
     }
 }
@@ -114,7 +149,7 @@ impl AnalyticsClient {
 
         for sink in &self.sinks {
             match catch_unwind(AssertUnwindSafe(|| sink.emit(&event))) {
-                Ok(Ok(())) => report.delivered += 1,
+                Ok(Ok(())) => report.succeeded += 1,
                 Ok(Err(err)) => {
                     report.failed += 1;
                     report.errors.push(err);
@@ -143,7 +178,7 @@ impl AnalyticsClient {
 
         for sink in &self.sinks {
             match catch_unwind(AssertUnwindSafe(|| sink.flush())) {
-                Ok(Ok(())) => report.delivered += 1,
+                Ok(Ok(())) => report.succeeded += 1,
                 Ok(Err(err)) => {
                     report.failed += 1;
                     report.errors.push(err);
@@ -329,6 +364,9 @@ pub mod web {
         match value {
             FieldValue::String(value) => JsValue::from_str(value),
             FieldValue::Bool(value) => JsValue::from_bool(*value),
+            // JavaScript numbers are f64 values; 64-bit integers above 2^53
+            // lose precision in Firebase/GA-style browser adapters. Treat
+            // long-lived IDs as strings before constructing the event.
             FieldValue::I64(value) => JsValue::from_f64(*value as f64),
             FieldValue::U64(value) => JsValue::from_f64(*value as f64),
             FieldValue::F64(value) => JsValue::from_f64(*value),
@@ -346,42 +384,71 @@ pub mod web {
 
 #[cfg(test)]
 mod tests {
-    use std::cell::RefCell;
-    use std::rc::Rc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
 
     use pocopine_observe::{FieldPrivacy, RedactionPolicy};
 
     use super::*;
 
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn analytics_client_is_send_sync_on_host() {
+        fn assert_send_sync<T: Send + Sync>() {}
+
+        assert_send_sync::<AnalyticsClient>();
+    }
+
     #[test]
     fn emit_continues_after_sink_error() {
-        let delivered = Rc::new(RefCell::new(0));
-        let delivered_sink = Rc::clone(&delivered);
+        let succeeded = Arc::new(AtomicUsize::new(0));
+        let succeeded_sink = Arc::clone(&succeeded);
         let client = AnalyticsClient::new()
             .without_tracing_events()
             .with_sink(|_: &ObservedEvent| Err(AnalyticsError::new("downstream failed")))
             .with_sink(move |_: &ObservedEvent| {
-                *delivered_sink.borrow_mut() += 1;
+                succeeded_sink.fetch_add(1, Ordering::SeqCst);
                 Ok(())
             });
 
         let report = client.emit(event("signup"));
 
         assert_eq!(report.attempted, 2);
-        assert_eq!(report.delivered, 1);
+        assert_eq!(report.succeeded, 1);
         assert_eq!(report.failed, 1);
-        assert_eq!(*delivered.borrow(), 1);
+        assert_eq!(succeeded.load(Ordering::SeqCst), 1);
+    }
+
+    #[test]
+    fn emit_continues_after_sink_panic() {
+        let succeeded = Arc::new(AtomicUsize::new(0));
+        let succeeded_sink = Arc::clone(&succeeded);
+        let client = AnalyticsClient::new()
+            .without_tracing_events()
+            .with_sink(|_: &ObservedEvent| panic!("sink failed"))
+            .with_sink(move |_: &ObservedEvent| {
+                succeeded_sink.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            });
+
+        let report = client.emit(event("signup"));
+
+        assert_eq!(report.attempted, 2);
+        assert_eq!(report.succeeded, 1);
+        assert_eq!(report.failed, 1);
+        assert_eq!(report.errors[0].message(), "analytics sink panicked");
+        assert_eq!(succeeded.load(Ordering::SeqCst), 1);
     }
 
     #[test]
     fn redacts_before_dispatch() {
-        let seen = Rc::new(RefCell::new(None));
-        let seen_sink = Rc::clone(&seen);
+        let seen = Arc::new(Mutex::new(None));
+        let seen_sink = Arc::clone(&seen);
         let client = AnalyticsClient::new()
             .without_tracing_events()
             .with_redaction(RedactionPolicy::public_only())
             .with_sink(move |event: &ObservedEvent| {
-                *seen_sink.borrow_mut() = Some(event.clone());
+                *seen_sink.lock().expect("seen lock poisoned") = Some(event.clone());
                 Ok(())
             });
 
@@ -391,8 +458,26 @@ mod tests {
                 .field("email", "person@example.test", FieldPrivacy::Sensitive),
         );
 
-        let event = seen.borrow().clone().expect("event captured");
+        let event = seen
+            .lock()
+            .expect("seen lock poisoned")
+            .clone()
+            .expect("event captured");
         assert!(event.fields.contains_key("plan"));
         assert!(!event.fields.contains_key("email"));
+    }
+
+    #[test]
+    fn flush_reports_success_without_delivery_wording() {
+        let client = AnalyticsClient::new()
+            .without_tracing_events()
+            .with_sink(|_: &ObservedEvent| Ok(()));
+
+        let report = client.flush();
+
+        assert_eq!(report.attempted, 1);
+        assert_eq!(report.succeeded, 1);
+        assert_eq!(report.failed, 0);
+        assert!(report.all_succeeded());
     }
 }

--- a/crates/pocopine-jobs/Cargo.toml
+++ b/crates/pocopine-jobs/Cargo.toml
@@ -16,3 +16,4 @@ cron = { workspace = true }
 inventory = { workspace = true }
 redis = { version = "0.27", features = ["tokio-comp"] }
 tokio = { version = "1", features = ["time"] }
+tracing = { workspace = true }

--- a/crates/pocopine-jobs/src/lib.rs
+++ b/crates/pocopine-jobs/src/lib.rs
@@ -696,7 +696,12 @@ return redis.call(
                     }
                     Err(err) => {
                         self.client.clear_connection();
-                        eprintln!("pocopine worker error: {err}; retrying in {backoff:?}");
+                        tracing::warn!(
+                            target: "pocopine.log",
+                            error = %err,
+                            retry_in_ms = backoff.as_millis() as u64,
+                            "pocopine worker error; retrying"
+                        );
                         tokio::time::sleep(backoff).await;
                         backoff = (backoff * 2)
                             .min(Duration::from_millis(DEFAULT_WORKER_ERROR_BACKOFF_MAX_MS));
@@ -733,14 +738,21 @@ return redis.call(
         // deployment where Redis was intended.
         fn log_startup_backend(&self) {
             match &self.config.backend {
-                JobBackend::Redis { .. } => eprintln!(
-                    "pocopine worker: backend = redis (durable, multi-process); app = {}",
-                    self.config.app
+                JobBackend::Redis { .. } => tracing::info!(
+                    target: "pocopine.log",
+                    backend = "redis",
+                    app = %self.config.app,
+                    durable = true,
+                    multi_process = true,
+                    "pocopine worker backend selected"
                 ),
-                JobBackend::Memory => eprintln!(
-                    "pocopine worker: backend = memory (process-local; \
-                     not shared across processes, lost on restart); app = {}",
-                    self.config.app
+                JobBackend::Memory => tracing::warn!(
+                    target: "pocopine.log",
+                    backend = "memory",
+                    app = %self.config.app,
+                    durable = false,
+                    multi_process = false,
+                    "pocopine worker backend selected; memory backend is process-local and lost on restart"
                 ),
             }
         }

--- a/crates/pocopine-logging/Cargo.toml
+++ b/crates/pocopine-logging/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "pocopine-logging"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Logging adapters for pocopine server and browser applications."
+
+[dependencies]
+pocopine-observe = { workspace = true }
+tracing = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+tracing-subscriber = { version = "0.3", features = ["ansi", "env-filter", "fmt", "json"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
+wasm-bindgen = { workspace = true }
+web-sys = { version = "0.3", features = ["console"] }

--- a/crates/pocopine-logging/src/lib.rs
+++ b/crates/pocopine-logging/src/lib.rs
@@ -1,0 +1,288 @@
+//! Logging adapters for pocopine applications.
+//!
+//! Runtime crates should emit `tracing` events. Application entrypoints
+//! install one logging subscriber appropriate for their environment.
+
+use pocopine_observe::{emit_tracing, ObservedEvent};
+
+pub fn log_event(event: &ObservedEvent) {
+    emit_tracing(event);
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+mod server {
+    use std::fmt;
+
+    use tracing_subscriber::fmt as tracing_fmt;
+    use tracing_subscriber::prelude::*;
+    use tracing_subscriber::util::SubscriberInitExt;
+    use tracing_subscriber::{filter, EnvFilter};
+
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub enum LogFormat {
+        Compact,
+        Pretty,
+        Json,
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub struct ServerLoggingConfig {
+        pub env_filter: Option<String>,
+        pub format: LogFormat,
+        pub ansi: bool,
+    }
+
+    impl ServerLoggingConfig {
+        pub fn compact() -> Self {
+            Self {
+                env_filter: None,
+                format: LogFormat::Compact,
+                ansi: true,
+            }
+        }
+
+        pub fn json() -> Self {
+            Self {
+                env_filter: None,
+                format: LogFormat::Json,
+                ansi: false,
+            }
+        }
+
+        pub fn with_env_filter(mut self, env_filter: impl Into<String>) -> Self {
+            self.env_filter = Some(env_filter.into());
+            self
+        }
+
+        pub fn with_ansi(mut self, ansi: bool) -> Self {
+            self.ansi = ansi;
+            self
+        }
+    }
+
+    impl Default for ServerLoggingConfig {
+        fn default() -> Self {
+            Self::compact()
+        }
+    }
+
+    #[derive(Debug)]
+    pub enum InitLoggingError {
+        Filter(filter::ParseError),
+        AlreadyInitialized,
+    }
+
+    impl fmt::Display for InitLoggingError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match self {
+                Self::Filter(err) => write!(f, "invalid tracing filter: {err}"),
+                Self::AlreadyInitialized => {
+                    f.write_str("global tracing subscriber is already initialized")
+                }
+            }
+        }
+    }
+
+    impl std::error::Error for InitLoggingError {}
+
+    pub fn init_server_logging(config: ServerLoggingConfig) -> Result<(), InitLoggingError> {
+        let filter = build_filter(config.env_filter)?;
+        match config.format {
+            LogFormat::Compact => tracing_subscriber::registry()
+                .with(filter)
+                .with(
+                    tracing_fmt::layer()
+                        .compact()
+                        .with_target(true)
+                        .with_ansi(config.ansi),
+                )
+                .try_init(),
+            LogFormat::Pretty => tracing_subscriber::registry()
+                .with(filter)
+                .with(
+                    tracing_fmt::layer()
+                        .pretty()
+                        .with_target(true)
+                        .with_ansi(config.ansi),
+                )
+                .try_init(),
+            LogFormat::Json => tracing_subscriber::registry()
+                .with(filter)
+                .with(
+                    tracing_fmt::layer()
+                        .json()
+                        .with_target(true)
+                        .with_ansi(false),
+                )
+                .try_init(),
+        }
+        .map_err(|_| InitLoggingError::AlreadyInitialized)
+    }
+
+    fn build_filter(env_filter: Option<String>) -> Result<EnvFilter, InitLoggingError> {
+        let filter = env_filter
+            .or_else(|| std::env::var("RUST_LOG").ok())
+            .unwrap_or_else(|| "info,pocopine=debug".to_owned());
+        EnvFilter::try_new(filter).map_err(InitLoggingError::Filter)
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use server::{init_server_logging, InitLoggingError, LogFormat, ServerLoggingConfig};
+
+#[cfg(target_arch = "wasm32")]
+mod web {
+    use std::fmt;
+
+    use tracing::field::{Field, Visit};
+    use tracing::{Event, Level, Metadata, Subscriber};
+    use tracing_subscriber::layer::{Context, Layer};
+    use tracing_subscriber::prelude::*;
+    use tracing_subscriber::util::SubscriberInitExt;
+    use wasm_bindgen::JsValue;
+
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub struct ConsoleLoggingConfig {
+        pub max_level: Level,
+        pub target_prefix: Option<String>,
+    }
+
+    impl ConsoleLoggingConfig {
+        pub fn debug() -> Self {
+            Self {
+                max_level: Level::DEBUG,
+                target_prefix: Some("pocopine".to_owned()),
+            }
+        }
+
+        pub fn with_max_level(mut self, max_level: Level) -> Self {
+            self.max_level = max_level;
+            self
+        }
+
+        pub fn with_target_prefix(mut self, target_prefix: impl Into<String>) -> Self {
+            self.target_prefix = Some(target_prefix.into());
+            self
+        }
+
+        pub fn without_target_prefix(mut self) -> Self {
+            self.target_prefix = None;
+            self
+        }
+    }
+
+    impl Default for ConsoleLoggingConfig {
+        fn default() -> Self {
+            Self::debug()
+        }
+    }
+
+    #[derive(Debug)]
+    pub enum InitLoggingError {
+        AlreadyInitialized,
+    }
+
+    impl fmt::Display for InitLoggingError {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            match self {
+                Self::AlreadyInitialized => {
+                    f.write_str("global tracing subscriber is already initialized")
+                }
+            }
+        }
+    }
+
+    impl std::error::Error for InitLoggingError {}
+
+    pub fn init_console_logging(config: ConsoleLoggingConfig) -> Result<(), InitLoggingError> {
+        tracing_subscriber::registry()
+            .with(ConsoleLayer { config })
+            .try_init()
+            .map_err(|_| InitLoggingError::AlreadyInitialized)
+    }
+
+    struct ConsoleLayer {
+        config: ConsoleLoggingConfig,
+    }
+
+    impl<S> Layer<S> for ConsoleLayer
+    where
+        S: Subscriber,
+    {
+        fn enabled(&self, metadata: &Metadata<'_>, _ctx: Context<'_, S>) -> bool {
+            if !level_allowed(*metadata.level(), self.config.max_level) {
+                return false;
+            }
+            match &self.config.target_prefix {
+                Some(prefix) => metadata.target().starts_with(prefix),
+                None => true,
+            }
+        }
+
+        fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+            let metadata = event.metadata();
+            let mut visitor = FieldVisitor::default();
+            event.record(&mut visitor);
+            let message = format!(
+                "{} {} {}",
+                metadata.level(),
+                metadata.target(),
+                visitor.finish()
+            );
+            let value = JsValue::from_str(message.trim_end());
+            match *metadata.level() {
+                Level::ERROR => web_sys::console::error_1(&value),
+                Level::WARN => web_sys::console::warn_1(&value),
+                Level::INFO => web_sys::console::info_1(&value),
+                Level::DEBUG | Level::TRACE => web_sys::console::debug_1(&value),
+            }
+        }
+    }
+
+    #[derive(Default)]
+    struct FieldVisitor {
+        message: Option<String>,
+        fields: Vec<String>,
+    }
+
+    impl FieldVisitor {
+        fn finish(self) -> String {
+            let mut out = self.message.unwrap_or_default();
+            for field in self.fields {
+                if !out.is_empty() {
+                    out.push(' ');
+                }
+                out.push_str(&field);
+            }
+            out
+        }
+    }
+
+    impl Visit for FieldVisitor {
+        fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+            let rendered = format!("{value:?}");
+            if field.name() == "message" {
+                self.message = Some(rendered);
+            } else {
+                self.fields.push(format!("{}={rendered}", field.name()));
+            }
+        }
+    }
+
+    fn level_allowed(level: Level, max_level: Level) -> bool {
+        level_rank(level) <= level_rank(max_level)
+    }
+
+    fn level_rank(level: Level) -> u8 {
+        match level {
+            Level::ERROR => 1,
+            Level::WARN => 2,
+            Level::INFO => 3,
+            Level::DEBUG => 4,
+            Level::TRACE => 5,
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub use web::{init_console_logging, ConsoleLoggingConfig, InitLoggingError};

--- a/crates/pocopine-observe/Cargo.toml
+++ b/crates/pocopine-observe/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "pocopine-observe"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Shared observability event contract for pocopine logging, tracing, and analytics."
+
+[dependencies]
+serde = { workspace = true }
+tracing = { workspace = true }

--- a/crates/pocopine-observe/src/lib.rs
+++ b/crates/pocopine-observe/src/lib.rs
@@ -1,0 +1,480 @@
+//! Stable observability event contract shared by pocopine logging,
+//! tracing, telemetry, and analytics integrations.
+//!
+//! Core/runtime crates should emit `tracing` spans and events, or
+//! construct an [`ObservedEvent`] when they need a stable public schema.
+//! Exporters live in `pocopine-logging` and `pocopine-analytics`.
+
+use std::collections::BTreeMap;
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+use tracing::Level;
+
+pub const LOG_TARGET: &str = "pocopine.log";
+pub const TRACE_TARGET: &str = "pocopine.trace";
+pub const METRIC_TARGET: &str = "pocopine.metric";
+pub const ANALYTICS_TARGET: &str = "pocopine.analytics";
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EventClass {
+    Log,
+    Trace,
+    Metric,
+    Analytics,
+}
+
+impl EventClass {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Log => "log",
+            Self::Trace => "trace",
+            Self::Metric => "metric",
+            Self::Analytics => "analytics",
+        }
+    }
+
+    pub fn target(self) -> &'static str {
+        match self {
+            Self::Log => LOG_TARGET,
+            Self::Trace => TRACE_TARGET,
+            Self::Metric => METRIC_TARGET,
+            Self::Analytics => ANALYTICS_TARGET,
+        }
+    }
+}
+
+impl fmt::Display for EventClass {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EventPriority {
+    Critical,
+    High,
+    Normal,
+    Low,
+}
+
+impl EventPriority {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Critical => "critical",
+            Self::High => "high",
+            Self::Normal => "normal",
+            Self::Low => "low",
+        }
+    }
+
+    pub fn level(self) -> Level {
+        match self {
+            Self::Critical => Level::ERROR,
+            Self::High => Level::WARN,
+            Self::Normal => Level::INFO,
+            Self::Low => Level::DEBUG,
+        }
+    }
+}
+
+impl fmt::Display for EventPriority {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FieldPrivacy {
+    Public,
+    Pseudonymous,
+    Sensitive,
+}
+
+impl FieldPrivacy {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Public => "public",
+            Self::Pseudonymous => "pseudonymous",
+            Self::Sensitive => "sensitive",
+        }
+    }
+}
+
+impl fmt::Display for FieldPrivacy {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum FieldValue {
+    String(String),
+    Bool(bool),
+    I64(i64),
+    U64(u64),
+    F64(f64),
+}
+
+impl FieldValue {
+    pub fn as_debug_value(&self) -> String {
+        match self {
+            Self::String(value) => value.clone(),
+            Self::Bool(value) => value.to_string(),
+            Self::I64(value) => value.to_string(),
+            Self::U64(value) => value.to_string(),
+            Self::F64(value) => value.to_string(),
+        }
+    }
+}
+
+impl From<&str> for FieldValue {
+    fn from(value: &str) -> Self {
+        Self::String(value.to_owned())
+    }
+}
+
+impl From<String> for FieldValue {
+    fn from(value: String) -> Self {
+        Self::String(value)
+    }
+}
+
+impl From<bool> for FieldValue {
+    fn from(value: bool) -> Self {
+        Self::Bool(value)
+    }
+}
+
+impl From<i64> for FieldValue {
+    fn from(value: i64) -> Self {
+        Self::I64(value)
+    }
+}
+
+impl From<i32> for FieldValue {
+    fn from(value: i32) -> Self {
+        Self::I64(value.into())
+    }
+}
+
+impl From<u64> for FieldValue {
+    fn from(value: u64) -> Self {
+        Self::U64(value)
+    }
+}
+
+impl From<u32> for FieldValue {
+    fn from(value: u32) -> Self {
+        Self::U64(value.into())
+    }
+}
+
+impl From<f64> for FieldValue {
+    fn from(value: f64) -> Self {
+        Self::F64(value)
+    }
+}
+
+impl From<f32> for FieldValue {
+    fn from(value: f32) -> Self {
+        Self::F64(value.into())
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ObservedField {
+    pub value: FieldValue,
+    pub privacy: FieldPrivacy,
+}
+
+impl ObservedField {
+    pub fn new(value: impl Into<FieldValue>, privacy: FieldPrivacy) -> Self {
+        Self {
+            value: value.into(),
+            privacy,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ObserveContext {
+    pub service: Option<String>,
+    pub environment: Option<String>,
+    pub route: Option<String>,
+    pub component: Option<String>,
+    pub trace_id: Option<String>,
+    pub session_id: Option<String>,
+    pub user_id_hash: Option<String>,
+}
+
+impl ObserveContext {
+    pub fn with_service(mut self, service: impl Into<String>) -> Self {
+        self.service = Some(service.into());
+        self
+    }
+
+    pub fn with_environment(mut self, environment: impl Into<String>) -> Self {
+        self.environment = Some(environment.into());
+        self
+    }
+
+    pub fn with_route(mut self, route: impl Into<String>) -> Self {
+        self.route = Some(route.into());
+        self
+    }
+
+    pub fn with_component(mut self, component: impl Into<String>) -> Self {
+        self.component = Some(component.into());
+        self
+    }
+
+    pub fn with_trace_id(mut self, trace_id: impl Into<String>) -> Self {
+        self.trace_id = Some(trace_id.into());
+        self
+    }
+
+    pub fn with_session_id(mut self, session_id: impl Into<String>) -> Self {
+        self.session_id = Some(session_id.into());
+        self
+    }
+
+    pub fn with_user_id_hash(mut self, user_id_hash: impl Into<String>) -> Self {
+        self.user_id_hash = Some(user_id_hash.into());
+        self
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ObservedEvent {
+    pub name: String,
+    pub version: u16,
+    pub class: EventClass,
+    pub priority: EventPriority,
+    pub privacy: FieldPrivacy,
+    pub context: ObserveContext,
+    pub fields: BTreeMap<String, ObservedField>,
+}
+
+impl ObservedEvent {
+    pub fn new(name: impl Into<String>, class: EventClass) -> Self {
+        Self {
+            name: name.into(),
+            version: 1,
+            class,
+            priority: EventPriority::Normal,
+            privacy: FieldPrivacy::Public,
+            context: ObserveContext::default(),
+            fields: BTreeMap::new(),
+        }
+    }
+
+    pub fn log(name: impl Into<String>) -> Self {
+        Self::new(name, EventClass::Log)
+    }
+
+    pub fn trace(name: impl Into<String>) -> Self {
+        Self::new(name, EventClass::Trace)
+    }
+
+    pub fn metric(name: impl Into<String>) -> Self {
+        Self::new(name, EventClass::Metric)
+    }
+
+    pub fn analytics(name: impl Into<String>) -> Self {
+        Self::new(name, EventClass::Analytics).privacy(FieldPrivacy::Pseudonymous)
+    }
+
+    pub fn version(mut self, version: u16) -> Self {
+        self.version = version;
+        self
+    }
+
+    pub fn priority(mut self, priority: EventPriority) -> Self {
+        self.priority = priority;
+        self
+    }
+
+    pub fn privacy(mut self, privacy: FieldPrivacy) -> Self {
+        self.privacy = privacy;
+        self
+    }
+
+    pub fn context(mut self, context: ObserveContext) -> Self {
+        self.context = context;
+        self
+    }
+
+    pub fn field(
+        mut self,
+        name: impl Into<String>,
+        value: impl Into<FieldValue>,
+        privacy: FieldPrivacy,
+    ) -> Self {
+        self.insert_field(name, value, privacy);
+        self
+    }
+
+    pub fn insert_field(
+        &mut self,
+        name: impl Into<String>,
+        value: impl Into<FieldValue>,
+        privacy: FieldPrivacy,
+    ) {
+        self.fields
+            .insert(name.into(), ObservedField::new(value, privacy));
+    }
+
+    pub fn redacted(&self, policy: RedactionPolicy) -> Self {
+        let mut event = self.clone();
+        event.fields.retain(|_, field| policy.allows(field.privacy));
+        if !policy.include_pseudonymous {
+            event.context.session_id = None;
+            event.context.user_id_hash = None;
+        }
+        event
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct RedactionPolicy {
+    pub include_pseudonymous: bool,
+    pub include_sensitive: bool,
+}
+
+impl RedactionPolicy {
+    pub const fn public_only() -> Self {
+        Self {
+            include_pseudonymous: false,
+            include_sensitive: false,
+        }
+    }
+
+    pub const fn allow_pseudonymous() -> Self {
+        Self {
+            include_pseudonymous: true,
+            include_sensitive: false,
+        }
+    }
+
+    pub const fn allow_sensitive() -> Self {
+        Self {
+            include_pseudonymous: true,
+            include_sensitive: true,
+        }
+    }
+
+    pub fn allows(self, privacy: FieldPrivacy) -> bool {
+        match privacy {
+            FieldPrivacy::Public => true,
+            FieldPrivacy::Pseudonymous => self.include_pseudonymous,
+            FieldPrivacy::Sensitive => self.include_sensitive,
+        }
+    }
+}
+
+impl Default for RedactionPolicy {
+    fn default() -> Self {
+        Self::public_only()
+    }
+}
+
+pub fn emit_tracing(event: &ObservedEvent) {
+    macro_rules! emit_for_target {
+        ($target:literal, $event:expr) => {
+            match $event.priority.level() {
+                Level::ERROR => tracing::event!(
+                    target: $target,
+                    Level::ERROR,
+                    event_name = %$event.name,
+                    event_version = $event.version,
+                    event_class = %$event.class,
+                    event_priority = %$event.priority,
+                    event_privacy = %$event.privacy,
+                    context = ?$event.context,
+                    fields = ?$event.fields,
+                ),
+                Level::WARN => tracing::event!(
+                    target: $target,
+                    Level::WARN,
+                    event_name = %$event.name,
+                    event_version = $event.version,
+                    event_class = %$event.class,
+                    event_priority = %$event.priority,
+                    event_privacy = %$event.privacy,
+                    context = ?$event.context,
+                    fields = ?$event.fields,
+                ),
+                Level::INFO => tracing::event!(
+                    target: $target,
+                    Level::INFO,
+                    event_name = %$event.name,
+                    event_version = $event.version,
+                    event_class = %$event.class,
+                    event_priority = %$event.priority,
+                    event_privacy = %$event.privacy,
+                    context = ?$event.context,
+                    fields = ?$event.fields,
+                ),
+                Level::DEBUG | Level::TRACE => tracing::event!(
+                    target: $target,
+                    Level::DEBUG,
+                    event_name = %$event.name,
+                    event_version = $event.version,
+                    event_class = %$event.class,
+                    event_priority = %$event.priority,
+                    event_privacy = %$event.privacy,
+                    context = ?$event.context,
+                    fields = ?$event.fields,
+                ),
+            }
+        };
+    }
+
+    match event.class {
+        EventClass::Log => emit_for_target!("pocopine.log", event),
+        EventClass::Trace => emit_for_target!("pocopine.trace", event),
+        EventClass::Metric => emit_for_target!("pocopine.metric", event),
+        EventClass::Analytics => emit_for_target!("pocopine.analytics", event),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn redacts_non_public_fields_by_default() {
+        let event = ObservedEvent::analytics("checkout")
+            .field("plan", "pro", FieldPrivacy::Public)
+            .field("session", "s-1", FieldPrivacy::Pseudonymous)
+            .field("email", "person@example.test", FieldPrivacy::Sensitive);
+
+        let redacted = event.redacted(RedactionPolicy::public_only());
+
+        assert!(redacted.fields.contains_key("plan"));
+        assert!(!redacted.fields.contains_key("session"));
+        assert!(!redacted.fields.contains_key("email"));
+    }
+
+    #[test]
+    fn can_allow_pseudonymous_without_sensitive_fields() {
+        let context = ObserveContext::default().with_session_id("s-1");
+        let event = ObservedEvent::analytics("route_view")
+            .context(context)
+            .field("route", "/settings", FieldPrivacy::Public)
+            .field("session", "s-1", FieldPrivacy::Pseudonymous)
+            .field("token", "secret", FieldPrivacy::Sensitive);
+
+        let redacted = event.redacted(RedactionPolicy::allow_pseudonymous());
+
+        assert_eq!(redacted.context.session_id.as_deref(), Some("s-1"));
+        assert!(redacted.fields.contains_key("route"));
+        assert!(redacted.fields.contains_key("session"));
+        assert!(!redacted.fields.contains_key("token"));
+    }
+}

--- a/crates/pocopine-server/Cargo.toml
+++ b/crates/pocopine-server/Cargo.toml
@@ -15,6 +15,7 @@ tokio = { version = "1", features = ["rt-multi-thread", "macros", "net", "signal
 tower = "0.5"
 tower-http = { version = "0.6", features = ["fs", "trace"] }
 serde_json = "1"
+tracing = { workspace = true }
 
 [dependencies]
 pocopine-auth = { workspace = true }

--- a/crates/pocopine-server/src/lib.rs
+++ b/crates/pocopine-server/src/lib.rs
@@ -48,18 +48,23 @@ pub mod auth {
 /// Resolved once on first access and reused for the lifetime of the process.
 pub fn server_function_body_limit() -> usize {
     static LIMIT: OnceLock<usize> = OnceLock::new();
-    *LIMIT.get_or_init(|| match std::env::var("POCOPINE_SERVER_FUNCTION_BODY_LIMIT") {
-        Ok(raw) => match parse_body_limit(&raw) {
-            Some(limit) => limit,
-            None => {
-                eprintln!(
-                    "invalid POCOPINE_SERVER_FUNCTION_BODY_LIMIT={raw:?}; using default {DEFAULT_SERVER_FUNCTION_BODY_LIMIT}"
-                );
-                DEFAULT_SERVER_FUNCTION_BODY_LIMIT
-            }
+    *LIMIT.get_or_init(
+        || match std::env::var("POCOPINE_SERVER_FUNCTION_BODY_LIMIT") {
+            Ok(raw) => match parse_body_limit(&raw) {
+                Some(limit) => limit,
+                None => {
+                    tracing::warn!(
+                        target: "pocopine.log",
+                        value = ?raw,
+                        default = DEFAULT_SERVER_FUNCTION_BODY_LIMIT,
+                        "invalid POCOPINE_SERVER_FUNCTION_BODY_LIMIT; using default"
+                    );
+                    DEFAULT_SERVER_FUNCTION_BODY_LIMIT
+                }
+            },
+            Err(_) => DEFAULT_SERVER_FUNCTION_BODY_LIMIT,
         },
-        Err(_) => DEFAULT_SERVER_FUNCTION_BODY_LIMIT,
-    })
+    )
 }
 
 fn parse_body_limit(raw: &str) -> Option<usize> {
@@ -97,6 +102,7 @@ pub async fn serve(router: Router, addr: &str) -> std::io::Result<()> {
         .parse()
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?;
     let listener = tokio::net::TcpListener::bind(addr).await?;
+    tracing::info!(target: "pocopine.log", %addr, "pocopine server listening");
     axum::serve(listener, router).await
 }
 

--- a/crates/pocopine/Cargo.toml
+++ b/crates/pocopine/Cargo.toml
@@ -11,15 +11,21 @@ description = "Rust/WASM framework with an Alpine.js-style client runtime."
 # opt into `devtools` (in-browser scope inspector) and
 # `mount-profiler` (per-mount timing instrumentation).
 default = ["runtime-expr-fallback"]
+analytics = ["dep:pocopine-analytics", "observe"]
 devtools = ["pocopine-core/devtools"]
+logging = ["dep:pocopine-logging", "observe"]
 mount-profiler = ["pocopine-core/mount-profiler"]
+observe = ["dep:pocopine-observe"]
 runtime-expr-fallback = ["pocopine-core/runtime-expr-fallback"]
 
 [dependencies]
+pocopine-analytics = { workspace = true, optional = true }
 pocopine-auth = { workspace = true }
 pocopine-core = { workspace = true, default-features = false }
 pocopine-jobs = { workspace = true }
+pocopine-logging = { workspace = true, optional = true }
 pocopine-macros = { workspace = true }
+pocopine-observe = { workspace = true, optional = true }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 js-sys = { workspace = true }

--- a/crates/pocopine/src/lib.rs
+++ b/crates/pocopine/src/lib.rs
@@ -47,6 +47,21 @@ pub mod auth {
     pub use pocopine_auth::*;
 }
 
+#[cfg(feature = "analytics")]
+pub mod analytics {
+    pub use pocopine_analytics::*;
+}
+
+#[cfg(feature = "logging")]
+pub mod logging {
+    pub use pocopine_logging::*;
+}
+
+#[cfg(feature = "observe")]
+pub mod observe {
+    pub use pocopine_observe::*;
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 pub mod jobs {
     pub use pocopine_jobs::*;

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ looks the way it does — the code itself tells you *what*.
   sorted-set scheduler + Lua-scripted state transitions, periodic
   firings, reclaim, and the memory backend. Includes redis-cli
   recipes for validating a live deployment.
-- [`loggine-tracing-observer.md`](./loggine-tracing-observer.md) —
+- [`logging-tracing-observer.md`](./logging-tracing-observer.md) —
   browser console logging, backend logging, structured observed
   events, analytics sinks, privacy labels, and target filtering.
 - [`postmortems/`](./postmortems/) — write-ups of subtle bugs + the

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,9 @@ looks the way it does — the code itself tells you *what*.
   sorted-set scheduler + Lua-scripted state transitions, periodic
   firings, reclaim, and the memory backend. Includes redis-cli
   recipes for validating a live deployment.
+- [`loggine-tracing-observer.md`](./loggine-tracing-observer.md) —
+  browser console logging, backend logging, structured observed
+  events, analytics sinks, privacy labels, and target filtering.
 - [`postmortems/`](./postmortems/) — write-ups of subtle bugs + the
   invariants new code should preserve.
 

--- a/docs/jobs.md
+++ b/docs/jobs.md
@@ -150,9 +150,9 @@ Order matters:
 - **⑤ Read new** — `XREADGROUP ... >` skips PEL entirely.
 
 The outer `Worker::run()` loop wraps `run_redis_once` with capped
-exponential-backoff reconnect on transient errors and prints a
-one-line backend banner so operators can see at startup which backend
-is bound.
+exponential-backoff reconnect on transient errors and logs a one-line
+backend banner through `tracing` so operators can see at startup which
+backend is bound.
 
 ## Lifecycle 1 — happy path
 

--- a/docs/loggine-tracing-observer.md
+++ b/docs/loggine-tracing-observer.md
@@ -1,0 +1,327 @@
+# Logging, tracing, and observability
+
+This doc explains the first observability slice introduced by
+[`RFC 069`](../rfcs/rfc-069-observability.md): browser console logging,
+backend logging, structured observed events, and analytics fan-out.
+
+## Mental model
+
+Pocopine uses `tracing` as the instrumentation API. Code emits spans and
+events. Application entrypoints decide where those events go.
+
+```text
+app / pocopine runtime
+  -> tracing events and spans
+  -> pocopine-observe event contract
+  -> pocopine-logging subscribers
+  -> pocopine-analytics sinks
+```
+
+The crates have different jobs:
+
+| Crate | Purpose |
+|---|---|
+| `pocopine-observe` | Shared event schema, context, priority, privacy labels, redaction, and fixed tracing targets. |
+| `pocopine-logging` | Browser console logging and server log formatting. |
+| `pocopine-analytics` | Redacted analytics/telemetry fan-out to custom or vendor sinks. |
+
+Framework/library code should emit `tracing` events or typed
+`ObservedEvent`s. It should not install global subscribers or vendor
+exporters. The final application entrypoint owns that.
+
+## Enable the feature
+
+For the umbrella crate:
+
+```toml
+[dependencies]
+pocopine = { path = "../../crates/pocopine", features = ["logging", "analytics"] }
+tracing = "0.1"
+```
+
+Use only what you need:
+
+```toml
+pocopine = { path = "../../crates/pocopine", features = ["logging"] }
+```
+
+The `logging` and `analytics` features also enable `observe`, because both
+use the shared event contract.
+
+## Browser console logging
+
+On `wasm32`, install console logging once during app startup:
+
+```rust
+use pocopine::logging::{init_console_logging, ConsoleLoggingConfig};
+
+#[wasm_bindgen::prelude::wasm_bindgen(start)]
+pub fn start() {
+    let _ = init_console_logging(ConsoleLoggingConfig::debug());
+
+    tracing::info!(target: "pocopine.log", "browser app started");
+    tracing::debug!(
+        target: "pocopine.log",
+        component = "Calendar",
+        "component mounted"
+    );
+
+    pocopine::App::new().run();
+}
+```
+
+The browser layer maps tracing levels to the matching browser console call:
+
+| Tracing level | Browser API |
+|---|---|
+| `ERROR` | `console.error` |
+| `WARN` | `console.warn` |
+| `INFO` | `console.info` |
+| `DEBUG` / `TRACE` | `console.debug` |
+
+### Why `target` matters
+
+`ConsoleLoggingConfig::debug()` filters to targets that start with
+`pocopine` so the browser console is not flooded by unrelated dependency
+logs.
+
+This shows:
+
+```rust
+tracing::info!(target: "pocopine.log", "app started");
+```
+
+This may be filtered out:
+
+```rust
+tracing::info!("app started");
+```
+
+Without an explicit target, `tracing` uses the Rust module path as the target,
+such as `my_app::pages::home`.
+
+If you want app module targets instead, configure the prefix:
+
+```rust
+init_console_logging(
+    ConsoleLoggingConfig::debug().with_target_prefix("my_app")
+)?;
+```
+
+If you want everything:
+
+```rust
+init_console_logging(
+    ConsoleLoggingConfig::debug().without_target_prefix()
+)?;
+```
+
+## Backend logging
+
+On the host/server side, install server logging once near process startup:
+
+```rust
+use pocopine::logging::{init_server_logging, ServerLoggingConfig};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    init_server_logging(
+        ServerLoggingConfig::json()
+            .with_env_filter("info,pocopine=debug")
+    )?;
+
+    tracing::info!(target: "pocopine.log", "server started");
+    tracing::warn!(
+        target: "pocopine.log",
+        route = "/api/posts",
+        "slow request"
+    );
+
+    Ok(())
+}
+```
+
+For human-readable development logs:
+
+```rust
+init_server_logging(ServerLoggingConfig::compact())?;
+```
+
+For structured production logs:
+
+```rust
+init_server_logging(
+    ServerLoggingConfig::json().with_env_filter("info,pocopine=debug")
+)?;
+```
+
+If `with_env_filter` is not provided, the server logger reads `RUST_LOG`.
+If `RUST_LOG` is unset, the default filter is:
+
+```text
+info,pocopine=debug
+```
+
+## Structured observed events
+
+Use `ObservedEvent` when you want a stable framework-facing event schema
+instead of a one-off debug log.
+
+```rust
+use pocopine::observe::{FieldPrivacy, ObservedEvent};
+
+let event = ObservedEvent::log("server_started")
+    .field("port", 3000_u32, FieldPrivacy::Public)
+    .field("environment", "dev", FieldPrivacy::Public);
+
+pocopine::logging::log_event(&event);
+```
+
+Observed events include:
+
+- `name`
+- `version`
+- `class`
+- `priority`
+- `privacy`
+- shared context
+- field privacy labels
+
+Fixed tracing targets:
+
+| Event class | Target |
+|---|---|
+| log | `pocopine.log` |
+| trace | `pocopine.trace` |
+| metric | `pocopine.metric` |
+| analytics | `pocopine.analytics` |
+
+## Analytics and telemetry
+
+Analytics is separate from logging. Logs are operational records. Analytics
+events are intentional product or telemetry events with a stable schema.
+
+```rust
+use pocopine::analytics::{route_view, AnalyticsClient, AnalyticsError};
+
+let analytics = AnalyticsClient::new()
+    .with_sink(|event| {
+        // Send to your vendor SDK, HTTP endpoint, or local test collector.
+        tracing::debug!(target: "pocopine.analytics", event = ?event);
+        Ok::<(), AnalyticsError>(())
+    });
+
+let report = analytics.emit(route_view("/settings"));
+
+if !report.all_delivered() {
+    tracing::warn!(
+        target: "pocopine.log",
+        failed = report.failed,
+        "analytics delivery failed"
+    );
+}
+```
+
+`AnalyticsClient` redacts before dispatch and keeps going when one sink fails.
+Sink panics are caught and reported in the delivery report.
+
+## Browser vendor bridges
+
+The wasm analytics module provides adapters around caller-supplied JavaScript
+functions or SDK handles. Pocopine does not directly initialize Firebase,
+Google Analytics, Cloudflare, AWS, or OpenTelemetry for you in the core
+runtime.
+
+That boundary is intentional:
+
+- the app owns vendor SDK initialization;
+- pocopine owns redaction and event shape;
+- vendor adapters translate redacted observed events into vendor calls.
+
+For Firebase/Google Analytics-style usage, initialize the SDK in the app, then
+attach the adapter as an analytics sink.
+
+## Privacy rules
+
+The default posture is allowlist-based.
+
+| Privacy label | Default behavior |
+|---|---|
+| `Public` | May be exported. |
+| `Pseudonymous` | Exported only when the redaction policy allows it. |
+| `Sensitive` | Dropped unless an explicitly trusted sink allows it. |
+
+Do not mark these as public:
+
+- raw auth headers;
+- cookies;
+- tokens;
+- emails;
+- raw model payloads;
+- DOM text;
+- route params that may contain user data.
+
+Prefer stable names and coarse fields:
+
+```rust
+ObservedEvent::analytics("checkout_started")
+    .field("plan", "pro", FieldPrivacy::Public)
+    .field("session_id", session_id_hash, FieldPrivacy::Pseudonymous);
+```
+
+## Reliability rules
+
+Observability must not change application behavior.
+
+- Exporter failure must not panic the app.
+- Analytics sink failure must not stop other sinks.
+- Analytics sinks receive redacted events, not raw debug fields.
+- Runtime/library crates do not install global subscribers.
+- Async exporters added later must use bounded queues and count drops.
+
+## Common recipes
+
+### Log from browser code
+
+```rust
+tracing::info!(target: "pocopine.log", "button clicked");
+```
+
+### Log from backend code
+
+```rust
+tracing::error!(
+    target: "pocopine.log",
+    error = %err,
+    "server function failed"
+);
+```
+
+### Create a trace span
+
+```rust
+let span = tracing::info_span!(
+    target: "pocopine.trace",
+    "server_function",
+    name = "save_profile"
+);
+
+let _entered = span.enter();
+```
+
+### Emit a stable analytics event
+
+```rust
+analytics.emit(
+    pocopine::analytics::event("feature_used")
+        .field("feature", "calendar", pocopine::observe::FieldPrivacy::Public)
+);
+```
+
+### Disable the browser target filter
+
+```rust
+init_console_logging(
+    ConsoleLoggingConfig::debug().without_target_prefix()
+)?;
+```

--- a/docs/logging-tracing-observer.md
+++ b/docs/logging-tracing-observer.md
@@ -205,7 +205,7 @@ events are intentional product or telemetry events with a stable schema.
 use pocopine::analytics::{route_view, AnalyticsClient, AnalyticsError};
 
 let analytics = AnalyticsClient::new()
-    .with_sink(|event| {
+    .with_sink(|event: &pocopine::observe::ObservedEvent| {
         // Send to your vendor SDK, HTTP endpoint, or local test collector.
         tracing::debug!(target: "pocopine.analytics", event = ?event);
         Ok::<(), AnalyticsError>(())
@@ -213,7 +213,7 @@ let analytics = AnalyticsClient::new()
 
 let report = analytics.emit(route_view("/settings"));
 
-if !report.all_delivered() {
+if !report.all_succeeded() {
     tracing::warn!(
         target: "pocopine.log",
         failed = report.failed,
@@ -224,6 +224,10 @@ if !report.all_delivered() {
 
 `AnalyticsClient` redacts before dispatch and keeps going when one sink fails.
 Sink panics are caught and reported in the delivery report.
+
+On host targets, analytics sinks must be `Send + Sync` so the client can be
+stored in shared server state such as axum state. On wasm targets this bound is
+relaxed because browser SDK handles are usually JavaScript objects.
 
 ## Browser vendor bridges
 

--- a/docs/logging-tracing-observer.md
+++ b/docs/logging-tracing-observer.md
@@ -227,7 +227,9 @@ Sink panics are caught and reported in the delivery report.
 
 On host targets, analytics sinks must be `Send + Sync` so the client can be
 stored in shared server state such as axum state. On wasm targets this bound is
-relaxed because browser SDK handles are usually JavaScript objects.
+relaxed because browser SDK handles are usually JavaScript objects. The closure
+example above spells out `&pocopine::observe::ObservedEvent` so Rust can infer
+the host closure sink against that `Send + Sync` blanket implementation.
 
 ## Browser vendor bridges
 

--- a/examples/blog/Cargo.toml
+++ b/examples/blog/Cargo.toml
@@ -31,7 +31,9 @@ required-features = []
 pocopine = { path = "../../crates/pocopine" }
 wasm-bindgen = { workspace = true }
 serde = { workspace = true }
+tracing = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+pocopine-logging = { workspace = true }
 pocopine-server = { path = "../../crates/pocopine-server" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net"] }

--- a/examples/blog/src/bin/server.rs
+++ b/examples/blog/src/bin/server.rs
@@ -9,7 +9,10 @@
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
     use blog::__get_post_route;
+    use pocopine_logging::{init_server_logging, ServerLoggingConfig};
     use pocopine_server::{axum::Router, serve, static_files};
+
+    init_server_logging(ServerLoggingConfig::compact()).map_err(std::io::Error::other)?;
 
     // Anchor static files to the crate root, so the server works
     // regardless of the shell's CWD (including when spawned by
@@ -19,7 +22,7 @@ async fn main() -> std::io::Result<()> {
     let router = __get_post_route(router);
 
     let addr = "127.0.0.1:3000";
-    println!("▶ serving blog example on http://{addr}");
+    tracing::info!(target: "pocopine.log", %addr, "serving blog example");
     serve(router, addr).await
 }
 

--- a/examples/blog/src/bin/worker.rs
+++ b/examples/blog/src/bin/worker.rs
@@ -4,8 +4,14 @@
 #[tokio::main]
 async fn main() -> pocopine::JobResult<()> {
     use blog as _;
+    use pocopine_logging::{init_server_logging, ServerLoggingConfig};
 
-    println!("▶ running blog worker (POCOPINE_JOB_BACKEND or POCOPINE_REDIS_URL)");
+    init_server_logging(ServerLoggingConfig::compact())
+        .map_err(|err| pocopine::JobError::Env(err.to_string()))?;
+    tracing::info!(
+        target: "pocopine.log",
+        "running blog worker (POCOPINE_JOB_BACKEND or POCOPINE_REDIS_URL)"
+    );
     pocopine::Worker::from_env()?.run().await
 }
 

--- a/examples/blog/src/lib.rs
+++ b/examples/blog/src/lib.rs
@@ -20,13 +20,17 @@ pub struct PostViewAudit {
 
 #[pocopine::job(queue = "blog", retries = 2)]
 pub async fn record_post_view(input: PostViewAudit) -> JobResult<()> {
-    eprintln!("post view audit: {}", input.post_id);
+    tracing::info!(
+        target: "pocopine.log",
+        post_id = input.post_id,
+        "post view audit"
+    );
     Ok(())
 }
 
 #[pocopine::job(queue = "blog", every = "10m")]
 pub async fn refresh_blog_index() -> JobResult<()> {
-    eprintln!("refresh blog index");
+    tracing::info!(target: "pocopine.log", "refresh blog index");
     Ok(())
 }
 

--- a/examples/hn/Cargo.toml
+++ b/examples/hn/Cargo.toml
@@ -24,6 +24,7 @@ web-sys = { version = "0.3", features = ["Window", "Performance"] }
 js-sys = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+pocopine-logging = { workspace = true }
 pocopine-server = { path = "../../crates/pocopine-server" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net"] }
 reqwest = { version = "0.12", default-features = false, features = [
@@ -31,3 +32,4 @@ reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls-webpki-roots",
 ] }
 futures = "0.3"
+tracing = { workspace = true }

--- a/examples/hn/src/bin/server.rs
+++ b/examples/hn/src/bin/server.rs
@@ -6,7 +6,10 @@
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
     use hn::{__get_item_tree_route, __search_stories_route};
+    use pocopine_logging::{init_server_logging, ServerLoggingConfig};
     use pocopine_server::{axum::Router, serve, static_files, tower_http::services::ServeFile};
+
+    init_server_logging(ServerLoggingConfig::compact()).map_err(std::io::Error::other)?;
 
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let index_path = format!("{manifest_dir}/index.html");
@@ -17,7 +20,7 @@ async fn main() -> std::io::Result<()> {
     let router = __get_item_tree_route(router);
 
     let addr = "127.0.0.1:3001";
-    println!("▶ serving pocopine HN on http://{addr}");
+    tracing::info!(target: "pocopine.log", %addr, "serving pocopine HN");
     serve(router, addr).await
 }
 

--- a/examples/site/Cargo.toml
+++ b/examples/site/Cargo.toml
@@ -20,7 +20,9 @@ path = "src/bin/server.rs"
 pocopine = { path = "../../crates/pocopine" }
 wasm-bindgen = { workspace = true }
 serde = { workspace = true }
+tracing = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+pocopine-logging = { workspace = true }
 pocopine-server = { path = "../../crates/pocopine-server" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net"] }

--- a/examples/site/src/bin/server.rs
+++ b/examples/site/src/bin/server.rs
@@ -8,8 +8,11 @@
 #[cfg(not(target_arch = "wasm32"))]
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
+    use pocopine_logging::{init_server_logging, ServerLoggingConfig};
     use pocopine_server::{axum::Router, serve, static_files, tower_http::services::ServeFile};
     use site::__submit_contact_route;
+
+    init_server_logging(ServerLoggingConfig::compact()).map_err(std::io::Error::other)?;
 
     // Anchor to the crate root so the binary works regardless of CWD.
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
@@ -21,7 +24,7 @@ async fn main() -> std::io::Result<()> {
     let router = __submit_contact_route(router);
 
     let addr = "127.0.0.1:3000";
-    println!("▶ serving site on http://{addr}");
+    tracing::info!(target: "pocopine.log", %addr, "serving site");
     serve(router, addr).await
 }
 

--- a/examples/site/src/lib.rs
+++ b/examples/site/src/lib.rs
@@ -28,11 +28,10 @@ use shared::{ContactMessage, ContactResponse};
 
 #[pocopine::server(public)]
 pub async fn submit_contact(msg: ContactMessage) -> ServerResult<ContactResponse> {
-    eprintln!(
-        "contact: {name} <{email}>: {msg}",
-        name = msg.name,
-        email = msg.email,
-        msg = msg.message,
+    tracing::info!(
+        target: "pocopine.log",
+        message_len = msg.message.len(),
+        "contact form submitted"
     );
     let id = (msg.message.len() as u32).wrapping_add(1000);
     Ok(ContactResponse { id, ok: true })

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -77,3 +77,4 @@ Conventions:
 | 066 | [Server-function auth and access policy](./rfc-066-server-function-auth.md) | Draft |
 | 067 | [Background jobs with Redis and memory backends](./rfc-067-redis-background-jobs.md) | Draft |
 | 068 | [SVG namespace template support](./rfc-068-svg-namespace-template-support.md) | Draft |
+| 069 | [Unified observability, logging, and analytics](./rfc-069-observability.md) | Draft |

--- a/rfcs/rfc-067-redis-background-jobs.md
+++ b/rfcs/rfc-067-redis-background-jobs.md
@@ -163,7 +163,7 @@ operators can periodically scrape and persist failed jobs. The Redis
 backend does not implement `drain_dead_letter`; the dead-letter stream
 `pocopine:{app}:dead` is queryable directly.
 
-`Worker::run` prints a one-line backend banner at startup so operators can
+`Worker::run` logs a one-line backend banner at startup so operators can
 confirm whether the worker bound to Redis or to the process-local memory
 backend, defending against the silent-default footgun in multi-process
 deployments where Redis was intended.

--- a/rfcs/rfc-069-observability.md
+++ b/rfcs/rfc-069-observability.md
@@ -1,0 +1,164 @@
+# RFC 069 - Unified observability, logging, and analytics
+
+| Field | Value |
+|---|---|
+| **Status** | Draft |
+| **Author** | pocopine team |
+| **Created** | 2026-05-03 |
+| **Related** | [`rfc-037-js-bridge.md`](./rfc-037-js-bridge.md), [`rfc-059-server-side-rendering-and-hydration.md`](./rfc-059-server-side-rendering-and-hydration.md), [`rfc-066-server-function-auth.md`](./rfc-066-server-function-auth.md), [`rfc-067-redis-background-jobs.md`](./rfc-067-redis-background-jobs.md) |
+| **Supersedes** | - |
+
+## 1. Summary
+
+Add a unified observability spine on top of `tracing` while keeping logs,
+traces, telemetry, and analytics separate at the schema and exporter layer.
+
+The implementation is split across three crates:
+
+- `pocopine-observe`: stable event contract, context, priorities, privacy
+  labels, redaction policy, and `tracing` emission helpers.
+- `pocopine-logging`: server and browser logging subscribers/adapters.
+- `pocopine-analytics`: product analytics and telemetry fan-out with
+  redaction, sink isolation, and vendor bridge adapters.
+
+Framework crates emit `tracing` events or typed `pocopine-observe` events.
+Application entrypoints decide which subscribers and exporters are installed.
+
+## 2. Motivation
+
+Real applications need several observability paths at once:
+
+- Developer logs in the browser console.
+- Structured server logs for stdout, AWS, Cloudflare, or another host.
+- Trace/telemetry data for request, server function, job, and route timing.
+- Product analytics for route views, feature usage, funnels, and performance
+  events.
+
+Those paths should not share one loose stringly API. Debug logs eventually
+carry sensitive context. Analytics events need stable schemas. Traces need
+causality and timing. Logs need operational detail. The framework should give
+all of them a shared context spine without treating them as interchangeable.
+
+## 3. Design
+
+### 3.1 Crate boundaries
+
+`pocopine-observe` is the only stable shared contract. It defines:
+
+- event class: `log`, `trace`, `metric`, `analytics`;
+- priority: `critical`, `high`, `normal`, `low`;
+- field privacy: `public`, `pseudonymous`, `sensitive`;
+- shared context: service, environment, route, component, trace ID, session
+  ID, and hashed user ID;
+- redaction policy;
+- fixed `tracing` targets:
+  - `pocopine.log`
+  - `pocopine.trace`
+  - `pocopine.metric`
+  - `pocopine.analytics`
+
+`pocopine-logging` owns log presentation and log export. The first slice
+ships:
+
+- host/server initialization through `tracing-subscriber`;
+- compact, pretty, and JSON server formats;
+- `RUST_LOG` / explicit filter support;
+- wasm browser console subscriber.
+
+`pocopine-analytics` owns analytics and telemetry dispatch. The first slice
+ships:
+
+- an `AnalyticsClient`;
+- an `AnalyticsSink` trait;
+- redaction before dispatch;
+- continued delivery after individual sink errors;
+- panic isolation around sink calls;
+- wasm JS function sinks for user-supplied vendor bridges;
+- wasm Firebase and Google Analytics function adapters.
+
+### 3.2 Framework integration rule
+
+Runtime crates must not install global subscribers or exporters. They may emit
+`tracing` spans/events and may construct typed `ObservedEvent`s for stable
+framework events.
+
+The final application binary or wasm entrypoint installs logging and analytics:
+
+```rust
+#[cfg(not(target_arch = "wasm32"))]
+pocopine::logging::init_server_logging(
+    pocopine::logging::ServerLoggingConfig::json(),
+)?;
+```
+
+```rust
+let analytics = pocopine::analytics::AnalyticsClient::new()
+    .with_sink(my_vendor_sink);
+
+analytics.emit(
+    pocopine::analytics::route_view("/settings")
+);
+```
+
+### 3.3 Vendor adapters
+
+Vendor SDKs are adapters, not framework contracts.
+
+- Firebase/Google Analytics are browser adapters that receive caller-provided
+  JS functions/SDK handles.
+- Cloudflare Workers can consume structured console logs through
+  `pocopine-logging`; Analytics Engine-style writes should be a
+  `pocopine-analytics` sink.
+- AWS logging belongs in `pocopine-logging` as a batched host-side log sink.
+- OpenTelemetry belongs in `pocopine-analytics`/telemetry as an adapter from
+  `tracing` spans/events, not as the core event model.
+
+This keeps vendor APIs out of `pocopine-core` and out of
+`pocopine-observe`.
+
+## 4. Reliability Rules
+
+- Telemetry/exporter failure must not fail app behavior.
+- Analytics fan-out continues after a sink returns an error.
+- Sink panics are caught and reported as analytics delivery failures.
+- Export queues must be bounded when asynchronous exporters are added.
+- Overflow should drop low-priority analytics before operational errors.
+- Exporters must expose dropped-event and export-error counters once metrics
+  sinks land.
+- Libraries do not install global subscribers.
+
+## 5. Privacy Rules
+
+The default posture is allowlist-based.
+
+- `public` fields may be exported everywhere.
+- `pseudonymous` fields require an explicit policy.
+- `sensitive` fields are removed unless the application explicitly opts into
+  them for a trusted sink.
+- Analytics sinks receive redacted events, not raw debug fields.
+- Route params, auth headers, cookies, raw model payloads, DOM text, and user
+  identifiers are not public fields.
+
+## 6. Non-goals
+
+- No default network exporter in the first slice.
+- No direct Firebase, AWS, Cloudflare, or OpenTelemetry dependency in
+  `pocopine-core`.
+- No automatic scraping of arbitrary `tracing` fields into analytics.
+- No consent-management UI in this RFC.
+- No guarantee that all future exporters are synchronous.
+
+## 7. Initial Implementation
+
+Phase 1 creates the three crates, workspace wiring, umbrella crate optional
+features, redaction tests, analytics fan-out tests, server logging setup, and
+wasm logging/analytics adapter compile checks.
+
+Later phases should add:
+
+- first-class route/server-function/job instrumentation points;
+- OpenTelemetry adapter;
+- AWS/Cloudflare host sinks;
+- bounded async exporter queues;
+- metrics for drops and exporter failures;
+- devtools panel integration on top of the same event stream.


### PR DESCRIPTION
## Summary

- add `pocopine-observe` as the shared event contract for logging, tracing, metrics, and analytics
- add `pocopine-logging` with server `tracing-subscriber` setup and wasm browser console logging
- add `pocopine-analytics` with redacted sink fan-out, panic/error isolation, host `Send + Sync` sinks, and wasm JS/Firebase/Google Analytics adapters
- expose optional `observe`, `logging`, and `analytics` features from the umbrella `pocopine` crate
- route backend/server/worker logs in the examples, `pocopine-server`, and `pocopine-jobs` through `tracing`/`pocopine-logging`
- document the design in RFC 069 and add a user-facing logging/tracing/observability guide

## Verification

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p pocopine-analytics -p pocopine-observe`
- `cargo test -p pocopine-logging`
- `cargo test -p pocopine-jobs -p pocopine-server -p pocopine-logging`
- `cargo check -p pocopine-analytics --target wasm32-unknown-unknown`
- `cargo check -p pocopine-logging --target wasm32-unknown-unknown`
- `cargo check -p blog --target wasm32-unknown-unknown`
- `cargo check -p site --target wasm32-unknown-unknown`
- `cargo check -p pocopine-server -p pocopine-jobs -p blog -p site -p hn`
- `cargo check -p pocopine-observe -p pocopine-analytics -p pocopine-logging -p pocopine --features pocopine/logging,pocopine/analytics`
- `cargo check --workspace --all-targets`
