### PR TITLE
Add server observability logging plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3299,6 +3299,7 @@ dependencies = [
  "opentelemetry_sdk",
  "pocopine-core",
  "pocopine-observe",
+ "pocopine-server",
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",

--- a/crates/pocopine-logging/Cargo.toml
+++ b/crates/pocopine-logging/Cargo.toml
@@ -20,6 +20,7 @@ pocopine-observe = { workspace = true }
 tracing = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+pocopine-server = { workspace = true }
 opentelemetry = { version = "0.31", optional = true, features = ["trace"] }
 opentelemetry-otlp = { version = "0.31", optional = true, default-features = false, features = ["grpc-tonic", "trace"] }
 opentelemetry_sdk = { version = "0.31", optional = true, features = ["trace"] }

--- a/crates/pocopine-logging/src/lib.rs
+++ b/crates/pocopine-logging/src/lib.rs
@@ -15,6 +15,14 @@ mod server {
     #[cfg(feature = "otlp")]
     use std::time::Duration;
 
+    use pocopine_observe::{
+        emit_tracing, EventClass, EventPriority, FieldPrivacy, ObserveContext, ObservedEvent,
+    };
+    use pocopine_server::{
+        request_event_layer, HttpRequestCompleted, HttpRequestFailed, HttpRequestStarted, Server,
+        ServerBootFailed, ServerBootStarted, ServerFunctionCompleted, ServerFunctionFailed,
+        ServerFunctionRejected, ServerFunctionStarted, ServerHook, ServerListening, ServerPlugin,
+    };
     use tracing_subscriber::fmt as tracing_fmt;
     use tracing_subscriber::prelude::*;
     use tracing_subscriber::util::SubscriberInitExt;
@@ -87,6 +95,347 @@ mod server {
     impl Default for ServerLoggingConfig {
         fn default() -> Self {
             Self::compact()
+        }
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub struct ServerObservabilityConfig {
+        pub service: Option<String>,
+        pub environment: Option<String>,
+        pub boot: bool,
+        pub http_requests: bool,
+        pub server_functions: bool,
+        pub include_unmatched_paths: bool,
+    }
+
+    impl ServerObservabilityConfig {
+        pub fn new() -> Self {
+            Self::default()
+        }
+
+        pub fn with_service(mut self, service: impl Into<String>) -> Self {
+            self.service = Some(service.into());
+            self
+        }
+
+        pub fn with_environment(mut self, environment: impl Into<String>) -> Self {
+            self.environment = Some(environment.into());
+            self
+        }
+
+        pub fn with_boot(mut self, enabled: bool) -> Self {
+            self.boot = enabled;
+            self
+        }
+
+        pub fn with_http_requests(mut self, enabled: bool) -> Self {
+            self.http_requests = enabled;
+            self
+        }
+
+        pub fn with_server_functions(mut self, enabled: bool) -> Self {
+            self.server_functions = enabled;
+            self
+        }
+
+        /// Include raw URI paths for unmatched HTTP requests.
+        ///
+        /// Matched routes always emit the route pattern instead of the concrete
+        /// path. Unmatched paths can contain tenant ids, slugs, or other
+        /// pseudonymous values, so the default is to omit them.
+        pub fn with_unmatched_paths(mut self, enabled: bool) -> Self {
+            self.include_unmatched_paths = enabled;
+            self
+        }
+    }
+
+    impl Default for ServerObservabilityConfig {
+        fn default() -> Self {
+            Self {
+                service: None,
+                environment: None,
+                boot: true,
+                http_requests: true,
+                server_functions: true,
+                include_unmatched_paths: false,
+            }
+        }
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq)]
+    pub struct ServerObservabilityPlugin {
+        config: ServerObservabilityConfig,
+    }
+
+    impl ServerObservabilityPlugin {
+        pub fn new(config: ServerObservabilityConfig) -> Self {
+            Self { config }
+        }
+    }
+
+    pub fn server_observability() -> ServerObservabilityPlugin {
+        ServerObservabilityPlugin::new(ServerObservabilityConfig::default())
+    }
+
+    pub fn server_observability_with_config(
+        config: ServerObservabilityConfig,
+    ) -> ServerObservabilityPlugin {
+        ServerObservabilityPlugin::new(config)
+    }
+
+    impl ServerPlugin for ServerObservabilityPlugin {
+        fn name(&self) -> &'static str {
+            "pocopine.logging.server_observability"
+        }
+
+        fn install(self, server: Server) -> Server {
+            let ServerObservabilityConfig {
+                service,
+                environment,
+                boot,
+                http_requests,
+                server_functions,
+                include_unmatched_paths,
+            } = self.config;
+
+            let mut server = server.provide_plugin(ServerObservability {
+                service,
+                environment,
+                include_unmatched_paths,
+            });
+
+            if http_requests || server_functions {
+                server = server.layer(request_event_layer());
+            }
+
+            if boot {
+                server = server
+                    .hook_plugin::<ServerObservability, ServerBootStarted>()
+                    .hook_plugin::<ServerObservability, ServerListening>()
+                    .hook_plugin::<ServerObservability, ServerBootFailed>();
+            }
+
+            if http_requests {
+                server = server
+                    .hook_plugin::<ServerObservability, HttpRequestStarted>()
+                    .hook_plugin::<ServerObservability, HttpRequestCompleted>()
+                    .hook_plugin::<ServerObservability, HttpRequestFailed>();
+            }
+
+            if server_functions {
+                server = server
+                    .hook_plugin::<ServerObservability, ServerFunctionStarted>()
+                    .hook_plugin::<ServerObservability, ServerFunctionCompleted>()
+                    .hook_plugin::<ServerObservability, ServerFunctionRejected>()
+                    .hook_plugin::<ServerObservability, ServerFunctionFailed>();
+            }
+
+            server
+        }
+    }
+
+    #[derive(Debug)]
+    pub struct ServerObservability {
+        service: Option<String>,
+        environment: Option<String>,
+        include_unmatched_paths: bool,
+    }
+
+    impl ServerObservability {
+        pub fn emit(&self, event: ObservedEvent) {
+            let event = self.with_base_context(event);
+            emit_tracing(&event);
+        }
+
+        fn with_base_context(&self, mut event: ObservedEvent) -> ObservedEvent {
+            if event.context.service.is_none() {
+                event.context.service = self.service.clone();
+            }
+            if event.context.environment.is_none() {
+                event.context.environment = self.environment.clone();
+            }
+            event
+        }
+
+        fn context(&self) -> ObserveContext {
+            ObserveContext {
+                service: self.service.clone(),
+                environment: self.environment.clone(),
+                ..ObserveContext::default()
+            }
+        }
+
+        fn context_with_route(&self, route: &str) -> ObserveContext {
+            self.context().with_route(route)
+        }
+
+        fn request_event(
+            &self,
+            name: &'static str,
+            class: EventClass,
+            method: String,
+            path: String,
+            route_pattern: Option<String>,
+            request_id: u64,
+        ) -> ObservedEvent {
+            let matched = route_pattern.is_some();
+            let mut event = ObservedEvent::new(name, class)
+                .field("method", method, FieldPrivacy::Public)
+                .field("matched", matched, FieldPrivacy::Public)
+                .field("request_id", request_id, FieldPrivacy::Public);
+
+            if let Some(route) = route_pattern {
+                event = event.context(self.context_with_route(&route)).field(
+                    "route",
+                    route,
+                    FieldPrivacy::Public,
+                );
+            } else {
+                event = event.context(self.context());
+                if self.include_unmatched_paths {
+                    event = event.field("path", path, FieldPrivacy::Pseudonymous);
+                }
+            }
+
+            event
+        }
+    }
+
+    impl ServerHook<ServerBootStarted> for ServerObservability {
+        fn call(&self, event: ServerBootStarted) {
+            self.emit(
+                ObservedEvent::trace("server_boot_started")
+                    .context(self.context())
+                    .field("addr", event.addr, FieldPrivacy::Public),
+            );
+        }
+    }
+
+    impl ServerHook<ServerListening> for ServerObservability {
+        fn call(&self, event: ServerListening) {
+            self.emit(
+                ObservedEvent::trace("server_listening")
+                    .context(self.context())
+                    .field("addr", event.addr, FieldPrivacy::Public),
+            );
+        }
+    }
+
+    impl ServerHook<ServerBootFailed> for ServerObservability {
+        fn call(&self, event: ServerBootFailed) {
+            self.emit(
+                ObservedEvent::log("server_boot_failed")
+                    .priority(EventPriority::Critical)
+                    .context(self.context())
+                    .field("reason", event.reason, FieldPrivacy::Public),
+            );
+        }
+    }
+
+    impl ServerHook<HttpRequestStarted> for ServerObservability {
+        fn call(&self, event: HttpRequestStarted) {
+            let observed = self
+                .request_event(
+                    "http_request_started",
+                    EventClass::Trace,
+                    event.method,
+                    event.path,
+                    event.route_pattern,
+                    event.request_id,
+                )
+                .priority(EventPriority::Low);
+            self.emit(observed);
+        }
+    }
+
+    impl ServerHook<HttpRequestCompleted> for ServerObservability {
+        fn call(&self, event: HttpRequestCompleted) {
+            let status = event.status as u64;
+            let duration_ms = event.duration_ms;
+            let observed = self
+                .request_event(
+                    "http_request_completed",
+                    EventClass::Trace,
+                    event.method,
+                    event.path,
+                    event.route_pattern,
+                    event.request_id,
+                )
+                .field("status", status, FieldPrivacy::Public)
+                .field("duration_ms", duration_ms, FieldPrivacy::Public);
+            self.emit(observed);
+        }
+    }
+
+    impl ServerHook<HttpRequestFailed> for ServerObservability {
+        fn call(&self, event: HttpRequestFailed) {
+            let reason = event.reason;
+            let duration_ms = event.duration_ms;
+            let observed = self
+                .request_event(
+                    "http_request_failed",
+                    EventClass::Log,
+                    event.method,
+                    event.path,
+                    event.route_pattern,
+                    event.request_id,
+                )
+                .priority(EventPriority::High)
+                .field("reason", reason, FieldPrivacy::Public)
+                .field("duration_ms", duration_ms, FieldPrivacy::Public);
+            self.emit(observed);
+        }
+    }
+
+    impl ServerHook<ServerFunctionStarted> for ServerObservability {
+        fn call(&self, event: ServerFunctionStarted) {
+            self.emit(
+                ObservedEvent::trace("server_function_started")
+                    .priority(EventPriority::Low)
+                    .context(self.context())
+                    .field("function", event.function, FieldPrivacy::Public)
+                    .field("request_id", event.request_id, FieldPrivacy::Public),
+            );
+        }
+    }
+
+    impl ServerHook<ServerFunctionCompleted> for ServerObservability {
+        fn call(&self, event: ServerFunctionCompleted) {
+            self.emit(
+                ObservedEvent::trace("server_function_completed")
+                    .context(self.context())
+                    .field("function", event.function, FieldPrivacy::Public)
+                    .field("request_id", event.request_id, FieldPrivacy::Public)
+                    .field("duration_ms", event.duration_ms, FieldPrivacy::Public),
+            );
+        }
+    }
+
+    impl ServerHook<ServerFunctionRejected> for ServerObservability {
+        fn call(&self, event: ServerFunctionRejected) {
+            self.emit(
+                ObservedEvent::log("server_function_rejected")
+                    .priority(EventPriority::High)
+                    .context(self.context())
+                    .field("function", event.function, FieldPrivacy::Public)
+                    .field("request_id", event.request_id, FieldPrivacy::Public)
+                    .field("status", event.status as u64, FieldPrivacy::Public)
+                    .field("reason", event.reason, FieldPrivacy::Public),
+            );
+        }
+    }
+
+    impl ServerHook<ServerFunctionFailed> for ServerObservability {
+        fn call(&self, event: ServerFunctionFailed) {
+            self.emit(
+                ObservedEvent::log("server_function_failed")
+                    .priority(EventPriority::High)
+                    .context(self.context())
+                    .field("function", event.function, FieldPrivacy::Public)
+                    .field("request_id", event.request_id, FieldPrivacy::Public)
+                    .field("error_class", event.error_class, FieldPrivacy::Public)
+                    .field("duration_ms", event.duration_ms, FieldPrivacy::Public),
+            );
         }
     }
 
@@ -375,7 +724,9 @@ mod server {
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use server::{
-    init_default, init_server_logging, InitLoggingError, LogFormat, ServerLoggingConfig,
+    init_default, init_server_logging, server_observability, server_observability_with_config,
+    InitLoggingError, LogFormat, ServerLoggingConfig, ServerObservability,
+    ServerObservabilityConfig, ServerObservabilityPlugin,
 };
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "otlp"))]

