### PR TITLE
Install frontend observability through app plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2648,6 +2648,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "observability-frontend"
+version = "0.1.0"
+dependencies = [
+ "phf 0.13.1",
+ "pocopine",
+ "serde",
+ "tracing",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "observability-smoke"
 version = "0.1.0"
 dependencies = [
@@ -3277,9 +3288,11 @@ dependencies = [
 name = "pocopine-logging"
 version = "0.1.0"
 dependencies = [
+ "js-sys",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
+ "pocopine-core",
  "pocopine-observe",
  "tracing",
  "tracing-opentelemetry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "examples/counter",
     "examples/hn",
     "examples/live",
+    "examples/observability-frontend",
     "examples/observability-smoke",
     "jsbench/pocopine",
     "jsbench/leptos",

--- a/crates/pocopine-core/src/fetch.rs
+++ b/crates/pocopine-core/src/fetch.rs
@@ -351,8 +351,14 @@ where
     freeze_middleware_chain();
     let options = options.with_active_context();
 
-    let body = serde_json::to_string(args)
-        .map_err(|e| ServerError::Network(format!("serialize args: {e}")))?;
+    let observe = FetchObservation::new(url);
+    let body = match serde_json::to_string(args) {
+        Ok(body) => body,
+        Err(err) => {
+            observe.failed("serialize");
+            return Err(ServerError::Network(format!("serialize args: {err}")));
+        }
+    };
 
     let request = FetchRequest {
         url: url.to_string(),
@@ -368,14 +374,30 @@ where
         index: 0,
         middlewares,
     };
-    let response = next.run(request).await?;
+    let response = match next.run(request).await {
+        Ok(response) => response,
+        Err(err) => {
+            observe.failed(server_error_kind(&err));
+            return Err(err);
+        }
+    };
 
     if !(200..300).contains(&response.status) {
+        observe.failed("http_status");
         return Err(ServerError::Network(format!("HTTP {}", response.status)));
     }
 
-    let outer: ServerResult<R> = serde_json::from_str(&response.body)
-        .map_err(|e| ServerError::Network(format!("parse response: {e}")))?;
+    let outer: ServerResult<R> = match serde_json::from_str(&response.body) {
+        Ok(outer) => outer,
+        Err(err) => {
+            observe.failed("parse_response");
+            return Err(ServerError::Network(format!("parse response: {err}")));
+        }
+    };
+    match &outer {
+        Ok(_) => observe.completed(response.status),
+        Err(err) => observe.failed(server_error_kind(err)),
+    }
     outer
 }
 
@@ -433,6 +455,83 @@ async fn perform_fetch(request: FetchRequest) -> Result<FetchResponse, ServerErr
         .ok_or_else(|| ServerError::Network("body was not a string".into()))?;
 
     Ok(FetchResponse { status, body })
+}
+
+struct FetchObservation {
+    route: Option<String>,
+    start_ms: Option<f64>,
+}
+
+impl FetchObservation {
+    fn new(url: &str) -> Self {
+        if !crate::plugin::has_server_function_client_hooks() {
+            return Self {
+                route: None,
+                start_ms: None,
+            };
+        }
+        let route = public_url_path(url);
+        crate::plugin::emit(crate::plugin::ServerFunctionClientStarted {
+            route: route.clone(),
+        });
+        Self {
+            route: Some(route),
+            start_ms: Some(js_sys::Date::now()),
+        }
+    }
+
+    fn completed(&self, status_code: u16) {
+        let Some(route) = self.route.as_ref() else {
+            return;
+        };
+        crate::plugin::emit(crate::plugin::ServerFunctionClientCompleted {
+            route: route.clone(),
+            duration_ms: self.elapsed_ms(),
+            status_code,
+        });
+    }
+
+    fn failed(&self, error_kind: &'static str) {
+        let Some(route) = self.route.as_ref() else {
+            return;
+        };
+        crate::plugin::emit(crate::plugin::ServerFunctionClientFailed {
+            route: route.clone(),
+            duration_ms: self.elapsed_ms(),
+            error_kind,
+        });
+    }
+
+    fn elapsed_ms(&self) -> f64 {
+        let Some(start_ms) = self.start_ms else {
+            return 0.0;
+        };
+        let elapsed = js_sys::Date::now() - start_ms;
+        if elapsed.is_finite() && elapsed >= 0.0 {
+            elapsed
+        } else {
+            0.0
+        }
+    }
+}
+
+fn server_error_kind(err: &ServerError) -> &'static str {
+    match err {
+        ServerError::App(_) => "app",
+        ServerError::Unauthorized(_) => "unauthorized",
+        ServerError::Forbidden(_) => "forbidden",
+        ServerError::BadRequest(_) => "bad_request",
+        ServerError::Network(_) => "network",
+    }
+}
+
+fn public_url_path(url: &str) -> String {
+    let without_query = url.split_once('?').map(|(path, _)| path).unwrap_or(url);
+    without_query
+        .split_once('#')
+        .map(|(path, _)| path)
+        .unwrap_or(without_query)
+        .to_owned()
 }
 
 #[cfg(test)]
@@ -528,5 +627,11 @@ mod tests {
         let options = FetchOptions::default();
         assert!(!options.replay_safe);
         assert!(options.abort_signal.is_none());
+    }
+
+    #[test]
+    fn strips_query_and_fragment_from_observed_urls() {
+        assert_eq!(public_url_path("/api/search?q=secret#frag"), "/api/search");
+        assert_eq!(public_url_path("/api/save"), "/api/save");
     }
 }

