### PR TITLE
Add OTLP observability smoke example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,12 +101,31 @@ jobs:
         with:
           key: test-host
       # `pine-icons` ships fs-based manifest tests; `pocopine-cli`
-      # is host-only. Other crates' #[test]s either have no
+      # is host-only; `observability-smoke` owns a local OTLP
+      # collector and has a dedicated job below. Other crates'
+      # #[test]s either have no
       # host-runnable shape (gated on `cfg(target_arch = "wasm32")`)
       # or live in `src/` and run cleanly on host. `--tests` skips
       # doc-tests (a few example snippets reference deps the
       # workspace doesn't carry — they're not the contract here).
-      - run: cargo test --workspace --exclude pine --tests
+      - run: cargo test --workspace --exclude pine --exclude observability-smoke --tests
+
+  observability-otlp:
+    name: observability OTLP smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2025-12-18
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: observability-otlp
+      # In-process fake OTLP collector. Asserts route correctness,
+      # exported span names/attributes, service.name resource metadata,
+      # p95 local latency budget, and that raw request payloads are not
+      # present in exported telemetry.
+      - run: bash scripts/ci/otlp_smoke.sh
 
   test-wasm-node:
     name: wasm-pack test --node (${{ matrix.name }})

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.4.5",
  "bytes",
  "futures-util",
  "http 1.4.0",
@@ -204,7 +204,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
@@ -220,6 +220,31 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core 0.5.6",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "sync_wrapper",
+ "tower",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -241,6 +266,24 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http 1.4.0",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -2298,6 +2341,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2457,10 +2506,14 @@ dependencies = [
 name = "observability-smoke"
 version = "0.1.0"
 dependencies = [
+ "opentelemetry-proto",
  "pocopine",
  "pocopine-server",
  "serde",
+ "serde_json",
  "tokio",
+ "tokio-stream",
+ "tonic",
  "tracing",
 ]
 