--- a/crates/pocopine/tests/observability_server.rs
+++ b/crates/pocopine/tests/observability_server.rs
@@ -1,0 +1,310 @@
+#![cfg(all(not(target_arch = "wasm32"), feature = "logging"))]
+// `registry_lock` serializes tests that share pocopine-server's process-global
+// plugin registry while driving async axum services on a current-thread runtime.
+#![allow(clippy::await_holding_lock)]
+
+mod support;
+
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+use pocopine::{ServerError, ServerResult};
+use pocopine_server::axum::body::{to_bytes, Body};
+use pocopine_server::axum::http::{Method, Request};
+use pocopine_server::axum::routing::get;
+use pocopine_server::axum::Router;
+use pocopine_server::tower::ServiceExt;
+use pocopine_server::Server;
+use support::{CapturedEvent, TraceCapture};
+
+fn registry_lock() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+}
+
+#[pocopine::server(public)]
+async fn observed_echo(value: String) -> ServerResult<String> {
+    Ok(format!("echo:{value}"))
+}
+
+#[pocopine::server(public)]
+async fn observed_fail(value: String) -> ServerResult<()> {
+    assert_eq!(value, "fail-secret");
+    Err(ServerError::App("boom".into()))
+}
+
+fn config() -> pocopine::logging::ServerObservabilityConfig {
+    pocopine::logging::ServerObservabilityConfig::new()
+        .with_service("server-observability-test")
+        .with_environment("test")
+}
+
+fn finalize(router: Router) -> Router {
+    Server::new(router)
+        .plugin(pocopine::logging::server_observability_with_config(config()))
+        .try_finalize()
+        .expect("server observability plugin should validate")
+}
+
+async fn send(
+    router: &Router,
+    request: Request<Body>,
+) -> pocopine_server::axum::response::Response {
+    router
+        .clone()
+        .oneshot(request)
+        .await
+        .expect("oneshot dispatch")
+}
+
+async fn response_body(response: pocopine_server::axum::response::Response) -> String {
+    let bytes = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("response body");
+    String::from_utf8(bytes.to_vec()).expect("utf8 response")
+}
+
+#[test]
+fn server_observability_http_events_use_route_patterns_and_redact_request_details() {
+    let _lock = registry_lock();
+    pocopine_server::__reset_for_test();
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let capture = TraceCapture::new();
+
+    capture.run(|| {
+        rt.block_on(async {
+            let router = finalize(Router::new().route("/accounts/:id", get(|| async { "ok" })));
+
+            let response = send(
+                &router,
+                Request::builder()
+                    .method(Method::GET)
+                    .uri("/accounts/path-secret?api_key=query-secret")
+                    .header("authorization", "Bearer auth-secret")
+                    .header("cookie", "session=cookie-secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await;
+
+            assert_eq!(response.status(), 200);
+            assert_eq!(response_body(response).await, "ok");
+        });
+    });
+
+    let events = capture.events();
+    let started = find_observed_event(&events, "pocopine.trace", "http_request_started");
+    let completed = find_observed_event(&events, "pocopine.trace", "http_request_completed");
+
+    assert_eq!(
+        request_id(started),
+        request_id(completed),
+        "HTTP start/completed events should share request_id"
+    );
+
+    assert!(fields(started).contains("/accounts/:id"));
+    assert!(fields(completed).contains("/accounts/:id"));
+    assert!(context(started).contains("server-observability-test"));
+    assert!(context(started).contains("/accounts/:id"));
+    assert_no_values_contain(
+        &events,
+        &[
+            "path-secret",
+            "query-secret",
+            "auth-secret",
+            "cookie-secret",
+        ],
+    );
+}
+
+#[test]
+fn server_observability_correlates_http_and_server_function_events_without_payload_leaks() {
+    let _lock = registry_lock();
+    pocopine_server::__reset_for_test();
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let capture = TraceCapture::new();
+
+    capture.run(|| {
+        rt.block_on(async {
+            let router = finalize(__observed_echo_route(Router::new()));
+            let response = send(
+                &router,
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/_pocopine/observed_echo")
+                    .header("content-type", "application/json")
+                    .body(Body::from("[\"payload-secret\"]"))
+                    .unwrap(),
+            )
+            .await;
+
+            assert_eq!(response.status(), 200);
+            assert!(
+                response_body(response).await.contains("payload-secret"),
+                "response sanity check should prove the handler saw the payload"
+            );
+        });
+    });
+
+    let events = capture.events();
+    let http_started = find_observed_event(&events, "pocopine.trace", "http_request_started");
+    let http_completed = find_observed_event(&events, "pocopine.trace", "http_request_completed");
+    let function_started =
+        find_observed_event(&events, "pocopine.trace", "server_function_started");
+    let function_completed =
+        find_observed_event(&events, "pocopine.trace", "server_function_completed");
+
+    let shared_request_id = request_id(http_started);
+    assert_eq!(request_id(http_completed), shared_request_id);
+    assert_eq!(request_id(function_started), shared_request_id);
+    assert_eq!(request_id(function_completed), shared_request_id);
+    assert!(fields(function_started).contains("observed_echo"));
+    assert!(fields(function_completed).contains("observed_echo"));
+    assert_no_values_contain(&events, &["payload-secret"]);
+}
+
+#[test]
+fn server_observability_logs_server_function_rejections_and_failures_without_payloads() {
+    let _lock = registry_lock();
+    pocopine_server::__reset_for_test();
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let capture = TraceCapture::new();
+
+    capture.run(|| {
+        rt.block_on(async {
+            let router = finalize(__observed_fail_route(__observed_echo_route(Router::new())));
+
+            let rejected = send(
+                &router,
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/_pocopine/observed_echo")
+                    .header("content-type", "application/json")
+                    .body(Body::from("\"reject-secret\""))
+                    .unwrap(),
+            )
+            .await;
+            assert_eq!(rejected.status(), 200);
+
+            let failed = send(
+                &router,
+                Request::builder()
+                    .method(Method::POST)
+                    .uri("/_pocopine/observed_fail")
+                    .header("content-type", "application/json")
+                    .body(Body::from("[\"fail-secret\"]"))
+                    .unwrap(),
+            )
+            .await;
+            assert_eq!(failed.status(), 200);
+        });
+    });
+
+    let events = capture.events();
+    let rejected = find_observed_event(&events, "pocopine.log", "server_function_rejected");
+    let failed = find_observed_event(&events, "pocopine.log", "server_function_failed");
+
+    assert!(fields(rejected).contains("observed_echo"));
+    assert!(fields(rejected).contains("bad_request"));
+    assert!(fields(rejected).contains("U64(400)"));
+    assert!(fields(failed).contains("observed_fail"));
+    assert!(fields(failed).contains("app"));
+    assert_no_values_contain(&events, &["reject-secret", "fail-secret"]);
+}
+
+#[test]
+fn server_observability_emits_boot_failure_for_invalid_address() {
+    let _lock = registry_lock();
+    pocopine_server::__reset_for_test();
+
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let capture = TraceCapture::new();
+
+    let err = capture.run(|| {
+        rt.block_on(async {
+            Server::new(Router::new())
+                .plugin(pocopine::logging::server_observability_with_config(config()))
+                .serve("not an address")
+                .await
+                .expect_err("invalid address should fail before bind")
+        })
+    });
+
+    assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    let events = capture.events();
+    let started = find_observed_event(&events, "pocopine.trace", "server_boot_started");
+    let failed = find_observed_event(&events, "pocopine.log", "server_boot_failed");
+
+    assert!(fields(started).contains("not an address"));
+    assert!(fields(failed).contains("address_parse"));
+}
+
+fn find_observed_event<'a>(
+    events: &'a [CapturedEvent],
+    target: &str,
+    name: &str,
+) -> &'a CapturedEvent {
+    events
+        .iter()
+        .find(|event| event.target == target && event.field("event_name") == Some(name))
+        .unwrap_or_else(|| {
+            panic!("missing observed event `{name}` on target `{target}`: {events:#?}")
+        })
+}
+
+fn fields(event: &CapturedEvent) -> &str {
+    event
+        .field("fields")
+        .expect("observed event should capture fields")
+}
+
+fn context(event: &CapturedEvent) -> &str {
+    event
+        .field("context")
+        .expect("observed event should capture context")
+}
+
+fn request_id(event: &CapturedEvent) -> u64 {
+    let fields = fields(event);
+    let needle = "\"request_id\": ObservedField { value: U64(";
+    let start = fields
+        .find(needle)
+        .unwrap_or_else(|| panic!("request_id missing from observed fields: {fields}"))
+        + needle.len();
+    let rest = &fields[start..];
+    let end = rest
+        .find(')')
+        .unwrap_or_else(|| panic!("request_id field is malformed: {fields}"));
+    rest[..end]
+        .parse()
+        .unwrap_or_else(|_| panic!("request_id is not numeric: {fields}"))
+}
+
+fn assert_no_values_contain(events: &[CapturedEvent], needles: &[&str]) {
+    for event in events {
+        for value in event.fields.values() {
+            for needle in needles {
+                assert!(
+                    !value.contains(needle),
+                    "captured event leaked `{needle}` in value `{value}`: {event:#?}"
+                );
+            }
+        }
+    }
+}