--- a/crates/pocopine-core/src/lib.rs
+++ b/crates/pocopine-core/src/lib.rs
@@ -87,7 +87,8 @@ pub use plugin::{
     AppBootCompleted, AppBootFailed, AppBootStarted, ComponentEvent, ComponentMounted,
     ComponentPluginExt, ComponentReady, ComponentSetup, ComponentUnmounted, ForComponent, Hook,
     Plugin, PluginValidationError, Plugins, RouteNavigationCompleted, RouteNavigationFailed,
-    RouteNavigationStarted,
+    RouteNavigationStarted, ServerFunctionClientCompleted, ServerFunctionClientFailed,
+    ServerFunctionClientStarted,
 };
 pub use profiler::mount::{
     enabled as mount_profile_enabled, report as report_mount_profile, reset as reset_mount_profile,

--- a/crates/pocopine-core/src/plugin.rs
+++ b/crates/pocopine-core/src/plugin.rs
@@ -37,10 +37,16 @@ const HOOK_COMPONENT_SETUP: HookMask = 1 << 6;
 const HOOK_COMPONENT_MOUNTED: HookMask = 1 << 7;
 const HOOK_COMPONENT_READY: HookMask = 1 << 8;
 const HOOK_COMPONENT_UNMOUNTED: HookMask = 1 << 9;
+const HOOK_SERVER_FUNCTION_CLIENT_STARTED: HookMask = 1 << 10;
+const HOOK_SERVER_FUNCTION_CLIENT_COMPLETED: HookMask = 1 << 11;
+const HOOK_SERVER_FUNCTION_CLIENT_FAILED: HookMask = 1 << 12;
 const HOOK_COMPONENT_NAME_EVENTS: HookMask =
     HOOK_COMPONENT_MOUNTED | HOOK_COMPONENT_READY | HOOK_COMPONENT_UNMOUNTED;
 const HOOK_ROUTE_NAVIGATION_EVENTS: HookMask =
     HOOK_ROUTE_NAVIGATION_STARTED | HOOK_ROUTE_NAVIGATION_COMPLETED | HOOK_ROUTE_NAVIGATION_FAILED;
+const HOOK_SERVER_FUNCTION_CLIENT_EVENTS: HookMask = HOOK_SERVER_FUNCTION_CLIENT_STARTED
+    | HOOK_SERVER_FUNCTION_CLIENT_COMPLETED
+    | HOOK_SERVER_FUNCTION_CLIENT_FAILED;
 
 /// Per-mount snapshot of which plugin-side stamps the runtime needs to
 /// produce. Sampled once from `ACTIVE_HOOK_MASK` at the top of a mount so
@@ -192,6 +198,36 @@ pub struct RouteNavigationFailed {
     pub component: Option<&'static str>,
     pub reason: &'static str,
     pub duration_ms: f64,
+}
+
+/// Emitted before the browser client sends a generated `#[server]`
+/// function request.
+///
+/// `route` is the public request path with any query string or fragment
+/// stripped. Request arguments and response bodies are never included.
+#[derive(Clone, Debug)]
+pub struct ServerFunctionClientStarted {
+    pub route: String,
+}
+
+/// Emitted after a generated `#[server]` client request succeeds.
+#[derive(Clone, Debug)]
+pub struct ServerFunctionClientCompleted {
+    pub route: String,
+    pub duration_ms: f64,
+    pub status_code: u16,
+}
+
+/// Emitted after a generated `#[server]` client request fails before
+/// returning an application value.
+///
+/// `error_kind` is a stable coarse reason such as `"serialize"`,
+/// `"fetch"`, `"http_status"`, or `"unauthorized"`.
+#[derive(Clone, Debug)]
+pub struct ServerFunctionClientFailed {
+    pub route: String,
+    pub duration_ms: f64,
+    pub error_kind: &'static str,
 }
 
 /// Component-scoped framework event.
@@ -556,6 +592,15 @@ impl PluginRegistry {
         if self.has_stored_hooks::<ComponentUnmounted>() {
             mask |= HOOK_COMPONENT_UNMOUNTED;
         }
+        if self.has_stored_hooks::<ServerFunctionClientStarted>() {
+            mask |= HOOK_SERVER_FUNCTION_CLIENT_STARTED;
+        }
+        if self.has_stored_hooks::<ServerFunctionClientCompleted>() {
+            mask |= HOOK_SERVER_FUNCTION_CLIENT_COMPLETED;
+        }
+        if self.has_stored_hooks::<ServerFunctionClientFailed>() {
+            mask |= HOOK_SERVER_FUNCTION_CLIENT_FAILED;
+        }
         mask
     }
 }
