### PR TITLE
docs(rfcs): mark 076/077/078 Implemented

### DIFF
--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -83,6 +83,6 @@ Conventions:
 | 072 | [Offline sync protocol](./rfc-072-offline-sync-protocol.md) | Draft |
 | 073 | [Yrs collaboration over WebSocket and Redis](./rfc-073-yrs-collaboration.md) | Draft |
 | 074 | [`pocopine-auth-credentials` and the `Provider` trait](./rfc-074-auth-credentials-and-provider-trait.md) | Draft |
-| 076 | [App plugin lifecycle](./rfc-076-app-plugin-lifecycle.md) | Draft |
-| 077 | [Server plugin lifecycle](./rfc-077-server-plugin-lifecycle.md) | Accepted (Phases 1-3 implemented; Phase 4 typed hooks rejected) |
-| 078 | [Client route guards, loaders, and fetch middleware](./rfc-078-client-route-guards-and-loaders.md) | Accepted (core implemented; auth-client follow-up pending) |
+| 076 | [App plugin lifecycle](./rfc-076-app-plugin-lifecycle.md) | Implemented |
+| 077 | [Server plugin lifecycle](./rfc-077-server-plugin-lifecycle.md) | Implemented (Phase 4 typed hooks rejected) |
+| 078 | [Client route guards, loaders, and fetch middleware](./rfc-078-client-route-guards-and-loaders.md) | Implemented |

--- a/rfcs/rfc-076-app-plugin-lifecycle.md
+++ b/rfcs/rfc-076-app-plugin-lifecycle.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Draft |
+| **Status** | Implemented |
 | **Author** | pocopine team |
 | **Created** | 2026-05-05 |
 | **Related** | [`rfc-002-app-stores-servers.md`](./rfc-002-app-stores-servers.md), [`rfc-060-component-uses-registry.md`](./rfc-060-component-uses-registry.md), [`rfc-069-observability.md`](./rfc-069-observability.md), [`rfc-071-event-spine-and-live-invalidation.md`](./rfc-071-event-spine-and-live-invalidation.md) |

--- a/rfcs/rfc-077-server-plugin-lifecycle.md
+++ b/rfcs/rfc-077-server-plugin-lifecycle.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Implemented (Phases 1-3); Phase 4 closed — typed job hooks rejected (2026-05-09), middleware-chain alternative deferred until demand |
+| **Status** | Implemented (Phase 4 typed hooks rejected 2026-05-09; middleware-chain alternative deferred until demand) |
 | **Author** | pocopine team |
 | **Created** | 2026-05-05 |
 | **Related** | [`rfc-066-server-function-auth.md`](./rfc-066-server-function-auth.md), [`rfc-067-redis-background-jobs.md`](./rfc-067-redis-background-jobs.md), [`rfc-069-observability.md`](./rfc-069-observability.md), [`rfc-076-app-plugin-lifecycle.md`](./rfc-076-app-plugin-lifecycle.md) |

--- a/rfcs/rfc-078-client-route-guards-and-loaders.md
+++ b/rfcs/rfc-078-client-route-guards-and-loaders.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Accepted (core primitives implemented; `pocopine-auth-client` follow-up pending) |
+| **Status** | Implemented (core primitives + `pocopine-auth-client` consumer landed) |
 | **Author** | pocopine team |
 | **Created** | 2026-05-07 |
 | **Related** | [`rfc-003-router.md`](./rfc-003-router.md), [`rfc-076-app-plugin-lifecycle.md`](./rfc-076-app-plugin-lifecycle.md), [`rfc-077-server-plugin-lifecycle.md`](./rfc-077-server-plugin-lifecycle.md), [`rfc-074-auth-credentials-and-provider-trait.md`](./rfc-074-auth-credentials-and-provider-trait.md) |


### PR DESCRIPTION
## Summary

Promote the three plugin-lifecycle RFCs to **Implemented** per the status lifecycle (\`Draft → Accepted → Implemented → Superseded\`).

| RFC | Old | New |
|---|---|---|
| 076 — App plugin lifecycle | Draft | **Implemented** |
| 077 — Server plugin lifecycle | Accepted (Phases 1-3 implemented; Phase 4 typed hooks rejected) | **Implemented** (Phase 4 typed hooks rejected) |
| 078 — Client route guards, loaders, and fetch middleware | Accepted (core implemented; auth-client follow-up pending) | **Implemented** |

## Why now

- **076** shipped before this batch began; no follow-ups.
- **077** Phases 1–3 shipped; Phase 4 (typed job hooks) formally rejected after the Sidekiq + Celery ecosystem study (PR #55). The middleware-chain alternative remains demand-gated but the RFC itself is closed.
- **078** core primitives shipped (PR #49); abort plumbing + \`#[server(idempotent)]\` shipped (PR #50); \`pocopine-auth-client\` consumer with refresh + identity-change fence shipped (PR #56). All consumers RFC-078 was waiting on are landed.

## Test plan

- [x] Docs only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)