--- a/crates/pocopine/tests/support.rs
+++ b/crates/pocopine/tests/support.rs
@@ -37,6 +37,15 @@ impl TraceCapture {
         tracing::subscriber::with_default(subscriber, f)
     }
 
+    #[allow(dead_code)]
+    pub fn events(&self) -> Vec<CapturedEvent> {
+        self.events
+            .lock()
+            .expect("trace capture lock poisoned")
+            .clone()
+    }
+
+    #[allow(dead_code)]
     pub fn events_with_message(&self, target: &str, message: &str) -> Vec<CapturedEvent> {
         // Message text is part of these observability contract assertions;
         // rename emitted messages only as a deliberate telemetry change.

--- a/docs/logging-tracing-observer.md
+++ b/docs/logging-tracing-observer.md
@@ -240,6 +240,81 @@ If `RUST_LOG` is unset, the default filter is:
 info,pocopine=debug
 ```
 
+## Backend observability plugin
+
+Server apps can install backend lifecycle observability through the server
+plugin system. Install routes first, then install the observability plugin so
+the HTTP request layer wraps the completed router:
+
+```rust
+use pocopine::logging::{
+    init_server_logging, server_observability_with_config,
+    ServerLoggingConfig, ServerObservabilityConfig,
+};
+use pocopine_server::{axum::Router, static_files, Server};
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    init_server_logging(ServerLoggingConfig::json())
+        .expect("logging should initialize");
+
+    let router = Router::new().nest_service("/", static_files("pkg"));
+    let router = my_app::__routes(router);
+
+    Server::new(router)
+        .plugin(server_observability_with_config(
+            ServerObservabilityConfig::new()
+                .with_service("blog-api")
+                .with_environment("production"),
+        ))
+        .serve("0.0.0.0:3000")
+        .await
+}
+```
+
+`server_observability()` uses the default config. It installs
+`pocopine_server::request_event_layer()` and translates RFC 077 typed server
+hooks into `ObservedEvent`s:
+
+| Server hook | Observed event |
+|---|---|
+| `ServerBootStarted` | `server_boot_started` trace |
+| `ServerListening` | `server_listening` trace |
+| `ServerBootFailed` | `server_boot_failed` log |
+| `HttpRequestStarted` | `http_request_started` trace |
+| `HttpRequestCompleted` | `http_request_completed` trace |
+| `HttpRequestFailed` | `http_request_failed` log |
+| `ServerFunctionStarted` | `server_function_started` trace |
+| `ServerFunctionCompleted` | `server_function_completed` trace |
+| `ServerFunctionRejected` | `server_function_rejected` log |
+| `ServerFunctionFailed` | `server_function_failed` log |
+
+HTTP events report axum's matched route pattern, such as `/posts/:id`, rather
+than the concrete request path. Headers, cookies, query strings, request
+bodies, response bodies, and raw server-function payloads are never exported by
+the plugin. For unmatched routes, the concrete path is omitted by default; opt
+in only when that value is acceptable for your deployment:
+
+```rust
+ServerObservabilityConfig::new()
+    .with_unmatched_paths(true);
+```
+
+Disable event groups when another plugin owns that surface:
+
+```rust
+ServerObservabilityConfig::new()
+    .with_http_requests(false)
+    .with_server_functions(true)
+    .with_boot(true);
+```
+
+When server-function hooks are enabled, the plugin still installs the request
+event layer so generated `#[server]` handlers can share the HTTP `request_id`
+with request events. Jobs are intentionally not mapped into typed server hooks:
+`pocopine-jobs` already emits structured `pocopine.trace` / `pocopine.log`
+events, and RFC 077 rejects typed job lifecycle hooks.
+
 ## OTLP trace export
 
 `pocopine-logging` can also install an OpenTelemetry layer for OTLP trace