@@ -628,6 +673,11 @@ pub(crate) fn has_component_unmounted_hooks() -> bool {
 #[inline]
 pub(crate) fn has_route_navigation_hooks() -> bool {
     active_hook_mask_contains(HOOK_ROUTE_NAVIGATION_EVENTS)
+}
+
+#[inline]
+pub(crate) fn has_server_function_client_hooks() -> bool {
+    active_hook_mask_contains(HOOK_SERVER_FUNCTION_CLIENT_EVENTS)
 }
 
 #[inline]

--- a/crates/pocopine-logging/Cargo.toml
+++ b/crates/pocopine-logging/Cargo.toml
@@ -27,6 +27,8 @@ tracing-subscriber = { version = "0.3", features = ["ansi", "env-filter", "fmt",
 tracing-opentelemetry = { version = "0.32", optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+pocopine-core = { workspace = true, default-features = false }
+js-sys = { workspace = true }
 tracing-subscriber = { version = "0.3", default-features = false, features = ["registry", "std"] }
 wasm-bindgen = { workspace = true }
 web-sys = { version = "0.3", features = ["console"] }

--- a/crates/pocopine-logging/src/lib.rs
+++ b/crates/pocopine-logging/src/lib.rs
@@ -385,6 +385,16 @@ pub use server::OtlpConfig;
 mod web {
     use std::fmt;
 
+    use js_sys::{Object, Reflect};
+    use pocopine_core::{
+        App, AppBootCompleted, AppBootFailed, AppBootStarted, AppPlugin, ComponentMounted,
+        ComponentReady, ComponentSetup, ComponentUnmounted, Hook, RouteNavigationCompleted,
+        RouteNavigationFailed, RouteNavigationStarted, ServerFunctionClientCompleted,
+        ServerFunctionClientFailed, ServerFunctionClientStarted,
+    };
+    use pocopine_observe::{
+        emit_tracing, EventPriority, FieldPrivacy, ObserveContext, ObservedEvent,
+    };
     use tracing::field::{Field, Visit};
     use tracing::{Event, Level, Metadata, Subscriber};
     use tracing_subscriber::layer::{Context, Layer};
@@ -392,10 +402,17 @@ mod web {
     use tracing_subscriber::util::SubscriberInitExt;
     use wasm_bindgen::JsValue;
 
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    pub enum ConsoleLogFormat {
+        Text,
+        Json,
+    }
+
     #[derive(Clone, Debug, Eq, PartialEq)]
     pub struct ConsoleLoggingConfig {
         pub max_level: Level,
         pub target_prefix: Option<String>,
+        pub format: ConsoleLogFormat,
     }
 
     impl ConsoleLoggingConfig {
@@ -403,11 +420,25 @@ mod web {
             Self {
                 max_level: Level::DEBUG,
                 target_prefix: Some("pocopine".to_owned()),
+                format: ConsoleLogFormat::Text,
+            }
+        }
+
+        pub fn json() -> Self {
+            Self {
+                max_level: Level::DEBUG,
+                target_prefix: Some("pocopine".to_owned()),
+                format: ConsoleLogFormat::Json,
             }
         }
 
         pub fn with_max_level(mut self, max_level: Level) -> Self {
             self.max_level = max_level;
+            self
+        }
+
+        pub fn with_format(mut self, format: ConsoleLogFormat) -> Self {
+            self.format = format;
             self
         }
 
@@ -474,18 +505,21 @@ mod web {
             let metadata = event.metadata();
             let mut visitor = FieldVisitor::default();
             event.record(&mut visitor);
-            let message = format!(
-                "{} {} {}",
-                metadata.level(),
-                metadata.target(),
-                visitor.finish()
-            );
-            let value = JsValue::from_str(message.trim_end());
-            match *metadata.level() {
-                Level::ERROR => web_sys::console::error_1(&value),
-                Level::WARN => web_sys::console::warn_1(&value),
-                Level::INFO => web_sys::console::info_1(&value),
-                Level::DEBUG | Level::TRACE => web_sys::console::debug_1(&value),
+
+            match self.config.format {
+                ConsoleLogFormat::Text => {
+                    let message = format!(
+                        "{} {} {}",
+                        metadata.level(),
+                        metadata.target(),
+                        visitor.finish_text()
+                    );
+                    write_console(*metadata.level(), &JsValue::from_str(message.trim_end()));
+                }
+                ConsoleLogFormat::Json => {
+                    let value = visitor.into_console_object(metadata);
+                    write_console(*metadata.level(), &value);
+                }
             }
         }
     }
@@ -493,30 +527,504 @@ mod web {
     #[derive(Default)]
     struct FieldVisitor {
         message: Option<String>,
-        fields: Vec<String>,
+        fields: Vec<ConsoleField>,
     }
 
     impl FieldVisitor {
-        fn finish(self) -> String {
-            let mut out = self.message.unwrap_or_default();
-            for field in self.fields {
+        fn finish_text(&self) -> String {
+            let mut out = self.message.clone().unwrap_or_default();
+            for field in &self.fields {
                 if !out.is_empty() {
                     out.push(' ');
                 }
-                out.push_str(&field);
+                out.push_str(&field.name);
+                out.push('=');
+                out.push_str(&field.value.to_field_text());
             }
             out
+        }
+
+        fn into_console_object(self, metadata: &Metadata<'_>) -> JsValue {
+            let object = Object::new();
+            set_property(
+                &object,
+                "level",
+                JsValue::from_str(&metadata.level().to_string()),
+            );
+            set_property(&object, "target", JsValue::from_str(metadata.target()));
+            if let Some(message) = self.message {
+                set_property(&object, "message", JsValue::from_str(&message));
+            }
+
+            let fields = Object::new();
+            for field in self.fields {
+                set_property(&fields, &field.name, field.value.into_js_value());
+            }
+            set_property(&object, "fields", fields.into());
+            object.into()
+        }
+
+        fn record_value(&mut self, field: &Field, value: ConsoleFieldValue) {
+            if field.name() == "message" {
+                self.message = Some(value.to_message_text());
+            } else {
+                self.fields.push(ConsoleField {
+                    name: field.name().to_owned(),
+                    value,
+                });
+            }
         }
     }
 
     impl Visit for FieldVisitor {
+        fn record_bool(&mut self, field: &Field, value: bool) {
+            self.record_value(field, ConsoleFieldValue::Bool(value));
+        }
+
+        fn record_f64(&mut self, field: &Field, value: f64) {
+            self.record_value(field, ConsoleFieldValue::F64(value));
+        }
+
+        fn record_i64(&mut self, field: &Field, value: i64) {
+            self.record_value(field, ConsoleFieldValue::I64(value));
+        }
+
+        fn record_u64(&mut self, field: &Field, value: u64) {
+            self.record_value(field, ConsoleFieldValue::U64(value));
+        }
+
+        fn record_str(&mut self, field: &Field, value: &str) {
+            self.record_value(field, ConsoleFieldValue::String(value.to_owned()));
+        }
+
         fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
-            let rendered = format!("{value:?}");
-            if field.name() == "message" {
-                self.message = Some(rendered);
-            } else {
-                self.fields.push(format!("{}={rendered}", field.name()));
+            self.record_value(field, ConsoleFieldValue::Debug(format!("{value:?}")));
+        }
+    }
+
+    struct ConsoleField {
+        name: String,
+        value: ConsoleFieldValue,
+    }
+
+    enum ConsoleFieldValue {
+        Bool(bool),
+        F64(f64),
+        I64(i64),
+        U64(u64),
+        String(String),
+        Debug(String),
+    }
+
+    impl ConsoleFieldValue {
+        fn to_field_text(&self) -> String {
+            match self {
+                Self::Bool(value) => value.to_string(),
+                Self::F64(value) => value.to_string(),
+                Self::I64(value) => value.to_string(),
+                Self::U64(value) => value.to_string(),
+                Self::String(value) => format!("{value:?}"),
+                Self::Debug(value) => value.clone(),
             }
+        }
+
+        fn to_message_text(&self) -> String {
+            match self {
+                Self::String(value) | Self::Debug(value) => value.clone(),
+                _ => self.to_field_text(),
+            }
+        }
+
+        fn into_js_value(self) -> JsValue {
+            match self {
+                Self::Bool(value) => JsValue::from_bool(value),
+                Self::F64(value) => JsValue::from_f64(value),
+                Self::I64(value) => js_value_from_i64(value),
+                Self::U64(value) => js_value_from_u64(value),
+                Self::String(value) | Self::Debug(value) => JsValue::from_str(&value),
+            }
+        }
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub struct FrontendObservabilityConfig {
+        pub console_logging: Option<ConsoleLoggingConfig>,
+        pub service: Option<String>,
+        pub environment: Option<String>,
+        pub component_setup: bool,
+        pub component_ready: bool,
+    }
+
+    impl FrontendObservabilityConfig {
+        pub fn new() -> Self {
+            Self::default()
+        }
+
+        pub fn with_console_logging(mut self, config: ConsoleLoggingConfig) -> Self {
+            self.console_logging = Some(config);
+            self
+        }
+
+        pub fn without_console_logging(mut self) -> Self {
+            self.console_logging = None;
+            self
+        }
+
+        pub fn with_service(mut self, service: impl Into<String>) -> Self {
+            self.service = Some(service.into());
+            self
+        }
+
+        pub fn with_environment(mut self, environment: impl Into<String>) -> Self {
+            self.environment = Some(environment.into());
+            self
+        }
+
+        pub fn with_component_setup(mut self, enabled: bool) -> Self {
+            self.component_setup = enabled;
+            self
+        }
+
+        pub fn with_component_ready(mut self, enabled: bool) -> Self {
+            self.component_ready = enabled;
+            self
+        }
+    }
+
+    impl Default for FrontendObservabilityConfig {
+        fn default() -> Self {
+            Self {
+                console_logging: Some(ConsoleLoggingConfig::json()),
+                service: None,
+                environment: None,
+                component_setup: false,
+                component_ready: false,
+            }
+        }
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub struct FrontendObservabilityPlugin {
+        config: FrontendObservabilityConfig,
+    }
+
+    impl FrontendObservabilityPlugin {
+        pub fn new(config: FrontendObservabilityConfig) -> Self {
+            Self { config }
+        }
+    }
+
+    pub fn frontend_observability() -> FrontendObservabilityPlugin {
+        FrontendObservabilityPlugin::new(FrontendObservabilityConfig::default())
+    }
+
+    pub fn frontend_observability_with_config(
+        config: FrontendObservabilityConfig,
+    ) -> FrontendObservabilityPlugin {
+        FrontendObservabilityPlugin::new(config)
+    }
+
+    impl AppPlugin for FrontendObservabilityPlugin {
+        fn name(&self) -> &'static str {
+            "pocopine.logging.frontend_observability"
+        }
+
+        fn install(self, app: App) -> App {
+            let FrontendObservabilityConfig {
+                console_logging,
+                service,
+                environment,
+                component_setup,
+                component_ready,
+            } = self.config;
+
+            if let Some(console_config) = console_logging {
+                if let Err(err) = init_console_logging(console_config) {
+                    web_sys::console::warn_1(&JsValue::from_str(&format!(
+                        "pocopine: frontend observability could not initialize console logging: {err}"
+                    )));
+                }
+            }
+
+            let mut app = app
+                .provide_plugin(FrontendObservability {
+                    service,
+                    environment,
+                })
+                .hook_plugin::<FrontendObservability, AppBootStarted>()
+                .hook_plugin::<FrontendObservability, AppBootCompleted>()
+                .hook_plugin::<FrontendObservability, AppBootFailed>()
+                .hook_plugin::<FrontendObservability, RouteNavigationStarted>()
+                .hook_plugin::<FrontendObservability, RouteNavigationCompleted>()
+                .hook_plugin::<FrontendObservability, RouteNavigationFailed>()
+                .hook_plugin::<FrontendObservability, ServerFunctionClientStarted>()
+                .hook_plugin::<FrontendObservability, ServerFunctionClientCompleted>()
+                .hook_plugin::<FrontendObservability, ServerFunctionClientFailed>()
+                .hook_plugin::<FrontendObservability, ComponentMounted>()
+                .hook_plugin::<FrontendObservability, ComponentUnmounted>();
+
+            if component_setup {
+                app = app.hook_plugin::<FrontendObservability, ComponentSetup>();
+            }
+            if component_ready {
+                app = app.hook_plugin::<FrontendObservability, ComponentReady>();
+            }
+            app
+        }
+    }
+
+    #[derive(Debug)]
+    pub struct FrontendObservability {
+        service: Option<String>,
+        environment: Option<String>,
+    }
+
+    impl FrontendObservability {
+        pub fn emit(&self, event: ObservedEvent) {
+            let event = self.with_base_context(event);
+            emit_tracing(&event);
+        }
+
+        fn with_base_context(&self, mut event: ObservedEvent) -> ObservedEvent {
+            if event.context.service.is_none() {
+                event.context.service = self.service.clone();
+            }
+            if event.context.environment.is_none() {
+                event.context.environment = self.environment.clone();
+            }
+            event
+        }
+
+        fn context(&self) -> ObserveContext {
+            ObserveContext {
+                service: self.service.clone(),
+                environment: self.environment.clone(),
+                ..ObserveContext::default()
+            }
+        }
+
+        fn context_with_component(&self, component: &str) -> ObserveContext {
+            self.context().with_component(component)
+        }
+
+        fn context_with_route(&self, route: &str) -> ObserveContext {
+            self.context().with_route(route)
+        }
+    }
+
+    impl Hook<AppBootStarted> for FrontendObservability {
+        fn call(&self, event: AppBootStarted) {
+            self.emit(
+                ObservedEvent::trace("frontend_app_started")
+                    .context(self.context())
+                    .field(
+                        "component_count",
+                        event.component_count as u64,
+                        FieldPrivacy::Public,
+                    )
+                    .field(
+                        "route_count",
+                        event.route_count as u64,
+                        FieldPrivacy::Public,
+                    ),
+            );
+        }
+    }
+
+    impl Hook<AppBootCompleted> for FrontendObservability {
+        fn call(&self, event: AppBootCompleted) {
+            self.emit(
+                ObservedEvent::trace("frontend_app_boot_completed")
+                    .context(self.context())
+                    .field("duration_ms", event.duration_ms, FieldPrivacy::Public),
+            );
+        }
+    }
+
+    impl Hook<AppBootFailed> for FrontendObservability {
+        fn call(&self, event: AppBootFailed) {
+            self.emit(
+                ObservedEvent::log("frontend_app_boot_failed")
+                    .priority(EventPriority::High)
+                    .context(self.context())
+                    .field("reason", event.reason, FieldPrivacy::Public),
+            );
+        }
+    }
+
+    impl Hook<RouteNavigationStarted> for FrontendObservability {
+        fn call(&self, event: RouteNavigationStarted) {
+            let mut observed = ObservedEvent::trace("route_navigation_started").field(
+                "matched",
+                event.route_pattern.is_some(),
+                FieldPrivacy::Public,
+            );
+            if let Some(route) = event.route_pattern {
+                observed = observed.context(self.context_with_route(route)).field(
+                    "route",
+                    route,
+                    FieldPrivacy::Public,
+                );
+            } else {
+                observed = observed.context(self.context());
+            }
+            if let Some(component) = event.component {
+                observed = observed.field("component", component, FieldPrivacy::Public);
+            }
+            self.emit(observed);
+        }
+    }
+
+    impl Hook<RouteNavigationCompleted> for FrontendObservability {
+        fn call(&self, event: RouteNavigationCompleted) {
+            match (event.route_pattern, event.component) {
+                (Some(route), Some(component)) => self.emit(
+                    ObservedEvent::analytics("route_view")
+                        .context(self.context_with_route(route))
+                        .field("route", route, FieldPrivacy::Public)
+                        .field("component", component, FieldPrivacy::Public)
+                        .field("duration_ms", event.duration_ms, FieldPrivacy::Public),
+                ),
+                _ => self.emit(
+                    ObservedEvent::trace("route_navigation_completed")
+                        .context(self.context())
+                        .field("matched", false, FieldPrivacy::Public)
+                        .field("duration_ms", event.duration_ms, FieldPrivacy::Public),
+                ),
+            }
+        }
+    }
+
+    impl Hook<RouteNavigationFailed> for FrontendObservability {
+        fn call(&self, event: RouteNavigationFailed) {
+            let mut observed = ObservedEvent::log("route_navigation_failed")
+                .priority(EventPriority::High)
+                .field("reason", event.reason, FieldPrivacy::Public)
+                .field("duration_ms", event.duration_ms, FieldPrivacy::Public);
+            if let Some(route) = event.route_pattern {
+                observed = observed.context(self.context_with_route(route)).field(
+                    "route",
+                    route,
+                    FieldPrivacy::Public,
+                );
+            } else {
+                observed = observed.context(self.context());
+            }
+            if let Some(component) = event.component {
+                observed = observed.field("component", component, FieldPrivacy::Public);
+            }
+            self.emit(observed);
+        }
+    }
+
+    impl Hook<ServerFunctionClientStarted> for FrontendObservability {
+        fn call(&self, event: ServerFunctionClientStarted) {
+            self.emit(
+                ObservedEvent::trace("server_function_client_started")
+                    .context(self.context_with_route(&event.route))
+                    .field("route", event.route, FieldPrivacy::Public),
+            );
+        }
+    }
+
+    impl Hook<ServerFunctionClientCompleted> for FrontendObservability {
+        fn call(&self, event: ServerFunctionClientCompleted) {
+            self.emit(
+                ObservedEvent::trace("server_function_client_completed")
+                    .context(self.context_with_route(&event.route))
+                    .field("route", event.route, FieldPrivacy::Public)
+                    .field("duration_ms", event.duration_ms, FieldPrivacy::Public)
+                    .field(
+                        "status_code",
+                        event.status_code as u64,
+                        FieldPrivacy::Public,
+                    ),
+            );
+        }
+    }
+
+    impl Hook<ServerFunctionClientFailed> for FrontendObservability {
+        fn call(&self, event: ServerFunctionClientFailed) {
+            self.emit(
+                ObservedEvent::log("server_function_client_failed")
+                    .priority(EventPriority::High)
+                    .context(self.context_with_route(&event.route))
+                    .field("route", event.route, FieldPrivacy::Public)
+                    .field("duration_ms", event.duration_ms, FieldPrivacy::Public)
+                    .field("error_kind", event.error_kind, FieldPrivacy::Public),
+            );
+        }
+    }
+
+    impl Hook<ComponentSetup> for FrontendObservability {
+        fn call(&self, event: ComponentSetup) {
+            self.emit(
+                ObservedEvent::trace("component_setup")
+                    .priority(EventPriority::Low)
+                    .context(self.context_with_component(event.component))
+                    .field("component", event.component, FieldPrivacy::Public),
+            );
+        }
+    }
+
+    impl Hook<ComponentMounted> for FrontendObservability {
+        fn call(&self, event: ComponentMounted) {
+            self.emit(
+                ObservedEvent::analytics("component_view")
+                    .context(self.context_with_component(event.component))
+                    .field("component", event.component, FieldPrivacy::Public)
+                    .field("duration_ms", event.duration_ms, FieldPrivacy::Public),
+            );
+        }
+    }
+
+    impl Hook<ComponentReady> for FrontendObservability {
+        fn call(&self, event: ComponentReady) {
+            self.emit(
+                ObservedEvent::trace("component_ready")
+                    .priority(EventPriority::Low)
+                    .context(self.context_with_component(event.component))
+                    .field("component", event.component, FieldPrivacy::Public),
+            );
+        }
+    }
+
+    impl Hook<ComponentUnmounted> for FrontendObservability {
+        fn call(&self, event: ComponentUnmounted) {
+            self.emit(
+                ObservedEvent::trace("component_unmounted")
+                    .context(self.context_with_component(event.component))
+                    .field("component", event.component, FieldPrivacy::Public),
+            );
+        }
+    }
+
+    fn write_console(level: Level, value: &JsValue) {
+        match level {
+            Level::ERROR => web_sys::console::error_1(value),
+            Level::WARN => web_sys::console::warn_1(value),
+            Level::INFO => web_sys::console::info_1(value),
+            Level::DEBUG | Level::TRACE => web_sys::console::debug_1(value),
+        }
+    }
+
+    fn set_property(object: &Object, name: &str, value: JsValue) {
+        let _ = Reflect::set(object, &JsValue::from_str(name), &value);
+    }
+
+    fn js_value_from_i64(value: i64) -> JsValue {
+        if (MIN_SAFE_INTEGER..=MAX_SAFE_INTEGER).contains(&value) {
+            JsValue::from_f64(value as f64)
+        } else {
+            JsValue::from_str(&value.to_string())
+        }
+    }
+
+    fn js_value_from_u64(value: u64) -> JsValue {
+        if value <= MAX_SAFE_INTEGER as u64 {
+            JsValue::from_f64(value as f64)
+        } else {
+            JsValue::from_str(&value.to_string())
         }
     }
 
@@ -533,7 +1041,14 @@ mod web {
             Level::TRACE => 5,
         }
     }
+
+    const MAX_SAFE_INTEGER: i64 = 9_007_199_254_740_991;
+    const MIN_SAFE_INTEGER: i64 = -MAX_SAFE_INTEGER;
 }
 
 #[cfg(target_arch = "wasm32")]
-pub use web::{init_console_logging, ConsoleLoggingConfig, InitLoggingError};
+pub use web::{
+    frontend_observability, frontend_observability_with_config, init_console_logging,
+    ConsoleLogFormat, ConsoleLoggingConfig, FrontendObservability, FrontendObservabilityConfig,
+    FrontendObservabilityPlugin, InitLoggingError,
+};

--- a/crates/pocopine/src/lib.rs
+++ b/crates/pocopine/src/lib.rs
@@ -35,9 +35,10 @@ pub use pocopine_core::{
     RouteConfig, RouteContext, RouteErrorSurface, RouteGuard, RouteGuardDecision, RouteLoader,
     RouteNavigationCompleted, RouteNavigationFailed, RouteNavigationStarted, RouteRejection,
     RouteRejectionAction, RouteRejectionContext, RouteRejectionHandler, RouteTarget,
-    RouteTargetError, RouteToken, RwSignal, Scope, ScopeId, ScopePath, ServerError, ServerResult,
-    Setter, Signal, SignalId, Store, StoreHandle, SubtreeHandle, TagName, TaskHandle, TeleportHost,
-    TypedEl, Win,
+    RouteTargetError, RouteToken, RwSignal, Scope, ScopeId, ScopePath, ServerError,
+    ServerFunctionClientCompleted, ServerFunctionClientFailed, ServerFunctionClientStarted,
+    ServerResult, Setter, Signal, SignalId, Store, StoreHandle, SubtreeHandle, TagName, TaskHandle,
+    TeleportHost, TypedEl, Win,
 };
 #[doc(inline)]
 pub use pocopine_core::{create_context, inject_key};
@@ -99,7 +100,8 @@ pub mod prelude {
         RouteGuardDecision, RouteLoader, RouteNavigationCompleted, RouteNavigationFailed,
         RouteNavigationStarted, RouteRejection, RouteRejectionAction, RouteRejectionContext,
         RouteRejectionHandler, RouteTarget, RouteTargetError, RwSignal, Scope, ScopeId,
-        ServerError, ServerResult, Setter, Signal, Store,
+        ServerError, ServerFunctionClientCompleted, ServerFunctionClientFailed,
+        ServerFunctionClientStarted, ServerResult, Setter, Signal, Store,
     };
     pub use wasm_bindgen::prelude::*;
 }

--- a/crates/pocopine/tests/observability_frontend.rs
+++ b/crates/pocopine/tests/observability_frontend.rs
@@ -1,0 +1,314 @@
+#![cfg(all(target_arch = "wasm32", feature = "logging"))]
+
+use std::collections::BTreeMap;
+use std::fmt;
+use std::sync::{Arc, Mutex};
+
+use pocopine::observe::{FieldPrivacy, ObservedEvent};
+use pocopine::prelude::*;
+use serde::{Deserialize, Serialize};
+use tracing::field::{Field, Visit};
+use tracing::{Event, Subscriber};
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::Layer;
+use wasm_bindgen::JsValue;
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+use web_sys::Element;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "obs-plugin-shell",
+    template_inline = r#"<main><h1>observability</h1><pp-outlet></pp-outlet></main>"#
+)]
+struct ObsPluginShell {}
+
+#[handlers]
+impl ObsPluginShell {}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "obs-plugin-secret-page",
+    template_inline = r#"<section><p pp-text="id"></p></section>"#
+)]
+struct ObsPluginSecretPage {
+    #[prop]
+    pub id: String,
+}
+
+#[handlers]
+impl ObsPluginSecretPage {}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "obs-plugin-custom",
+    template_inline = r#"<section><p>custom observability</p></section>"#
+)]
+struct ObsPluginCustom {}
+
+#[handlers]
+impl ObsPluginCustom {
+    pub fn on_mount(&self) {
+        self.plugin::<pocopine::logging::FrontendObservability>()
+            .emit(ObservedEvent::analytics("component_custom_event").field(
+                "source",
+                "component",
+                FieldPrivacy::Public,
+            ));
+    }
+}
+
+#[wasm_bindgen_test]
+fn frontend_observability_plugin_emits_route_and_component_events_without_param_leaks() {
+    let _host = append_app_host("<obs-plugin-shell></obs-plugin-shell>");
+    push_url("/__obs-plugin/secret-42");
+
+    let capture = TraceCapture::new();
+    capture.run(|| {
+        App::new()
+            .plugin(observability_without_console())
+            .register::<ObsPluginShell>()
+            .route::<ObsPluginSecretPage>("/__obs-plugin/:id")
+            .run();
+    });
+
+    let events = capture.events();
+    assert!(
+        events.iter().any(|event| event.target == "pocopine.trace"
+            && event.field("event_name") == Some("frontend_app_started")),
+        "observability plugin should translate AppBootStarted into a trace event",
+    );
+
+    let route_event = events
+        .iter()
+        .find(|event| {
+            event.target == "pocopine.analytics" && event.field("event_name") == Some("route_view")
+        })
+        .expect("route_view analytics event should be emitted");
+    let route_fields = route_event
+        .field("fields")
+        .expect("ObservedEvent fields should be captured");
+    assert!(
+        route_fields.contains("/__obs-plugin/:id"),
+        "route_view should report the route pattern, not the concrete path",
+    );
+    assert!(
+        route_fields.contains("obs-plugin-secret-page"),
+        "route_view should include the mounted component name",
+    );
+
+    let component_event = events
+        .iter()
+        .find(|event| {
+            event.target == "pocopine.analytics"
+                && event.field("event_name") == Some("component_view")
+                && event
+                    .field("fields")
+                    .is_some_and(|fields| fields.contains("obs-plugin-secret-page"))
+        })
+        .expect("component_view analytics event should be emitted for the route component");
+    let duration_ms = f64_debug_field(
+        component_event
+            .field("fields")
+            .expect("component_view fields should be captured"),
+        "duration_ms",
+    )
+    .expect("component_view should include a numeric duration_ms");
+    assert!(
+        (0.0..250.0).contains(&duration_ms),
+        "simple component mount duration should stay inside the CI smoke budget, got {duration_ms}ms",
+    );
+
+    assert!(
+        events
+            .iter()
+            .all(|event| !event.contains_value("secret-42")),
+        "route params and DOM text must not leak into observability event fields",
+    );
+}
+
+#[wasm_bindgen_test]
+fn frontend_observability_service_is_available_to_components() {
+    let app_root = append_app_host("");
+
+    let capture = TraceCapture::new();
+    capture.run(|| {
+        App::new().plugin(observability_without_console()).run();
+
+        let host = append_plain_host("");
+        let handle = App::mount_subtree::<ObsPluginCustom>(&host);
+        handle.unmount();
+        host.remove();
+    });
+
+    let events = capture.events();
+    assert!(
+        events
+            .iter()
+            .any(|event| event.target == "pocopine.analytics"
+                && event.field("event_name") == Some("component_custom_event")
+                && event
+                    .field("fields")
+                    .is_some_and(|fields| fields.contains("component"))),
+        "components should be able to emit custom events through Plugin<FrontendObservability>",
+    );
+    assert!(
+        events.iter().any(|event| event.target == "pocopine.trace"
+            && event.field("event_name") == Some("component_unmounted")
+            && event
+                .field("fields")
+                .is_some_and(|fields| fields.contains("obs-plugin-custom"))),
+        "subtree unmount should flow through the plugin component hook",
+    );
+
+    app_root.remove();
+}
+
+fn observability_without_console() -> pocopine::logging::FrontendObservabilityPlugin {
+    pocopine::logging::frontend_observability_with_config(
+        pocopine::logging::FrontendObservabilityConfig::default().without_console_logging(),
+    )
+}
+
+#[derive(Clone, Debug)]
+struct CapturedEvent {
+    target: String,
+    fields: BTreeMap<String, String>,
+}
+
+impl CapturedEvent {
+    fn field(&self, name: &str) -> Option<&str> {
+        self.fields.get(name).map(String::as_str)
+    }
+
+    fn contains_value(&self, needle: &str) -> bool {
+        self.fields.values().any(|value| value.contains(needle))
+    }
+}
+
+#[derive(Clone, Default)]
+struct TraceCapture {
+    events: Arc<Mutex<Vec<CapturedEvent>>>,
+}
+
+impl TraceCapture {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn run<T>(&self, f: impl FnOnce() -> T) -> T {
+        let subscriber = tracing_subscriber::registry().with(CaptureLayer {
+            events: Arc::clone(&self.events),
+        });
+        tracing::subscriber::with_default(subscriber, f)
+    }
+
+    fn events(&self) -> Vec<CapturedEvent> {
+        self.events
+            .lock()
+            .expect("trace capture lock poisoned")
+            .clone()
+    }
+}
+
+struct CaptureLayer {
+    events: Arc<Mutex<Vec<CapturedEvent>>>,
+}
+
+impl<S> Layer<S> for CaptureLayer
+where
+    S: Subscriber,
+{
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let mut visitor = FieldVisitor::default();
+        event.record(&mut visitor);
+        self.events
+            .lock()
+            .expect("trace capture lock poisoned")
+            .push(CapturedEvent {
+                target: event.metadata().target().to_owned(),
+                fields: visitor.fields,
+            });
+    }
+}
+
+#[derive(Default)]
+struct FieldVisitor {
+    fields: BTreeMap<String, String>,
+}
+
+impl FieldVisitor {
+    fn insert(&mut self, field: &Field, value: impl Into<String>) {
+        self.fields.insert(field.name().to_owned(), value.into());
+    }
+}
+
+impl Visit for FieldVisitor {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        self.insert(field, value);
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.insert(field, value.to_string());
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.insert(field, value.to_string());
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.insert(field, value.to_string());
+    }
+
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.insert(field, value.to_string());
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        self.insert(field, format!("{value:?}"));
+    }
+}
+
+fn append_app_host(inner_html: &str) -> Element {
+    append_host(inner_html, true)
+}
+
+fn append_plain_host(inner_html: &str) -> Element {
+    append_host(inner_html, false)
+}
+
+fn append_host(inner_html: &str, is_app_root: bool) -> Element {
+    let document = web_sys::window()
+        .and_then(|window| window.document())
+        .expect("browser document");
+    let host = document.create_element("div").expect("host element");
+    if is_app_root {
+        let _ = host.set_attribute("pp-app", "");
+    }
+    host.set_inner_html(inner_html);
+    document
+        .body()
+        .expect("document body")
+        .append_child(host.as_ref())
+        .expect("append host");
+    host
+}
+
+fn push_url(path: &str) {
+    let window = web_sys::window().expect("browser window");
+    window
+        .history()
+        .expect("history")
+        .push_state_with_url(&JsValue::NULL, "", Some(path))
+        .expect("push test URL");
+}
+
+fn f64_debug_field(fields: &str, name: &str) -> Option<f64> {
+    let needle = format!("\"{name}\": ObservedField {{ value: F64(");
+    let start = fields.find(&needle)? + needle.len();
+    let rest = &fields[start..];
+    let end = rest.find(')')?;
+    rest[..end].parse().ok()
+}

