### PR TITLE
Add composable Cartesian chart series

### DIFF
--- a/crates/pine-charts/src/cartesian_chart/PineAreaSeries.poco
+++ b/crates/pine-charts/src/cartesian_chart/PineAreaSeries.poco
@@ -1,0 +1,4 @@
+<root class="pine-chart-definition pine-area-series-definition"
+      hidden
+      aria-hidden="true"
+      :data-key="component_key"></root>

--- a/crates/pine-charts/src/cartesian_chart/PineCartesianChart.poco
+++ b/crates/pine-charts/src/cartesian_chart/PineCartesianChart.poco
@@ -113,6 +113,29 @@
               :data-value="bar.value"></rect>
       </template>
     </g>
+    <g pp-show="ready && show_areas"
+       class="pine-chart-areas"
+       data-layer="area"
+       aria-hidden="true">
+      <template pp-for="series in areas" pp-key="series.key">
+        <path class="pine-chart-area"
+              :d="series.area_d"
+              :fill="series.fill"
+              stroke="none"
+              :data-series="series.label"></path>
+      </template>
+      <template pp-for="series in areas" pp-key="series.key">
+        <path class="pine-chart-line pine-chart-area-line"
+              :d="series.line_d"
+              fill="none"
+              :stroke="series.color"
+              :stroke-width="series.stroke_width"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              vector-effect="non-scaling-stroke"
+              :data-series="series.label"></path>
+      </template>
+    </g>
     <g pp-show="ready"
        class="pine-chart-lines"
        data-layer="series"
@@ -127,6 +150,23 @@
               stroke-linejoin="round"
               vector-effect="non-scaling-stroke"
               :data-series="series.label"></path>
+      </template>
+    </g>
+    <g pp-show="ready && show_scatter"
+       class="pine-chart-points pine-chart-scatter-points"
+       data-layer="points">
+      <template pp-for="point in scatter_points" pp-key="point.key">
+        <circle class="pine-chart-point pine-chart-scatter-point"
+                :cx="point.x"
+                :cy="point.y"
+                :r="point.radius"
+                :fill="point.color"
+                role="option"
+                :aria-label="point.aria_label"
+                :data-key="point.key"
+                :data-x="point.data_x"
+                :data-y="point.data_y"
+                :data-series="point.series_label"></circle>
       </template>
     </g>
     <g pp-show="ready && show_markers"

--- a/crates/pine-charts/src/cartesian_chart/PineCartesianChart.poco
+++ b/crates/pine-charts/src/cartesian_chart/PineCartesianChart.poco
@@ -95,6 +95,37 @@
               pp-text="y_label"></text>
       </g>
     </g>
+    <g pp-show="ready && show_reference_background"
+       class="pine-chart-reference pine-chart-reference-background"
+       data-layer="reference-background">
+      <template pp-for="line in reference_background_lines" pp-key="line.key">
+        <line class="pine-chart-reference-line"
+              :x1="line.x1"
+              :y1="line.y1"
+              :x2="line.x2"
+              :y2="line.y2"
+              :stroke="line.color"
+              :stroke-width="line.stroke_width"
+              :stroke-dasharray="line.stroke_dasharray"
+              stroke-linecap="round"
+              vector-effect="non-scaling-stroke"
+              :data-label="line.label"
+              :aria-label="line.aria_label"></line>
+      </template>
+      <template pp-for="dot in reference_background_dots" pp-key="dot.key">
+        <circle class="pine-chart-reference-dot"
+                :cx="dot.x"
+                :cy="dot.y"
+                :r="dot.radius"
+                :fill="dot.fill"
+                :stroke="dot.stroke"
+                :stroke-width="dot.stroke_width"
+                :data-x="dot.data_x"
+                :data-y="dot.data_y"
+                :data-label="dot.label"
+                :aria-label="dot.aria_label"></circle>
+      </template>
+    </g>
     <g pp-show="ready && show_bars"
        class="pine-chart-bars"
        data-layer="bars">
@@ -184,6 +215,53 @@
                 :data-y="marker.data_y"
                 :data-series="marker.series_label"
                 :aria-label="marker.aria_label"></circle>
+      </template>
+    </g>
+    <g pp-show="ready && show_reference_foreground"
+       class="pine-chart-reference pine-chart-reference-foreground"
+       data-layer="reference-foreground">
+      <template pp-for="line in reference_foreground_lines" pp-key="line.key">
+        <line class="pine-chart-reference-line"
+              :x1="line.x1"
+              :y1="line.y1"
+              :x2="line.x2"
+              :y2="line.y2"
+              :stroke="line.color"
+              :stroke-width="line.stroke_width"
+              :stroke-dasharray="line.stroke_dasharray"
+              stroke-linecap="round"
+              vector-effect="non-scaling-stroke"
+              :data-label="line.label"
+              :aria-label="line.aria_label"></line>
+      </template>
+      <template pp-for="dot in reference_foreground_dots" pp-key="dot.key">
+        <circle class="pine-chart-reference-dot"
+                :cx="dot.x"
+                :cy="dot.y"
+                :r="dot.radius"
+                :fill="dot.fill"
+                :stroke="dot.stroke"
+                :stroke-width="dot.stroke_width"
+                :data-x="dot.data_x"
+                :data-y="dot.data_y"
+                :data-label="dot.label"
+                :aria-label="dot.aria_label"></circle>
+      </template>
+    </g>
+    <g pp-show="ready && show_reference_labels"
+       class="pine-chart-reference-labels"
+       data-layer="labels">
+      <template pp-for="label in svg_reference_labels" pp-key="label.key">
+        <text class="pine-chart-reference-label"
+              :x="label.x"
+              :y="label.y"
+              :fill="label.fill"
+              :text-anchor="label.text_anchor"
+              :font-weight="label.font_weight"
+              :transform="label.transform"
+              :data-x="label.data_x"
+              :data-y="label.data_y"
+              pp-text="label.text"></text>
       </template>
     </g>
   </svg>

--- a/crates/pine-charts/src/cartesian_chart/PineCartesianReferenceDot.poco
+++ b/crates/pine-charts/src/cartesian_chart/PineCartesianReferenceDot.poco
@@ -1,0 +1,4 @@
+<root class="pine-chart-definition pine-cartesian-reference-dot-definition"
+      hidden
+      aria-hidden="true"
+      :data-key="component_key"></root>

--- a/crates/pine-charts/src/cartesian_chart/PineCartesianReferenceLabel.poco
+++ b/crates/pine-charts/src/cartesian_chart/PineCartesianReferenceLabel.poco
@@ -1,0 +1,4 @@
+<root class="pine-chart-definition pine-cartesian-reference-label-definition"
+      hidden
+      aria-hidden="true"
+      :data-key="component_key"></root>

--- a/crates/pine-charts/src/cartesian_chart/PineCartesianReferenceLine.poco
+++ b/crates/pine-charts/src/cartesian_chart/PineCartesianReferenceLine.poco
@@ -1,0 +1,4 @@
+<root class="pine-chart-definition pine-cartesian-reference-line-definition"
+      hidden
+      aria-hidden="true"
+      :data-key="component_key"></root>

--- a/crates/pine-charts/src/cartesian_chart/PineScatterSeries.poco
+++ b/crates/pine-charts/src/cartesian_chart/PineScatterSeries.poco
@@ -1,0 +1,4 @@
+<root class="pine-chart-definition pine-scatter-series-definition"
+      hidden
+      aria-hidden="true"
+      :data-key="component_key"></root>

--- a/crates/pine-charts/src/cartesian_chart/mod.rs
+++ b/crates/pine-charts/src/cartesian_chart/mod.rs
@@ -13,7 +13,7 @@ use crate::legend::series_label_or_default;
 use crate::line::{
     ChartLineSeries, ChartPoint, LineChartGeometry, LineChartOptions, LineChartSample,
 };
-use crate::path::line_path;
+use crate::path::{area_path, line_path};
 use crate::scale::{BandScale, LinearScale};
 use crate::svg::{format_tick, SvgAxisLabel, SvgLine, SvgTickLabel};
 