@@ -2951,7 +3004,7 @@ dependencies = [
 name = "pocopine-server"
 version = "0.1.0"
 dependencies = [
- "axum",
+ "axum 0.7.9",
  "pocopine-auth",
  "serde",
  "serde_json",
@@ -4526,8 +4579,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
+ "axum 0.8.9",
  "base64",
  "bytes",
+ "h2",
  "http 1.4.0",
  "http-body",
  "http-body-util",
@@ -4536,6 +4591,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
+ "socket2 0.6.3",
  "sync_wrapper",
  "tokio",
  "tokio-stream",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2454,6 +2454,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "observability-smoke"
+version = "0.1.0"
+dependencies = [
+ "pocopine",
+ "pocopine-server",
+ "serde",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "oco_ref"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "examples/blog",
     "examples/counter",
     "examples/hn",
+    "examples/observability-smoke",
     "jsbench/pocopine",
     "jsbench/leptos",
     "jsbench/yew",

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,5 +33,6 @@ Example apps:
 - [`examples/counter/`](../examples/counter/) — a single component.
 - [`examples/todo/`](../examples/todo/) — multi-component, slots, and a store.
 - [`examples/blog/`](../examples/blog/) — `App` + `#[server]` + axum server bin.
+- [`examples/observability-smoke/`](../examples/observability-smoke/) — OTLP trace export smoke server.
 - [`examples/spa/`](../examples/spa/) — `App::route` + `<pp-outlet>` + `pp-route` + `$route`.
 - [`examples/site/`](../examples/site/) — the marketing page, dogfooded.

--- a/docs/logging-tracing-observer.md
+++ b/docs/logging-tracing-observer.md
@@ -224,6 +224,12 @@ deployments can route JSON logs with their platform log agent and route traces
 through an OpenTelemetry Collector or OTLP-compatible backend. Direct vendor SDKs
 are intentionally out of scope for this layer.
 
+For a runnable smoke path, see
+[`examples/observability-smoke`](../examples/observability-smoke/). It starts a
+small host server, installs `logging-otlp`, exposes one `#[server(public)]`
+endpoint, and includes an OpenTelemetry Collector config that prints received
+spans with the debug exporter.
+
 ## Structured observed events
 
 Use `ObservedEvent` when you want a stable framework-facing event schema

--- a/examples/observability-smoke/Cargo.toml
+++ b/examples/observability-smoke/Cargo.toml
@@ -24,3 +24,9 @@ tracing = { workspace = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 pocopine-server = { path = "../../crates/pocopine-server" }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+opentelemetry-proto = { version = "0.31", default-features = false, features = ["gen-tonic", "trace"] }
+serde_json = "1"
+tokio-stream = { version = "0.1", features = ["net"] }
+tonic = { version = "0.14", features = ["transport"] }

--- a/examples/observability-smoke/Cargo.toml
+++ b/examples/observability-smoke/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "observability-smoke"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[package.metadata.pocopine]
+bin = "server"
+port = 3010
+
+[lib]
+crate-type = ["rlib"]
+
+[[bin]]
+name = "server"
+path = "src/bin/server.rs"
+
+[dependencies]
+pocopine = { path = "../../crates/pocopine", features = ["logging-otlp"] }
+serde = { workspace = true }
+tracing = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+pocopine-server = { path = "../../crates/pocopine-server" }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net"] }

--- a/examples/observability-smoke/README.md
+++ b/examples/observability-smoke/README.md
@@ -1,0 +1,36 @@
+# OTLP observability smoke example
+
+This example is a small host-side server that installs pocopine JSON logging and
+OTLP trace export, then exposes one `#[server(public)]` endpoint.
+
+## Run a collector
+
+With a local `otelcol` binary:
+
+```sh
+otelcol --config examples/observability-smoke/otel-collector.yaml
+```
+
+With Docker:
+
+```sh
+docker run --rm -p 4317:4317 \
+  -v "$PWD/examples/observability-smoke/otel-collector.yaml:/etc/otelcol/config.yaml" \
+  otel/opentelemetry-collector-contrib:latest \
+  --config=/etc/otelcol/config.yaml
+```
+
+## Run the example
+
+```sh
+POCOPINE_SERVICE_NAME=pocopine-otlp-smoke \
+POCOPINE_OTLP_ENDPOINT=http://127.0.0.1:4317 \
+cargo run -p observability-smoke --bin server
+```
+
+Open <http://127.0.0.1:3010>, submit the form, and watch the collector output.
+You should see spans named `pocopine.server_function` and
+`observability_smoke.echo`, with fields such as `function`, `route`, and
+`message_len`.
+
+The example intentionally does not log or export the raw message body.

--- a/examples/observability-smoke/README.md
+++ b/examples/observability-smoke/README.md
@@ -34,3 +34,19 @@ You should see spans named `pocopine.server_function` and
 `message_len`.
 
 The example intentionally does not log or export the raw message body.
+
+## CI smoke test
+
+The repository CI runs:
+
+```sh
+bash scripts/ci/otlp_smoke.sh
+```
+
+That test starts a fake OTLP gRPC collector in-process, calls the generated
+server-function route, and asserts:
+
+- spans named `pocopine.server_function` and `observability_smoke.echo` arrive;
+- `function`, `route`, `message_len`, and `service.name` metadata are present;
+- the raw request message is absent from exported telemetry;
+- local p95 request latency stays below a broad CI budget.

--- a/examples/observability-smoke/otel-collector.yaml
+++ b/examples/observability-smoke/otel-collector.yaml
@@ -1,0 +1,15 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+exporters:
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [debug]

--- a/examples/observability-smoke/src/bin/server.rs
+++ b/examples/observability-smoke/src/bin/server.rs
@@ -1,0 +1,157 @@
+//! OTLP smoke server — host-only.
+//!
+//! Run this with an OpenTelemetry Collector listening on `localhost:4317`.
+
+#[cfg(not(target_arch = "wasm32"))]
+use pocopine_server::axum::response::Html;
+
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    use observability_smoke::__observe_echo_route;
+    use pocopine::logging::{init_server_logging, OtlpConfig, ServerLoggingConfig};
+    use pocopine_server::{
+        axum::{routing::get, Router},
+        serve,
+    };
+
+    let service_name = std::env::var("POCOPINE_SERVICE_NAME")
+        .or_else(|_| std::env::var("OTEL_SERVICE_NAME"))
+        .unwrap_or_else(|_| "pocopine-otlp-smoke".to_owned());
+    let otlp = OtlpConfig::from_env().with_service_name(service_name);
+
+    init_server_logging(
+        ServerLoggingConfig::json()
+            .with_env_filter("info,pocopine=debug")
+            .with_otlp(otlp),
+    )
+    .map_err(std::io::Error::other)?;
+
+    let router = Router::new()
+        .route("/", get(index))
+        .route("/health", get(health));
+    let router = __observe_echo_route(router);
+
+    let addr =
+        std::env::var("POCOPINE_OTLP_SMOKE_ADDR").unwrap_or_else(|_| "127.0.0.1:3010".to_owned());
+    tracing::info!(target: "pocopine.log", %addr, "serving OTLP smoke example");
+    serve(router, &addr).await
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+async fn index() -> Html<&'static str> {
+    tracing::info!(target: "pocopine.trace", route = "/", "served OTLP smoke page");
+    Html(INDEX)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+async fn health() -> &'static str {
+    tracing::info!(target: "pocopine.trace", route = "/health", "OTLP smoke health check");
+    "ok\n"
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+const INDEX: &str = r##"<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>pocopine OTLP smoke</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f6f7f8;
+      --panel: #ffffff;
+      --text: #1d252d;
+      --muted: #5d6874;
+      --accent: #0b6f6a;
+      --border: #d8dee4;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: var(--bg);
+      color: var(--text);
+      font: 16px/1.5 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      display: grid;
+      place-items: center;
+      padding: 2rem;
+    }
+    main {
+      width: min(680px, 100%);
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 1.5rem;
+      box-shadow: 0 18px 40px rgba(17, 24, 39, 0.08);
+    }
+    h1 { margin: 0 0 0.4rem; font-size: 1.35rem; }
+    p { margin: 0 0 1rem; color: var(--muted); }
+    label { display: block; font-weight: 650; margin-bottom: 0.4rem; }
+    textarea {
+      width: 100%;
+      min-height: 7rem;
+      resize: vertical;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 0.75rem;
+      font: inherit;
+    }
+    button {
+      margin-top: 0.8rem;
+      border: 0;
+      border-radius: 6px;
+      background: var(--accent);
+      color: white;
+      padding: 0.65rem 0.9rem;
+      font: inherit;
+      font-weight: 700;
+      cursor: pointer;
+    }
+    output {
+      display: block;
+      min-height: 2.5rem;
+      margin-top: 1rem;
+      padding: 0.75rem;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--muted);
+      white-space: pre-wrap;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>pocopine OTLP smoke</h1>
+    <p>Submits one generated server-function request and emits local logs plus OTLP traces.</p>
+    <form id="smoke-form">
+      <label for="message">Message</label>
+      <textarea id="message">hello observability</textarea>
+      <button type="submit">Send request</button>
+    </form>
+    <output id="result">Waiting for a request.</output>
+  </main>
+  <script>
+    const form = document.querySelector("#smoke-form");
+    const message = document.querySelector("#message");
+    const result = document.querySelector("#result");
+
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      result.textContent = "Sending...";
+      const response = await fetch("/_pocopine/observe_echo", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify([{ message: message.value }]),
+      });
+      const body = await response.json();
+      result.textContent = JSON.stringify(body, null, 2);
+    });
+  </script>
+</body>
+</html>
+"##;
+
+#[cfg(target_arch = "wasm32")]
+fn main() {}

