### PR TITLE
Add controlled chart visibility states

### DIFF
--- a/crates/pine-charts/src/area/PineAreaChart.poco
+++ b/crates/pine-charts/src/area/PineAreaChart.poco
@@ -174,4 +174,8 @@
   <span pp-show="invalid"
         class="pine-chart-status"
         pp-text="error"></span>
+  <span pp-show="empty"
+        class="pine-chart-status pine-chart-status-empty"
+        role="status"
+        pp-text="empty_message"></span>
 </root>

--- a/crates/pine-charts/src/area/PineAreaChart.poco
+++ b/crates/pine-charts/src/area/PineAreaChart.poco
@@ -153,8 +153,8 @@
               :data-series="hover_series"></circle>
     </g>
   </svg>
-  <div pp-show="hover_visible"
-       class="pine-chart-tooltip"
+  <div class="pine-chart-tooltip"
+       :aria-hidden="hover_visible ? 'false' : 'true'"
        role="status"
        :aria-label="hover_aria_label"
        :style="hover_style"

--- a/crates/pine-charts/src/area/mod.rs
+++ b/crates/pine-charts/src/area/mod.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::cartesian::{
     centered_plot_y, optional_domain, plot_rect_from_edges, pointer_event_svg_point,
     CartesianChartState, CartesianGuideFields, CartesianGuideUpdate, CartesianHoverFields,
-    ChartStateFields, PlotEdgeFields,
+    ChartStateFields, PlotEdgeFields, DEFAULT_EMPTY_MESSAGE,
 };
 use crate::error::{ChartError, ChartResult};
 use crate::geometry::{ChartMargins, ChartRect, Point};
