### PR TITLE
Update chart composition docs

### DIFF
--- a/docs/charts/axes-grid.md
+++ b/docs/charts/axes-grid.md
@@ -68,6 +68,7 @@ Example:
 Preset charts (`pine-line-chart`, `pine-scatter-chart`, `pine-area-chart`, and
 `pine-bar-chart`) still own their generated axes and grid. That keeps the common
 case compact: set `x_label` / `y_label`, bind data, and style the emitted hooks.
+(`pine-pie-chart` is radial and has no axes or grid.)
 
 `pine-cartesian-chart` exposes guide ownership as child components:
 

--- a/docs/charts/axes-grid.md
+++ b/docs/charts/axes-grid.md
@@ -65,8 +65,22 @@ Example:
 
 ## Composition Boundary
 
-Axes and grid are currently part of each chart component instead of separate
-child components. That is deliberate for the first SVG pass: HTML custom elements
-inside SVG have namespace and slotting edge cases, so the first stable component
-keeps the SVG tree self-contained. Once that path is proven in examples, the
-same generated guide data can be exposed to composable axis and grid components.
+Preset charts (`pine-line-chart`, `pine-scatter-chart`, `pine-area-chart`, and
+`pine-bar-chart`) still own their generated axes and grid. That keeps the common
+case compact: set `x_label` / `y_label`, bind data, and style the emitted hooks.
+
+`pine-cartesian-chart` exposes guide ownership as child components:
+
+```html
+<pine-cartesian-chart label="Revenue">
+  <pine-chart-grid></pine-chart-grid>
+  <pine-x-axis label="Week"></pine-x-axis>
+  <pine-y-axis label="Revenue"></pine-y-axis>
+  <!-- series and reference children -->
+</pine-cartesian-chart>
+```
+
+Those child tags are definitions, not nested SVG nodes. They register intent with
+the nearest Cartesian root, and the root still renders one valid SVG tree. This
+preserves namespace correctness, shared scales, responsive sizing, and paint
+order while letting applications opt into or omit guides explicitly.

--- a/docs/charts/examples.md
+++ b/docs/charts/examples.md
@@ -13,8 +13,10 @@ all visual styling in `index.html` CSS so the chart crate can stay unstyled.
 The example intentionally uses the same public API an application would use:
 
 - `pine_charts::register_all()` at startup,
-- `<pine-cartesian-chart>` with `pine-chart-grid`, `pine-x-axis`,
-  `pine-y-axis`, mixed bar/line/scatter series, and Cartesian reference marks,
+- `<pine-cartesian-chart>` with `pine-chart-grid`, `pine-x-axis`, and
+  `pine-y-axis` guide children,
+- `<pine-cartesian-chart>` mixing bar, line, and scatter series with Cartesian
+  reference lines, dots, and labels,
 - `<pine-layer-chart>` with child layers, reference dots, labels, and icons for
   custom SVG compositions,
 - `Vec<ChartLineSeries>`, `Vec<ChartScatterSeries>`,

--- a/docs/charts/examples.md
+++ b/docs/charts/examples.md
@@ -13,23 +13,32 @@ all visual styling in `index.html` CSS so the chart crate can stay unstyled.
 The example intentionally uses the same public API an application would use:
 
 - `pine_charts::register_all()` at startup,
+- `<pine-cartesian-chart>` with `pine-chart-grid`, `pine-x-axis`,
+  `pine-y-axis`, mixed bar/line/scatter series, and Cartesian reference marks,
+- `<pine-layer-chart>` with child layers, reference dots, labels, and icons for
+  custom SVG compositions,
 - `Vec<ChartLineSeries>`, `Vec<ChartScatterSeries>`,
   `Vec<ChartAreaSeries>`, and `Vec<ChartBarSeries>` data in the parent
   component,
+- `Vec<ChartPieSlice>` plus bound `inner_radius`, `start_angle`, and
+  `end_angle` props for pie, donut, and half-donut variants,
 - `line_legend_items(&line_series)` to drive a separate line legend,
 - `scatter_legend_items(&scatter_series)` to drive a separate scatter legend,
 - `area_legend_items(&area_series)` to drive a separate area legend,
 - `bar_legend_items(&bar_series)` to drive a separate legend,
+- `pie_legend_items(&pie_data)` to drive radial legends,
 - `<pine-line-chart pp-bind:series="line_series">` in the template,
 - `<pine-scatter-chart pp-bind:series="scatter_series">` in the template,
 - `<pine-area-chart pp-bind:series="area_series">` in the template,
 - `<pine-bar-chart pp-bind:series="bar_series" pp-bind:mode="bar_mode">` in
   the template,
+- `<pine-pie-chart pp-bind:data="pie_data">` in the template,
 - `x_label` and `y_label` attributes for chart axis labels,
 - `<pine-chart-legend pp-bind:items="line_legend">`,
   `<pine-chart-legend pp-bind:items="scatter_legend">`,
-  `<pine-chart-legend pp-bind:items="area_legend">`, and
-  `<pine-chart-legend pp-bind:items="bar_legend">` in the template,
+  `<pine-chart-legend pp-bind:items="area_legend">`,
+  `<pine-chart-legend pp-bind:items="bar_legend">`, and
+  `<pine-chart-legend pp-bind:items="pie_legend">` in the template,
 - CSS selectors from the chart styling contract.
 
 This example should be extended whenever a new chart primitive becomes public.


### PR DESCRIPTION
## Summary
- update axes/grid docs now that composable Cartesian guide children exist
- document the charts example's current combo, layered, and pie/donut public API usage

## Validation
- docs-only change; reviewed stale chart docs references with rg