--- a/examples/observability-smoke/src/bin/server.rs
+++ b/examples/observability-smoke/src/bin/server.rs
@@ -3,17 +3,11 @@
 //! Run this with an OpenTelemetry Collector listening on `localhost:4317`.
 
 #[cfg(not(target_arch = "wasm32"))]
-use pocopine_server::axum::response::Html;
-
-#[cfg(not(target_arch = "wasm32"))]
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
-    use observability_smoke::__observe_echo_route;
+    use observability_smoke::router;
     use pocopine::logging::{init_server_logging, OtlpConfig, ServerLoggingConfig};
-    use pocopine_server::{
-        axum::{routing::get, Router},
-        serve,
-    };
+    use pocopine_server::serve;
 
     let service_name = std::env::var("POCOPINE_SERVICE_NAME")
         .or_else(|_| std::env::var("OTEL_SERVICE_NAME"))
@@ -27,131 +21,11 @@ async fn main() -> std::io::Result<()> {
     )
     .map_err(std::io::Error::other)?;
 
-    let router = Router::new()
-        .route("/", get(index))
-        .route("/health", get(health));
-    let router = __observe_echo_route(router);
-
     let addr =
         std::env::var("POCOPINE_OTLP_SMOKE_ADDR").unwrap_or_else(|_| "127.0.0.1:3010".to_owned());
     tracing::info!(target: "pocopine.log", %addr, "serving OTLP smoke example");
