### PR TITLE
Assert host observability events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2729,6 +2729,8 @@ dependencies = [
  "testcontainers-modules",
  "tokio",
  "tower",
+ "tracing",
+ "tracing-subscriber",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",

--- a/crates/pocopine/Cargo.toml
+++ b/crates/pocopine/Cargo.toml
@@ -41,6 +41,8 @@ pocopine-server = { path = "../pocopine-server" }
 serde_json = "1"
 tokio = { version = "1", features = ["macros", "rt", "time"] }
 tower = { version = "0.5", features = ["util"] }
+tracing = { workspace = true }
+tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
 wasm-bindgen-test = "0.3"
 web-sys = { version = "0.3", features = [
     "CustomEvent",

--- a/crates/pocopine/tests/job_macro.rs
+++ b/crates/pocopine/tests/job_macro.rs
@@ -3,11 +3,14 @@
 // `<fn>_job` modules don't exist. Skip the whole file under wasm.
 #![cfg(not(target_arch = "wasm32"))]
 
+mod support;
+
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use pocopine::JobResult;
 use serde::{Deserialize, Serialize};
+use support::TraceCapture;
 
 static MEMORY_APP_COUNTER: AtomicUsize = AtomicUsize::new(1);
 static MEMORY_JOB_RUNS: AtomicUsize = AtomicUsize::new(0);
@@ -27,6 +30,12 @@ async fn macro_registered_job(input: JobPayload) -> JobResult<()> {
 async fn memory_backend_job(input: JobPayload) -> JobResult<()> {
     assert_eq!(input.value, "memory");
     MEMORY_JOB_RUNS.fetch_add(1, Ordering::SeqCst);
+    Ok(())
+}
+
+#[pocopine::job(queue = "trace", retries = 0)]
+async fn traced_memory_job(input: JobPayload) -> JobResult<()> {
+    assert_eq!(input.value, "trace-payload");
     Ok(())
 }
 
@@ -154,53 +163,149 @@ fn memory_backend_routes_handler_panic_through_dead_letter() {
         .enable_all()
         .build()
         .unwrap();
+    let capture = TraceCapture::new();
 
-    rt.block_on(async {
-        let app = format!(
-            "job-macro-panic-{}-{}",
-            std::process::id(),
-            MEMORY_APP_COUNTER.fetch_add(1, Ordering::SeqCst)
-        );
-        let client = pocopine::JobClient::memory(app.clone());
-        panicking_memory_job_job::enqueue_with(
-            &client,
-            JobPayload {
-                value: "panic".into(),
-            },
-        )
-        .await
-        .unwrap();
+    capture.run(|| {
+        rt.block_on(async {
+            let app = format!(
+                "job-macro-panic-{}-{}",
+                std::process::id(),
+                MEMORY_APP_COUNTER.fetch_add(1, Ordering::SeqCst)
+            );
+            let client = pocopine::JobClient::memory(app.clone());
+            panicking_memory_job_job::enqueue_with(
+                &client,
+                JobPayload {
+                    value: "panic".into(),
+                },
+            )
+            .await
+            .unwrap();
 
-        let worker = pocopine::Worker::new(pocopine::WorkerConfig {
-            backend: pocopine::JobBackend::Memory,
-            app,
-            queues: vec!["panic".to_string()],
-            group: "test".to_string(),
-            consumer: "test".to_string(),
-            block_ms: 0,
-            visibility_timeout: Duration::from_secs(60),
-            scheduler_interval: Duration::from_millis(1),
-            max_periodic_catch_up: 16,
-            batch_size: 10,
-        })
-        .unwrap();
+            let worker = pocopine::Worker::new(pocopine::WorkerConfig {
+                backend: pocopine::JobBackend::Memory,
+                app,
+                queues: vec!["panic".to_string()],
+                group: "test".to_string(),
+                consumer: "test".to_string(),
+                block_ms: 0,
+                visibility_timeout: Duration::from_secs(60),
+                scheduler_interval: Duration::from_millis(1),
+                max_periodic_catch_up: 16,
+                batch_size: 10,
+            })
+            .unwrap();
 
-        // retries = 0 → max_attempts = 1, so a panic on the first attempt
-        // dead-letters immediately. The worker must NOT propagate the
-        // panic; if catch-unwind were broken, the spawned task would
-        // unwind through `run_once` and crash this test.
-        assert_eq!(worker.run_once().await.unwrap(), 1);
-        let dead = worker.drain_dead_letter().unwrap();
-        assert_eq!(dead.len(), 1);
-        assert!(
-            dead[0].error.contains("panic"),
-            "expected panic message, got `{}`",
-            dead[0].error
-        );
-        assert_eq!(dead[0].attempt, 1);
-        assert_eq!(dead[0].max_attempts, 1);
+            // retries = 0 → max_attempts = 1, so a panic on the first attempt
+            // dead-letters immediately. The worker must NOT propagate the
+            // panic; if catch-unwind were broken, the spawned task would
+            // unwind through `run_once` and crash this test.
+            assert_eq!(worker.run_once().await.unwrap(), 1);
+            let dead = worker.drain_dead_letter().unwrap();
+            assert_eq!(dead.len(), 1);
+            assert!(
+                dead[0].error.contains("panic"),
+                "expected panic message, got `{}`",
+                dead[0].error
+            );
+            assert_eq!(dead[0].attempt, 1);
+            assert_eq!(dead[0].max_attempts, 1);
 
-        // Drain is single-shot.
-        assert!(worker.drain_dead_letter().unwrap().is_empty());
+            // Drain is single-shot.
+            assert!(worker.drain_dead_letter().unwrap().is_empty());
+        });
     });
+
+    let events = capture.events_with_message("pocopine.log", "job moved to dead letter");
+    let event = events
+        .iter()
+        .find(|event| event.field("queue") == Some("panic"))
+        .expect("dead-letter event should be captured");
+    assert_eq!(event.field("backend"), Some("memory"));
+    assert_eq!(event.field("attempt"), Some("1"));
+    assert_eq!(event.field("max_attempts"), Some("1"));
+    assert!(
+        event
+            .field("error")
+            .is_some_and(|value| value.contains("panic")),
+        "dead-letter event should include the terminal error class"
+    );
+}
+
+#[test]
+fn memory_backend_emits_job_lifecycle_trace_without_payload() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let capture = TraceCapture::new();
+
+    capture.run(|| {
+        rt.block_on(async {
+            let app = format!(
+                "job-macro-trace-{}-{}",
+                std::process::id(),
+                MEMORY_APP_COUNTER.fetch_add(1, Ordering::SeqCst)
+            );
+            let client = pocopine::JobClient::memory(app.clone());
+            traced_memory_job_job::enqueue_with(
+                &client,
+                JobPayload {
+                    value: "trace-payload".into(),
+                },
+            )
+            .await
+            .unwrap();
+
+            let worker = pocopine::Worker::new(pocopine::WorkerConfig {
+                backend: pocopine::JobBackend::Memory,
+                app,
+                queues: vec!["trace".to_string()],
+                group: "test".to_string(),
+                consumer: "test".to_string(),
+                block_ms: 0,
+                visibility_timeout: Duration::from_secs(60),
+                scheduler_interval: Duration::from_millis(1),
+                max_periodic_catch_up: 16,
+                batch_size: 10,
+            })
+            .unwrap();
+
+            assert_eq!(worker.run_once().await.unwrap(), 1);
+        });
+    });
+
+    let started = capture.events_with_message("pocopine.trace", "job started");
+    let started = started
+        .iter()
+        .find(|event| event.field("queue") == Some("trace"))
+        .expect("job-start event should be captured");
+    assert_eq!(started.field("backend"), Some("memory"));
+    assert!(started
+        .field("job_name")
+        .is_some_and(|value| value.ends_with("::traced_memory_job")));
+    assert_eq!(started.field("attempt"), Some("1"));
+    assert_eq!(started.field("max_attempts"), Some("1"));
+
+    let completed = capture.events_with_message("pocopine.trace", "job completed");
+    let completed = completed
+        .iter()
+        .find(|event| event.field("queue") == Some("trace"))
+        .expect("job-completed event should be captured");
+    assert_eq!(completed.field("backend"), Some("memory"));
+    assert!(
+        completed
+            .field("duration_ms")
+            .and_then(|value| value.parse::<u64>().ok())
+            .is_some(),
+        "duration_ms should be a numeric tracing field"
+    );
+    assert!(
+        started
+            .fields
+            .values()
+            .chain(completed.fields.values())
+            .all(|value| !value.contains("trace-payload")),
+        "job lifecycle logs must not include raw payloads"
+    );
 }

--- a/crates/pocopine/tests/server_auth.rs
+++ b/crates/pocopine/tests/server_auth.rs
@@ -5,12 +5,15 @@
 // wasm.
 #![cfg(not(target_arch = "wasm32"))]
 
+mod support;
+
 use pocopine::{AuthUser, Role, ServerError, ServerResult};
 use pocopine_server::axum::{
     body::{to_bytes, Body},
     http::{Extensions, HeaderMap, Method, Request, Uri},
 };
 use pocopine_server::tower::ServiceExt;
+use support::TraceCapture;
 
 async fn require_token(ctx: pocopine_server::auth::RequestContext) -> ServerResult<()> {
     match ctx.bearer_token() {
@@ -97,23 +100,73 @@ fn oversized_body_returns_bad_request() {
         .unwrap();
 
     rt.block_on(async {
-        std::env::set_var("POCOPINE_SERVER_FUNCTION_BODY_LIMIT", "1");
         let router = __public_echo_route(pocopine_server::axum::Router::new());
+        let oversized_body = vec![b'a'; pocopine_server::DEFAULT_SERVER_FUNCTION_BODY_LIMIT + 1];
         let response = router
             .oneshot(
                 Request::builder()
                     .method(Method::POST)
                     .uri("/_pocopine/public_echo")
                     .header("content-type", "application/json")
-                    .body(Body::from("[\"too large\"]"))
+                    .body(Body::from(oversized_body))
                     .unwrap(),
             )
             .await
             .unwrap();
-        std::env::remove_var("POCOPINE_SERVER_FUNCTION_BODY_LIMIT");
 
         let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let result: ServerResult<String> = serde_json::from_slice(&bytes).unwrap();
         assert!(matches!(result, Err(ServerError::BadRequest(_))));
     });
+}
+
+#[test]
+fn server_function_route_emits_trace_without_payload() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let capture = TraceCapture::new();
+
+    let result = capture.run(|| {
+        rt.block_on(async {
+            let router = __public_echo_route(pocopine_server::axum::Router::new());
+            let response = router
+                .oneshot(
+                    Request::builder()
+                        .method(Method::POST)
+                        .uri("/_pocopine/public_echo")
+                        .header("content-type", "application/json")
+                        .body(Body::from("[\"hello\"]"))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+            serde_json::from_slice::<ServerResult<String>>(&bytes).unwrap()
+        })
+    });
+
+    assert_eq!(result.unwrap(), "hello");
+
+    let events = capture.events_with_message("pocopine.trace", "server function completed");
+    let event = events
+        .iter()
+        .find(|event| event.field("route") == Some("/_pocopine/public_echo"))
+        .expect("server function completion event should be captured");
+
+    assert_eq!(event.field("function"), Some("public_echo"));
+    assert_eq!(event.field("body_bytes"), Some("9"));
+    assert!(
+        event
+            .field("duration_ms")
+            .and_then(|value| value.parse::<u64>().ok())
+            .is_some(),
+        "duration_ms should be a numeric tracing field"
+    );
+    assert!(
+        event.fields.values().all(|value| !value.contains("hello")),
+        "server-function logs must not include raw request payloads"
+    );
 }

--- a/crates/pocopine/tests/support.rs
+++ b/crates/pocopine/tests/support.rs
@@ -38,6 +38,8 @@ impl TraceCapture {
     }
 
     pub fn events_with_message(&self, target: &str, message: &str) -> Vec<CapturedEvent> {
+        // Message text is part of these observability contract assertions;
+        // rename emitted messages only as a deliberate telemetry change.
         self.events
             .lock()
             .expect("trace capture lock poisoned")

--- a/crates/pocopine/tests/support.rs
+++ b/crates/pocopine/tests/support.rs
@@ -1,0 +1,103 @@
+use std::collections::BTreeMap;
+use std::fmt;
+use std::sync::{Arc, Mutex};
+
+use tracing::field::{Field, Visit};
+use tracing::{Event, Subscriber};
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::Layer;
+
+#[derive(Clone, Debug)]
+pub struct CapturedEvent {
+    pub target: String,
+    pub fields: BTreeMap<String, String>,
+}
+
+impl CapturedEvent {
+    pub fn field(&self, name: &str) -> Option<&str> {
+        self.fields.get(name).map(String::as_str)
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct TraceCapture {
+    events: Arc<Mutex<Vec<CapturedEvent>>>,
+}
+
+impl TraceCapture {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn run<T>(&self, f: impl FnOnce() -> T) -> T {
+        let subscriber = tracing_subscriber::registry().with(CaptureLayer {
+            events: Arc::clone(&self.events),
+        });
+        tracing::subscriber::with_default(subscriber, f)
+    }
+
+    pub fn events_with_message(&self, target: &str, message: &str) -> Vec<CapturedEvent> {
+        self.events
+            .lock()
+            .expect("trace capture lock poisoned")
+            .iter()
+            .filter(|event| event.target == target && event.field("message") == Some(message))
+            .cloned()
+            .collect()
+    }
+}
+
+struct CaptureLayer {
+    events: Arc<Mutex<Vec<CapturedEvent>>>,
+}
+
+impl<S> Layer<S> for CaptureLayer
+where
+    S: Subscriber,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let mut visitor = FieldVisitor::default();
+        event.record(&mut visitor);
+        self.events
+            .lock()
+            .expect("trace capture lock poisoned")
+            .push(CapturedEvent {
+                target: event.metadata().target().to_owned(),
+                fields: visitor.fields,
+            });
+    }
+}
+
+#[derive(Default)]
+struct FieldVisitor {
+    fields: BTreeMap<String, String>,
+}
+
+impl FieldVisitor {
+    fn insert(&mut self, field: &Field, value: impl Into<String>) {
+        self.fields.insert(field.name().to_owned(), value.into());
+    }
+}
+
+impl Visit for FieldVisitor {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.insert(field, value);
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.insert(field, value.to_string());
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.insert(field, value.to_string());
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.insert(field, value.to_string());
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        self.insert(field, format!("{value:?}"));
+    }
+}


### PR DESCRIPTION
## Summary
- add an integration-test tracing capture layer for host tests
- assert generated server-function routes emit the expected pocopine.trace fields without raw request payloads
- assert memory job workers emit lifecycle and dead-letter events without raw job payloads
- remove the process-global env race from the oversized server body test by exceeding the default body limit directly

## Verification
- cargo test -p pocopine --test server_auth --test job_macro
- cargo check --workspace --all-targets
- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- git diff --check