### PR TITLE
Restore numeric chart font weights

### DIFF
--- a/crates/pine-charts/tests/charts.rs
+++ b/crates/pine-charts/tests/charts.rs
@@ -264,7 +264,7 @@ impl LineChartFixture {}
                         angle="-65"
                         fill="#18212f"
                         text_anchor="start"
-                        font_weight="bold"></pine-chart-label>
+                        font_weight="700"></pine-chart-label>
     </pine-chart-layer>
   </pine-layer-chart>
 </div>
@@ -386,7 +386,7 @@ impl ComposedCartesianFixture {}
                                     y="18"
                                     dy="-8"
                                     fill="#18212f"
-                                    font_weight="bold"></pine-cartesian-reference-label>
+                                    font_weight="700"></pine-cartesian-reference-label>
   </pine-cartesian-chart>
 </div>
 "##)]
@@ -690,7 +690,7 @@ async fn cartesian_chart_composes_bar_and_line_series_on_one_axis() {
     assert_eq!(reference_label.get_attribute("y").as_deref(), Some("2"));
     assert_eq!(
         reference_label.get_attribute("font-weight").as_deref(),
-        Some("bold")
+        Some("700")
     );
 
     let markers = host.query_selector_all(".pine-chart-marker").unwrap();

--- a/examples/charts/src/ChartDemo.poco
+++ b/examples/charts/src/ChartDemo.poco
@@ -87,7 +87,7 @@
                                       pp-bind:y="combo_latest_y"
                                       dy="-12"
                                       fill="#18212f"
-                                      font_weight="bold"></pine-cartesian-reference-label>
+                                      font_weight="700"></pine-cartesian-reference-label>
     </pine-cartesian-chart>
   </pine-chart-responsive>
 
@@ -141,11 +141,11 @@
         <pine-chart-icon key="airport-east" kind="plane" x="770" y="82" scale="0.075" fill="#18212f"></pine-chart-icon>
       </pine-chart-layer>
       <pine-chart-layer name="labels">
-        <pine-chart-label key="airport-label" text="Airport" x="100" y="120" dx="8" dy="-24" angle="-65" fill="#19a974" text_anchor="start" font_weight="bold"></pine-chart-label>
-        <pine-chart-label key="central-label" text="Central" x="420" y="180" dx="14" dy="-24" angle="-65" fill="#18212f" text_anchor="start" font_weight="bold"></pine-chart-label>
-        <pine-chart-label key="museum-label" text="Museum" x="480" y="300" dx="-12" dy="42" angle="-65" fill="#18212f" text_anchor="end" font_weight="bold"></pine-chart-label>
-        <pine-chart-label key="republic-label" text="Republic" x="520" y="180" dx="12" dy="-24" angle="-65" fill="#18212f" text_anchor="start" font_weight="bold"></pine-chart-label>
-        <pine-chart-label key="east-gate-label" text="East Gate" x="840" y="240" dx="8" dy="-24" angle="-65" fill="#f2c230" text_anchor="start" font_weight="bold"></pine-chart-label>
+        <pine-chart-label key="airport-label" text="Airport" x="100" y="120" dx="8" dy="-24" angle="-65" fill="#19a974" text_anchor="start" font_weight="700"></pine-chart-label>
+        <pine-chart-label key="central-label" text="Central" x="420" y="180" dx="14" dy="-24" angle="-65" fill="#18212f" text_anchor="start" font_weight="700"></pine-chart-label>
+        <pine-chart-label key="museum-label" text="Museum" x="480" y="300" dx="-12" dy="42" angle="-65" fill="#18212f" text_anchor="end" font_weight="700"></pine-chart-label>
+        <pine-chart-label key="republic-label" text="Republic" x="520" y="180" dx="12" dy="-24" angle="-65" fill="#18212f" text_anchor="start" font_weight="700"></pine-chart-label>
+        <pine-chart-label key="east-gate-label" text="East Gate" x="840" y="240" dx="8" dy="-24" angle="-65" fill="#f2c230" text_anchor="start" font_weight="700"></pine-chart-label>
       </pine-chart-layer>
     </pine-layer-chart>
   </pine-chart-responsive>


### PR DESCRIPTION
## Summary
- restore numeric string font weights in the charts demo now that static String prop coercion is fixed
- update pine-charts browser fixtures and assertions to expect font-weight="700"

## Validation
- cargo check -p pine-charts --all-targets
- cargo run -p pocopine-cli -- build --path examples/charts
- cargo fmt --check
- wasm-pack test --firefox --headless crates/pine-charts
- cargo clippy -p pine-charts --all-targets -- -D warnings