--- a/docs/server-plugins.md
+++ b/docs/server-plugins.md
@@ -10,8 +10,9 @@ around an axum `Router`. Apps opt into optional integrations
 ## Quickstart
 
 ```rust
+use pocopine::logging::server_observability;
 use pocopine_server::axum::Router;
-use pocopine_server::{request_event_layer, static_files, Server};
+use pocopine_server::{static_files, Server};
 
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
@@ -20,8 +21,7 @@ async fn main() -> std::io::Result<()> {
     let router = my_app::__routes(router);
 
     Server::new(router)
-        .layer(request_event_layer())   // emit HTTP request events
-        .plugin(my_observability::server(config()))
+        .plugin(server_observability()) // installs hooks + HTTP request layer
         .serve("0.0.0.0:3000")
         .await
 }


### PR DESCRIPTION
## Summary

- add `pocopine::logging::server_observability()` and config for backend lifecycle observability
- translate RFC 077 server hooks into `ObservedEvent`s for boot, HTTP request, and server-function lifecycle events
- install the request event layer from the plugin while keeping jobs tracing-first and typed job hooks out of scope
- document backend plugin usage and add integration tests for request-id correlation and privacy/no payload leaks

## Tests

- `cargo fmt --all -- --check`
- `cargo test -p pocopine-logging`
- `cargo test -p pocopine --features logging --test observability_server`
- `cargo clippy -p pocopine-logging -p pocopine --features logging --tests -- -D warnings`

Additional checks run before push:

- `cargo check -p pocopine-logging --target wasm32-unknown-unknown`
- `cargo check -p pocopine-logging --features otlp`