--- a/crates/pocopine/tests/observability_frontend.rs
+++ b/crates/pocopine/tests/observability_frontend.rs
@@ -41,6 +41,8 @@ struct ObsPluginSecretPage {
 #[handlers]
 impl ObsPluginSecretPage {}
 
+impl RouteComponent for ObsPluginSecretPage {}
+
 #[derive(Default, Serialize, Deserialize)]
 #[component(
     name = "obs-plugin-custom",

--- a/docs/app-plugins.md
+++ b/docs/app-plugins.md
@@ -410,12 +410,32 @@ RouteNavigationFailed {
     reason,
     duration_ms,
 }
+
+ServerFunctionClientStarted {
+    route,
+}
+
+ServerFunctionClientCompleted {
+    route,
+    duration_ms,
+    status_code,
+}
+
+ServerFunctionClientFailed {
+    route,
+    duration_ms,
+    error_kind,
+}
 ```
 
 Route events include both the current URL path and the matched route pattern
 when one exists. Observability plugins should prefer `route_pattern` for
 aggregate analytics and treat `path` as potentially identifying, because apps
 often encode IDs in route segments.
+
+Server-function client events include the public request path with query
+strings and fragments stripped. They never include serialized arguments,
+response bodies, headers, or cookies.
 
 `AppBootCompleted.duration_ms` measures synchronous boot through root mount and
 post-mount scheduling. It does not include execution time for deferred
@@ -492,6 +512,8 @@ Observability is the reference use case:
   overrides without string filters in the hook implementation;
 - `hook_plugin` should subscribe to `AppBoot*` and `RouteNavigation*` events
   for boot and navigation telemetry;
+- `hook_plugin` should subscribe to `ServerFunctionClient*` events for
+  browser-side generated `#[server]` request telemetry;
 - component hooks can extract `Plugin<Observability>` for app-authored events;
 - reusable components can extract `Option<Plugin<Observability>>` to
   participate when observability is installed and remain portable when it is

--- a/docs/logging-tracing-observer.md
+++ b/docs/logging-tracing-observer.md
@@ -79,6 +79,84 @@ The browser layer maps tracing levels to the matching browser console call:
 | `INFO` | `console.info` |
 | `DEBUG` / `TRACE` | `console.debug` |
 
+`ConsoleLoggingConfig::debug()` writes a compact text line.
+`ConsoleLoggingConfig::json()` writes a structured console object with
+`level`, `target`, `message`, and `fields`, which is usually easier to inspect
+in browser DevTools.
+
+## Frontend observability plugin
+
+Apps can install framework observability without editing `pocopine-core` by
+using the logging app plugin:
+
+```rust
+#[wasm_bindgen::prelude::wasm_bindgen(start)]
+pub fn start() {
+    pocopine::app! {
+        components: [AppShell, HomePage, ReportPage],
+        plugins: [
+            pocopine::logging::frontend_observability(),
+        ],
+        routes: [
+            ("/", HomePage),
+            ("/report/:id", ReportPage),
+        ],
+    };
+}
+```
+
+The default plugin installs JSON browser console logging and translates typed
+framework lifecycle hooks into `ObservedEvent`s:
+
+| Framework hook | Observed event |
+|---|---|
+| `AppBootStarted` | `frontend_app_started` trace |
+| `AppBootCompleted` | `frontend_app_boot_completed` trace |
+| `AppBootFailed` | `frontend_app_boot_failed` log |
+| `RouteNavigationCompleted` | `route_view` analytics event |
+| `RouteNavigationFailed` | `route_navigation_failed` log |
+| `ComponentMounted` | `component_view` analytics event |
+| `ComponentUnmounted` | `component_unmounted` trace |
+| `ServerFunctionClientCompleted` | `server_function_client_completed` trace |
+| `ServerFunctionClientFailed` | `server_function_client_failed` log |
+
+Route events report the route pattern, such as `/report/:id`, not the concrete
+path. Server-function client events strip query strings and fragments from the
+request URL. Raw route params, DOM text, request arguments, and response bodies
+are not exported.
+
+For tests or apps that initialize their own subscriber, disable the console
+subscriber and keep only the lifecycle hooks:
+
+```rust
+let plugin = pocopine::logging::frontend_observability_with_config(
+    pocopine::logging::FrontendObservabilityConfig::default()
+        .without_console_logging()
+        .with_service("admin-ui")
+        .with_environment("staging"),
+);
+```
+
+The plugin also provides `Plugin<FrontendObservability>` to components:
+
+```rust
+use pocopine::logging::FrontendObservability;
+use pocopine::observe::{FieldPrivacy, ObservedEvent};
+
+#[handlers]
+impl ReportPage {
+    pub fn opened(&self) {
+        self.plugin::<FrontendObservability>().emit(
+            ObservedEvent::analytics("report_opened")
+                .field("source", "cta", FieldPrivacy::Public),
+        );
+    }
+}
+```
+
+Use `Option<Plugin<FrontendObservability>>` in reusable components when the
+component should work whether or not the app installed observability.
+
 ### Why `target` matters
 
 `ConsoleLoggingConfig::debug()` filters to targets that start with

--- a/examples/observability-frontend/Cargo.toml
+++ b/examples/observability-frontend/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "observability-frontend"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+publish = false
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+pocopine = { path = "../../crates/pocopine", features = ["logging"] }
+phf = { version = "0.13", features = ["macros"] }
+serde = { workspace = true }
+tracing = { workspace = true }
+wasm-bindgen = { workspace = true }

--- a/examples/observability-frontend/index.html
+++ b/examples/observability-frontend/index.html
@@ -1,0 +1,154 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>pocopine observability frontend</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family:
+          Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+          "Segoe UI", sans-serif;
+        background: #f7f7f4;
+        color: #202124;
+      }
+
+      body {
+        margin: 0;
+      }
+
+      [pp-app] {
+        min-height: 100vh;
+      }
+
+      .shell {
+        min-height: 100vh;
+        display: grid;
+        grid-template-rows: auto 1fr;
+      }
+
+      header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 24px;
+        padding: 18px 24px;
+        border-bottom: 1px solid #d8d6ce;
+        background: #ffffff;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: 18px;
+        font-weight: 700;
+      }
+
+      nav {
+        display: flex;
+        gap: 10px;
+      }
+
+      a,
+      button {
+        border: 1px solid #b9b7ad;
+        border-radius: 6px;
+        background: #ffffff;
+        color: #202124;
+        font: inherit;
+        font-weight: 600;
+        line-height: 1;
+        text-decoration: none;
+      }
+
+      a {
+        padding: 10px 12px;
+      }
+
+      button {
+        cursor: pointer;
+        padding: 11px 14px;
+      }
+
+      main {
+        width: min(920px, calc(100vw - 32px));
+        margin: 0 auto;
+        padding: 32px 0;
+      }
+
+      section {
+        display: grid;
+        gap: 14px;
+      }
+
+      h2 {
+        margin: 0;
+        font-size: 26px;
+      }
+
+      p {
+        margin: 0;
+        color: #4d4f52;
+      }
+
+      .metric-grid {
+        display: grid;
+        grid-template-columns: repeat(4, minmax(0, 1fr));
+        gap: 12px;
+        margin-top: 8px;
+      }
+
+      .metric-card {
+        display: grid;
+        gap: 10px;
+        min-width: 0;
+        padding: 14px;
+        border: 1px solid #d8d6ce;
+        border-radius: 6px;
+        background: #ffffff;
+      }
+
+      .metric-card span {
+        color: #65676b;
+        font-size: 13px;
+        font-weight: 600;
+      }
+
+      output {
+        font-weight: 700;
+        color: #202124;
+      }
+
+      .metric-card output {
+        overflow-wrap: anywhere;
+      }
+
+      @media (max-width: 760px) {
+        header {
+          align-items: flex-start;
+          flex-direction: column;
+        }
+
+        .metric-grid {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+
+      @media (max-width: 460px) {
+        .metric-grid {
+          grid-template-columns: 1fr;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div pp-app>
+      <obs-frontend-shell></obs-frontend-shell>
+    </div>
+    <script type="module">
+      import init from "/pkg/observability_frontend.js";
+
+      await init();
+    </script>
+  </body>
+</html>

--- a/examples/observability-frontend/src/lib.rs
+++ b/examples/observability-frontend/src/lib.rs
@@ -56,6 +56,8 @@ impl ObsFrontendHome {
     }
 }
 
+impl RouteComponent for ObsFrontendHome {}
+
 #[derive(Default, Serialize, Deserialize)]
 #[component(
     name = "obs-frontend-report",
@@ -124,6 +126,8 @@ impl ObsFrontendReport {
     }
 }
 
+impl RouteComponent for ObsFrontendReport {}
+
 #[derive(Default, Serialize, Deserialize)]
 #[component(
     name = "obs-frontend-not-found",
@@ -138,6 +142,8 @@ pub struct ObsFrontendNotFound {}
 
 #[handlers]
 impl ObsFrontendNotFound {}
+
+impl RouteComponent for ObsFrontendNotFound {}
 
 #[wasm_bindgen(start)]
 pub fn main() {

--- a/examples/observability-frontend/src/lib.rs
+++ b/examples/observability-frontend/src/lib.rs
@@ -1,0 +1,166 @@
+#![cfg(target_arch = "wasm32")]
+
+use pocopine::logging::{FrontendObservability, FrontendObservabilityConfig};
+use pocopine::observe::{FieldPrivacy, ObservedEvent};
+use pocopine::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "obs-frontend-shell",
+    template_inline = r#"
+    <div class="shell">
+      <header>
+        <h1>Frontend observability</h1>
+        <nav>
+          <a href="/" pp-route>Home</a>
+          <a href="/report/demo-42" pp-route>Report</a>
+        </nav>
+      </header>
+      <main>
+        <pp-outlet></pp-outlet>
+      </main>
+    </div>
+    "#
+)]
+pub struct ObsFrontendShell {}
+
+#[handlers]
+impl ObsFrontendShell {}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "obs-frontend-home",
+    template_inline = r#"
+    <section>
+      <h2>Home</h2>
+      <p>Open DevTools to see structured pocopine events in the console.</p>
+      <button @click="track_feature">Track feature</button>
+      <p>Tracked feature uses: <output pp-text="tracked"></output></p>
+    </section>
+    "#
+)]
+pub struct ObsFrontendHome {
+    pub tracked: u32,
+}
+
+#[handlers]
+impl ObsFrontendHome {
+    pub fn track_feature(&mut self) {
+        self.tracked += 1;
+        self.plugin::<FrontendObservability>().emit(
+            ObservedEvent::analytics("feature_used")
+                .field("feature", "observability_button", FieldPrivacy::Public)
+                .field("count", self.tracked, FieldPrivacy::Public),
+        );
+    }
+}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "obs-frontend-report",
+    template_inline = r#"
+    <section>
+      <h2>Report</h2>
+      <p>Current report: <output pp-text="id"></output></p>
+      <div class="metric-grid">
+        <article class="metric-card">
+          <span>Route pattern</span>
+          <output pp-text="route_pattern"></output>
+        </article>
+        <article class="metric-card">
+          <span>Report id length</span>
+          <output pp-text="report_id_len"></output>
+        </article>
+        <article class="metric-card">
+          <span>Events emitted</span>
+          <output pp-text="events_emitted"></output>
+        </article>
+        <article class="metric-card">
+          <span>Private fields exported</span>
+          <output pp-text="private_fields_exported"></output>
+        </article>
+      </div>
+      <p>Latest metric event: <output pp-text="latest_metric"></output></p>
+    </section>
+    "#
+)]
+pub struct ObsFrontendReport {
+    #[prop]
+    pub id: String,
+    pub route_pattern: String,
+    pub report_id_len: u64,
+    pub events_emitted: u32,
+    pub private_fields_exported: u32,
+    pub latest_metric: String,
+}
+
+#[handlers]
+impl ObsFrontendReport {
+    pub fn on_setup(&mut self) {
+        self.route_pattern = "/report/:id".to_string();
+        self.report_id_len = self.id.len() as u64;
+        self.events_emitted = 3;
+        self.private_fields_exported = 0;
+        self.latest_metric = "report_metrics_visible".to_string();
+    }
+
+    pub fn on_mount(&self) {
+        // Keep the raw report id out of telemetry; route params may contain
+        // customer or account identifiers in real applications.
+        self.plugin::<FrontendObservability>().emit(
+            ObservedEvent::analytics("report_viewed").field(
+                "report_id_len",
+                self.id.len() as u64,
+                FieldPrivacy::Public,
+            ),
+        );
+        self.plugin::<FrontendObservability>().emit(
+            ObservedEvent::metric("report_metrics_visible")
+                .field("route", "/report/:id", FieldPrivacy::Public)
+                .field("report_id_len", self.report_id_len, FieldPrivacy::Public)
+                .field("visible_metrics", 4_u64, FieldPrivacy::Public),
+        );
+    }
+}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "obs-frontend-not-found",
+    template_inline = r#"
+    <section>
+      <h2>Not Found</h2>
+      <p>The requested route does not exist.</p>
+    </section>
+    "#
+)]
+pub struct ObsFrontendNotFound {}
+
+#[handlers]
+impl ObsFrontendNotFound {}
+
+#[wasm_bindgen(start)]
+pub fn main() {
+    let observability = pocopine::logging::frontend_observability_with_config(
+        FrontendObservabilityConfig::default()
+            .with_service("observability-frontend")
+            .with_environment("dev"),
+    );
+
+    pocopine::app! {
+        components: [
+            ObsFrontendShell,
+            ObsFrontendHome,
+            ObsFrontendReport,
+            ObsFrontendNotFound,
+        ],
+        plugins: [
+            observability,
+        ],
+        routes: [
+            ("/", ObsFrontendHome),
+            ("/report/:id", ObsFrontendReport),
+            ("*", ObsFrontendNotFound),
+        ],
+    };
+}

