### PR TITLE
feat(pocopine-server): auth middleware install path (PR #2 of 4)

### DIFF
--- a/crates/pocopine-server/src/lib.rs
+++ b/crates/pocopine-server/src/lib.rs
@@ -28,9 +28,14 @@ pub use tower_http;
 pub use tracing;
 
 use std::net::SocketAddr;
+use std::sync::Arc;
 use std::sync::OnceLock;
 
+use axum::extract::{Request, State};
+use axum::middleware::Next;
+use axum::response::Response;
 use axum::Router;
+use pocopine_auth::{AuthProvider, Principal, RequestContext};
 use tower_http::services::ServeDir;
 
 /// Default maximum JSON request body accepted by generated
@@ -95,6 +100,110 @@ fn parse_body_limit(raw: &str) -> Option<usize> {
 /// that `wasm-pack build --target web` produces, plus `index.html`).
 pub fn static_files(dir: impl AsRef<std::path::Path>) -> ServeDir {
     ServeDir::new(dir)
+}
+
+/// Type-erased handle to an [`AuthProvider`] suitable for use as
+/// axum middleware state. Cloning is a `Arc::clone`.
+pub type SharedAuthProvider = Arc<dyn AuthProvider>;
+
+/// Axum middleware that runs an [`AuthProvider`] before downstream
+/// handlers and inserts the resolved [`Principal`] into the request
+/// extensions. Server-function guards (`#[server(guard = ...)]`)
+/// then read that principal off `RequestContext`.
+///
+/// Errors from the provider are logged and treated as anonymous —
+/// guards on protected routes will reject the request, public
+/// routes still work. Providers that need to **reject** a malformed
+/// token at middleware (e.g. JWT verifiers per RFC-070 §5.6) should
+/// either return `Ok(None)` for "no credential" and use a different
+/// short-circuit mechanism for "bad credential," or layer their own
+/// middleware that returns a 401 directly.
+async fn auth_middleware(
+    State(provider): State<SharedAuthProvider>,
+    mut req: Request,
+    next: Next,
+) -> Response {
+    // Build a request context the provider can inspect. Cloning is
+    // unfortunate but Method/Uri/HeaderMap/Extensions are all cheap
+    // to clone (Extensions clones each entry; standard axum types
+    // implement Clone).
+    let ctx = RequestContext::from_parts(
+        req.method().clone(),
+        req.uri().clone(),
+        req.headers().clone(),
+        req.extensions().clone(),
+    );
+
+    match provider.authenticate(&ctx).await {
+        Ok(Some(user)) => {
+            req.extensions_mut().insert(Principal::from_user(user));
+        }
+        Ok(None) => {
+            // No credential present (or provider explicitly returned
+            // anonymous). Don't insert anything — guards see whatever
+            // was already there (default = anonymous).
+        }
+        Err(err) => {
+            tracing::warn!(
+                target: "pocopine.log",
+                error = %err,
+                "auth provider failed; treating request as anonymous"
+            );
+        }
+    }
+
+    next.run(req).await
+}
+
+/// Extension trait that installs an [`AuthProvider`] on an axum
+/// [`Router`] in one line.
+///
+/// **Install after routes.** `Router::layer` (which this calls
+/// under the hood) only wraps the routes that exist at the call
+/// site — routes added afterwards silently bypass the middleware.
+/// Always call `with_auth` last:
+///
+/// ```no_run
+/// # use pocopine_server::{axum::Router, RouterAuthExt};
+/// # use pocopine_auth::{AuthProvider, AuthFuture, AuthUser, RequestContext};
+/// # struct StubProvider;
+/// # impl AuthProvider for StubProvider {
+/// #     fn authenticate<'a>(&'a self, _: &'a RequestContext)
+/// #         -> AuthFuture<'a, Option<AuthUser>>
+/// #     { Box::pin(async { Ok(None) }) }
+/// # }
+/// # mod app { pub fn __whoami_route(r: pocopine_server::axum::Router)
+/// #     -> pocopine_server::axum::Router { r } }
+/// let router = Router::new();
+/// let router = app::__whoami_route(router);
+/// // ... register all server-function routes first ...
+/// let router = router.with_auth(StubProvider);
+/// ```
+///
+/// The middleware runs once per request, before any
+/// `#[server(guard = ...)]` route handler. Identity flows from
+/// middleware → request `Extensions` → `RequestContext` → guard.
+pub trait RouterAuthExt {
+    /// Install an `AuthProvider` as request middleware.
+    fn with_auth<P: AuthProvider + 'static>(self, provider: P) -> Self;
+
+    /// Install a pre-`Arc`'d provider — useful when the provider is
+    /// shared with other middleware or accessed via app state.
+    fn with_auth_arc(self, provider: SharedAuthProvider) -> Self;
+}
+
+impl RouterAuthExt for Router {
+    fn with_auth<P: AuthProvider + 'static>(self, provider: P) -> Self {
+        let provider: SharedAuthProvider = Arc::new(provider);
+        self.with_auth_arc(provider)
+    }
+
+    fn with_auth_arc(self, provider: SharedAuthProvider) -> Self {
+        self.layer(axum::middleware::from_fn_with_state(
+            provider,
+            auth_middleware,
+        ))
+    }
 }
 
 /// Bind `router` to `addr` and serve forever.

--- a/crates/pocopine/tests/auth_middleware.rs
+++ b/crates/pocopine/tests/auth_middleware.rs
@@ -1,0 +1,162 @@
+// End-to-end check that the `pocopine_server::RouterAuthExt`
+// middleware feeds the resolved `Principal` into request extensions
+// before macro-generated server-function guards run.
+//
+// Host-only: the middleware lives in `pocopine-server`, which itself
+// is `#![cfg(not(target_arch = "wasm32"))]`.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::sync::Arc;
+
+use pocopine::{AuthUser, ServerResult};
+use pocopine_auth::{AuthFuture, AuthProvider, RequestContext};
+use pocopine_server::axum::{
+    body::{to_bytes, Body},
+    http::{Method, Request},
+    Router,
+};
+use pocopine_server::tower::ServiceExt;
+use pocopine_server::RouterAuthExt;
+
+/// Stub provider:
+/// * `Authorization: Bearer good-token` → `Ok(Some(user))`
+/// * No bearer header                    → `Ok(None)` (anonymous)
+/// * `Authorization: Bearer bad-token`   → `Err(_)` (provider failure)
+#[derive(Clone)]
+struct StubProvider;
+
+impl AuthProvider for StubProvider {
+    fn authenticate<'a>(&'a self, ctx: &'a RequestContext) -> AuthFuture<'a, Option<AuthUser>> {
+        Box::pin(async move {
+            match ctx.bearer_token() {
+                Some("good-token") => Ok(Some(AuthUser::new("user-1").with_email("a@example.com"))),
+                Some("bad-token") => Err(pocopine_auth::AuthError::new("invalid bearer token")),
+                Some(_) | None => Ok(None),
+            }
+        })
+    }
+}
+
+/// Server function under `pocopine::auth::require_login`. Body is
+/// `(name: String,)` per the macro-generated tuple-style decode.
+#[pocopine::server(guard = pocopine::auth::require_login)]
+async fn whoami(echo: String) -> ServerResult<String> {
+    Ok(format!("hello, {echo}"))
+}
+
+fn build_router() -> Router {
+    // axum's `Router::layer` only wraps routes that exist at the
+    // call site, so `with_auth` must run AFTER the server-function
+    // route helpers have registered their routes. Get this order
+    // wrong and the middleware silently no-ops on the unwrapped
+    // routes.
+    let router = pocopine_server::axum::Router::new();
+    let router = __whoami_route(router);
+    router.with_auth(StubProvider)
+}
+
+async fn body_text(response: pocopine_server::axum::response::Response) -> String {
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    String::from_utf8(bytes.to_vec()).unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn good_token_reaches_guarded_handler() {
+    let router = build_router();
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/_pocopine/whoami")
+                .header("content-type", "application/json")
+                .header("authorization", "Bearer good-token")
+                .body(Body::from(r#"["world"]"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(response.status().is_success());
+    let body = body_text(response).await;
+    // Macro wraps the result in Json(Result<R, ServerError>) — happy
+    // path is the `Ok` variant.
+    assert!(body.contains(r#""Ok":"hello, world""#), "got: {body}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn missing_token_falls_through_as_anonymous_and_guard_rejects() {
+    let router = build_router();
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/_pocopine/whoami")
+                .header("content-type", "application/json")
+                .body(Body::from(r#"["world"]"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // The route generator returns Json(Err(ServerError::Unauthorized(_)))
+    // which serializes to HTTP 200 with an error envelope (per
+    // RFC-066's "typed error in JSON, not HTTP status" decision).
+    assert!(response.status().is_success());
+    let body = body_text(response).await;
+    assert!(
+        body.contains(r#""Err":{"Unauthorized":"login required"}"#),
+        "got: {body}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn provider_error_treated_as_anonymous_and_guard_rejects() {
+    let router = build_router();
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/_pocopine/whoami")
+                .header("content-type", "application/json")
+                .header("authorization", "Bearer bad-token")
+                .body(Body::from(r#"["world"]"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    // Provider returned Err(_); middleware logs and falls through as
+    // anonymous; guard then rejects with Unauthorized.
+    assert!(response.status().is_success());
+    let body = body_text(response).await;
+    assert!(
+        body.contains(r#""Err":{"Unauthorized":"login required"}"#),
+        "got: {body}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn with_auth_arc_shares_a_single_provider_handle() {
+    // Asserting the Arc-shaped install path compiles and routes
+    // identically. Useful when the same provider is referenced by
+    // other middleware or by app state.
+    let provider: pocopine_server::SharedAuthProvider = Arc::new(StubProvider);
+    let router = pocopine_server::axum::Router::new();
+    let router = __whoami_route(router);
+    let router = router.with_auth_arc(provider);
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/_pocopine/whoami")
+                .header("content-type", "application/json")
+                .header("authorization", "Bearer good-token")
+                .body(Body::from(r#"["world"]"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert!(response.status().is_success());
+    let body = body_text(response).await;
+    assert!(body.contains(r#""Ok":"hello, world""#), "got: {body}");
+}


### PR DESCRIPTION
## Summary

Adds the integration seam from RFC-070 §8 OQ #1: a tower middleware that runs an `AuthProvider` before route handlers and inserts the resolved `Principal` into request `Extensions` for `#[server(guard = ...)]` guards to read.

```rust
use pocopine_server::RouterAuthExt;

let router = pocopine_server::axum::Router::new();
let router = app::__whoami_route(router);          // register routes first
let router = router.with_auth(my_provider);         // then wrap with auth
```

## Why this shape

`pocopine_core::App` is the wasm-side runtime app (mounts components in the browser) — wrong home for server-side auth wiring. The shape that fits axum cleanly is a `tower::Layer` on the `Router`, exposed via a small extension trait so the install is one line.

Implementation uses `axum::middleware::from_fn_with_state` so the provider rides as middleware state rather than per-request data.

## API surface

| Symbol | Purpose |
|---|---|
| `pocopine_server::SharedAuthProvider` | `Arc<dyn AuthProvider>` type alias |
| `RouterAuthExt::with_auth(provider)` | Install a concrete provider; wraps in `Arc` internally |
| `RouterAuthExt::with_auth_arc(provider)` | Install a pre-`Arc`'d handle (sharing across other middleware / app state) |

## Failure semantics

`AuthProvider::authenticate` returning `Err(_)` is logged via `tracing` (target `pocopine.log`, no token text) and treated as anonymous. Guards on protected routes still reject; `#[server(public)]` routes still work. Providers that need to short-circuit a malformed token at middleware (e.g. JWT verifiers per RFC-070 §5.6) layer their own middleware.

## Footgun documented

axum's `Router::layer` only wraps routes that exist at the call site, so `with_auth` must be called **after** the macro-generated `__<fn>_route` helpers. Get the order wrong and the middleware silently no-ops on the unwrapped routes. The doc and the test suite both call this out — the first version of the test installed the layer first and silently observed anonymous principals.

## Test plan

End-to-end test (`crates/pocopine/tests/auth_middleware.rs`) drives a full request through middleware → guard → handler with a stub `AuthProvider`:

- [x] `good_token_reaches_guarded_handler` — `Bearer good-token` → Principal set → `require_login` accepts → handler returns `\"hello, world\"`.
- [x] `missing_token_falls_through_as_anonymous_and_guard_rejects` — no auth header → guard returns `Unauthorized` JSON envelope.
- [x] `provider_error_treated_as_anonymous_and_guard_rejects` — `Bearer bad-token` (stub returns `Err`) → log + anonymous → guard rejects.
- [x] `with_auth_arc_shares_a_single_provider_handle` — install via pre-`Arc`'d handle.
- [x] All 14 prior pocopine integration tests still pass (server_auth, jobs, jobs_redis testcontainers, memory backend).
- [x] Workspace + wasm32 clippy clean. fmt clean.

## Sequence

This is **PR #2 of 4** in the JWT auth slice planned in RFC-070:

1. Tier-1 type refactor — merged (#29).
2. **Auth middleware install path** — this PR.
3. `pocopine-auth-jwt` crate (the substantive RFC-070 work) — next.
4. Wasm client bridge for outgoing `#[server]` calls — last.

🤖 Generated with [Claude Code](https://claude.com/claude-code)