### PR TITLE
Assert observability error paths

### DIFF
--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -3277,7 +3277,7 @@ pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
                                     duration_ms = __pocopine_duration_ms,
                                     body_bytes = __pocopine_body_bytes,
                                     error_kind = "bad_request",
-                                    error = %__pocopine_error,
+                                    error = "request body parse failed",
                                     "server function request body parse failed"
                                 );
                                 let result = ::core::result::Result::Err(__pocopine_error);

--- a/crates/pocopine/tests/job_macro.rs
+++ b/crates/pocopine/tests/job_macro.rs
@@ -14,6 +14,7 @@ use support::TraceCapture;
 
 static MEMORY_APP_COUNTER: AtomicUsize = AtomicUsize::new(1);
 static MEMORY_JOB_RUNS: AtomicUsize = AtomicUsize::new(0);
+static RETRY_JOB_RUNS: AtomicUsize = AtomicUsize::new(0);
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct JobPayload {
@@ -37,6 +38,13 @@ async fn memory_backend_job(input: JobPayload) -> JobResult<()> {
 async fn traced_memory_job(input: JobPayload) -> JobResult<()> {
     assert_eq!(input.value, "trace-payload");
     Ok(())
+}
+
+#[pocopine::job(queue = "retry", retries = 1)]
+async fn retrying_memory_job(input: JobPayload) -> JobResult<()> {
+    assert_eq!(input.value, "retry-payload");
+    RETRY_JOB_RUNS.fetch_add(1, Ordering::SeqCst);
+    Err(pocopine::JobError::Handler("retry failure".into()))
 }
 
 #[pocopine::job(queue = "panic", retries = 0)]
@@ -307,5 +315,92 @@ fn memory_backend_emits_job_lifecycle_trace_without_payload() {
             .chain(completed.fields.values())
             .all(|value| !value.contains("trace-payload")),
         "job lifecycle logs must not include raw payloads"
+    );
+}
+
+#[test]
+fn memory_backend_retry_emits_schedule_log_without_payload() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let capture = TraceCapture::new();
+
+    capture.run(|| {
+        rt.block_on(async {
+            RETRY_JOB_RUNS.store(0, Ordering::SeqCst);
+            let app = format!(
+                "job-macro-retry-{}-{}",
+                std::process::id(),
+                MEMORY_APP_COUNTER.fetch_add(1, Ordering::SeqCst)
+            );
+            let client = pocopine::JobClient::memory(app.clone());
+            retrying_memory_job_job::enqueue_with(
+                &client,
+                JobPayload {
+                    value: "retry-payload".into(),
+                },
+            )
+            .await
+            .unwrap();
+
+            let worker = pocopine::Worker::new(pocopine::WorkerConfig {
+                backend: pocopine::JobBackend::Memory,
+                app,
+                queues: vec!["retry".to_string()],
+                group: "test".to_string(),
+                consumer: "test".to_string(),
+                block_ms: 0,
+                visibility_timeout: Duration::from_secs(60),
+                scheduler_interval: Duration::from_millis(1),
+                max_periodic_catch_up: 16,
+                batch_size: 10,
+            })
+            .unwrap();
+
+            assert_eq!(worker.run_once().await.unwrap(), 1);
+            assert_eq!(RETRY_JOB_RUNS.load(Ordering::SeqCst), 1);
+            assert!(worker.drain_dead_letter().unwrap().is_empty());
+        });
+    });
+
+    let events = capture.events_with_message("pocopine.log", "job retry scheduled");
+    let event = events
+        .iter()
+        .find(|event| event.field("queue") == Some("retry"))
+        .expect("retry-scheduled event should be captured");
+    assert_eq!(event.field("backend"), Some("memory"));
+    assert!(event
+        .field("job_name")
+        .is_some_and(|value| value.ends_with("::retrying_memory_job")));
+    assert_eq!(event.field("attempt"), Some("1"));
+    assert_eq!(event.field("next_attempt"), Some("2"));
+    assert_eq!(event.field("max_attempts"), Some("2"));
+    assert!(
+        event
+            .field("due_ms")
+            .and_then(|value| value.parse::<u64>().ok())
+            .is_some(),
+        "due_ms should be a numeric tracing field"
+    );
+    assert!(
+        event
+            .field("duration_ms")
+            .and_then(|value| value.parse::<u64>().ok())
+            .is_some(),
+        "duration_ms should be a numeric tracing field"
+    );
+    assert!(
+        event
+            .field("error")
+            .is_some_and(|value| value.contains("retry failure")),
+        "retry event should include the retry cause"
+    );
+    assert!(
+        event
+            .fields
+            .values()
+            .all(|value| !value.contains("retry-payload")),
+        "retry logs must not include raw job payloads"
     );
 }