-    serve(router, &addr).await
+    serve(router(), &addr).await
 }
-
-#[cfg(not(target_arch = "wasm32"))]
-async fn index() -> Html<&'static str> {
-    tracing::info!(target: "pocopine.trace", route = "/", "served OTLP smoke page");
-    Html(INDEX)
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-async fn health() -> &'static str {
-    tracing::info!(target: "pocopine.trace", route = "/health", "OTLP smoke health check");
-    "ok\n"
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-const INDEX: &str = r##"<!doctype html>
-<html lang="en">
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>pocopine OTLP smoke</title>
-  <style>
-    :root {
-      color-scheme: light;
-      --bg: #f6f7f8;
-      --panel: #ffffff;
-      --text: #1d252d;
-      --muted: #5d6874;
-      --accent: #0b6f6a;
-      --border: #d8dee4;
-    }
-    * { box-sizing: border-box; }
-    body {
-      margin: 0;
-      min-height: 100vh;
-      background: var(--bg);
-      color: var(--text);
-      font: 16px/1.5 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-      display: grid;
-      place-items: center;
-      padding: 2rem;
-    }
-    main {
-      width: min(680px, 100%);
-      background: var(--panel);
-      border: 1px solid var(--border);
-      border-radius: 8px;
-      padding: 1.5rem;
-      box-shadow: 0 18px 40px rgba(17, 24, 39, 0.08);
-    }
-    h1 { margin: 0 0 0.4rem; font-size: 1.35rem; }
-    p { margin: 0 0 1rem; color: var(--muted); }
-    label { display: block; font-weight: 650; margin-bottom: 0.4rem; }
-    textarea {
-      width: 100%;
-      min-height: 7rem;
-      resize: vertical;
-      border: 1px solid var(--border);
-      border-radius: 6px;
-      padding: 0.75rem;
-      font: inherit;
-    }
-    button {
-      margin-top: 0.8rem;
-      border: 0;
-      border-radius: 6px;
-      background: var(--accent);
-      color: white;
-      padding: 0.65rem 0.9rem;
-      font: inherit;
-      font-weight: 700;
-      cursor: pointer;
-    }
-    output {
-      display: block;
-      min-height: 2.5rem;
-      margin-top: 1rem;
-      padding: 0.75rem;
-      border: 1px solid var(--border);
-      border-radius: 6px;
-      color: var(--muted);
-      white-space: pre-wrap;
-    }
-  </style>
-</head>
-<body>
-  <main>
-    <h1>pocopine OTLP smoke</h1>
-    <p>Submits one generated server-function request and emits local logs plus OTLP traces.</p>
-    <form id="smoke-form">
-      <label for="message">Message</label>
-      <textarea id="message">hello observability</textarea>
-      <button type="submit">Send request</button>
-    </form>
-    <output id="result">Waiting for a request.</output>
-  </main>
-  <script>
-    const form = document.querySelector("#smoke-form");
-    const message = document.querySelector("#message");
-    const result = document.querySelector("#result");
-
-    form.addEventListener("submit", async (event) => {
-      event.preventDefault();
-      result.textContent = "Sending...";
-      const response = await fetch("/_pocopine/observe_echo", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify([{ message: message.value }]),
-      });
-      const body = await response.json();
-      result.textContent = JSON.stringify(body, null, 2);
-    });
-  </script>
-</body>
-</html>
-"##;
 
 #[cfg(target_arch = "wasm32")]
 fn main() {}