--- a/rfcs/rfc-069-observability.md
+++ b/rfcs/rfc-069-observability.md
@@ -176,7 +176,8 @@ wasm logging/analytics adapter compile checks.
 
 Later phases should add:
 
-- first-class route/server-function/job instrumentation points;
+- first-class route and server-function instrumentation points;
+- job observability export from the existing `pocopine-jobs` tracing events;
 - OpenTelemetry adapter;
 - AWS/Cloudflare host sinks;
 - bounded async exporter queues;

--- a/rfcs/rfc-069-observability.md
+++ b/rfcs/rfc-069-observability.md
@@ -63,7 +63,10 @@ ships:
 - host/server initialization through `tracing-subscriber`;
 - compact, pretty, and JSON server formats;
 - `RUST_LOG` / explicit filter support;
-- wasm browser console subscriber.
+- wasm browser console subscriber;
+- wasm frontend observability app plugin that subscribes to core lifecycle
+  hooks and emits stable `ObservedEvent`s without adding exporter dependencies
+  to `pocopine-core`.
 
 `pocopine-analytics` owns analytics and telemetry dispatch. The first slice
 ships:
@@ -82,6 +85,11 @@ Runtime crates must not install global subscribers or exporters. They may emit
 `tracing` spans/events and may construct typed `ObservedEvent`s for stable
 framework events.
 