@@ -70,6 +70,25 @@ pub struct CartesianBarSeriesConfig {
     pub data: Vec<ChartBar>,
 }
 
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct CartesianAreaSeriesConfig {
+    pub key: String,
+    pub label: String,
+    pub fill: String,
+    pub color: String,
+    pub stroke_width: f64,
+    pub points: Vec<ChartPoint>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct CartesianScatterSeriesConfig {
+    pub key: String,
+    pub label: String,
+    pub color: String,
+    pub point_radius: f64,
+    pub points: Vec<ChartPoint>,
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct CartesianLineSeriesRender {
     pub key: String,
@@ -107,6 +126,30 @@ pub struct CartesianBarRender {
     pub height: f64,
 }
 
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct CartesianAreaSeriesRender {
+    pub key: String,
+    pub label: String,
+    pub area_d: String,
+    pub line_d: String,
+    pub fill: String,
+    pub color: String,
+    pub stroke_width: f64,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct CartesianScatterPointRender {
+    pub key: String,
+    pub series_label: String,
+    pub x: f64,
+    pub y: f64,
+    pub data_x: f64,
+    pub data_y: f64,
+    pub color: String,
+    pub radius: f64,
+    pub aria_label: String,
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct CartesianChartRender {
     pub view_box: String,
@@ -120,7 +163,9 @@ pub struct CartesianChartRender {
     pub x_axis: SvgLine,
     pub y_axis: SvgLine,
     pub bars: Vec<CartesianBarRender>,
+    pub areas: Vec<CartesianAreaSeriesRender>,
     pub line_series: Vec<CartesianLineSeriesRender>,
+    pub scatter_points: Vec<CartesianScatterPointRender>,
     pub markers: Vec<CartesianMarkerRender>,
 }
 
@@ -141,7 +186,7 @@ pub struct CartesianChartOptions<'a> {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[component(template = "PineCartesianChart.poco", role = "panel")]
-#[slot(default, accepts = [PineChartGrid, PineXAxis, PineYAxis, PineLineSeries, PineBarSeries])]
+#[slot(default, accepts = [PineChartGrid, PineXAxis, PineYAxis, PineLineSeries, PineBarSeries, PineAreaSeries, PineScatterSeries])]
 pub struct PineCartesianChart {
     #[prop]
     pub label: String,
@@ -178,8 +223,12 @@ pub struct PineCartesianChart {
     pub y_axis_config: Option<CartesianAxisConfig>,
     pub series: Vec<CartesianLineSeriesConfig>,
     pub bar_series: Vec<CartesianBarSeriesConfig>,
+    pub area_series: Vec<CartesianAreaSeriesConfig>,
+    pub scatter_series: Vec<CartesianScatterSeriesConfig>,
     pub bars: Vec<CartesianBarRender>,
+    pub areas: Vec<CartesianAreaSeriesRender>,
     pub line_series: Vec<CartesianLineSeriesRender>,
+    pub scatter_points: Vec<CartesianScatterPointRender>,
     pub markers: Vec<CartesianMarkerRender>,
     pub plot_x: f64,
     pub plot_y: f64,
@@ -199,6 +248,8 @@ pub struct PineCartesianChart {
     pub show_x_axis: bool,
     pub show_y_axis: bool,
     pub show_bars: bool,
+    pub show_areas: bool,
+    pub show_scatter: bool,
     pub show_markers: bool,
     pub error: String,
     pub ready: bool,
@@ -231,8 +282,12 @@ impl Default for PineCartesianChart {
             y_axis_config: None,
             series: Vec::new(),
             bar_series: Vec::new(),
+            area_series: Vec::new(),
+            scatter_series: Vec::new(),
             bars: Vec::new(),
+            areas: Vec::new(),
             line_series: Vec::new(),
+            scatter_points: Vec::new(),
             markers: Vec::new(),
             plot_x: 0.0,
             plot_y: 0.0,
@@ -252,6 +307,8 @@ impl Default for PineCartesianChart {
             show_x_axis: false,
             show_y_axis: false,
             show_bars: false,
+            show_areas: false,
+            show_scatter: false,
             show_markers: false,
             error: String::new(),
             ready: false,
@@ -393,6 +450,44 @@ impl PineCartesianChart {
         self.recompute();
     }
 
+    pub fn upsert_area_series(&mut self, series: CartesianAreaSeriesConfig) {
+        let key = series.key.clone();
+        if let Some(existing) = self
+            .area_series
+            .iter_mut()
+            .find(|existing| existing.key == key)
+        {
+            *existing = series;
+        } else {
+            self.area_series.push(series);
+        }
+        self.recompute();
+    }
+
+    pub fn remove_area_series(&mut self, key: &str) {
+        self.area_series.retain(|series| series.key != key);
+        self.recompute();
+    }
+
+    pub fn upsert_scatter_series(&mut self, series: CartesianScatterSeriesConfig) {
+        let key = series.key.clone();
+        if let Some(existing) = self
+            .scatter_series
+            .iter_mut()
+            .find(|existing| existing.key == key)
+        {
+            *existing = series;
+        } else {
+            self.scatter_series.push(series);
+        }
+        self.recompute();
+    }
+
+    pub fn remove_scatter_series(&mut self, key: &str) {
+        self.scatter_series.retain(|series| series.key != key);
+        self.recompute();
+    }
+
     fn recompute(&mut self) {
         let options = CartesianChartOptions {
             width: self.width,
@@ -408,7 +503,13 @@ impl PineCartesianChart {
             y_axis: self.y_axis_config.as_ref(),
         };
 
-        match render_cartesian_chart(options, &self.series, &self.bar_series) {
+        match render_cartesian_chart(
+            options,
+            &self.series,
+            &self.bar_series,
+            &self.area_series,
+            &self.scatter_series,
+        ) {
             Ok(render) => {
                 self.view_box = render.view_box;
                 self.plot_x = render.plot.x;
@@ -424,7 +525,9 @@ impl PineCartesianChart {
                 self.x_axis = render.x_axis;
                 self.y_axis = render.y_axis;
                 self.bars = render.bars;
+                self.areas = render.areas;
                 self.line_series = render.line_series;
+                self.scatter_points = render.scatter_points;
                 self.markers = render.markers;
                 self.show_grid = !self.x_grid.is_empty() || !self.y_grid.is_empty();
                 self.show_x_axis = self.x_axis_config.is_some();
@@ -440,6 +543,8 @@ impl PineCartesianChart {
                     .map(|axis| axis.label.clone())
                     .unwrap_or_default();
                 self.show_bars = !self.bars.is_empty();
+                self.show_areas = !self.areas.is_empty();
+                self.show_scatter = !self.scatter_points.is_empty();
                 self.show_markers = !self.markers.is_empty();
                 self.error.clear();
                 self.state = "ready".into();
@@ -468,7 +573,9 @@ impl PineCartesianChart {
 
     fn clear_render(&mut self) {
         self.bars.clear();
+        self.areas.clear();
         self.line_series.clear();
+        self.scatter_points.clear();
         self.markers.clear();
         self.x_grid.clear();
         self.y_grid.clear();
@@ -486,6 +593,8 @@ impl PineCartesianChart {
         self.show_x_axis = false;
         self.show_y_axis = false;
         self.show_bars = false;
+        self.show_areas = false;
+        self.show_scatter = false;
         self.show_markers = false;
     }
 
@@ -800,26 +909,211 @@ impl PineBarSeries {
     }
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[component(template = "PineAreaSeries.poco", role = "visual")]
+pub struct PineAreaSeries {
+    #[prop]
+    pub key: String,
+    #[prop]
+    pub label: String,
+    #[prop]
+    pub fill: String,
+    #[prop]
+    pub color: String,
+    #[prop]
+    pub stroke_width: f64,
+    #[prop]
+    pub points: Vec<ChartPoint>,
+    pub component_key: String,
+}
+
+impl Default for PineAreaSeries {
+    fn default() -> Self {
+        Self {
+            key: String::new(),
+            label: String::new(),
+            fill: "currentColor".into(),
+            color: "currentColor".into(),
+            stroke_width: DEFAULT_STROKE_WIDTH,
+            points: Vec::new(),
+            component_key: String::new(),
+        }
+    }
+}
+
+#[handlers]
+impl PineAreaSeries {
+    fn on_setup(&mut self) {
+        ensure_component_key(&mut self.component_key, "area-series", &self.key);
+        self.sync();
+    }
+
+    fn on_unmount(&mut self) {
+        update_root(|root| root.remove_area_series(&self.component_key));
+    }
+
+    #[watch(label)]
+    fn on_label(&mut self, _: String, _: Option<String>) {
+        self.sync();
+    }
+
+    #[watch(fill)]
+    fn on_fill(&mut self, _: String, _: Option<String>) {
+        self.sync();
+    }
+
+    #[watch(color)]
+    fn on_color(&mut self, _: String, _: Option<String>) {
+        self.sync();
+    }
+
+    #[watch(stroke_width)]
+    fn on_stroke_width(&mut self, _: f64, _: Option<f64>) {
+        self.sync();
+    }
+
+    #[watch(points)]
+    fn on_points(&mut self, _: Vec<ChartPoint>, _: Option<Vec<ChartPoint>>) {
+        self.sync();
+    }
+}
+
+impl PineAreaSeries {
+    fn sync(&self) {
+        update_root(|root| {
+            root.upsert_area_series(CartesianAreaSeriesConfig {
+                key: self.component_key.clone(),
+                label: self.label.clone(),
+                fill: color_or_current(&self.fill),
+                color: color_or_current(&self.color),
+                stroke_width: self.stroke_width,
+                points: self.points.clone(),
+            });
+        });
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[component(template = "PineScatterSeries.poco", role = "visual")]
+pub struct PineScatterSeries {
+    #[prop]
+    pub key: String,
+    #[prop]
+    pub label: String,
+    #[prop]
+    pub color: String,
+    #[prop]
+    pub point_radius: f64,
+    #[prop]
+    pub points: Vec<ChartPoint>,
+    pub component_key: String,
+}
+
+impl Default for PineScatterSeries {
+    fn default() -> Self {
+        Self {
+            key: String::new(),
+            label: String::new(),
+            color: "currentColor".into(),
+            point_radius: DEFAULT_MARKER_RADIUS,
+            points: Vec::new(),
+            component_key: String::new(),
+        }
+    }
+}
+
+#[handlers]
+impl PineScatterSeries {
+    fn on_setup(&mut self) {
+        ensure_component_key(&mut self.component_key, "scatter-series", &self.key);
+        self.sync();
+    }
+
+    fn on_unmount(&mut self) {
+        update_root(|root| root.remove_scatter_series(&self.component_key));
+    }
+
+    #[watch(label)]
+    fn on_label(&mut self, _: String, _: Option<String>) {
+        self.sync();
+    }
+
+    #[watch(color)]
+    fn on_color(&mut self, _: String, _: Option<String>) {
+        self.sync();
+    }
+
+    #[watch(point_radius)]
+    fn on_point_radius(&mut self, _: f64, _: Option<f64>) {
+        self.sync();
+    }
+
+    #[watch(points)]
+    fn on_points(&mut self, _: Vec<ChartPoint>, _: Option<Vec<ChartPoint>>) {
+        self.sync();
+    }
+}
+
+impl PineScatterSeries {
+    fn sync(&self) {
+        update_root(|root| {
+            root.upsert_scatter_series(CartesianScatterSeriesConfig {
+                key: self.component_key.clone(),
+                label: self.label.clone(),
+                color: color_or_current(&self.color),
+                point_radius: self.point_radius,
+                points: self.points.clone(),
+            });
+        });
+    }
+}
+
 pub fn render_cartesian_chart(
     options: CartesianChartOptions<'_>,
     line_series: &[CartesianLineSeriesConfig],
     bar_series: &[CartesianBarSeriesConfig],
+    area_series: &[CartesianAreaSeriesConfig],
+    scatter_series: &[CartesianScatterSeriesConfig],
 ) -> ChartResult<CartesianChartRender> {
-    if !has_renderable_series(line_series, bar_series) {
+    if !has_renderable_series(line_series, bar_series, area_series, scatter_series) {
         return Err(ChartError::EmptySeries);
     }
 
     if uses_categorical_x(line_series, bar_series) {
-        return render_categorical_chart(options, line_series, bar_series);
+        return render_categorical_chart(
+            options,
+            line_series,
+            bar_series,
+            area_series,
+            scatter_series,
+        );
     }
 
     let renderable_lines: Vec<&CartesianLineSeriesConfig> = line_series
         .iter()
         .filter(|series| !series.points.is_empty())
         .collect();
-    let line_series = renderable_lines
+    let renderable_areas: Vec<&CartesianAreaSeriesConfig> = area_series
+        .iter()
+        .filter(|series| !series.points.is_empty())
+        .collect();
+    let renderable_scatters: Vec<&CartesianScatterSeriesConfig> = scatter_series
+        .iter()
+        .filter(|series| !series.points.is_empty())
+        .collect();
+    let numeric_series = renderable_lines
         .iter()
         .map(|series| ChartLineSeries::new(series.label.clone(), series.points.clone()))
+        .chain(
+            renderable_areas
+                .iter()
+                .map(|series| ChartLineSeries::new(series.label.clone(), series.points.clone())),
+        )
+        .chain(
+            renderable_scatters
+                .iter()
+                .map(|series| ChartLineSeries::new(series.label.clone(), series.points.clone())),
+        )
         .collect::<Vec<_>>();
     let line_options = LineChartOptions {
         width: options.width,
@@ -828,15 +1122,17 @@ pub fn render_cartesian_chart(
         x_domain: options.x_domain,
         y_domain: options.y_domain,
     };
-    let geometry = LineChartGeometry::from_series(&line_series, &line_options)?;
+    let geometry = LineChartGeometry::from_series(&numeric_series, &line_options)?;
 
-    Ok(render_from_geometry(
+    render_from_geometry(
         geometry,
         options.grid,
         options.x_axis,
         options.y_axis,
         &renderable_lines,
-    ))
+        &renderable_areas,
+        &renderable_scatters,
+    )
 }
 
 fn render_from_geometry(
@@ -844,14 +1140,17 @@ fn render_from_geometry(
     grid: Option<&CartesianGridConfig>,
     x_axis: Option<&CartesianAxisConfig>,
     y_axis: Option<&CartesianAxisConfig>,
-    series_config: &[&CartesianLineSeriesConfig],
-) -> CartesianChartRender {
-    let rendered_series = geometry
-        .series
+    line_config: &[&CartesianLineSeriesConfig],
+    area_config: &[&CartesianAreaSeriesConfig],
+    scatter_config: &[&CartesianScatterSeriesConfig],
+) -> ChartResult<CartesianChartRender> {
+    let mut cursor = 0;
+    let line_end = cursor + line_config.len();
+    let rendered_series = geometry.series[cursor..line_end]
         .iter()
         .enumerate()
         .map(|(index, series)| {
-            let config = series_config[index];
+            let config = line_config[index];
             CartesianLineSeriesRender {
                 key: config.key.clone(),
                 label: series.label.clone(),
@@ -861,17 +1160,53 @@ fn render_from_geometry(
             }
         })
         .collect::<Vec<_>>();
+    cursor = line_end;
 
-    let markers = geometry
-        .series
+    let markers = geometry.series[..line_end]
         .iter()
         .enumerate()
-        .filter(|(index, _)| series_config[*index].show_markers)
+        .filter(|(index, _)| line_config[*index].show_markers)
         .flat_map(|(index, series)| {
             series
                 .samples
                 .iter()
-                .map(move |sample| marker_from_sample(sample, series_config[index]))
+                .map(move |sample| marker_from_sample(sample, line_config[index]))
+        })
+        .collect();
+
+    let area_end = cursor + area_config.len();
+    let areas = geometry.series[cursor..area_end]
+        .iter()
+        .enumerate()
+        .map(|(index, series)| {
+            let config = area_config[index];
+            Ok(CartesianAreaSeriesRender {
+                key: config.key.clone(),
+                label: series.label.clone(),
+                area_d: area_path(
+                    series.samples.iter().map(|sample| crate::geometry::Point {
+                        x: sample.x,
+                        y: sample.y,
+                    }),
+                    geometry.plot.bottom(),
+                )?,
+                line_d: series.line_d.clone(),
+                fill: color_or_current(&config.fill),
+                color: color_or_current(&config.color),
+                stroke_width: positive_or_default(config.stroke_width, DEFAULT_STROKE_WIDTH),
+            })
+        })
+        .collect::<ChartResult<Vec<_>>>()?;
+    cursor = area_end;
+
+    let scatter_points = geometry.series[cursor..]
+        .iter()
+        .enumerate()
+        .flat_map(|(index, series)| {
+            series
+                .samples
+                .iter()
+                .map(move |sample| scatter_point_from_sample(sample, scatter_config[index]))
         })
         .collect();
 
@@ -881,7 +1216,7 @@ fn render_from_geometry(
         y: false,
     });
 
-    CartesianChartRender {
+    Ok(CartesianChartRender {
         view_box: geometry.view_box,
         plot: geometry.plot,
         x_grid: if grid.x { geometry.x_grid } else { Vec::new() },
@@ -901,21 +1236,31 @@ fn render_from_geometry(
         x_axis: geometry.x_axis,
         y_axis: geometry.y_axis,
         bars: Vec::new(),
+        areas,
         line_series: rendered_series,
+        scatter_points,
         markers,
-    }
+    })
 }
 
 fn render_categorical_chart(
     options: CartesianChartOptions<'_>,
     line_series: &[CartesianLineSeriesConfig],
     bar_series: &[CartesianBarSeriesConfig],
+    area_series: &[CartesianAreaSeriesConfig],
+    scatter_series: &[CartesianScatterSeriesConfig],
 ) -> ChartResult<CartesianChartRender> {
     let categories = categorical_categories(line_series, bar_series)?;
     let width = finite("width", options.width)?;
     let height = finite("height", options.height)?;
     let plot = ChartRect::from_outer(width, height, options.margins)?;
-    let y_domain = categorical_y_domain(options.y_domain, line_series, bar_series)?;
+    let y_domain = categorical_y_domain(
+        options.y_domain,
+        line_series,
+        bar_series,
+        area_series,
+        scatter_series,
+    )?;
     let y_scale = LinearScale::new(y_domain, (plot.bottom(), plot.y))?;
     let x_scale = BandScale::new(
         categories.len(),
@@ -942,6 +1287,9 @@ fn render_categorical_chart(
     )?;
     let (line_series, markers) =
         render_categorical_lines(line_series, &categories, x_scale, y_scale)?;
+    let areas = render_categorical_areas(area_series, &categories, x_scale, y_scale, plot)?;
+    let scatter_points =
+        render_categorical_scatter_points(scatter_series, &categories, x_scale, y_scale)?;
 
     Ok(CartesianChartRender {
         view_box: format!("0 0 {width} {height}"),
@@ -977,7 +1325,9 @@ fn render_categorical_chart(
         ),
         y_axis: SvgLine::new("y-axis".into(), plot.x, plot.y, plot.x, plot.bottom()),
         bars,
+        areas,
         line_series,
+        scatter_points,
         markers,
     })
 }
@@ -985,11 +1335,17 @@ fn render_categorical_chart(
 fn has_renderable_series(
     line_series: &[CartesianLineSeriesConfig],
     bar_series: &[CartesianBarSeriesConfig],
+    area_series: &[CartesianAreaSeriesConfig],
+    scatter_series: &[CartesianScatterSeriesConfig],
 ) -> bool {
     line_series
         .iter()
         .any(|series| !series.points.is_empty() || !series.data.is_empty())
         || bar_series.iter().any(|series| !series.data.is_empty())
+        || area_series.iter().any(|series| !series.points.is_empty())
+        || scatter_series
+            .iter()
+            .any(|series| !series.points.is_empty())
 }
 
 fn uses_categorical_x(
@@ -1077,6 +1433,8 @@ fn categorical_y_domain(
     domain: Option<(f64, f64)>,
     line_series: &[CartesianLineSeriesConfig],
     bar_series: &[CartesianBarSeriesConfig],
+    area_series: &[CartesianAreaSeriesConfig],
+    scatter_series: &[CartesianScatterSeriesConfig],
 ) -> ChartResult<(f64, f64)> {
     let include_zero = bar_series.iter().any(|series| !series.data.is_empty());
     let values = bar_series
@@ -1089,6 +1447,16 @@ fn categorical_y_domain(
         )
         .chain(
             line_series
+                .iter()
+                .flat_map(|series| series.points.iter().map(|point| point.y)),
+        )
+        .chain(
+            area_series
+                .iter()
+                .flat_map(|series| series.points.iter().map(|point| point.y)),
+        )
+        .chain(
+            scatter_series
                 .iter()
                 .flat_map(|series| series.points.iter().map(|point| point.y)),
         );
@@ -1188,6 +1556,78 @@ fn render_categorical_lines(
     Ok((rendered, markers))
 }
 
+fn render_categorical_areas(
+    area_series: &[CartesianAreaSeriesConfig],
+    categories: &[String],
+    category_scale: BandScale,
+    y_scale: LinearScale,
+    plot: ChartRect,
+) -> ChartResult<Vec<CartesianAreaSeriesRender>> {
+    area_series
+        .iter()
+        .filter(|series| !series.points.is_empty())
+        .enumerate()
+        .map(|(series_index, config)| {
+            let series_label = series_label_or_default(&config.label, series_index);
+            let samples = categorical_points_samples(
+                &config.key,
+                &config.points,
+                &series_label,
+                categories,
+                category_scale,
+                y_scale,
+            )?;
+            let points = samples
+                .iter()
+                .map(|sample| crate::geometry::Point {
+                    x: sample.x,
+                    y: sample.y,
+                })
+                .collect::<Vec<_>>();
+            Ok(CartesianAreaSeriesRender {
+                key: config.key.clone(),
+                label: series_label,
+                area_d: area_path(points.iter().copied(), plot.bottom())?,
+                line_d: line_path(points.iter().copied())?,
+                fill: color_or_current(&config.fill),
+                color: color_or_current(&config.color),
+                stroke_width: positive_or_default(config.stroke_width, DEFAULT_STROKE_WIDTH),
+            })
+        })
+        .collect()
+}
+
+fn render_categorical_scatter_points(
+    scatter_series: &[CartesianScatterSeriesConfig],
+    categories: &[String],
+    category_scale: BandScale,
+    y_scale: LinearScale,
+) -> ChartResult<Vec<CartesianScatterPointRender>> {
+    let mut points = Vec::new();
+    for (series_index, config) in scatter_series
+        .iter()
+        .filter(|series| !series.points.is_empty())
+        .enumerate()
+    {
+        let series_label = series_label_or_default(&config.label, series_index);
+        let samples = categorical_points_samples(
+            &config.key,
+            &config.points,
+            &series_label,
+            categories,
+            category_scale,
+            y_scale,
+        )?;
+        points.extend(
+            samples
+                .iter()
+                .map(|sample| scatter_point_from_sample(sample, config)),
+        );
+    }
+
+    Ok(points)
+}
+
 fn categorical_data_samples(
     config: &CartesianLineSeriesConfig,
     series_label: &str,
@@ -1225,8 +1665,25 @@ fn categorical_point_samples(
     category_scale: BandScale,
     y_scale: LinearScale,
 ) -> ChartResult<Vec<LineChartSample>> {
-    config
-        .points
+    categorical_points_samples(
+        &config.key,
+        &config.points,
+        series_label,
+        categories,
+        category_scale,
+        y_scale,
+    )
+}
+
+fn categorical_points_samples(
+    key: &str,
+    points: &[ChartPoint],
+    series_label: &str,
+    categories: &[String],
+    category_scale: BandScale,
+    y_scale: LinearScale,
+) -> ChartResult<Vec<LineChartSample>> {
+    points
         .iter()
         .enumerate()
         .map(|(index, point)| {
@@ -1237,7 +1694,7 @@ fn categorical_point_samples(
             let label_index = data_x.round().clamp(0.0, categories.len() as f64 - 1.0) as usize;
             let x_label = categories.get(label_index).cloned().unwrap_or_default();
             Ok(LineChartSample {
-                key: format!("{}-point-{index}-{}", config.key, format_tick(data_x)),
+                key: format!("{}-point-{index}-{}", key, format_tick(data_x)),
                 series_label: series_label.into(),
                 data_x,
                 data_y,
@@ -1321,6 +1778,23 @@ fn marker_from_sample(
         data_y: sample.data_y,
         color: color_or_current(&config.color),
         radius: positive_or_default(config.marker_radius, DEFAULT_MARKER_RADIUS),
+        aria_label: sample.aria_label.clone(),
+    }
+}
+
+fn scatter_point_from_sample(
+    sample: &LineChartSample,
+    config: &CartesianScatterSeriesConfig,
+) -> CartesianScatterPointRender {
+    CartesianScatterPointRender {
+        key: format!("{}-{}", config.key, sample.key),
+        series_label: sample.series_label.clone(),
+        x: sample.x,
+        y: sample.y,
+        data_x: sample.data_x,
+        data_y: sample.data_y,
+        color: color_or_current(&config.color),
+        radius: positive_or_default(config.point_radius, DEFAULT_MARKER_RADIUS),
         aria_label: sample.aria_label.clone(),
     }
 }
@@ -1411,6 +1885,8 @@ mod tests {
             },
             &series,
             &[],
+            &[],
+            &[],
         )
         .unwrap();
 
@@ -1464,6 +1940,8 @@ mod tests {
             },
             &lines,
             &bars,
+            &[],
+            &[],
         )
         .unwrap();
 
@@ -1474,6 +1952,55 @@ mod tests {
         assert_eq!(render.markers.len(), 2);
         assert_eq!(render.x_tick_labels[0].label, "W1");
         assert_eq!(render.x_tick_labels[1].label, "W2");
+    }
+
+    #[test]
+    fn cartesian_chart_composes_area_and_scatter_series() {
+        let areas = vec![CartesianAreaSeriesConfig {
+            key: "forecast-band".into(),
+            label: "Forecast".into(),
+            fill: "#1d6fd833".into(),
+            color: "#1d6fd8".into(),
+            stroke_width: 2.0,
+            points: vec![ChartPoint::new(0.0, 0.0), ChartPoint::new(10.0, 10.0)],
+        }];
+        let scatters = vec![CartesianScatterSeriesConfig {
+            key: "samples".into(),
+            label: "Samples".into(),
+            color: "#d96c2c".into(),
+            point_radius: 6.0,
+            points: vec![ChartPoint::new(5.0, 5.0)],
+        }];
+
+        let render = render_cartesian_chart(
+            CartesianChartOptions {
+                width: 100.0,
+                height: 100.0,
+                margins: ChartMargins::ZERO,
+                x_domain: None,
+                y_domain: None,
+                padding_inner: DEFAULT_PADDING_INNER,
+                padding_outer: DEFAULT_PADDING_OUTER,
+                series_padding_inner: DEFAULT_SERIES_PADDING_INNER,
+                grid: None,
+                x_axis: None,
+                y_axis: None,
+            },
+            &[],
+            &[],
+            &areas,
+            &scatters,
+        )
+        .unwrap();
+
+        assert_eq!(render.areas.len(), 1);
+        assert_eq!(render.areas[0].area_d, "M0,100 L0,100 L100,0 L100,100Z");
+        assert_eq!(render.areas[0].line_d, "M0,100 L100,0");
+        assert_eq!(render.scatter_points.len(), 1);
+        assert_eq!(render.scatter_points[0].series_label, "Samples");
+        assert_eq!(render.scatter_points[0].x, 50.0);
+        assert_eq!(render.scatter_points[0].y, 50.0);
+        assert!(render.line_series.is_empty());
     }
 
     #[test]
@@ -1492,6 +2019,8 @@ mod tests {
                 x_axis: None,
                 y_axis: None,
             },
+            &[],
+            &[],
             &[],
             &[],
         )

--- a/crates/pine-charts/src/cartesian_chart/mod.rs
+++ b/crates/pine-charts/src/cartesian_chart/mod.rs
@@ -13,6 +13,9 @@ use crate::legend::series_label_or_default;
 use crate::line::{
     ChartLineSeries, ChartPoint, LineChartGeometry, LineChartOptions, LineChartSample,
 };
+use crate::marks::{
+    color_or, color_or_current, key_or_index, label_or_key, rotation_transform, text_anchor,
+};
 use crate::path::{area_path, line_path};
 use crate::scale::{BandScale, LinearScale};
 use crate::svg::{format_tick, SvgAxisLabel, SvgLine, SvgTickLabel};
@@ -2545,19 +2548,6 @@ fn component_key(prefix: &str, authored_key: &str) -> String {
         .unwrap_or_else(|| prefix.into())
 }
 
-fn color_or_current(value: &str) -> String {
-    color_or(value, "currentColor")
-}
-
-fn color_or(value: &str, fallback: &str) -> String {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        fallback.into()
-    } else {
-        trimmed.into()
-    }
-}
-
 fn positive_or_default(value: f64, default: f64) -> f64 {
     if value.is_finite() && value > 0.0 {
         value
@@ -2582,38 +2572,6 @@ fn reference_layer(value: &str, field: &'static str) -> ChartResult<&'static str
             field,
             value: value.into(),
         }),
-    }
-}
-
-fn text_anchor(value: &str) -> &'static str {
-    match value.trim() {
-        "start" => "start",
-        "end" => "end",
-        _ => "middle",
-    }
-}
-
-fn rotation_transform(angle: f64, x: f64, y: f64) -> String {
-    if angle.abs() <= f64::EPSILON {
-        String::new()
-    } else {
-        format!("rotate({angle} {x} {y})")
-    }
-}
-
-fn label_or_key(label: &str, key: &str, index: usize) -> String {
-    if label.trim().is_empty() {
-        key_or_index("item", key, index)
-    } else {
-        label.trim().into()
-    }
-}
-
-fn key_or_index(prefix: &str, key: &str, index: usize) -> String {
-    if key.trim().is_empty() {
-        format!("{prefix}-{index}")
-    } else {
-        key.trim().into()
     }
 }
 

--- a/crates/pine-charts/src/cartesian_chart/mod.rs
+++ b/crates/pine-charts/src/cartesian_chart/mod.rs
@@ -21,6 +21,7 @@ const DEFAULT_WIDTH: f64 = 640.0;
 const DEFAULT_HEIGHT: f64 = 320.0;
 const DEFAULT_STROKE_WIDTH: f64 = 3.0;
 const DEFAULT_MARKER_RADIUS: f64 = 3.0;
+const DEFAULT_REFERENCE_RADIUS: f64 = 6.0;
 const DEFAULT_PADDING_INNER: f64 = 0.2;
 const DEFAULT_PADDING_OUTER: f64 = 0.1;
 const DEFAULT_SERIES_PADDING_INNER: f64 = 0.1;
@@ -89,6 +90,45 @@ pub struct CartesianScatterSeriesConfig {
     pub points: Vec<ChartPoint>,
 }
 
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct CartesianReferenceLineConfig {
+    pub key: String,
+    pub label: String,
+    pub x: Option<f64>,
+    pub y: Option<f64>,
+    pub color: String,
+    pub stroke_width: f64,
+    pub stroke_dasharray: String,
+    pub layer: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct CartesianReferenceDotConfig {
+    pub key: String,
+    pub label: String,
+    pub x: f64,
+    pub y: f64,
+    pub radius: f64,
+    pub fill: String,
+    pub stroke: String,
+    pub stroke_width: f64,
+    pub layer: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct CartesianReferenceLabelConfig {
+    pub key: String,
+    pub text: String,
+    pub x: f64,
+    pub y: f64,
+    pub dx: f64,
+    pub dy: f64,
+    pub angle: f64,
+    pub fill: String,
+    pub text_anchor: String,
+    pub font_weight: String,
+}
+
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct CartesianLineSeriesRender {
     pub key: String,
@@ -150,6 +190,51 @@ pub struct CartesianScatterPointRender {
     pub aria_label: String,
 }
 
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct CartesianReferenceLineRender {
+    pub key: String,
+    pub label: String,
+    pub x1: f64,
+    pub y1: f64,
+    pub x2: f64,
+    pub y2: f64,
+    pub color: String,
+    pub stroke_width: f64,
+    pub stroke_dasharray: String,
+    pub layer: String,
+    pub aria_label: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct CartesianReferenceDotRender {
+    pub key: String,
+    pub label: String,
+    pub x: f64,
+    pub y: f64,
+    pub data_x: f64,
+    pub data_y: f64,
+    pub radius: f64,
+    pub fill: String,
+    pub stroke: String,
+    pub stroke_width: f64,
+    pub layer: String,
+    pub aria_label: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct CartesianReferenceLabelRender {
+    pub key: String,
+    pub text: String,
+    pub x: f64,
+    pub y: f64,
+    pub data_x: f64,
+    pub data_y: f64,
+    pub fill: String,
+    pub text_anchor: String,
+    pub font_weight: String,
+    pub transform: String,
+}
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct CartesianChartRender {
     pub view_box: String,
@@ -167,6 +252,9 @@ pub struct CartesianChartRender {
     pub line_series: Vec<CartesianLineSeriesRender>,
     pub scatter_points: Vec<CartesianScatterPointRender>,
     pub markers: Vec<CartesianMarkerRender>,
+    pub reference_lines: Vec<CartesianReferenceLineRender>,
+    pub reference_dots: Vec<CartesianReferenceDotRender>,
+    pub reference_labels: Vec<CartesianReferenceLabelRender>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -184,9 +272,20 @@ pub struct CartesianChartOptions<'a> {
     pub y_axis: Option<&'a CartesianAxisConfig>,
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct CartesianChartInputs<'a> {
+    pub line_series: &'a [CartesianLineSeriesConfig],
+    pub bar_series: &'a [CartesianBarSeriesConfig],
+    pub area_series: &'a [CartesianAreaSeriesConfig],
+    pub scatter_series: &'a [CartesianScatterSeriesConfig],
+    pub reference_lines: &'a [CartesianReferenceLineConfig],
+    pub reference_dots: &'a [CartesianReferenceDotConfig],
+    pub reference_labels: &'a [CartesianReferenceLabelConfig],
+}
+
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[component(template = "PineCartesianChart.poco", role = "panel")]
-#[slot(default, accepts = [PineChartGrid, PineXAxis, PineYAxis, PineLineSeries, PineBarSeries, PineAreaSeries, PineScatterSeries])]
+#[slot(default, accepts = [PineChartGrid, PineXAxis, PineYAxis, PineLineSeries, PineBarSeries, PineAreaSeries, PineScatterSeries, PineCartesianReferenceLine, PineCartesianReferenceDot, PineCartesianReferenceLabel])]
 pub struct PineCartesianChart {
     #[prop]
     pub label: String,
@@ -225,11 +324,19 @@ pub struct PineCartesianChart {
     pub bar_series: Vec<CartesianBarSeriesConfig>,
     pub area_series: Vec<CartesianAreaSeriesConfig>,
     pub scatter_series: Vec<CartesianScatterSeriesConfig>,
+    pub reference_lines: Vec<CartesianReferenceLineConfig>,
+    pub reference_dots: Vec<CartesianReferenceDotConfig>,
+    pub reference_labels: Vec<CartesianReferenceLabelConfig>,
     pub bars: Vec<CartesianBarRender>,
     pub areas: Vec<CartesianAreaSeriesRender>,
     pub line_series: Vec<CartesianLineSeriesRender>,
     pub scatter_points: Vec<CartesianScatterPointRender>,
     pub markers: Vec<CartesianMarkerRender>,
+    pub reference_background_lines: Vec<CartesianReferenceLineRender>,
+    pub reference_foreground_lines: Vec<CartesianReferenceLineRender>,
+    pub reference_background_dots: Vec<CartesianReferenceDotRender>,
+    pub reference_foreground_dots: Vec<CartesianReferenceDotRender>,
+    pub svg_reference_labels: Vec<CartesianReferenceLabelRender>,
     pub plot_x: f64,
     pub plot_y: f64,
     pub plot_right: f64,
@@ -251,6 +358,9 @@ pub struct PineCartesianChart {
     pub show_areas: bool,
     pub show_scatter: bool,
     pub show_markers: bool,
+    pub show_reference_background: bool,
+    pub show_reference_foreground: bool,
+    pub show_reference_labels: bool,
     pub error: String,
     pub ready: bool,
     pub empty: bool,
@@ -284,11 +394,19 @@ impl Default for PineCartesianChart {
             bar_series: Vec::new(),
             area_series: Vec::new(),
             scatter_series: Vec::new(),
+            reference_lines: Vec::new(),
+            reference_dots: Vec::new(),
+            reference_labels: Vec::new(),
             bars: Vec::new(),
             areas: Vec::new(),
             line_series: Vec::new(),
             scatter_points: Vec::new(),
             markers: Vec::new(),
+            reference_background_lines: Vec::new(),
+            reference_foreground_lines: Vec::new(),
+            reference_background_dots: Vec::new(),
+            reference_foreground_dots: Vec::new(),
+            svg_reference_labels: Vec::new(),
             plot_x: 0.0,
             plot_y: 0.0,
             plot_right: 0.0,
@@ -310,6 +428,9 @@ impl Default for PineCartesianChart {
             show_areas: false,
             show_scatter: false,
             show_markers: false,
+            show_reference_background: false,
+            show_reference_foreground: false,
+            show_reference_labels: false,
             error: String::new(),
             ready: false,
             empty: true,
@@ -488,6 +609,63 @@ impl PineCartesianChart {
         self.recompute();
     }
 
+    pub fn upsert_reference_line(&mut self, line: CartesianReferenceLineConfig) {
+        let key = line.key.clone();
+        if let Some(existing) = self
+            .reference_lines
+            .iter_mut()
+            .find(|existing| existing.key == key)
+        {
+            *existing = line;
+        } else {
+            self.reference_lines.push(line);
+        }
+        self.recompute();
+    }
+
+    pub fn remove_reference_line(&mut self, key: &str) {
+        self.reference_lines.retain(|line| line.key != key);
+        self.recompute();
+    }
+
+    pub fn upsert_reference_dot(&mut self, dot: CartesianReferenceDotConfig) {
+        let key = dot.key.clone();
+        if let Some(existing) = self
+            .reference_dots
+            .iter_mut()
+            .find(|existing| existing.key == key)
+        {
+            *existing = dot;
+        } else {
+            self.reference_dots.push(dot);
+        }
+        self.recompute();
+    }
+
+    pub fn remove_reference_dot(&mut self, key: &str) {
+        self.reference_dots.retain(|dot| dot.key != key);
+        self.recompute();
+    }
+
+    pub fn upsert_reference_label(&mut self, label: CartesianReferenceLabelConfig) {
+        let key = label.key.clone();
+        if let Some(existing) = self
+            .reference_labels
+            .iter_mut()
+            .find(|existing| existing.key == key)
+        {
+            *existing = label;
+        } else {
+            self.reference_labels.push(label);
+        }
+        self.recompute();
+    }
+
+    pub fn remove_reference_label(&mut self, key: &str) {
+        self.reference_labels.retain(|label| label.key != key);
+        self.recompute();
+    }
+
     fn recompute(&mut self) {
         let options = CartesianChartOptions {
             width: self.width,
@@ -505,10 +683,15 @@ impl PineCartesianChart {
 
         match render_cartesian_chart(
             options,
-            &self.series,
-            &self.bar_series,
-            &self.area_series,
-            &self.scatter_series,
+            CartesianChartInputs {
+                line_series: &self.series,
+                bar_series: &self.bar_series,
+                area_series: &self.area_series,
+                scatter_series: &self.scatter_series,
+                reference_lines: &self.reference_lines,
+                reference_dots: &self.reference_dots,
+                reference_labels: &self.reference_labels,
+            },
         ) {
             Ok(render) => {
                 self.view_box = render.view_box;
@@ -529,6 +712,19 @@ impl PineCartesianChart {
                 self.line_series = render.line_series;
                 self.scatter_points = render.scatter_points;
                 self.markers = render.markers;
+                let (foreground_lines, background_lines): (Vec<_>, Vec<_>) = render
+                    .reference_lines
+                    .into_iter()
+                    .partition(|line| line.layer == "reference-foreground");
+                let (foreground_dots, background_dots): (Vec<_>, Vec<_>) = render
+                    .reference_dots
+                    .into_iter()
+                    .partition(|dot| dot.layer == "reference-foreground");
+                self.reference_background_lines = background_lines;
+                self.reference_foreground_lines = foreground_lines;
+                self.reference_background_dots = background_dots;
+                self.reference_foreground_dots = foreground_dots;
+                self.svg_reference_labels = render.reference_labels;
                 self.show_grid = !self.x_grid.is_empty() || !self.y_grid.is_empty();
                 self.show_x_axis = self.x_axis_config.is_some();
                 self.show_y_axis = self.y_axis_config.is_some();
@@ -546,6 +742,11 @@ impl PineCartesianChart {
                 self.show_areas = !self.areas.is_empty();
                 self.show_scatter = !self.scatter_points.is_empty();
                 self.show_markers = !self.markers.is_empty();
+                self.show_reference_background = !self.reference_background_lines.is_empty()
+                    || !self.reference_background_dots.is_empty();
+                self.show_reference_foreground = !self.reference_foreground_lines.is_empty()
+                    || !self.reference_foreground_dots.is_empty();
+                self.show_reference_labels = !self.svg_reference_labels.is_empty();
                 self.error.clear();
                 self.state = "ready".into();
                 self.ready = true;
@@ -577,6 +778,11 @@ impl PineCartesianChart {
         self.line_series.clear();
         self.scatter_points.clear();
         self.markers.clear();
+        self.reference_background_lines.clear();
+        self.reference_foreground_lines.clear();
+        self.reference_background_dots.clear();
+        self.reference_foreground_dots.clear();
+        self.svg_reference_labels.clear();
         self.x_grid.clear();
         self.y_grid.clear();
         self.x_tick_labels.clear();
@@ -596,6 +802,9 @@ impl PineCartesianChart {
         self.show_areas = false;
         self.show_scatter = false;
         self.show_markers = false;
+        self.show_reference_background = false;
+        self.show_reference_foreground = false;
+        self.show_reference_labels = false;
     }
 
     fn margins(&self) -> ChartMargins {
@@ -1068,36 +1277,368 @@ impl PineScatterSeries {
     }
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[component(template = "PineCartesianReferenceLine.poco", role = "visual")]
+pub struct PineCartesianReferenceLine {
+    #[prop]
+    pub key: String,
+    #[prop]
+    pub label: String,
+    #[prop]
+    pub x: Option<f64>,
+    #[prop]
+    pub y: Option<f64>,
+    #[prop]
+    pub color: String,
+    #[prop]
+    pub stroke_width: f64,
+    #[prop]
+    pub stroke_dasharray: String,
+    #[prop]
+    pub layer: String,
+    pub component_key: String,
+}
+
+impl Default for PineCartesianReferenceLine {
+    fn default() -> Self {
+        Self {
+            key: String::new(),
+            label: String::new(),
+            x: None,
+            y: None,
+            color: "currentColor".into(),
+            stroke_width: 1.0,
+            stroke_dasharray: String::new(),
+            layer: "reference-background".into(),
+            component_key: String::new(),
+        }
+    }
+}
+
+#[handlers]
+impl PineCartesianReferenceLine {
+    fn on_setup(&mut self) {
+        ensure_component_key(&mut self.component_key, "reference-line", &self.key);
+        self.sync();
+    }
+
+    fn on_unmount(&mut self) {
+        update_root(|root| root.remove_reference_line(&self.component_key));
+    }
+
+    #[watch(label)]
+    fn on_label(&mut self, _: String, _: Option<String>) {
+        self.sync();
+    }
+
+    #[watch(x)]
+    fn on_x(&mut self, _: Option<f64>, _: Option<Option<f64>>) {
+        self.sync();
+    }
+
+    #[watch(y)]
+    fn on_y(&mut self, _: Option<f64>, _: Option<Option<f64>>) {
+        self.sync();
+    }
+
+    #[watch(color)]
+    fn on_color(&mut self, _: String, _: Option<String>) {
+        self.sync();
+    }
+
+    #[watch(stroke_width)]
+    fn on_stroke_width(&mut self, _: f64, _: Option<f64>) {
+        self.sync();
+    }
+
+    #[watch(stroke_dasharray)]
+    fn on_stroke_dasharray(&mut self, _: String, _: Option<String>) {
+        self.sync();
+    }
+
+    #[watch(layer)]
+    fn on_layer(&mut self, _: String, _: Option<String>) {
+        self.sync();
+    }
+}
+
+impl PineCartesianReferenceLine {
+    fn sync(&self) {
+        update_root(|root| {
+            root.upsert_reference_line(CartesianReferenceLineConfig {
+                key: self.component_key.clone(),
+                label: self.label.clone(),
+                x: self.x,
+                y: self.y,
+                color: color_or_current(&self.color),
+                stroke_width: self.stroke_width,
+                stroke_dasharray: self.stroke_dasharray.clone(),
+                layer: self.layer.clone(),
+            });
+        });
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[component(template = "PineCartesianReferenceDot.poco", role = "visual")]
+pub struct PineCartesianReferenceDot {
+    #[prop]
+    pub key: String,
+    #[prop]
+    pub label: String,
+    #[prop]
+    pub x: f64,
+    #[prop]
+    pub y: f64,
+    #[prop]
+    pub radius: f64,
+    #[prop]
+    pub fill: String,
+    #[prop]
+    pub stroke: String,
+    #[prop]
+    pub stroke_width: f64,
+    #[prop]
+    pub layer: String,
+    pub component_key: String,
+}
+
+impl Default for PineCartesianReferenceDot {
+    fn default() -> Self {
+        Self {
+            key: String::new(),
+            label: String::new(),
+            x: 0.0,
+            y: 0.0,
+            radius: DEFAULT_REFERENCE_RADIUS,
+            fill: "currentColor".into(),
+            stroke: "none".into(),
+            stroke_width: 0.0,
+            layer: "reference-foreground".into(),
+            component_key: String::new(),
+        }
+    }
+}
+
+#[handlers]
+impl PineCartesianReferenceDot {
+    fn on_setup(&mut self) {
+        ensure_component_key(&mut self.component_key, "reference-dot", &self.key);
+        self.sync();
+    }
+
+    fn on_unmount(&mut self) {
+        update_root(|root| root.remove_reference_dot(&self.component_key));
+    }
+
+    #[watch(label)]
+    fn on_label(&mut self, _: String, _: Option<String>) {
+        self.sync();
+    }
+
+    #[watch(x)]
+    fn on_x(&mut self, _: f64, _: Option<f64>) {
+        self.sync();
+    }
+
+    #[watch(y)]
+    fn on_y(&mut self, _: f64, _: Option<f64>) {
+        self.sync();
+    }
+
+    #[watch(radius)]
+    fn on_radius(&mut self, _: f64, _: Option<f64>) {
+        self.sync();
+    }
+
+    #[watch(fill)]
+    fn on_fill(&mut self, _: String, _: Option<String>) {
+        self.sync();
+    }
+
+    #[watch(stroke)]
+    fn on_stroke(&mut self, _: String, _: Option<String>) {
+        self.sync();
+    }
+
+    #[watch(stroke_width)]
+    fn on_stroke_width(&mut self, _: f64, _: Option<f64>) {
+        self.sync();
+    }
+
+    #[watch(layer)]
+    fn on_layer(&mut self, _: String, _: Option<String>) {
+        self.sync();
+    }
+}
+
+impl PineCartesianReferenceDot {
+    fn sync(&self) {
+        update_root(|root| {
+            root.upsert_reference_dot(CartesianReferenceDotConfig {
+                key: self.component_key.clone(),
+                label: self.label.clone(),
+                x: self.x,
+                y: self.y,
+                radius: self.radius,
+                fill: color_or_current(&self.fill),
+                stroke: color_or(&self.stroke, "none"),
+                stroke_width: self.stroke_width,
+                layer: self.layer.clone(),
+            });
+        });
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[component(template = "PineCartesianReferenceLabel.poco", role = "visual")]
+pub struct PineCartesianReferenceLabel {
+    #[prop]
+    pub key: String,
+    #[prop]
+    pub text: String,
+    #[prop]
+    pub x: f64,
+    #[prop]
+    pub y: f64,
+    #[prop]
+    pub dx: f64,
+    #[prop]
+    pub dy: f64,
+    #[prop]
+    pub angle: f64,
+    #[prop]
+    pub fill: String,
+    #[prop]
+    pub text_anchor: String,
+    #[prop]
+    pub font_weight: String,
+    pub component_key: String,
+}
+
+impl Default for PineCartesianReferenceLabel {
+    fn default() -> Self {
+        Self {
+            key: String::new(),
+            text: String::new(),
+            x: 0.0,
+            y: 0.0,
+            dx: 0.0,
+            dy: 0.0,
+            angle: 0.0,
+            fill: "currentColor".into(),
+            text_anchor: "middle".into(),
+            font_weight: "600".into(),
+            component_key: String::new(),
+        }
+    }
+}
+
+#[handlers]
+impl PineCartesianReferenceLabel {
+    fn on_setup(&mut self) {
+        ensure_component_key(&mut self.component_key, "reference-label", &self.key);
+        self.sync();
+    }
+
+    fn on_unmount(&mut self) {
+        update_root(|root| root.remove_reference_label(&self.component_key));
+    }
+
+    #[watch(text)]
+    fn on_text(&mut self, _: String, _: Option<String>) {
+        self.sync();
+    }
+
+    #[watch(x)]
+    fn on_x(&mut self, _: f64, _: Option<f64>) {
+        self.sync();
+    }
+
+    #[watch(y)]
+    fn on_y(&mut self, _: f64, _: Option<f64>) {
+        self.sync();
+    }
+
+    #[watch(dx)]
+    fn on_dx(&mut self, _: f64, _: Option<f64>) {
+        self.sync();
+    }
+
+    #[watch(dy)]
+    fn on_dy(&mut self, _: f64, _: Option<f64>) {
+        self.sync();
+    }
+
+    #[watch(angle)]
+    fn on_angle(&mut self, _: f64, _: Option<f64>) {
+        self.sync();
+    }
+
+    #[watch(fill)]
+    fn on_fill(&mut self, _: String, _: Option<String>) {
+        self.sync();
+    }
+
+    #[watch(text_anchor)]
+    fn on_text_anchor(&mut self, _: String, _: Option<String>) {
+        self.sync();
+    }
+
+    #[watch(font_weight)]
+    fn on_font_weight(&mut self, _: String, _: Option<String>) {
+        self.sync();
+    }
+}
+
+impl PineCartesianReferenceLabel {
+    fn sync(&self) {
+        update_root(|root| {
+            root.upsert_reference_label(CartesianReferenceLabelConfig {
+                key: self.component_key.clone(),
+                text: self.text.clone(),
+                x: self.x,
+                y: self.y,
+                dx: self.dx,
+                dy: self.dy,
+                angle: self.angle,
+                fill: color_or_current(&self.fill),
+                text_anchor: self.text_anchor.clone(),
+                font_weight: self.font_weight.clone(),
+            });
+        });
+    }
+}
+
 pub fn render_cartesian_chart(
     options: CartesianChartOptions<'_>,
-    line_series: &[CartesianLineSeriesConfig],
-    bar_series: &[CartesianBarSeriesConfig],
-    area_series: &[CartesianAreaSeriesConfig],
-    scatter_series: &[CartesianScatterSeriesConfig],
+    inputs: CartesianChartInputs<'_>,
 ) -> ChartResult<CartesianChartRender> {
-    if !has_renderable_series(line_series, bar_series, area_series, scatter_series) {
+    if !has_renderable_series(
+        inputs.line_series,
+        inputs.bar_series,
+        inputs.area_series,
+        inputs.scatter_series,
+    ) {
         return Err(ChartError::EmptySeries);
     }
 
-    if uses_categorical_x(line_series, bar_series) {
-        return render_categorical_chart(
-            options,
-            line_series,
-            bar_series,
-            area_series,
-            scatter_series,
-        );
+    if uses_categorical_x(inputs.line_series, inputs.bar_series) {
+        return render_categorical_chart(options, inputs);
     }
 
-    let renderable_lines: Vec<&CartesianLineSeriesConfig> = line_series
+    let renderable_lines: Vec<&CartesianLineSeriesConfig> = inputs
+        .line_series
         .iter()
         .filter(|series| !series.points.is_empty())
         .collect();
-    let renderable_areas: Vec<&CartesianAreaSeriesConfig> = area_series
+    let renderable_areas: Vec<&CartesianAreaSeriesConfig> = inputs
+        .area_series
         .iter()
         .filter(|series| !series.points.is_empty())
         .collect();
-    let renderable_scatters: Vec<&CartesianScatterSeriesConfig> = scatter_series
+    let renderable_scatters: Vec<&CartesianScatterSeriesConfig> = inputs
+        .scatter_series
         .iter()
         .filter(|series| !series.points.is_empty())
         .collect();
@@ -1129,10 +1670,25 @@ pub fn render_cartesian_chart(
         options.grid,
         options.x_axis,
         options.y_axis,
-        &renderable_lines,
-        &renderable_areas,
-        &renderable_scatters,
+        GeometryRenderInputs {
+            line_config: &renderable_lines,
+            area_config: &renderable_areas,
+            scatter_config: &renderable_scatters,
+            reference_lines: inputs.reference_lines,
+            reference_dots: inputs.reference_dots,
+            reference_labels: inputs.reference_labels,
+        },
     )
+}
+
+#[derive(Clone, Copy)]
+struct GeometryRenderInputs<'a> {
+    line_config: &'a [&'a CartesianLineSeriesConfig],
+    area_config: &'a [&'a CartesianAreaSeriesConfig],
+    scatter_config: &'a [&'a CartesianScatterSeriesConfig],
+    reference_lines: &'a [CartesianReferenceLineConfig],
+    reference_dots: &'a [CartesianReferenceDotConfig],
+    reference_labels: &'a [CartesianReferenceLabelConfig],
 }
 
 fn render_from_geometry(
@@ -1140,17 +1696,15 @@ fn render_from_geometry(
     grid: Option<&CartesianGridConfig>,
     x_axis: Option<&CartesianAxisConfig>,
     y_axis: Option<&CartesianAxisConfig>,
-    line_config: &[&CartesianLineSeriesConfig],
-    area_config: &[&CartesianAreaSeriesConfig],
-    scatter_config: &[&CartesianScatterSeriesConfig],
+    inputs: GeometryRenderInputs<'_>,
 ) -> ChartResult<CartesianChartRender> {
     let mut cursor = 0;
-    let line_end = cursor + line_config.len();
+    let line_end = cursor + inputs.line_config.len();
     let rendered_series = geometry.series[cursor..line_end]
         .iter()
         .enumerate()
         .map(|(index, series)| {
-            let config = line_config[index];
+            let config = inputs.line_config[index];
             CartesianLineSeriesRender {
                 key: config.key.clone(),
                 label: series.label.clone(),
@@ -1165,21 +1719,21 @@ fn render_from_geometry(
     let markers = geometry.series[..line_end]
         .iter()
         .enumerate()
-        .filter(|(index, _)| line_config[*index].show_markers)
+        .filter(|(index, _)| inputs.line_config[*index].show_markers)
         .flat_map(|(index, series)| {
             series
                 .samples
                 .iter()
-                .map(move |sample| marker_from_sample(sample, line_config[index]))
+                .map(move |sample| marker_from_sample(sample, inputs.line_config[index]))
         })
         .collect();
 
-    let area_end = cursor + area_config.len();
+    let area_end = cursor + inputs.area_config.len();
     let areas = geometry.series[cursor..area_end]
         .iter()
         .enumerate()
         .map(|(index, series)| {
-            let config = area_config[index];
+            let config = inputs.area_config[index];
             Ok(CartesianAreaSeriesRender {
                 key: config.key.clone(),
                 label: series.label.clone(),
@@ -1206,9 +1760,25 @@ fn render_from_geometry(
             series
                 .samples
                 .iter()
-                .map(move |sample| scatter_point_from_sample(sample, scatter_config[index]))
+                .map(move |sample| scatter_point_from_sample(sample, inputs.scatter_config[index]))
         })
         .collect();
+    let rendered_reference_lines = render_reference_lines(
+        inputs.reference_lines,
+        geometry.plot,
+        |value| geometry.x_scale.map(value),
+        |value| geometry.y_scale.map(value),
+    )?;
+    let rendered_reference_dots = render_reference_dots(
+        inputs.reference_dots,
+        |value| geometry.x_scale.map(value),
+        |value| geometry.y_scale.map(value),
+    )?;
+    let rendered_reference_labels = render_reference_labels(
+        inputs.reference_labels,
+        |value| geometry.x_scale.map(value),
+        |value| geometry.y_scale.map(value),
+    )?;
 
     let grid = grid.cloned().unwrap_or(CartesianGridConfig {
         key: String::new(),
@@ -1240,26 +1810,26 @@ fn render_from_geometry(
         line_series: rendered_series,
         scatter_points,
         markers,
+        reference_lines: rendered_reference_lines,
+        reference_dots: rendered_reference_dots,
+        reference_labels: rendered_reference_labels,
     })
 }
 
 fn render_categorical_chart(
     options: CartesianChartOptions<'_>,
-    line_series: &[CartesianLineSeriesConfig],
-    bar_series: &[CartesianBarSeriesConfig],
-    area_series: &[CartesianAreaSeriesConfig],
-    scatter_series: &[CartesianScatterSeriesConfig],
+    inputs: CartesianChartInputs<'_>,
 ) -> ChartResult<CartesianChartRender> {
-    let categories = categorical_categories(line_series, bar_series)?;
+    let categories = categorical_categories(inputs.line_series, inputs.bar_series)?;
     let width = finite("width", options.width)?;
     let height = finite("height", options.height)?;
     let plot = ChartRect::from_outer(width, height, options.margins)?;
     let y_domain = categorical_y_domain(
         options.y_domain,
-        line_series,
-        bar_series,
-        area_series,
-        scatter_series,
+        inputs.line_series,
+        inputs.bar_series,
+        inputs.area_series,
+        inputs.scatter_series,
     )?;
     let y_scale = LinearScale::new(y_domain, (plot.bottom(), plot.y))?;
     let x_scale = BandScale::new(
@@ -1278,7 +1848,7 @@ fn render_categorical_chart(
     });
 
     let bars = render_categorical_bars(
-        bar_series,
+        inputs.bar_series,
         &categories,
         x_scale,
         y_scale,
@@ -1286,10 +1856,26 @@ fn render_categorical_chart(
         options.series_padding_inner,
     )?;
     let (line_series, markers) =
-        render_categorical_lines(line_series, &categories, x_scale, y_scale)?;
-    let areas = render_categorical_areas(area_series, &categories, x_scale, y_scale, plot)?;
+        render_categorical_lines(inputs.line_series, &categories, x_scale, y_scale)?;
+    let areas = render_categorical_areas(inputs.area_series, &categories, x_scale, y_scale, plot)?;
     let scatter_points =
-        render_categorical_scatter_points(scatter_series, &categories, x_scale, y_scale)?;
+        render_categorical_scatter_points(inputs.scatter_series, &categories, x_scale, y_scale)?;
+    let rendered_reference_lines = render_reference_lines(
+        inputs.reference_lines,
+        plot,
+        |value| categorical_point_x(value, categories.len(), x_scale),
+        |value| y_scale.map(value),
+    )?;
+    let rendered_reference_dots = render_reference_dots(
+        inputs.reference_dots,
+        |value| categorical_point_x(value, categories.len(), x_scale),
+        |value| y_scale.map(value),
+    )?;
+    let rendered_reference_labels = render_reference_labels(
+        inputs.reference_labels,
+        |value| categorical_point_x(value, categories.len(), x_scale),
+        |value| y_scale.map(value),
+    )?;
 
     Ok(CartesianChartRender {
         view_box: format!("0 0 {width} {height}"),
@@ -1329,6 +1915,9 @@ fn render_categorical_chart(
         line_series,
         scatter_points,
         markers,
+        reference_lines: rendered_reference_lines,
+        reference_dots: rendered_reference_dots,
+        reference_labels: rendered_reference_labels,
     })
 }
 
@@ -1628,6 +2217,125 @@ fn render_categorical_scatter_points(
     Ok(points)
 }
 
+fn render_reference_lines(
+    lines: &[CartesianReferenceLineConfig],
+    plot: ChartRect,
+    mut map_x: impl FnMut(f64) -> ChartResult<f64>,
+    mut map_y: impl FnMut(f64) -> ChartResult<f64>,
+) -> ChartResult<Vec<CartesianReferenceLineRender>> {
+    lines
+        .iter()
+        .enumerate()
+        .map(|(index, line)| {
+            let layer = reference_layer(&line.layer, "reference_line.layer")?;
+            let label = label_or_key(&line.label, &line.key, index);
+            let (x1, y1, x2, y2, axis, value) = match (line.x, line.y) {
+                (Some(x), None) => {
+                    let value = finite("reference_line.x", x)?;
+                    let x = map_x(value)?;
+                    (x, plot.y, x, plot.bottom(), "x", value)
+                }
+                (None, Some(y)) => {
+                    let value = finite("reference_line.y", y)?;
+                    let y = map_y(value)?;
+                    (plot.x, y, plot.right(), y, "y", value)
+                }
+                (Some(_), Some(_)) => {
+                    return Err(ChartError::InvalidOption {
+                        field: "reference_line.axis",
+                        value: "x and y".into(),
+                    });
+                }
+                (None, None) => {
+                    return Err(ChartError::InvalidOption {
+                        field: "reference_line.axis",
+                        value: "missing".into(),
+                    });
+                }
+            };
+
+            Ok(CartesianReferenceLineRender {
+                key: key_or_index("reference-line", &line.key, index),
+                label: label.clone(),
+                x1,
+                y1,
+                x2,
+                y2,
+                color: color_or_current(&line.color),
+                stroke_width: positive_or_default(line.stroke_width, 1.0),
+                stroke_dasharray: line.stroke_dasharray.trim().into(),
+                layer: layer.into(),
+                aria_label: format!("{label}: {axis} {value}"),
+            })
+        })
+        .collect()
+}
+
+fn render_reference_dots(
+    dots: &[CartesianReferenceDotConfig],
+    mut map_x: impl FnMut(f64) -> ChartResult<f64>,
+    mut map_y: impl FnMut(f64) -> ChartResult<f64>,
+) -> ChartResult<Vec<CartesianReferenceDotRender>> {
+    dots.iter()
+        .enumerate()
+        .map(|(index, dot)| {
+            let data_x = finite("reference_dot.x", dot.x)?;
+            let data_y = finite("reference_dot.y", dot.y)?;
+            let label = label_or_key(&dot.label, &dot.key, index);
+            Ok(CartesianReferenceDotRender {
+                key: key_or_index("reference-dot", &dot.key, index),
+                label: label.clone(),
+                x: map_x(data_x)?,
+                y: map_y(data_y)?,
+                data_x,
+                data_y,
+                radius: positive_or_default(dot.radius, DEFAULT_REFERENCE_RADIUS),
+                fill: color_or_current(&dot.fill),
+                stroke: color_or(&dot.stroke, "none"),
+                stroke_width: non_negative(dot.stroke_width),
+                layer: reference_layer(&dot.layer, "reference_dot.layer")?.into(),
+                aria_label: format!("{label}: x {data_x}, y {data_y}"),
+            })
+        })
+        .collect()
+}
+
+fn render_reference_labels(
+    labels: &[CartesianReferenceLabelConfig],
+    mut map_x: impl FnMut(f64) -> ChartResult<f64>,
+    mut map_y: impl FnMut(f64) -> ChartResult<f64>,
+) -> ChartResult<Vec<CartesianReferenceLabelRender>> {
+    labels
+        .iter()
+        .enumerate()
+        .map(|(index, label)| {
+            let data_x = finite("reference_label.x", label.x)?;
+            let data_y = finite("reference_label.y", label.y)?;
+            let dx = finite("reference_label.dx", label.dx)?;
+            let dy = finite("reference_label.dy", label.dy)?;
+            let angle = finite("reference_label.angle", label.angle)?;
+            let x = map_x(data_x)? + dx;
+            let y = map_y(data_y)? + dy;
+            Ok(CartesianReferenceLabelRender {
+                key: key_or_index("reference-label", &label.key, index),
+                text: label.text.clone(),
+                x,
+                y,
+                data_x,
+                data_y,
+                fill: color_or_current(&label.fill),
+                text_anchor: text_anchor(&label.text_anchor).into(),
+                font_weight: if label.font_weight.trim().is_empty() {
+                    "600".into()
+                } else {
+                    label.font_weight.trim().into()
+                },
+                transform: rotation_transform(angle, x, y),
+            })
+        })
+        .collect()
+}
+
 fn categorical_data_samples(
     config: &CartesianLineSeriesConfig,
     series_label: &str,
@@ -1823,9 +2531,13 @@ fn component_key(prefix: &str, authored_key: &str) -> String {
 }
 
 fn color_or_current(value: &str) -> String {
+    color_or(value, "currentColor")
+}
+
+fn color_or(value: &str, fallback: &str) -> String {
     let trimmed = value.trim();
     if trimmed.is_empty() {
-        "currentColor".into()
+        fallback.into()
     } else {
         trimmed.into()
     }
@@ -1836,6 +2548,57 @@ fn positive_or_default(value: f64, default: f64) -> f64 {
         value
     } else {
         default
+    }
+}
+
+fn non_negative(value: f64) -> f64 {
+    if value.is_finite() {
+        value.max(0.0)
+    } else {
+        0.0
+    }
+}
+
+fn reference_layer(value: &str, field: &'static str) -> ChartResult<&'static str> {
+    match value.trim() {
+        "reference-foreground" | "foreground" => Ok("reference-foreground"),
+        "reference-background" | "background" | "" => Ok("reference-background"),
+        value => Err(ChartError::InvalidOption {
+            field,
+            value: value.into(),
+        }),
+    }
+}
+
+fn text_anchor(value: &str) -> &'static str {
+    match value.trim() {
+        "start" => "start",
+        "end" => "end",
+        _ => "middle",
+    }
+}
+
+fn rotation_transform(angle: f64, x: f64, y: f64) -> String {
+    if angle.abs() <= f64::EPSILON {
+        String::new()
+    } else {
+        format!("rotate({angle} {x} {y})")
+    }
+}
+
+fn label_or_key(label: &str, key: &str, index: usize) -> String {
+    if label.trim().is_empty() {
+        key_or_index("item", key, index)
+    } else {
+        label.trim().into()
+    }
+}
+
+fn key_or_index(prefix: &str, key: &str, index: usize) -> String {
+    if key.trim().is_empty() {
+        format!("{prefix}-{index}")
+    } else {
+        key.trim().into()
     }
 }
 
@@ -1883,10 +2646,10 @@ mod tests {
                 x_axis: Some(&x_axis),
                 y_axis: Some(&y_axis),
             },
-            &series,
-            &[],
-            &[],
-            &[],
+            CartesianChartInputs {
+                line_series: &series,
+                ..CartesianChartInputs::default()
+            },
         )
         .unwrap();
 
@@ -1938,10 +2701,11 @@ mod tests {
                     label: "Metric".into(),
                 }),
             },
-            &lines,
-            &bars,
-            &[],
-            &[],
+            CartesianChartInputs {
+                line_series: &lines,
+                bar_series: &bars,
+                ..CartesianChartInputs::default()
+            },
         )
         .unwrap();
 
@@ -1986,10 +2750,11 @@ mod tests {
                 x_axis: None,
                 y_axis: None,
             },
-            &[],
-            &[],
-            &areas,
-            &scatters,
+            CartesianChartInputs {
+                area_series: &areas,
+                scatter_series: &scatters,
+                ..CartesianChartInputs::default()
+            },
         )
         .unwrap();
 
@@ -2001,6 +2766,89 @@ mod tests {
         assert_eq!(render.scatter_points[0].x, 50.0);
         assert_eq!(render.scatter_points[0].y, 50.0);
         assert!(render.line_series.is_empty());
+    }
+
+    #[test]
+    fn cartesian_chart_maps_reference_marks_through_shared_scales() {
+        let series = vec![CartesianLineSeriesConfig {
+            key: "actual".into(),
+            label: "Actual".into(),
+            color: "#1d6fd8".into(),
+            stroke_width: 2.0,
+            show_markers: false,
+            marker_radius: 3.0,
+            points: vec![ChartPoint::new(0.0, 0.0), ChartPoint::new(10.0, 10.0)],
+            data: Vec::new(),
+        }];
+        let reference_lines = vec![CartesianReferenceLineConfig {
+            key: "goal".into(),
+            label: "Goal".into(),
+            x: None,
+            y: Some(5.0),
+            color: "#667085".into(),
+            stroke_width: 1.5,
+            stroke_dasharray: "4 4".into(),
+            layer: "reference-background".into(),
+        }];
+        let reference_dots = vec![CartesianReferenceDotConfig {
+            key: "release".into(),
+            label: "Release".into(),
+            x: 5.0,
+            y: 5.0,
+            radius: 7.0,
+            fill: "#d96c2c".into(),
+            stroke: "#ffffff".into(),
+            stroke_width: 2.0,
+            layer: "reference-foreground".into(),
+        }];
+        let reference_labels = vec![CartesianReferenceLabelConfig {
+            key: "release-label".into(),
+            text: "Release".into(),
+            x: 5.0,
+            y: 5.0,
+            dx: 0.0,
+            dy: -8.0,
+            angle: 0.0,
+            fill: "#18212f".into(),
+            text_anchor: "middle".into(),
+            font_weight: "700".into(),
+        }];
+
+        let render = render_cartesian_chart(
+            CartesianChartOptions {
+                width: 100.0,
+                height: 100.0,
+                margins: ChartMargins::ZERO,
+                x_domain: None,
+                y_domain: None,
+                padding_inner: DEFAULT_PADDING_INNER,
+                padding_outer: DEFAULT_PADDING_OUTER,
+                series_padding_inner: DEFAULT_SERIES_PADDING_INNER,
+                grid: None,
+                x_axis: None,
+                y_axis: None,
+            },
+            CartesianChartInputs {
+                line_series: &series,
+                reference_lines: &reference_lines,
+                reference_dots: &reference_dots,
+                reference_labels: &reference_labels,
+                ..CartesianChartInputs::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(render.reference_lines.len(), 1);
+        assert_eq!(render.reference_lines[0].x1, 0.0);
+        assert_eq!(render.reference_lines[0].y1, 50.0);
+        assert_eq!(render.reference_lines[0].x2, 100.0);
+        assert_eq!(render.reference_lines[0].layer, "reference-background");
+        assert_eq!(render.reference_dots[0].x, 50.0);
+        assert_eq!(render.reference_dots[0].y, 50.0);
+        assert_eq!(render.reference_dots[0].layer, "reference-foreground");
+        assert_eq!(render.reference_labels[0].x, 50.0);
+        assert_eq!(render.reference_labels[0].y, 42.0);
+        assert_eq!(render.reference_labels[0].text, "Release");
     }
 
     #[test]
@@ -2019,10 +2867,7 @@ mod tests {
                 x_axis: None,
                 y_axis: None,
             },
-            &[],
-            &[],
-            &[],
-            &[],
+            CartesianChartInputs::default(),
         )
         .unwrap_err();
 

--- a/crates/pine-charts/src/cartesian_chart/mod.rs
+++ b/crates/pine-charts/src/cartesian_chart/mod.rs
@@ -1698,9 +1698,27 @@ fn render_from_geometry(
     y_axis: Option<&CartesianAxisConfig>,
     inputs: GeometryRenderInputs<'_>,
 ) -> ChartResult<CartesianChartRender> {
-    let mut cursor = 0;
-    let line_end = cursor + inputs.line_config.len();
-    let rendered_series = geometry.series[cursor..line_end]
+    let line_end = inputs.line_config.len();
+    let area_start = line_end;
+    let area_end = area_start + inputs.area_config.len();
+    let scatter_start = area_end;
+    let scatter_end = scatter_start + inputs.scatter_config.len();
+    if geometry.series.len() != scatter_end {
+        return Err(ChartError::InvalidOption {
+            field: "cartesian.series_order",
+            value: format!(
+                "expected {} derived series, got {}",
+                scatter_end,
+                geometry.series.len()
+            ),
+        });
+    }
+
+    let line_geometry = &geometry.series[..line_end];
+    let area_geometry = &geometry.series[area_start..area_end];
+    let scatter_geometry = &geometry.series[scatter_start..scatter_end];
+
+    let rendered_series = line_geometry
         .iter()
         .enumerate()
         .map(|(index, series)| {
@@ -1714,9 +1732,8 @@ fn render_from_geometry(
             }
         })
         .collect::<Vec<_>>();
-    cursor = line_end;
 
-    let markers = geometry.series[..line_end]
+    let markers = line_geometry
         .iter()
         .enumerate()
         .filter(|(index, _)| inputs.line_config[*index].show_markers)
@@ -1728,8 +1745,7 @@ fn render_from_geometry(
         })
         .collect();
 
-    let area_end = cursor + inputs.area_config.len();
-    let areas = geometry.series[cursor..area_end]
+    let areas = area_geometry
         .iter()
         .enumerate()
         .map(|(index, series)| {
@@ -1751,9 +1767,8 @@ fn render_from_geometry(
             })
         })
         .collect::<ChartResult<Vec<_>>>()?;
-    cursor = area_end;
 
-    let scatter_points = geometry.series[cursor..]
+    let scatter_points = scatter_geometry
         .iter()
         .enumerate()
         .flat_map(|(index, series)| {
@@ -2243,13 +2258,13 @@ fn render_reference_lines(
                 (Some(_), Some(_)) => {
                     return Err(ChartError::InvalidOption {
                         field: "reference_line.axis",
-                        value: "x and y".into(),
+                        value: "expected exactly one of x or y, got both".into(),
                     });
                 }
                 (None, None) => {
                     return Err(ChartError::InvalidOption {
                         field: "reference_line.axis",
-                        value: "missing".into(),
+                        value: "expected exactly one of x or y, got neither".into(),
                     });
                 }
             };
@@ -2561,8 +2576,8 @@ fn non_negative(value: f64) -> f64 {
 
 fn reference_layer(value: &str, field: &'static str) -> ChartResult<&'static str> {
     match value.trim() {
-        "reference-foreground" | "foreground" => Ok("reference-foreground"),
-        "reference-background" | "background" | "" => Ok("reference-background"),
+        "reference-foreground" => Ok("reference-foreground"),
+        "reference-background" | "" => Ok("reference-background"),
         value => Err(ChartError::InvalidOption {
             field,
             value: value.into(),
@@ -2765,6 +2780,7 @@ mod tests {
         assert_eq!(render.scatter_points[0].series_label, "Samples");
         assert_eq!(render.scatter_points[0].x, 50.0);
         assert_eq!(render.scatter_points[0].y, 50.0);
+        assert_eq!(render.scatter_points[0].aria_label, "Samples: x 5, y 5");
         assert!(render.line_series.is_empty());
     }
 
@@ -2849,6 +2865,115 @@ mod tests {
         assert_eq!(render.reference_labels[0].x, 50.0);
         assert_eq!(render.reference_labels[0].y, 42.0);
         assert_eq!(render.reference_labels[0].text, "Release");
+    }
+
+    #[test]
+    fn cartesian_chart_rejects_reference_line_without_exactly_one_axis() {
+        let series = vec![CartesianLineSeriesConfig {
+            key: "actual".into(),
+            label: "Actual".into(),
+            color: "#1d6fd8".into(),
+            stroke_width: 2.0,
+            show_markers: false,
+            marker_radius: 3.0,
+            points: vec![ChartPoint::new(0.0, 0.0), ChartPoint::new(10.0, 10.0)],
+            data: Vec::new(),
+        }];
+        let reference_lines = vec![CartesianReferenceLineConfig {
+            key: "bad".into(),
+            label: "Bad".into(),
+            x: Some(1.0),
+            y: Some(2.0),
+            color: "#667085".into(),
+            stroke_width: 1.0,
+            stroke_dasharray: String::new(),
+            layer: "reference-background".into(),
+        }];
+
+        let error = render_cartesian_chart(
+            CartesianChartOptions {
+                width: 100.0,
+                height: 100.0,
+                margins: ChartMargins::ZERO,
+                x_domain: None,
+                y_domain: None,
+                padding_inner: DEFAULT_PADDING_INNER,
+                padding_outer: DEFAULT_PADDING_OUTER,
+                series_padding_inner: DEFAULT_SERIES_PADDING_INNER,
+                grid: None,
+                x_axis: None,
+                y_axis: None,
+            },
+            CartesianChartInputs {
+                line_series: &series,
+                reference_lines: &reference_lines,
+                ..CartesianChartInputs::default()
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error,
+            ChartError::InvalidOption {
+                field: "reference_line.axis",
+                value: "expected exactly one of x or y, got both".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn cartesian_chart_rejects_short_reference_layer_aliases() {
+        let series = vec![CartesianLineSeriesConfig {
+            key: "actual".into(),
+            label: "Actual".into(),
+            color: "#1d6fd8".into(),
+            stroke_width: 2.0,
+            show_markers: false,
+            marker_radius: 3.0,
+            points: vec![ChartPoint::new(0.0, 0.0), ChartPoint::new(10.0, 10.0)],
+            data: Vec::new(),
+        }];
+        let reference_dots = vec![CartesianReferenceDotConfig {
+            key: "dot".into(),
+            label: "Dot".into(),
+            x: 1.0,
+            y: 2.0,
+            radius: 6.0,
+            fill: "#d96c2c".into(),
+            stroke: "none".into(),
+            stroke_width: 0.0,
+            layer: "foreground".into(),
+        }];
+
+        let error = render_cartesian_chart(
+            CartesianChartOptions {
+                width: 100.0,
+                height: 100.0,
+                margins: ChartMargins::ZERO,
+                x_domain: None,
+                y_domain: None,
+                padding_inner: DEFAULT_PADDING_INNER,
+                padding_outer: DEFAULT_PADDING_OUTER,
+                series_padding_inner: DEFAULT_SERIES_PADDING_INNER,
+                grid: None,
+                x_axis: None,
+                y_axis: None,
+            },
+            CartesianChartInputs {
+                line_series: &series,
+                reference_dots: &reference_dots,
+                ..CartesianChartInputs::default()
+            },
+        )
+        .unwrap_err();
+
+        assert_eq!(
+            error,
+            ChartError::InvalidOption {
+                field: "reference_dot.layer",
+                value: "foreground".into(),
+            }
+        );
     }
 
     #[test]

--- a/crates/pine-charts/src/layered/mod.rs
+++ b/crates/pine-charts/src/layered/mod.rs
@@ -4,6 +4,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::error::{finite, ChartError, ChartResult};
 use crate::geometry::Point;
+use crate::marks::{
+    color_or, color_or_current, key_or_index, label_or_key, rotation_transform, text_anchor,
+};
 use crate::path::line_path;
 
 const DEFAULT_WIDTH: f64 = 900.0;
@@ -1278,19 +1281,6 @@ fn non_negative(field: &'static str, value: f64) -> ChartResult<f64> {
     Ok(value.max(0.0))
 }
 
-fn color_or_current(value: &str) -> String {
-    color_or(value, "currentColor")
-}
-
-fn color_or(value: &str, fallback: &str) -> String {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        fallback.into()
-    } else {
-        trimmed.into()
-    }
-}
-
 fn reference_layer(value: &str) -> ChartResult<&'static str> {
     match value.trim() {
         "reference-foreground" | "foreground" => Ok("reference-foreground"),
@@ -1302,42 +1292,10 @@ fn reference_layer(value: &str) -> ChartResult<&'static str> {
     }
 }
 
-fn text_anchor(value: &str) -> &'static str {
-    match value.trim() {
-        "start" => "start",
-        "end" => "end",
-        _ => "middle",
-    }
-}
-
 fn icon_resolution(value: &str) -> (&'static str, &'static str) {
     match value.trim() {
         "plane" => ("plane", PLANE_ICON_PATH),
         _ => ("custom", ""),
-    }
-}
-
-fn rotation_transform(angle: f64, x: f64, y: f64) -> String {
-    if angle.abs() <= f64::EPSILON {
-        String::new()
-    } else {
-        format!("rotate({angle} {x} {y})")
-    }
-}
-
-fn label_or_key(label: &str, key: &str, index: usize) -> String {
-    if label.trim().is_empty() {
-        key_or_index("item", key, index)
-    } else {
-        label.trim().into()
-    }
-}
-
-fn key_or_index(prefix: &str, key: &str, index: usize) -> String {
-    if key.trim().is_empty() {
-        format!("{prefix}-{index}")
-    } else {
-        key.trim().into()
     }
 }
 

--- a/crates/pine-charts/src/lib.rs
+++ b/crates/pine-charts/src/lib.rs
@@ -14,6 +14,7 @@ pub mod geometry;
 pub mod layered;
 pub mod legend;
 pub mod line;
+mod marks;
 pub mod path;
 pub mod pie;
 pub mod responsive;

--- a/crates/pine-charts/src/lib.rs
+++ b/crates/pine-charts/src/lib.rs
@@ -30,11 +30,14 @@ pub use bar::{
 };
 pub use cartesian_chart::{
     render_cartesian_chart, CartesianAreaSeriesConfig, CartesianAreaSeriesRender,
-    CartesianAxisConfig, CartesianBarRender, CartesianBarSeriesConfig, CartesianChartOptions,
-    CartesianChartRender, CartesianGridConfig, CartesianLineSeriesConfig,
-    CartesianLineSeriesRender, CartesianMarkerRender, CartesianScatterPointRender,
-    CartesianScatterSeriesConfig, PineAreaSeries, PineBarSeries, PineCartesianChart, PineChartGrid,
-    PineLineSeries, PineScatterSeries, PineXAxis, PineYAxis,
+    CartesianAxisConfig, CartesianBarRender, CartesianBarSeriesConfig, CartesianChartInputs,
+    CartesianChartOptions, CartesianChartRender, CartesianGridConfig, CartesianLineSeriesConfig,
+    CartesianLineSeriesRender, CartesianMarkerRender, CartesianReferenceDotConfig,
+    CartesianReferenceDotRender, CartesianReferenceLabelConfig, CartesianReferenceLabelRender,
+    CartesianReferenceLineConfig, CartesianReferenceLineRender, CartesianScatterPointRender,
+    CartesianScatterSeriesConfig, PineAreaSeries, PineBarSeries, PineCartesianChart,
+    PineCartesianReferenceDot, PineCartesianReferenceLabel, PineCartesianReferenceLine,
+    PineChartGrid, PineLineSeries, PineScatterSeries, PineXAxis, PineYAxis,
 };
 pub use error::{ChartError, ChartResult};
 pub use events::{ChartSelection, LegendToggle, CHART_SELECT_EVENT, LEGEND_TOGGLE_EVENT};
@@ -70,6 +73,9 @@ pub fn register_all() {
     PineBarChart::register();
     PineBarSeries::register();
     PineCartesianChart::register();
+    PineCartesianReferenceDot::register();
+    PineCartesianReferenceLabel::register();
+    PineCartesianReferenceLine::register();
     PineChartGuide::register();
     PineChartGrid::register();
     PineChartIcon::register();

--- a/crates/pine-charts/src/lib.rs
+++ b/crates/pine-charts/src/lib.rs
@@ -29,10 +29,12 @@ pub use bar::{
     PineBarChart, SvgBar,
 };
 pub use cartesian_chart::{
-    render_cartesian_chart, CartesianAxisConfig, CartesianBarRender, CartesianBarSeriesConfig,
-    CartesianChartOptions, CartesianChartRender, CartesianGridConfig, CartesianLineSeriesConfig,
-    CartesianLineSeriesRender, CartesianMarkerRender, PineBarSeries, PineCartesianChart,
-    PineChartGrid, PineLineSeries, PineXAxis, PineYAxis,
+    render_cartesian_chart, CartesianAreaSeriesConfig, CartesianAreaSeriesRender,
+    CartesianAxisConfig, CartesianBarRender, CartesianBarSeriesConfig, CartesianChartOptions,
+    CartesianChartRender, CartesianGridConfig, CartesianLineSeriesConfig,
+    CartesianLineSeriesRender, CartesianMarkerRender, CartesianScatterPointRender,
+    CartesianScatterSeriesConfig, PineAreaSeries, PineBarSeries, PineCartesianChart, PineChartGrid,
+    PineLineSeries, PineScatterSeries, PineXAxis, PineYAxis,
 };
 pub use error::{ChartError, ChartResult};
 pub use events::{ChartSelection, LegendToggle, CHART_SELECT_EVENT, LEGEND_TOGGLE_EVENT};
@@ -64,6 +66,7 @@ pub use svg::{SvgAxisLabel, SvgLine, SvgTickLabel};
 /// Register every Pine Charts custom-element tag.
 pub fn register_all() {
     PineAreaChart::register();
+    PineAreaSeries::register();
     PineBarChart::register();
     PineBarSeries::register();
     PineCartesianChart::register();
@@ -82,6 +85,7 @@ pub fn register_all() {
     PineLineChart::register();
     PinePieChart::register();
     PineScatterChart::register();
+    PineScatterSeries::register();
     PineXAxis::register();
     PineYAxis::register();
 }

--- a/crates/pine-charts/src/line/mod.rs
+++ b/crates/pine-charts/src/line/mod.rs
@@ -12,6 +12,7 @@ use crate::events::{ChartSelection, CHART_SELECT_EVENT};
 use crate::geometry::{ChartMargins, ChartRect, Point};
 use crate::legend::{series_label_or_default, series_legend_items};
 use crate::path::line_path;
+use crate::scale::LinearScale;
 use crate::svg::{format_tick, SvgAxisLabel, SvgLine, SvgTickLabel};
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
@@ -75,6 +76,8 @@ pub struct LineChartGeometry {
     pub line_d: String,
     pub series: Vec<LineChartSeriesRender>,
     pub plot: ChartRect,
+    pub x_scale: LinearScale,
+    pub y_scale: LinearScale,
     pub samples: Vec<LineChartSample>,
     pub x_ticks: Vec<crate::Tick>,
     pub y_ticks: Vec<crate::Tick>,
@@ -165,6 +168,8 @@ impl LineChartGeometry {
             line_d,
             series,
             plot: layout.plot,
+            x_scale: layout.x_scale,
+            y_scale: layout.y_scale,
             samples,
             x_grid: layout.x_grid,
             y_grid: layout.y_grid,

--- a/crates/pine-charts/src/marks.rs
+++ b/crates/pine-charts/src/marks.rs
@@ -1,0 +1,44 @@
+pub(crate) fn color_or_current(value: &str) -> String {
+    color_or(value, "currentColor")
+}
+
+pub(crate) fn color_or(value: &str, fallback: &str) -> String {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        fallback.into()
+    } else {
+        trimmed.into()
+    }
+}
+
+pub(crate) fn text_anchor(value: &str) -> &'static str {
+    match value.trim() {
+        "start" => "start",
+        "end" => "end",
+        _ => "middle",
+    }
+}
+
+pub(crate) fn rotation_transform(angle: f64, x: f64, y: f64) -> String {
+    if angle.abs() <= f64::EPSILON {
+        String::new()
+    } else {
+        format!("rotate({angle} {x} {y})")
+    }
+}
+
+pub(crate) fn label_or_key(label: &str, key: &str, index: usize) -> String {
+    if label.trim().is_empty() {
+        key_or_index("item", key, index)
+    } else {
+        label.trim().into()
+    }
+}
+
+pub(crate) fn key_or_index(prefix: &str, key: &str, index: usize) -> String {
+    if key.trim().is_empty() {
+        format!("{prefix}-{index}")
+    } else {
+        key.trim().into()
+    }
+}

--- a/crates/pine-charts/tests/charts.rs
+++ b/crates/pine-charts/tests/charts.rs
@@ -353,12 +353,25 @@ impl ComposedCartesianFixture {}
                       show_markers="true"
                       marker_radius="4"
                       pp-bind:data="target"></pine-line-series>
+    <pine-area-series key="forecast"
+                      label="Forecast"
+                      fill="#1d6fd833"
+                      color="#1d6fd8"
+                      stroke_width="2"
+                      pp-bind:points="forecast"></pine-area-series>
+    <pine-scatter-series key="samples"
+                         label="Samples"
+                         color="#d96c2c"
+                         point_radius="6"
+                         pp-bind:points="samples"></pine-scatter-series>
   </pine-cartesian-chart>
 </div>
 "##)]
 struct ComboCartesianFixture {
     actual: Vec<ChartBar>,
     target: Vec<ChartBar>,
+    forecast: Vec<ChartPoint>,
+    samples: Vec<ChartPoint>,
 }
 
 impl Default for ComboCartesianFixture {
@@ -366,6 +379,8 @@ impl Default for ComboCartesianFixture {
         Self {
             actual: vec![ChartBar::new("W1", 10.0), ChartBar::new("W2", 20.0)],
             target: vec![ChartBar::new("W1", 12.0), ChartBar::new("W2", 18.0)],
+            forecast: vec![ChartPoint::new(0.0, 8.0), ChartPoint::new(1.0, 16.0)],
+            samples: vec![ChartPoint::new(0.5, 14.0)],
         }
     }
 }
@@ -497,7 +512,7 @@ async fn cartesian_chart_composes_grid_axes_and_line_series() {
     assert_eq!(svg.get_attribute("viewBox").as_deref(), Some("0 0 100 100"));
     assert_eq!(
         direct_svg_layers(&svg),
-        vec!["grid", "axes", "bars", "series", "markers"]
+        vec!["grid", "axes", "bars", "area", "series", "points", "markers"]
     );
 
     let line = host.query_selector(".pine-chart-line").unwrap().unwrap();
@@ -541,7 +556,7 @@ async fn cartesian_chart_composes_bar_and_line_series_on_one_axis() {
         .unwrap();
     assert_eq!(
         direct_svg_layers(&svg),
-        vec!["grid", "axes", "bars", "series", "markers"]
+        vec!["grid", "axes", "bars", "area", "series", "points", "markers"]
     );
 
     let bars = host.query_selector_all(".pine-chart-bar").unwrap();
@@ -561,10 +576,37 @@ async fn cartesian_chart_composes_bar_and_line_series_on_one_axis() {
         Some("Actual, W1: 10")
     );
 
-    let line = host.query_selector(".pine-chart-line").unwrap().unwrap();
+    let area = host.query_selector(".pine-chart-area").unwrap().unwrap();
+    assert_eq!(
+        area.get_attribute("d").as_deref(),
+        Some("M25,100 L25,60 L75,20 L75,100Z")
+    );
+    assert_eq!(area.get_attribute("fill").as_deref(), Some("#1d6fd833"));
+    assert_eq!(
+        area.get_attribute("data-series").as_deref(),
+        Some("Forecast")
+    );
+
+    let line = host
+        .query_selector(".pine-chart-lines .pine-chart-line")
+        .unwrap()
+        .unwrap();
     assert_eq!(line.get_attribute("d").as_deref(), Some("M25,40 L75,10"));
     assert_eq!(line.get_attribute("stroke").as_deref(), Some("#1d6fd8"));
     assert_eq!(line.get_attribute("data-series").as_deref(), Some("Target"));
+
+    let point = host
+        .query_selector(".pine-chart-scatter-point")
+        .unwrap()
+        .unwrap();
+    assert_eq!(point.get_attribute("cx").as_deref(), Some("50"));
+    assert_eq!(point.get_attribute("cy").as_deref(), Some("30"));
+    assert_eq!(point.get_attribute("r").as_deref(), Some("6"));
+    assert_eq!(point.get_attribute("fill").as_deref(), Some("#d96c2c"));
+    assert_eq!(
+        point.get_attribute("aria-label").as_deref(),
+        Some("Samples, W2: 14")
+    );
 
     let markers = host.query_selector_all(".pine-chart-marker").unwrap();
     assert_eq!(markers.length(), 2);

--- a/crates/pine-charts/tests/charts.rs
+++ b/crates/pine-charts/tests/charts.rs
@@ -264,7 +264,7 @@ impl LineChartFixture {}
                         angle="-65"
                         fill="#18212f"
                         text_anchor="start"
-                        font_weight="700"></pine-chart-label>
+                        font_weight="bold"></pine-chart-label>
     </pine-chart-layer>
   </pine-layer-chart>
 </div>
@@ -353,6 +353,13 @@ impl ComposedCartesianFixture {}
                       show_markers="true"
                       marker_radius="4"
                       pp-bind:data="target"></pine-line-series>
+    <pine-cartesian-reference-line key="goal"
+                                   label="Goal"
+                                   y="16"
+                                   color="#667085"
+                                   stroke_width="1.5"
+                                   stroke_dasharray="4 4"
+                                   layer="reference-background"></pine-cartesian-reference-line>
     <pine-area-series key="forecast"
                       label="Forecast"
                       fill="#1d6fd833"
@@ -364,6 +371,22 @@ impl ComposedCartesianFixture {}
                          color="#d96c2c"
                          point_radius="6"
                          pp-bind:points="samples"></pine-scatter-series>
+    <pine-cartesian-reference-dot key="release"
+                                  label="Release"
+                                  x="1"
+                                  y="18"
+                                  radius="7"
+                                  fill="#5b6ee1"
+                                  stroke="#ffffff"
+                                  stroke_width="2"
+                                  layer="reference-foreground"></pine-cartesian-reference-dot>
+    <pine-cartesian-reference-label key="release-label"
+                                    text="Release"
+                                    x="1"
+                                    y="18"
+                                    dy="-8"
+                                    fill="#18212f"
+                                    font_weight="bold"></pine-cartesian-reference-label>
   </pine-cartesian-chart>
 </div>
 "##)]
@@ -512,7 +535,18 @@ async fn cartesian_chart_composes_grid_axes_and_line_series() {
     assert_eq!(svg.get_attribute("viewBox").as_deref(), Some("0 0 100 100"));
     assert_eq!(
         direct_svg_layers(&svg),
-        vec!["grid", "axes", "bars", "area", "series", "points", "markers"]
+        vec![
+            "grid",
+            "axes",
+            "reference-background",
+            "bars",
+            "area",
+            "series",
+            "points",
+            "markers",
+            "reference-foreground",
+            "labels",
+        ]
     );
 
     let line = host.query_selector(".pine-chart-line").unwrap().unwrap();
@@ -556,7 +590,18 @@ async fn cartesian_chart_composes_bar_and_line_series_on_one_axis() {
         .unwrap();
     assert_eq!(
         direct_svg_layers(&svg),
-        vec!["grid", "axes", "bars", "area", "series", "points", "markers"]
+        vec![
+            "grid",
+            "axes",
+            "reference-background",
+            "bars",
+            "area",
+            "series",
+            "points",
+            "markers",
+            "reference-foreground",
+            "labels",
+        ]
     );
 
     let bars = host.query_selector_all(".pine-chart-bar").unwrap();
@@ -574,6 +619,22 @@ async fn cartesian_chart_composes_bar_and_line_series_on_one_axis() {
     assert_eq!(
         first_bar.get_attribute("aria-label").as_deref(),
         Some("Actual, W1: 10")
+    );
+
+    let reference_line = host
+        .query_selector(".pine-chart-reference-background .pine-chart-reference-line")
+        .unwrap()
+        .unwrap();
+    assert_eq!(reference_line.get_attribute("x1").as_deref(), Some("0"));
+    assert_eq!(reference_line.get_attribute("y1").as_deref(), Some("20"));
+    assert_eq!(reference_line.get_attribute("x2").as_deref(), Some("100"));
+    assert_eq!(
+        reference_line.get_attribute("stroke-dasharray").as_deref(),
+        Some("4 4")
+    );
+    assert_eq!(
+        reference_line.get_attribute("aria-label").as_deref(),
+        Some("Goal: y 16")
     );
 
     let area = host.query_selector(".pine-chart-area").unwrap().unwrap();
@@ -606,6 +667,30 @@ async fn cartesian_chart_composes_bar_and_line_series_on_one_axis() {
     assert_eq!(
         point.get_attribute("aria-label").as_deref(),
         Some("Samples, W2: 14")
+    );
+
+    let reference_dot = host
+        .query_selector(".pine-chart-reference-foreground .pine-chart-reference-dot")
+        .unwrap()
+        .unwrap();
+    assert_eq!(reference_dot.get_attribute("cx").as_deref(), Some("75"));
+    assert_eq!(reference_dot.get_attribute("cy").as_deref(), Some("10"));
+    assert_eq!(reference_dot.get_attribute("r").as_deref(), Some("7"));
+    assert_eq!(
+        reference_dot.get_attribute("aria-label").as_deref(),
+        Some("Release: x 1, y 18")
+    );
+
+    let reference_label = host
+        .query_selector(".pine-chart-reference-label")
+        .unwrap()
+        .unwrap();
+    assert_eq!(reference_label.text_content().as_deref(), Some("Release"));
+    assert_eq!(reference_label.get_attribute("x").as_deref(), Some("75"));
+    assert_eq!(reference_label.get_attribute("y").as_deref(), Some("2"));
+    assert_eq!(
+        reference_label.get_attribute("font-weight").as_deref(),
+        Some("bold")
     );
 
     let markers = host.query_selector_all(".pine-chart-marker").unwrap();

--- a/docs/charts/cartesian.md
+++ b/docs/charts/cartesian.md
@@ -15,6 +15,10 @@ validation.
                    label="Actual"
                    color="#16a085"
                    pp-bind:data="actual"></pine-bar-series>
+  <pine-cartesian-reference-line key="goal"
+                                 label="Goal"
+                                 y="16"
+                                 stroke_dasharray="4 4"></pine-cartesian-reference-line>
   <pine-area-series key="band"
                     label="Trend band"
                     fill="#1d6fd833"
@@ -29,6 +33,15 @@ validation.
                        label="Samples"
                        color="#5b6ee1"
                        pp-bind:points="samples"></pine-scatter-series>
+  <pine-cartesian-reference-dot key="release"
+                                label="Release"
+                                x="2"
+                                y="18"></pine-cartesian-reference-dot>
+  <pine-cartesian-reference-label key="release-label"
+                                  text="Release"
+                                  x="2"
+                                  y="18"
+                                  dy="-10"></pine-cartesian-reference-label>
 </pine-cartesian-chart>
 ```
 
@@ -48,6 +61,11 @@ namespace handling, responsive sizing, scales, and paint order in one place.
 - `pine-area-series`: registers one numeric area series from `Vec<ChartPoint>`.
 - `pine-scatter-series`: registers one numeric scatter series from
   `Vec<ChartPoint>`.
+- `pine-cartesian-reference-line`: registers one horizontal or vertical
+  reference line in data space. Set exactly one of `x` or `y`.
+- `pine-cartesian-reference-dot`: registers one reference point in data space.
+- `pine-cartesian-reference-label`: registers one text label anchored in data
+  space.
 
 `pine-line-chart` and `pine-bar-chart` remain the presets for simple dashboards. Use
 `pine-cartesian-chart` when the chart needs explicit child composition or when a
@@ -94,6 +112,11 @@ chart, their `x` values are treated as zero-based category positions, so
 `ChartPoint::new(1.5, value)` lands halfway between the second and third
 category centers.
 
-Reference marks and free-form annotations still belong to `pine-layer-chart`.
-Use the Cartesian root when the chart needs shared axes and scales; use the
-layered root when the app needs absolute SVG composition.
+Reference dots and labels follow the same coordinate rule. Reference lines use
+the mapped `x` position for vertical lines or the mapped `y` position for
+horizontal lines. Lines and dots accept `layer="reference-background"` or
+`layer="reference-foreground"`; labels always paint in the final label layer.
+
+Free-form annotations still belong to `pine-layer-chart`. Use the Cartesian
+root when the chart needs shared axes and scales; use the layered root when the
+app needs absolute SVG composition.

--- a/docs/charts/cartesian.md
+++ b/docs/charts/cartesian.md
@@ -15,11 +15,20 @@ validation.
                    label="Actual"
                    color="#16a085"
                    pp-bind:data="actual"></pine-bar-series>
+  <pine-area-series key="band"
+                    label="Trend band"
+                    fill="#1d6fd833"
+                    color="#1d6fd8"
+                    pp-bind:points="band"></pine-area-series>
   <pine-line-series key="target"
                     label="Target"
                     color="#1d6fd8"
                     show_markers="true"
                     pp-bind:data="target"></pine-line-series>
+  <pine-scatter-series key="samples"
+                       label="Samples"
+                       color="#5b6ee1"
+                       pp-bind:points="samples"></pine-scatter-series>
 </pine-cartesian-chart>
 ```
 
@@ -36,6 +45,9 @@ namespace handling, responsive sizing, scales, and paint order in one place.
 - `pine-line-series`: registers one line series from numeric `Vec<ChartPoint>`
   or categorical `Vec<ChartBar>`.
 - `pine-bar-series`: registers one categorical bar series from `Vec<ChartBar>`.
+- `pine-area-series`: registers one numeric area series from `Vec<ChartPoint>`.
+- `pine-scatter-series`: registers one numeric scatter series from
+  `Vec<ChartPoint>`.
 
 `pine-line-chart` and `pine-bar-chart` remain the presets for simple dashboards. Use
 `pine-cartesian-chart` when the chart needs explicit child composition or when a
@@ -76,9 +88,12 @@ let target = vec![
 ];
 ```
 
-## Current Scope
+Area and scatter children use numeric `ChartPoint` data. In a categorical combo
+chart, their `x` values are treated as zero-based category positions, so
+`ChartPoint::new(0.0, value)` lands on the first category and
+`ChartPoint::new(1.5, value)` lands halfway between the second and third
+category centers.
 
-This phase supports numeric line charts and categorical bar/line combo charts.
-Area, scatter, references, and annotations should join this root in follow-up
-phases so the preset components and the composable root share the same geometry
-contracts.
+Reference marks and free-form annotations still belong to `pine-layer-chart`.
+Use the Cartesian root when the chart needs shared axes and scales; use the
+layered root when the app needs absolute SVG composition.

--- a/docs/charts/cartesian.md
+++ b/docs/charts/cartesian.md
@@ -117,6 +117,11 @@ the mapped `x` position for vertical lines or the mapped `y` position for
 horizontal lines. Lines and dots accept `layer="reference-background"` or
 `layer="reference-foreground"`; labels always paint in the final label layer.
 
+The compound root recomputes when a child series or reference component changes.
+For live charts, prefer updating the bound data vector in one state write, such
+as `pp-bind:points`, instead of driving many individual child prop writes in the
+same tick.
+
 Free-form annotations still belong to `pine-layer-chart`. Use the Cartesian
 root when the chart needs shared axes and scales; use the layered root when the
 app needs absolute SVG composition.

--- a/docs/charts/components.md
+++ b/docs/charts/components.md
@@ -10,7 +10,7 @@ SVG compositions: child tags register lines, guides, markers, labels, and
 annotations into one root-owned SVG.
 `PineCartesianChart` provides the compound surface for Cartesian charts: child
 tags register grid, axes, bar series, line series, area series, and scatter
-series into one root-owned SVG.
+series plus reference lines, dots, and labels into one root-owned SVG.
 
 Use `PineChartResponsive` when a chart should follow its parent size. The
 responsive container measures its content box and writes concrete `width` and

--- a/docs/charts/components.md
+++ b/docs/charts/components.md
@@ -9,7 +9,8 @@ bars, and `PinePieChart` renders pie, donut, half-pie, and half-donut slices.
 SVG compositions: child tags register lines, guides, markers, labels, and
 annotations into one root-owned SVG.
 `PineCartesianChart` provides the compound surface for Cartesian charts: child
-tags register grid, axes, bar series, and line series into one root-owned SVG.
+tags register grid, axes, bar series, line series, area series, and scatter
+series into one root-owned SVG.
 
 Use `PineChartResponsive` when a chart should follow its parent size. The
 responsive container measures its content box and writes concrete `width` and

--- a/docs/charts/layers.md
+++ b/docs/charts/layers.md
@@ -29,8 +29,10 @@ their strokes:
 
 Bar charts currently use `grid`, `axes`, then `series`.
 
-Composable Cartesian combo charts use `grid`, `axes`, `bars`, `series`, then
-optional `markers`, so line strokes and point markers paint above bars.
+Composable Cartesian combo charts use `grid`, `axes`, `bars`, `area`,
+`series`, `points`, then optional `markers`, so area fills stay behind line
+strokes, scatter points paint above lines, and line markers can still sit on
+top.
 
 ## Radial Order
 

--- a/docs/charts/layers.md
+++ b/docs/charts/layers.md
@@ -29,10 +29,11 @@ their strokes:
 
 Bar charts currently use `grid`, `axes`, then `series`.
 
-Composable Cartesian combo charts use `grid`, `axes`, `bars`, `area`,
-`series`, `points`, then optional `markers`, so area fills stay behind line
-strokes, scatter points paint above lines, and line markers can still sit on
-top.
+Composable Cartesian combo charts use `grid`, `axes`,
+`reference-background`, `bars`, `area`, `series`, `points`, optional
+`markers`, `reference-foreground`, then `labels`. Background references can sit
+behind data marks, area fills stay behind line strokes, scatter points paint
+above lines, and foreground references plus labels stay readable.
 
 ## Radial Order
 

--- a/examples/charts/src/ChartDemo.poco
+++ b/examples/charts/src/ChartDemo.poco
@@ -49,6 +49,12 @@
                        pp-bind:label="combo_bar_label"
                        pp-bind:color="combo_bar_color"
                        pp-bind:data="combo_bar_data"></pine-bar-series>
+      <pine-area-series key="band"
+                        label="Trend band"
+                        fill="#1d6fd833"
+                        color="#1d6fd8"
+                        stroke_width="2"
+                        pp-bind:points="combo_area_points"></pine-area-series>
       <pine-line-series key="target"
                         pp-bind:label="combo_line_label"
                         pp-bind:color="combo_line_color"
@@ -56,6 +62,11 @@
                         show_markers="true"
                         marker_radius="3"
                         pp-bind:data="combo_line_data"></pine-line-series>
+      <pine-scatter-series key="samples"
+                           label="Samples"
+                           color="#5b6ee1"
+                           point_radius="4"
+                           pp-bind:points="combo_scatter_points"></pine-scatter-series>
     </pine-cartesian-chart>
   </pine-chart-responsive>
 

--- a/examples/charts/src/ChartDemo.poco
+++ b/examples/charts/src/ChartDemo.poco
@@ -49,6 +49,12 @@
                        pp-bind:label="combo_bar_label"
                        pp-bind:color="combo_bar_color"
                        pp-bind:data="combo_bar_data"></pine-bar-series>
+      <pine-cartesian-reference-line key="goal"
+                                     label="Goal"
+                                     pp-bind:y="combo_goal"
+                                     color="#667085"
+                                     stroke_width="1.5"
+                                     stroke_dasharray="4 4"></pine-cartesian-reference-line>
       <pine-area-series key="band"
                         label="Trend band"
                         fill="#1d6fd833"
@@ -67,6 +73,21 @@
                            color="#5b6ee1"
                            point_radius="4"
                            pp-bind:points="combo_scatter_points"></pine-scatter-series>
+      <pine-cartesian-reference-dot key="latest"
+                                    label="Latest"
+                                    pp-bind:x="combo_latest_x"
+                                    pp-bind:y="combo_latest_y"
+                                    radius="7"
+                                    fill="#18212f"
+                                    stroke="#ffffff"
+                                    stroke_width="2"></pine-cartesian-reference-dot>
+      <pine-cartesian-reference-label key="latest-label"
+                                      text="Latest"
+                                      pp-bind:x="combo_latest_x"
+                                      pp-bind:y="combo_latest_y"
+                                      dy="-12"
+                                      fill="#18212f"
+                                      font_weight="bold"></pine-cartesian-reference-label>
     </pine-cartesian-chart>
   </pine-chart-responsive>
 
@@ -120,11 +141,11 @@
         <pine-chart-icon key="airport-east" kind="plane" x="770" y="82" scale="0.075" fill="#18212f"></pine-chart-icon>
       </pine-chart-layer>
       <pine-chart-layer name="labels">
-        <pine-chart-label key="airport-label" text="Airport" x="100" y="120" dx="8" dy="-24" angle="-65" fill="#19a974" text_anchor="start" font_weight="700"></pine-chart-label>
-        <pine-chart-label key="central-label" text="Central" x="420" y="180" dx="14" dy="-24" angle="-65" fill="#18212f" text_anchor="start" font_weight="700"></pine-chart-label>
-        <pine-chart-label key="museum-label" text="Museum" x="480" y="300" dx="-12" dy="42" angle="-65" fill="#18212f" text_anchor="end" font_weight="700"></pine-chart-label>
-        <pine-chart-label key="republic-label" text="Republic" x="520" y="180" dx="12" dy="-24" angle="-65" fill="#18212f" text_anchor="start" font_weight="700"></pine-chart-label>
-        <pine-chart-label key="east-gate-label" text="East Gate" x="840" y="240" dx="8" dy="-24" angle="-65" fill="#f2c230" text_anchor="start" font_weight="700"></pine-chart-label>
+        <pine-chart-label key="airport-label" text="Airport" x="100" y="120" dx="8" dy="-24" angle="-65" fill="#19a974" text_anchor="start" font_weight="bold"></pine-chart-label>
+        <pine-chart-label key="central-label" text="Central" x="420" y="180" dx="14" dy="-24" angle="-65" fill="#18212f" text_anchor="start" font_weight="bold"></pine-chart-label>
+        <pine-chart-label key="museum-label" text="Museum" x="480" y="300" dx="-12" dy="42" angle="-65" fill="#18212f" text_anchor="end" font_weight="bold"></pine-chart-label>
+        <pine-chart-label key="republic-label" text="Republic" x="520" y="180" dx="12" dy="-24" angle="-65" fill="#18212f" text_anchor="start" font_weight="bold"></pine-chart-label>
+        <pine-chart-label key="east-gate-label" text="East Gate" x="840" y="240" dx="8" dy="-24" angle="-65" fill="#f2c230" text_anchor="start" font_weight="bold"></pine-chart-label>
       </pine-chart-layer>
     </pine-layer-chart>
   </pine-chart-responsive>

--- a/examples/charts/src/lib.rs
+++ b/examples/charts/src/lib.rs
@@ -20,6 +20,8 @@ pub struct ChartDemo {
     pub combo_line_label: String,
     pub combo_line_color: String,
     pub combo_line_data: Vec<ChartBar>,
+    pub combo_area_points: Vec<ChartPoint>,
+    pub combo_scatter_points: Vec<ChartPoint>,
     pub metro_line_a: Vec<ChartLayerPoint>,
     pub metro_line_b: Vec<ChartLayerPoint>,
     pub metro_line_c: Vec<ChartLayerPoint>,
@@ -57,6 +59,8 @@ impl Default for ChartDemo {
             combo_line_label: line_series[1].label.clone(),
             combo_line_color: "#d96c2c".into(),
             combo_line_data: bars_from_points(&line_series[1].data),
+            combo_area_points: combo_area_points(&line_series[0].data),
+            combo_scatter_points: combo_scatter_points(&line_series[0].data),
             line_series,
             metro_line_a: metro_line_a(),
             metro_line_b: metro_line_b(),
@@ -172,6 +176,10 @@ impl ChartDemo {
             self.combo_line_data = bars_from_points(&secondary.data);
             self.combo_line_color = line_color.into();
         }
+        if let Some(primary) = series.first() {
+            self.combo_area_points = combo_area_points(&primary.data);
+            self.combo_scatter_points = combo_scatter_points(&primary.data);
+        }
     }
 
     fn update_pie_center(&mut self) {
@@ -194,6 +202,22 @@ fn bars_from_points(points: &[ChartPoint]) -> Vec<ChartBar> {
         .iter()
         .enumerate()
         .map(|(index, point)| ChartBar::new(format!("W{}", index + 1), point.y))
+        .collect()
+}
+
+fn combo_area_points(points: &[ChartPoint]) -> Vec<ChartPoint> {
+    points
+        .iter()
+        .map(|point| ChartPoint::new(point.x, point.y * 0.82))
+        .collect()
+}
+
+fn combo_scatter_points(points: &[ChartPoint]) -> Vec<ChartPoint> {
+    points
+        .iter()
+        .enumerate()
+        .filter(|(index, _)| index % 3 == 1)
+        .map(|(_, point)| ChartPoint::new(point.x, point.y * 1.05))
         .collect()
 }
 

--- a/examples/charts/src/lib.rs
+++ b/examples/charts/src/lib.rs
@@ -22,6 +22,9 @@ pub struct ChartDemo {
     pub combo_line_data: Vec<ChartBar>,
     pub combo_area_points: Vec<ChartPoint>,
     pub combo_scatter_points: Vec<ChartPoint>,
+    pub combo_goal: Option<f64>,
+    pub combo_latest_x: f64,
+    pub combo_latest_y: f64,
     pub metro_line_a: Vec<ChartLayerPoint>,
     pub metro_line_b: Vec<ChartLayerPoint>,
     pub metro_line_c: Vec<ChartLayerPoint>,
@@ -61,6 +64,9 @@ impl Default for ChartDemo {
             combo_line_data: bars_from_points(&line_series[1].data),
             combo_area_points: combo_area_points(&line_series[0].data),
             combo_scatter_points: combo_scatter_points(&line_series[0].data),
+            combo_goal: combo_goal(&line_series[1].data),
+            combo_latest_x: latest_x(&line_series[0].data),
+            combo_latest_y: latest_y(&line_series[0].data),
             line_series,
             metro_line_a: metro_line_a(),
             metro_line_b: metro_line_b(),
@@ -179,6 +185,11 @@ impl ChartDemo {
         if let Some(primary) = series.first() {
             self.combo_area_points = combo_area_points(&primary.data);
             self.combo_scatter_points = combo_scatter_points(&primary.data);
+            self.combo_latest_x = latest_x(&primary.data);
+            self.combo_latest_y = latest_y(&primary.data);
+        }
+        if let Some(secondary) = series.get(1) {
+            self.combo_goal = combo_goal(&secondary.data);
         }
     }
 
@@ -219,6 +230,18 @@ fn combo_scatter_points(points: &[ChartPoint]) -> Vec<ChartPoint> {
         .filter(|(index, _)| index % 3 == 1)
         .map(|(_, point)| ChartPoint::new(point.x, point.y * 1.05))
         .collect()
+}
+
+fn combo_goal(points: &[ChartPoint]) -> Option<f64> {
+    points.last().map(|point| point.y)
+}
+
+fn latest_x(points: &[ChartPoint]) -> f64 {
+    points.last().map(|point| point.x).unwrap_or_default()
+}
+
+fn latest_y(points: &[ChartPoint]) -> f64 {
+    points.last().map(|point| point.y).unwrap_or_default()
 }
 
 fn growth_points() -> Vec<ChartPoint> {


### PR DESCRIPTION
Summary
- Add composable Cartesian area and scatter series to Pine Charts.
- Add Cartesian reference line, dot, and label components that render on shared chart scales.
- Update the charts demo and docs/charts pages for combo charts, layer order, and component composition.

Validation
- cargo fmt --check
- cargo check -p pine-charts --all-targets
- cargo test -p pine-charts
- cargo clippy -p pine-charts --all-targets -- -D warnings
- wasm-pack test --firefox --headless crates/pine-charts
- cargo check --manifest-path examples/charts/Cargo.toml --target wasm32-unknown-unknown
- cargo run -p pocopine-cli -- build --path examples/charts

Notes
- Static numeric-looking string props such as font_weight=700 are still a separate runtime coercion follow-up. The demo uses font_weight=bold for this PR.