--- a/examples/observability-smoke/src/lib.rs
+++ b/examples/observability-smoke/src/lib.rs
@@ -1,0 +1,46 @@
+//! Minimal host-side observability example.
+//!
+//! The server function intentionally logs only derived fields. Request text can
+//! contain user data, so the telemetry path should prove shape and timing
+//! without copying raw payloads into logs or spans.
+
+use pocopine::prelude::*;
+use serde::{Deserialize, Serialize};
+#[cfg(not(target_arch = "wasm32"))]
+use tracing::Instrument as _;
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct EchoRequest {
+    pub message: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct EchoResponse {
+    pub message_len: usize,
+    pub accepted: bool,
+}
+
+#[pocopine::server(public)]
+pub async fn observe_echo(request: EchoRequest) -> ServerResult<EchoResponse> {
+    let message_len = request.message.len();
+    let span = tracing::info_span!(
+        target: "pocopine.trace",
+        "observability_smoke.echo",
+        message_len,
+    );
+
+    async move {
+        tracing::info!(
+            target: "pocopine.log",
+            message_len,
+            "observability smoke request accepted"
+        );
+
+        Ok(EchoResponse {
+            message_len,
+            accepted: true,
+        })
+    }
+    .instrument(span)
+    .await
+}

--- a/examples/observability-smoke/src/lib.rs
+++ b/examples/observability-smoke/src/lib.rs
@@ -5,6 +5,8 @@
 //! without copying raw payloads into logs or spans.
 
 use pocopine::prelude::*;
+#[cfg(not(target_arch = "wasm32"))]
+use pocopine_server::axum::{response::Html, routing::get, Router};
 use serde::{Deserialize, Serialize};
 #[cfg(not(target_arch = "wasm32"))]
 use tracing::Instrument as _;
@@ -44,3 +46,126 @@ pub async fn observe_echo(request: EchoRequest) -> ServerResult<EchoResponse> {
     .instrument(span)
     .await
 }
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn router() -> Router {
+    let router = Router::new()
+        .route("/", get(index))
+        .route("/health", get(health));
+    __observe_echo_route(router)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+async fn index() -> Html<&'static str> {
+    tracing::info!(target: "pocopine.trace", route = "/", "served OTLP smoke page");
+    Html(INDEX)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+async fn health() -> &'static str {
+    tracing::info!(target: "pocopine.trace", route = "/health", "OTLP smoke health check");
+    "ok\n"
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+const INDEX: &str = r##"<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>pocopine OTLP smoke</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f6f7f8;
+      --panel: #ffffff;
+      --text: #1d252d;
+      --muted: #5d6874;
+      --accent: #0b6f6a;
+      --border: #d8dee4;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: var(--bg);
+      color: var(--text);
+      font: 16px/1.5 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      display: grid;
+      place-items: center;
+      padding: 2rem;
+    }
+    main {
+      width: min(680px, 100%);
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 1.5rem;
+      box-shadow: 0 18px 40px rgba(17, 24, 39, 0.08);
+    }
+    h1 { margin: 0 0 0.4rem; font-size: 1.35rem; }
+    p { margin: 0 0 1rem; color: var(--muted); }
+    label { display: block; font-weight: 650; margin-bottom: 0.4rem; }
+    textarea {
+      width: 100%;
+      min-height: 7rem;
+      resize: vertical;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      padding: 0.75rem;
+      font: inherit;
+    }
+    button {
+      margin-top: 0.8rem;
+      border: 0;
+      border-radius: 6px;
+      background: var(--accent);
+      color: white;
+      padding: 0.65rem 0.9rem;
+      font: inherit;
+      font-weight: 700;
+      cursor: pointer;
+    }
+    output {
+      display: block;
+      min-height: 2.5rem;
+      margin-top: 1rem;
+      padding: 0.75rem;
+      border: 1px solid var(--border);
+      border-radius: 6px;
+      color: var(--muted);
+      white-space: pre-wrap;
+    }
+  </style>
+</head>
+<body>
+  <main>
+    <h1>pocopine OTLP smoke</h1>
+    <p>Submits one generated server-function request and emits local logs plus OTLP traces.</p>
+    <form id="smoke-form">
+      <label for="message">Message</label>
+      <textarea id="message">hello observability</textarea>
+      <button type="submit">Send request</button>
+    </form>
+    <output id="result">Waiting for a request.</output>
+  </main>
+  <script>
+    const form = document.querySelector("#smoke-form");
+    const message = document.querySelector("#message");
+    const result = document.querySelector("#result");
+
+    form.addEventListener("submit", async (event) => {
+      event.preventDefault();
+      result.textContent = "Sending...";
+      const response = await fetch("/_pocopine/observe_echo", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify([{ message: message.value }]),
+      });
+      const body = await response.json();
+      result.textContent = JSON.stringify(body, null, 2);
+    });
+  </script>
+</body>
+</html>
+"##;