+Frontend framework lifecycle instrumentation is installed through the app plugin
+surface. Core emits typed hooks such as `AppBoot*`, `RouteNavigation*`,
+`ComponentMounted`, `ComponentUnmounted`, and `ServerFunctionClient*`; the
+logging plugin converts those hooks into `ObservedEvent`s.
+
 The final application binary or wasm entrypoint installs logging and analytics:
 
 ```rust
@@ -98,6 +106,18 @@ let analytics = pocopine::analytics::AnalyticsClient::new()
 analytics.emit(
     pocopine::analytics::route_view("/settings")
 );
+```
+
+```rust
+pocopine::app! {
+    components: [AppShell, Home],
+    plugins: [
+        pocopine::logging::frontend_observability(),
+    ],
+    routes: [
+        ("/", Home),
+    ],
+};
 ```
 
 ### 3.3 Vendor adapters

--- a/rfcs/rfc-076-app-plugin-lifecycle.md
+++ b/rfcs/rfc-076-app-plugin-lifecycle.md
@@ -468,5 +468,6 @@ The first slice ships:
 - wasm tests for direct builder plugins, macro plugins, plugin extractors, and
   framework hook dispatch.
 
-Later slices can add convenience plugins in separate crates, beginning with
-observability.
+The first downstream consumer is `pocopine-logging`'s frontend observability
+plugin, which installs console logging and subscribes to the lifecycle hooks
+without patching `pocopine-core`.