@@ -155,6 +155,8 @@ pub struct PineAreaChart {
     #[prop]
     pub label: String,
     #[prop]
+    pub empty_message: String,
+    #[prop]
     pub x_label: String,
     #[prop]
     pub y_label: String,
@@ -221,6 +223,7 @@ impl Default for PineAreaChart {
             points: Vec::new(),
             series: Vec::new(),
             label: "Area chart".into(),
+            empty_message: DEFAULT_EMPTY_MESSAGE.into(),
             x_label: String::new(),
             y_label: String::new(),
             width: options.width,

--- a/crates/pine-charts/src/area/mod.rs
+++ b/crates/pine-charts/src/area/mod.rs
@@ -8,7 +8,7 @@ use crate::cartesian::{
 };
 use crate::error::{ChartError, ChartResult};
 use crate::geometry::{ChartMargins, ChartRect, Point};
-use crate::legend::{series_label_or_default, series_legend_items};
+use crate::legend::{series_label_or_default, series_legend_items_with_visibility};
 use crate::line::{
     nearest_line_sample_at, ChartLineSeries, ChartPoint, LineChartGeometry, LineChartOptions,
     LineChartSample,
@@ -17,10 +17,22 @@ use crate::path::area_path;
 use crate::svg::{SvgAxisLabel, SvgLine, SvgTickLabel};
 use crate::LegendItem;
 
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ChartAreaSeries {
     pub label: String,
     pub data: Vec<ChartPoint>,
+    #[serde(default = "crate::legend::default_visible")]
+    pub visible: bool,
+}
+
+impl Default for ChartAreaSeries {
+    fn default() -> Self {
+        Self {
+            label: String::new(),
+            data: Vec::new(),
+            visible: true,
+        }
+    }
 }
 
 impl ChartAreaSeries {
@@ -28,6 +40,7 @@ impl ChartAreaSeries {
         Self {
             label: label.into(),
             data,
+            visible: true,
         }
     }
 }
@@ -61,7 +74,11 @@ impl AreaChartGeometry {
     ) -> ChartResult<Self> {
         let line_series = series
             .iter()
-            .map(|series| ChartLineSeries::new(series.label.clone(), series.data.clone()))
+            .map(|series| {
+                let mut line = ChartLineSeries::new(series.label.clone(), series.data.clone());
+                line.visible = series.visible;
+                line
+            })
             .collect::<Vec<_>>();
         Self::from_line_geometry(LineChartGeometry::from_series(&line_series, options)?)
     }
@@ -117,12 +134,14 @@ pub struct AreaChartSeriesRender {
 }
 
 pub fn area_legend_items(series: &[ChartAreaSeries]) -> Vec<LegendItem> {
-    series_legend_items(
+    series_legend_items_with_visibility(
         "area-series",
-        series
-            .iter()
-            .enumerate()
-            .map(|(index, series)| series_label_or_default(&series.label, index)),
+        series.iter().enumerate().map(|(index, series)| {
+            (
+                series_label_or_default(&series.label, index),
+                series.visible,
+            )
+        }),
     )
 }
 

--- a/crates/pine-charts/src/bar/PineBarChart.poco
+++ b/crates/pine-charts/src/bar/PineBarChart.poco
@@ -133,4 +133,8 @@
   <span pp-show="invalid"
         class="pine-chart-status"
         pp-text="error"></span>
+  <span pp-show="empty"
+        class="pine-chart-status pine-chart-status-empty"
+        role="status"
+        pp-text="empty_message"></span>
 </root>

--- a/crates/pine-charts/src/bar/PineBarChart.poco
+++ b/crates/pine-charts/src/bar/PineBarChart.poco
@@ -112,8 +112,8 @@
       </template>
     </g>
   </svg>
-  <div pp-show="hover_visible"
-       class="pine-chart-tooltip pine-chart-bar-tooltip"
+  <div class="pine-chart-tooltip pine-chart-bar-tooltip"
+       :aria-hidden="hover_visible ? 'false' : 'true'"
        role="status"
        :aria-label="hover_aria_label"
        :style="hover_style"

--- a/crates/pine-charts/src/bar/mod.rs
+++ b/crates/pine-charts/src/bar/mod.rs
@@ -5,7 +5,7 @@ use crate::cartesian::{
     expanded_domain, grid_lines_for_y, optional_domain, plot_rect_from_edges,
     pointer_event_svg_point, step_key, tick_labels_for_y, x_axis_label, y_axis_label,
     CartesianChartState, CartesianHoverPlacement, CategoricalGuideFields, CategoricalGuideUpdate,
-    ChartStateFields, PlotEdgeFields,
+    ChartStateFields, PlotEdgeFields, DEFAULT_EMPTY_MESSAGE,
 };
 use crate::error::{finite, ChartError, ChartResult};
 use crate::events::{ChartSelection, CHART_SELECT_EVENT};
@@ -553,6 +553,8 @@ pub struct PineBarChart {
     #[prop]
     pub label: String,
     #[prop]
+    pub empty_message: String,
+    #[prop]
     pub x_label: String,
     #[prop]
     pub y_label: String,
@@ -619,6 +621,7 @@ impl Default for PineBarChart {
             series: Vec::new(),
             mode: "grouped".into(),
             label: "Bar chart".into(),
+            empty_message: DEFAULT_EMPTY_MESSAGE.into(),
             x_label: String::new(),
             y_label: String::new(),
             width: options.width,

--- a/crates/pine-charts/src/bar/mod.rs
+++ b/crates/pine-charts/src/bar/mod.rs
@@ -10,7 +10,7 @@ use crate::cartesian::{
 use crate::error::{finite, ChartError, ChartResult};
 use crate::events::{ChartSelection, CHART_SELECT_EVENT};
 use crate::geometry::{ChartMargins, ChartRect, Point};
-use crate::legend::{series_label_or_default, series_legend_items, LegendItem};
+use crate::legend::{series_label_or_default, series_legend_items_with_visibility, LegendItem};
 use crate::scale::{BandScale, LinearScale};
 use crate::svg::{format_tick, SvgAxisLabel, SvgLine, SvgTickLabel};
 
@@ -29,10 +29,22 @@ impl ChartBar {
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ChartBarSeries {
     pub label: String,
     pub data: Vec<ChartBar>,
+    #[serde(default = "crate::legend::default_visible")]
+    pub visible: bool,
+}
+
+impl Default for ChartBarSeries {
+    fn default() -> Self {
+        Self {
+            label: String::new(),
+            data: Vec::new(),
+            visible: true,
+        }
+    }
 }
 
 impl ChartBarSeries {
@@ -40,6 +52,7 @@ impl ChartBarSeries {
         Self {
             label: label.into(),
             data,
+            visible: true,
         }
     }
 }
@@ -163,19 +176,23 @@ impl BarChartGeometry {
                 baseline_y,
             ),
             y_axis: SvgLine::new("y-axis".into(), plot.x, plot.y, plot.x, plot.bottom()),
-            legend_items: data.legend_items(),
+            legend_items: if series.len() > 1 {
+                bar_legend_items(series)
+            } else {
+                Vec::new()
+            },
             y_ticks,
         })
     }
 }
 
 pub fn bar_legend_items(series: &[ChartBarSeries]) -> Vec<LegendItem> {
-    series_legend_items(
+    series_legend_items_with_visibility(
         "bar-series",
         series
             .iter()
             .enumerate()
-            .map(|(index, series)| series_label(series, index)),
+            .map(|(index, series)| (series_label(series, index), series.visible)),
     )
 }
 
@@ -259,13 +276,24 @@ struct NormalizedBarData {
 
 impl NormalizedBarData {
     fn from_series(series: &[ChartBarSeries]) -> ChartResult<Self> {
-        if series.is_empty() || series.iter().all(|series| series.data.is_empty()) {
+        let visible_series = series
+            .iter()
+            .enumerate()
+            .filter(|(_, series)| series.visible)
+            .collect::<Vec<_>>();
+
+        if visible_series.is_empty()
+            || visible_series
+                .iter()
+                .all(|(_, series)| series.data.is_empty())
+        {
             return Err(ChartError::EmptySeries);
         }
 
-        let first = series
+        let first = visible_series
             .iter()
-            .find(|series| !series.data.is_empty())
+            .find(|(_, series)| !series.data.is_empty())
+            .map(|(_, series)| *series)
             .ok_or(ChartError::EmptySeries)?;
         let categories = first
             .data
@@ -273,8 +301,8 @@ impl NormalizedBarData {
             .map(|bar| bar.label.clone())
             .collect::<Vec<_>>();
 
-        let mut normalized = Vec::with_capacity(series.len());
-        for (series_index, series) in series.iter().enumerate() {
+        let mut normalized = Vec::with_capacity(visible_series.len());
+        for (series_index, series) in visible_series {
             if series.data.len() != categories.len() {
                 let expected = categories
                     .get(series.data.len())
@@ -318,17 +346,6 @@ impl NormalizedBarData {
 
     fn values(&self) -> impl Iterator<Item = &f64> {
         self.series.iter().flat_map(|series| series.values.iter())
-    }
-
-    fn legend_items(&self) -> Vec<LegendItem> {
-        if self.series.len() <= 1 {
-            return Vec::new();
-        }
-
-        series_legend_items(
-            "bar-series",
-            self.series.iter().map(|series| series.label.clone()),
-        )
     }
 }
 
@@ -1060,6 +1077,38 @@ mod tests {
         assert_eq!(geometry.legend_items.len(), 2);
         assert_eq!(geometry.legend_items[0].label, "New");
         assert_eq!(geometry.legend_items[1].series, "Returning");
+    }
+
+    #[test]
+    fn grouped_bar_geometry_skips_hidden_series() {
+        let options = BarChartOptions {
+            width: 100.0,
+            height: 100.0,
+            margins: ChartMargins::ZERO,
+            y_domain: Some((0.0, 10.0)),
+            mode: BarChartMode::Grouped,
+            padding_inner: 0.0,
+            padding_outer: 0.0,
+            series_padding_inner: 0.0,
+        };
+        let mut series = vec![
+            ChartBarSeries::new(
+                "New",
+                vec![ChartBar::new("A", 2.0), ChartBar::new("B", 4.0)],
+            ),
+            ChartBarSeries::new(
+                "Hidden",
+                vec![ChartBar::new("A", 3.0), ChartBar::new("B", 10.0)],
+            ),
+        ];
+        series[1].visible = false;
+
+        let geometry = BarChartGeometry::from_series(&series, &options).unwrap();
+
+        assert_eq!(geometry.bars.len(), 2);
+        assert!(geometry.bars.iter().all(|bar| bar.series_label == "New"));
+        assert!(geometry.legend_items[0].active);
+        assert!(!geometry.legend_items[1].active);
     }
 
     #[test]

--- a/crates/pine-charts/src/cartesian.rs
+++ b/crates/pine-charts/src/cartesian.rs
@@ -5,6 +5,8 @@ use crate::geometry::{ChartMargins, ChartRect, Point};
 use crate::scale::LinearScale;
 use crate::svg::{format_tick, SvgAxisLabel, SvgLine, SvgTickLabel};
 
+pub(crate) const DEFAULT_EMPTY_MESSAGE: &str = "No visible data";
+
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct CartesianLayout {
     pub view_box: String,

--- a/crates/pine-charts/src/cartesian_chart/PineCartesianChart.poco
+++ b/crates/pine-charts/src/cartesian_chart/PineCartesianChart.poco
@@ -268,4 +268,8 @@
   <span pp-show="invalid"
         class="pine-chart-status"
         pp-text="error"></span>
+  <span pp-show="empty"
+        class="pine-chart-status pine-chart-status-empty"
+        role="status"
+        pp-text="empty_message"></span>
 </root>

--- a/crates/pine-charts/src/cartesian_chart/mod.rs
+++ b/crates/pine-charts/src/cartesian_chart/mod.rs
@@ -64,6 +64,8 @@ pub struct CartesianLineSeriesConfig {
     pub marker_radius: f64,
     pub points: Vec<ChartPoint>,
     pub data: Vec<ChartBar>,
+    #[serde(default = "crate::legend::default_visible")]
+    pub visible: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -72,6 +74,8 @@ pub struct CartesianBarSeriesConfig {
     pub label: String,
     pub color: String,
     pub data: Vec<ChartBar>,
+    #[serde(default = "crate::legend::default_visible")]
+    pub visible: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -82,6 +86,8 @@ pub struct CartesianAreaSeriesConfig {
     pub color: String,
     pub stroke_width: f64,
     pub points: Vec<ChartPoint>,
+    #[serde(default = "crate::legend::default_visible")]
+    pub visible: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -91,6 +97,8 @@ pub struct CartesianScatterSeriesConfig {
     pub color: String,
     pub point_radius: f64,
     pub points: Vec<ChartPoint>,
+    #[serde(default = "crate::legend::default_visible")]
+    pub visible: bool,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
@@ -972,6 +980,8 @@ pub struct PineLineSeries {
     pub points: Vec<ChartPoint>,
     #[prop]
     pub data: Vec<ChartBar>,
+    #[prop]
+    pub visible: bool,
     pub component_key: String,
 }
 
@@ -986,6 +996,7 @@ impl Default for PineLineSeries {
             marker_radius: DEFAULT_MARKER_RADIUS,
             points: Vec::new(),
             data: Vec::new(),
+            visible: true,
             component_key: String::new(),
         }
     }
@@ -1036,6 +1047,11 @@ impl PineLineSeries {
     fn on_data(&mut self, _: Vec<ChartBar>, _: Option<Vec<ChartBar>>) {
         self.sync();
     }
+
+    #[watch(visible)]
+    fn on_visible(&mut self, _: bool, _: Option<bool>) {
+        self.sync();
+    }
 }
 
 impl PineLineSeries {
@@ -1050,6 +1066,7 @@ impl PineLineSeries {
                 marker_radius: self.marker_radius,
                 points: self.points.clone(),
                 data: self.data.clone(),
+                visible: self.visible,
             });
         });
     }
@@ -1066,6 +1083,8 @@ pub struct PineBarSeries {
     pub color: String,
     #[prop]
     pub data: Vec<ChartBar>,
+    #[prop]
+    pub visible: bool,
     pub component_key: String,
 }
 
@@ -1076,6 +1095,7 @@ impl Default for PineBarSeries {
             label: String::new(),
             color: "currentColor".into(),
             data: Vec::new(),
+            visible: true,
             component_key: String::new(),
         }
     }
@@ -1106,6 +1126,11 @@ impl PineBarSeries {
     fn on_data(&mut self, _: Vec<ChartBar>, _: Option<Vec<ChartBar>>) {
         self.sync();
     }
+
+    #[watch(visible)]
+    fn on_visible(&mut self, _: bool, _: Option<bool>) {
+        self.sync();
+    }
 }
 
 impl PineBarSeries {
@@ -1116,6 +1141,7 @@ impl PineBarSeries {
                 label: self.label.clone(),
                 color: color_or_current(&self.color),
                 data: self.data.clone(),
+                visible: self.visible,
             });
         });
     }
@@ -1136,6 +1162,8 @@ pub struct PineAreaSeries {
     pub stroke_width: f64,
     #[prop]
     pub points: Vec<ChartPoint>,
+    #[prop]
+    pub visible: bool,
     pub component_key: String,
 }
 
@@ -1148,6 +1176,7 @@ impl Default for PineAreaSeries {
             color: "currentColor".into(),
             stroke_width: DEFAULT_STROKE_WIDTH,
             points: Vec::new(),
+            visible: true,
             component_key: String::new(),
         }
     }
@@ -1188,6 +1217,11 @@ impl PineAreaSeries {
     fn on_points(&mut self, _: Vec<ChartPoint>, _: Option<Vec<ChartPoint>>) {
         self.sync();
     }
+
+    #[watch(visible)]
+    fn on_visible(&mut self, _: bool, _: Option<bool>) {
+        self.sync();
+    }
 }
 
 impl PineAreaSeries {
@@ -1200,6 +1234,7 @@ impl PineAreaSeries {
                 color: color_or_current(&self.color),
                 stroke_width: self.stroke_width,
                 points: self.points.clone(),
+                visible: self.visible,
             });
         });
     }
@@ -1218,6 +1253,8 @@ pub struct PineScatterSeries {
     pub point_radius: f64,
     #[prop]
     pub points: Vec<ChartPoint>,
+    #[prop]
+    pub visible: bool,
     pub component_key: String,
 }
 
@@ -1229,6 +1266,7 @@ impl Default for PineScatterSeries {
             color: "currentColor".into(),
             point_radius: DEFAULT_MARKER_RADIUS,
             points: Vec::new(),
+            visible: true,
             component_key: String::new(),
         }
     }
@@ -1264,6 +1302,11 @@ impl PineScatterSeries {
     fn on_points(&mut self, _: Vec<ChartPoint>, _: Option<Vec<ChartPoint>>) {
         self.sync();
     }
+
+    #[watch(visible)]
+    fn on_visible(&mut self, _: bool, _: Option<bool>) {
+        self.sync();
+    }
 }
 
 impl PineScatterSeries {
@@ -1275,6 +1318,7 @@ impl PineScatterSeries {
                 color: color_or_current(&self.color),
                 point_radius: self.point_radius,
                 points: self.points.clone(),
+                visible: self.visible,
             });
         });
     }
@@ -1633,17 +1677,17 @@ pub fn render_cartesian_chart(
     let renderable_lines: Vec<&CartesianLineSeriesConfig> = inputs
         .line_series
         .iter()
-        .filter(|series| !series.points.is_empty())
+        .filter(|series| series.visible && !series.points.is_empty())
         .collect();
     let renderable_areas: Vec<&CartesianAreaSeriesConfig> = inputs
         .area_series
         .iter()
-        .filter(|series| !series.points.is_empty())
+        .filter(|series| series.visible && !series.points.is_empty())
         .collect();
     let renderable_scatters: Vec<&CartesianScatterSeriesConfig> = inputs
         .scatter_series
         .iter()
-        .filter(|series| !series.points.is_empty())
+        .filter(|series| series.visible && !series.points.is_empty())
         .collect();
     let numeric_series = renderable_lines
         .iter()
@@ -1947,20 +1991,28 @@ fn has_renderable_series(
 ) -> bool {
     line_series
         .iter()
-        .any(|series| !series.points.is_empty() || !series.data.is_empty())
-        || bar_series.iter().any(|series| !series.data.is_empty())
-        || area_series.iter().any(|series| !series.points.is_empty())
+        .any(|series| series.visible && (!series.points.is_empty() || !series.data.is_empty()))
+        || bar_series
+            .iter()
+            .any(|series| series.visible && !series.data.is_empty())
+        || area_series
+            .iter()
+            .any(|series| series.visible && !series.points.is_empty())
         || scatter_series
             .iter()
-            .any(|series| !series.points.is_empty())
+            .any(|series| series.visible && !series.points.is_empty())
 }
 
 fn uses_categorical_x(
     line_series: &[CartesianLineSeriesConfig],
     bar_series: &[CartesianBarSeriesConfig],
 ) -> bool {
-    bar_series.iter().any(|series| !series.data.is_empty())
-        || line_series.iter().any(|series| !series.data.is_empty())
+    bar_series
+        .iter()
+        .any(|series| series.visible && !series.data.is_empty())
+        || line_series
+            .iter()
+            .any(|series| series.visible && !series.data.is_empty())
 }
 
 fn categorical_categories(
@@ -1969,7 +2021,7 @@ fn categorical_categories(
 ) -> ChartResult<Vec<String>> {
     let categories = bar_series
         .iter()
-        .find(|series| !series.data.is_empty())
+        .find(|series| series.visible && !series.data.is_empty())
         .map(|series| {
             series
                 .data
@@ -1980,7 +2032,7 @@ fn categorical_categories(
         .or_else(|| {
             line_series
                 .iter()
-                .find(|series| !series.data.is_empty())
+                .find(|series| series.visible && !series.data.is_empty())
                 .map(|series| {
                     series
                         .data
@@ -1991,14 +2043,20 @@ fn categorical_categories(
         })
         .ok_or(ChartError::EmptySeries)?;
 
-    for series in bar_series.iter().filter(|series| !series.data.is_empty()) {
+    for series in bar_series
+        .iter()
+        .filter(|series| series.visible && !series.data.is_empty())
+    {
         validate_categories(
             &series_label_or_default(&series.label, 0),
             &categories,
             &series.data,
         )?;
     }
-    for series in line_series.iter().filter(|series| !series.data.is_empty()) {
+    for series in line_series
+        .iter()
+        .filter(|series| series.visible && !series.data.is_empty())
+    {
         validate_categories(
             &series_label_or_default(&series.label, 0),
             &categories,
@@ -2043,28 +2101,35 @@ fn categorical_y_domain(
     area_series: &[CartesianAreaSeriesConfig],
     scatter_series: &[CartesianScatterSeriesConfig],
 ) -> ChartResult<(f64, f64)> {
-    let include_zero = bar_series.iter().any(|series| !series.data.is_empty());
+    let include_zero = bar_series
+        .iter()
+        .any(|series| series.visible && !series.data.is_empty());
     let values = bar_series
         .iter()
+        .filter(|series| series.visible)
         .flat_map(|series| series.data.iter().map(|bar| bar.value))
         .chain(
             line_series
                 .iter()
+                .filter(|series| series.visible)
                 .flat_map(|series| series.data.iter().map(|bar| bar.value)),
         )
         .chain(
             line_series
                 .iter()
+                .filter(|series| series.visible)
                 .flat_map(|series| series.points.iter().map(|point| point.y)),
         )
         .chain(
             area_series
                 .iter()
+                .filter(|series| series.visible)
                 .flat_map(|series| series.points.iter().map(|point| point.y)),
         )
         .chain(
             scatter_series
                 .iter()
+                .filter(|series| series.visible)
                 .flat_map(|series| series.points.iter().map(|point| point.y)),
         );
 
@@ -2081,7 +2146,7 @@ fn render_categorical_bars(
 ) -> ChartResult<Vec<CartesianBarRender>> {
     let renderable = bar_series
         .iter()
-        .filter(|series| !series.data.is_empty())
+        .filter(|series| series.visible && !series.data.is_empty())
         .collect::<Vec<_>>();
     let mut bars = Vec::with_capacity(categories.len() * renderable.len());
 
@@ -2131,7 +2196,7 @@ fn render_categorical_lines(
 
     for (series_index, config) in line_series
         .iter()
-        .filter(|series| !series.data.is_empty() || !series.points.is_empty())
+        .filter(|series| series.visible && (!series.data.is_empty() || !series.points.is_empty()))
         .enumerate()
     {
         let series_label = series_label_or_default(&config.label, series_index);
@@ -2172,7 +2237,7 @@ fn render_categorical_areas(
 ) -> ChartResult<Vec<CartesianAreaSeriesRender>> {
     area_series
         .iter()
-        .filter(|series| !series.points.is_empty())
+        .filter(|series| series.visible && !series.points.is_empty())
         .enumerate()
         .map(|(series_index, config)| {
             let series_label = series_label_or_default(&config.label, series_index);
@@ -2213,7 +2278,7 @@ fn render_categorical_scatter_points(
     let mut points = Vec::new();
     for (series_index, config) in scatter_series
         .iter()
-        .filter(|series| !series.points.is_empty())
+        .filter(|series| series.visible && !series.points.is_empty())
         .enumerate()
     {
         let series_label = series_label_or_default(&config.label, series_index);
@@ -2594,6 +2659,7 @@ mod tests {
                 ChartPoint::new(10.0, 15.0),
             ],
             data: Vec::new(),
+            visible: true,
         }];
 
         let grid = CartesianGridConfig::default();
@@ -2642,6 +2708,7 @@ mod tests {
             label: "Actual".into(),
             color: "#16a085".into(),
             data: vec![ChartBar::new("W1", 10.0), ChartBar::new("W2", 20.0)],
+            visible: true,
         }];
         let lines = vec![CartesianLineSeriesConfig {
             key: "target".into(),
@@ -2652,6 +2719,7 @@ mod tests {
             marker_radius: 4.0,
             points: Vec::new(),
             data: vec![ChartBar::new("W1", 12.0), ChartBar::new("W2", 18.0)],
+            visible: true,
         }];
 
         let render = render_cartesian_chart(
@@ -2700,6 +2768,7 @@ mod tests {
             color: "#1d6fd8".into(),
             stroke_width: 2.0,
             points: vec![ChartPoint::new(0.0, 0.0), ChartPoint::new(10.0, 10.0)],
+            visible: true,
         }];
         let scatters = vec![CartesianScatterSeriesConfig {
             key: "samples".into(),
@@ -2707,6 +2776,7 @@ mod tests {
             color: "#d96c2c".into(),
             point_radius: 6.0,
             points: vec![ChartPoint::new(5.0, 5.0)],
+            visible: true,
         }];
 
         let render = render_cartesian_chart(
@@ -2753,6 +2823,7 @@ mod tests {
             marker_radius: 3.0,
             points: vec![ChartPoint::new(0.0, 0.0), ChartPoint::new(10.0, 10.0)],
             data: Vec::new(),
+            visible: true,
         }];
         let reference_lines = vec![CartesianReferenceLineConfig {
             key: "goal".into(),
@@ -2836,6 +2907,7 @@ mod tests {
             marker_radius: 3.0,
             points: vec![ChartPoint::new(0.0, 0.0), ChartPoint::new(10.0, 10.0)],
             data: Vec::new(),
+            visible: true,
         }];
         let reference_lines = vec![CartesianReferenceLineConfig {
             key: "bad".into(),
@@ -2890,6 +2962,7 @@ mod tests {
             marker_radius: 3.0,
             points: vec![ChartPoint::new(0.0, 0.0), ChartPoint::new(10.0, 10.0)],
             data: Vec::new(),
+            visible: true,
         }];
         let reference_dots = vec![CartesianReferenceDotConfig {
             key: "dot".into(),

--- a/crates/pine-charts/src/cartesian_chart/mod.rs
+++ b/crates/pine-charts/src/cartesian_chart/mod.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::bar::{bar_aria_label, baseline_value, category_tick_labels, ChartBar};
 use crate::cartesian::{
     expanded_domain, grid_lines_for_y, optional_domain, tick_labels_for_y, x_axis_label,
-    y_axis_label,
+    y_axis_label, DEFAULT_EMPTY_MESSAGE,
 };
 use crate::error::{finite, ChartError, ChartResult};
 use crate::geometry::{ChartMargins, ChartRect};
@@ -301,6 +301,8 @@ pub struct PineCartesianChart {
     #[prop]
     pub label: String,
     #[prop]
+    pub empty_message: String,
+    #[prop]
     pub width: f64,
     #[prop]
     pub height: f64,
@@ -383,6 +385,7 @@ impl Default for PineCartesianChart {
         let margins = ChartMargins::default();
         Self {
             label: "Cartesian chart".into(),
+            empty_message: DEFAULT_EMPTY_MESSAGE.into(),
             width: DEFAULT_WIDTH,
             height: DEFAULT_HEIGHT,
             margin_top: margins.top,

--- a/crates/pine-charts/src/events.rs
+++ b/crates/pine-charts/src/events.rs
@@ -87,3 +87,17 @@ pub struct LegendToggle {
     pub series: String,
     pub active: bool,
 }
+
+impl LegendToggle {
+    #[cfg(target_arch = "wasm32")]
+    pub fn from_event_value(event: wasm_bindgen::JsValue) -> Option<Self> {
+        let detail =
+            js_sys::Reflect::get(&event, &wasm_bindgen::JsValue::from_str("detail")).ok()?;
+        pocopine::__private::serde_wasm_bindgen::from_value(detail).ok()
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn from_event_value(_: wasm_bindgen::JsValue) -> Option<Self> {
+        None
+    }
+}

--- a/crates/pine-charts/src/layered/PineLayerChart.poco
+++ b/crates/pine-charts/src/layered/PineLayerChart.poco
@@ -124,4 +124,8 @@
   <span pp-show="invalid"
         class="pine-chart-status"
         pp-text="error"></span>
+  <span pp-show="empty"
+        class="pine-chart-status pine-chart-status-empty"
+        role="status"
+        pp-text="empty_message"></span>
 </root>

--- a/crates/pine-charts/src/layered/mod.rs
+++ b/crates/pine-charts/src/layered/mod.rs
@@ -11,6 +11,7 @@ use crate::path::line_path;
 
 const DEFAULT_WIDTH: f64 = 900.0;
 const DEFAULT_HEIGHT: f64 = 480.0;
+const DEFAULT_EMPTY_MESSAGE: &str = crate::cartesian::DEFAULT_EMPTY_MESSAGE;
 const DEFAULT_LINE_WIDTH: f64 = 3.0;
 const DEFAULT_MARKER_RADIUS: f64 = 4.0;
 const DEFAULT_REFERENCE_RADIUS: f64 = 12.0;
@@ -247,6 +248,8 @@ pub struct PineLayerChart {
     #[prop]
     pub label: String,
     #[prop]
+    pub empty_message: String,
+    #[prop]
     pub width: f64,
     #[prop]
     pub height: f64,
@@ -275,6 +278,7 @@ impl Default for PineLayerChart {
     fn default() -> Self {
         Self {
             label: "Layer chart".into(),
+            empty_message: DEFAULT_EMPTY_MESSAGE.into(),
             width: DEFAULT_WIDTH,
             height: DEFAULT_HEIGHT,
             state: "empty".into(),

--- a/crates/pine-charts/src/legend/mod.rs
+++ b/crates/pine-charts/src/legend/mod.rs
@@ -37,13 +37,26 @@ impl LegendItem {
         label: impl Into<String>,
         series: impl Into<String>,
     ) -> Self {
+        Self::with_series_active(key, label, series, true)
+    }
+
+    pub fn with_series_active(
+        key: impl Into<String>,
+        label: impl Into<String>,
+        series: impl Into<String>,
+        active: bool,
+    ) -> Self {
         Self {
             key: key.into(),
             label: label.into(),
             series: series.into(),
-            active: true,
+            active,
         }
     }
+}
+
+pub(crate) const fn default_visible() -> bool {
+    true
 }
 
 pub(crate) fn series_label_or_default(label: &str, index: usize) -> String {
@@ -54,18 +67,19 @@ pub(crate) fn series_label_or_default(label: &str, index: usize) -> String {
     }
 }
 
-pub(crate) fn series_legend_items(
+pub(crate) fn series_legend_items_with_visibility(
     key_prefix: &str,
-    labels: impl IntoIterator<Item = String>,
+    labels: impl IntoIterator<Item = (String, bool)>,
 ) -> Vec<LegendItem> {
     labels
         .into_iter()
         .enumerate()
-        .map(|(index, label)| {
-            LegendItem::with_series(
+        .map(|(index, (label, active))| {
+            LegendItem::with_series_active(
                 format!("{key_prefix}-{index}-{label}"),
                 label.clone(),
                 label,
+                active,
             )
         })
         .collect()
@@ -153,9 +167,12 @@ mod tests {
 
     #[test]
     fn helper_builds_series_legend_items() {
-        let items = series_legend_items(
+        let items = series_legend_items_with_visibility(
             "line-series",
-            ["Actual".to_owned(), series_label_or_default("", 1)],
+            [
+                ("Actual".to_owned(), true),
+                (series_label_or_default("", 1), true),
+            ],
         );
 
         assert_eq!(items.len(), 2);
@@ -164,6 +181,19 @@ mod tests {
         assert_eq!(items[0].series, "Actual");
         assert_eq!(items[1].key, "line-series-1-Series 2");
         assert_eq!(items[1].label, "Series 2");
+        assert!(items[1].active);
+    }
+
+    #[test]
+    fn helper_preserves_series_visibility() {
+        let items = series_legend_items_with_visibility(
+            "line-series",
+            [("Actual".to_owned(), false), ("Target".to_owned(), true)],
+        );
+
+        assert_eq!(items[0].key, "line-series-0-Actual");
+        assert!(!items[0].active);
+        assert_eq!(items[1].key, "line-series-1-Target");
         assert!(items[1].active);
     }
 

--- a/crates/pine-charts/src/lib.rs
+++ b/crates/pine-charts/src/lib.rs
@@ -21,6 +21,7 @@ pub mod responsive;
 pub mod scale;
 pub mod scatter;
 pub mod svg;
+mod visibility;
 
 pub use area::{
     area_legend_items, AreaChartGeometry, AreaChartSeriesRender, ChartAreaSeries, PineAreaChart,
@@ -66,6 +67,12 @@ pub use scatter::{
     ScatterChartGeometry, ScatterChartOptions, ScatterChartSample, ScatterChartSeriesRender,
 };
 pub use svg::{SvgAxisLabel, SvgLine, SvgTickLabel};
+pub use visibility::{
+    set_area_series_visible, set_bar_series_visible, set_line_series_visible,
+    set_pie_slice_visible, set_scatter_series_visible, toggle_area_series_visibility,
+    toggle_bar_series_visibility, toggle_line_series_visibility, toggle_pie_slice_visibility,
+    toggle_scatter_series_visibility,
+};
 
 /// Register every Pine Charts custom-element tag.
 pub fn register_all() {

--- a/crates/pine-charts/src/line/PineLineChart.poco
+++ b/crates/pine-charts/src/line/PineLineChart.poco
@@ -176,4 +176,8 @@
   <span pp-show="invalid"
         class="pine-chart-status"
         pp-text="error"></span>
+  <span pp-show="empty"
+        class="pine-chart-status pine-chart-status-empty"
+        role="status"
+        pp-text="empty_message"></span>
 </root>

--- a/crates/pine-charts/src/line/PineLineChart.poco
+++ b/crates/pine-charts/src/line/PineLineChart.poco
@@ -155,8 +155,8 @@
               :data-series="hover_series"></circle>
     </g>
   </svg>
-  <div pp-show="hover_visible"
-       class="pine-chart-tooltip"
+  <div class="pine-chart-tooltip"
+       :aria-hidden="hover_visible ? 'false' : 'true'"
        role="status"
        :aria-label="hover_aria_label"
        :style="hover_style"

--- a/crates/pine-charts/src/line/mod.rs
+++ b/crates/pine-charts/src/line/mod.rs
@@ -10,7 +10,7 @@ use crate::cartesian::{
 use crate::error::{finite, ChartError, ChartResult};
 use crate::events::{ChartSelection, CHART_SELECT_EVENT};
 use crate::geometry::{ChartMargins, ChartRect, Point};
-use crate::legend::{series_label_or_default, series_legend_items};
+use crate::legend::{series_label_or_default, series_legend_items_with_visibility};
 use crate::path::line_path;
 use crate::scale::LinearScale;
 use crate::svg::{format_tick, SvgAxisLabel, SvgLine, SvgTickLabel};
@@ -34,10 +34,22 @@ impl ChartPoint {
     }
 }
 
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ChartLineSeries {
     pub label: String,
     pub data: Vec<ChartPoint>,
+    #[serde(default = "crate::legend::default_visible")]
+    pub visible: bool,
+}
+
+impl Default for ChartLineSeries {
+    fn default() -> Self {
+        Self {
+            label: String::new(),
+            data: Vec::new(),
+            visible: true,
+        }
+    }
 }
 
 impl ChartLineSeries {
@@ -45,6 +57,7 @@ impl ChartLineSeries {
         Self {
             label: label.into(),
             data,
+            visible: true,
         }
     }
 }
@@ -100,10 +113,6 @@ impl LineChartGeometry {
         series: &[ChartLineSeries],
         options: &LineChartOptions,
     ) -> ChartResult<Self> {
-        if series.is_empty() || series.iter().any(|series| series.data.is_empty()) {
-            return Err(ChartError::EmptySeries);
-        }
-
         let normalized = normalize_line_series(series)?;
         let layout = CartesianLayout::new(
             options.width,
@@ -252,12 +261,14 @@ impl LineChartSample {
 }
 
 pub fn line_legend_items(series: &[ChartLineSeries]) -> Vec<crate::LegendItem> {
-    series_legend_items(
+    series_legend_items_with_visibility(
         "line-series",
-        series
-            .iter()
-            .enumerate()
-            .map(|(index, series)| series_label_or_default(&series.label, index)),
+        series.iter().enumerate().map(|(index, series)| {
+            (
+                series_label_or_default(&series.label, index),
+                series.visible,
+            )
+        }),
     )
 }
 
@@ -286,9 +297,10 @@ struct NormalizedLineSeries {
 }
 
 fn normalize_line_series(series: &[ChartLineSeries]) -> ChartResult<Vec<NormalizedLineSeries>> {
-    series
+    let normalized = series
         .iter()
         .enumerate()
+        .filter(|(_, series)| series.visible)
         .map(|(index, series)| {
             if series.data.is_empty() {
                 return Err(ChartError::EmptySeries);
@@ -298,7 +310,13 @@ fn normalize_line_series(series: &[ChartLineSeries]) -> ChartResult<Vec<Normaliz
                 data: validate_points(&series.data)?,
             })
         })
-        .collect()
+        .collect::<ChartResult<Vec<_>>>()?;
+
+    if normalized.is_empty() {
+        Err(ChartError::EmptySeries)
+    } else {
+        Ok(normalized)
+    }
 }
 
 fn line_series_label(series: &ChartLineSeries, _index: usize) -> String {
@@ -802,6 +820,48 @@ mod tests {
         assert_eq!(legend[0].series, "Actual");
         assert_eq!(legend[1].label, "Target");
         assert_eq!(legend[1].series, "Target");
+    }
+
+    #[test]
+    fn line_geometry_skips_hidden_series_and_marks_legend_inactive() {
+        let options = LineChartOptions {
+            width: 100.0,
+            height: 100.0,
+            margins: ChartMargins::ZERO,
+            x_domain: Some((0.0, 1.0)),
+            y_domain: Some((0.0, 2.0)),
+        };
+        let mut series = vec![
+            ChartLineSeries::new(
+                "Actual",
+                vec![ChartPoint::new(0.0, 0.0), ChartPoint::new(1.0, 2.0)],
+            ),
+            ChartLineSeries::new("Hidden", Vec::new()),
+        ];
+        series[1].visible = false;
+
+        let geometry = LineChartGeometry::from_series(&series, &options).unwrap();
+
+        assert_eq!(geometry.series.len(), 1);
+        assert_eq!(geometry.series[0].label, "Actual");
+        let legend = line_legend_items(&series);
+        assert!(legend[0].active);
+        assert!(!legend[1].active);
+    }
+
+    #[test]
+    fn line_geometry_is_empty_when_all_series_are_hidden() {
+        let options = LineChartOptions::default();
+        let mut series = vec![ChartLineSeries::new(
+            "Hidden",
+            vec![ChartPoint::new(0.0, 0.0)],
+        )];
+        series[0].visible = false;
+
+        assert_eq!(
+            LineChartGeometry::from_series(&series, &options).unwrap_err(),
+            ChartError::EmptySeries
+        );
     }
 
     #[test]

--- a/crates/pine-charts/src/line/mod.rs
+++ b/crates/pine-charts/src/line/mod.rs
@@ -5,7 +5,7 @@ use crate::cartesian::{
     centered_plot_y, nearest_sample_by_point, nearest_sample_by_x, optional_domain,
     plot_rect_from_edges, pointer_event_svg_point, step_key, CartesianChartState,
     CartesianGuideFields, CartesianGuideUpdate, CartesianHoverFields, CartesianHoverSample,
-    CartesianHoverUpdate, CartesianLayout, ChartStateFields, PlotEdgeFields,
+    CartesianHoverUpdate, CartesianLayout, ChartStateFields, PlotEdgeFields, DEFAULT_EMPTY_MESSAGE,
 };
 use crate::error::{finite, ChartError, ChartResult};
 use crate::events::{ChartSelection, CHART_SELECT_EVENT};
@@ -342,6 +342,8 @@ pub struct PineLineChart {
     #[prop]
     pub label: String,
     #[prop]
+    pub empty_message: String,
+    #[prop]
     pub x_label: String,
     #[prop]
     pub y_label: String,
@@ -410,6 +412,7 @@ impl Default for PineLineChart {
         Self {
             points: Vec::new(),
             label: "Line chart".into(),
+            empty_message: DEFAULT_EMPTY_MESSAGE.into(),
             x_label: String::new(),
             y_label: String::new(),
             width: options.width,

--- a/crates/pine-charts/src/pie/PinePieChart.poco
+++ b/crates/pine-charts/src/pie/PinePieChart.poco
@@ -71,8 +71,8 @@
             pp-text="center_label_text"></text>
     </g>
   </svg>
-  <div pp-show="hover_visible"
-       class="pine-chart-tooltip pine-chart-pie-tooltip"
+  <div class="pine-chart-tooltip pine-chart-pie-tooltip"
+       :aria-hidden="hover_visible ? 'false' : 'true'"
        role="status"
        :aria-label="hover_aria_label"
        :style="hover_style"

--- a/crates/pine-charts/src/pie/PinePieChart.poco
+++ b/crates/pine-charts/src/pie/PinePieChart.poco
@@ -23,7 +23,7 @@
        @pointermove="on_pointer_move"
        @pointerleave="clear_hover">
     <g class="pine-chart-pie-slices" data-layer="series">
-      <template pp-for="slice in slices" pp-key="slice.key">
+      <template pp-for="slice in painted_slices" pp-key="slice.key">
         <path class="pine-chart-pie-slice"
               :d="slice.d"
               role="option"

--- a/crates/pine-charts/src/pie/PinePieChart.poco
+++ b/crates/pine-charts/src/pie/PinePieChart.poco
@@ -23,7 +23,7 @@
        @pointermove="on_pointer_move"
        @pointerleave="clear_hover">
     <g class="pine-chart-pie-slices" data-layer="series">
-      <template pp-for="slice in painted_slices" pp-key="slice.key">
+      <template pp-for="slice in slices" pp-key="slice.key">
         <path class="pine-chart-pie-slice"
               :d="slice.d"
               role="option"
@@ -38,6 +38,19 @@
               :data-selected="slice.key == selected_key"
               @click.stop="select_slice(slice.key)"></path>
       </template>
+    </g>
+    <g pp-show="hover_visible"
+       class="pine-chart-pie-hover"
+       data-layer="hover"
+       aria-hidden="true"
+       pointer-events="none">
+      <path class="pine-chart-pie-slice pine-chart-pie-hover-slice"
+            :d="hover_slice.d"
+            :data-key="hover_slice.key"
+            :data-label="hover_slice.label"
+            :data-value="hover_slice.value"
+            :data-percentage="hover_slice.percentage"
+            data-hovered="true"></path>
     </g>
     <g pp-show="center_visible"
        class="pine-chart-center"

--- a/crates/pine-charts/src/pie/PinePieChart.poco
+++ b/crates/pine-charts/src/pie/PinePieChart.poco
@@ -89,4 +89,8 @@
           pp-text="hover_percentage_label"></span>
   </div>
   <span class="pine-chart-status" pp-show="invalid" pp-text="error"></span>
+  <span pp-show="empty"
+        class="pine-chart-status pine-chart-status-empty"
+        role="status"
+        pp-text="empty_message"></span>
 </root>

--- a/crates/pine-charts/src/pie/mod.rs
+++ b/crates/pine-charts/src/pie/mod.rs
@@ -281,7 +281,7 @@ pub struct PinePieChart {
     pub state: String,
     pub view_box: String,
     pub slices: Vec<SvgPieSlice>,
-    pub painted_slices: Vec<SvgPieSlice>,
+    pub hover_slice: SvgPieSlice,
     pub legend_items: Vec<LegendItem>,
     pub center_x: f64,
     pub center_y: f64,
@@ -331,7 +331,7 @@ impl Default for PinePieChart {
             state: "empty".into(),
             view_box: format!("0 0 {} {}", options.width, options.height),
             slices: Vec::new(),
-            painted_slices: Vec::new(),
+            hover_slice: SvgPieSlice::default(),
             legend_items: Vec::new(),
             center_x: 0.0,
             center_y: 0.0,
@@ -448,7 +448,7 @@ impl PinePieChart {
         self.hover_placement_x = "right".into();
         self.hover_placement_y = "above".into();
         self.hover_style.clear();
-        self.update_painted_slices();
+        self.hover_slice = SvgPieSlice::default();
     }
 
     pub fn select_slice(&mut self, key: String) {
@@ -582,7 +582,7 @@ impl PinePieChart {
 
     fn clear_geometry(&mut self) {
         self.slices.clear();
-        self.painted_slices.clear();
+        self.hover_slice = SvgPieSlice::default();
         self.legend_items.clear();
         self.center_x = 0.0;
         self.center_y = 0.0;
@@ -647,28 +647,12 @@ impl PinePieChart {
         self.hover_placement_x = update.placement.x.into();
         self.hover_placement_y = update.placement.y.into();
         self.hover_style = update.placement.style;
-        self.update_painted_slices();
-    }
-
-    fn update_painted_slices(&mut self) {
-        if self.hover_key.is_empty() {
-            self.painted_slices = self.slices.clone();
-            return;
-        }
-
-        let mut hovered = None;
-        let mut painted = Vec::with_capacity(self.slices.len());
-        for slice in &self.slices {
-            if slice.key == self.hover_key {
-                hovered = Some(slice.clone());
-            } else {
-                painted.push(slice.clone());
-            }
-        }
-        if let Some(slice) = hovered {
-            painted.push(slice);
-        }
-        self.painted_slices = painted;
+        self.hover_slice = self
+            .slices
+            .iter()
+            .find(|slice| slice.key == self.hover_key)
+            .cloned()
+            .unwrap_or_default();
     }
 
     fn reconcile_selection(&mut self) {

--- a/crates/pine-charts/src/pie/mod.rs
+++ b/crates/pine-charts/src/pie/mod.rs
@@ -281,6 +281,7 @@ pub struct PinePieChart {
     pub state: String,
     pub view_box: String,
     pub slices: Vec<SvgPieSlice>,
+    pub painted_slices: Vec<SvgPieSlice>,
     pub legend_items: Vec<LegendItem>,
     pub center_x: f64,
     pub center_y: f64,
@@ -330,6 +331,7 @@ impl Default for PinePieChart {
             state: "empty".into(),
             view_box: format!("0 0 {} {}", options.width, options.height),
             slices: Vec::new(),
+            painted_slices: Vec::new(),
             legend_items: Vec::new(),
             center_x: 0.0,
             center_y: 0.0,
@@ -446,6 +448,7 @@ impl PinePieChart {
         self.hover_placement_x = "right".into();
         self.hover_placement_y = "above".into();
         self.hover_style.clear();
+        self.update_painted_slices();
     }
 
     pub fn select_slice(&mut self, key: String) {
@@ -579,6 +582,7 @@ impl PinePieChart {
 
     fn clear_geometry(&mut self) {
         self.slices.clear();
+        self.painted_slices.clear();
         self.legend_items.clear();
         self.center_x = 0.0;
         self.center_y = 0.0;
@@ -643,6 +647,28 @@ impl PinePieChart {
         self.hover_placement_x = update.placement.x.into();
         self.hover_placement_y = update.placement.y.into();
         self.hover_style = update.placement.style;
+        self.update_painted_slices();
+    }
+
+    fn update_painted_slices(&mut self) {
+        if self.hover_key.is_empty() {
+            self.painted_slices = self.slices.clone();
+            return;
+        }
+
+        let mut hovered = None;
+        let mut painted = Vec::with_capacity(self.slices.len());
+        for slice in &self.slices {
+            if slice.key == self.hover_key {
+                hovered = Some(slice.clone());
+            } else {
+                painted.push(slice.clone());
+            }
+        }
+        if let Some(slice) = hovered {
+            painted.push(slice);
+        }
+        self.painted_slices = painted;
     }
 
     fn reconcile_selection(&mut self) {

--- a/crates/pine-charts/src/pie/mod.rs
+++ b/crates/pine-charts/src/pie/mod.rs
@@ -15,10 +15,22 @@ use crate::svg::format_tick;
 
 const FULL_CIRCLE_DEGREES: f64 = 360.0;
 
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ChartPieSlice {
     pub label: String,
     pub value: f64,
+    #[serde(default = "crate::legend::default_visible")]
+    pub visible: bool,
+}
+
+impl Default for ChartPieSlice {
+    fn default() -> Self {
+        Self {
+            label: String::new(),
+            value: 0.0,
+            visible: true,
+        }
+    }
 }
 
 impl ChartPieSlice {
@@ -26,6 +38,7 @@ impl ChartPieSlice {
         Self {
             label: label.into(),
             value,
+            visible: true,
         }
     }
 }
@@ -133,12 +146,7 @@ impl PieChartGeometry {
                 })
             })
             .collect::<ChartResult<Vec<_>>>()?;
-        let legend_items = slices
-            .iter()
-            .map(|slice| {
-                LegendItem::with_series(slice.key.clone(), slice.label.clone(), slice.label.clone())
-            })
-            .collect();
+        let legend_items = pie_legend_items(data);
 
         Ok(Self {
             view_box: format!("0 0 {width} {height}"),
@@ -159,7 +167,12 @@ pub fn pie_legend_items(data: &[ChartPieSlice]) -> Vec<LegendItem> {
         .filter(|(_, slice)| slice.value > 0.0)
         .map(|(index, slice)| {
             let label = slice_label(&slice.label, index);
-            LegendItem::with_series(format!("pie-slice-{index}-{label}"), label.clone(), label)
+            LegendItem::with_series_active(
+                format!("pie-slice-{index}-{label}"),
+                label.clone(),
+                label,
+                slice.visible,
+            )
         })
         .collect()
 }
@@ -676,7 +689,7 @@ fn normalize_slices(data: &[ChartPieSlice]) -> ChartResult<Vec<NormalizedPieSlic
                 value: value.to_string(),
             });
         }
-        if value == 0.0 {
+        if value == 0.0 || !slice.visible {
             continue;
         }
         output.push(NormalizedPieSlice {
@@ -703,7 +716,7 @@ fn validate_inner_radius(value: f64) -> ChartResult<f64> {
     Ok(value)
 }
 
-fn slice_label(label: &str, index: usize) -> String {
+pub(crate) fn slice_label(label: &str, index: usize) -> String {
     if label.is_empty() {
         format!("Slice {}", index + 1)
     } else {
@@ -850,6 +863,28 @@ mod tests {
         assert_eq!(geometry.slices[0].percentage, 25.0);
         assert_eq!(geometry.slices[0].d, "M50,50 L50,0 A50,50 0 0 1 100,50 Z");
         assert_eq!(geometry.legend_items.len(), 2);
+    }
+
+    #[test]
+    fn pie_geometry_skips_hidden_slices_and_marks_legend_inactive() {
+        let options = PieChartOptions {
+            width: 100.0,
+            height: 100.0,
+            margins: ChartMargins::ZERO,
+            inner_radius: 0.0,
+            start_angle: -90.0,
+            end_angle: 270.0,
+        };
+        let mut data = vec![ChartPieSlice::new("A", 1.0), ChartPieSlice::new("B", 3.0)];
+        data[1].visible = false;
+
+        let geometry = PieChartGeometry::new(&data, &options).unwrap();
+
+        assert_eq!(geometry.slices.len(), 1);
+        assert_eq!(geometry.slices[0].label, "A");
+        assert_eq!(geometry.total, 1.0);
+        assert!(geometry.legend_items[0].active);
+        assert!(!geometry.legend_items[1].active);
     }
 
     #[test]

--- a/crates/pine-charts/src/pie/mod.rs
+++ b/crates/pine-charts/src/pie/mod.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::cartesian::{
     pointer_event_svg_point, step_key, CartesianHoverPlacement, ChartStateFields,
+    DEFAULT_EMPTY_MESSAGE,
 };
 use crate::error::{finite, ChartError, ChartResult};
 use crate::events::{ChartSelection, CHART_SELECT_EVENT};
@@ -257,6 +258,8 @@ pub struct PinePieChart {
     #[prop]
     pub label: String,
     #[prop]
+    pub empty_message: String,
+    #[prop]
     pub width: f64,
     #[prop]
     pub height: f64,
@@ -317,6 +320,7 @@ impl Default for PinePieChart {
         Self {
             data: Vec::new(),
             label: "Pie chart".into(),
+            empty_message: DEFAULT_EMPTY_MESSAGE.into(),
             width: options.width,
             height: options.height,
             margin_top: options.margins.top,

--- a/crates/pine-charts/src/scatter/PineScatterChart.poco
+++ b/crates/pine-charts/src/scatter/PineScatterChart.poco
@@ -167,4 +167,8 @@
   <span pp-show="invalid"
         class="pine-chart-status"
         pp-text="error"></span>
+  <span pp-show="empty"
+        class="pine-chart-status pine-chart-status-empty"
+        role="status"
+        pp-text="empty_message"></span>
 </root>

--- a/crates/pine-charts/src/scatter/PineScatterChart.poco
+++ b/crates/pine-charts/src/scatter/PineScatterChart.poco
@@ -146,8 +146,8 @@
               :data-series="hover_series"></circle>
     </g>
   </svg>
-  <div pp-show="hover_visible"
-       class="pine-chart-tooltip"
+  <div class="pine-chart-tooltip"
+       :aria-hidden="hover_visible ? 'false' : 'true'"
        role="status"
        :aria-label="hover_aria_label"
        :style="hover_style"

--- a/crates/pine-charts/src/scatter/mod.rs
+++ b/crates/pine-charts/src/scatter/mod.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::cartesian::{
     nearest_sample_by_point, optional_domain, plot_rect_from_edges, pointer_event_svg_point,
     step_key, CartesianChartState, CartesianGuideFields, CartesianGuideUpdate,
-    CartesianHoverFields, ChartStateFields, PlotEdgeFields,
+    CartesianHoverFields, ChartStateFields, PlotEdgeFields, DEFAULT_EMPTY_MESSAGE,
 };
 use crate::error::{ChartError, ChartResult};
 use crate::events::{ChartSelection, CHART_SELECT_EVENT};
@@ -153,6 +153,8 @@ pub struct PineScatterChart {
     #[prop]
     pub label: String,
     #[prop]
+    pub empty_message: String,
+    #[prop]
     pub x_label: String,
     #[prop]
     pub y_label: String,
@@ -221,6 +223,7 @@ impl Default for PineScatterChart {
             points: Vec::new(),
             series: Vec::new(),
             label: "Scatter chart".into(),
+            empty_message: DEFAULT_EMPTY_MESSAGE.into(),
             x_label: String::new(),
             y_label: String::new(),
             width: options.width,

--- a/crates/pine-charts/src/scatter/mod.rs
+++ b/crates/pine-charts/src/scatter/mod.rs
@@ -9,7 +9,7 @@ use crate::cartesian::{
 use crate::error::{ChartError, ChartResult};
 use crate::events::{ChartSelection, CHART_SELECT_EVENT};
 use crate::geometry::{ChartMargins, ChartRect, Point};
-use crate::legend::{series_label_or_default, series_legend_items};
+use crate::legend::{series_label_or_default, series_legend_items_with_visibility};
 use crate::line::{ChartLineSeries, ChartPoint, LineChartGeometry, LineChartOptions};
 use crate::svg::{SvgAxisLabel, SvgLine, SvgTickLabel};
 use crate::{LegendItem, LineChartSample};
@@ -17,10 +17,22 @@ use crate::{LegendItem, LineChartSample};
 pub type ScatterChartOptions = LineChartOptions;
 pub type ScatterChartSample = LineChartSample;
 
-#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ChartScatterSeries {
     pub label: String,
     pub data: Vec<ChartPoint>,
+    #[serde(default = "crate::legend::default_visible")]
+    pub visible: bool,
+}
+
+impl Default for ChartScatterSeries {
+    fn default() -> Self {
+        Self {
+            label: String::new(),
+            data: Vec::new(),
+            visible: true,
+        }
+    }
 }
 
 impl ChartScatterSeries {
@@ -28,6 +40,7 @@ impl ChartScatterSeries {
         Self {
             label: label.into(),
             data,
+            visible: true,
         }
     }
 }
@@ -61,7 +74,11 @@ impl ScatterChartGeometry {
     ) -> ChartResult<Self> {
         let line_series = series
             .iter()
-            .map(|series| ChartLineSeries::new(series.label.clone(), series.data.clone()))
+            .map(|series| {
+                let mut line = ChartLineSeries::new(series.label.clone(), series.data.clone());
+                line.visible = series.visible;
+                line
+            })
             .collect::<Vec<_>>();
         Self::from_line_geometry(LineChartGeometry::from_series(&line_series, options)?)
     }
@@ -105,12 +122,14 @@ pub struct ScatterChartSeriesRender {
 }
 
 pub fn scatter_legend_items(series: &[ChartScatterSeries]) -> Vec<LegendItem> {
-    series_legend_items(
+    series_legend_items_with_visibility(
         "scatter-series",
-        series
-            .iter()
-            .enumerate()
-            .map(|(index, series)| series_label_or_default(&series.label, index)),
+        series.iter().enumerate().map(|(index, series)| {
+            (
+                series_label_or_default(&series.label, index),
+                series.visible,
+            )
+        }),
     )
 }
 

--- a/crates/pine-charts/src/visibility.rs
+++ b/crates/pine-charts/src/visibility.rs
@@ -1,0 +1,214 @@
+use crate::legend::series_label_or_default;
+use crate::pie::slice_label;
+use crate::{ChartAreaSeries, ChartBarSeries, ChartLineSeries, ChartPieSlice, ChartScatterSeries};
+
+trait VisibleSeries {
+    fn label(&self) -> &str;
+    fn visible(&self) -> bool;
+    fn set_visible(&mut self, visible: bool);
+}
+
+impl VisibleSeries for ChartLineSeries {
+    fn label(&self) -> &str {
+        &self.label
+    }
+
+    fn visible(&self) -> bool {
+        self.visible
+    }
+
+    fn set_visible(&mut self, visible: bool) {
+        self.visible = visible;
+    }
+}
+
+impl VisibleSeries for ChartAreaSeries {
+    fn label(&self) -> &str {
+        &self.label
+    }
+
+    fn visible(&self) -> bool {
+        self.visible
+    }
+
+    fn set_visible(&mut self, visible: bool) {
+        self.visible = visible;
+    }
+}
+
+impl VisibleSeries for ChartScatterSeries {
+    fn label(&self) -> &str {
+        &self.label
+    }
+
+    fn visible(&self) -> bool {
+        self.visible
+    }
+
+    fn set_visible(&mut self, visible: bool) {
+        self.visible = visible;
+    }
+}
+
+impl VisibleSeries for ChartBarSeries {
+    fn label(&self) -> &str {
+        &self.label
+    }
+
+    fn visible(&self) -> bool {
+        self.visible
+    }
+
+    fn set_visible(&mut self, visible: bool) {
+        self.visible = visible;
+    }
+}
+
+fn series_key(prefix: &str, index: usize, label: &str) -> String {
+    format!("{prefix}-{index}-{}", series_label_or_default(label, index))
+}
+
+fn set_series_visible<T: VisibleSeries>(
+    prefix: &str,
+    series: &mut [T],
+    key: &str,
+    visible: bool,
+) -> bool {
+    let Some(item) = series
+        .iter_mut()
+        .enumerate()
+        .find(|(index, series)| series_key(prefix, *index, series.label()) == key)
+        .map(|(_, series)| series)
+    else {
+        return false;
+    };
+    item.set_visible(visible);
+    true
+}
+
+fn toggle_series_visible<T: VisibleSeries>(prefix: &str, series: &mut [T], key: &str) -> bool {
+    let Some(item) = series
+        .iter_mut()
+        .enumerate()
+        .find(|(index, series)| series_key(prefix, *index, series.label()) == key)
+        .map(|(_, series)| series)
+    else {
+        return false;
+    };
+    item.set_visible(!item.visible());
+    true
+}
+
+pub fn set_line_series_visible(series: &mut [ChartLineSeries], key: &str, visible: bool) -> bool {
+    set_series_visible("line-series", series, key, visible)
+}
+
+pub fn toggle_line_series_visibility(series: &mut [ChartLineSeries], key: &str) -> bool {
+    toggle_series_visible("line-series", series, key)
+}
+
+pub fn set_area_series_visible(series: &mut [ChartAreaSeries], key: &str, visible: bool) -> bool {
+    set_series_visible("area-series", series, key, visible)
+}
+
+pub fn toggle_area_series_visibility(series: &mut [ChartAreaSeries], key: &str) -> bool {
+    toggle_series_visible("area-series", series, key)
+}
+
+pub fn set_scatter_series_visible(
+    series: &mut [ChartScatterSeries],
+    key: &str,
+    visible: bool,
+) -> bool {
+    set_series_visible("scatter-series", series, key, visible)
+}
+
+pub fn toggle_scatter_series_visibility(series: &mut [ChartScatterSeries], key: &str) -> bool {
+    toggle_series_visible("scatter-series", series, key)
+}
+
+pub fn set_bar_series_visible(series: &mut [ChartBarSeries], key: &str, visible: bool) -> bool {
+    set_series_visible("bar-series", series, key, visible)
+}
+
+pub fn toggle_bar_series_visibility(series: &mut [ChartBarSeries], key: &str) -> bool {
+    toggle_series_visible("bar-series", series, key)
+}
+
+pub fn set_pie_slice_visible(data: &mut [ChartPieSlice], key: &str, visible: bool) -> bool {
+    let Some(slice) = data
+        .iter_mut()
+        .enumerate()
+        .find(|(index, slice)| {
+            format!("pie-slice-{index}-{}", slice_label(&slice.label, *index)) == key
+        })
+        .map(|(_, slice)| slice)
+    else {
+        return false;
+    };
+    slice.visible = visible;
+    true
+}
+
+pub fn toggle_pie_slice_visibility(data: &mut [ChartPieSlice], key: &str) -> bool {
+    let Some(slice) = data
+        .iter_mut()
+        .enumerate()
+        .find(|(index, slice)| {
+            format!("pie-slice-{index}-{}", slice_label(&slice.label, *index)) == key
+        })
+        .map(|(_, slice)| slice)
+    else {
+        return false;
+    };
+    slice.visible = !slice.visible;
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ChartBar, ChartPoint};
+
+    #[test]
+    fn updates_series_visibility_by_legend_key() {
+        let mut series = vec![
+            ChartLineSeries::new("Actual", vec![ChartPoint::new(0.0, 1.0)]),
+            ChartLineSeries::new("", vec![ChartPoint::new(0.0, 2.0)]),
+        ];
+
+        assert!(set_line_series_visible(
+            &mut series,
+            "line-series-1-Series 2",
+            false,
+        ));
+        assert!(series[0].visible);
+        assert!(!series[1].visible);
+    }
+
+    #[test]
+    fn toggles_bar_visibility_by_legend_key() {
+        let mut series = vec![ChartBarSeries::new(
+            "Revenue",
+            vec![ChartBar::new("Q1", 42.0)],
+        )];
+
+        assert!(toggle_bar_series_visibility(
+            &mut series,
+            "bar-series-0-Revenue",
+        ));
+        assert!(!series[0].visible);
+    }
+
+    #[test]
+    fn updates_pie_visibility_by_slice_key() {
+        let mut data = vec![ChartPieSlice::new("", 4.0)];
+
+        assert!(set_pie_slice_visible(
+            &mut data,
+            "pie-slice-0-Slice 1",
+            false,
+        ));
+        assert!(!data[0].visible);
+    }
+}

--- a/crates/pine-charts/tests/charts.rs
+++ b/crates/pine-charts/tests/charts.rs
@@ -1732,7 +1732,9 @@ async fn pie_chart_renders_donut_slices_and_selection() {
     assert_eq!(chart.get_attribute("tabindex").as_deref(), Some("0"));
     assert!(!chart.has_attribute("data-hover"));
 
-    let slices = host.query_selector_all(".pine-chart-pie-slice").unwrap();
+    let slices = host
+        .query_selector_all(".pine-chart-pie-slices .pine-chart-pie-slice")
+        .unwrap();
     assert_eq!(slices.length(), 2);
     let first = slices.get(0).unwrap().dyn_into::<Element>().unwrap();
     assert_eq!(
@@ -1765,24 +1767,23 @@ async fn pie_chart_renders_donut_slices_and_selection() {
     assert_eq!(center_label.get_attribute("y").as_deref(), Some("66"));
 
     let svg = host.query_selector("svg.pine-chart-svg").unwrap().unwrap();
-    assert_eq!(direct_svg_layers(&svg), vec!["series", "labels"]);
+    assert_eq!(direct_svg_layers(&svg), vec!["series", "hover", "labels"]);
     dispatch_pointer_move(&svg, 50.0, 10.0);
     settle().await;
 
     assert!(first.has_attribute("data-hovered"));
     let hovered_key = first.get_attribute("data-key").unwrap();
-    let painted_slices = host.query_selector_all(".pine-chart-pie-slice").unwrap();
-    assert_eq!(painted_slices.length(), 2);
-    let top_slice = painted_slices
-        .get(painted_slices.length() - 1)
+    let hover_slice = host
+        .query_selector(".pine-chart-pie-hover .pine-chart-pie-slice")
+        .unwrap()
         .unwrap()
         .dyn_into::<Element>()
         .unwrap();
     assert_eq!(
-        top_slice.get_attribute("data-key").as_deref(),
+        hover_slice.get_attribute("data-key").as_deref(),
         Some(hovered_key.as_str())
     );
-    assert!(top_slice.has_attribute("data-hovered"));
+    assert!(hover_slice.has_attribute("data-hovered"));
     let tooltip = host
         .query_selector(".pine-chart-pie-tooltip")
         .unwrap()

--- a/crates/pine-charts/tests/charts.rs
+++ b/crates/pine-charts/tests/charts.rs
@@ -1770,6 +1770,19 @@ async fn pie_chart_renders_donut_slices_and_selection() {
     settle().await;
 
     assert!(first.has_attribute("data-hovered"));
+    let hovered_key = first.get_attribute("data-key").unwrap();
+    let painted_slices = host.query_selector_all(".pine-chart-pie-slice").unwrap();
+    assert_eq!(painted_slices.length(), 2);
+    let top_slice = painted_slices
+        .get(painted_slices.length() - 1)
+        .unwrap()
+        .dyn_into::<Element>()
+        .unwrap();
+    assert_eq!(
+        top_slice.get_attribute("data-key").as_deref(),
+        Some(hovered_key.as_str())
+    );
+    assert!(top_slice.has_attribute("data-hovered"));
     let tooltip = host
         .query_selector(".pine-chart-pie-tooltip")
         .unwrap()

--- a/crates/pine-charts/tests/charts.rs
+++ b/crates/pine-charts/tests/charts.rs
@@ -1116,6 +1116,11 @@ async fn line_chart_shows_crosshair_and_tooltip_on_pointer_move() {
 
     let chart = host.query_selector(".pine-line-chart").unwrap().unwrap();
     assert!(!chart.has_attribute("data-hover"));
+    let tooltip = host.query_selector(".pine-chart-tooltip").unwrap().unwrap();
+    assert_eq!(
+        tooltip.get_attribute("aria-hidden").as_deref(),
+        Some("true")
+    );
 
     let svg = host.query_selector("svg.pine-chart-svg").unwrap().unwrap();
     dispatch_pointer_move(&svg, 50.0, 50.0);
@@ -1139,6 +1144,10 @@ async fn line_chart_shows_crosshair_and_tooltip_on_pointer_move() {
     assert_eq!(marker.get_attribute("data-y").as_deref(), Some("10"));
 
     let tooltip = host.query_selector(".pine-chart-tooltip").unwrap().unwrap();
+    assert_eq!(
+        tooltip.get_attribute("aria-hidden").as_deref(),
+        Some("false")
+    );
     assert_eq!(tooltip.get_attribute("data-x").as_deref(), Some("5"));
     assert_eq!(tooltip.get_attribute("data-y").as_deref(), Some("10"));
     assert_eq!(
@@ -1166,6 +1175,11 @@ async fn line_chart_shows_crosshair_and_tooltip_on_pointer_move() {
     assert!(!chart.has_attribute("data-hover"));
     let hover = host.query_selector(".pine-chart-hover").unwrap().unwrap();
     assert_eq!(hover.get_attribute("visibility").as_deref(), Some("hidden"));
+    let tooltip = host.query_selector(".pine-chart-tooltip").unwrap().unwrap();
+    assert_eq!(
+        tooltip.get_attribute("aria-hidden").as_deref(),
+        Some("true")
+    );
 
     host.remove();
 }

--- a/crates/pine-charts/tests/charts.rs
+++ b/crates/pine-charts/tests/charts.rs
@@ -7,8 +7,9 @@ use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use pine_charts::{
-    ChartAreaSeries, ChartBar, ChartBarSeries, ChartLayerPoint, ChartLineSeries, ChartPieSlice,
-    ChartPoint, ChartScatterSeries, LegendItem, CHART_SELECT_EVENT, LEGEND_TOGGLE_EVENT,
+    line_legend_items, set_line_series_visible, ChartAreaSeries, ChartBar, ChartBarSeries,
+    ChartLayerPoint, ChartLineSeries, ChartPieSlice, ChartPoint, ChartScatterSeries, LegendItem,
+    LegendToggle, CHART_SELECT_EVENT, LEGEND_TOGGLE_EVENT,
 };
 use pocopine::prelude::*;
 use wasm_bindgen::closure::Closure;
@@ -1900,6 +1901,96 @@ async fn chart_legend_renders_items_and_updates() {
         .unwrap()
         .unwrap();
     assert_eq!(first_label.text_content().as_deref(), Some("API"));
+
+    host.remove();
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[component(template_inline = r#"
+<div>
+  <pine-line-chart class="controlled-line"
+                   label="Controlled"
+                   width="100"
+                   height="100"
+                   margin_top="0"
+                   margin_right="0"
+                   margin_bottom="0"
+                   margin_left="0"
+                   pp-bind:series="series"></pine-line-chart>
+  <pine-chart-legend class="controlled-legend"
+                     label="Controlled legend"
+                     interactive="true"
+                     @pp:chart:legend-toggle="toggle"
+                     pp-bind:items="legend"></pine-chart-legend>
+</div>
+"#)]
+struct ControlledLegendFixture {
+    series: Vec<ChartLineSeries>,
+    legend: Vec<LegendItem>,
+}
+
+impl Default for ControlledLegendFixture {
+    fn default() -> Self {
+        let series = vec![
+            ChartLineSeries::new(
+                "Actual",
+                vec![ChartPoint::new(0.0, 0.0), ChartPoint::new(1.0, 1.0)],
+            ),
+            ChartLineSeries::new(
+                "Target",
+                vec![ChartPoint::new(0.0, 1.0), ChartPoint::new(1.0, 0.0)],
+            ),
+        ];
+        Self {
+            legend: line_legend_items(&series),
+            series,
+        }
+    }
+}
+
+#[handlers]
+impl ControlledLegendFixture {
+    pub fn toggle(&mut self, event: JsValue) {
+        let Some(toggle) = LegendToggle::from_event_value(event) else {
+            return;
+        };
+        if set_line_series_visible(&mut self.series, &toggle.key, toggle.active) {
+            self.legend = line_legend_items(&self.series);
+        }
+    }
+}
+
+#[wasm_bindgen_test]
+async fn legend_toggle_can_control_chart_visibility() {
+    let host = mount_fixture::<ControlledLegendFixture>();
+    settle().await;
+
+    let paths = host
+        .query_selector_all(".controlled-line .pine-chart-line")
+        .unwrap();
+    assert_eq!(paths.length(), 2);
+
+    let first = host
+        .query_selector(".controlled-legend .pine-chart-legend-item")
+        .unwrap()
+        .unwrap()
+        .dyn_into::<Element>()
+        .unwrap();
+    dispatch_keydown(&first, "Enter");
+    settle().await;
+
+    let paths = host
+        .query_selector_all(".controlled-line .pine-chart-line")
+        .unwrap();
+    assert_eq!(paths.length(), 1);
+    let first = host
+        .query_selector(".controlled-legend .pine-chart-legend-item")
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        first.get_attribute("aria-pressed").as_deref(),
+        Some("false")
+    );
 
     host.remove();
 }

--- a/crates/pine-charts/tests/charts.rs
+++ b/crates/pine-charts/tests/charts.rs
@@ -1311,6 +1311,11 @@ async fn line_chart_reports_empty_state() {
             .is_none(),
         "empty charts should not render a data path",
     );
+    let status = host
+        .query_selector(".pine-chart-status-empty")
+        .unwrap()
+        .unwrap();
+    assert_eq!(status.text_content().as_deref(), Some("No visible data"));
 
     host.remove();
 }
@@ -2005,6 +2010,30 @@ async fn legend_toggle_can_control_chart_visibility() {
         first.get_attribute("aria-pressed").as_deref(),
         Some("false")
     );
+    let second = host
+        .query_selector_all(".controlled-legend .pine-chart-legend-item")
+        .unwrap()
+        .get(1)
+        .unwrap()
+        .dyn_into::<Element>()
+        .unwrap();
+    dispatch_keydown(&second, "Enter");
+    settle().await;
+
+    let chart = host.query_selector(".controlled-line").unwrap().unwrap();
+    assert_eq!(chart.get_attribute("data-state").as_deref(), Some("empty"));
+    assert!(chart.has_attribute("data-empty"));
+    assert!(
+        host.query_selector(".controlled-line .pine-chart-line")
+            .unwrap()
+            .is_none(),
+        "all-hidden chart should not render stale line geometry",
+    );
+    let status = chart
+        .query_selector(".pine-chart-status-empty")
+        .unwrap()
+        .unwrap();
+    assert_eq!(status.text_content().as_deref(), Some("No visible data"));
 
     host.remove();
 }

--- a/docs/charts/cartesian.md
+++ b/docs/charts/cartesian.md
@@ -71,6 +71,11 @@ namespace handling, responsive sizing, scales, and paint order in one place.
 `pine-cartesian-chart` when the chart needs explicit child composition or when a
 chart should mix bars, lines, areas, scatters, references, and annotations.
 
+Each series child accepts `visible`. Hidden children stay mounted and keep their
+app-authored props, but they do not contribute domains, axes, paths, bars, or
+points. Use this with interactive legends when a dashboard needs controlled
+filtering without letting the chart own application state.
+
 ## Data
 
 Line-only numeric charts use the same `ChartPoint` type as `pine-line-chart`:

--- a/docs/charts/components.md
+++ b/docs/charts/components.md
@@ -347,6 +347,12 @@ Add `interactive="true"` when legend items should toggle and emit
 `pp:chart:legend-toggle`. The legend owns only item active state and hooks; the
 application still decides how toggles affect chart data.
 
+For controlled filtering, set `visible` on `ChartLineSeries`,
+`ChartScatterSeries`, `ChartAreaSeries`, `ChartBarSeries`, or `ChartPieSlice`.
+Renderers skip hidden items, and `*_legend_items` helpers expose the same state
+as `LegendItem.active`. Helper functions such as `set_line_series_visible` and
+`set_pie_slice_visible` update app-owned data by the stable legend key.
+
 ## Styling Hooks
 
 The component emits stable hooks:

--- a/docs/charts/components.md
+++ b/docs/charts/components.md
@@ -434,6 +434,10 @@ use `fill="currentColor"`. Application CSS should own the final visual
 treatment:
 
 ```css
+.pine-chart-root {
+  position: relative;
+}
+
 .pine-line-chart {
   color: var(--series-accent);
 }
@@ -480,7 +484,15 @@ treatment:
 
 .pine-chart-tooltip {
   left: var(--pine-chart-tooltip-x);
+  opacity: 0;
   top: var(--pine-chart-tooltip-y);
+  transition: opacity 120ms ease;
+  visibility: hidden;
+}
+
+.pine-chart-root[data-hover] .pine-chart-tooltip {
+  opacity: 1;
+  visibility: visible;
 }
 
 .pine-chart-tooltip[data-tooltip-x="left"] {
@@ -497,6 +509,19 @@ treatment:
 
 .pine-chart-pie-slice[data-hovered] {
   transform: scale(1.03);
+}
+
+.pine-chart-root[data-empty] .pine-chart-svg {
+  visibility: hidden;
+}
+
+.pine-chart-status-empty {
+  align-items: center;
+  display: flex;
+  inset: 0;
+  justify-content: center;
+  pointer-events: none;
+  position: absolute;
 }
 
 .pine-chart-bar[data-series="Organic"] {

--- a/docs/charts/components.md
+++ b/docs/charts/components.md
@@ -353,6 +353,11 @@ Renderers skip hidden items, and `*_legend_items` helpers expose the same state
 as `LegendItem.active`. Helper functions such as `set_line_series_visible` and
 `set_pie_slice_visible` update app-owned data by the stable legend key.
 
+When every item is hidden, chart roots switch to `data-state="empty"` and expose
+a `.pine-chart-status-empty` status node. The default text is `No visible data`;
+set `empty_message` on a chart to use application-specific copy while keeping
+the same styling hook.
+
 ## Styling Hooks
 
 The component emits stable hooks:
@@ -404,6 +409,7 @@ The component emits stable hooks:
 - `.pine-chart-legend-marker`
 - `.pine-chart-legend-label`
 - `.pine-chart-status`
+- `.pine-chart-status-empty`
 - `data-state="empty|ready|invalid"`
 - `data-hover`
 - `data-tooltip-x="left|right"`

--- a/docs/charts/events.md
+++ b/docs/charts/events.md
@@ -41,6 +41,7 @@ legend items toggle their own `active` state, expose `data-active`, and emit
 
 ```rust
 use pine_charts::LegendToggle;
+use pocopine::prelude::JsValue;
 ```
 
 Payload fields:
@@ -53,3 +54,20 @@ Payload fields:
 The legend intentionally does not hide chart series by itself. Applications use
 the event to decide whether toggling should filter data, dim marks, open a
 drilldown, or do nothing.
+
+For the common controlled-filtering case, update chart data with the visibility
+helpers, then rebuild legend items from that same data:
+
+```rust
+use pine_charts::{line_legend_items, set_line_series_visible, LegendToggle};
+use pocopine::prelude::JsValue;
+
+pub fn toggle_series(&mut self, event: JsValue) {
+    let Some(event) = LegendToggle::from_event_value(event) else {
+        return;
+    };
+    if set_line_series_visible(&mut self.series, &event.key, event.active) {
+        self.legend = line_legend_items(&self.series);
+    }
+}
+```

--- a/docs/charts/legend.md
+++ b/docs/charts/legend.md
@@ -73,6 +73,40 @@ The component renders an HTML list with stable styling hooks:
 Interactive items also expose `aria-pressed`. Toggling emits
 `pp:chart:legend-toggle`; the chart does not filter itself.
 
+## Controlled Visibility
+
+Series and pie slices have an explicit `visible` field. Chart renderers skip
+items where `visible == false`, and the legend helpers mirror that state through
+`LegendItem.active`. Use the toggle event to update the same app-owned data:
+
+```rust
+use pine_charts::{
+    line_legend_items, set_line_series_visible, ChartLineSeries, LegendItem,
+    LegendToggle,
+};
+use pocopine::prelude::JsValue;
+
+pub struct Metrics {
+    series: Vec<ChartLineSeries>,
+    legend_items: Vec<LegendItem>,
+}
+
+impl Metrics {
+    pub fn toggle_series(&mut self, event: JsValue) {
+        let Some(event) = LegendToggle::from_event_value(event) else {
+            return;
+        };
+        if set_line_series_visible(&mut self.series, &event.key, event.active) {
+            self.legend_items = line_legend_items(&self.series);
+        }
+    }
+}
+```
+
+Matching helpers exist for area, scatter, bar, and pie data:
+`set_area_series_visible`, `set_scatter_series_visible`,
+`set_bar_series_visible`, and `set_pie_slice_visible`.
+
 Markers do not ship with framework colors. Applications map `data-series` to
 their palette:
 

--- a/examples/charts/index.html
+++ b/examples/charts/index.html
@@ -386,6 +386,14 @@
       text-transform: uppercase;
     }
 
+    .pine-chart-status-empty {
+      color: #526173;
+      display: block;
+      font-size: 14px;
+      margin-block-start: 10px;
+      text-align: center;
+    }
+
     .pine-chart-legend {
       display: block;
       color: #18212f;

--- a/examples/charts/index.html
+++ b/examples/charts/index.html
@@ -141,6 +141,10 @@
       overflow: visible;
     }
 
+    .pine-chart-root[data-empty] .pine-chart-svg {
+      visibility: hidden;
+    }
+
     .pine-chart-grid-line {
       stroke: #d9e2ec;
       stroke-width: 1;
@@ -297,8 +301,16 @@
       padding: 6px 8px;
       pointer-events: none;
       position: absolute;
+      opacity: 0;
       top: var(--pine-chart-tooltip-y);
       transform: translate(10px, calc(-100% - 10px));
+      transition: opacity 120ms ease;
+      visibility: hidden;
+    }
+
+    .pine-chart-root[data-hover] .pine-chart-tooltip {
+      opacity: 1;
+      visibility: visible;
     }
 
     .pine-chart-tooltip[data-tooltip-x="left"] {
@@ -387,10 +399,14 @@
     }
 
     .pine-chart-status-empty {
+      align-items: center;
       color: #526173;
-      display: block;
+      display: flex;
       font-size: 14px;
-      margin-block-start: 10px;
+      inset: 0;
+      justify-content: center;
+      pointer-events: none;
+      position: absolute;
       text-align: center;
     }
 

--- a/examples/charts/src/ChartDemo.poco
+++ b/examples/charts/src/ChartDemo.poco
@@ -159,6 +159,8 @@
   </pine-chart-responsive>
 
   <pine-chart-legend label="Cohort spread legend"
+                     interactive="true"
+                     @pp:chart:legend-toggle="toggle_scatter_series"
                      pp-bind:items="scatter_legend"></pine-chart-legend>
 
   <pine-chart-responsive class="chart-panel" aspect_ratio="2.25" min_height="220">
@@ -170,6 +172,8 @@
   </pine-chart-responsive>
 
   <pine-chart-legend label="Trend area legend"
+                     interactive="true"
+                     @pp:chart:legend-toggle="toggle_area_series"
                      pp-bind:items="area_legend"></pine-chart-legend>
 
   <pine-chart-responsive class="chart-panel" aspect_ratio="2.25" min_height="220">
@@ -181,6 +185,8 @@
   </pine-chart-responsive>
 
   <pine-chart-legend label="Distribution legend"
+                     interactive="true"
+                     @pp:chart:legend-toggle="toggle_bar_series"
                      pp-bind:items="bar_legend"></pine-chart-legend>
 
   <pine-chart-responsive class="chart-panel chart-panel--radial"
@@ -198,5 +204,6 @@
 
   <pine-chart-legend label="Channel share legend"
                      interactive="true"
+                     @pp:chart:legend-toggle="toggle_pie_slice"
                      pp-bind:items="pie_legend"></pine-chart-legend>
 </root>

--- a/examples/charts/src/lib.rs
+++ b/examples/charts/src/lib.rs
@@ -1,7 +1,8 @@
 use pine_charts::{
-    area_legend_items, bar_legend_items, line_legend_items, scatter_legend_items, ChartAreaSeries,
-    ChartBar, ChartBarSeries, ChartLayerPoint, ChartLineSeries, ChartPieSlice, ChartPoint,
-    ChartScatterSeries, LegendItem,
+    area_legend_items, bar_legend_items, line_legend_items, scatter_legend_items,
+    set_area_series_visible, set_bar_series_visible, set_pie_slice_visible,
+    set_scatter_series_visible, ChartAreaSeries, ChartBar, ChartBarSeries, ChartLayerPoint,
+    ChartLineSeries, ChartPieSlice, ChartPoint, ChartScatterSeries, LegendItem, LegendToggle,
 };
 use pocopine::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -162,6 +163,43 @@ impl ChartDemo {
         self.pie_start_angle = 180.0;
         self.pie_end_angle = 360.0;
         self.update_pie_center();
+    }
+
+    pub fn toggle_scatter_series(&mut self, event: JsValue) {
+        let Some(toggle) = LegendToggle::from_event_value(event) else {
+            return;
+        };
+        if set_scatter_series_visible(&mut self.scatter_series, &toggle.key, toggle.active) {
+            self.scatter_legend = scatter_legend_items(&self.scatter_series);
+        }
+    }
+
+    pub fn toggle_area_series(&mut self, event: JsValue) {
+        let Some(toggle) = LegendToggle::from_event_value(event) else {
+            return;
+        };
+        if set_area_series_visible(&mut self.area_series, &toggle.key, toggle.active) {
+            self.area_legend = area_legend_items(&self.area_series);
+        }
+    }
+
+    pub fn toggle_bar_series(&mut self, event: JsValue) {
+        let Some(toggle) = LegendToggle::from_event_value(event) else {
+            return;
+        };
+        if set_bar_series_visible(&mut self.bar_series, &toggle.key, toggle.active) {
+            self.bar_legend = bar_legend_items(&self.bar_series);
+        }
+    }
+
+    pub fn toggle_pie_slice(&mut self, event: JsValue) {
+        let Some(toggle) = LegendToggle::from_event_value(event) else {
+            return;
+        };
+        if set_pie_slice_visible(&mut self.pie_data, &toggle.key, toggle.active) {
+            self.pie_legend = pine_charts::pie_legend_items(&self.pie_data);
+            self.update_pie_center();
+        }
     }
 }
 
@@ -520,6 +558,7 @@ fn latency_pie_data() -> Vec<ChartPieSlice> {
 
 fn pie_total_label(data: &[ChartPieSlice]) -> String {
     data.iter()
+        .filter(|slice| slice.visible)
         .map(|slice| slice.value)
         .sum::<f64>()
         .round()


### PR DESCRIPTION
## Summary

- add controlled visibility helpers for chart series and pie slices so legends can drive app-owned data state
- render hovered pie slices in a dedicated SVG overlay layer so the active slice paints above neighboring slices
- show a reusable empty-state status when all legend-controlled data is hidden, with `empty_message` customization and `.pine-chart-status-empty` styling hook
- update chart docs/demo styling and add browser coverage for the all-legends-off path

## Verification

- `cargo check -p pine-charts --all-targets`
- `cargo test -p pine-charts`
- `wasm-pack test --firefox --headless crates/pine-charts`
- `cargo clippy -p pine-charts --all-targets -- -D warnings`
- `cargo fmt --check`
- `cargo run -p pocopine-cli -- build --path examples/charts`
- live browser check on `http://localhost:8026` for pie hover layering and all-off legend empty states
