### PR TITLE
Add LiveQuery client for live invalidation

### DIFF
--- a/crates/pocopine-live/src/lib.rs
+++ b/crates/pocopine-live/src/lib.rs
@@ -4,16 +4,22 @@
 //! neutral event spine, while this crate owns the safe browser protocol
 //! for collection/query invalidation.
 //!
-//! Browser components can either consume raw typed events with
-//! `LiveClient` or use `LiveRefresh` to map collection/query
-//! invalidations to refetch callbacks:
+//! Browser components should usually store data in `QueryState<T>` and
+//! open a `LiveQuery` that refetches when a collection/query invalidation
+//! arrives:
 //!
 //! ```ignore
-//! let handle = pocopine::this::<PostList>();
-//! pocopine::live::LiveRefresh::scoped()
-//!     .collection("posts", move |_| handle.update(|s| s.reload()))
+//! pocopine::live::LiveQuery::scoped(
+//!     |s: &mut PostList| &mut s.posts,
+//!     || async { list_posts().await },
+//! )
+//!     .query_tag("posts:list")
 //!     .open()?;
 //! ```
+//!
+//! Use `LiveClient` for raw typed events and `LiveRefresh` when a
+//! component needs custom collection/query callbacks instead of a query
+//! refetch.
 
 use std::fmt;
 
@@ -23,7 +29,7 @@ use serde_json::{json, Value};
 
 mod query;
 
-pub use query::{LiveQuery, QueryReason, QueryRequest, QueryState};
+pub use query::{LiveQuery, QueryReason, QueryRequest, QuerySelector, QueryState};
 
 /// Current browser live protocol identifier.
 pub const LIVE_PROTOCOL_V1: &str = "pocopine.live.v1";

--- a/crates/pocopine-live/src/lib.rs
+++ b/crates/pocopine-live/src/lib.rs
@@ -21,6 +21,13 @@ use pocopine_events::{EventDraft, EventError, EventKind, EventResult, IntoTopic,
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
+mod query;
+
+pub use query::{
+    QueryRequest, QueryState, QUERY_REASON_GAP, QUERY_REASON_INITIAL, QUERY_REASON_LIVE,
+    QUERY_REASON_MANUAL, QUERY_REASON_STREAM_ERROR,
+};
+
 /// Current browser live protocol identifier.
 pub const LIVE_PROTOCOL_V1: &str = "pocopine.live.v1";
 

--- a/crates/pocopine-live/src/lib.rs
+++ b/crates/pocopine-live/src/lib.rs
@@ -23,10 +23,7 @@ use serde_json::{json, Value};
 
 mod query;
 
-pub use query::{
-    QueryRequest, QueryState, QUERY_REASON_GAP, QUERY_REASON_INITIAL, QUERY_REASON_LIVE,
-    QUERY_REASON_MANUAL, QUERY_REASON_STREAM_ERROR,
-};
+pub use query::{LiveQuery, QueryReason, QueryRequest, QueryState};
 
 /// Current browser live protocol identifier.
 pub const LIVE_PROTOCOL_V1: &str = "pocopine.live.v1";

--- a/crates/pocopine-live/src/query.rs
+++ b/crates/pocopine-live/src/query.rs
@@ -1,10 +1,30 @@
+use std::marker::PhantomData;
+
 use serde::{Deserialize, Serialize};
 
-pub const QUERY_REASON_INITIAL: &str = "initial";
-pub const QUERY_REASON_MANUAL: &str = "manual";
-pub const QUERY_REASON_LIVE: &str = "live";
-pub const QUERY_REASON_GAP: &str = "gap";
-pub const QUERY_REASON_STREAM_ERROR: &str = "stream_error";
+#[cfg(target_arch = "wasm32")]
+use {
+    pocopine_core::{current_scope_id, Handle, Scope},
+    std::{future::Future, rc::Rc},
+};
+
+use crate::LiveClientError;
+
+#[cfg(any(test, target_arch = "wasm32"))]
+use crate::{live_refresh_targets, LiveEvent};
+
+/// Reason attached to the most recent query state transition.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QueryReason {
+    #[default]
+    Idle,
+    Initial,
+    Manual,
+    Live,
+    Gap,
+    StreamError,
+}
 
 /// Opaque generation token for one query request.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -34,7 +54,7 @@ pub struct QueryState<T> {
     pub version: u64,
     pub refresh_count: u64,
     pub live_event_count: u64,
-    pub last_reason: String,
+    pub last_reason: QueryReason,
     #[serde(skip)]
     request_generation: u64,
 }
@@ -56,20 +76,20 @@ impl<T> QueryState<T> {
             version: 0,
             refresh_count: 0,
             live_event_count: 0,
-            last_reason: String::new(),
+            last_reason: QueryReason::Idle,
             request_generation: 0,
         }
     }
 
     pub fn begin_initial(&mut self) -> QueryRequest {
-        self.begin(QUERY_REASON_INITIAL, false)
+        self.begin(QueryReason::Initial, false)
     }
 