--- a/crates/pocopine/tests/server_auth.rs
+++ b/crates/pocopine/tests/server_auth.rs
@@ -33,6 +33,12 @@ async fn public_echo(value: String) -> ServerResult<String> {
     Ok(value)
 }
 
+#[pocopine::server(public)]
+async fn failing_echo(value: String) -> ServerResult<String> {
+    assert_eq!(value, "fail-input");
+    Err(ServerError::from("app failure"))
+}
+
 pocopine::protected! {
     require |ctx| ctx.user.has_role(Role::Admin);
 
@@ -46,6 +52,7 @@ fn guarded_and_public_route_helpers_typecheck() {
     let router = pocopine_server::axum::Router::new();
     let router = __guarded_echo_route(router);
     let router = __public_echo_route(router);
+    let router = __failing_echo_route(router);
     let _router = __admin_echo_route(router);
 }
 
@@ -168,5 +175,115 @@ fn server_function_route_emits_trace_without_payload() {
     assert!(
         event.fields.values().all(|value| !value.contains("hello")),
         "server-function logs must not include raw request payloads"
+    );
+}
+
+#[test]
+fn server_function_guard_rejection_emits_log_without_payload() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let capture = TraceCapture::new();
+
+    let result = capture.run(|| {
+        rt.block_on(async {
+            let router = __guarded_echo_route(pocopine_server::axum::Router::new());
+            let response = router
+                .oneshot(
+                    Request::builder()
+                        .method(Method::POST)
+                        .uri("/_pocopine/guarded_echo")
+                        .header("content-type", "application/json")
+                        .body(Body::from("[\"guard-secret\"]"))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+            serde_json::from_slice::<ServerResult<String>>(&bytes).unwrap()
+        })
+    });
+
+    assert!(matches!(result, Err(ServerError::Unauthorized(_))));
+
+    let events =
+        capture.events_with_message("pocopine.log", "server function guard rejected request");
+    let event = events
+        .iter()
+        .find(|event| event.field("route") == Some("/_pocopine/guarded_echo"))
+        .expect("guard rejection event should be captured");
+
+    assert_eq!(event.field("function"), Some("guarded_echo"));
+    assert_eq!(event.field("error_kind"), Some("unauthorized"));
+    assert!(
+        event
+            .field("duration_ms")
+            .and_then(|value| value.parse::<u64>().ok())
+            .is_some(),
+        "duration_ms should be a numeric tracing field"
+    );
+    assert!(
+        event
+            .fields
+            .values()
+            .all(|value| !value.contains("guard-secret")),
+        "guard rejection logs must not include raw request payloads"
+    );
+}
+
+#[test]
+fn server_function_app_failure_emits_log_without_payload() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let capture = TraceCapture::new();
+
+    let result = capture.run(|| {
+        rt.block_on(async {
+            let router = __failing_echo_route(pocopine_server::axum::Router::new());
+            let response = router
+                .oneshot(
+                    Request::builder()
+                        .method(Method::POST)
+                        .uri("/_pocopine/failing_echo")
+                        .header("content-type", "application/json")
+                        .body(Body::from("[\"fail-input\"]"))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+            serde_json::from_slice::<ServerResult<String>>(&bytes).unwrap()
+        })
+    });
+
+    assert!(matches!(result, Err(ServerError::App(_))));
+
+    let events = capture.events_with_message("pocopine.log", "server function failed");
+    let event = events
+        .iter()
+        .find(|event| event.field("route") == Some("/_pocopine/failing_echo"))
+        .expect("server function failure event should be captured");
+
+    assert_eq!(event.field("function"), Some("failing_echo"));
+    assert_eq!(event.field("body_bytes"), Some("14"));
+    assert_eq!(event.field("error_kind"), Some("app"));
+    assert!(
+        event
+            .field("duration_ms")
+            .and_then(|value| value.parse::<u64>().ok())
+            .is_some(),
+        "duration_ms should be a numeric tracing field"
+    );
+    assert!(
+        event
+            .fields
+            .values()
+            .all(|value| !value.contains("fail-input")),
+        "server-function failure logs must not include raw request payloads"
     );
 }

--- a/crates/pocopine/tests/server_auth.rs
+++ b/crates/pocopine/tests/server_auth.rs
@@ -105,26 +105,115 @@ fn oversized_body_returns_bad_request() {
         .enable_all()
         .build()
         .unwrap();
+    let capture = TraceCapture::new();
 
-    rt.block_on(async {
-        let router = __public_echo_route(pocopine_server::axum::Router::new());
-        let oversized_body = vec![b'a'; pocopine_server::DEFAULT_SERVER_FUNCTION_BODY_LIMIT + 1];
-        let response = router
-            .oneshot(
-                Request::builder()
-                    .method(Method::POST)
-                    .uri("/_pocopine/public_echo")
-                    .header("content-type", "application/json")
-                    .body(Body::from(oversized_body))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
+    let result = capture.run(|| {
+        rt.block_on(async {
+            let router = __public_echo_route(pocopine_server::axum::Router::new());
+            let mut oversized_body = b"oversized-secret".to_vec();
+            oversized_body.resize(
+                pocopine_server::DEFAULT_SERVER_FUNCTION_BODY_LIMIT + 1,
+                b'a',
+            );
+            let response = router
+                .oneshot(
+                    Request::builder()
+                        .method(Method::POST)
+                        .uri("/_pocopine/public_echo")
+                        .header("content-type", "application/json")
+                        .body(Body::from(oversized_body))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
 
-        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
-        let result: ServerResult<String> = serde_json::from_slice(&bytes).unwrap();
-        assert!(matches!(result, Err(ServerError::BadRequest(_))));
+            let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+            serde_json::from_slice::<ServerResult<String>>(&bytes).unwrap()
+        })
     });
+
+    assert!(matches!(result, Err(ServerError::BadRequest(_))));
+
+    let events =
+        capture.events_with_message("pocopine.log", "server function request body read failed");
+    let event = events
+        .iter()
+        .find(|event| event.field("route") == Some("/_pocopine/public_echo"))
+        .expect("body-read failure event should be captured");
+
+    assert_eq!(event.field("function"), Some("public_echo"));
+    assert_eq!(event.field("error_kind"), Some("bad_request"));
+    assert!(
+        event
+            .field("duration_ms")
+            .and_then(|value| value.parse::<u64>().ok())
+            .is_some(),
+        "duration_ms should be a numeric tracing field"
+    );
+    assert!(
+        event
+            .fields
+            .values()
+            .all(|value| !value.contains("oversized-secret")),
+        "body-read failure logs must not include raw request payloads"
+    );
+}
+
+#[test]
+fn malformed_body_returns_bad_request_and_emits_parse_log_without_payload() {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let capture = TraceCapture::new();
+
+    let result = capture.run(|| {
+        rt.block_on(async {
+            let router = __public_echo_route(pocopine_server::axum::Router::new());
+            let response = router
+                .oneshot(
+                    Request::builder()
+                        .method(Method::POST)
+                        .uri("/_pocopine/public_echo")
+                        .header("content-type", "application/json")
+                        .body(Body::from("\"parse-secret\""))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+
+            let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+            serde_json::from_slice::<ServerResult<String>>(&bytes).unwrap()
+        })
+    });
+
+    assert!(matches!(result, Err(ServerError::BadRequest(_))));
+
+    let events =
+        capture.events_with_message("pocopine.log", "server function request body parse failed");
+    let event = events
+        .iter()
+        .find(|event| event.field("route") == Some("/_pocopine/public_echo"))
+        .expect("body-parse failure event should be captured");
+
+    assert_eq!(event.field("function"), Some("public_echo"));
+    assert_eq!(event.field("body_bytes"), Some("14"));
+    assert_eq!(event.field("error_kind"), Some("bad_request"));
+    assert_eq!(event.field("error"), Some("request body parse failed"));
+    assert!(
+        event
+            .field("duration_ms")
+            .and_then(|value| value.parse::<u64>().ok())
+            .is_some(),
+        "duration_ms should be a numeric tracing field"
+    );
+    assert!(
+        event
+            .fields
+            .values()
+            .all(|value| !value.contains("parse-secret")),
+        "body-parse failure logs must not include raw request payloads"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add capture assertions for server-function guard rejection, app failure, body-read failure, and body-parse failure
- add capture assertions for memory job retry scheduling
- keep server-function body parse logs payload-free while preserving detailed BadRequest responses

## Verification
- cargo test -p pocopine --test server_auth --test job_macro
- cargo check --workspace --all-targets
- cargo fmt --check
- cargo clippy --workspace --all-targets -- -D warnings
- git diff --check