### PR TITLE
Complete RFC 078 core follow-ups

### DIFF
--- a/crates/pocopine-core/Cargo.toml
+++ b/crates/pocopine-core/Cargo.toml
@@ -41,6 +41,8 @@ features = [
     "AddEventListenerOptions",
     "Animation",
     "AnimationEvent",
+    "AbortController",
+    "AbortSignal",
     "Attr",
     "Clipboard",
     "ClipboardEvent",

--- a/crates/pocopine-core/src/app.rs
+++ b/crates/pocopine-core/src/app.rs
@@ -294,7 +294,10 @@ where
 /// router has moved on (RFC-078 §5.10.5). The router itself drops
 /// any result returned under a stale token, so honoring this is
 /// only an optimisation — correctness of the painted view does
-/// not depend on the loader checking.
+/// not depend on the loader checking. `abort_signal` is also
+/// inherited automatically by generated `#[server]` calls made while
+/// the loader future is being polled, so route supersession cancels
+/// the underlying browser fetch.
 #[derive(Clone, Debug)]
 pub struct LoaderContext {
     pub path: String,
@@ -302,6 +305,7 @@ pub struct LoaderContext {
     pub query: HashMap<String, String>,
     pub matched_pattern: Option<&'static str>,
     pub navigation_token: crate::router::RouteToken,
+    pub(crate) abort_signal: Option<web_sys::AbortSignal>,
 }
 
 impl LoaderContext {
@@ -311,6 +315,14 @@ impl LoaderContext {
     /// loader can early-exit (its result will be dropped anyway).
     pub fn is_navigation_active(&self) -> bool {
         crate::router::route_token_is_current(self.navigation_token)
+    }
+
+    /// Browser abort signal for this route navigation, when the
+    /// platform supplied one. Generated `#[server]` stubs inherit this
+    /// automatically inside loader futures; direct `fetch::call`
+    /// users can also pass it through `FetchOptions`.
+    pub fn abort_signal(&self) -> Option<web_sys::AbortSignal> {
+        self.abort_signal.clone()
     }
 }
 
@@ -394,8 +406,12 @@ where
     T: 'static,
 {
     fn run(&self, ctx: LoaderContext) -> RouteLoaderFuture {
+        let abort_signal = ctx.abort_signal();
         let fut = (self.f)(ctx);
-        Box::pin(async move { fut.await.map(|t| Box::new(t) as Box<dyn Any>) })
+        Box::pin(crate::fetch::with_abort_signal_future(
+            abort_signal,
+            async move { fut.await.map(|t| Box::new(t) as Box<dyn Any>) },
+        ))
     }
 }
 
@@ -481,6 +497,11 @@ impl<C: Component> RouteConfig<C> {
         }
     }
 
+    /// Attach a synchronous client-side guard.
+    ///
+    /// Guards are a paint/UX primitive, not an authorization
+    /// boundary. Any sensitive data touched by the route must still be
+    /// protected by server-side `#[server(guard = ...)]` checks.
     pub fn guard(mut self, guard: impl RouteGuard) -> Self {
         self.guards.push(Rc::new(guard));
         self

--- a/crates/pocopine-core/src/fetch.rs
+++ b/crates/pocopine-core/src/fetch.rs
@@ -42,6 +42,7 @@ use crate::server::{Result as ServerResult, ServerError};
 /// a middleware before forwarding (`next.run(request)`) lets a
 /// plugin add headers, rewrite the URL, sign the body, etc.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub struct FetchRequest {
     pub url: String,
     pub method: String,
@@ -55,7 +56,7 @@ pub struct FetchRequest {
     /// the call replay-safe (`#[server(idempotent)]`). Auth middleware
     /// may retry these after token refresh; it must fail closed for
     /// the default `false` case.
-    pub replay_safe: bool,
+    pub(crate) replay_safe: bool,
 }
 
 impl FetchRequest {
@@ -309,9 +310,10 @@ where
 
 /// Options for [`call_with_options`].
 #[derive(Clone, Debug, Default)]
+#[non_exhaustive]
 pub struct FetchOptions {
-    pub abort_signal: Option<AbortSignal>,
-    pub replay_safe: bool,
+    pub(crate) abort_signal: Option<AbortSignal>,
+    pub(crate) replay_safe: bool,
 }
 
 impl FetchOptions {

--- a/crates/pocopine-core/src/fetch.rs
+++ b/crates/pocopine-core/src/fetch.rs
@@ -27,11 +27,12 @@ use std::cell::{Cell, RefCell};
 use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
+use std::task::{Context, Poll};
 
 use serde::{de::DeserializeOwned, Serialize};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
-use web_sys::{Request, RequestInit, Response};
+use web_sys::{AbortSignal, Request, RequestInit, Response};
 
 use crate::server::{Result as ServerResult, ServerError};
 
@@ -46,6 +47,15 @@ pub struct FetchRequest {
     pub method: String,
     pub body: String,
     pub headers: Vec<(String, String)>,
+    /// Browser abort signal for this request. Route loaders populate
+    /// this automatically while their future is being polled so
+    /// navigation supersession cancels the underlying `window.fetch`.
+    pub abort_signal: Option<AbortSignal>,
+    /// `true` when the generated server-function stub has declared
+    /// the call replay-safe (`#[server(idempotent)]`). Auth middleware
+    /// may retry these after token refresh; it must fail closed for
+    /// the default `false` case.
+    pub replay_safe: bool,
 }
 
 impl FetchRequest {
@@ -62,6 +72,13 @@ impl FetchRequest {
         } else {
             self.headers.push((name, value));
         }
+    }
+
+    /// Whether middleware may replay this request after refreshing
+    /// credentials. Defaults to `false` unless the generated
+    /// `#[server]` client stub opted in with `#[server(idempotent)]`.
+    pub fn is_replay_safe(&self) -> bool {
+        self.replay_safe
     }
 }
 
@@ -145,6 +162,65 @@ thread_local! {
     /// dispatch clones an `Rc` instead of cloning the `Vec`.
     static MIDDLEWARE_SNAPSHOT: RefCell<Option<MiddlewareChain>> =
         const { RefCell::new(None) };
+    /// Task-local-ish route-loader fetch context. The router wraps
+    /// each loader future so this slot is set only while that future
+    /// is being polled, letting generated `#[server]` stubs inherit
+    /// the right abort signal without changing every server-function
+    /// signature.
+    static ACTIVE_ABORT_SIGNAL: RefCell<Option<AbortSignal>> =
+        const { RefCell::new(None) };
+}
+
+struct AbortSignalScope {
+    previous: Option<AbortSignal>,
+}
+
+impl Drop for AbortSignalScope {
+    fn drop(&mut self) {
+        ACTIVE_ABORT_SIGNAL.with(|cell| {
+            *cell.borrow_mut() = self.previous.take();
+        });
+    }
+}
+
+fn enter_abort_signal(signal: Option<AbortSignal>) -> AbortSignalScope {
+    let previous =
+        ACTIVE_ABORT_SIGNAL.with(|cell| std::mem::replace(&mut *cell.borrow_mut(), signal));
+    AbortSignalScope { previous }
+}
+
+fn current_abort_signal() -> Option<AbortSignal> {
+    ACTIVE_ABORT_SIGNAL.with(|cell| cell.borrow().clone())
+}
+
+/// Future wrapper used by the router to make loader-owned abort
+/// signals visible to generated `#[server]` stubs while a specific
+/// loader future is being polled.
+pub(crate) struct AbortSignalFuture<F> {
+    signal: Option<AbortSignal>,
+    future: Pin<Box<F>>,
+}
+
+impl<F> Unpin for AbortSignalFuture<F> {}
+
+impl<F: Future> Future for AbortSignalFuture<F> {
+    type Output = F::Output;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        let _scope = enter_abort_signal(this.signal.clone());
+        this.future.as_mut().poll(cx)
+    }
+}
+
+pub(crate) fn with_abort_signal_future<F: Future>(
+    signal: Option<AbortSignal>,
+    future: F,
+) -> AbortSignalFuture<F> {
+    AbortSignalFuture {
+        signal,
+        future: Box::pin(future),
+    }
 }
 
 /// Install a middleware. Must run before the first
@@ -228,7 +304,50 @@ where
     A: Serialize,
     R: DeserializeOwned,
 {
+    call_with_options(url, args, FetchOptions::default()).await
+}
+
+/// Options for [`call_with_options`].
+#[derive(Clone, Debug, Default)]
+pub struct FetchOptions {
+    pub abort_signal: Option<AbortSignal>,
+    pub replay_safe: bool,
+}
+
+impl FetchOptions {
+    /// Attach an explicit browser abort signal.
+    pub fn abort_signal(mut self, signal: Option<AbortSignal>) -> Self {
+        self.abort_signal = signal;
+        self
+    }
+
+    /// Mark whether middleware may replay this call after a recoverable
+    /// authentication failure.
+    pub fn replay_safe(mut self, enabled: bool) -> Self {
+        self.replay_safe = enabled;
+        self
+    }
+
+    fn with_active_context(mut self) -> Self {
+        if self.abort_signal.is_none() {
+            self.abort_signal = current_abort_signal();
+        }
+        self
+    }
+}
+
+/// Post `args` like [`call`] but with explicit request metadata.
+///
+/// This is primarily used by macro-generated `#[server]` stubs and
+/// by integration tests. Application code should usually call the
+/// generated server function directly.
+pub async fn call_with_options<A, R>(url: &str, args: &A, options: FetchOptions) -> ServerResult<R>
+where
+    A: Serialize,
+    R: DeserializeOwned,
+{
     freeze_middleware_chain();
+    let options = options.with_active_context();
 
     let body = serde_json::to_string(args)
         .map_err(|e| ServerError::Network(format!("serialize args: {e}")))?;
@@ -238,6 +357,8 @@ where
         method: "POST".to_string(),
         body,
         headers: vec![("content-type".to_string(), "application/json".to_string())],
+        abort_signal: options.abort_signal,
+        replay_safe: options.replay_safe,
     };
 
     let middlewares = snapshot_chain();
@@ -256,12 +377,26 @@ where
     outer
 }
 
+/// Post `args` and mark the generated request replay-safe.
+///
+/// `#[server(idempotent)]` stubs use this helper. Auth middleware may
+/// replay a request with this marker at most once after a successful
+/// refresh. Unmarked requests must be treated as unsafe to replay.
+pub async fn call_replay_safe<A, R>(url: &str, args: &A) -> ServerResult<R>
+where
+    A: Serialize,
+    R: DeserializeOwned,
+{
+    call_with_options(url, args, FetchOptions::default().replay_safe(true)).await
+}
+
 // ─── transport ──────────────────────────────────────────────────────
 
 async fn perform_fetch(request: FetchRequest) -> Result<FetchResponse, ServerError> {
     let init = RequestInit::new();
     init.set_method(&request.method);
     init.set_body(&JsValue::from_str(&request.body));
+    init.set_signal(request.abort_signal.as_ref());
 
     let headers =
         web_sys::Headers::new().map_err(|e| ServerError::Network(format!("headers: {e:?}")))?;
@@ -339,6 +474,8 @@ mod tests {
             method: "POST".into(),
             body: "".into(),
             headers: vec![("Content-Type".into(), "text/plain".into())],
+            abort_signal: None,
+            replay_safe: false,
         };
         req.set_header("content-type", "application/json");
         assert_eq!(req.headers.len(), 1);
@@ -354,6 +491,8 @@ mod tests {
             method: "POST".into(),
             body: "".into(),
             headers: vec![],
+            abort_signal: None,
+            replay_safe: false,
         };
         req.set_header("authorization", "Bearer t");
         assert_eq!(
@@ -380,5 +519,12 @@ mod tests {
 
         // Reset for any subsequent test in this binary.
         reset();
+    }
+
+    #[test]
+    fn fetch_options_default_to_not_replay_safe() {
+        let options = FetchOptions::default();
+        assert!(!options.replay_safe);
+        assert!(options.abort_signal.is_none());
     }
 }

--- a/crates/pocopine-core/src/router.rs
+++ b/crates/pocopine-core/src/router.rs
@@ -206,6 +206,12 @@ thread_local! {
     /// while the loader was in flight, so the result is dropped
     /// rather than painted (RFC-078 §5.10.5).
     static ROUTE_TOKEN: Cell<u64> = const { Cell::new(0) };
+    /// Abort controller for the currently in-flight route loader.
+    /// Navigation supersession aborts this before the token advances
+    /// so loader-owned `fetch::call` requests stop in the browser,
+    /// not just at the Rust result boundary.
+    static ACTIVE_LOADER_ABORT: RefCell<Option<(RouteToken, web_sys::AbortController)>> =
+        const { RefCell::new(None) };
     /// `App::route_error_component<C>()` recorded component name,
     /// painted by `paint_route_error` when set instead of the
     /// built-in HTML banner.
@@ -260,6 +266,34 @@ fn is_token_current(token: RouteToken) -> bool {
 /// stamps the value into their context.
 pub(crate) fn route_token_is_current(token: RouteToken) -> bool {
     is_token_current(token)
+}
+
+fn begin_loader_abort(token: RouteToken) -> Option<web_sys::AbortSignal> {
+    let controller = web_sys::AbortController::new().ok()?;
+    let signal = controller.signal();
+    ACTIVE_LOADER_ABORT.with(|cell| {
+        *cell.borrow_mut() = Some((token, controller));
+    });
+    Some(signal)
+}
+
+fn abort_active_loader() {
+    if let Some((_, controller)) = ACTIVE_LOADER_ABORT.with(|cell| cell.borrow_mut().take()) {
+        controller.abort();
+    }
+}
+
+fn clear_active_loader_abort(token: RouteToken) {
+    ACTIVE_LOADER_ABORT.with(|cell| {
+        let should_clear = cell
+            .borrow()
+            .as_ref()
+            .map(|(active_token, _)| *active_token == token)
+            .unwrap_or(false);
+        if should_clear {
+            cell.borrow_mut().take();
+        }
+    });
 }
 
 /// Stash a router-produced loader result for the next component
@@ -499,6 +533,11 @@ fn clear_outlet() {
 fn mount_current() {
     ensure_route_scope();
 
+    // Abort any loader request from the previous navigation before
+    // advancing the token. The stale-result check below still guards
+    // correctness, but this stops browser fetches on the wire.
+    abort_active_loader();
+
     // Defense in depth: drop any leftover loader data from a
     // prior navigation that didn't reach `finish_route_mount`
     // (early `missing_window` / `missing_outlet` returns, panics
@@ -511,10 +550,7 @@ fn mount_current() {
 
     // Mark this navigation. Any loader spawned by an earlier
     // `mount_current` captured the previous token at start; when it
-    // resolves it'll find this new value and drop its result. The
-    // token bump is the cheapest possible signal — actual abort of
-    // an in-flight `fetch::call` will land with Slice G when the
-    // middleware chain plumbs `AbortSignal` end-to-end.
+    // resolves it'll find this new value and drop its result.
     let nav_token = bump_route_token();
 
     let has_route_hooks = crate::plugin::has_route_navigation_hooks();
@@ -595,12 +631,14 @@ fn mount_current() {
         // `spawn_local` so the synchronous fast path is still
         // available for routes without loaders.
         if let Some(loader) = matched.config.loader.clone() {
+            let abort_signal = begin_loader_abort(nav_token);
             let loader_ctx = LoaderContext {
                 path: path.clone(),
                 params: params.clone(),
                 query: query.clone(),
                 matched_pattern: route_pattern,
                 navigation_token: nav_token,
+                abort_signal,
             };
             update_route_state(&path, &params, query.clone());
             let matched_for_async = matched.clone();
@@ -619,6 +657,7 @@ fn mount_current() {
                     clear_pending_loader_data();
                     return;
                 }
+                clear_active_loader_abort(nav_token);
                 match result {
                     Ok(data) => {
                         put_pending_loader_data(data);

--- a/crates/pocopine-core/src/router.rs
+++ b/crates/pocopine-core/src/router.rs
@@ -548,9 +548,9 @@ fn mount_current() {
     // on every code path remembering to clear.
     clear_pending_loader_data();
 
-    // Mark this navigation. Any loader spawned by an earlier
-    // `mount_current` captured the previous token at start; when it
-    // resolves it'll find this new value and drop its result.
+    // Mark this navigation. The abort above stops loader-owned
+    // fetches on the wire; this token bump is the residual stale-result
+    // fence for any previous loader that still resolves.
     let nav_token = bump_route_token();
 
     let has_route_hooks = crate::plugin::has_route_navigation_hooks();

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -3070,6 +3070,10 @@ pub fn store(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// * `#[server(guard = require_user)]` protects the endpoint. The guard
 ///   must be an async function that accepts
 ///   `pocopine_server::auth::RequestContext` and returns a `Result`.
+/// * `#[server(idempotent)]` marks the generated client request as
+///   replay-safe for middleware. Auth middleware may retry these at
+///   most once after a successful refresh; unmarked calls remain
+///   fail-closed.
 /// * `#[server]` without either marker still compiles, but emits a
 ///   warning so authors do not accidentally ship unreviewed endpoints.
 ///
@@ -3084,6 +3088,7 @@ pub fn store(attr: TokenStream, item: TokenStream) -> TokenStream {
 struct ServerPolicy {
     public: bool,
     guard: Option<Path>,
+    idempotent: bool,
 }
 
 impl ServerPolicy {
@@ -3104,6 +3109,15 @@ fn parse_server_policy(attr: TokenStream) -> syn::Result<ServerPolicy> {
                 }
                 policy.public = true;
             }
+            Meta::Path(path) if path.is_ident("idempotent") => {
+                if policy.idempotent {
+                    return Err(syn::Error::new_spanned(
+                        path,
+                        "duplicate `idempotent` marker",
+                    ));
+                }
+                policy.idempotent = true;
+            }
             Meta::NameValue(MetaNameValue { path, value, .. }) if path.is_ident("guard") => {
                 if policy.guard.is_some() {
                     return Err(syn::Error::new_spanned(path, "duplicate auth guard"));
@@ -3119,7 +3133,7 @@ fn parse_server_policy(attr: TokenStream) -> syn::Result<ServerPolicy> {
             other => {
                 return Err(syn::Error::new_spanned(
                     other,
-                    "unsupported `#[server]` option; expected `public` or `guard = path`",
+                    "unsupported `#[server]` option; expected `public`, `idempotent`, or `guard = path`",
                 ));
             }
         }
@@ -3239,10 +3253,16 @@ pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let sig_without_body = quote! { #vis #sig };
 
+    let client_call = if policy.idempotent {
+        quote! { ::pocopine::fetch::call_replay_safe::<#args_tuple_type, _> }
+    } else {
+        quote! { ::pocopine::fetch::call::<#args_tuple_type, _> }
+    };
+
     let client = quote! {
         #[cfg(target_arch = "wasm32")]
         #sig_without_body {
-            ::pocopine::fetch::call::<#args_tuple_type, _>(
+            #client_call(
                 #route_path,
                 &#args_tuple_value,
             ).await

--- a/crates/pocopine/tests/route_guards_loaders.rs
+++ b/crates/pocopine/tests/route_guards_loaders.rs
@@ -12,6 +12,7 @@ use js_sys::Promise;
 use pocopine::prelude::*;
 use pocopine::App;
 use serde::{Deserialize, Serialize};
+use std::{cell::RefCell, rc::Rc};
 use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
 use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
@@ -519,6 +520,125 @@ async fn reevaluate_current_drops_mount_when_guards_flip_to_reject() {
 }
 
 // ─── Fetch middleware: install + freeze panic ───────────────────────
+
+#[pocopine::server(public, idempotent)]
+async fn rgl_replay_safe_value() -> pocopine::ServerResult<u32> {
+    Ok(0)
+}
+
+#[wasm_bindgen_test(async)]
+async fn server_idempotent_marks_fetch_request_replay_safe() {
+    pocopine::fetch::__reset_middleware_chain_for_test();
+    let seen_replay_safe = Rc::new(RefCell::new(None));
+    let seen_replay_safe_for_middleware = seen_replay_safe.clone();
+
+    pocopine::fetch::install_middleware(
+        move |req: pocopine::fetch::FetchRequest, _next: pocopine::fetch::FetchNext| {
+            let seen_replay_safe = seen_replay_safe_for_middleware.clone();
+            async move {
+                *seen_replay_safe.borrow_mut() = Some(req.is_replay_safe());
+                Ok(pocopine::fetch::FetchResponse {
+                    status: 200,
+                    body: serde_json::to_string(&Ok::<u32, pocopine::ServerError>(42)).unwrap(),
+                })
+            }
+        },
+    );
+
+    let value = rgl_replay_safe_value().await.unwrap();
+    assert_eq!(value, 42);
+    assert_eq!(
+        *seen_replay_safe.borrow(),
+        Some(true),
+        "#[server(idempotent)] stubs should mark requests replay-safe"
+    );
+
+    pocopine::fetch::__reset_middleware_chain_for_test();
+}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "rgl-abort-slow",
+    template_inline = r#"<div>slow loader should never paint</div>"#
+)]
+struct AbortSlowRoute {}
+
+#[handlers]
+impl AbortSlowRoute {}
+
+impl RouteComponent for AbortSlowRoute {
+    fn config() -> RouteConfig<Self> {
+        RouteConfig::new().loader(|_ctx: LoaderContext| async move {
+            let _: u32 = pocopine::fetch::call("/test-abort-never", &()).await?;
+            Ok::<_, LoaderError>(())
+        })
+    }
+}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "rgl-abort-target",
+    template_inline = r#"<div class="rgl-abort-target">target</div>"#
+)]
+struct AbortTargetRoute {}
+
+#[handlers]
+impl AbortTargetRoute {}
+
+impl RouteComponent for AbortTargetRoute {}
+
+#[wasm_bindgen_test(async)]
+async fn loader_fetch_signal_aborts_on_navigation_supersession() {
+    pocopine::fetch::__reset_middleware_chain_for_test();
+    let captured_signal = Rc::new(RefCell::new(None));
+    let captured_signal_for_middleware = captured_signal.clone();
+
+    pocopine::fetch::install_middleware(
+        move |req: pocopine::fetch::FetchRequest, _next: pocopine::fetch::FetchNext| {
+            let captured_signal = captured_signal_for_middleware.clone();
+            async move {
+                *captured_signal.borrow_mut() = req.abort_signal.clone();
+                std::future::pending::<Result<pocopine::fetch::FetchResponse, pocopine::ServerError>>()
+                    .await
+            }
+        },
+    );
+
+    let host = app_host_with_outlet();
+    replace_url("/");
+    App::new()
+        .route_component::<AbortSlowRoute>("/test-abort-loader")
+        .route_component::<AbortTargetRoute>("/test-abort-target")
+        .run();
+
+    navigate_to("/test-abort-loader");
+    yield_event_loop_for_loaders().await;
+
+    let signal = captured_signal
+        .borrow()
+        .clone()
+        .expect("loader-owned fetch::call should receive an AbortSignal");
+    assert!(
+        !signal.aborted(),
+        "fresh loader abort signal should not be aborted before supersession"
+    );
+
+    navigate_to("/test-abort-target");
+    next_microtask().await;
+
+    assert!(
+        signal.aborted(),
+        "superseding navigation should abort the loader's fetch signal"
+    );
+    assert!(
+        outlet_html().contains("rgl-abort-target"),
+        "target route should paint after superseding the loader route"
+    );
+
+    replace_url("/");
+    host.remove();
+    pocopine::fetch::__reset_middleware_chain_for_test();
+}
 
 #[wasm_bindgen_test]
 #[should_panic(expected = "called after the chain was frozen")]

--- a/docs/route-guards-and-loaders.md
+++ b/docs/route-guards-and-loaders.md
@@ -13,6 +13,10 @@ This doc walks through each, then shows how they compose. The
 running example is an auth-aware dashboard — but everything here
 is generic; auth is just the marquee consumer.
 
+> **Security boundary:** client route guards are UX only. They
+> prevent protected components from painting, but every sensitive
+> `#[server]` function must still declare its own server-side guard.
+
 ## Route configuration lives with the component
 
 Every component that wants route-local behavior implements
@@ -219,23 +223,25 @@ trap.
 
 ### Cancellation
 
-Each navigation gets a monotonic `RouteToken`. Loaders capture
-the token at spawn; when they resolve, the router compares
-against the current token. Mismatch means navigation moved on
-(the user clicked a different link) and the result is **dropped
-silently** — no painting, no `RouteNavigationFailed` event (the
-new navigation is healthy and already running).
+Each navigation gets a monotonic `RouteToken` and an
+`AbortSignal`. Loaders capture both at spawn. When a later
+navigation supersedes the loader, the router aborts the controller
+first, then advances the token. That gives two layers of protection:
+browser `fetch` calls stop on the wire, and any stale result that
+still resolves is **dropped silently** — no painting, no
+`RouteNavigationFailed` event (the new navigation is healthy and
+already running).
 
 Long-running loaders can poll `LoaderContext::is_navigation_active()`
 to short-circuit voluntarily. Honoring it is an optimisation;
 correctness of the painted view doesn't depend on the loader
 checking.
 
-> **Real `AbortSignal` propagation** — letting the browser
-> actually cancel the in-flight `fetch::call` so bandwidth and
-> server work stop — lands as a follow-up. Until then,
-> cancelled loaders complete on the wire and the result is
-> dropped Rust-side.
+Generated `#[server]` client stubs inherit the loader's abort signal
+automatically while the loader future is being polled. If a loader
+starts work in a separate task, pass `ctx.abort_signal()` explicitly
+through `fetch::FetchOptions` for direct `fetch::call_with_options`
+usage.
 
 ## Route rejection chain
 
@@ -365,10 +371,13 @@ fetch::install_middleware(|req: FetchRequest, next: FetchNext| async move {
     }
     let response = next.clone().run(req.clone()).await;
     if let Err(ServerError::Unauthorized(_)) = &response {
-        // Refresh + replay.
-        if let Some(new_token) = refresh_token().await {
-            store_token(new_token);
-            return next.run(req).await;
+        // Refresh + replay only when the server function opted in
+        // with #[server(idempotent)].
+        if req.is_replay_safe() {
+            if let Some(new_token) = refresh_token().await {
+                store_token(new_token);
+                return next.run(req).await;
+            }
         }
     }
     response
@@ -377,6 +386,24 @@ fetch::install_middleware(|req: FetchRequest, next: FetchNext| async move {
 
 `FetchNext: Clone` so middleware can replay; `FetchRequest:
 Clone` for the same reason.
+
+### Replay-safe requests
+
+Generated `#[server]` stubs are **not** replay-safe by default.
+Mark read-only or otherwise idempotent server functions explicitly:
+
+```rust
+#[pocopine::server(public, idempotent)]
+async fn dashboard_stats() -> pocopine::ServerResult<DashboardStats> {
+    // ...
+}
+```
+
+The client stub marks the outgoing `FetchRequest` as
+`replay_safe`. Auth middleware may replay such a request at most once
+after a successful refresh. Unmarked server functions stay
+fail-closed: middleware should propagate `Unauthorized` rather than
+retry a POST that may have already taken effect.
 
 ### Freeze-at-boot
 
@@ -414,9 +441,9 @@ negotiable per RFC-078 §5.10:
 6. **Sign-out re-evaluates guards** synchronously
    (`reevaluate_current()`) so PII never survives the
    identity-change moment.
-7. **Replay-after-Unauthorized is fail-closed** until
-   `#[server(idempotent)]` lands; auth middleware should
-   propagate `Unauthorized` rather than retry POSTs that may
+7. **Replay-after-Unauthorized is fail-closed** unless the generated
+   request is marked by `#[server(idempotent)]`; auth middleware
+   should propagate `Unauthorized` rather than retry POSTs that may
    have already taken effect.
 
 ## End-to-end example

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -85,4 +85,4 @@ Conventions:
 | 074 | [`pocopine-auth-credentials` and the `Provider` trait](./rfc-074-auth-credentials-and-provider-trait.md) | Draft |
 | 076 | [App plugin lifecycle](./rfc-076-app-plugin-lifecycle.md) | Draft |
 | 077 | [Server plugin lifecycle](./rfc-077-server-plugin-lifecycle.md) | Draft |
-| 078 | [Client route guards, loaders, and fetch middleware](./rfc-078-client-route-guards-and-loaders.md) | Draft |
+| 078 | [Client route guards, loaders, and fetch middleware](./rfc-078-client-route-guards-and-loaders.md) | Accepted (core implemented; auth-client follow-up pending) |

--- a/rfcs/rfc-078-client-route-guards-and-loaders.md
+++ b/rfcs/rfc-078-client-route-guards-and-loaders.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Draft (open questions resolved 2026-05-07; extensibility redesign applied) |
+| **Status** | Accepted (core primitives implemented; `pocopine-auth-client` follow-up pending) |
 | **Author** | pocopine team |
 | **Created** | 2026-05-07 |
 | **Related** | [`rfc-003-router.md`](./rfc-003-router.md), [`rfc-076-app-plugin-lifecycle.md`](./rfc-076-app-plugin-lifecycle.md), [`rfc-077-server-plugin-lifecycle.md`](./rfc-077-server-plugin-lifecycle.md), [`rfc-074-auth-credentials-and-provider-trait.md`](./rfc-074-auth-credentials-and-provider-trait.md) |
@@ -158,7 +158,8 @@ honest about what's "auth concern" vs "router concern."
 - Loader data has **per-mount lifetime** — cleared when the route's
   component unmounts, no built-in cache. Caching/SWR ships separately
   as a plugin or explicit route option.
-- Cancellation: navigating away from an in-flight loader aborts it.
+- Cancellation: navigating away from an in-flight loader aborts its
+  browser fetches and drops stale results.
 - Compose with RFC-076's plugin lifecycle — the auth plugin
   registers guards, route-rejection handlers, loaders, and fetch
   middleware through `AppPlugin` install paths, not auth-shaped
@@ -1066,12 +1067,11 @@ The auth plugin's middleware **MUST** follow these rules:
 3. **Replay-safe gate.** Replay only fires for requests the
    framework knows are safe to retry. The default safe set:
    - `#[server]` functions explicitly marked
-     `#[server(idempotent)]`. RFC-078 requires RFC-066 (server-
-     function auth and access policy) to add this attribute as a
-     follow-up; until it does, the replay-safe set is **empty**
-     and the auth middleware MUST propagate the original
-     `Err(Unauthorized)` upward without retry. (This is a
-     deliberate fail-closed default.)
+     `#[server(idempotent)]`. RFC-078 adds this marker to generated
+     client stubs so middleware can inspect `FetchRequest::replay_safe`.
+     Until `pocopine-auth-client` consumes the marker, Unauthorized
+     propagates upward without retry. (This is a deliberate
+     fail-closed default.)
    - GET-style server functions, when RFC-066 grows them.
    For non-replay-safe requests, the middleware does **NOT**
    replay; it propagates `Err(Unauthorized)` upward, the loader
@@ -1195,7 +1195,7 @@ through the default UI or through plugin event consumers.
 
 ## 6. Phased Plan
 
-### Phase 1 — Generic route primitives + auth `Predicate`
+### Phase 1 — Generic route primitives + auth `Predicate` (implemented)
 
 - Add `RouteGuard` trait, `RouteGuardDecision` enum, and the
   `RouteContext` carrying `path`, `params`, `query`,
@@ -1216,7 +1216,7 @@ through the default UI or through plugin event consumers.
 - (Client-side `Predicate`-as-`RouteGuard` blanket impl ships in
   `pocopine-auth-client` later, not in this RFC.)
 
-### Phase 2 — Client route guards + rejection extension dispatch
+### Phase 2 — Client route guards + rejection extension dispatch (implemented)
 
 - Add `RouteComponent` and `RouteConfig<C>`.
 - `App::route::<C: RouteComponent>(...)` calls
@@ -1237,7 +1237,7 @@ through the default UI or through plugin event consumers.
   characters.
 - `router::reevaluate_current()` primitive (§5.10.6).
 
-### Phase 3 — Client route loaders + abort plumbing
+### Phase 3 — Client route loaders + abort plumbing (core implemented; auth-client handler pending)
 
 - `RouteConfig::loader(...)` records a single async loader (panic
   on second registration for the same route).
@@ -1255,9 +1255,11 @@ through the default UI or through plugin event consumers.
 - `pocopine-auth-client` installs its auth-owned rejection handler
   via `AppPlugin`: login route, return-intent parameter, validation
   strictness, modal/external-provider variants, and post-login
-  policy all live on the plugin builder.
+  policy all live on the plugin builder. This is delegated to the
+  auth-client follow-up because the generic router/fetch primitives
+  are now present.
 
-### Phase 4 — Fetch middleware chain + replay contract
+### Phase 4 — Fetch middleware chain + replay contract (core implemented)
 
 - `pocopine_core::fetch::install_middleware`. Chain freezes at
   first `App::run` / `fetch::call`; later install panics
@@ -1265,25 +1267,25 @@ through the default UI or through plugin event consumers.
 - Macro-generated `#[server]` stub passes through the chain.
 - Middleware contract: `Result<FetchResponse, ServerError>`, `Err`
   short-circuits.
-- `#[server(idempotent)]` attribute (RFC-066 follow-up) so the
-  framework knows which requests are replay-safe (§5.10.4).
-  Until that attribute lands, the auth replay-safe set is empty
-  and Unauthorized always propagates.
+- `#[server(idempotent)]` attribute so the framework knows which
+  generated server-function client requests are replay-safe
+  (§5.10.4). Until `pocopine-auth-client` consumes it, Unauthorized
+  still propagates.
 - `RouteNavigationFailed` events use the closed-set reasons
   from §5.10.7.
 
-### Phase 5 — Documentation + integration tests
+### Phase 5 — Documentation + integration tests (core implemented; auth-client integration pending)
 
 - `docs/route-guards-and-loaders.md` walking through the four
   phases AND the security model with a "client guards are not
   authorization" callout at the top.
 - wasm tests covering: guard outcomes; loader success/failure
   paths; fetch middleware ordering; the `Unauthorized`
-  route-rejection flow; the auth-plugin return-intent round trip
-  including every rejection case from §5.10.2; abort propagation
-  (request cancelled when navigation supersedes); session-epoch
-  rejection on post-sign-out responses; replay-safe vs
-  not-replay-safe Unauthorized behavior.
+  route-rejection flow; abort propagation (request cancelled when
+  navigation supersedes); and `#[server(idempotent)]` replay-safe
+  request marking. The auth-plugin return-intent round trip,
+  session-epoch rejection on post-sign-out responses, and replay
+  consumption belong to the `pocopine-auth-client` follow-up.
 - Update RFC-074 / RFC-076 to point at this RFC for the
   `Predicate` trait and the `RouteGuard` primitive.
 

--- a/rfcs/rfc-078-client-route-guards-and-loaders.md
+++ b/rfcs/rfc-078-client-route-guards-and-loaders.md
@@ -838,16 +838,18 @@ pub struct LoaderContext<'a> {
     pub path: &'a str,
     pub params: &'a HashMap<String, String>,
     pub query: &'a HashMap<String, String>,
-    /// Abort signal for this navigation. Loaders pass it into
-    /// `fetch::call(request.with_signal(ctx.abort_signal()))`
-    /// so the underlying `window.fetch` is cancelled on
-    /// supersession.
-    pub fn abort_signal(&self) -> AbortSignal;
+    /// Abort signal for this navigation, when the browser supplied
+    /// one. Generated `#[server]` calls inherit it automatically
+    /// while the loader future is being polled.
+    pub fn abort_signal(&self) -> Option<AbortSignal>;
 }
 
+#[non_exhaustive]
 pub struct FetchRequest {
     // ... existing fields ...
     pub abort_signal: Option<AbortSignal>,
+    // Private; middleware reads this through `is_replay_safe()`.
+    replay_safe: bool,
 }
 ```
 


### PR DESCRIPTION
## Summary

- Mark RFC 078 as accepted for the implemented core primitives while leaving the auth-client plugin follow-up explicit.
- Add real route-loader abort plumbing via `AbortController` / `AbortSignal`, including automatic abort-signal inheritance for generated server calls made from loader futures.
- Add replay-safety groundwork for auth middleware with `FetchRequest::is_replay_safe()`, `FetchOptions`, `call_with_options`, `call_replay_safe`, and `#[server(idempotent)]` client stubs.
- Update route-guard/loader docs and add focused wasm tests for abort propagation and replay-safe request marking.

## Deferred

The `pocopine-auth-client` plugin integration remains intentionally deferred for the next agent/pass. That follow-up should consume the new core primitives for Unauthorized route handling, auth fetch middleware, refresh/replay behavior, and session-epoch reevaluation.

## Verification

- `cargo check -p pocopine-core --lib`
- `cargo check -p pocopine --tests`
- `cargo check --workspace --all-targets`
- `cargo test -p pocopine-core --lib`
- `cargo test -p pocopine --test server_auth`
- `wasm-pack test --firefox --headless crates/pocopine --test route_guards_loaders`
- `wasm-pack test --firefox --headless crates/pocopine --test app_plugins`