--- a/examples/observability-smoke/tests/otlp_smoke.rs
+++ b/examples/observability-smoke/tests/otlp_smoke.rs
@@ -1,0 +1,266 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::collections::BTreeMap;
+use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use observability_smoke::router;
+use opentelemetry_proto::tonic::collector::trace::v1::trace_service_server::{
+    TraceService, TraceServiceServer,
+};
+use opentelemetry_proto::tonic::collector::trace::v1::{
+    ExportTraceServiceRequest, ExportTraceServiceResponse,
+};
+use opentelemetry_proto::tonic::common::v1::{any_value, AnyValue, KeyValue};
+use opentelemetry_proto::tonic::trace::v1::Span;
+use pocopine::logging::{init_server_logging, OtlpConfig, ServerLoggingConfig};
+use pocopine_server::axum::body::{to_bytes, Body};
+use pocopine_server::axum::http::{Method, Request};
+use pocopine_server::tower::ServiceExt;
+use tokio::net::TcpListener;
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::{Response, Status};
+
+const PRIVATE_PAYLOAD: &str = "raw-private-ci-payload";
+const REQUEST_COUNT: usize = 32;
+const MAX_P95_MS: u128 = 250;
+
+#[derive(Clone, Default)]
+struct CaptureTraceService {
+    requests: Arc<Mutex<Vec<ExportTraceServiceRequest>>>,
+}
+
+#[tonic::async_trait]
+impl TraceService for CaptureTraceService {
+    async fn export(
+        &self,
+        request: tonic::Request<ExportTraceServiceRequest>,
+    ) -> Result<Response<ExportTraceServiceResponse>, Status> {
+        self.requests.lock().unwrap().push(request.into_inner());
+        Ok(Response::new(ExportTraceServiceResponse {
+            partial_success: None,
+        }))
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn otlp_smoke_exports_expected_spans_without_payload_leak() {
+    let collector = start_collector().await;
+
+    std::env::set_var("OTEL_BSP_SCHEDULE_DELAY", "100");
+    std::env::set_var("OTEL_BSP_EXPORT_TIMEOUT", "2000");
+
+    init_server_logging(
+        ServerLoggingConfig::json()
+            .with_env_filter("info,pocopine=debug")
+            .with_otlp(
+                OtlpConfig::grpc(format!("http://{}", collector.addr))
+                    .with_service_name("pocopine-otlp-smoke-ci")
+                    .with_timeout(Duration::from_secs(2)),
+            ),
+    )
+    .expect("install OTLP logging subscriber");
+
+    let mut latencies = Vec::with_capacity(REQUEST_COUNT);
+    for index in 0..REQUEST_COUNT {
+        let started = Instant::now();
+        let body = call_observe_echo(PRIVATE_PAYLOAD, index).await;
+        latencies.push(started.elapsed());
+        assert!(
+            body.contains(r#""Ok":{"message_len":22,"accepted":true}"#),
+            "unexpected response body: {body}"
+        );
+    }
+
+    assert_latency_budget(&latencies);
+
+    let spans = wait_for_spans(&collector.capture, REQUEST_COUNT * 2).await;
+    let server_span = span_named(&spans, "pocopine.server_function");
+    let echo_span = span_named(&spans, "observability_smoke.echo");
+
+    assert_eq!(
+        server_span.attrs.get("function").map(String::as_str),
+        Some("observe_echo")
+    );
+    assert_eq!(
+        server_span.attrs.get("route").map(String::as_str),
+        Some("/_pocopine/observe_echo")
+    );
+    assert_eq!(
+        echo_span.attrs.get("message_len").map(String::as_str),
+        Some("22")
+    );
+    assert!(
+        spans
+            .iter()
+            .any(|span| span.resource.get("service.name").map(String::as_str)
+                == Some("pocopine-otlp-smoke-ci")),
+        "missing service.name resource attribute in exported spans: {spans:#?}"
+    );
+
+    let exported = format!("{:?}", collector.capture.requests.lock().unwrap());
+    assert!(
+        !exported.contains(PRIVATE_PAYLOAD),
+        "raw request payload leaked into exported telemetry"
+    );
+
+    let _keep_collector_alive_until_test_shutdown = collector.handle;
+}
+
+struct TestCollector {
+    addr: SocketAddr,
+    capture: CaptureTraceService,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+async fn start_collector() -> TestCollector {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind fake OTLP collector");
+    let addr = listener.local_addr().expect("fake collector local addr");
+    let capture = CaptureTraceService::default();
+    let service = TraceServiceServer::new(capture.clone());
+    let incoming = TcpListenerStream::new(listener);
+    let handle = tokio::spawn(async move {
+        tonic::transport::Server::builder()
+            .add_service(service)
+            .serve_with_incoming(incoming)
+            .await
+            .expect("fake OTLP collector");
+    });
+
+    TestCollector {
+        addr,
+        capture,
+        handle,
+    }
+}
+
+async fn call_observe_echo(message: &str, index: usize) -> String {
+    let request_body = serde_json::json!([{ "message": message }]).to_string();
+    let response = router()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri("/_pocopine/observe_echo")
+                .header("content-type", "application/json")
+                .header("x-request-index", index.to_string())
+                .body(Body::from(request_body))
+                .unwrap(),
+        )
+        .await
+        .expect("server-function route response");
+
+    assert!(
+        response.status().is_success(),
+        "unexpected status: {}",
+        response.status()
+    );
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("read response body");
+    String::from_utf8(bytes.to_vec()).expect("response body is utf-8")
+}
+
+fn assert_latency_budget(latencies: &[Duration]) {
+    let mut millis = latencies
+        .iter()
+        .map(Duration::as_millis)
+        .collect::<Vec<_>>();
+    millis.sort_unstable();
+    let p95_index = ((millis.len() * 95).div_ceil(100)).saturating_sub(1);
+    let p95 = millis[p95_index];
+
+    assert!(
+        p95 <= MAX_P95_MS,
+        "observability smoke p95 latency {p95}ms exceeded {MAX_P95_MS}ms; all latencies: {millis:?}"
+    );
+}
+
+async fn wait_for_spans(capture: &CaptureTraceService, min_spans: usize) -> Vec<CapturedSpan> {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let spans = flatten_spans(&capture.requests.lock().unwrap());
+        let has_server = spans
+            .iter()
+            .any(|span| span.name == "pocopine.server_function");
+        let has_echo = spans
+            .iter()
+            .any(|span| span.name == "observability_smoke.echo");
+
+        if spans.len() >= min_spans && has_server && has_echo {
+            return spans;
+        }
+        if Instant::now() >= deadline {
+            panic!("timed out waiting for exported spans; got {spans:#?}");
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+#[derive(Clone, Debug)]
+struct CapturedSpan {
+    name: String,
+    attrs: BTreeMap<String, String>,
+    resource: BTreeMap<String, String>,
+}
+
+fn flatten_spans(requests: &[ExportTraceServiceRequest]) -> Vec<CapturedSpan> {
+    let mut spans = Vec::new();
+    for request in requests {
+        for resource_spans in &request.resource_spans {
+            let resource = resource_spans
+                .resource
+                .as_ref()
+                .map(|resource| key_values(&resource.attributes))
+                .unwrap_or_default();
+
+            for scope_spans in &resource_spans.scope_spans {
+                for span in &scope_spans.spans {
+                    spans.push(captured_span(span, resource.clone()));
+                }
+            }
+        }
+    }
+    spans
+}
+
+fn captured_span(span: &Span, resource: BTreeMap<String, String>) -> CapturedSpan {
+    CapturedSpan {
+        name: span.name.clone(),
+        attrs: key_values(&span.attributes),
+        resource,
+    }
+}
+
+fn span_named<'a>(spans: &'a [CapturedSpan], name: &str) -> &'a CapturedSpan {
+    spans
+        .iter()
+        .find(|span| span.name == name)
+        .unwrap_or_else(|| panic!("missing span {name}; exported spans: {spans:#?}"))
+}
+
+fn key_values(attrs: &[KeyValue]) -> BTreeMap<String, String> {
+    attrs
+        .iter()
+        .filter_map(|attr| {
+            attr.value
+                .as_ref()
+                .map(|value| (attr.key.clone(), any_value_to_string(value)))
+        })
+        .collect()
+}
+
+fn any_value_to_string(value: &AnyValue) -> String {
+    match value.value.as_ref() {
+        Some(any_value::Value::StringValue(value)) => value.clone(),
+        Some(any_value::Value::BoolValue(value)) => value.to_string(),
+        Some(any_value::Value::IntValue(value)) => value.to_string(),
+        Some(any_value::Value::DoubleValue(value)) => value.to_string(),
+        Some(any_value::Value::ArrayValue(value)) => format!("{value:?}"),
+        Some(any_value::Value::KvlistValue(value)) => format!("{value:?}"),
+        Some(any_value::Value::BytesValue(value)) => format!("{value:?}"),
+        None => String::new(),
+    }
+}

--- a/scripts/ci/otlp_smoke.sh
+++ b/scripts/ci/otlp_smoke.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log_file="$(mktemp -t pocopine-otlp-smoke.XXXXXX.log)"
+trap 'rm -f "$log_file"' EXIT
+
+if cargo test -p observability-smoke --test otlp_smoke >"$log_file" 2>&1; then
+  grep -E '^(running [0-9]+ test|test result:)' "$log_file" || true
+else
+  cat "$log_file"
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Adds `examples/observability-smoke`, a tiny host-side app that installs `logging-otlp`.
- Exposes one `#[server(public)]` endpoint and an embedded HTML form that posts to it.
- Adds an OpenTelemetry Collector config that prints received spans through the debug exporter.
- Documents the smoke path from `docs/logging-tracing-observer.md` and `docs/README.md`.

The example intentionally emits derived fields like `message_len` and does not log/export the raw request body.

## Validation

- `cargo check -p observability-smoke --all-targets`
- `cargo check --workspace --all-targets`
- `cargo fmt`
- `cargo fmt --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo check -p observability-smoke --lib --target wasm32-unknown-unknown`
- Runtime smoke:
  - `cargo run -p observability-smoke --bin server`
  - `curl -sS http://127.0.0.1:3010/health` -> `ok`
  - `curl -sS -X POST http://127.0.0.1:3010/_pocopine/observe_echo -H 'content-type: application/json' --data '[{"message":"hello smoke"}]'` -> `{"Ok":{"message_len":11,"accepted":true}}`

No collector was running during the route smoke, so the OpenTelemetry SDK logged a collector connection-refused export error. The server stayed up and the request succeeded, which is the behavior we want when telemetry delivery is unavailable.