--- a/rfcs/rfc-077-server-plugin-lifecycle.md
+++ b/rfcs/rfc-077-server-plugin-lifecycle.md
@@ -252,19 +252,13 @@ function payloads are never part of framework events. Observability plugins may
 derive fields such as payload size or error class, but raw payload logging
 stays opt-in application code.
 
-Job lifecycle events should either be added to this same hook registry or
-bridged from `pocopine-jobs` through a small server plugin:
-
-```rust
-JobStarted { job_name, job_id, attempt, max_attempts }
-JobCompleted { job_name, job_id, duration_ms }
-JobRetryScheduled { job_name, job_id, attempt, retry_in_ms }
-JobDeadLettered { job_name, job_id, attempts, error_class }
-```
-
-The preferred first slice is to make jobs emit through their existing tracing
-targets and let the observability plugin consume them. A later slice can add
-typed job hooks if callers need in-process behavior.
+Job lifecycle observability stays tracing-first. `pocopine-jobs` already emits
+structured events on the `pocopine.trace` and `pocopine.log` targets; server
+observability plugins should subscribe to and export those events through the
+normal tracing pipeline. Do not mirror them into typed `ServerHook<E>` events.
+Phase 4 records why the typed hook shape was rejected. If a future plugin needs
+to change job execution behavior, design the around-job middleware chain
+described in Phase 4 instead of lifecycle callbacks.
 
 ### 5.4 HTTP middleware
 


### PR DESCRIPTION
## Summary

- install frontend observability through the app plugin lifecycle instead of patching framework core directly
- add `FrontendObservability` service/plugin wiring, route/component/app lifecycle event translation, and JSON browser console formatting docs/examples
- add a focused browser observability example and wasm tests for route/component emissions and privacy boundaries
- align RFC 069/077 docs with the latest decision that job observability remains tracing-first and typed job hooks are rejected

## Tests

- `cargo fmt --all -- --check`
- `cargo test -p pocopine --test observability_frontend`
- `cargo clippy -p pocopine --features logging --tests -- -D warnings`
- `wasm-pack test --firefox --headless crates/pocopine --features logging --test observability_frontend`