### PR TITLE
feat(pocopine-auth-client): storage + cross-tab + single-flight refresh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3131,6 +3131,8 @@ version = "0.1.0"
 dependencies = [
  "pocopine-auth",
  "pocopine-core",
+ "wasm-bindgen",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3129,9 +3129,12 @@ dependencies = [
 name = "pocopine-auth-client"
 version = "0.1.0"
 dependencies = [
+ "js-sys",
  "pocopine-auth",
  "pocopine-core",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
  "web-sys",
 ]
 

--- a/crates/pocopine-auth-client/Cargo.toml
+++ b/crates/pocopine-auth-client/Cargo.toml
@@ -9,3 +9,12 @@ description = "Wasm-side bearer-token bridge for outgoing #[server] auth: token 
 [dependencies]
 pocopine-auth = { workspace = true }
 pocopine-core = { workspace = true, default-features = false }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = { workspace = true }
+web-sys = { version = "0.3", features = [
+    "Window",
+    "Storage",
+    "BroadcastChannel",
+    "MessageEvent",
+] }

--- a/crates/pocopine-auth-client/Cargo.toml
+++ b/crates/pocopine-auth-client/Cargo.toml
@@ -18,3 +18,11 @@ web-sys = { version = "0.3", features = [
     "BroadcastChannel",
     "MessageEvent",
 ] }
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3"
+wasm-bindgen-futures = { workspace = true }
+js-sys = { workspace = true }
+# Window::set_timeout_* lives behind a separate feature gate; tests
+# need it to yield through the task queue.
+web-sys = { version = "0.3", features = ["Window"] }

--- a/crates/pocopine-auth-client/Cargo.toml
+++ b/crates/pocopine-auth-client/Cargo.toml
@@ -23,6 +23,6 @@ web-sys = { version = "0.3", features = [
 wasm-bindgen-test = "0.3"
 wasm-bindgen-futures = { workspace = true }
 js-sys = { workspace = true }
-# Window::set_timeout_* lives behind a separate feature gate; tests
-# need it to yield through the task queue.
-web-sys = { version = "0.3", features = ["Window"] }
+# `web-sys` features (incl. `Window` for `set_timeout_*`) are unioned
+# from the `[dependencies]` block above — no additional declaration
+# needed here.

--- a/crates/pocopine-auth-client/src/cross_tab.rs
+++ b/crates/pocopine-auth-client/src/cross_tab.rs
@@ -97,19 +97,14 @@ pub(crate) fn install(session: AuthSession) {
     let session_for_listener = session;
     let listener = Closure::<dyn FnMut(MessageEvent)>::new(move |_evt: MessageEvent| {
         SUPPRESS_BROADCAST.with(|c| c.set(true));
-        // 1. Re-read token from storage so this tab's bearer
-        //    middleware switches credentials on its next outgoing
-        //    request.
         crate::hydrate_from_storage();
-        // 2. Bump epoch so any in-flight responses captured under the
-        //    previous identity get fenced by `BearerMiddleware`.
         session_for_listener.bump_epoch();
         SUPPRESS_BROADCAST.with(|c| c.set(false));
     });
     channel.set_onmessage(Some(listener.as_ref().unchecked_ref()));
-    // Leak the closure; it lives for the app's lifetime. Storing it
-    // in the thread_local would tie its lifetime to module unload,
-    // which never happens for wasm apps.
+    // Leaked intentionally: the listener lives for the app's
+    // lifetime. Storing it would force a Drop boundary that wasm
+    // apps never cross.
     listener.forget();
 
     CHANNEL.with(|c| *c.borrow_mut() = Some(channel));
@@ -124,9 +119,6 @@ pub fn broadcast_session_changed() {
         return;
     }
     if let Some(channel) = CHANNEL.with(|c| c.borrow().clone()) {
-        // Payload is intentionally minimal: receivers re-load token
-        // from storage and bump epoch; they don't need a payload to
-        // act on.
         let _ = channel.post_message(&JsValue::from_str("session_changed"));
     }
 }

--- a/crates/pocopine-auth-client/src/cross_tab.rs
+++ b/crates/pocopine-auth-client/src/cross_tab.rs
@@ -62,9 +62,22 @@ pub const CHANNEL_NAME: &str = "pocopine-auth";
 #[cfg(target_arch = "wasm32")]
 thread_local! {
     static CHANNEL: RefCell<Option<BroadcastChannel>> = const { RefCell::new(None) };
-    /// Re-entrancy flag: set to `true` while we're applying an inbound
-    /// message so the resulting `set_principal` / `bump_epoch` doesn't
-    /// loop the broadcast back out again.
+    /// Re-entrancy guard for inbound message handling.
+    ///
+    /// Currently dormant — the framework's listener calls
+    /// [`crate::hydrate_from_storage`] (which writes only to the
+    /// token slot and storage, never the session) and
+    /// [`crate::session::AuthSession::bump_epoch`] (which is
+    /// deliberately the broadcast-free epoch advance). Neither
+    /// triggers `broadcast_session_changed`, so today the flag never
+    /// fires.
+    ///
+    /// Kept as defensive scaffolding so app code that wraps inbound
+    /// handling (e.g., calling `session.set_principal` from a custom
+    /// listener) doesn't ping-pong messages between tabs. Per the
+    /// `BroadcastChannel` spec, posts are not delivered to the
+    /// origin tab, so the flag protects against
+    /// `set_principal`-from-listener loops, not against self-echo.
     static SUPPRESS_BROADCAST: Cell<bool> = const { Cell::new(false) };
 }
 
@@ -127,6 +140,16 @@ pub fn __teardown_for_test() {
         channel.close();
     }
     SUPPRESS_BROADCAST.with(|c| c.set(false));
+}
+
+/// Install the cross-tab listener directly. Test seam — production
+/// goes through `auth_plugin().with_cross_tab_sync(true)` which
+/// validates the storage requirement first. Bypassing the builder
+/// in production code is unsupported.
+#[cfg(target_arch = "wasm32")]
+#[doc(hidden)]
+pub fn __install_for_test(session: AuthSession) {
+    install(session);
 }
 
 // ─── Host stubs ─────────────────────────────────────────────────────

--- a/crates/pocopine-auth-client/src/cross_tab.rs
+++ b/crates/pocopine-auth-client/src/cross_tab.rs
@@ -1,0 +1,142 @@
+//! Cross-tab session coordination via `BroadcastChannel`.
+//!
+//! Without this, signing in or out in tab A leaves tab B oblivious:
+//! tab B keeps issuing requests under the previous identity until the
+//! server returns 401. This module wires a `BroadcastChannel` named
+//! `"pocopine-auth"` so identity-change events propagate across tabs of
+//! the same origin.
+//!
+//! ## How it works
+//!
+//! 1. `auth_plugin().with_cross_tab_sync(true)` opens a `BroadcastChannel`
+//!    at boot and registers a listener.
+//! 2. Whenever [`AuthSession::set_principal`] runs, it calls
+//!    [`broadcast_session_changed`]. The local sender is suppressed
+//!    via a re-entrancy flag so we don't loop.
+//! 3. A peer tab's listener fires:
+//!    - Hydrates the local in-memory token from configured
+//!      [`crate::TokenStorage`] (the persistent tokens are how peer
+//!      tabs see *what* the new credential is).
+//!    - Bumps the local [`AuthSession`]'s epoch via
+//!      [`AuthSession::bump_epoch`] so the bearer middleware's fence
+//!      drops any in-flight responses captured under the old identity.
+//!    - Apps observing the session can react (call `/me`, refresh
+//!      reactive views, navigate, etc.).
+//!
+//! ## What's *not* synced
+//!
+//! The full `Principal` (user id, roles, claims) is **not** sent
+//! across the channel. The peer tab only knows "something changed" —
+//! it must call its own `/me` server fn to learn the new identity.
+//! Reasons:
+//! - Cross-tab messages are visible to `BroadcastChannel` listeners
+//!   on the same origin; broadcasting principal payloads needlessly
+//!   widens the data surface.
+//! - `Principal` doesn't have a stable wire format defined here.
+//! - The token + a bumped epoch are the minimum needed for the bearer
+//!   middleware to switch identities cleanly; anything richer is an
+//!   app-level concern.
+//!
+//! ## Falling back when unavailable
+//!
+//! `BroadcastChannel` ships in all evergreen browsers but can be
+//! unavailable in test runners, `file://` contexts, or older Safari.
+//! The install path silently degrades to a no-op when the constructor
+//! fails — apps don't see a panic; they just don't get cross-tab sync.
+
+#[cfg(target_arch = "wasm32")]
+use std::cell::{Cell, RefCell};
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::{closure::Closure, JsCast, JsValue};
+#[cfg(target_arch = "wasm32")]
+use web_sys::{BroadcastChannel, MessageEvent};
+
+#[cfg(target_arch = "wasm32")]
+use crate::session::AuthSession;
+
+/// Channel name used for the cross-tab handshake. Stable to keep the
+/// surface predictable for app integrations that want to observe it
+/// directly (e.g. devtools).
+pub const CHANNEL_NAME: &str = "pocopine-auth";
+
+#[cfg(target_arch = "wasm32")]
+thread_local! {
+    static CHANNEL: RefCell<Option<BroadcastChannel>> = const { RefCell::new(None) };
+    /// Re-entrancy flag: set to `true` while we're applying an inbound
+    /// message so the resulting `set_principal` / `bump_epoch` doesn't
+    /// loop the broadcast back out again.
+    static SUPPRESS_BROADCAST: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Wire up the cross-tab channel for `session`. Idempotent — repeat
+/// installs are no-ops.
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn install(session: AuthSession) {
+    if CHANNEL.with(|c| c.borrow().is_some()) {
+        return;
+    }
+
+    let Ok(channel) = BroadcastChannel::new(CHANNEL_NAME) else {
+        // Browser doesn't support BroadcastChannel — silent fallback.
+        return;
+    };
+
+    let session_for_listener = session;
+    let listener = Closure::<dyn FnMut(MessageEvent)>::new(move |_evt: MessageEvent| {
+        SUPPRESS_BROADCAST.with(|c| c.set(true));
+        // 1. Re-read token from storage so this tab's bearer
+        //    middleware switches credentials on its next outgoing
+        //    request.
+        crate::hydrate_from_storage();
+        // 2. Bump epoch so any in-flight responses captured under the
+        //    previous identity get fenced by `BearerMiddleware`.
+        session_for_listener.bump_epoch();
+        SUPPRESS_BROADCAST.with(|c| c.set(false));
+    });
+    channel.set_onmessage(Some(listener.as_ref().unchecked_ref()));
+    // Leak the closure; it lives for the app's lifetime. Storing it
+    // in the thread_local would tie its lifetime to module unload,
+    // which never happens for wasm apps.
+    listener.forget();
+
+    CHANNEL.with(|c| *c.borrow_mut() = Some(channel));
+}
+
+/// Notify peer tabs that this tab's session changed. No-op when the
+/// channel isn't installed or when we're already inside an inbound
+/// message handler (re-entrancy guard prevents broadcast loops).
+#[cfg(target_arch = "wasm32")]
+pub fn broadcast_session_changed() {
+    if SUPPRESS_BROADCAST.with(|c| c.get()) {
+        return;
+    }
+    if let Some(channel) = CHANNEL.with(|c| c.borrow().clone()) {
+        // Payload is intentionally minimal: receivers re-load token
+        // from storage and bump epoch; they don't need a payload to
+        // act on.
+        let _ = channel.post_message(&JsValue::from_str("session_changed"));
+    }
+}
+
+/// Tear down the channel. Used by tests; production doesn't need to
+/// call this because the channel lives for the app's lifetime.
+#[cfg(target_arch = "wasm32")]
+#[doc(hidden)]
+pub fn __teardown_for_test() {
+    if let Some(channel) = CHANNEL.with(|c| c.borrow_mut().take()) {
+        channel.close();
+    }
+    SUPPRESS_BROADCAST.with(|c| c.set(false));
+}
+
+// ─── Host stubs ─────────────────────────────────────────────────────
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn install(_: crate::session::AuthSession) {}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn broadcast_session_changed() {}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[doc(hidden)]
+pub fn __teardown_for_test() {}

--- a/crates/pocopine-auth-client/src/lib.rs
+++ b/crates/pocopine-auth-client/src/lib.rs
@@ -85,13 +85,16 @@
 //! headers, cookies, or query strings enter framework events. Bearer
 //! attachment is a pure mutation on the in-flight `FetchRequest`.
 
+pub mod cross_tab;
 mod plugin;
 mod refresh;
 mod session;
+pub mod storage;
 
 pub use plugin::{auth_plugin, predicate_guard, AuthPluginBuilder, DEFAULT_RETURN_TO_PARAM};
 pub use refresh::{TokenRefresh, TokenRefreshFuture};
 pub use session::{active_principal, active_session, AuthSession};
+pub use storage::TokenStorage;
 
 use std::cell::Cell;
 use std::sync::Mutex;
@@ -108,19 +111,28 @@ use pocopine_core::ServerError;
 static TOKEN: Mutex<Option<String>> = Mutex::new(None);
 
 /// Register the bearer token attached to subsequent `#[server]` calls.
-/// Replaces any previously-set token.
+/// Replaces any previously-set token. Writes through to the configured
+/// [`TokenStorage`] when one is installed via
+/// [`AuthPluginBuilder::with_token_storage`].
 pub fn set_token(token: impl Into<String>) {
+    let token = token.into();
     *TOKEN
         .lock()
-        .expect("pocopine_auth_client::TOKEN mutex poisoned") = Some(token.into());
+        .expect("pocopine_auth_client::TOKEN mutex poisoned") = Some(token.clone());
+    if let Some(storage) = storage::current_storage() {
+        storage.save(&token);
+    }
 }
 
 /// Drop the active token. Subsequent calls go out without an
-/// `Authorization` header.
+/// `Authorization` header. Also clears the configured [`TokenStorage`].
 pub fn clear_token() {
     *TOKEN
         .lock()
         .expect("pocopine_auth_client::TOKEN mutex poisoned") = None;
+    if let Some(storage) = storage::current_storage() {
+        storage.clear();
+    }
 }
 
 /// Read the active token, if any.
@@ -129,6 +141,30 @@ pub fn active_token() -> Option<String> {
         .lock()
         .expect("pocopine_auth_client::TOKEN mutex poisoned")
         .clone()
+}
+
+/// Replace the in-memory token slot from the configured
+/// [`TokenStorage`]. Called at boot (so a refreshing user's token
+/// survives reload) and from the cross-tab listener (so a sign-in in
+/// tab A propagates to tab B without an extra round-trip). No-op if
+/// no storage is installed or storage has no value.
+///
+/// Does **not** broadcast across tabs — this is the inbound side of
+/// the broadcast handshake; calling it inside the broadcast listener
+/// without recursion guard is the correct shape.
+pub fn hydrate_from_storage() {
+    let Some(storage) = storage::current_storage() else {
+        return;
+    };
+    if let Some(token) = storage.load() {
+        *TOKEN
+            .lock()
+            .expect("pocopine_auth_client::TOKEN mutex poisoned") = Some(token);
+    } else {
+        *TOKEN
+            .lock()
+            .expect("pocopine_auth_client::TOKEN mutex poisoned") = None;
+    }
 }
 
 /// Fetch middleware that attaches `Authorization: Bearer <token>` to
@@ -187,16 +223,25 @@ impl FetchMiddleware for BearerMiddleware {
             // `is_replay_safe` (i.e. `#[server(idempotent)]`) per RFC-078
             // §5.10.4 and on having actually attached a token (refresh
             // can't help an endpoint that 401s without auth context).
+            // Routed through `refresh_single_flight` so concurrent
+            // 401s coalesce into one refresh call to the issuer.
             let response = if unauthorized && had_token && is_replay_safe {
-                if let Some(refresh) = refresh::current_refresh() {
-                    match refresh.refresh().await {
+                if refresh::current_refresh().is_some() {
+                    match refresh::refresh_single_flight().await {
                         Ok(new_token) => {
-                            set_token(new_token.clone());
+                            // `set_token` writes through to storage,
+                            // which (with cross-tab sync installed)
+                            // also propagates the new token to peer
+                            // tabs on their next storage read.
+                            set_token(new_token.as_str());
                             let mut retry = request;
-                            retry.set_header("authorization", format!("Bearer {new_token}"));
+                            retry.set_header(
+                                "authorization",
+                                format!("Bearer {}", new_token.as_str()),
+                            );
                             next.run(retry).await
                         }
-                        Err(err) => Err(err),
+                        Err(err) => Err((*err).clone()),
                     }
                 } else {
                     // No refresh configured — propagate fail-closed with
@@ -297,6 +342,7 @@ mod tests {
         clear_token();
         __reset_middleware_chain_for_test();
         refresh::__reset_refresh_for_test();
+        storage::__reset_storage_for_test();
         INSTALLED.with(|c| c.set(false));
     }
 
@@ -742,5 +788,226 @@ mod tests {
         );
 
         full_reset_with_session();
+    }
+
+    // ─── TokenStorage write-through + hydration ─────────────────────
+
+    #[test]
+    fn set_token_writes_through_to_configured_storage() {
+        let _guard = lock_serial();
+        full_reset();
+
+        let test_storage = Rc::new(storage::TestStorage::default());
+        storage::install_storage(test_storage.clone());
+
+        set_token("persisted");
+        assert_eq!(test_storage.saved.borrow().as_deref(), Some("persisted"));
+
+        clear_token();
+        assert_eq!(test_storage.saved.borrow().as_deref(), None);
+
+        full_reset();
+    }
+
+    #[test]
+    fn hydrate_from_storage_repopulates_in_memory_token() {
+        let _guard = lock_serial();
+        full_reset();
+
+        let test_storage = Rc::new(storage::TestStorage::default());
+        *test_storage.saved.borrow_mut() = Some("from-storage".to_string());
+        storage::install_storage(test_storage.clone());
+
+        // Slot starts empty (full_reset cleared it).
+        assert_eq!(active_token(), None);
+
+        hydrate_from_storage();
+        assert_eq!(active_token().as_deref(), Some("from-storage"));
+
+        full_reset();
+    }
+
+    #[test]
+    fn hydrate_with_no_storage_is_a_noop() {
+        let _guard = lock_serial();
+        full_reset();
+        // No storage installed.
+        hydrate_from_storage();
+        assert_eq!(active_token(), None);
+        full_reset();
+    }
+
+    #[test]
+    fn hydrate_clears_in_memory_token_when_storage_is_empty() {
+        let _guard = lock_serial();
+        full_reset();
+
+        // Pre-populate the in-memory slot, then hydrate from an empty
+        // storage. Hydration should clear the slot to match storage.
+        set_token("in-memory");
+        let test_storage = Rc::new(storage::TestStorage::default());
+        storage::install_storage(test_storage);
+        // saved is None.
+
+        hydrate_from_storage();
+        assert_eq!(active_token(), None);
+
+        full_reset();
+    }
+
+    // ─── Single-flight refresh integrated through middleware ────────
+
+    /// Install a counter middleware that returns Unauthorized on the
+    /// first call, then 200 on subsequent calls. Counts how many
+    /// distinct requests reached the chain bottom.
+    fn install_401_then_ok_n_times(reach: Rc<std::cell::Cell<usize>>) {
+        let reach_inner = reach;
+        install_middleware(move |request: FetchRequest, _next: FetchNext| {
+            let reach = reach_inner.clone();
+            async move {
+                let _ = request;
+                let attempt = {
+                    let n = reach.get() + 1;
+                    reach.set(n);
+                    n
+                };
+                if attempt == 1 {
+                    Ok(FetchResponse {
+                        status: 401,
+                        body: r#"{"Err":{"Unauthorized":"token expired"}}"#.to_string(),
+                    })
+                } else {
+                    Ok(FetchResponse {
+                        status: 200,
+                        body: r#"{"Ok":null}"#.to_string(),
+                    })
+                }
+            }
+        });
+    }
+
+    #[test]
+    fn single_flight_refresh_through_middleware() {
+        // Verifies the middleware path uses refresh_single_flight,
+        // not refresh.refresh() directly. We can't easily run two
+        // concurrent fetch::call invocations through one block_on,
+        // so this is the integration-level smoke: one call with
+        // refresh configured drives one refresh, replays once, gets
+        // Ok.
+        let _guard = lock_serial();
+        full_reset();
+
+        set_token("stale");
+        install();
+
+        let refresh_count = Rc::new(std::cell::Cell::new(0));
+        let refresh_count_inner = refresh_count.clone();
+        refresh::set_refresh(Rc::new(move || {
+            let c = refresh_count_inner.clone();
+            async move {
+                c.set(c.get() + 1);
+                Ok("fresh".to_string())
+            }
+        }));
+
+        let chain_calls = Rc::new(std::cell::Cell::new(0));
+        install_401_then_ok_n_times(chain_calls.clone());
+
+        let result = block_on(pocopine_core::fetch::call_replay_safe::<(), ()>(
+            "/probe",
+            &(),
+        ));
+        assert!(result.is_ok());
+        assert_eq!(refresh_count.get(), 1);
+        assert_eq!(chain_calls.get(), 2, "one 401 + one replay");
+        assert_eq!(active_token().as_deref(), Some("fresh"));
+
+        full_reset();
+    }
+
+    #[test]
+    fn aborted_refresh_unblocks_waiters_with_error() {
+        // Drive refresh_single_flight directly. First caller drops
+        // its future before the refresh resolves — second caller
+        // should not hang; it should receive the synthetic
+        // "refresh aborted" Unauthorized.
+        let _guard = lock_serial();
+        full_reset();
+
+        // Refresh future yields once before resolving so we can drop
+        // the driver mid-flight.
+        let yielded = Rc::new(std::cell::Cell::new(false));
+        let yielded_inner = yielded.clone();
+        refresh::set_refresh(Rc::new(move || {
+            let yielded = yielded_inner.clone();
+            async move {
+                if !yielded.get() {
+                    yielded.set(true);
+                    futures_yield_once().await;
+                }
+                Ok("never-reached".to_string())
+            }
+        }));
+
+        // Driver
+        let mut driver = Box::pin(refresh::refresh_single_flight());
+        // Poll once → Pending (yields inside refresh).
+        struct NoopWake;
+        impl std::task::Wake for NoopWake {
+            fn wake(self: std::sync::Arc<Self>) {}
+            fn wake_by_ref(self: &std::sync::Arc<Self>) {}
+        }
+        let waker: std::task::Waker = std::sync::Arc::new(NoopWake).into();
+        let mut cx = std::task::Context::from_waker(&waker);
+        assert!(matches!(
+            driver.as_mut().poll(&mut cx),
+            std::task::Poll::Pending
+        ));
+
+        // Spawn a waiter while the driver is still pending.
+        let mut waiter = Box::pin(refresh::refresh_single_flight());
+        assert!(matches!(
+            waiter.as_mut().poll(&mut cx),
+            std::task::Poll::Pending
+        ));
+
+        // Drop the driver — its ClearOnDrop guard publishes a
+        // synthetic error and clears IN_FLIGHT. The waiter must
+        // resolve to that error on next poll.
+        drop(driver);
+
+        match waiter.as_mut().poll(&mut cx) {
+            std::task::Poll::Ready(Err(e)) => match &*e {
+                ServerError::Unauthorized(msg) => {
+                    assert!(msg.contains("aborted"), "unexpected reason: {msg}");
+                }
+                other => panic!("expected Unauthorized, got {other:?}"),
+            },
+            other => panic!("waiter must resolve after driver drops, got {other:?}"),
+        }
+
+        full_reset();
+    }
+
+    /// Yields control once. Used to introduce an await point so the
+    /// caller can drop the future before completion.
+    async fn futures_yield_once() {
+        struct YieldOnce(bool);
+        impl Future for YieldOnce {
+            type Output = ();
+            fn poll(
+                mut self: Pin<&mut Self>,
+                cx: &mut std::task::Context<'_>,
+            ) -> std::task::Poll<()> {
+                if self.0 {
+                    std::task::Poll::Ready(())
+                } else {
+                    self.0 = true;
+                    cx.waker().wake_by_ref();
+                    std::task::Poll::Pending
+                }
+            }
+        }
+        YieldOnce(false).await
     }
 }

--- a/crates/pocopine-auth-client/src/lib.rs
+++ b/crates/pocopine-auth-client/src/lib.rs
@@ -196,36 +196,21 @@ pub fn hydrate_from_storage() {
     }
 }
 
-/// Fetch middleware that attaches `Authorization: Bearer <token>` to
-/// every outgoing request when [`active_token`] is `Some`, refreshes
-/// the token once on `Unauthorized` for replay-safe requests, and
-/// fences the response against identity changes that happened while
-/// the request was in flight.
-///
-/// All three concerns live in one middleware so the active-token,
-/// epoch, and refresh state are observed atomically with respect to
-/// one outgoing request — a single rejection handler position in the
-/// chain (registered once at `install` time) wins by being simple to
-/// reason about.
+/// Fetch middleware that attaches `Authorization: Bearer <token>`,
+/// refreshes once on `Unauthorized` for replay-safe requests, and
+/// fences responses against identity changes that happened in
+/// flight. All three concerns live here so token, epoch, and
+/// refresh state are observed atomically per outgoing request.
 pub struct BearerMiddleware;
 
 impl FetchMiddleware for BearerMiddleware {
     fn call(&self, mut request: FetchRequest, next: FetchNext) -> FetchMiddlewareFuture {
-        // Single read of the token slot: the "did we authenticate this
-        // request?" decision and the actual header attachment must
-        // observe the same value, otherwise a concurrent `set_token` /
-        // `clear_token` between two locks could leave us with
-        // had_token=true but no header attached (or vice versa). Wasm
-        // is single-threaded so this is impossible in production, but
-        // tighten the invariant for host-test robustness and to keep
-        // the code honest if pocopine ever grows a multi-threaded
-        // wasm runtime.
+        // Snapshot once: the auth-decision and the header-attach must
+        // observe the same token, else a `set_token`/`clear_token`
+        // between two locks could split the invariant.
         let token_snapshot = active_token();
         let had_token = token_snapshot.is_some();
         let captured_epoch = if had_token {
-            // Only capture when we're actually authenticating this
-            // request. An anonymous request can't go stale on identity
-            // change because it didn't depend on identity.
             session::active_session().map(|s| s.epoch())
         } else {
             None
@@ -239,42 +224,27 @@ impl FetchMiddleware for BearerMiddleware {
         Box::pin(async move {
             let response = next.clone().run(request.clone()).await;
 
-            // Normalize 401-shaped signals. `pocopine_core::fetch::call`
-            // converts non-2xx to `ServerError::Network("HTTP 401")` at
-            // the top, dropping any body before the auth middleware can
-            // see it. We need to recognise the auth-shaped error before
-            // that happens, so we treat both `Ok(status == 401)` and
-            // `Err(Unauthorized)` as the same logical signal.
+            // `pocopine_core::fetch::call` collapses non-2xx into
+            // `Network("HTTP 401")` before deserializing the body, so
+            // we recognise both shapes as the same auth signal.
             let unauthorized = matches!(&response, Ok(r) if r.status == 401)
                 || matches!(&response, Err(ServerError::Unauthorized(_)));
 
-            // Refresh-on-Unauthorized + replay once. Gated on
-            // `is_replay_safe` (i.e. `#[server(idempotent)]`) per RFC-078
-            // §5.10.4 and on having actually attached a token (refresh
-            // can't help an endpoint that 401s without auth context).
-            // Routed through `refresh_single_flight` so concurrent
-            // 401s coalesce into one refresh call to the issuer.
+            // RFC-078 §5.10.4: refresh + replay only for replay-safe
+            // requests that actually carried a token. Concurrent 401s
+            // coalesce into one issuer call via `refresh_single_flight`.
             let response = if unauthorized && had_token && is_replay_safe {
                 if refresh::current_refresh().is_some() {
                     match refresh::refresh_single_flight().await {
                         Ok(new_token) => {
-                            // Identity-change fence on the WRITE side.
-                            // If the user signed out (or signed in as a
-                            // different identity) during the refresh,
-                            // the epoch advanced. Writing `new_token`
-                            // would re-pollute the cleared slot with a
-                            // valid bearer the user no longer has any
-                            // intent to use. Drop the result here; the
-                            // outer fence below handles the response
-                            // side, but it can't undo a token-slot
-                            // write — only this gate can.
+                            // Write-side identity fence: a sign-out
+                            // during refresh advances the epoch; writing
+                            // the new token would re-pollute a cleared
+                            // slot. The response-side fence below can't
+                            // undo a slot write — only this gate can.
                             let still_valid =
                                 session::active_session().map(|s| s.epoch()) == captured_epoch;
                             if still_valid {
-                                // `set_token` writes through to storage,
-                                // which (with cross-tab sync installed)
-                                // also propagates the new token to peer
-                                // tabs on their next storage read.
                                 set_token(new_token.as_str());
                                 let mut retry = request;
                                 retry.set_header(
@@ -289,27 +259,19 @@ impl FetchMiddleware for BearerMiddleware {
                         Err(err) => Err((*err).clone()),
                     }
                 } else {
-                    // No refresh configured — propagate fail-closed with
-                    // an auth-shaped error so the caller can match on it.
                     Err(ServerError::unauthorized("token expired"))
                 }
             } else if unauthorized && had_token {
-                // Replay disabled (or non-idempotent server fn). Still
-                // surface the Unauthorized shape for callers.
                 Err(ServerError::unauthorized("token expired"))
             } else if unauthorized {
-                // Anonymous request that 401'd. Refresh wouldn't help;
-                // surface the auth shape for the caller.
                 Err(ServerError::unauthorized("auth required"))
             } else {
                 response
             };
 
-            // Identity-change fence. Refresh rotates the token but does
-            // *not* bump the epoch (epoch tracks principal changes), so
-            // a successful refresh-replay still passes the fence. A
-            // concurrent sign-in/sign-out that bumped the epoch trips
-            // it — the response is from the previous identity.
+            // Refresh rotates the token but does NOT bump the epoch;
+            // sign-in/out does. So a refresh-replay passes; a
+            // concurrent identity change trips this fence.
             if let Some(captured) = captured_epoch {
                 let now = session::active_session().map(|s| s.epoch());
                 if now != Some(captured) {
@@ -323,12 +285,8 @@ impl FetchMiddleware for BearerMiddleware {
 }
 
 thread_local! {
-    /// Tracks whether [`install`] has already registered
-    /// [`BearerMiddleware`] on the current thread's chain. Makes
-    /// repeated calls (e.g. `install()` plus
-    /// `auth_plugin().with_bearer_middleware(true)`) safe — the
-    /// second one is a no-op rather than a silent
-    /// double-register.
+    /// Idempotency guard for [`install`]; second-and-later calls
+    /// no-op rather than double-registering on the fetch chain.
     static INSTALLED: Cell<bool> = const { Cell::new(false) };
 }
 

--- a/crates/pocopine-auth-client/src/lib.rs
+++ b/crates/pocopine-auth-client/src/lib.rs
@@ -1,6 +1,6 @@
 //! Wasm-side auth surface for pocopine.
 //!
-//! Five surfaces:
+//! Seven surfaces:
 //!
 //! - **Token slot.** [`set_token`], [`clear_token`], and [`active_token`]
 //!   manage a process-global `Option<String>`.
@@ -13,15 +13,33 @@
 //!   register the middleware via [`install`] or via the plugin builder
 //!   ([`auth_plugin().with_bearer_middleware(true)`](auth_plugin)) — both
 //!   are idempotent, so mixing them is safe.
+//! - **Token refresh + single-flight coordinator.** Apps install a
+//!   provider-specific [`TokenRefresh`] via
+//!   [`AuthPluginBuilder::with_token_refresh`]; concurrent in-flight
+//!   401s coalesce into one issuer call via [`refresh`]'s shared-slot
+//!   coordinator (see module docs).
+//! - **Token persistence.** Pluggable [`TokenStorage`] so the bearer
+//!   token survives reload. Provided impls in [`storage`]:
+//!   `InMemory` (default no-op), `LocalStorage`, `SessionStorage`.
+//!   Wired via [`AuthPluginBuilder::with_token_storage`].
+//! - **Cross-tab session coordination.** Sign-in / sign-out in tab A
+//!   propagates to peer tabs of the same origin via a
+//!   `BroadcastChannel`. Opt-in via
+//!   [`AuthPluginBuilder::with_cross_tab_sync`]; requires
+//!   [`with_token_storage`](AuthPluginBuilder::with_token_storage)
+//!   so peer tabs can read the new credential. See [`cross_tab`].
 //! - **Reactive identity.** [`AuthSession`] is a plugin service the
 //!   [`auth_plugin`] installs. It holds the active [`pocopine_auth::Principal`]
 //!   plus a monotonic epoch; components extract it via
 //!   `Plugin<AuthSession>` / `Option<Plugin<AuthSession>>` per RFC-076.
 //!   The bearer middleware also captures the epoch on outgoing
-//!   authenticated requests and fences the response on completion: if the
-//!   user signed in/out while the request was in flight, the middleware
-//!   returns `Err(ServerError::Unauthorized("session_changed"))` instead
-//!   of letting stale-identity data through (RFC-078 §5.10.5).
+//!   authenticated requests and fences the response on completion: if
+//!   the user signed in/out while the request was in flight, the
+//!   middleware returns `Err(ServerError::Unauthorized("session_changed"))`
+//!   instead of letting stale-identity data through (RFC-078 §5.10.5).
+//!   The fence runs on both the response side AND the refresh-replay
+//!   write side, so a refresh resolving after a sign-out doesn't
+//!   re-pollute the cleared token slot.
 //! - **Auth-aware route guards + login redirect.** [`auth_plugin`]
 //!   is an [`AppPlugin`](pocopine_core::AppPlugin) that registers a
 //!   [`RouteRejectionHandler`](pocopine_core::RouteRejectionHandler)
@@ -30,23 +48,24 @@
 //!   [`pocopine_auth::Predicate`] (`require_auth`, `require_role`,
 //!   …) into a [`RouteGuard`](pocopine_core::RouteGuard) that reads
 //!   the live [`AuthSession`].
-//! - **Token refresh.** Apps install a provider-specific [`TokenRefresh`]
-//!   via [`AuthPluginBuilder::with_token_refresh`]; the bearer middleware
-//!   uses it for the replay-on-401 flow described above.
 //!
 //! ## Usage
 //!
 //! ```ignore
 //! use pocopine::App;
-//! use pocopine_auth_client::auth_plugin;
+//! use pocopine_auth_client::{auth_plugin, storage::LocalStorage};
 //!
 //! App::new()
 //!     .plugin(
 //!         auth_plugin()
 //!             .login_route("/login")
 //!             .with_bearer_middleware(true)
+//!             // Persist token across reload:
+//!             .with_token_storage(LocalStorage::new("auth_token"))
+//!             // Sync identity changes across tabs:
+//!             .with_cross_tab_sync(true)
+//!             // Refresh + replay on Unauthorized for idempotent calls:
 //!             .with_token_refresh(|| async {
-//!                 // Talk to your provider here. For example:
 //!                 my_app::refresh_session_token().await
 //!             }),
 //!     )
@@ -65,19 +84,26 @@
 //! pocopine_auth_client::clear_token();
 //! ```
 //!
+//! See `docs/auth-client.md` for a step-by-step walkthrough of each
+//! surface, the security tradeoffs, and the cross-tab/refresh wire
+//! traces.
+//!
 //! ## What this is *not*
 //!
-//! - **Not a token store.** Storage is in-memory and per-process;
-//!   persistence across reloads (cookie, localStorage, IndexedDB) is
-//!   the app's job.
 //! - **Not provider-coupled.** [`set_token`] accepts any string; the
 //!   server-side verifier decides validity. [`TokenRefresh`] is a
 //!   provider-supplied closure or struct, not a built-in.
-//! - **Not a single-flight refresh coordinator yet.** Multiple
-//!   concurrent requests that all 401 may each trigger an independent
-//!   refresh. The wasm runtime is single-threaded so the practical
-//!   blast radius is bounded; coalescing is a follow-up — see
-//!   [`refresh`] module docs.
+//! - **Not an `httpOnly` cookie issuer.** The [`storage`] impls
+//!   persist the bearer in JavaScript-readable browser storage; for
+//!   high-value applications, prefer an `httpOnly` cookie set by the
+//!   server (then skip the bearer middleware entirely — the browser
+//!   sends the cookie automatically). See `storage.rs` module docs
+//!   for the full XSS-vs-durability tradeoff.
+//! - **Not a route-aware predicate adapter.** [`predicate_guard`] is
+//!   `Principal`-only; guards that need to inspect `params` /
+//!   `query` (e.g., `/users/:id` requiring `principal.id == params["id"]`)
+//!   must write the closure directly. See [`predicate_guard`]'s
+//!   docstring for the pattern.
 //!
 //! ## Privacy
 //!

--- a/crates/pocopine-auth-client/src/lib.rs
+++ b/crates/pocopine-auth-client/src/lib.rs
@@ -185,15 +185,9 @@ pub fn hydrate_from_storage() {
     let Some(storage) = storage::current_storage() else {
         return;
     };
-    if let Some(token) = storage.load() {
-        *TOKEN
-            .lock()
-            .expect("pocopine_auth_client::TOKEN mutex poisoned") = Some(token);
-    } else {
-        *TOKEN
-            .lock()
-            .expect("pocopine_auth_client::TOKEN mutex poisoned") = None;
-    }
+    *TOKEN
+        .lock()
+        .expect("pocopine_auth_client::TOKEN mutex poisoned") = storage.load();
 }
 
 /// Fetch middleware that attaches `Authorization: Bearer <token>`,
@@ -210,11 +204,17 @@ impl FetchMiddleware for BearerMiddleware {
         // between two locks could split the invariant.
         let token_snapshot = active_token();
         let had_token = token_snapshot.is_some();
-        let captured_epoch = if had_token {
-            session::active_session().map(|s| s.epoch())
+        // Capture the session handle once. Both fences below
+        // (write-side after refresh, response-side post-completion)
+        // read its epoch — sharing the handle avoids two extra
+        // RwLock reads + Arc clones on the plugin registry per
+        // authenticated request.
+        let session_handle = if had_token {
+            session::active_session()
         } else {
             None
         };
+        let captured_epoch = session_handle.as_ref().map(|s| s.epoch());
 
         if let Some(token) = token_snapshot.as_deref() {
             request.set_header("authorization", format!("Bearer {token}"));
@@ -243,7 +243,7 @@ impl FetchMiddleware for BearerMiddleware {
                             // slot. The response-side fence below can't
                             // undo a slot write — only this gate can.
                             let still_valid =
-                                session::active_session().map(|s| s.epoch()) == captured_epoch;
+                                session_handle.as_ref().map(|s| s.epoch()) == captured_epoch;
                             if still_valid {
                                 set_token(new_token.as_str());
                                 let mut retry = request;
@@ -273,7 +273,7 @@ impl FetchMiddleware for BearerMiddleware {
             // sign-in/out does. So a refresh-replay passes; a
             // concurrent identity change trips this fence.
             if let Some(captured) = captured_epoch {
-                let now = session::active_session().map(|s| s.epoch());
+                let now = session_handle.as_ref().map(|s| s.epoch());
                 if now != Some(captured) {
                     return Err(ServerError::unauthorized("session_changed"));
                 }

--- a/crates/pocopine-auth-client/src/lib.rs
+++ b/crates/pocopine-auth-client/src/lib.rs
@@ -91,6 +91,9 @@ mod refresh;
 mod session;
 pub mod storage;
 
+#[cfg(test)]
+mod test_util;
+
 pub use plugin::{auth_plugin, predicate_guard, AuthPluginBuilder, DEFAULT_RETURN_TO_PARAM};
 pub use refresh::{TokenRefresh, TokenRefreshFuture};
 pub use session::{active_principal, active_session, AuthSession};
@@ -229,17 +232,33 @@ impl FetchMiddleware for BearerMiddleware {
                 if refresh::current_refresh().is_some() {
                     match refresh::refresh_single_flight().await {
                         Ok(new_token) => {
-                            // `set_token` writes through to storage,
-                            // which (with cross-tab sync installed)
-                            // also propagates the new token to peer
-                            // tabs on their next storage read.
-                            set_token(new_token.as_str());
-                            let mut retry = request;
-                            retry.set_header(
-                                "authorization",
-                                format!("Bearer {}", new_token.as_str()),
-                            );
-                            next.run(retry).await
+                            // Identity-change fence on the WRITE side.
+                            // If the user signed out (or signed in as a
+                            // different identity) during the refresh,
+                            // the epoch advanced. Writing `new_token`
+                            // would re-pollute the cleared slot with a
+                            // valid bearer the user no longer has any
+                            // intent to use. Drop the result here; the
+                            // outer fence below handles the response
+                            // side, but it can't undo a token-slot
+                            // write — only this gate can.
+                            let still_valid =
+                                session::active_session().map(|s| s.epoch()) == captured_epoch;
+                            if still_valid {
+                                // `set_token` writes through to storage,
+                                // which (with cross-tab sync installed)
+                                // also propagates the new token to peer
+                                // tabs on their next storage read.
+                                set_token(new_token.as_str());
+                                let mut retry = request;
+                                retry.set_header(
+                                    "authorization",
+                                    format!("Bearer {}", new_token.as_str()),
+                                );
+                                next.run(retry).await
+                            } else {
+                                Err(ServerError::unauthorized("session_changed"))
+                            }
                         }
                         Err(err) => Err((*err).clone()),
                     }
@@ -309,16 +328,15 @@ pub fn install() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_util::{block_on, noop_waker, yield_once};
     use pocopine_auth::{AuthUser, Principal};
     use pocopine_core::fetch::{
         __reset_middleware_chain_for_test, freeze_middleware_chain, FetchResponse,
     };
     use std::cell::RefCell;
     use std::future::Future;
-    use std::pin::Pin;
     use std::rc::Rc;
-    use std::sync::Arc;
-    use std::task::{Context, Poll, Wake, Waker};
+    use std::task::{Context, Poll};
 
     // The token store, INSTALLED flag, and `pocopine_core::fetch`
     // chain are all process- or thread-local globals. Serialize all
@@ -410,25 +428,6 @@ mod tests {
     }
 
     // ─── BearerMiddleware ───────────────────────────────────────────
-
-    /// Synchronous block_on for tests. The chain returns immediately
-    /// (no real network), so a single poll-loop is sufficient.
-    fn block_on<F: Future>(future: F) -> F::Output {
-        struct NoopWake;
-        impl Wake for NoopWake {
-            fn wake(self: Arc<Self>) {}
-            fn wake_by_ref(self: &Arc<Self>) {}
-        }
-        let waker: Waker = Arc::new(NoopWake).into();
-        let mut cx = Context::from_waker(&waker);
-        let mut fut = Box::pin(future);
-        loop {
-            match Pin::new(&mut fut).as_mut().poll(&mut cx) {
-                Poll::Ready(v) => return v,
-                Poll::Pending => continue,
-            }
-        }
-    }
 
     /// Drive a `pocopine_core::fetch::call::<(), ()>("/probe", &())`
     /// through the chain and return the request the trailing capture
@@ -926,6 +925,70 @@ mod tests {
     }
 
     #[test]
+    fn refresh_does_not_pollute_token_slot_after_signout_during_flight() {
+        // P1 scenario: user calls sign_out() while a refresh is in
+        // flight. Refresh resolves with a fresh token; the middleware
+        // must NOT write that token to the slot — otherwise the
+        // signed-out user has a valid bearer for the next request.
+        let _guard = lock_serial();
+        full_reset_with_session();
+
+        let session = AuthSession::new();
+        session.set_principal(Principal::from_user(AuthUser::new("u1")));
+        install_session_for_test(session.clone());
+        set_token("stale");
+        install();
+
+        // Refresh that mutates session epoch (simulating sign-out
+        // arriving while refresh is in flight) before returning the
+        // new token.
+        let session_for_refresh = session.clone();
+        refresh::set_refresh(Rc::new(move || {
+            let s = session_for_refresh.clone();
+            async move {
+                // Sign-out happens while we wait for the issuer.
+                s.set_principal(Principal::anonymous());
+                Ok("would-be-leaked".to_string())
+            }
+        }));
+
+        // 401 then 200 (so a successful retry would happen if the
+        // middleware didn't gate on epoch).
+        let chain_calls = Rc::new(std::cell::Cell::new(0));
+        install_401_then_ok_n_times(chain_calls.clone());
+
+        let result = block_on(pocopine_core::fetch::call_replay_safe::<(), ()>(
+            "/probe",
+            &(),
+        ));
+
+        match result {
+            Err(ServerError::Unauthorized(msg)) => {
+                assert!(
+                    msg.contains("session_changed") || msg.contains("session"),
+                    "unexpected reason: {msg}"
+                );
+            }
+            other => panic!("expected Unauthorized session_changed, got {other:?}"),
+        }
+        // Token slot must NOT contain the leaked token. The pre-refresh
+        // value ("stale") is fine; the leaked value ("would-be-leaked")
+        // is not. Either is acceptable as long as we didn't write the
+        // refreshed bearer post-signout.
+        let token = active_token();
+        assert_ne!(
+            token.as_deref(),
+            Some("would-be-leaked"),
+            "refresh post-signout must not pollute the token slot"
+        );
+        // The replay must NOT have happened either (chain saw the 401
+        // only).
+        assert_eq!(chain_calls.get(), 1, "replay must not run after signout");
+
+        full_reset_with_session();
+    }
+
+    #[test]
     fn aborted_refresh_unblocks_waiters_with_error() {
         // Drive refresh_single_flight directly. First caller drops
         // its future before the refresh resolves — second caller
@@ -943,7 +1006,7 @@ mod tests {
             async move {
                 if !yielded.get() {
                     yielded.set(true);
-                    futures_yield_once().await;
+                    yield_once().await;
                 }
                 Ok("never-reached".to_string())
             }
@@ -951,25 +1014,13 @@ mod tests {
 
         // Driver
         let mut driver = Box::pin(refresh::refresh_single_flight());
-        // Poll once → Pending (yields inside refresh).
-        struct NoopWake;
-        impl std::task::Wake for NoopWake {
-            fn wake(self: std::sync::Arc<Self>) {}
-            fn wake_by_ref(self: &std::sync::Arc<Self>) {}
-        }
-        let waker: std::task::Waker = std::sync::Arc::new(NoopWake).into();
-        let mut cx = std::task::Context::from_waker(&waker);
-        assert!(matches!(
-            driver.as_mut().poll(&mut cx),
-            std::task::Poll::Pending
-        ));
+        let waker = noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        assert!(matches!(driver.as_mut().poll(&mut cx), Poll::Pending));
 
         // Spawn a waiter while the driver is still pending.
         let mut waiter = Box::pin(refresh::refresh_single_flight());
-        assert!(matches!(
-            waiter.as_mut().poll(&mut cx),
-            std::task::Poll::Pending
-        ));
+        assert!(matches!(waiter.as_mut().poll(&mut cx), Poll::Pending));
 
         // Drop the driver — its ClearOnDrop guard publishes a
         // synthetic error and clears IN_FLIGHT. The waiter must
@@ -977,7 +1028,7 @@ mod tests {
         drop(driver);
 
         match waiter.as_mut().poll(&mut cx) {
-            std::task::Poll::Ready(Err(e)) => match &*e {
+            Poll::Ready(Err(e)) => match &*e {
                 ServerError::Unauthorized(msg) => {
                     assert!(msg.contains("aborted"), "unexpected reason: {msg}");
                 }
@@ -987,27 +1038,5 @@ mod tests {
         }
 
         full_reset();
-    }
-
-    /// Yields control once. Used to introduce an await point so the
-    /// caller can drop the future before completion.
-    async fn futures_yield_once() {
-        struct YieldOnce(bool);
-        impl Future for YieldOnce {
-            type Output = ();
-            fn poll(
-                mut self: Pin<&mut Self>,
-                cx: &mut std::task::Context<'_>,
-            ) -> std::task::Poll<()> {
-                if self.0 {
-                    std::task::Poll::Ready(())
-                } else {
-                    self.0 = true;
-                    cx.waker().wake_by_ref();
-                    std::task::Poll::Pending
-                }
-            }
-        }
-        YieldOnce(false).await
     }
 }

--- a/crates/pocopine-auth-client/src/plugin.rs
+++ b/crates/pocopine-auth-client/src/plugin.rs
@@ -201,6 +201,21 @@ impl AppPlugin for AuthPluginBuilder {
     }
 
     fn install(self, app: App) -> App {
+        // Cross-tab sync requires storage to read the new credential
+        // when peer tabs receive a broadcast — without it, peer tabs
+        // bump their epoch but have no way to learn the new token,
+        // and their bearer middleware keeps using the stale value.
+        // Fail loudly at install time rather than ship a broken UX
+        // that only surfaces under the sign-in-on-tab-A scenario.
+        if self.cross_tab_sync && self.token_storage.is_none() {
+            panic!(
+                "auth_plugin: with_cross_tab_sync(true) requires \
+                 with_token_storage(...) — peer tabs read the new \
+                 credential from shared storage. Without storage, \
+                 they bump epoch but keep using the stale token."
+            );
+        }
+
         // Storage first: hydrate the token slot before middleware
         // runs so the very first outgoing request carries a persisted
         // credential.
@@ -414,6 +429,31 @@ mod tests {
         assert_eq!(plugin.return_to_query_param, "next");
         assert!(plugin.install_bearer_middleware);
         assert!(plugin.token_refresh.is_some());
+    }
+
+    #[test]
+    #[should_panic(expected = "with_cross_tab_sync(true) requires with_token_storage")]
+    fn cross_tab_without_storage_panics_at_install() {
+        // P2: without storage, cross-tab broadcast can't tell peer
+        // tabs what the new token is. Fail at install time.
+        use pocopine_core::App;
+        let plugin = auth_plugin().with_cross_tab_sync(true);
+        let _ = AppPlugin::install(plugin, App::new());
+    }
+
+    #[test]
+    fn cross_tab_with_storage_installs_cleanly() {
+        use pocopine_core::App;
+        // Stand-up storage (using a test impl) and cross-tab; install
+        // should not panic. We can't observe the cross-tab channel on
+        // host (it's wasm-only), but the install path itself is safe.
+        crate::storage::__reset_storage_for_test();
+        let plugin = auth_plugin()
+            .with_token_storage(crate::storage::TestStorage::default())
+            .with_cross_tab_sync(true);
+        // Install consumes self; we just need to confirm no panic.
+        let _ = AppPlugin::install(plugin, App::new());
+        crate::storage::__reset_storage_for_test();
     }
 
     #[test]

--- a/crates/pocopine-auth-client/src/plugin.rs
+++ b/crates/pocopine-auth-client/src/plugin.rs
@@ -30,6 +30,7 @@ use pocopine_core::{
 
 use crate::refresh::{set_refresh, TokenRefresh};
 use crate::session::{active_principal, AuthSession};
+use crate::storage::{install_storage, TokenStorage};
 
 /// Default query parameter name used for the post-login redirect
 /// intent. Configurable per-app via
@@ -62,6 +63,8 @@ pub struct AuthPluginBuilder {
     return_to_query_param: &'static str,
     install_bearer_middleware: bool,
     token_refresh: Option<Rc<dyn TokenRefresh>>,
+    token_storage: Option<Rc<dyn TokenStorage>>,
+    cross_tab_sync: bool,
 }
 
 impl Default for AuthPluginBuilder {
@@ -71,6 +74,8 @@ impl Default for AuthPluginBuilder {
             return_to_query_param: DEFAULT_RETURN_TO_PARAM,
             install_bearer_middleware: false,
             token_refresh: None,
+            token_storage: None,
+            cross_tab_sync: false,
         }
     }
 }
@@ -136,6 +141,58 @@ impl AuthPluginBuilder {
         self.token_refresh = Some(Rc::new(refresh));
         self
     }
+
+    /// Persist the bearer token through the supplied [`TokenStorage`]
+    /// implementation. Without this, the token slot is in-memory only
+    /// and a page reload signs the user out.
+    ///
+    /// At plugin install time the token slot is hydrated from the
+    /// storage's [`TokenStorage::load`] so a returning user picks up
+    /// where they left off. Subsequent [`crate::set_token`] /
+    /// [`crate::clear_token`] calls write through automatically.
+    ///
+    /// ```ignore
+    /// auth_plugin()
+    ///     .with_token_storage(
+    ///         pocopine_auth_client::storage::LocalStorage::new("auth_token"),
+    ///     )
+    /// ```
+    ///
+    /// **Security tradeoff.** Persisting access tokens in
+    /// JavaScript-readable storage means an XSS vulnerability can
+    /// steal them. For high-value applications, prefer an `httpOnly`
+    /// cookie issued by the server (the bearer middleware then doesn't
+    /// need a token slot at all). See [`crate::storage`] for the full
+    /// rundown.
+    pub fn with_token_storage<S: TokenStorage>(mut self, storage: S) -> Self {
+        self.token_storage = Some(Rc::new(storage));
+        self
+    }
+
+    /// Sync sign-in / sign-out across tabs of the same origin via a
+    /// `BroadcastChannel`. Off by default.
+    ///
+    /// When enabled, calls to [`AuthSession::set_principal`],
+    /// [`AuthSession::sign_in`], [`AuthSession::sign_out`] (and any
+    /// app code that goes through `set_principal`) post a message to
+    /// the channel. Other tabs of the same origin running this app
+    /// receive it and:
+    /// 1. Re-load the token from the configured [`TokenStorage`].
+    /// 2. Bump the local [`AuthSession`]'s epoch so the bearer
+    ///    middleware fences any in-flight responses captured under
+    ///    the previous identity.
+    ///
+    /// **Requires [`with_token_storage`](Self::with_token_storage)** for
+    /// the peer tab to read the new credential — otherwise the peer
+    /// just bumps its epoch with no way to learn the new token.
+    /// Combine the two for end-to-end coordination.
+    ///
+    /// See [`crate::cross_tab`] for the full description and security
+    /// considerations.
+    pub fn with_cross_tab_sync(mut self, enabled: bool) -> Self {
+        self.cross_tab_sync = enabled;
+        self
+    }
 }
 
 impl AppPlugin for AuthPluginBuilder {
@@ -144,6 +201,13 @@ impl AppPlugin for AuthPluginBuilder {
     }
 
     fn install(self, app: App) -> App {
+        // Storage first: hydrate the token slot before middleware
+        // runs so the very first outgoing request carries a persisted
+        // credential.
+        if let Some(storage) = self.token_storage {
+            install_storage(storage);
+            crate::hydrate_from_storage();
+        }
         if self.install_bearer_middleware {
             crate::install();
         }
@@ -152,6 +216,9 @@ impl AppPlugin for AuthPluginBuilder {
         }
 
         let session = AuthSession::new();
+        if self.cross_tab_sync {
+            crate::cross_tab::install(session.clone());
+        }
         let login_route = self.login_route;
         let param = self.return_to_query_param;
 

--- a/crates/pocopine-auth-client/src/plugin.rs
+++ b/crates/pocopine-auth-client/src/plugin.rs
@@ -201,12 +201,6 @@ impl AppPlugin for AuthPluginBuilder {
     }
 
     fn install(self, app: App) -> App {
-        // Cross-tab sync requires storage to read the new credential
-        // when peer tabs receive a broadcast — without it, peer tabs
-        // bump their epoch but have no way to learn the new token,
-        // and their bearer middleware keeps using the stale value.
-        // Fail loudly at install time rather than ship a broken UX
-        // that only surfaces under the sign-in-on-tab-A scenario.
         if self.cross_tab_sync && self.token_storage.is_none() {
             panic!(
                 "auth_plugin: with_cross_tab_sync(true) requires \
@@ -216,9 +210,8 @@ impl AppPlugin for AuthPluginBuilder {
             );
         }
 
-        // Storage first: hydrate the token slot before middleware
-        // runs so the very first outgoing request carries a persisted
-        // credential.
+        // Hydrate before middleware so the first outgoing request
+        // carries a persisted credential.
         if let Some(storage) = self.token_storage {
             install_storage(storage);
             crate::hydrate_from_storage();

--- a/crates/pocopine-auth-client/src/refresh.rs
+++ b/crates/pocopine-auth-client/src/refresh.rs
@@ -85,9 +85,7 @@ pub fn __reset_refresh_for_test() {
 
 // ─── Single-flight coordinator ──────────────────────────────────────
 
-/// Shared outcome cell for the in-flight refresh. Result is wrapped in
-/// `Rc` so all waiters get a cheap clone instead of duplicating either
-/// the token string or the `ServerError`.
+/// `Rc`-wrapped so all waiters share one allocation per outcome.
 struct RefreshSlot {
     result: RefCell<Option<Result<Rc<String>, Rc<ServerError>>>>,
     wakers: RefCell<Vec<Waker>>,
@@ -108,10 +106,8 @@ pub(crate) async fn refresh_single_flight() -> Result<Rc<String>, Rc<ServerError
     });
     IN_FLIGHT.with(|cell| *cell.borrow_mut() = Some(slot.clone()));
 
-    // RAII guard: clears the in-flight slot on every exit path,
-    // including the case where the driver future is dropped before
-    // `refresh.refresh().await` resolves. Without this, peer waiters
-    // would hang on a never-published slot.
+    // RAII so a driver dropped mid-await still publishes to waiters
+    // (otherwise they hang forever).
     let _guard = ClearOnDrop { slot: slot.clone() };
 
     let result = match current_refresh() {
@@ -149,12 +145,9 @@ impl Future for SlotWait {
     }
 }
 
-/// Clear the in-flight slot on Drop and, if no result was ever
-/// published, surface a synthetic error to waiters so they don't
-/// hang. Drops happen on:
-/// 1. Normal completion (after `publish` set the result).
-/// 2. The driving future being cancelled mid-await.
-/// 3. A panic in `refresh.refresh()`.
+/// On Drop: clear `IN_FLIGHT` and, if nothing was published yet,
+/// publish a synthetic error so waiters don't hang on a cancelled
+/// or panicked driver.
 struct ClearOnDrop {
     slot: Rc<RefreshSlot>,
 }
@@ -169,8 +162,8 @@ impl Drop for ClearOnDrop {
             );
         }
         IN_FLIGHT.with(|cell| {
-            // Only clear if the cell still points at our slot — a
-            // re-entrant test reset may have already cleared it.
+            // Don't clobber a successor slot if a test reset or a
+            // later driver already replaced ours.
             let mut cell = cell.borrow_mut();
             let same = cell
                 .as_ref()
@@ -290,10 +283,6 @@ mod tests {
     impl<A: Future, B: Future> Future for Join<A, B> {
         type Output = (A::Output, B::Output);
         fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-            // `Self: Unpin` (declared below), so `Pin::get_mut` is the
-            // safe API. The inner futures are `Pin<Box<F>>` and
-            // remain individually pinned regardless of how we treat
-            // `Self`.
             let this = self.get_mut();
             if this.a_out.is_none() {
                 if let Some(fut) = this.a.as_mut() {

--- a/crates/pocopine-auth-client/src/refresh.rs
+++ b/crates/pocopine-auth-client/src/refresh.rs
@@ -2,23 +2,28 @@
 //! outgoing `#[server]` call returns [`ServerError::Unauthorized`] for a
 //! request the client marked replay-safe (`#[server(idempotent)]`).
 //!
-//! The contract is provider-agnostic: pocopine doesn't know how Firebase,
-//! Clerk, or your own JWT issuer mints fresh credentials. Apps install a
-//! refresh implementation through
+//! The contract is provider-agnostic: pocopine doesn't know how
+//! Firebase, Clerk, or your own JWT issuer mints fresh credentials.
+//! Apps install a refresh implementation through
 //! [`crate::AuthPluginBuilder::with_token_refresh`] and the middleware
-//! invokes it on demand, calling [`crate::set_token`] with the fresh value
-//! before replaying once. If no refresh is configured the middleware
-//! propagates `Unauthorized` unchanged — fail-closed per RFC-078 §5.10.4.
+//! invokes it on demand, calling [`crate::set_token`] with the fresh
+//! value before replaying once. If no refresh is configured the
+//! middleware propagates `Unauthorized` unchanged — fail-closed per
+//! RFC-078 §5.10.4.
 //!
 //! ## Single-flight
 //!
-//! The current implementation runs **at most one replay per failed
-//! request**, but does *not* deduplicate concurrent refreshes across
-//! parallel in-flight requests: if requests A and B both 401 while a
-//! refresh is in flight, B can start a second refresh. Single-flight
-//! coordination (one shared refresh future per stale-token window) is a
-//! follow-up — the wasm runtime is single-threaded so the practical
-//! impact is bounded, but a coordinator avoids hammering the issuer.
+//! Concurrent in-flight requests that all 401 used to each fire an
+//! independent refresh, hammering the issuer. The middleware now
+//! routes every refresh request through [`refresh_single_flight`]:
+//! the first caller drives the refresh future to completion; peers
+//! that arrive while it's in flight wait on the same outcome.
+//! Resolution wakes all waiters and clears the slot for the next
+//! refresh window.
+//!
+//! Wasm is single-threaded, so "concurrent" means "interleaved via
+//! `.await`". The coordinator is `Rc<RefCell<…>>`-backed (no atomics
+//! needed) and is correct for that execution model.
 //!
 //! [`ServerError::Unauthorized`]: pocopine_core::ServerError::Unauthorized
 
@@ -26,6 +31,7 @@ use std::cell::RefCell;
 use std::future::Future;
 use std::pin::Pin;
 use std::rc::Rc;
+use std::task::{Context, Poll, Waker};
 
 use pocopine_core::ServerError;
 
@@ -56,6 +62,7 @@ where
 
 thread_local! {
     static REFRESH: RefCell<Option<Rc<dyn TokenRefresh>>> = const { RefCell::new(None) };
+    static IN_FLIGHT: RefCell<Option<Rc<RefreshSlot>>> = const { RefCell::new(None) };
 }
 
 /// Register the active token-refresh implementation. Called from
@@ -73,11 +80,114 @@ pub(crate) fn current_refresh() -> Option<Rc<dyn TokenRefresh>> {
 #[doc(hidden)]
 pub fn __reset_refresh_for_test() {
     REFRESH.with(|cell| *cell.borrow_mut() = None);
+    IN_FLIGHT.with(|cell| *cell.borrow_mut() = None);
+}
+
+// ─── Single-flight coordinator ──────────────────────────────────────
+
+/// Shared outcome cell for the in-flight refresh. Result is wrapped in
+/// `Rc` so all waiters get a cheap clone instead of duplicating either
+/// the token string or the `ServerError`.
+struct RefreshSlot {
+    result: RefCell<Option<Result<Rc<String>, Rc<ServerError>>>>,
+    wakers: RefCell<Vec<Waker>>,
+}
+
+/// Run the configured `TokenRefresh` if one is installed; if a refresh
+/// is already in flight on this thread, await its outcome instead of
+/// starting a new one. All concurrent callers receive the same shared
+/// `Result<Rc<String>, Rc<ServerError>>`.
+pub(crate) async fn refresh_single_flight() -> Result<Rc<String>, Rc<ServerError>> {
+    if let Some(slot) = IN_FLIGHT.with(|cell| cell.borrow().clone()) {
+        return SlotWait { slot }.await;
+    }
+
+    let slot = Rc::new(RefreshSlot {
+        result: RefCell::new(None),
+        wakers: RefCell::new(Vec::new()),
+    });
+    IN_FLIGHT.with(|cell| *cell.borrow_mut() = Some(slot.clone()));
+
+    // RAII guard: clears the in-flight slot on every exit path,
+    // including the case where the driver future is dropped before
+    // `refresh.refresh().await` resolves. Without this, peer waiters
+    // would hang on a never-published slot.
+    let _guard = ClearOnDrop { slot: slot.clone() };
+
+    let result = match current_refresh() {
+        Some(r) => r.refresh().await.map(Rc::new).map_err(Rc::new),
+        None => Err(Rc::new(ServerError::unauthorized(
+            "no token refresh configured",
+        ))),
+    };
+
+    publish(&slot, result.clone());
+    result
+}
+
+fn publish(slot: &Rc<RefreshSlot>, result: Result<Rc<String>, Rc<ServerError>>) {
+    *slot.result.borrow_mut() = Some(result);
+    let wakers: Vec<_> = slot.wakers.borrow_mut().drain(..).collect();
+    for w in wakers {
+        w.wake();
+    }
+}
+
+struct SlotWait {
+    slot: Rc<RefreshSlot>,
+}
+
+impl Future for SlotWait {
+    type Output = Result<Rc<String>, Rc<ServerError>>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        if let Some(result) = self.slot.result.borrow().clone() {
+            return Poll::Ready(result);
+        }
+        self.slot.wakers.borrow_mut().push(cx.waker().clone());
+        Poll::Pending
+    }
+}
+
+/// Clear the in-flight slot on Drop and, if no result was ever
+/// published, surface a synthetic error to waiters so they don't
+/// hang. Drops happen on:
+/// 1. Normal completion (after `publish` set the result).
+/// 2. The driving future being cancelled mid-await.
+/// 3. A panic in `refresh.refresh()`.
+struct ClearOnDrop {
+    slot: Rc<RefreshSlot>,
+}
+
+impl Drop for ClearOnDrop {
+    fn drop(&mut self) {
+        let unpublished = self.slot.result.borrow().is_none();
+        if unpublished {
+            publish(
+                &self.slot,
+                Err(Rc::new(ServerError::unauthorized("refresh aborted"))),
+            );
+        }
+        IN_FLIGHT.with(|cell| {
+            // Only clear if the cell still points at our slot — a
+            // re-entrant test reset may have already cleared it.
+            let mut cell = cell.borrow_mut();
+            let same = cell
+                .as_ref()
+                .map(|in_flight| Rc::ptr_eq(in_flight, &self.slot))
+                .unwrap_or(false);
+            if same {
+                *cell = None;
+            }
+        });
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
+    use std::task::{Wake, Waker};
 
     #[test]
     fn closure_blanket_impl_drives_through_trait_object() {
@@ -94,19 +204,101 @@ mod tests {
         assert!(matches!(result, Err(ServerError::Unauthorized(_))));
     }
 
-    /// Minimal block_on: spin-poll a `Pin<Box<dyn Future>>` until it
-    /// resolves. Adequate because the futures here never yield to a
-    /// runtime — they resolve on the first poll.
-    fn block_on<T>(mut fut: Pin<Box<dyn Future<Output = T>>>) -> T {
-        use std::sync::Arc;
-        use std::task::{Context, Poll, Wake, Waker};
+    #[test]
+    fn single_flight_dedupes_concurrent_callers() {
+        __reset_refresh_for_test();
+
+        // Refresh yields once before resolving so the second caller
+        // can enter `refresh_single_flight` while the first is still
+        // in-flight. Without the yield, refresh would resolve
+        // synchronously and the second caller would arrive after the
+        // slot was already cleared — a meaningless test.
+        let count: Rc<std::cell::Cell<usize>> = Rc::new(std::cell::Cell::new(0));
+        let count_inner = count.clone();
+        set_refresh(Rc::new(move || {
+            let count = count_inner.clone();
+            async move {
+                yield_once().await;
+                count.set(count.get() + 1);
+                Ok("shared-fresh".to_string())
+            }
+        }));
+
+        let f1 = Box::pin(refresh_single_flight());
+        let f2 = Box::pin(refresh_single_flight());
+
+        let pair = Box::pin(join(f1, f2));
+        let (r1, r2) = block_on_unpin(pair);
+
+        assert_eq!(count.get(), 1, "single-flight must coalesce");
+        let r1 = r1.expect("first caller resolved Err");
+        let r2 = r2.expect("second caller resolved Err");
+        assert_eq!(&*r1, "shared-fresh");
+        assert_eq!(&*r2, "shared-fresh");
+        assert!(
+            Rc::ptr_eq(&r1, &r2),
+            "both waiters must share the same Rc<String>"
+        );
+
+        __reset_refresh_for_test();
+    }
+
+    /// Future that returns Pending once, schedules its own waker,
+    /// then resolves on the next poll.
+    async fn yield_once() {
+        struct YieldOnce(bool);
+        impl Future for YieldOnce {
+            type Output = ();
+            fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+                if self.0 {
+                    Poll::Ready(())
+                } else {
+                    self.0 = true;
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                }
+            }
+        }
+        YieldOnce(false).await
+    }
+
+    #[test]
+    fn single_flight_releases_after_completion() {
+        __reset_refresh_for_test();
+
+        let count: Rc<std::cell::Cell<usize>> = Rc::new(std::cell::Cell::new(0));
+        let count_inner = count.clone();
+        set_refresh(Rc::new(move || {
+            let count = count_inner.clone();
+            async move {
+                count.set(count.get() + 1);
+                Ok("ok".to_string())
+            }
+        }));
+
+        let _ = block_on(refresh_single_flight());
+        let _ = block_on(refresh_single_flight());
+        assert_eq!(count.get(), 2, "second call must start a new refresh");
+
+        __reset_refresh_for_test();
+    }
+
+    #[test]
+    fn no_refresh_configured_yields_unauthorized() {
+        __reset_refresh_for_test();
+        let result = block_on(refresh_single_flight());
+        assert!(matches!(result, Err(e) if matches!(*e, ServerError::Unauthorized(_))));
+    }
+
+    fn block_on<F: Future>(fut: F) -> F::Output {
         struct NoopWake;
         impl Wake for NoopWake {
             fn wake(self: Arc<Self>) {}
             fn wake_by_ref(self: &Arc<Self>) {}
         }
         let waker: Waker = Arc::new(NoopWake).into();
-        let mut cx = Context::from_waker(&waker);
+        let mut cx = std::task::Context::from_waker(&waker);
+        let mut fut = Box::pin(fut);
         loop {
             match fut.as_mut().poll(&mut cx) {
                 Poll::Ready(v) => return v,
@@ -114,4 +306,73 @@ mod tests {
             }
         }
     }
+
+    fn block_on_unpin<F: Future + Unpin>(mut fut: F) -> F::Output {
+        struct NoopWake;
+        impl Wake for NoopWake {
+            fn wake(self: Arc<Self>) {}
+            fn wake_by_ref(self: &Arc<Self>) {}
+        }
+        let waker: Waker = Arc::new(NoopWake).into();
+        let mut cx = std::task::Context::from_waker(&waker);
+        loop {
+            match Pin::new(&mut fut).poll(&mut cx) {
+                Poll::Ready(v) => return v,
+                Poll::Pending => continue,
+            }
+        }
+    }
+
+    /// Hand-rolled join, avoids pulling `futures-util` just for tests.
+    struct Join<A: Future, B: Future> {
+        a: Option<Pin<Box<A>>>,
+        b: Option<Pin<Box<B>>>,
+        a_out: Option<A::Output>,
+        b_out: Option<B::Output>,
+    }
+
+    fn join<A: Future, B: Future>(a: Pin<Box<A>>, b: Pin<Box<B>>) -> Join<A, B> {
+        Join {
+            a: Some(a),
+            b: Some(b),
+            a_out: None,
+            b_out: None,
+        }
+    }
+
+    impl<A: Future, B: Future> Future for Join<A, B> {
+        type Output = (A::Output, B::Output);
+        fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            // Safety: we never move `self` out, and the inner Box<F>
+            // futures are individually pinned (Pin<Box<F>>). Treating
+            // `Self` as Unpin is sound for this aggregator.
+            let this = unsafe { self.get_unchecked_mut() };
+            if this.a_out.is_none() {
+                if let Some(fut) = this.a.as_mut() {
+                    if let Poll::Ready(v) = fut.as_mut().poll(cx) {
+                        this.a_out = Some(v);
+                        this.a = None;
+                    }
+                }
+            }
+            if this.b_out.is_none() {
+                if let Some(fut) = this.b.as_mut() {
+                    if let Poll::Ready(v) = fut.as_mut().poll(cx) {
+                        this.b_out = Some(v);
+                        this.b = None;
+                    }
+                }
+            }
+            match (this.a_out.take(), this.b_out.take()) {
+                (Some(a), Some(b)) => Poll::Ready((a, b)),
+                (a, b) => {
+                    this.a_out = a;
+                    this.b_out = b;
+                    Poll::Pending
+                }
+            }
+        }
+    }
+
+    impl<A: Future, B: Future> Unpin for Join<A, B> {}
 }

--- a/crates/pocopine-auth-client/src/refresh.rs
+++ b/crates/pocopine-auth-client/src/refresh.rs
@@ -186,8 +186,7 @@ impl Drop for ClearOnDrop {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::Arc;
-    use std::task::{Wake, Waker};
+    use crate::test_util::{block_on, block_on_unpin, yield_once};
 
     #[test]
     fn closure_blanket_impl_drives_through_trait_object() {
@@ -243,25 +242,6 @@ mod tests {
         __reset_refresh_for_test();
     }
 
-    /// Future that returns Pending once, schedules its own waker,
-    /// then resolves on the next poll.
-    async fn yield_once() {
-        struct YieldOnce(bool);
-        impl Future for YieldOnce {
-            type Output = ();
-            fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
-                if self.0 {
-                    Poll::Ready(())
-                } else {
-                    self.0 = true;
-                    cx.waker().wake_by_ref();
-                    Poll::Pending
-                }
-            }
-        }
-        YieldOnce(false).await
-    }
-
     #[test]
     fn single_flight_releases_after_completion() {
         __reset_refresh_for_test();
@@ -290,39 +270,6 @@ mod tests {
         assert!(matches!(result, Err(e) if matches!(*e, ServerError::Unauthorized(_))));
     }
 
-    fn block_on<F: Future>(fut: F) -> F::Output {
-        struct NoopWake;
-        impl Wake for NoopWake {
-            fn wake(self: Arc<Self>) {}
-            fn wake_by_ref(self: &Arc<Self>) {}
-        }
-        let waker: Waker = Arc::new(NoopWake).into();
-        let mut cx = std::task::Context::from_waker(&waker);
-        let mut fut = Box::pin(fut);
-        loop {
-            match fut.as_mut().poll(&mut cx) {
-                Poll::Ready(v) => return v,
-                Poll::Pending => continue,
-            }
-        }
-    }
-
-    fn block_on_unpin<F: Future + Unpin>(mut fut: F) -> F::Output {
-        struct NoopWake;
-        impl Wake for NoopWake {
-            fn wake(self: Arc<Self>) {}
-            fn wake_by_ref(self: &Arc<Self>) {}
-        }
-        let waker: Waker = Arc::new(NoopWake).into();
-        let mut cx = std::task::Context::from_waker(&waker);
-        loop {
-            match Pin::new(&mut fut).poll(&mut cx) {
-                Poll::Ready(v) => return v,
-                Poll::Pending => continue,
-            }
-        }
-    }
-
     /// Hand-rolled join, avoids pulling `futures-util` just for tests.
     struct Join<A: Future, B: Future> {
         a: Option<Pin<Box<A>>>,
@@ -343,10 +290,11 @@ mod tests {
     impl<A: Future, B: Future> Future for Join<A, B> {
         type Output = (A::Output, B::Output);
         fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-            // Safety: we never move `self` out, and the inner Box<F>
-            // futures are individually pinned (Pin<Box<F>>). Treating
-            // `Self` as Unpin is sound for this aggregator.
-            let this = unsafe { self.get_unchecked_mut() };
+            // `Self: Unpin` (declared below), so `Pin::get_mut` is the
+            // safe API. The inner futures are `Pin<Box<F>>` and
+            // remain individually pinned regardless of how we treat
+            // `Self`.
+            let this = self.get_mut();
             if this.a_out.is_none() {
                 if let Some(fut) = this.a.as_mut() {
                     if let Poll::Ready(v) = fut.as_mut().poll(cx) {

--- a/crates/pocopine-auth-client/src/session.rs
+++ b/crates/pocopine-auth-client/src/session.rs
@@ -56,10 +56,29 @@ impl AuthSession {
         self.inner.borrow().epoch
     }
 
-    /// Replace the active principal. Bumps the epoch.
+    /// Replace the active principal. Bumps the epoch and (when
+    /// cross-tab sync is installed via
+    /// [`crate::AuthPluginBuilder::with_cross_tab_sync`]) broadcasts
+    /// the change so peer tabs can re-hydrate.
     pub fn set_principal(&self, principal: Principal) {
+        {
+            let mut inner = self.inner.borrow_mut();
+            inner.principal = principal;
+            inner.epoch = inner.epoch.saturating_add(1);
+        }
+        crate::cross_tab::broadcast_session_changed();
+    }
+
+    /// Bump the epoch without changing the principal. Use this when
+    /// some external signal (websocket message, cross-tab broadcast,
+    /// iframe communication) tells you the session state has shifted
+    /// but you don't yet have a fresh `Principal` to publish. The
+    /// bearer middleware's identity-change fence reads the epoch, so
+    /// a bump alone is enough to drop in-flight responses captured
+    /// under the previous identity. Does NOT re-broadcast — call this
+    /// from inbound handlers without triggering a feedback loop.
+    pub fn bump_epoch(&self) {
         let mut inner = self.inner.borrow_mut();
-        inner.principal = principal;
         inner.epoch = inner.epoch.saturating_add(1);
     }
 
@@ -168,5 +187,17 @@ mod tests {
         a.set_principal(Principal::from_user(AuthUser::new("u1")));
         assert_eq!(a.epoch(), b.epoch());
         assert_eq!(a.principal(), b.principal());
+    }
+
+    #[test]
+    fn bump_epoch_advances_without_changing_principal() {
+        let session = AuthSession::new();
+        let user = AuthUser::new("u1");
+        session.set_principal(Principal::from_user(user.clone()));
+        let before = session.epoch();
+        let principal_before = session.principal();
+        session.bump_epoch();
+        assert_eq!(session.epoch(), before + 1);
+        assert_eq!(session.principal(), principal_before);
     }
 }

--- a/crates/pocopine-auth-client/src/storage.rs
+++ b/crates/pocopine-auth-client/src/storage.rs
@@ -1,0 +1,208 @@
+//! Pluggable bearer-token persistence.
+//!
+//! By default the token slot is in-memory only — page reloads sign the
+//! user out. Real apps persist the token through some browser surface
+//! (`localStorage`, `sessionStorage`, an `httpOnly` cookie set by the
+//! server, IndexedDB, …). Each option has tradeoffs around durability,
+//! cross-tab visibility, and XSS exposure.
+//!
+//! `pocopine-auth-client` ships [`InMemory`] (the no-op default) plus
+//! [`LocalStorage`] and [`SessionStorage`] for the two common
+//! browser-side patterns. Apps wire one in at boot:
+//!
+//! ```ignore
+//! auth_plugin()
+//!     .with_token_storage(pocopine_auth_client::storage::LocalStorage::new("auth_token"))
+//! ```
+//!
+//! ## Security
+//!
+//! Persisting access tokens in JavaScript-readable storage
+//! (`localStorage` / `sessionStorage`) means an XSS bug can steal them.
+//! For high-value applications, prefer an `httpOnly` cookie issued by
+//! the server (the bearer middleware then doesn't need a token slot at
+//! all — the browser sends the cookie automatically). The
+//! [`LocalStorage`] / [`SessionStorage`] impls are appropriate when
+//! that tradeoff is acceptable; document it for your app's threat
+//! model.
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+/// Persistence layer for the bearer token. Implementations talk to a
+/// browser storage surface (or, for tests, an in-memory mock).
+pub trait TokenStorage: 'static {
+    /// Read the persisted token. `None` if no token has been saved or
+    /// the underlying surface is unavailable.
+    fn load(&self) -> Option<String>;
+
+    /// Persist `token`, overwriting any previously-saved value.
+    fn save(&self, token: &str);
+
+    /// Drop the persisted token.
+    fn clear(&self);
+}
+
+thread_local! {
+    static STORAGE: RefCell<Option<Rc<dyn TokenStorage>>> = const { RefCell::new(None) };
+}
+
+pub(crate) fn install_storage(storage: Rc<dyn TokenStorage>) {
+    STORAGE.with(|s| *s.borrow_mut() = Some(storage));
+}
+
+pub(crate) fn current_storage() -> Option<Rc<dyn TokenStorage>> {
+    STORAGE.with(|s| s.borrow().clone())
+}
+
+#[doc(hidden)]
+pub fn __reset_storage_for_test() {
+    STORAGE.with(|s| *s.borrow_mut() = None);
+}
+
+// ─── In-memory default (no persistence) ─────────────────────────────
+
+/// No-op storage. Token lives only in the in-memory slot — page reload
+/// signs the user out. The default when no other storage is configured.
+#[derive(Default)]
+pub struct InMemory;
+
+impl TokenStorage for InMemory {
+    fn load(&self) -> Option<String> {
+        None
+    }
+    fn save(&self, _: &str) {}
+    fn clear(&self) {}
+}
+
+// ─── Browser-side localStorage / sessionStorage ─────────────────────
+
+/// Persist the token in `window.localStorage` under a configurable
+/// key. Survives page reload, browser restart, and is shared across
+/// tabs of the same origin (which the cross-tab broadcast feature
+/// relies on).
+#[cfg(target_arch = "wasm32")]
+pub struct LocalStorage {
+    key: String,
+}
+
+#[cfg(target_arch = "wasm32")]
+impl LocalStorage {
+    pub fn new(key: impl Into<String>) -> Self {
+        Self { key: key.into() }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl TokenStorage for LocalStorage {
+    fn load(&self) -> Option<String> {
+        let storage = web_sys::window()?.local_storage().ok()??;
+        storage.get_item(&self.key).ok()?
+    }
+
+    fn save(&self, token: &str) {
+        if let Some(window) = web_sys::window() {
+            if let Ok(Some(storage)) = window.local_storage() {
+                let _ = storage.set_item(&self.key, token);
+            }
+        }
+    }
+
+    fn clear(&self) {
+        if let Some(window) = web_sys::window() {
+            if let Ok(Some(storage)) = window.local_storage() {
+                let _ = storage.remove_item(&self.key);
+            }
+        }
+    }
+}
+
+/// Persist the token in `window.sessionStorage`. Survives navigation
+/// within a tab but is dropped when the tab closes; not shared across
+/// tabs. Use when "stay signed in across page reloads in this tab"
+/// is the right durability tradeoff.
+#[cfg(target_arch = "wasm32")]
+pub struct SessionStorage {
+    key: String,
+}
+
+#[cfg(target_arch = "wasm32")]
+impl SessionStorage {
+    pub fn new(key: impl Into<String>) -> Self {
+        Self { key: key.into() }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl TokenStorage for SessionStorage {
+    fn load(&self) -> Option<String> {
+        let storage = web_sys::window()?.session_storage().ok()??;
+        storage.get_item(&self.key).ok()?
+    }
+
+    fn save(&self, token: &str) {
+        if let Some(window) = web_sys::window() {
+            if let Ok(Some(storage)) = window.session_storage() {
+                let _ = storage.set_item(&self.key, token);
+            }
+        }
+    }
+
+    fn clear(&self) {
+        if let Some(window) = web_sys::window() {
+            if let Ok(Some(storage)) = window.session_storage() {
+                let _ = storage.remove_item(&self.key);
+            }
+        }
+    }
+}
+
+/// In-memory storage with observable state for host tests. Lives at
+/// the module top-level (not inside `mod tests`) so other test modules
+/// in the crate (`lib.rs`) can use it for write-through assertions.
+#[cfg(test)]
+#[derive(Default)]
+pub(crate) struct TestStorage {
+    pub(crate) saved: std::cell::RefCell<Option<String>>,
+}
+
+#[cfg(test)]
+impl TokenStorage for TestStorage {
+    fn load(&self) -> Option<String> {
+        self.saved.borrow().clone()
+    }
+    fn save(&self, token: &str) {
+        *self.saved.borrow_mut() = Some(token.to_string());
+    }
+    fn clear(&self) {
+        *self.saved.borrow_mut() = None;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn in_memory_storage_is_a_no_op() {
+        let storage = InMemory;
+        storage.save("hello");
+        assert_eq!(storage.load(), None);
+        storage.clear();
+        assert_eq!(storage.load(), None);
+    }
+
+    #[test]
+    fn install_and_read_back_through_thread_local() {
+        __reset_storage_for_test();
+        let test = Rc::new(TestStorage::default());
+        install_storage(test.clone());
+        let storage = current_storage().expect("installed storage missing");
+        storage.save("xyz");
+        assert_eq!(test.saved.borrow().as_deref(), Some("xyz"));
+        assert_eq!(storage.load().as_deref(), Some("xyz"));
+        storage.clear();
+        assert_eq!(test.saved.borrow().as_deref(), None);
+        __reset_storage_for_test();
+    }
+}

--- a/crates/pocopine-auth-client/src/test_util.rs
+++ b/crates/pocopine-auth-client/src/test_util.rs
@@ -1,0 +1,70 @@
+//! Crate-private test helpers shared across module tests. Compiled
+//! only under `#[cfg(test)]`.
+
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll, Wake, Waker};
+
+struct NoopWake;
+impl Wake for NoopWake {
+    fn wake(self: Arc<Self>) {}
+    fn wake_by_ref(self: &Arc<Self>) {}
+}
+
+/// Public for tests that need to manually poll a future (e.g.,
+/// drop-mid-await scenarios) rather than using the `block_on`
+/// convenience.
+pub(crate) fn noop_waker() -> Waker {
+    Arc::new(NoopWake).into()
+}
+
+/// Spin-poll any `Future` to completion. Adequate because the
+/// futures driven by these tests don't bind a real runtime — they
+/// either resolve synchronously or schedule their own waker via
+/// [`yield_once`].
+pub(crate) fn block_on<F: Future>(fut: F) -> F::Output {
+    let waker = noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    let mut fut = Box::pin(fut);
+    loop {
+        match fut.as_mut().poll(&mut cx) {
+            Poll::Ready(v) => return v,
+            Poll::Pending => continue,
+        }
+    }
+}
+
+/// Like [`block_on`] but for already-`Unpin` futures (e.g., a
+/// `Pin<Box<F>>` aggregator) that you want to poll without a
+/// double-Box.
+pub(crate) fn block_on_unpin<F: Future + Unpin>(mut fut: F) -> F::Output {
+    let waker = noop_waker();
+    let mut cx = Context::from_waker(&waker);
+    loop {
+        match Pin::new(&mut fut).poll(&mut cx) {
+            Poll::Ready(v) => return v,
+            Poll::Pending => continue,
+        }
+    }
+}
+
+/// Future that returns `Pending` once, schedules its own waker, and
+/// resolves on the next poll. Use to introduce a real `.await` point
+/// in synthetic test futures so concurrent callers can interleave.
+pub(crate) async fn yield_once() {
+    struct YieldOnce(bool);
+    impl Future for YieldOnce {
+        type Output = ();
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+            if self.0 {
+                Poll::Ready(())
+            } else {
+                self.0 = true;
+                cx.waker().wake_by_ref();
+                Poll::Pending
+            }
+        }
+    }
+    YieldOnce(false).await
+}

--- a/crates/pocopine-auth-client/tests/cross_tab_wasm.rs
+++ b/crates/pocopine-auth-client/tests/cross_tab_wasm.rs
@@ -23,20 +23,13 @@ use web_sys::BroadcastChannel;
 
 wasm_bindgen_test_configure!(run_in_browser);
 
-/// Yield through the task queue (NOT the microtask queue):
-/// `BroadcastChannel` `MessageEvent` delivery is dispatched as a
-/// task, so awaiting `Promise.resolve()` (which fires on the
-/// microtask queue) is too eager — the listener hasn't run yet by
-/// the time we resume. Schedule resolution via `setTimeout(0)`
-/// instead so the test continuation lands AFTER pending message
-/// tasks.
+/// Yield through the task queue. `MessageEvent` delivery is a task,
+/// not a microtask, so `Promise.resolve()` resumes too eagerly.
 async fn next_task() {
     let promise = Promise::new(&mut |resolve, _reject| {
         if let Some(window) = web_sys::window() {
             let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, 0);
         } else {
-            // No window — just resolve immediately (test will likely
-            // fail downstream, which is the right signal).
             let _ = resolve.call0(&JsValue::UNDEFINED);
         }
     });
@@ -50,30 +43,22 @@ async fn settle() {
 
 #[wasm_bindgen_test(async)]
 async fn outbound_post_triggers_inbound_listener_in_peer() {
-    // Fresh state.
     cross_tab::__teardown_for_test();
     pocopine_auth_client::storage::__reset_storage_for_test();
 
     let session = AuthSession::new();
     let initial_epoch = session.epoch();
     cross_tab::__install_for_test(session.clone());
-
-    // Yield once after install so Firefox finishes wiring the
-    // listener before we post.
     next_task().await;
 
-    // Origin channel — distinct from the framework's, but on the
-    // same name, so its posts are delivered to the framework's
-    // listener.
     let origin =
         BroadcastChannel::new("pocopine-auth").expect("BroadcastChannel must be available");
     origin
         .post_message(&JsValue::from_str("session_changed"))
         .expect("post_message must succeed");
 
-    // Give the browser plenty of task cycles to deliver and run the
-    // listener — different browsers schedule MessageEvents
-    // differently.
+    // Bounded retry — different browsers schedule MessageEvents on
+    // slightly different ticks; bail early on success so CI is fast.
     for _ in 0..5 {
         next_task().await;
         if session.epoch() > initial_epoch {
@@ -94,11 +79,9 @@ async fn outbound_post_triggers_inbound_listener_in_peer() {
 
 #[wasm_bindgen_test(async)]
 async fn local_broadcast_channel_does_not_echo_to_origin() {
-    // Sanity check on the BroadcastChannel spec: a channel does not
-    // receive its own posts. The framework relies on this — without
-    // it, `broadcast_session_changed` would feed back into the
-    // origin tab's listener and SUPPRESS_BROADCAST would need to
-    // be load-bearing instead of dormant.
+    // Pins the spec invariant that a channel doesn't receive its own
+    // posts; otherwise `SUPPRESS_BROADCAST` would have to be
+    // load-bearing instead of dormant.
     let channel = BroadcastChannel::new("pocopine-auth-test-echo")
         .expect("BroadcastChannel must be available");
 

--- a/crates/pocopine-auth-client/tests/cross_tab_wasm.rs
+++ b/crates/pocopine-auth-client/tests/cross_tab_wasm.rs
@@ -1,0 +1,126 @@
+//! Wasm integration test for cross-tab `BroadcastChannel` routing.
+//!
+//! `BroadcastChannel` doesn't deliver messages to the origin tab, so
+//! we simulate the peer-tab scenario from a single wasm runtime by:
+//! 1. Installing the framework's cross-tab listener (it owns one
+//!    `BroadcastChannel` named `"pocopine-auth"`) — this plays the
+//!    role of "peer tab" in our test.
+//! 2. Opening a SECOND `BroadcastChannel` ourselves with the same
+//!    name — this plays the role of "origin tab".
+//! 3. Posting from our (origin) channel.
+//! 4. Awaiting microtasks so the listener has a chance to fire.
+//! 5. Asserting the framework listener actually ran by observing
+//!    `AuthSession::epoch` advanced.
+
+#![cfg(target_arch = "wasm32")]
+
+use js_sys::Promise;
+use pocopine_auth_client::{cross_tab, AuthSession};
+use wasm_bindgen::JsValue;
+use wasm_bindgen_futures::JsFuture;
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+use web_sys::BroadcastChannel;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+/// Yield through the task queue (NOT the microtask queue):
+/// `BroadcastChannel` `MessageEvent` delivery is dispatched as a
+/// task, so awaiting `Promise.resolve()` (which fires on the
+/// microtask queue) is too eager — the listener hasn't run yet by
+/// the time we resume. Schedule resolution via `setTimeout(0)`
+/// instead so the test continuation lands AFTER pending message
+/// tasks.
+async fn next_task() {
+    let promise = Promise::new(&mut |resolve, _reject| {
+        if let Some(window) = web_sys::window() {
+            let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, 0);
+        } else {
+            // No window — just resolve immediately (test will likely
+            // fail downstream, which is the right signal).
+            let _ = resolve.call0(&JsValue::UNDEFINED);
+        }
+    });
+    let _ = JsFuture::from(promise).await;
+}
+
+async fn settle() {
+    next_task().await;
+    next_task().await;
+}
+
+#[wasm_bindgen_test(async)]
+async fn outbound_post_triggers_inbound_listener_in_peer() {
+    // Fresh state.
+    cross_tab::__teardown_for_test();
+    pocopine_auth_client::storage::__reset_storage_for_test();
+
+    let session = AuthSession::new();
+    let initial_epoch = session.epoch();
+    cross_tab::__install_for_test(session.clone());
+
+    // Yield once after install so Firefox finishes wiring the
+    // listener before we post.
+    next_task().await;
+
+    // Origin channel — distinct from the framework's, but on the
+    // same name, so its posts are delivered to the framework's
+    // listener.
+    let origin =
+        BroadcastChannel::new("pocopine-auth").expect("BroadcastChannel must be available");
+    origin
+        .post_message(&JsValue::from_str("session_changed"))
+        .expect("post_message must succeed");
+
+    // Give the browser plenty of task cycles to deliver and run the
+    // listener — different browsers schedule MessageEvents
+    // differently.
+    for _ in 0..5 {
+        next_task().await;
+        if session.epoch() > initial_epoch {
+            break;
+        }
+    }
+
+    assert!(
+        session.epoch() > initial_epoch,
+        "framework listener should have called bump_epoch \
+         (initial={initial_epoch}, now={})",
+        session.epoch()
+    );
+
+    origin.close();
+    cross_tab::__teardown_for_test();
+}
+
+#[wasm_bindgen_test(async)]
+async fn local_broadcast_channel_does_not_echo_to_origin() {
+    // Sanity check on the BroadcastChannel spec: a channel does not
+    // receive its own posts. The framework relies on this — without
+    // it, `broadcast_session_changed` would feed back into the
+    // origin tab's listener and SUPPRESS_BROADCAST would need to
+    // be load-bearing instead of dormant.
+    let channel = BroadcastChannel::new("pocopine-auth-test-echo")
+        .expect("BroadcastChannel must be available");
+
+    let received = std::rc::Rc::new(std::cell::RefCell::new(false));
+    let received_inner = received.clone();
+    let listener =
+        wasm_bindgen::closure::Closure::<dyn FnMut(web_sys::MessageEvent)>::new(move |_evt| {
+            *received_inner.borrow_mut() = true;
+        });
+    use wasm_bindgen::JsCast;
+    channel.set_onmessage(Some(listener.as_ref().unchecked_ref()));
+
+    channel
+        .post_message(&JsValue::from_str("self"))
+        .expect("post_message must succeed");
+    settle().await;
+
+    assert!(
+        !*received.borrow(),
+        "BroadcastChannel must not deliver to its own origin"
+    );
+
+    drop(listener);
+    channel.close();
+}

--- a/docs/auth-client.md
+++ b/docs/auth-client.md
@@ -1,7 +1,7 @@
 # Wasm-side auth — `pocopine-auth-client`
 
 The wasm-side companion to the credentials core / Firebase preset /
-Clerk preset / etc. Four surfaces:
+Clerk preset / etc. Seven surfaces:
 
 - **Token slot.** `set_token` / `clear_token` / `active_token`
   manage a process-global `Option<String>` the bearer middleware
@@ -10,7 +10,19 @@ Clerk preset / etc. Four surfaces:
   `pocopine_core::fetch::FetchMiddleware`; `install()` registers it
   on the global RFC-078 chain. From then on every outgoing
   `#[server]` call gets `Authorization: Bearer <token>` when a
-  token is set.
+  token is set. The middleware also enforces an identity-change
+  fence: if the user signs in/out while a request is in flight,
+  the response is dropped with `Unauthorized("session_changed")`.
+- **Token refresh + replay (single-flight).** Apps install a
+  `TokenRefresh` via `with_token_refresh(...)`. On `Unauthorized`
+  for a `#[server(idempotent)]` request the middleware refreshes
+  once and replays. Concurrent in-flight 401s coalesce into a
+  single refresh call to the issuer.
+- **Token persistence (`TokenStorage`).** Pluggable storage so the
+  token survives reload. Provided impls: `LocalStorage`,
+  `SessionStorage`, `InMemory` (default no-op).
+- **Cross-tab session coordination.** Sign-in/out in one tab
+  propagates to peer tabs of the same origin via `BroadcastChannel`.
 - **Reactive identity.** `AuthSession` is a plugin service the
   `auth_plugin()` builder installs. Holds the active `Principal` +
   monotonic epoch; cheap to clone, internally `Rc<RefCell<…>>`.
@@ -503,20 +515,289 @@ pub async fn admin_audit() -> ServerResult<Vec<Event>> {
 }
 ```
 
+## Step 5 — keep users signed in across reloads (`TokenStorage`)
+
+By default the token slot is in-memory only. Refresh the page and
+the user is signed out. Real apps persist the token through some
+browser surface; pocopine ships a `TokenStorage` trait + provided
+impls so you don't hand-roll that.
+
+### Pick a storage backend
+
+| Impl | Survives reload | Survives tab close | XSS-readable |
+|---|---|---|---|
+| `InMemory` (default) | no | no | no |
+| `SessionStorage` | yes | no (per-tab) | yes |
+| `LocalStorage` | yes | yes (cross-tab) | yes |
+| `httpOnly` cookie (server-side) | yes | yes | **no** |
+
+If your access tokens are short-lived bearer JWTs and you accept
+the XSS exposure, `LocalStorage` is the standard choice. For
+high-value applications, prefer an `httpOnly` cookie issued by the
+server — pocopine then doesn't need a token slot at all (the
+browser sends the cookie automatically; skip the bearer middleware).
+
+### Wire it in
+
+```rust
+use pocopine_auth_client::{auth_plugin, storage::LocalStorage};
+
+App::new()
+    .plugin(
+        auth_plugin()
+            .login_route("/login")
+            .with_bearer_middleware(true)
+            .with_token_storage(LocalStorage::new("auth_token")),
+    )
+    .run();
+```
+
+That's it. Three things change:
+
+1. At plugin install time, the in-memory slot is hydrated from
+   storage (`hydrate_from_storage()` runs). Returning users keep
+   their session.
+2. `set_token` writes through to storage on every call.
+3. `clear_token` / `AuthSession::sign_out` clear storage too.
+
+### Custom storage
+
+The trait is small. Implement it for a cookie writer, IndexedDB
+adapter, native iOS keychain via a JS bridge, etc.:
+
+```rust
+use pocopine_auth_client::TokenStorage;
+
+struct MyKeychainStorage;
+
+impl TokenStorage for MyKeychainStorage {
+    fn load(&self) -> Option<String> {
+        // call into your bridge
+        Some(call_native_keychain_get())
+    }
+    fn save(&self, token: &str) {
+        call_native_keychain_set(token);
+    }
+    fn clear(&self) {
+        call_native_keychain_clear();
+    }
+}
+```
+
+## Step 6 — sync sign-in/out across tabs (`BroadcastChannel`)
+
+Without coordination, signing in on tab A leaves tab B oblivious:
+tab B keeps issuing requests under the previous identity until it
+catches a 401. Worse for sign-out: tab B keeps rendering the
+authenticated dashboard with stale data.
+
+Enable cross-tab sync at builder time:
+
+```rust
+auth_plugin()
+    .login_route("/login")
+    .with_bearer_middleware(true)
+    .with_token_storage(LocalStorage::new("auth_token"))  // required
+    .with_cross_tab_sync(true)
+```
+
+**`with_token_storage` is required** for cross-tab sync to work
+end-to-end. The broadcast tells peer tabs "something changed" but
+doesn't carry the new token over the channel — peers re-read it
+from shared storage. Without storage, peers just bump their epoch
+and have no way to learn the new credential.
+
+### What happens on the wire
+
+1. Tab A: `session.sign_in("token-xyz", principal)`.
+2. Tab A's `set_token` writes `"token-xyz"` to localStorage.
+3. Tab A's `set_principal` posts a message to the
+   `"pocopine-auth"` `BroadcastChannel`.
+4. Tab B's listener fires:
+   - Calls `hydrate_from_storage()` → reads `"token-xyz"` into
+     tab B's in-memory slot.
+   - Calls `session.bump_epoch()` → tab B's bearer-middleware
+     fence trips on any in-flight request still under the old
+     identity, returning `Err(Unauthorized("session_changed"))`.
+5. Tab B's app code reacts to the epoch bump (reactive view,
+   call `/me`, navigate, etc.) — that's app-level wiring; the
+   framework provides the primitive, not the UX.
+
+Re-entrancy is handled internally: when tab B's listener runs,
+the principal-set inside the listener is suppressed from
+re-broadcasting. No infinite ping-pong.
+
+### Optional: react to peer-tab events
+
+The broadcast itself is the framework's signal. If your app needs
+to do something specific on a peer-tab change (refetch profile,
+flash a notification), watch the session epoch:
+
+```rust
+impl Dashboard {
+    pub fn on_setup(&mut self, session: Plugin<AuthSession>) {
+        // Capture the current epoch.
+        let captured_epoch = session.epoch();
+        // After every render, check if epoch advanced; if so,
+        // re-fetch /me. (Concrete shape depends on the reactive
+        // system you're using — this is illustrative.)
+        // ...
+    }
+}
+```
+
+### Falling back when unavailable
+
+`BroadcastChannel` ships in all evergreen browsers but is missing
+in older Safari and `file://` contexts. `with_cross_tab_sync(true)`
+silently degrades to a no-op when the constructor fails — apps
+don't see a panic; they just don't get cross-tab coordination.
+
+## Step 7 — refresh tokens automatically (`TokenRefresh`)
+
+Access tokens expire. Without refresh, the user sees an
+authentication error mid-session even when their identity is still
+valid (the issuer would gladly hand them a new token if asked).
+
+The bearer middleware can refresh and replay automatically when:
+- The server function is marked `#[server(idempotent)]` (replay-safe).
+- A `TokenRefresh` is configured.
+- The original request actually carried a token.
+
+```rust
+auth_plugin()
+    .login_route("/login")
+    .with_bearer_middleware(true)
+    .with_token_storage(LocalStorage::new("auth_token"))
+    .with_token_refresh(|| async {
+        // Talk to your provider. The closure can call any of:
+        //   - your own #[server] function
+        //   - Firebase / Clerk / Auth0 SDK
+        //   - a refresh-cookie-backed endpoint
+        // Return Ok(new_token) on success; Err propagates the
+        // original Unauthorized to the caller.
+        my_app::refresh_session_token().await
+    })
+```
+
+The closure is `Fn() -> Future<Output = Result<String, ServerError>>`
+— stateless, can be called repeatedly. For stateful refresh logic
+(e.g. capturing a refresh-token cookie) implement the
+`TokenRefresh` trait directly:
+
+```rust
+use pocopine_auth_client::{TokenRefresh, TokenRefreshFuture};
+use std::rc::Rc;
+
+struct MyRefresher {
+    client: Rc<HttpClient>,
+}
+
+impl TokenRefresh for MyRefresher {
+    fn refresh(&self) -> TokenRefreshFuture {
+        let client = self.client.clone();
+        Box::pin(async move {
+            client.post("/auth/refresh").await
+        })
+    }
+}
+```
+
+### Mark idempotent server functions
+
+The middleware **only** retries server functions you've explicitly
+marked replay-safe. Non-idempotent calls (POST that creates an
+order, transfer money, send an email) must NEVER be replayed —
+the user might end up double-charged. Marking is opt-in:
+
+```rust
+#[pocopine::server(public, idempotent)]
+async fn get_dashboard_stats() -> ServerResult<DashboardStats> {
+    // GET-shaped: read-only, replay-safe
+}
+
+#[pocopine::server(public)]
+async fn place_order(order: Order) -> ServerResult<OrderId> {
+    // NOT marked: middleware propagates Unauthorized rather
+    // than retry. The user sees the error and can re-submit
+    // with intent.
+}
+```
+
+This is RFC-078 §5.10.4's fail-closed default.
+
+### Single-flight coalescing
+
+If five concurrent requests all 401 (e.g. user came back to the
+tab after a network blip), the middleware fires a **single**
+refresh call to the issuer. The first 401 starts the refresh; the
+others wait for that same outcome. After it resolves, all five
+requests replay with the new token.
+
+This matters because token issuers rate-limit. A naive "one
+refresh per failed request" implementation exhausts the quota
+during a quota-burst event.
+
+### What if refresh fails?
+
+Refresh failure (network error, the user's refresh token is
+itself revoked, the issuer is down) propagates as
+`ServerError::Unauthorized` with the refresh's own message. Your
+app should handle that the same way as a fresh `Unauthorized`:
+clear the session, navigate to `/login`, surface a UI message.
+
+```rust
+match user_request_result {
+    Err(ServerError::Unauthorized(_)) => {
+        session.sign_out();
+        // The auth_plugin's rejection handler will redirect.
+    }
+    // ...
+}
+```
+
+## Putting it all together — production-shape config
+
+```rust
+use pocopine::App;
+use pocopine_auth_client::{auth_plugin, storage::LocalStorage};
+
+App::new()
+    .plugin(
+        auth_plugin()
+            // Where to redirect on Unauthorized:
+            .login_route("/login")
+            .return_to_query_param("redirect")
+            // Wire the bearer middleware on the fetch chain:
+            .with_bearer_middleware(true)
+            // Persist the token across reloads:
+            .with_token_storage(LocalStorage::new("auth_token"))
+            // Sync identity changes across tabs:
+            .with_cross_tab_sync(true)
+            // Refresh on Unauthorized for #[server(idempotent)]:
+            .with_token_refresh(|| async {
+                my_app::refresh_session_token().await
+            }),
+    )
+    .run();
+```
+
+That's the complete client-side auth picture: persisted, coordinated
+across tabs, transparently refreshing, fenced against
+identity-change races, and routing rejected requests to the login
+flow with `ReturnTo`.
+
 ## What's deferred
 
-- **Single-flight refresh + replay-on-401.** RFC-078 §5.5 / §5.10.4.
-  Depends on a `#[server(idempotent)]` attribute that doesn't
-  exist yet; until then the bearer middleware doesn't retry —
-  `Unauthorized` propagates upward and the loader/component
-  surfaces `RouteRejection::Unauthorized` to the rejection chain.
-- **Session-epoch dispatch / response gate.** RFC-078 §5.10.5.
-  Will read `AuthSession::epoch()` on outgoing requests and
-  abort/drop responses computed under a stale identity.
 - **The `pocopine::auth::client::…` umbrella re-export.**
   Deferred until the public surface stabilizes; apps `use
   pocopine_auth_client::{set_token, install, …};` directly for
   now.
+- **Route-aware predicate adapters.** `predicate_guard` is
+  `Principal`-only. Guards that need to inspect `params` /
+  `query` (e.g. `/users/:id` requiring `principal.id == params["id"]`)
+  must write the closure directly — see the docstring on
+  `predicate_guard` for the pattern.
 
 ## See also
 

--- a/docs/auth-client.md
+++ b/docs/auth-client.md
@@ -584,6 +584,39 @@ impl TokenStorage for MyKeychainStorage {
 }
 ```
 
+Plug it into the builder the same way as the provided impls — the
+`with_token_storage` method takes any `TokenStorage`:
+
+```rust
+auth_plugin()
+    .login_route("/login")
+    .with_bearer_middleware(true)
+    .with_token_storage(MyKeychainStorage)  // ← pass your impl by value
+```
+
+For storage that needs runtime configuration (e.g., a
+keychain-service name read from app state), give your impl
+fields and construct accordingly:
+
+```rust
+struct MyKeychainStorage {
+    service: String,
+}
+
+impl MyKeychainStorage {
+    pub fn new(service: impl Into<String>) -> Self {
+        Self { service: service.into() }
+    }
+}
+
+// Usage:
+auth_plugin()
+    .with_token_storage(MyKeychainStorage::new("com.example.app.auth"))
+```
+
+The plugin builder wraps your impl in an `Rc<dyn TokenStorage>`
+internally, so the impl doesn't need to be `Clone` or `Send`.
+
 ## Step 6 — sync sign-in/out across tabs (`BroadcastChannel`)
 
 Without coordination, signing in on tab A leaves tab B oblivious:
@@ -682,26 +715,68 @@ auth_plugin()
 
 The closure is `Fn() -> Future<Output = Result<String, ServerError>>`
 — stateless, can be called repeatedly. For stateful refresh logic
-(e.g. capturing a refresh-token cookie) implement the
-`TokenRefresh` trait directly:
+(e.g. capturing a refresh-token cookie, holding a configured
+issuer URL, sharing a connection with the rest of the app)
+implement the `TokenRefresh` trait directly:
 
 ```rust
 use pocopine_auth_client::{TokenRefresh, TokenRefreshFuture};
+use pocopine_core::ServerError;
 use std::rc::Rc;
 
 struct MyRefresher {
     client: Rc<HttpClient>,
+    issuer_url: String,
+}
+
+impl MyRefresher {
+    pub fn new(client: Rc<HttpClient>, issuer_url: impl Into<String>) -> Self {
+        Self { client, issuer_url: issuer_url.into() }
+    }
 }
 
 impl TokenRefresh for MyRefresher {
     fn refresh(&self) -> TokenRefreshFuture {
+        // Clone what the future needs to own; the future must be
+        // 'static so it can outlive the &self borrow.
         let client = self.client.clone();
+        let url = self.issuer_url.clone();
         Box::pin(async move {
-            client.post("/auth/refresh").await
+            client
+                .post(&url)
+                .await
+                .map_err(|e| ServerError::unauthorized(format!("refresh: {e}")))
         })
     }
 }
 ```
+
+Plug it into the builder — `with_token_refresh` accepts both
+forms because of the blanket `impl<F, Fut> TokenRefresh for F`
+that covers closures:
+
+```rust
+auth_plugin()
+    .login_route("/login")
+    .with_bearer_middleware(true)
+    .with_token_refresh(MyRefresher::new(http_client.clone(), issuer))
+    //  ↑ trait-impl form
+```
+
+vs. the closure form:
+
+```rust
+auth_plugin()
+    .with_token_refresh(|| async {
+        my_app::refresh_session_token().await
+    })
+    //  ↑ closure form (uses the blanket impl)
+```
+
+Both end up as `Rc<dyn TokenRefresh>` inside the plugin. Pick the
+trait-impl form when you have configuration to thread through;
+pick the closure form when the refresh is a one-line call into an
+SDK or `#[server]` function.
 
 ### Mark idempotent server functions
 


### PR DESCRIPTION
## Summary

End-to-end fixes for the three top adoption gaps in the auth-client plugin (the ones flagged in the post-merge review of PR #56):

### 1. Token persistence — `TokenStorage` trait + provided impls
Page reload no longer signs the user out. `set_token` / `clear_token` write through to a configurable storage; the in-memory slot is hydrated from storage at plugin install time so returning users pick up where they left off.

```rust
auth_plugin()
    .with_token_storage(
        pocopine_auth_client::storage::LocalStorage::new(\"auth_token\"),
    )
```

Provided impls: \`InMemory\` (default no-op), \`LocalStorage\`, \`SessionStorage\`. Security tradeoff (XSS exposure vs httpOnly cookies) documented in module docs.

### 2. Cross-tab session coordination — \`BroadcastChannel\`
Sign-in / sign-out in tab A propagates to peer tabs of the same origin. \`AuthSession::set_principal\` broadcasts; peer-tab listeners hydrate the local token from shared storage and bump the local epoch (so in-flight responses fence). Re-entrancy guard prevents broadcast loops; silent fallback when \`BroadcastChannel\` is unavailable.

\`with_cross_tab_sync(true)\` opt-in. Pairs with \`with_token_storage\` — peer tabs read the new credential from shared storage rather than receiving the principal payload over the channel (intentional, see module docs for security rationale).

### 3. Single-flight refresh coordinator
The bearer middleware previously fired one refresh per failed request. Five concurrent 401s = five refreshes hammering the issuer. New \`refresh::refresh_single_flight\` routes all concurrent refreshes through one in-flight slot; subsequent callers await the same \`Rc<String>\` outcome. Drop-safety via \`ClearOnDrop\` guard so cancelled drivers don't strand waiters.

## Surface changes

- \`pub mod storage\` — \`TokenStorage\` trait + provided impls.
- \`pub mod cross_tab\` — \`broadcast_session_changed\`, \`CHANNEL_NAME\`.
- \`AuthSession::bump_epoch()\` — advance fence without touching principal.
- \`AuthSession::set_principal\` now broadcasts on cross-tab when installed (no-op otherwise).
- \`AuthPluginBuilder::with_token_storage\` / \`with_cross_tab_sync\` builder methods.
- \`pub fn hydrate_from_storage()\` — explicit re-hydration entry point.

## Cargo deps

Adds \`wasm-bindgen\` and \`web-sys\` (Storage, BroadcastChannel, MessageEvent, Window) as **wasm32-only** target deps. Host build is unchanged.

## Tests

**43 pass** (+12 new):

- TokenStorage write-through, hydration with/without storage, clear-when-empty.
- \`AuthSession::bump_epoch\` advances without touching principal.
- Single-flight: dedupes concurrent callers (uses a yielding refresh for genuine interleaving), releases after completion, propagates Unauthorized when no refresh configured, aborted-refresh unblocks waiters with synthetic error.
- Single-flight integrated through middleware (one 401 + replay, one refresh call).

## Test plan

- [x] \`cargo test -p pocopine-auth-client\` — 43/43 pass
- [x] \`cargo clippy -p pocopine-auth-client --all-targets -- -D warnings\` — clean
- [x] \`cargo clippy -p pocopine-auth-client --target wasm32-unknown-unknown -- -D warnings\` — clean
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all --check\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)