-    pub fn begin_refresh(&mut self, reason: impl Into<String>) -> QueryRequest {
+    pub fn begin_refresh(&mut self, reason: QueryReason) -> QueryRequest {
         self.begin(reason, false)
     }
 
-    pub fn begin_live_refresh(&mut self, reason: impl Into<String>) -> QueryRequest {
+    pub fn begin_live_refresh(&mut self, reason: QueryReason) -> QueryRequest {
         self.live_event_count = self.live_event_count.saturating_add(1);
         self.begin(reason, true)
     }
@@ -110,15 +130,15 @@ impl<T> QueryState<T> {
         self.error.clear();
     }
 
-    pub fn mark_stale(&mut self, reason: impl Into<String>) {
+    pub fn mark_stale(&mut self, reason: QueryReason) {
         self.stale = true;
-        self.last_reason = reason.into();
+        self.last_reason = reason;
     }
 
     pub fn record_stream_error(&mut self, error: impl ToString) {
         self.loading = false;
         self.refreshing = false;
-        self.last_reason = QUERY_REASON_STREAM_ERROR.to_string();
+        self.last_reason = QueryReason::StreamError;
         self.error = error.to_string();
     }
 
@@ -126,10 +146,10 @@ impl<T> QueryState<T> {
         self.request_generation == request.generation
     }
 
-    fn begin(&mut self, reason: impl Into<String>, stale_during_refresh: bool) -> QueryRequest {
+    fn begin(&mut self, reason: QueryReason, stale_during_refresh: bool) -> QueryRequest {
         self.request_generation = self.request_generation.saturating_add(1);
         self.refresh_count = self.refresh_count.saturating_add(1);
-        self.last_reason = reason.into();
+        self.last_reason = reason;
         self.error.clear();
         self.stale = stale_during_refresh;
 
@@ -145,6 +165,304 @@ impl<T> QueryState<T> {
             generation: self.request_generation,
         }
     }
+}
+
+/// Scope-bound browser query runner for server-function backed data.
+pub struct LiveQuery<C = (), T = (), S = (), F = ()> {
+    selector: S,
+    fetch: F,
+    endpoint: Option<String>,
+    collections: Vec<String>,
+    query_tags: Vec<String>,
+    last_event_id: Option<String>,
+    with_credentials: bool,
+    refetch_on_open: bool,
+    _marker: PhantomData<fn(C) -> T>,
+}
+
+impl LiveQuery<(), (), (), ()> {
+    pub fn scoped<C, T, S, F>(selector: S, fetch: F) -> LiveQuery<C, T, S, F> {
+        LiveQuery {
+            selector,
+            fetch,
+            endpoint: None,
+            collections: Vec::new(),
+            query_tags: Vec::new(),
+            last_event_id: None,
+            with_credentials: false,
+            refetch_on_open: true,
+            _marker: PhantomData,
+        }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub fn refresh_scoped<C, T, S, F, Fut, E>(selector: S, fetch: F) -> Result<(), LiveClientError>
+    where
+        C: 'static,
+        T: 'static,
+        S: for<'a> Fn(&'a mut C) -> &'a mut QueryState<T> + 'static,
+        F: Fn() -> Fut + 'static,
+        Fut: Future<Output = Result<T, E>> + 'static,
+        E: ToString + 'static,
+    {
+        let handle = current_component_handle::<C>()?;
+        start_query(
+            handle,
+            Rc::new(selector),
+            Rc::new(fetch),
+            QueryReason::Manual,
+            false,
+        );
+        Ok(())
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn refresh_scoped<C, T, S, F, Fut, E>(selector: S, fetch: F) -> Result<(), LiveClientError>
+    where
+        C: 'static,
+        T: 'static,
+        S: for<'a> Fn(&'a mut C) -> &'a mut QueryState<T> + 'static,
+        F: Fn() -> Fut + 'static,
+        Fut: std::future::Future<Output = Result<T, E>> + 'static,
+        E: ToString + 'static,
+    {
+        let _ = (selector, fetch);
+        Ok(())
+    }
+}
+
+impl<C, T, S, F> LiveQuery<C, T, S, F> {
+    pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.endpoint = Some(endpoint.into());
+        self
+    }
+
+    pub fn collection(mut self, collection: impl Into<String>) -> Self {
+        self.collections.push(collection.into());
+        self
+    }
+
+    pub fn query_tag(mut self, tag: impl Into<String>) -> Self {
+        self.query_tags.push(tag.into());
+        self
+    }
+
+    pub fn last_event_id(mut self, cursor: impl Into<String>) -> Self {
+        self.last_event_id = Some(cursor.into());
+        self
+    }
+
+    pub fn with_credentials(mut self, enabled: bool) -> Self {
+        self.with_credentials = enabled;
+        self
+    }
+
+    pub fn refetch_on_open(mut self, enabled: bool) -> Self {
+        self.refetch_on_open = enabled;
+        self
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub fn open<Fut, E>(self) -> Result<(), LiveClientError>
+    where
+        C: 'static,
+        T: 'static,
+        S: for<'a> Fn(&'a mut C) -> &'a mut QueryState<T> + 'static,
+        F: Fn() -> Fut + 'static,
+        Fut: Future<Output = Result<T, E>> + 'static,
+        E: ToString + 'static,
+    {
+        let handle = current_component_handle::<C>()?;
+        let selector = Rc::new(self.selector);
+        let fetch = Rc::new(self.fetch);
+
+        if self.refetch_on_open {
+            start_query(
+                handle.clone(),
+                selector.clone(),
+                fetch.clone(),
+                QueryReason::Initial,
+                false,
+            );
+        }
+
+        if self.collections.is_empty() && self.query_tags.is_empty() {
+            return Ok(());
+        }
+
+        let mut client = crate::LiveClient::new();
+        if let Some(endpoint) = self.endpoint {
+            client = client.endpoint(endpoint);
+        }
+        if let Some(cursor) = self.last_event_id {
+            client = client.last_event_id(cursor);
+        }
+        client = client.with_credentials(self.with_credentials);
+        for collection in &self.collections {
+            client = client.collection(collection.clone());
+        }
+        for query_tag in &self.query_tags {
+            client = client.query_tag(query_tag.clone());
+        }
+
+        let collections = Rc::new(self.collections);
+        let query_tags = Rc::new(self.query_tags);
+        client.connect_scoped(move |event| {
+            match live_query_action(&event, &collections, &query_tags) {
+                LiveQueryAction::Refresh(reason) => {
+                    start_query(
+                        handle.clone(),
+                        selector.clone(),
+                        fetch.clone(),
+                        reason,
+                        true,
+                    );
+                }
+                LiveQueryAction::Error(error) => {
+                    handle.update(|state| {
+                        (selector)(state).record_stream_error(error);
+                    });
+                }
+                LiveQueryAction::Ignore => {}
+            }
+        })
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn open<Fut, E>(self) -> Result<(), LiveClientError>
+    where
+        C: 'static,
+        T: 'static,
+        S: for<'a> Fn(&'a mut C) -> &'a mut QueryState<T> + 'static,
+        F: Fn() -> Fut + 'static,
+        Fut: std::future::Future<Output = Result<T, E>> + 'static,
+        E: ToString + 'static,
+    {
+        let LiveQuery {
+            selector,
+            fetch,
+            endpoint,
+            collections,
+            query_tags,
+            last_event_id,
+            with_credentials,
+            refetch_on_open,
+            _marker,
+        } = self;
+        let _ = (
+            selector,
+            fetch,
+            endpoint,
+            collections,
+            query_tags,
+            last_event_id,
+            with_credentials,
+            refetch_on_open,
+        );
+        Ok(())
+    }
+}
+
+#[cfg(any(test, target_arch = "wasm32"))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+enum LiveQueryAction {
+    Refresh(QueryReason),
+    Error(String),
+    Ignore,
+}
+
+#[cfg(any(test, target_arch = "wasm32"))]
+fn live_query_action(
+    event: &LiveEvent,
+    collections: &[String],
+    query_tags: &[String],
+) -> LiveQueryAction {
+    let targets = live_refresh_targets(event);
+
+    if let Some(reason) = targets.error {
+        return LiveQueryAction::Error(reason);
+    }
+
+    if targets.gap.is_some() {
+        return LiveQueryAction::Refresh(QueryReason::Gap);
+    }
+
+    let matches_collection = targets
+        .collections
+        .iter()
+        .any(|target| collections.iter().any(|value| value == target));
+    let matches_query_tag = targets
+        .query_tags
+        .iter()
+        .any(|target| query_tags.iter().any(|value| value == target));
+
+    if matches_collection || matches_query_tag {
+        LiveQueryAction::Refresh(QueryReason::Live)
+    } else {
+        LiveQueryAction::Ignore
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn current_component_handle<C: 'static>() -> Result<Handle<C>, LiveClientError> {
+    let scope_id = current_scope_id().ok_or_else(|| {
+        LiveClientError::Browser(
+            "LiveQuery::scoped used outside a component handler or lifecycle hook".to_string(),
+        )
+    })?;
+    let scope = Scope::find(scope_id)
+        .ok_or_else(|| LiveClientError::Browser("current component scope is gone".to_string()))?;
+    let typed = scope.typed::<C>().ok_or_else(|| {
+        LiveClientError::Browser(format!(
+            "LiveQuery::scoped expected current scope to be {}",
+            std::any::type_name::<C>()
+        ))
+    })?;
+    Ok(Handle::new(typed, scope_id))
+}
+
+#[cfg(target_arch = "wasm32")]
+fn start_query<C, T, S, F, Fut, E>(
+    handle: Handle<C>,
+    selector: Rc<S>,
+    fetch: Rc<F>,
+    reason: QueryReason,
+    live_event: bool,
+) where
+    C: 'static,
+    T: 'static,
+    S: for<'a> Fn(&'a mut C) -> &'a mut QueryState<T> + 'static,
+    F: Fn() -> Fut + 'static,
+    Fut: Future<Output = Result<T, E>> + 'static,
+    E: ToString + 'static,
+{
+    let request = handle.update(|state| {
+        let query = (selector)(state);
+        if live_event {
+            query.begin_live_refresh(reason)
+        } else {
+            query.begin_refresh(reason)
+        }
+    });
+    let scope_id = handle.scope_id();
+    pocopine_core::spawn_for_scope(scope_id, async move {
+        let result = (fetch)().await;
+        if Scope::find(scope_id).is_none() {
+            return;
+        }
+
+        handle.update(|state| {
+            let query = (selector)(state);
+            match result {
+                Ok(data) => {
+                    query.finish_success(request, data);
+                }
+                Err(error) => {
+                    query.finish_error(request, error);
+                }
+            }
+        });
+    });
 }
 
 #[cfg(test)]
@@ -180,14 +498,14 @@ mod tests {
         assert!(state.error.is_empty());
         assert_eq!(state.version, 1);
         assert_eq!(state.refresh_count, 1);
-        assert_eq!(state.last_reason, QUERY_REASON_INITIAL);
+        assert_eq!(state.last_reason, QueryReason::Initial);
     }
 
     #[test]
     fn query_state_ignores_stale_success() {
         let mut state = QueryState::new(vec![1]);
         let stale = state.begin_initial();
-        let current = state.begin_refresh(QUERY_REASON_MANUAL);
+        let current = state.begin_refresh(QueryReason::Manual);
 
         assert!(!state.finish_success(stale, vec![9]));
         assert_eq!(state.data, vec![1]);
@@ -201,7 +519,7 @@ mod tests {
         let request = state.begin_initial();
         assert!(state.finish_success(request, vec![2]));
 
-        let request = state.begin_refresh(QUERY_REASON_MANUAL);
+        let request = state.begin_refresh(QueryReason::Manual);
         assert!(state.finish_error(request, "network down"));
 
         assert_eq!(state.data, vec![2]);
@@ -217,13 +535,60 @@ mod tests {
         let request = state.begin_initial();
         assert!(state.finish_success(request, vec![1]));
 
-        let live = state.begin_live_refresh(QUERY_REASON_LIVE);
+        let live = state.begin_live_refresh(QueryReason::Live);
 
         assert_eq!(state.live_event_count, 1);
-        assert_eq!(state.last_reason, QUERY_REASON_LIVE);
+        assert_eq!(state.last_reason, QueryReason::Live);
         assert!(state.stale);
         assert!(state.refreshing);
         assert!(state.finish_success(live, vec![2]));
         assert!(!state.stale);
+    }
+
+    #[test]
+    fn live_query_action_matches_collection_or_query_tag() {
+        let event = LiveEvent::CollectionChanged {
+            collection: "posts".to_string(),
+            op: crate::LiveOp::Upsert,
+            keys: vec![],
+            query_tags: vec!["posts:list".to_string()],
+            schema_version: 1,
+            cursor: None,
+            created_at_ms: None,
+        };
+
+        assert_eq!(
+            live_query_action(&event, &[], &["posts:list".to_string()]),
+            LiveQueryAction::Refresh(QueryReason::Live)
+        );
+        assert_eq!(
+            live_query_action(&event, &["posts".to_string()], &[]),
+            LiveQueryAction::Refresh(QueryReason::Live)
+        );
+        assert_eq!(live_query_action(&event, &[], &[]), LiveQueryAction::Ignore);
+    }
+
+    #[test]
+    fn live_query_action_refreshes_on_gap_and_records_error() {
+        assert_eq!(
+            live_query_action(
+                &LiveEvent::Gap {
+                    reason: "retention_gap".to_string()
+                },
+                &[],
+                &[]
+            ),
+            LiveQueryAction::Refresh(QueryReason::Gap)
+        );
+        assert_eq!(
+            live_query_action(
+                &LiveEvent::Error {
+                    reason: "forbidden_topic".to_string()
+                },
+                &[],
+                &[]
+            ),
+            LiveQueryAction::Error("forbidden_topic".to_string())
+        );
     }
 }

--- a/crates/pocopine-live/src/query.rs
+++ b/crates/pocopine-live/src/query.rs
@@ -168,8 +168,11 @@ impl<T> QueryState<T> {
 }
 
 /// Scope-bound browser query runner for server-function backed data.
-pub struct LiveQuery<C = (), T = (), S = (), F = ()> {
-    selector: S,
+pub type QuerySelector<C, T> = for<'a> fn(&'a mut C) -> &'a mut QueryState<T>;
+
+/// Scope-bound browser query runner for server-function backed data.
+pub struct LiveQuery<C = (), T = (), F = ()> {
+    selector: QuerySelector<C, T>,
     fetch: F,
     endpoint: Option<String>,
     collections: Vec<String>,
@@ -180,8 +183,8 @@ pub struct LiveQuery<C = (), T = (), S = (), F = ()> {
     _marker: PhantomData<fn(C) -> T>,
 }
 
-impl LiveQuery<(), (), (), ()> {
-    pub fn scoped<C, T, S, F>(selector: S, fetch: F) -> LiveQuery<C, T, S, F> {
+impl LiveQuery<(), (), ()> {
+    pub fn scoped<C, T, F>(selector: QuerySelector<C, T>, fetch: F) -> LiveQuery<C, T, F> {
         LiveQuery {
             selector,
             fetch,
@@ -196,32 +199,30 @@ impl LiveQuery<(), (), (), ()> {
     }
 
     #[cfg(target_arch = "wasm32")]
-    pub fn refresh_scoped<C, T, S, F, Fut, E>(selector: S, fetch: F) -> Result<(), LiveClientError>
+    pub fn refresh_scoped<C, T, F, Fut, E>(
+        selector: QuerySelector<C, T>,
+        fetch: F,
+    ) -> Result<(), LiveClientError>
     where
         C: 'static,
         T: 'static,
-        S: for<'a> Fn(&'a mut C) -> &'a mut QueryState<T> + 'static,
         F: Fn() -> Fut + 'static,
         Fut: Future<Output = Result<T, E>> + 'static,
         E: ToString + 'static,
     {
         let handle = current_component_handle::<C>()?;
-        start_query(
-            handle,
-            Rc::new(selector),
-            Rc::new(fetch),
-            QueryReason::Manual,
-            false,
-        );
+        start_query(handle, selector, Rc::new(fetch), QueryReason::Manual, false);
         Ok(())
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    pub fn refresh_scoped<C, T, S, F, Fut, E>(selector: S, fetch: F) -> Result<(), LiveClientError>
+    pub fn refresh_scoped<C, T, F, Fut, E>(
+        selector: QuerySelector<C, T>,
+        fetch: F,
+    ) -> Result<(), LiveClientError>
     where
         C: 'static,
         T: 'static,
-        S: for<'a> Fn(&'a mut C) -> &'a mut QueryState<T> + 'static,
         F: Fn() -> Fut + 'static,
         Fut: std::future::Future<Output = Result<T, E>> + 'static,
         E: ToString + 'static,
@@ -231,7 +232,7 @@ impl LiveQuery<(), (), (), ()> {
     }
 }
 
-impl<C, T, S, F> LiveQuery<C, T, S, F> {
+impl<C, T, F> LiveQuery<C, T, F> {
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = Some(endpoint.into());
         self
@@ -267,19 +268,18 @@ impl<C, T, S, F> LiveQuery<C, T, S, F> {
     where
         C: 'static,
         T: 'static,
-        S: for<'a> Fn(&'a mut C) -> &'a mut QueryState<T> + 'static,
         F: Fn() -> Fut + 'static,
         Fut: Future<Output = Result<T, E>> + 'static,
         E: ToString + 'static,
     {
         let handle = current_component_handle::<C>()?;
-        let selector = Rc::new(self.selector);
+        let selector = self.selector;
         let fetch = Rc::new(self.fetch);
 
         if self.refetch_on_open {
             start_query(
                 handle.clone(),
-                selector.clone(),
+                selector,
                 fetch.clone(),
                 QueryReason::Initial,
                 false,
@@ -310,17 +310,11 @@ impl<C, T, S, F> LiveQuery<C, T, S, F> {
         client.connect_scoped(move |event| {
             match live_query_action(&event, &collections, &query_tags) {
                 LiveQueryAction::Refresh(reason) => {
-                    start_query(
-                        handle.clone(),
-                        selector.clone(),
-                        fetch.clone(),
-                        reason,
-                        true,
-                    );
+                    start_query(handle.clone(), selector, fetch.clone(), reason, true);
                 }
                 LiveQueryAction::Error(error) => {
                     handle.update(|state| {
-                        (selector)(state).record_stream_error(error);
+                        selector(state).record_stream_error(error);
                     });
                 }
                 LiveQueryAction::Ignore => {}
@@ -333,7 +327,6 @@ impl<C, T, S, F> LiveQuery<C, T, S, F> {
     where
         C: 'static,
         T: 'static,
-        S: for<'a> Fn(&'a mut C) -> &'a mut QueryState<T> + 'static,
         F: Fn() -> Fut + 'static,
         Fut: std::future::Future<Output = Result<T, E>> + 'static,
         E: ToString + 'static,
@@ -422,22 +415,21 @@ fn current_component_handle<C: 'static>() -> Result<Handle<C>, LiveClientError> 
 }
 
 #[cfg(target_arch = "wasm32")]
-fn start_query<C, T, S, F, Fut, E>(
+fn start_query<C, T, F, Fut, E>(
     handle: Handle<C>,
-    selector: Rc<S>,
+    selector: QuerySelector<C, T>,
     fetch: Rc<F>,
     reason: QueryReason,
     live_event: bool,
 ) where
     C: 'static,
     T: 'static,
-    S: for<'a> Fn(&'a mut C) -> &'a mut QueryState<T> + 'static,
     F: Fn() -> Fut + 'static,
     Fut: Future<Output = Result<T, E>> + 'static,
     E: ToString + 'static,
 {
     let request = handle.update(|state| {
-        let query = (selector)(state);
+        let query = selector(state);
         if live_event {
             query.begin_live_refresh(reason)
         } else {
@@ -452,7 +444,7 @@ fn start_query<C, T, S, F, Fut, E>(
         }
 
         handle.update(|state| {
-            let query = (selector)(state);
+            let query = selector(state);
             match result {
                 Ok(data) => {
                     query.finish_success(request, data);
@@ -481,6 +473,13 @@ mod tests {
         assert_eq!(state.version, 0);
         assert_eq!(state.refresh_count, 0);
         assert_eq!(state.live_event_count, 0);
+    }
+
+    #[test]
+    fn query_reason_serializes_as_snake_case_string() {
+        let value = serde_json::to_value(QueryReason::StreamError).unwrap();
+
+        assert_eq!(value, serde_json::json!("stream_error"));
     }
 
     #[test]

--- a/crates/pocopine-live/src/query.rs
+++ b/crates/pocopine-live/src/query.rs
@@ -1,0 +1,229 @@
+use serde::{Deserialize, Serialize};
+
+pub const QUERY_REASON_INITIAL: &str = "initial";
+pub const QUERY_REASON_MANUAL: &str = "manual";
+pub const QUERY_REASON_LIVE: &str = "live";
+pub const QUERY_REASON_GAP: &str = "gap";
+pub const QUERY_REASON_STREAM_ERROR: &str = "stream_error";
+
+/// Opaque generation token for one query request.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct QueryRequest {
+    generation: u64,
+}
+
+impl QueryRequest {
+    pub fn generation(self) -> u64 {
+        self.generation
+    }
+}
+
+/// Serializable component field for server-function backed data.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+#[serde(bound(
+    serialize = "T: Serialize",
+    deserialize = "T: Default + Deserialize<'de>"
+))]
+pub struct QueryState<T> {
+    pub data: T,
+    pub loading: bool,
+    pub refreshing: bool,
+    pub stale: bool,
+    pub error: String,
+    pub version: u64,
+    pub refresh_count: u64,
+    pub live_event_count: u64,
+    pub last_reason: String,
+    #[serde(skip)]
+    request_generation: u64,
+}
+
+impl<T: Default> Default for QueryState<T> {
+    fn default() -> Self {
+        Self::new(T::default())
+    }
+}
+
+impl<T> QueryState<T> {
+    pub fn new(data: T) -> Self {
+        Self {
+            data,
+            loading: false,
+            refreshing: false,
+            stale: false,
+            error: String::new(),
+            version: 0,
+            refresh_count: 0,
+            live_event_count: 0,
+            last_reason: String::new(),
+            request_generation: 0,
+        }
+    }
+
+    pub fn begin_initial(&mut self) -> QueryRequest {
+        self.begin(QUERY_REASON_INITIAL, false)
+    }
+
+    pub fn begin_refresh(&mut self, reason: impl Into<String>) -> QueryRequest {
+        self.begin(reason, false)
+    }
+
+    pub fn begin_live_refresh(&mut self, reason: impl Into<String>) -> QueryRequest {
+        self.live_event_count = self.live_event_count.saturating_add(1);
+        self.begin(reason, true)
+    }
+
+    pub fn finish_success(&mut self, request: QueryRequest, data: T) -> bool {
+        if !self.is_current(request) {
+            return false;
+        }
+
+        self.data = data;
+        self.loading = false;
+        self.refreshing = false;
+        self.stale = false;
+        self.error.clear();
+        self.version = self.version.saturating_add(1);
+        true
+    }
+
+    pub fn finish_error(&mut self, request: QueryRequest, error: impl ToString) -> bool {
+        if !self.is_current(request) {
+            return false;
+        }
+
+        self.loading = false;
+        self.refreshing = false;
+        self.stale = self.version > 0 || self.stale;
+        self.error = error.to_string();
+        true
+    }
+
+    pub fn set_error(&mut self, error: impl Into<String>) {
+        self.loading = false;
+        self.refreshing = false;
+        self.error = error.into();
+    }
+
+    pub fn clear_error(&mut self) {
+        self.error.clear();
+    }
+
+    pub fn mark_stale(&mut self, reason: impl Into<String>) {
+        self.stale = true;
+        self.last_reason = reason.into();
+    }
+
+    pub fn record_stream_error(&mut self, error: impl ToString) {
+        self.loading = false;
+        self.refreshing = false;
+        self.last_reason = QUERY_REASON_STREAM_ERROR.to_string();
+        self.error = error.to_string();
+    }
+
+    pub fn is_current(&self, request: QueryRequest) -> bool {
+        self.request_generation == request.generation
+    }
+
+    fn begin(&mut self, reason: impl Into<String>, stale_during_refresh: bool) -> QueryRequest {
+        self.request_generation = self.request_generation.saturating_add(1);
+        self.refresh_count = self.refresh_count.saturating_add(1);
+        self.last_reason = reason.into();
+        self.error.clear();
+        self.stale = stale_during_refresh;
+
+        if self.version == 0 {
+            self.loading = true;
+            self.refreshing = false;
+        } else {
+            self.loading = false;
+            self.refreshing = true;
+        }
+
+        QueryRequest {
+            generation: self.request_generation,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn query_state_defaults_to_idle_empty_data() {
+        let state = QueryState::<Vec<u32>>::default();
+
+        assert_eq!(state.data, Vec::<u32>::new());
+        assert!(!state.loading);
+        assert!(!state.refreshing);
+        assert!(!state.stale);
+        assert!(state.error.is_empty());
+        assert_eq!(state.version, 0);
+        assert_eq!(state.refresh_count, 0);
+        assert_eq!(state.live_event_count, 0);
+    }
+
+    #[test]
+    fn query_state_success_updates_data_and_clears_flags() {
+        let mut state = QueryState::new(vec![1]);
+        let request = state.begin_initial();
+
+        assert!(state.loading);
+        assert!(state.finish_success(request, vec![2, 3]));
+
+        assert_eq!(state.data, vec![2, 3]);
+        assert!(!state.loading);
+        assert!(!state.refreshing);
+        assert!(!state.stale);
+        assert!(state.error.is_empty());
+        assert_eq!(state.version, 1);
+        assert_eq!(state.refresh_count, 1);
+        assert_eq!(state.last_reason, QUERY_REASON_INITIAL);
+    }
+
+    #[test]
+    fn query_state_ignores_stale_success() {
+        let mut state = QueryState::new(vec![1]);
+        let stale = state.begin_initial();
+        let current = state.begin_refresh(QUERY_REASON_MANUAL);
+
+        assert!(!state.finish_success(stale, vec![9]));
+        assert_eq!(state.data, vec![1]);
+        assert!(state.finish_success(current, vec![2]));
+        assert_eq!(state.data, vec![2]);
+    }
+
+    #[test]
+    fn query_state_error_preserves_existing_data() {
+        let mut state = QueryState::new(vec![1]);
+        let request = state.begin_initial();
+        assert!(state.finish_success(request, vec![2]));
+
+        let request = state.begin_refresh(QUERY_REASON_MANUAL);
+        assert!(state.finish_error(request, "network down"));
+
+        assert_eq!(state.data, vec![2]);
+        assert_eq!(state.error, "network down");
+        assert!(state.stale);
+        assert!(!state.loading);
+        assert!(!state.refreshing);
+    }
+
+    #[test]
+    fn live_refresh_counts_event_and_marks_stale_while_fetching() {
+        let mut state = QueryState::new(vec![1]);
+        let request = state.begin_initial();
+        assert!(state.finish_success(request, vec![1]));
+
+        let live = state.begin_live_refresh(QUERY_REASON_LIVE);
+
+        assert_eq!(state.live_event_count, 1);
+        assert_eq!(state.last_reason, QUERY_REASON_LIVE);
+        assert!(state.stale);
+        assert!(state.refreshing);
+        assert!(state.finish_success(live, vec![2]));
+        assert!(!state.stale);
+    }
+}

--- a/docs/live.md
+++ b/docs/live.md
@@ -9,8 +9,9 @@ sync or collaboration:
 - offline sync will own local persistence, conflict handling, and CDC,
 - collaboration will own CRDT document updates.
 
-The current transport is SSE. The current browser API is
-`LiveRefresh::scoped()`. The runnable source of truth is
+The current transport is SSE. The recommended browser API is
+`LiveQuery::scoped(...)`, which stores loading/error/data state in a
+component-owned `QueryState<T>`. The runnable source of truth is
 [`examples/live`](../examples/live/), and the CI regression test is
 [`examples/live/tests/live_refresh.rs`](../examples/live/tests/live_refresh.rs).
 
@@ -24,7 +25,7 @@ A live app needs four pieces:
 1. Stable topic names for the data you expose.
 2. A host-side event backend and `LiveHub`.
 3. Server mutations that publish invalidations after they commit.
-4. Browser components that subscribe and refetch.
+4. Browser components that use `LiveQuery` to subscribe and refetch.
 
 The example below tracks a posts list. A post mutation publishes both a
 collection invalidation and a query-tag invalidation:
@@ -231,77 +232,106 @@ The server function body does not need `#[cfg(pocopine_host)]`; the
 `#[pocopine::server]` macro already compiles the original body only for
 the host target and generates a browser fetch stub for wasm.
 
-## 6. Subscribe In The Component
+## 6. Query In The Component
 
-Open the stream in `on_mount`. Use `LiveRefresh::scoped()` so the stream
-closes when the component unmounts.
+Store server-function data in a `QueryState<T>` field. The field is
+serializable, so templates can read `data`, `loading`, `refreshing`,
+`stale`, `error`, and counters directly.
 
 ```rust
+#[derive(Default, serde::Serialize, serde::Deserialize)]
+#[component(style = "live_board.css")]
+pub struct LiveBoard {
+    pub posts: pocopine::live::QueryState<Vec<Post>>,
+    pub title: String,
+    pub body: String,
+    pub saving: bool,
+    pub status: String,
+}
+
 #[handlers]
 impl LiveBoard {
     pub fn on_mount(&mut self) {
-        self.status = "live stream opening".to_string();
-        self.reload();
-
-        #[cfg(pocopine_browser)]
+        self.status = "live query opening".to_string();
+        if let Err(err) = pocopine::live::LiveQuery::scoped(
+            |s: &mut Self| &mut s.posts,
+            || async { list_posts().await },
+        )
+        .query_tag(POSTS_LIST_QUERY_TAG)
+        .open()
         {
-            let handle = this::<Self>();
-            let refresh_handle = handle.clone();
-            let gap_handle = handle.clone();
-            let error_handle = handle;
-
-            if let Err(err) = pocopine::live::LiveRefresh::scoped()
-                .query_tag(POSTS_LIST_QUERY_TAG, move |_event| {
-                    refresh_handle.update(|s| {
-                        s.status = "live event received".to_string();
-                        s.reload();
-                    });
-                })
-                .on_gap(move |_event| {
-                    gap_handle.update(|s| {
-                        s.status = "live cursor gap; refetching".to_string();
-                    });
-                })
-                .on_error(move |event| {
-                    error_handle.update(|s| {
-                        s.status = "live stream error".to_string();
-                        s.error = format!("{:?}", event.live_event);
-                    });
-                })
-                .open()
-            {
-                self.status = "live stream failed".to_string();
-                self.error = err.to_string();
-            }
+            self.status = "live query failed".to_string();
+            self.posts.set_error(err.to_string());
         }
     }
 }
 ```
 
-The `reload` method should use the same server function you already use
-for first load:
+`LiveQuery::scoped(...)` does three things:
+
+- it fetches once on mount,
+- it subscribes to the query tag and closes the SSE stream on unmount,
+- it refetches when the server publishes a matching live invalidation or
+  reports a replay gap.
+
+Manual refresh uses the same field selector and server function:
 
 ```rust
 pub fn reload(&mut self) {
-    self.loading = true;
-    dispatch!(list_posts().await, |s, result| {
-        s.loading = false;
-        match result {
-            Ok(posts) => {
-                s.posts = posts;
-                s.error.clear();
-            }
-            Err(err) => {
-                s.status = "refresh failed".to_string();
-                s.error = err.to_string();
-            }
-        }
-    },);
+    self.status = "refreshing".to_string();
+    if let Err(err) = pocopine::live::LiveQuery::refresh_scoped(
+        |s: &mut Self| &mut s.posts,
+        || async { list_posts().await },
+    ) {
+        self.status = "refresh failed".to_string();
+        self.posts.set_error(err.to_string());
+    }
 }
 ```
 
 If a component cares about every change to a collection, subscribe with
-`.collection(POSTS_COLLECTION, ...)` instead of `.query_tag(...)`.
+`.collection(POSTS_COLLECTION)` instead of `.query_tag(...)`.
+
+Templates read the query field:
+
+```html
+<p pp-show="posts.error" class="error">
+  <span pp-text="posts.error"></span>
+</p>
+<p pp-show="posts.loading">Loading posts.</p>
+<p pp-show="posts.refreshing">Refreshing posts.</p>
+
+<ol pp-show="posts.data.length">
+  <template pp-for="post in posts.data" pp-key="post.id">
+    <li>
+      <h2 pp-text="post.title"></h2>
+      <p pp-text="post.body"></p>
+    </li>
+  </template>
+</ol>
+```
+
+`QueryState<T>` preserves existing data on refresh errors. A stale async
+response cannot overwrite a newer request, so rapid manual refreshes and
+live invalidations are safe.
+
+## Advanced: Manual Streams
+
+Use `LiveRefresh::scoped()` directly only when a component needs custom
+event handling instead of a query refetch:
+
+```rust
+let handle = this::<LiveBoard>();
+pocopine::live::LiveRefresh::scoped()
+    .query_tag(POSTS_LIST_QUERY_TAG, move |_event| {
+        handle.update(|s| {
+            s.status = "custom live event".to_string();
+        });
+    })
+    .open()?;
+```
+
+Most app data should use `LiveQuery`; manual streams are the escape hatch.
 
 ## 7. Run The Example
 
@@ -332,12 +362,11 @@ change.
 ## Failure Model
 
 - SSE delivery is at-least-once. Refresh callbacks must tolerate
-  duplicate events.
+  duplicate events. `LiveQuery` handles this by refetching idempotently.
 - A `gap` means the backend could not replay enough retained history.
-  Pocopine invokes registered refresh callbacks so the component refetches
-  from scratch.
-- An `error` goes to `on_error` callbacks and does not automatically
-  refetch data.
+  `LiveQuery` refetches from scratch.
+- A stream `error` is recorded on the query state and does not erase the
+  last successful data.
 - Topic authorization is server-side. `LiveHub` denies all topics until
   the app installs a topic policy or explicit allowlist.
 - Audience fields are descriptive metadata today. Do not rely on them for

--- a/examples/live/README.md
+++ b/examples/live/README.md
@@ -4,7 +4,7 @@ Small app showing the current live invalidation flow:
 
 - server functions mutate a process-local `posts` collection,
 - the host publishes `LiveInvalidation` events through a memory backend,
-- the browser subscribes with `LiveRefresh::scoped()`,
+- the browser uses `LiveQuery::scoped(...)` with `QueryState<Vec<Post>>`,
 - matching query-tag events refetch the list.
 
 Run it with the CLI:

--- a/examples/live/src/LiveBoard.poco
+++ b/examples/live/src/LiveBoard.poco
@@ -26,15 +26,16 @@
   <section class="feed" aria-label="posts">
     <div class="feed__bar">
       <span class="status" pp-text="status"></span>
-      <span class="counter"><strong pp-text="event_count"></strong> live events</span>
+      <span class="counter"><strong pp-text="posts.live_event_count"></strong> live events</span>
     </div>
 
-    <p pp-show="error" class="error"><span pp-text="error"></span></p>
-    <p pp-show="loading" class="empty">Loading posts.</p>
-    <p pp-show="!loading && !posts.length" class="empty">No posts yet.</p>
+    <p pp-show="posts.error" class="error"><span pp-text="posts.error"></span></p>
+    <p pp-show="posts.loading" class="empty">Loading posts.</p>
+    <p pp-show="posts.refreshing" class="empty">Refreshing posts.</p>
+    <p pp-show="!posts.loading && !posts.data.length" class="empty">No posts yet.</p>
 
-    <ol class="posts" pp-show="posts.length">
-      <template pp-for="post in posts" pp-key="post.id">
+    <ol class="posts" pp-show="posts.data.length">
+      <template pp-for="post in posts.data" pp-key="post.id">
         <li class="post">
           <div class="post__meta">
             <span pp-text="post.id"></span>

--- a/examples/live/src/lib.rs
+++ b/examples/live/src/lib.rs
@@ -138,62 +138,35 @@ pub async fn reset_posts() -> ServerResult<()> {
 pub struct LiveBoard {
     pub title: String,
     pub body: String,
-    pub posts: Vec<Post>,
-    pub loading: bool,
+    pub posts: pocopine::live::QueryState<Vec<Post>>,
     pub saving: bool,
-    pub error: String,
     pub status: String,
-    pub event_count: u32,
 }
 
 #[handlers]
 impl LiveBoard {
     pub fn on_mount(&mut self) {
-        self.status = "live stream opening".to_string();
-        self.reload();
-
-        #[cfg(pocopine_browser)]
+        self.status = "live query opening".to_string();
+        if let Err(err) = pocopine::live::LiveQuery::scoped(
+            |s: &mut Self| &mut s.posts,
+            || async { list_posts().await },
+        )
+        .query_tag(POSTS_LIST_QUERY_TAG)
+        .open()
         {
-            let handle = this::<Self>();
-            let refresh_handle = handle.clone();
-            let gap_handle = handle.clone();
-            let error_handle = handle;
-
-            if let Err(err) = pocopine::live::LiveRefresh::scoped()
-                .query_tag(POSTS_LIST_QUERY_TAG, move |_event| {
-                    refresh_handle.update(|s| {
-                        s.event_count += 1;
-                        s.status = "live event received".to_string();
-                        s.reload();
-                    });
-                })
-                .on_gap(move |_event| {
-                    gap_handle.update(|s| {
-                        s.status = "live cursor gap; refetching".to_string();
-                    });
-                })
-                .on_error(move |event| {
-                    error_handle.update(|s| {
-                        s.status = "live stream error".to_string();
-                        s.error = format!("{:?}", event.live_event);
-                    });
-                })
-                .open()
-            {
-                self.status = "live stream failed".to_string();
-                self.error = err.to_string();
-            }
+            self.status = "live query failed".to_string();
+            self.posts.set_error(err.to_string());
         }
     }
 
     pub fn create(&mut self) {
         if self.title.trim().is_empty() || self.body.trim().is_empty() {
-            self.error = "title and body are required".to_string();
+            self.posts.set_error("title and body are required");
             return;
         }
 
         self.saving = true;
-        self.error.clear();
+        self.posts.clear_error();
         self.status = "saving".to_string();
         let draft = PostDraft {
             title: self.title.clone(),
@@ -210,35 +183,26 @@ impl LiveBoard {
                 }
                 Err(err) => {
                     s.status = "save failed".to_string();
-                    s.error = err.to_string();
+                    s.posts.set_error(err.to_string());
                 }
             }
         },);
     }
 
     pub fn reload(&mut self) {
-        self.loading = true;
-        dispatch!(list_posts().await, |s, result| {
-            s.loading = false;
-            match result {
-                Ok(posts) => {
-                    s.posts = posts;
-                    s.error.clear();
-                    if s.status.is_empty() || s.status == "live stream opening" {
-                        s.status = "ready".to_string();
-                    }
-                }
-                Err(err) => {
-                    s.status = "refresh failed".to_string();
-                    s.error = err.to_string();
-                }
-            }
-        },);
+        self.status = "refreshing".to_string();
+        if let Err(err) = pocopine::live::LiveQuery::refresh_scoped(
+            |s: &mut Self| &mut s.posts,
+            || async { list_posts().await },
+        ) {
+            self.status = "refresh failed".to_string();
+            self.posts.set_error(err.to_string());
+        }
     }
 
     pub fn reset(&mut self) {
         self.saving = true;
-        self.error.clear();
+        self.posts.clear_error();
         self.status = "resetting".to_string();
         dispatch!(reset_posts().await, |s, result| {
             s.saving = false;
@@ -248,7 +212,7 @@ impl LiveBoard {
                 }
                 Err(err) => {
                     s.status = "reset failed".to_string();
-                    s.error = err.to_string();
+                    s.posts.set_error(err.to_string());
                 }
             }
         },);


### PR DESCRIPTION
## Summary
- add QueryState<T> and typed QueryReason for component-owned query data
- add scoped LiveQuery runner that fetches server-function data and refetches on live invalidation/gap
- migrate examples/live and docs/live.md to LiveQuery while keeping LiveRefresh as the advanced escape hatch

## Validation
- cargo fmt --check
- cargo test -p pocopine-live
- cargo test -p live-example --test live_refresh
- cargo check -p live-example --target wasm32-unknown-unknown
- cargo clippy --workspace --all-targets -- -D warnings