### PR TITLE
Instrument server functions and jobs

### DIFF
--- a/crates/pocopine-jobs/src/lib.rs
+++ b/crates/pocopine-jobs/src/lib.rs
@@ -79,7 +79,7 @@ mod host {
     use std::str::FromStr;
     use std::sync::atomic::{AtomicU64, Ordering};
     use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
-    use std::time::{Duration, SystemTime, UNIX_EPOCH};
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     use chrono::{Duration as ChronoDuration, Utc};
     use cron::Schedule;
@@ -977,6 +977,7 @@ return redis.call(
                             &id.id,
                             &envelope,
                             "job reclaimed after max attempts",
+                            None,
                         )
                         .await?;
                         continue;
@@ -1039,14 +1040,19 @@ return redis.call(
             envelope: JobEnvelope,
         ) -> JobResult<()> {
             let Some(descriptor) = self.descriptors.get(envelope.job_name.as_str()) else {
-                self.move_to_dead_and_ack(conn, stream, stream_id, &envelope, "unknown job")
+                self.move_to_dead_and_ack(conn, stream, stream_id, &envelope, "unknown job", None)
                     .await?;
                 return Ok(());
             };
 
+            let started = Instant::now();
+            log_job_started(&envelope, "redis");
             let payload = serde_json::to_vec(&envelope.payload)?;
             match run_handler_safely(descriptor.handler, payload).await {
-                Ok(()) => self.ack(conn, stream, stream_id).await,
+                Ok(()) => {
+                    log_job_completed(&envelope, "redis", elapsed_ms(started));
+                    self.ack(conn, stream, stream_id).await
+                }
                 Err(err) => {
                     if envelope.attempt < envelope.max_attempts {
                         let mut retry = envelope.clone();
@@ -1065,6 +1071,14 @@ return redis.call(
                             due_ms,
                         )
                         .await?;
+                        log_job_retry_scheduled(
+                            &envelope,
+                            &retry,
+                            due_ms,
+                            "redis",
+                            elapsed_ms(started),
+                            &err,
+                        );
                     } else {
                         self.move_to_dead_and_ack(
                             conn,
@@ -1072,6 +1086,7 @@ return redis.call(
                             stream_id,
                             &envelope,
                             &err.to_string(),
+                            Some(elapsed_ms(started)),
                         )
                         .await?;
                     }
@@ -1082,13 +1097,18 @@ return redis.call(
 
         async fn run_envelope_memory(&self, envelope: JobEnvelope) -> JobResult<()> {
             let Some(descriptor) = self.descriptors.get(envelope.job_name.as_str()) else {
-                self.move_to_dead_memory(envelope, "unknown job")?;
+                self.move_to_dead_memory(envelope, "unknown job", None)?;
                 return Ok(());
             };
 
+            let started = Instant::now();
+            log_job_started(&envelope, "memory");
             let payload = serde_json::to_vec(&envelope.payload)?;
             match run_handler_safely(descriptor.handler, payload).await {
-                Ok(()) => Ok(()),
+                Ok(()) => {
+                    log_job_completed(&envelope, "memory", elapsed_ms(started));
+                    Ok(())
+                }
                 Err(err) => {
                     if envelope.attempt < envelope.max_attempts {
                         let mut retry = envelope.clone();
@@ -1097,18 +1117,37 @@ return redis.call(
                             .saturating_add(retry_delay_ms(retry.attempt, &retry.job_id));
                         retry.scheduled_for_ms = Some(due_ms);
                         let store = self.client.cached_memory_store()?;
-                        memory_schedule_envelope(&store, retry)?;
+                        memory_schedule_envelope(&store, retry.clone())?;
+                        log_job_retry_scheduled(
+                            &envelope,
+                            &retry,
+                            due_ms,
+                            "memory",
+                            elapsed_ms(started),
+                            &err,
+                        );
                     } else {
-                        self.move_to_dead_memory(envelope, &err.to_string())?;
+                        self.move_to_dead_memory(
+                            envelope,
+                            &err.to_string(),
+                            Some(elapsed_ms(started)),
+                        )?;
                     }
                     Ok(())
                 }
             }
         }
 
-        fn move_to_dead_memory(&self, envelope: JobEnvelope, error: &str) -> JobResult<()> {
+        fn move_to_dead_memory(
+            &self,
+            envelope: JobEnvelope,
+            error: &str,
+            duration_ms: Option<u64>,
+        ) -> JobResult<()> {
             let store = self.client.cached_memory_store()?;
-            memory_move_to_dead(&store, envelope, error)
+            memory_move_to_dead(&store, envelope.clone(), error)?;
+            log_job_dead_lettered(&envelope, "memory", error, duration_ms);
+            Ok(())
         }
 
         async fn move_to_dead_and_ack(
@@ -1118,6 +1157,7 @@ return redis.call(
             stream_id: &str,
             envelope: &JobEnvelope,
             error: &str,
+            duration_ms: Option<u64>,
         ) -> JobResult<()> {
             dead_letter_and_ack(
                 conn,
@@ -1128,7 +1168,9 @@ return redis.call(
                 envelope,
                 error,
             )
-            .await
+            .await?;
+            log_job_dead_lettered(envelope, "redis", error, duration_ms);
+            Ok(())
         }
 
         async fn ack(
@@ -1144,6 +1186,94 @@ return redis.call(
                 .query_async(conn)
                 .await?;
             Ok(())
+        }
+    }
+
+    fn elapsed_ms(started: Instant) -> u64 {
+        started.elapsed().as_millis().min(u128::from(u64::MAX)) as u64
+    }
+
+    fn log_job_started(envelope: &JobEnvelope, backend: &'static str) {
+        tracing::info!(
+            target: "pocopine.trace",
+            backend = backend,
+            job_id = %envelope.job_id,
+            job_name = %envelope.job_name,
+            queue = %envelope.queue,
+            attempt = envelope.attempt,
+            max_attempts = envelope.max_attempts,
+            "job started"
+        );
+    }
+
+    fn log_job_completed(envelope: &JobEnvelope, backend: &'static str, duration_ms: u64) {
+        tracing::info!(
+            target: "pocopine.trace",
+            backend = backend,
+            job_id = %envelope.job_id,
+            job_name = %envelope.job_name,
+            queue = %envelope.queue,
+            attempt = envelope.attempt,
+            max_attempts = envelope.max_attempts,
+            duration_ms = duration_ms,
+            "job completed"
+        );
+    }
+
+    fn log_job_retry_scheduled(
+        envelope: &JobEnvelope,
+        retry: &JobEnvelope,
+        due_ms: u64,
+        backend: &'static str,
+        duration_ms: u64,
+        error: &JobError,
+    ) {
+        tracing::warn!(
+            target: "pocopine.log",
+            backend = backend,
+            job_id = %envelope.job_id,
+            job_name = %envelope.job_name,
+            queue = %envelope.queue,
+            attempt = envelope.attempt,
+            next_attempt = retry.attempt,
+            max_attempts = envelope.max_attempts,
+            due_ms = due_ms,
+            duration_ms = duration_ms,
+            error = %error,
+            "job retry scheduled"
+        );
+    }
+
+    fn log_job_dead_lettered(
+        envelope: &JobEnvelope,
+        backend: &'static str,
+        error: &str,
+        duration_ms: Option<u64>,
+    ) {
+        match duration_ms {
+            Some(duration_ms) => tracing::warn!(
+                target: "pocopine.log",
+                backend = backend,
+                job_id = %envelope.job_id,
+                job_name = %envelope.job_name,
+                queue = %envelope.queue,
+                attempt = envelope.attempt,
+                max_attempts = envelope.max_attempts,
+                duration_ms = duration_ms,
+                error = error,
+                "job moved to dead letter"
+            ),
+            None => tracing::warn!(
+                target: "pocopine.log",
+                backend = backend,
+                job_id = %envelope.job_id,
+                job_name = %envelope.job_name,
+                queue = %envelope.queue,
+                attempt = envelope.attempt,
+                max_attempts = envelope.max_attempts,
+                error = error,
+                "job moved to dead letter"
+            ),
         }
     }
 

--- a/crates/pocopine-logging/src/lib.rs
+++ b/crates/pocopine-logging/src/lib.rs
@@ -85,6 +85,11 @@ mod server {
 
     impl std::error::Error for InitLoggingError {}
 
+    /// Install compact server logging with the default `RUST_LOG` handling.
+    pub fn init_default() -> Result<(), InitLoggingError> {
+        init_server_logging(ServerLoggingConfig::compact())
+    }
+
     pub fn init_server_logging(config: ServerLoggingConfig) -> Result<(), InitLoggingError> {
         let filter = build_filter(config.env_filter)?;
         match config.format {
@@ -128,7 +133,9 @@ mod server {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use server::{init_server_logging, InitLoggingError, LogFormat, ServerLoggingConfig};
+pub use server::{
+    init_default, init_server_logging, InitLoggingError, LogFormat, ServerLoggingConfig,
+};
 
 #[cfg(target_arch = "wasm32")]
 mod web {

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -3196,9 +3196,27 @@ pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
                 parts.extensions,
             );
             if let Err(err) = #guard_path(ctx).await {
-                let result = ::core::result::Result::Err(
-                    ::core::convert::Into::into(err),
+                let __pocopine_error: ::pocopine::ServerError =
+                    ::core::convert::Into::into(err);
+                let __pocopine_duration_ms =
+                    __pocopine_started.elapsed().as_millis() as u64;
+                let __pocopine_error_kind = match &__pocopine_error {
+                    ::pocopine::ServerError::App(_) => "app",
+                    ::pocopine::ServerError::Unauthorized(_) => "unauthorized",
+                    ::pocopine::ServerError::Forbidden(_) => "forbidden",
+                    ::pocopine::ServerError::BadRequest(_) => "bad_request",
+                    ::pocopine::ServerError::Network(_) => "network",
+                };
+                ::pocopine_server::tracing::warn!(
+                    target: "pocopine.log",
+                    function = #fn_name_str,
+                    route = #route_path,
+                    duration_ms = __pocopine_duration_ms,
+                    error_kind = __pocopine_error_kind,
+                    error = %__pocopine_error,
+                    "server function guard rejected request"
                 );
+                let result = ::core::result::Result::Err(__pocopine_error);
                 return ::pocopine_server::axum::Json(result);
             }
         },
@@ -3211,37 +3229,104 @@ pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
     let route_handler = quote! {
         ::pocopine_server::axum::routing::post(
             |request: ::pocopine_server::axum::extract::Request| async move {
-                #parts_binding
-                #guard_prologue
-                let body_limit = ::pocopine_server::server_function_body_limit();
-                let body_bytes = match ::pocopine_server::axum::body::to_bytes(
-                    body,
-                    body_limit,
-                ).await {
-                    Ok(bytes) => bytes,
-                    Err(err) => {
-                        let result = ::core::result::Result::Err(
-                            ::pocopine::ServerError::BadRequest(
-                                format!("read server-function request body: {err}"),
-                            ),
-                        );
-                        return ::pocopine_server::axum::Json(result);
-                    }
-                };
-                let #destructure: #args_tuple_type =
-                    match ::pocopine_server::serde_json::from_slice(&body_bytes) {
-                        Ok(args) => args,
+                use ::pocopine_server::tracing::Instrument as _;
+
+                async move {
+                    let __pocopine_started = ::std::time::Instant::now();
+                    #parts_binding
+                    #guard_prologue
+                    let body_limit = ::pocopine_server::server_function_body_limit();
+                    let body_bytes = match ::pocopine_server::axum::body::to_bytes(
+                        body,
+                        body_limit,
+                    ).await {
+                        Ok(bytes) => bytes,
                         Err(err) => {
-                            let result = ::core::result::Result::Err(
-                                ::pocopine::ServerError::BadRequest(
-                                    format!("parse server-function request body: {err}"),
-                                ),
+                            let __pocopine_error = ::pocopine::ServerError::BadRequest(
+                                format!("read server-function request body: {err}"),
                             );
+                            let __pocopine_duration_ms =
+                                __pocopine_started.elapsed().as_millis() as u64;
+                            ::pocopine_server::tracing::warn!(
+                                target: "pocopine.log",
+                                function = #fn_name_str,
+                                route = #route_path,
+                                duration_ms = __pocopine_duration_ms,
+                                error_kind = "bad_request",
+                                error = %__pocopine_error,
+                                "server function request body read failed"
+                            );
+                            let result = ::core::result::Result::Err(__pocopine_error);
                             return ::pocopine_server::axum::Json(result);
                         }
                     };
-                let result = #fn_ident( #(#arg_idents),* ).await;
-                ::pocopine_server::axum::Json(result)
+                    let __pocopine_body_bytes = body_bytes.len() as u64;
+                    let #destructure: #args_tuple_type =
+                        match ::pocopine_server::serde_json::from_slice(&body_bytes) {
+                            Ok(args) => args,
+                            Err(err) => {
+                                let __pocopine_error = ::pocopine::ServerError::BadRequest(
+                                    format!("parse server-function request body: {err}"),
+                                );
+                                let __pocopine_duration_ms =
+                                    __pocopine_started.elapsed().as_millis() as u64;
+                                ::pocopine_server::tracing::warn!(
+                                    target: "pocopine.log",
+                                    function = #fn_name_str,
+                                    route = #route_path,
+                                    duration_ms = __pocopine_duration_ms,
+                                    body_bytes = __pocopine_body_bytes,
+                                    error_kind = "bad_request",
+                                    error = %__pocopine_error,
+                                    "server function request body parse failed"
+                                );
+                                let result = ::core::result::Result::Err(__pocopine_error);
+                                return ::pocopine_server::axum::Json(result);
+                            }
+                        };
+                    let result = #fn_ident( #(#arg_idents),* ).await;
+                    let __pocopine_duration_ms =
+                        __pocopine_started.elapsed().as_millis() as u64;
+                    match &result {
+                        ::core::result::Result::Ok(_) => {
+                            ::pocopine_server::tracing::info!(
+                                target: "pocopine.trace",
+                                function = #fn_name_str,
+                                route = #route_path,
+                                duration_ms = __pocopine_duration_ms,
+                                body_bytes = __pocopine_body_bytes,
+                                "server function completed"
+                            );
+                        }
+                        ::core::result::Result::Err(err) => {
+                            let __pocopine_error_kind = match err {
+                                ::pocopine::ServerError::App(_) => "app",
+                                ::pocopine::ServerError::Unauthorized(_) => "unauthorized",
+                                ::pocopine::ServerError::Forbidden(_) => "forbidden",
+                                ::pocopine::ServerError::BadRequest(_) => "bad_request",
+                                ::pocopine::ServerError::Network(_) => "network",
+                            };
+                            ::pocopine_server::tracing::warn!(
+                                target: "pocopine.log",
+                                function = #fn_name_str,
+                                route = #route_path,
+                                duration_ms = __pocopine_duration_ms,
+                                body_bytes = __pocopine_body_bytes,
+                                error_kind = __pocopine_error_kind,
+                                error = %err,
+                                "server function failed"
+                            );
+                        }
+                    }
+                    ::pocopine_server::axum::Json(result)
+                }
+                .instrument(::pocopine_server::tracing::info_span!(
+                    target: "pocopine.trace",
+                    "pocopine.server_function",
+                    function = #fn_name_str,
+                    route = #route_path,
+                ))
+                .await
             },
         )
     };

--- a/crates/pocopine-server/src/lib.rs
+++ b/crates/pocopine-server/src/lib.rs
@@ -25,6 +25,7 @@ pub use serde_json;
 pub use tokio;
 pub use tower;
 pub use tower_http;
+pub use tracing;
 
 use std::net::SocketAddr;
 use std::sync::OnceLock;

--- a/docs/logging-tracing-observer.md
+++ b/docs/logging-tracing-observer.md
@@ -144,7 +144,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 For human-readable development logs:
 
 ```rust
-init_server_logging(ServerLoggingConfig::compact())?;
+pocopine::logging::init_default()?;
 ```
 
 For structured production logs:

--- a/examples/blog/src/bin/server.rs
+++ b/examples/blog/src/bin/server.rs
@@ -9,10 +9,10 @@
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
     use blog::__get_post_route;
-    use pocopine_logging::{init_server_logging, ServerLoggingConfig};
+    use pocopine_logging::init_default;
     use pocopine_server::{axum::Router, serve, static_files};
 
-    init_server_logging(ServerLoggingConfig::compact()).map_err(std::io::Error::other)?;
+    init_default().map_err(std::io::Error::other)?;
 
     // Anchor static files to the crate root, so the server works
     // regardless of the shell's CWD (including when spawned by

--- a/examples/blog/src/bin/worker.rs
+++ b/examples/blog/src/bin/worker.rs
@@ -4,10 +4,9 @@
 #[tokio::main]
 async fn main() -> pocopine::JobResult<()> {
     use blog as _;
-    use pocopine_logging::{init_server_logging, ServerLoggingConfig};
+    use pocopine_logging::init_default;
 
-    init_server_logging(ServerLoggingConfig::compact())
-        .map_err(|err| pocopine::JobError::Env(err.to_string()))?;
+    init_default().map_err(|err| pocopine::JobError::Env(err.to_string()))?;
     tracing::info!(
         target: "pocopine.log",
         "running blog worker (POCOPINE_JOB_BACKEND or POCOPINE_REDIS_URL)"

--- a/examples/hn/src/bin/server.rs
+++ b/examples/hn/src/bin/server.rs
@@ -6,10 +6,10 @@
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
     use hn::{__get_item_tree_route, __search_stories_route};
-    use pocopine_logging::{init_server_logging, ServerLoggingConfig};
+    use pocopine_logging::init_default;
     use pocopine_server::{axum::Router, serve, static_files, tower_http::services::ServeFile};
 
-    init_server_logging(ServerLoggingConfig::compact()).map_err(std::io::Error::other)?;
+    init_default().map_err(std::io::Error::other)?;
 
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let index_path = format!("{manifest_dir}/index.html");

--- a/examples/site/src/bin/server.rs
+++ b/examples/site/src/bin/server.rs
@@ -8,11 +8,11 @@
 #[cfg(not(target_arch = "wasm32"))]
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
-    use pocopine_logging::{init_server_logging, ServerLoggingConfig};
+    use pocopine_logging::init_default;
     use pocopine_server::{axum::Router, serve, static_files, tower_http::services::ServeFile};
     use site::__submit_contact_route;
 
-    init_server_logging(ServerLoggingConfig::compact()).map_err(std::io::Error::other)?;
+    init_default().map_err(std::io::Error::other)?;
 
     // Anchor to the crate root so the binary works regardless of CWD.
     let manifest_dir = env!("CARGO_MANIFEST_DIR");

--- a/examples/site/src/lib.rs
+++ b/examples/site/src/lib.rs
@@ -28,6 +28,7 @@ use shared::{ContactMessage, ContactResponse};
 
 #[pocopine::server(public)]
 pub async fn submit_contact(msg: ContactMessage) -> ServerResult<ContactResponse> {
+    // Contact fields may contain personal data; keep raw payloads out of logs.
     tracing::info!(
         target: "pocopine.log",
         message_len = msg.message.len(),


### PR DESCRIPTION
## Summary
- add privacy-safe tracing events around generated #[server] routes
- emit job lifecycle events for start, success, retry, and dead-letter paths across Redis and memory backends
- re-export tracing from pocopine-server so macro output can instrument host routes without requiring app crates to depend on tracing directly

## Verification
- cargo check --workspace --all-targets
- cargo test -p pocopine --test server_auth --test job_macro
- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- git diff --check