### PR TITLE
Add chart enter and exit animations

### DIFF
--- a/crates/pine-charts/src/animation.rs
+++ b/crates/pine-charts/src/animation.rs
@@ -1,14 +1,21 @@
-use crate::svg::format_tick;
-
 pub(crate) const DEFAULT_ANIMATION_DURATION_MS: f64 = 160.0;
 pub(crate) const DEFAULT_ANIMATION_EASING: &str = "ease";
+const EXIT_ANIMATION_BUFFER_MS: u32 = 40;
+
+pub(crate) fn animation_duration_ms(duration_ms: f64) -> u32 {
+    if duration_ms.is_finite() && duration_ms >= 0.0 {
+        duration_ms.round().min(u32::MAX as f64) as u32
+    } else {
+        DEFAULT_ANIMATION_DURATION_MS as u32
+    }
+}
+
+pub(crate) fn exit_animation_delay_ms(duration_ms: f64) -> u32 {
+    animation_duration_ms(duration_ms).saturating_add(EXIT_ANIMATION_BUFFER_MS)
+}
 
 pub(crate) fn animation_style(duration_ms: f64, easing: &str) -> String {
-    let duration_ms = if duration_ms.is_finite() && duration_ms >= 0.0 {
-        duration_ms
-    } else {
-        DEFAULT_ANIMATION_DURATION_MS
-    };
+    let duration_ms = animation_duration_ms(duration_ms);
     let easing = easing.trim();
     let easing = if easing.is_empty() {
         DEFAULT_ANIMATION_EASING
@@ -16,10 +23,7 @@ pub(crate) fn animation_style(duration_ms: f64, easing: &str) -> String {
         easing
     };
 
-    format!(
-        "--pine-chart-animation-duration: {}ms; --pine-chart-animation-easing: {easing};",
-        format_tick(duration_ms)
-    )
+    format!("--pine-chart-animation-duration: {duration_ms}ms; --pine-chart-animation-easing: {easing};")
 }
 
 #[cfg(test)]
@@ -40,5 +44,11 @@ mod tests {
             animation_style(f64::NAN, "  "),
             "--pine-chart-animation-duration: 160ms; --pine-chart-animation-easing: ease;"
         );
+    }
+
+    #[test]
+    fn exit_animation_delay_adds_cleanup_buffer() {
+        assert_eq!(exit_animation_delay_ms(120.0), 160);
+        assert_eq!(exit_animation_delay_ms(f64::NAN), 200);
     }
 }

--- a/crates/pine-charts/src/area/PineAreaChart.poco
+++ b/crates/pine-charts/src/area/PineAreaChart.poco
@@ -102,6 +102,7 @@
               :d="series.area_d"
               fill="currentColor"
               stroke="none"
+              :data-leaving="series.leaving ? 'true' : 'false'"
               :data-series="series.label"></path>
       </template>
     </g>
@@ -116,6 +117,7 @@
               pathLength="1"
               stroke="currentColor"
               vector-effect="non-scaling-stroke"
+              :data-leaving="series.leaving ? 'true' : 'false'"
               :data-series="series.label"></path>
       </template>
     </g>

--- a/crates/pine-charts/src/area/mod.rs
+++ b/crates/pine-charts/src/area/mod.rs
@@ -1,7 +1,10 @@
 use pocopine::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::animation::{animation_style, DEFAULT_ANIMATION_DURATION_MS, DEFAULT_ANIMATION_EASING};
+use crate::animation::{
+    animation_style, exit_animation_delay_ms, DEFAULT_ANIMATION_DURATION_MS,
+    DEFAULT_ANIMATION_EASING,
+};
 use crate::cartesian::{
     centered_plot_y, optional_domain, plot_rect_from_edges, pointer_event_svg_point,
     CartesianChartState, CartesianGuideFields, CartesianGuideUpdate, CartesianHoverFields,
@@ -102,6 +105,7 @@ impl AreaChartGeometry {
                     )?,
                     line_d: series.line_d.clone(),
                     samples: series.samples.clone(),
+                    leaving: false,
                 })
             })
             .collect::<ChartResult<Vec<_>>>()?;
@@ -132,6 +136,7 @@ pub struct AreaChartSeriesRender {
     pub area_d: String,
     pub line_d: String,
     pub samples: Vec<LineChartSample>,
+    pub leaving: bool,
 }
 
 pub fn area_legend_items(series: &[ChartAreaSeries]) -> Vec<LegendItem> {
@@ -190,6 +195,7 @@ pub struct PineAreaChart {
     #[prop]
     pub animation_easing: String,
     pub animation_style: String,
+    pub exit_generation: u32,
     pub state: String,
     pub view_box: String,
     pub area_series: Vec<AreaChartSeriesRender>,
@@ -252,6 +258,7 @@ impl Default for PineAreaChart {
                 DEFAULT_ANIMATION_DURATION_MS,
                 DEFAULT_ANIMATION_EASING,
             ),
+            exit_generation: 0,
             state: "empty".into(),
             view_box: format!("0 0 {} {}", options.width, options.height),
             area_series: Vec::new(),
@@ -312,12 +319,12 @@ impl PineAreaChart {
 
     #[watch(points)]
     fn on_points(&mut self, _: Vec<ChartPoint>, _: Option<Vec<ChartPoint>>) {
-        self.recompute();
+        self.recompute_with_leaving();
     }
 
     #[watch(series)]
     fn on_series(&mut self, _: Vec<ChartAreaSeries>, _: Option<Vec<ChartAreaSeries>>) {
-        self.recompute();
+        self.recompute_with_leaving();
     }
 
     #[watch(width)]
@@ -388,6 +395,14 @@ impl PineAreaChart {
     }
 
     fn recompute(&mut self) {
+        self.recompute_inner(false);
+    }
+
+    fn recompute_with_leaving(&mut self) {
+        self.recompute_inner(self.animate);
+    }
+
+    fn recompute_inner(&mut self, retain_leaving: bool) {
         let geometry = if self.series.is_empty() {
             AreaChartGeometry::new(&self.points, &self.options())
         } else {
@@ -397,7 +412,11 @@ impl PineAreaChart {
         match geometry {
             Ok(geometry) => {
                 self.view_box = geometry.view_box;
-                self.area_series = geometry.series;
+                let mut area_series = geometry.series;
+                if retain_leaving && self.merge_leaving_area_series(&mut area_series) {
+                    self.schedule_leaving_cleanup();
+                }
+                self.area_series = area_series;
                 self.samples = geometry.samples;
                 self.plot_edges().apply(geometry.plot);
                 self.guides().apply(CartesianGuideUpdate {
@@ -415,6 +434,17 @@ impl PineAreaChart {
                 self.clear_hover();
             }
             Err(ChartError::EmptySeries) => {
+                if retain_leaving && !self.area_series.is_empty() {
+                    self.area_series.iter_mut().for_each(|series| {
+                        series.leaving = true;
+                    });
+                    self.samples.clear();
+                    self.clear_hover();
+                    self.error.clear();
+                    self.state_fields().apply(CartesianChartState::Ready);
+                    self.schedule_leaving_cleanup();
+                    return;
+                }
                 self.area_series.clear();
                 self.samples.clear();
                 self.plot_edges().clear();
@@ -432,6 +462,40 @@ impl PineAreaChart {
                 self.error = error.to_string();
                 self.state_fields().apply(CartesianChartState::Invalid);
             }
+        }
+    }
+
+    fn merge_leaving_area_series(&self, next: &mut Vec<AreaChartSeriesRender>) -> bool {
+        let mut added = false;
+        for previous in &self.area_series {
+            if next.iter().any(|series| series.key == previous.key) {
+                continue;
+            }
+            let mut leaving = previous.clone();
+            leaving.leaving = true;
+            next.push(leaving);
+            added = true;
+        }
+        added
+    }
+
+    fn schedule_leaving_cleanup(&mut self) {
+        self.exit_generation = self.exit_generation.wrapping_add(1);
+        let generation = self.exit_generation;
+        let delay = exit_animation_delay_ms(self.animation_duration);
+        let me = pocopine::this::<Self>();
+        pocopine::timers::after_scoped(delay, move || {
+            me.update(|chart| chart.prune_leaving_area_series(generation));
+        });
+    }
+
+    fn prune_leaving_area_series(&mut self, generation: u32) {
+        if generation != self.exit_generation {
+            return;
+        }
+        self.area_series.retain(|series| !series.leaving);
+        if self.area_series.is_empty() {
+            self.state_fields().apply(CartesianChartState::Empty);
         }
     }
 

--- a/crates/pine-charts/src/pie/PinePieChart.poco
+++ b/crates/pine-charts/src/pie/PinePieChart.poco
@@ -40,9 +40,17 @@
               :data-hovered="slice.key == hover_key"
               :data-focused="slice.key == focused_key"
               :data-selected="slice.key == selected_key"
+              :data-entering="slice.entering ? 'true' : 'false'"
               :data-leaving="slice.leaving ? 'true' : 'false'"
               :style="slice.animation_style"
-              @click.stop="select_slice(slice.key)"></path>
+              @click.stop="select_slice(slice.key)">
+          <animate attributeName="d"
+                   :from="slice.morph_from_d"
+                   :to="slice.morph_to_d"
+                   :dur="slice.morph_duration"
+                   :begin="slice.morph_begin"
+                   fill="freeze"></animate>
+        </path>
       </template>
     </g>
     <g pp-show="hover_visible"

--- a/crates/pine-charts/src/pie/PinePieChart.poco
+++ b/crates/pine-charts/src/pie/PinePieChart.poco
@@ -43,14 +43,7 @@
               :data-entering="slice.entering ? 'true' : 'false'"
               :data-leaving="slice.leaving ? 'true' : 'false'"
               :style="slice.animation_style"
-              @click.stop="select_slice(slice.key)">
-          <animate attributeName="d"
-                   :from="slice.morph_from_d"
-                   :to="slice.morph_to_d"
-                   :dur="slice.morph_duration"
-                   :begin="slice.morph_begin"
-                   fill="freeze"></animate>
-        </path>
+              @click.stop="select_slice(slice.key)"></path>
       </template>
     </g>
     <g pp-show="hover_visible"

--- a/crates/pine-charts/src/pie/PinePieChart.poco
+++ b/crates/pine-charts/src/pie/PinePieChart.poco
@@ -7,6 +7,7 @@
       :data-donut="inner_radius > 0"
       :data-hover="hover_visible"
       :data-animate="animate"
+      :data-slice-animating="animating_slices"
       :data-animation-duration="animation_duration"
       :data-animation-easing="animation_easing"
       :style="animation_style"
@@ -28,29 +29,33 @@
        @pointerleave="clear_hover">
     <g class="pine-chart-pie-slices" data-layer="series">
       <template pp-for="slice in slices" pp-key="slice.key">
-        <path class="pine-chart-pie-slice"
-              :d="slice.d"
-              role="option"
-              :aria-label="slice.aria_label"
-              :aria-selected="slice.key == selected_key ? 'true' : 'false'"
-              :data-key="slice.key"
-              :data-label="slice.label"
-              :data-value="slice.value"
-              :data-percentage="slice.percentage"
-              :data-hovered="slice.key == hover_key"
-              :data-focused="slice.key == focused_key"
-              :data-selected="slice.key == selected_key"
-              :data-entering="slice.entering ? 'true' : 'false'"
-              :data-leaving="slice.leaving ? 'true' : 'false'"
-              :style="slice.animation_style"
-              @click.stop="select_slice(slice.key)"></path>
+        <g class="pine-chart-pie-slice-group"
+           :data-key="slice.key"
+           :data-label="slice.label">
+          <path class="pine-chart-pie-slice"
+                :d="slice.d"
+                role="option"
+                :aria-label="slice.aria_label"
+                :aria-selected="slice.key == selected_key ? 'true' : 'false'"
+                :data-key="slice.key"
+                :data-label="slice.label"
+                :data-value="slice.value"
+                :data-percentage="slice.percentage"
+                :data-hovered="slice.key == hover_key && animating_slices"
+                :data-focused="slice.key == focused_key"
+                :data-selected="slice.key == selected_key"
+                :data-entering="slice.entering ? 'true' : 'false'"
+                :data-leaving="slice.leaving ? 'true' : 'false'"
+                :style="slice.animation_style"
+                @click.stop="select_slice(slice.key)"></path>
+        </g>
       </template>
     </g>
-    <g pp-show="hover_visible"
-       class="pine-chart-pie-hover"
+    <g class="pine-chart-pie-hover"
        data-layer="hover"
        aria-hidden="true"
-       pointer-events="none">
+       pointer-events="none"
+       :style="hover_overlay_visible ? '' : 'display: none;'">
       <path class="pine-chart-pie-slice pine-chart-pie-hover-slice"
             :d="hover_slice.d"
             :data-key="hover_slice.key"

--- a/crates/pine-charts/src/pie/PinePieChart.poco
+++ b/crates/pine-charts/src/pie/PinePieChart.poco
@@ -40,6 +40,7 @@
               :data-hovered="slice.key == hover_key"
               :data-focused="slice.key == focused_key"
               :data-selected="slice.key == selected_key"
+              :data-leaving="slice.leaving ? 'true' : 'false'"
               :style="slice.animation_style"
               @click.stop="select_slice(slice.key)"></path>
       </template>

--- a/crates/pine-charts/src/pie/mod.rs
+++ b/crates/pine-charts/src/pie/mod.rs
@@ -5,8 +5,7 @@ use pocopine::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::animation::{
-    animation_style, exit_animation_delay_ms, DEFAULT_ANIMATION_DURATION_MS,
-    DEFAULT_ANIMATION_EASING,
+    animation_duration_ms, animation_style, DEFAULT_ANIMATION_DURATION_MS, DEFAULT_ANIMATION_EASING,
 };
 use crate::cartesian::{
     pointer_event_svg_point, step_key, CartesianHoverPlacement, ChartStateFields,
@@ -19,6 +18,8 @@ use crate::legend::LegendItem;
 use crate::svg::format_tick;
 
 const FULL_CIRCLE_DEGREES: f64 = 360.0;
+const PIE_SLICE_DELAY_MS: u32 = 28;
+const PIE_ANIMATION_BUFFER_MS: u32 = 40;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ChartPieSlice {
@@ -130,6 +131,11 @@ impl PieChartGeometry {
                 let label = slice.label.clone();
                 let aria_label = format!("{label}: {value_label} ({percentage_label})");
                 let d = pie_slice_path(center, outer_radius, inner_radius, slice_start, slice_end)?;
+                let enter_d =
+                    collapsed_pie_slice_path(center, outer_radius, inner_radius, slice_start)?;
+                let exit_d =
+                    collapsed_pie_slice_path(center, outer_radius, inner_radius, slice_end)?;
+                let delay_ms = slice_delay_ms(index);
                 let label_point = polar_point(
                     center,
                     label_radius(outer_radius, inner_radius),
@@ -143,15 +149,19 @@ impl PieChartGeometry {
                     percentage,
                     percentage_label,
                     aria_label,
-                    d,
+                    d: d.clone(),
                     start_angle: slice_start,
                     end_angle: slice_end,
                     label_x: label_point.x,
                     label_y: label_point.y,
-                    animation_style: format!(
-                        "--pine-chart-slice-delay: {}ms;",
-                        format_tick(index as f64 * 28.0)
-                    ),
+                    animation_style: format!("--pine-chart-slice-delay: {delay_ms}ms;"),
+                    morph_from_d: d.clone(),
+                    morph_to_d: d.clone(),
+                    morph_duration: "0ms".into(),
+                    morph_begin: "0ms".into(),
+                    enter_d,
+                    exit_d,
+                    entering: false,
                     leaving: false,
                 })
             })
@@ -202,6 +212,13 @@ pub struct SvgPieSlice {
     pub label_x: f64,
     pub label_y: f64,
     pub animation_style: String,
+    pub morph_from_d: String,
+    pub morph_to_d: String,
+    pub morph_duration: String,
+    pub morph_begin: String,
+    pub enter_d: String,
+    pub exit_d: String,
+    pub entering: bool,
     pub leaving: bool,
 }
 
@@ -299,7 +316,7 @@ pub struct PinePieChart {
     #[prop]
     pub animation_easing: String,
     pub animation_style: String,
-    pub exit_generation: u32,
+    pub animation_generation: u32,
     pub state: String,
     pub view_box: String,
     pub slices: Vec<SvgPieSlice>,
@@ -358,7 +375,7 @@ impl Default for PinePieChart {
                 DEFAULT_ANIMATION_DURATION_MS,
                 DEFAULT_ANIMATION_EASING,
             ),
-            exit_generation: 0,
+            animation_generation: 0,
             state: "empty".into(),
             view_box: format!("0 0 {} {}", options.width, options.height),
             slices: Vec::new(),
@@ -543,8 +560,17 @@ impl PinePieChart {
             Ok(geometry) => {
                 self.view_box = geometry.view_box;
                 let mut slices = geometry.slices;
-                if retain_leaving && self.merge_leaving_slices(&mut slices) {
-                    self.schedule_leaving_cleanup();
+                if retain_leaving {
+                    let mut needs_animation_cleanup = false;
+                    if self.mark_entering_slices(&mut slices) {
+                        needs_animation_cleanup = true;
+                    }
+                    if self.merge_leaving_slices(&mut slices) {
+                        needs_animation_cleanup = true;
+                    }
+                    if needs_animation_cleanup {
+                        self.schedule_slice_animation_cleanup(slices.len());
+                    }
                 }
                 self.slices = slices;
                 self.legend_items = geometry.legend_items;
@@ -562,6 +588,7 @@ impl PinePieChart {
             Err(ChartError::EmptySeries) => {
                 if retain_leaving && !self.slices.is_empty() {
                     self.slices.iter_mut().for_each(|slice| {
+                        configure_leaving_slice(slice, self.animation_duration);
                         slice.leaving = true;
                     });
                     self.legend_items = pie_legend_items(&self.data);
@@ -570,7 +597,7 @@ impl PinePieChart {
                     self.error.clear();
                     self.state_fields()
                         .apply(crate::cartesian::CartesianChartState::Ready);
-                    self.schedule_leaving_cleanup();
+                    self.schedule_slice_animation_cleanup(self.slices.len());
                     return;
                 }
                 self.clear_geometry();
@@ -591,6 +618,28 @@ impl PinePieChart {
         }
     }
 
+    fn mark_entering_slices(&self, next: &mut [SvgPieSlice]) -> bool {
+        let has_previous = self.slices.iter().any(|slice| !slice.leaving);
+        if !has_previous {
+            return false;
+        }
+
+        let mut added = false;
+        for slice in next {
+            if self
+                .slices
+                .iter()
+                .any(|previous| !previous.leaving && previous.key == slice.key)
+            {
+                configure_static_slice(slice);
+                continue;
+            }
+            configure_entering_slice(slice, self.animation_duration);
+            added = true;
+        }
+        added
+    }
+
     fn merge_leaving_slices(&self, next: &mut Vec<SvgPieSlice>) -> bool {
         let mut added = false;
         for previous in &self.slices {
@@ -598,6 +647,8 @@ impl PinePieChart {
                 continue;
             }
             let mut leaving = previous.clone();
+            configure_leaving_slice(&mut leaving, self.animation_duration);
+            leaving.entering = false;
             leaving.leaving = true;
             next.push(leaving);
             added = true;
@@ -605,21 +656,25 @@ impl PinePieChart {
         added
     }
 
-    fn schedule_leaving_cleanup(&mut self) {
-        self.exit_generation = self.exit_generation.wrapping_add(1);
-        let generation = self.exit_generation;
-        let delay = exit_animation_delay_ms(self.animation_duration);
+    fn schedule_slice_animation_cleanup(&mut self, slice_count: usize) {
+        self.animation_generation = self.animation_generation.wrapping_add(1);
+        let generation = self.animation_generation;
+        let delay = pie_animation_cleanup_delay_ms(self.animation_duration, slice_count);
         let me = pocopine::this::<Self>();
         pocopine::timers::after_scoped(delay, move || {
-            me.update(|chart| chart.prune_leaving_slices(generation));
+            me.update(|chart| chart.finish_slice_animations(generation));
         });
     }
 
-    fn prune_leaving_slices(&mut self, generation: u32) {
-        if generation != self.exit_generation {
+    fn finish_slice_animations(&mut self, generation: u32) {
+        if generation != self.animation_generation {
             return;
         }
         self.slices.retain(|slice| !slice.leaving);
+        self.slices.iter_mut().for_each(|slice| {
+            slice.entering = false;
+            configure_static_slice(slice);
+        });
         if self.slices.is_empty() {
             self.clear_geometry();
             self.state_fields()
@@ -910,6 +965,65 @@ fn pie_slice_path(
     )
     .expect("writing to string should not fail");
     Ok(path)
+}
+
+fn collapsed_pie_slice_path(
+    center: Point,
+    outer_radius: f64,
+    inner_radius: f64,
+    angle: f64,
+) -> ChartResult<String> {
+    pie_slice_path(center, outer_radius, inner_radius, angle, angle)
+}
+
+fn configure_static_slice(slice: &mut SvgPieSlice) {
+    slice.morph_from_d = slice.d.clone();
+    slice.morph_to_d = slice.d.clone();
+    slice.morph_duration = "0ms".into();
+    slice.morph_begin = "0ms".into();
+}
+
+fn configure_entering_slice(slice: &mut SvgPieSlice, duration_ms: f64) {
+    slice.entering = true;
+    slice.leaving = false;
+    slice.morph_from_d = slice.enter_d.clone();
+    slice.morph_to_d = slice.d.clone();
+    slice.morph_duration = animation_duration_attr(duration_ms);
+    slice.morph_begin = slice_begin_attr(slice);
+}
+
+fn configure_leaving_slice(slice: &mut SvgPieSlice, duration_ms: f64) {
+    slice.entering = false;
+    slice.morph_from_d = slice.d.clone();
+    slice.morph_to_d = slice.exit_d.clone();
+    slice.morph_duration = animation_duration_attr(duration_ms);
+    slice.morph_begin = "0ms".into();
+}
+
+fn animation_duration_attr(duration_ms: f64) -> String {
+    format!("{}ms", animation_duration_ms(duration_ms))
+}
+
+fn slice_begin_attr(slice: &SvgPieSlice) -> String {
+    format!("{}ms", slice_animation_delay_ms(&slice.animation_style))
+}
+
+fn slice_animation_delay_ms(animation_style: &str) -> u32 {
+    animation_style
+        .trim()
+        .strip_prefix("--pine-chart-slice-delay:")
+        .and_then(|value| value.trim().strip_suffix("ms;"))
+        .and_then(|value| value.trim().parse().ok())
+        .unwrap_or(0)
+}
+
+fn slice_delay_ms(index: usize) -> u32 {
+    index as u32 * PIE_SLICE_DELAY_MS
+}
+
+fn pie_animation_cleanup_delay_ms(duration_ms: f64, slice_count: usize) -> u32 {
+    let max_delay = slice_count.saturating_sub(1) as u32 * PIE_SLICE_DELAY_MS;
+    animation_duration_ms(duration_ms) + max_delay + PIE_ANIMATION_BUFFER_MS
 }
 
 fn visible_arc_end(start_angle: f64, end_angle: f64) -> f64 {

--- a/crates/pine-charts/src/pie/mod.rs
+++ b/crates/pine-charts/src/pie/mod.rs
@@ -131,11 +131,6 @@ impl PieChartGeometry {
                 let label = slice.label.clone();
                 let aria_label = format!("{label}: {value_label} ({percentage_label})");
                 let d = pie_slice_path(center, outer_radius, inner_radius, slice_start, slice_end)?;
-                let enter_d =
-                    collapsed_pie_slice_path(center, outer_radius, inner_radius, slice_start)?;
-                let exit_d =
-                    collapsed_pie_slice_path(center, outer_radius, inner_radius, slice_end)?;
-                let delay_ms = slice_delay_ms(index);
                 let label_point = polar_point(
                     center,
                     label_radius(outer_radius, inner_radius),
@@ -149,18 +144,12 @@ impl PieChartGeometry {
                     percentage,
                     percentage_label,
                     aria_label,
-                    d: d.clone(),
+                    d,
                     start_angle: slice_start,
                     end_angle: slice_end,
                     label_x: label_point.x,
                     label_y: label_point.y,
-                    animation_style: format!("--pine-chart-slice-delay: {delay_ms}ms;"),
-                    morph_from_d: d.clone(),
-                    morph_to_d: d.clone(),
-                    morph_duration: "0ms".into(),
-                    morph_begin: "0ms".into(),
-                    enter_d,
-                    exit_d,
+                    animation_style: slice_animation_style(index, slice_start, slice_end),
                     entering: false,
                     leaving: false,
                 })
@@ -212,12 +201,6 @@ pub struct SvgPieSlice {
     pub label_x: f64,
     pub label_y: f64,
     pub animation_style: String,
-    pub morph_from_d: String,
-    pub morph_to_d: String,
-    pub morph_duration: String,
-    pub morph_begin: String,
-    pub enter_d: String,
-    pub exit_d: String,
     pub entering: bool,
     pub leaving: bool,
 }
@@ -588,7 +571,7 @@ impl PinePieChart {
             Err(ChartError::EmptySeries) => {
                 if retain_leaving && !self.slices.is_empty() {
                     self.slices.iter_mut().for_each(|slice| {
-                        configure_leaving_slice(slice, self.animation_duration);
+                        configure_leaving_slice(slice);
                         slice.leaving = true;
                     });
                     self.legend_items = pie_legend_items(&self.data);
@@ -626,15 +609,20 @@ impl PinePieChart {
 
         let mut added = false;
         for slice in next {
-            if self
+            if let Some(previous) = self
                 .slices
                 .iter()
-                .any(|previous| !previous.leaving && previous.key == slice.key)
+                .find(|previous| !previous.leaving && previous.key == slice.key)
             {
-                configure_static_slice(slice);
+                if previous.entering {
+                    configure_entering_slice(slice);
+                    added = true;
+                } else {
+                    configure_static_slice(slice);
+                }
                 continue;
             }
-            configure_entering_slice(slice, self.animation_duration);
+            configure_entering_slice(slice);
             added = true;
         }
         added
@@ -647,7 +635,7 @@ impl PinePieChart {
                 continue;
             }
             let mut leaving = previous.clone();
-            configure_leaving_slice(&mut leaving, self.animation_duration);
+            configure_leaving_slice(&mut leaving);
             leaving.entering = false;
             leaving.leaving = true;
             next.push(leaving);
@@ -672,7 +660,6 @@ impl PinePieChart {
         }
         self.slices.retain(|slice| !slice.leaving);
         self.slices.iter_mut().for_each(|slice| {
-            slice.entering = false;
             configure_static_slice(slice);
         });
         if self.slices.is_empty() {
@@ -967,54 +954,41 @@ fn pie_slice_path(
     Ok(path)
 }
 
-fn collapsed_pie_slice_path(
-    center: Point,
-    outer_radius: f64,
-    inner_radius: f64,
-    angle: f64,
-) -> ChartResult<String> {
-    pie_slice_path(center, outer_radius, inner_radius, angle, angle)
-}
-
 fn configure_static_slice(slice: &mut SvgPieSlice) {
-    slice.morph_from_d = slice.d.clone();
-    slice.morph_to_d = slice.d.clone();
-    slice.morph_duration = "0ms".into();
-    slice.morph_begin = "0ms".into();
+    slice.entering = false;
+    slice.leaving = false;
 }
 
-fn configure_entering_slice(slice: &mut SvgPieSlice, duration_ms: f64) {
+fn configure_entering_slice(slice: &mut SvgPieSlice) {
     slice.entering = true;
     slice.leaving = false;
-    slice.morph_from_d = slice.enter_d.clone();
-    slice.morph_to_d = slice.d.clone();
-    slice.morph_duration = animation_duration_attr(duration_ms);
-    slice.morph_begin = slice_begin_attr(slice);
 }
 
-fn configure_leaving_slice(slice: &mut SvgPieSlice, duration_ms: f64) {
+fn configure_leaving_slice(slice: &mut SvgPieSlice) {
     slice.entering = false;
-    slice.morph_from_d = slice.d.clone();
-    slice.morph_to_d = slice.exit_d.clone();
-    slice.morph_duration = animation_duration_attr(duration_ms);
-    slice.morph_begin = "0ms".into();
+    slice.leaving = true;
 }
 
-fn animation_duration_attr(duration_ms: f64) -> String {
-    format!("{}ms", animation_duration_ms(duration_ms))
+fn slice_animation_style(index: usize, start_angle: f64, end_angle: f64) -> String {
+    format!(
+        "--pine-chart-slice-delay: {}ms; --pine-chart-slice-enter-clip: {}; --pine-chart-slice-exit-clip: {};",
+        slice_delay_ms(index),
+        collapsed_clip_for_angle(start_angle),
+        collapsed_clip_for_angle(end_angle),
+    )
 }
 
-fn slice_begin_attr(slice: &SvgPieSlice) -> String {
-    format!("{}ms", slice_animation_delay_ms(&slice.animation_style))
-}
-
-fn slice_animation_delay_ms(animation_style: &str) -> u32 {
-    animation_style
-        .trim()
-        .strip_prefix("--pine-chart-slice-delay:")
-        .and_then(|value| value.trim().strip_suffix("ms;"))
-        .and_then(|value| value.trim().parse().ok())
-        .unwrap_or(0)
+fn collapsed_clip_for_angle(angle: f64) -> &'static str {
+    let angle = angle.rem_euclid(FULL_CIRCLE_DEGREES);
+    if !(45.0..315.0).contains(&angle) {
+        "polygon(100% 0, 100% 0, 100% 100%, 100% 100%)"
+    } else if angle < 135.0 {
+        "polygon(0 100%, 100% 100%, 100% 100%, 0 100%)"
+    } else if angle < 225.0 {
+        "polygon(0 0, 0 0, 0 100%, 0 100%)"
+    } else {
+        "polygon(0 0, 100% 0, 100% 0, 0 0)"
+    }
 }
 
 fn slice_delay_ms(index: usize) -> u32 {

--- a/crates/pine-charts/src/pie/mod.rs
+++ b/crates/pine-charts/src/pie/mod.rs
@@ -19,7 +19,7 @@ use crate::svg::format_tick;
 
 const FULL_CIRCLE_DEGREES: f64 = 360.0;
 const PIE_SLICE_DELAY_MS: u32 = 28;
-const PIE_ANIMATION_BUFFER_MS: u32 = 40;
+const PIE_LEAVING_PRUNE_PROGRESS: f64 = 0.995;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ChartPieSlice {
@@ -144,12 +144,16 @@ impl PieChartGeometry {
                     percentage,
                     percentage_label,
                     aria_label,
-                    d,
+                    d: d.clone(),
                     start_angle: slice_start,
                     end_angle: slice_end,
                     label_x: label_point.x,
                     label_y: label_point.y,
-                    animation_style: slice_animation_style(index, slice_start, slice_end),
+                    animation_style: slice_animation_style(index),
+                    center_x: center.x,
+                    center_y: center.y,
+                    outer_radius,
+                    inner_radius,
                     entering: false,
                     leaving: false,
                 })
@@ -201,6 +205,10 @@ pub struct SvgPieSlice {
     pub label_x: f64,
     pub label_y: f64,
     pub animation_style: String,
+    pub center_x: f64,
+    pub center_y: f64,
+    pub outer_radius: f64,
+    pub inner_radius: f64,
     pub entering: bool,
     pub leaving: bool,
 }
@@ -247,6 +255,33 @@ impl SvgPieSlice {
             ),
         }
     }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+struct PieSliceFrame {
+    center_x: f64,
+    center_y: f64,
+    outer_radius: f64,
+    inner_radius: f64,
+    start_angle: f64,
+    end_angle: f64,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+struct PieSliceAnimation {
+    key: String,
+    from: PieSliceFrame,
+    to: PieSliceFrame,
+    delay_ms: u32,
+    duration_ms: u32,
+    entering: bool,
+    leaving: bool,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct PieSliceBoundary {
+    key: String,
+    frame: PieSliceFrame,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -300,6 +335,9 @@ pub struct PinePieChart {
     pub animation_easing: String,
     pub animation_style: String,
     pub animation_generation: u32,
+    pub animating_slices: bool,
+    slice_animations: Vec<PieSliceAnimation>,
+    animation_started_at_ms: f64,
     pub state: String,
     pub view_box: String,
     pub slices: Vec<SvgPieSlice>,
@@ -315,6 +353,7 @@ pub struct PinePieChart {
     pub center_label_y: f64,
     pub center_value_y: f64,
     pub hover_visible: bool,
+    pub hover_overlay_visible: bool,
     pub hover_key: String,
     pub hover_label: String,
     pub hover_value: f64,
@@ -359,6 +398,9 @@ impl Default for PinePieChart {
                 DEFAULT_ANIMATION_EASING,
             ),
             animation_generation: 0,
+            animating_slices: false,
+            slice_animations: Vec::new(),
+            animation_started_at_ms: 0.0,
             state: "empty".into(),
             view_box: format!("0 0 {} {}", options.width, options.height),
             slices: Vec::new(),
@@ -374,6 +416,7 @@ impl Default for PinePieChart {
             center_label_y: 0.0,
             center_value_y: 0.0,
             hover_visible: false,
+            hover_overlay_visible: false,
             hover_key: String::new(),
             hover_label: String::new(),
             hover_value: 0.0,
@@ -453,17 +496,17 @@ impl PinePieChart {
 
     #[watch(inner_radius)]
     fn on_inner_radius(&mut self, _: f64, _: Option<f64>) {
-        self.recompute();
+        self.recompute_shape();
     }
 
     #[watch(start_angle)]
     fn on_start_angle(&mut self, _: f64, _: Option<f64>) {
-        self.recompute();
+        self.recompute_shape();
     }
 
     #[watch(end_angle)]
     fn on_end_angle(&mut self, _: f64, _: Option<f64>) {
-        self.recompute();
+        self.recompute_shape();
     }
 
     #[watch(center_label)]
@@ -485,6 +528,7 @@ impl PinePieChart {
 
     pub fn clear_hover(&mut self) {
         self.hover_visible = false;
+        self.hover_overlay_visible = false;
         self.hover_key.clear();
         self.hover_label.clear();
         self.hover_value = 0.0;
@@ -531,29 +575,26 @@ impl PinePieChart {
     }
 
     fn recompute(&mut self) {
-        self.recompute_inner(false);
+        self.recompute_inner(false, false);
     }
 
     fn recompute_with_leaving(&mut self) {
-        self.recompute_inner(self.animate);
+        self.recompute_inner(self.animate, self.animate);
     }
 
-    fn recompute_inner(&mut self, retain_leaving: bool) {
+    fn recompute_shape(&mut self) {
+        self.recompute_inner(false, self.animate);
+    }
+
+    fn recompute_inner(&mut self, retain_leaving: bool, animate_geometry: bool) {
         match PieChartGeometry::new(&self.data, &self.options()) {
             Ok(geometry) => {
                 self.view_box = geometry.view_box;
                 let mut slices = geometry.slices;
-                if retain_leaving {
-                    let mut needs_animation_cleanup = false;
-                    if self.mark_entering_slices(&mut slices) {
-                        needs_animation_cleanup = true;
-                    }
-                    if self.merge_leaving_slices(&mut slices) {
-                        needs_animation_cleanup = true;
-                    }
-                    if needs_animation_cleanup {
-                        self.schedule_slice_animation_cleanup(slices.len());
-                    }
+                if animate_geometry || retain_leaving {
+                    self.prepare_slice_animations(&mut slices, retain_leaving);
+                } else {
+                    self.clear_slice_animations();
                 }
                 self.slices = slices;
                 self.legend_items = geometry.legend_items;
@@ -569,18 +610,17 @@ impl PinePieChart {
                 self.clear_hover();
             }
             Err(ChartError::EmptySeries) => {
-                if retain_leaving && !self.slices.is_empty() {
-                    self.slices.iter_mut().for_each(|slice| {
-                        configure_leaving_slice(slice);
-                        slice.leaving = true;
-                    });
+                if retain_leaving
+                    && !self.slices.is_empty()
+                    && animation_duration_ms(self.animation_duration) > 0
+                {
+                    self.prepare_empty_slice_exit();
                     self.legend_items = pie_legend_items(&self.data);
                     self.clear_hover();
                     self.clear_selection();
                     self.error.clear();
                     self.state_fields()
                         .apply(crate::cartesian::CartesianChartState::Ready);
-                    self.schedule_slice_animation_cleanup(self.slices.len());
                     return;
                 }
                 self.clear_geometry();
@@ -601,67 +641,233 @@ impl PinePieChart {
         }
     }
 
-    fn mark_entering_slices(&self, next: &mut [SvgPieSlice]) -> bool {
-        let has_previous = self.slices.iter().any(|slice| !slice.leaving);
-        if !has_previous {
-            return false;
+    fn prepare_slice_animations(&mut self, next: &mut Vec<SvgPieSlice>, retain_leaving: bool) {
+        let previous_boundaries = slice_boundaries(&self.slices);
+        if previous_boundaries.is_empty() {
+            self.clear_slice_animations();
+            return;
+        }
+        let next_boundaries = slice_boundaries(next);
+
+        let duration_ms = animation_duration_ms(self.animation_duration);
+        if duration_ms == 0 {
+            self.clear_slice_animations();
+            return;
         }
 
-        let mut added = false;
-        for slice in next {
+        let mut animations = Vec::new();
+        for (index, slice) in next.iter_mut().enumerate() {
             if let Some(previous) = self
                 .slices
                 .iter()
                 .find(|previous| !previous.leaving && previous.key == slice.key)
             {
-                if previous.entering {
-                    configure_entering_slice(slice);
-                    added = true;
-                } else {
+                let from = slice_frame(previous);
+                let to = slice_frame(slice);
+                if frames_match(&from, &to) && !previous.entering {
                     configure_static_slice(slice);
+                    continue;
                 }
+                let entering = previous.entering;
+                slice.entering = entering;
+                slice.leaving = false;
+                let delay_ms = if entering { slice_delay_ms(index) } else { 0 };
+                animations.push(PieSliceAnimation {
+                    key: slice.key.clone(),
+                    from: from.clone(),
+                    to,
+                    delay_ms,
+                    duration_ms,
+                    entering,
+                    leaving: false,
+                });
+                apply_slice_frame(slice, &from);
                 continue;
             }
-            configure_entering_slice(slice);
-            added = true;
-        }
-        added
-    }
 
-    fn merge_leaving_slices(&self, next: &mut Vec<SvgPieSlice>) -> bool {
-        let mut added = false;
-        for previous in &self.slices {
-            if next.iter().any(|slice| slice.key == previous.key) {
-                continue;
+            let to = slice_frame(slice);
+            let collapse_angle = entering_collapse_angle(
+                index,
+                &next_boundaries,
+                &previous_boundaries,
+                to.start_angle,
+            );
+            let from = collapsed_frame(&to, collapse_angle);
+            slice.entering = true;
+            slice.leaving = false;
+            animations.push(PieSliceAnimation {
+                key: slice.key.clone(),
+                from: from.clone(),
+                to,
+                delay_ms: slice_delay_ms(index),
+                duration_ms,
+                entering: true,
+                leaving: false,
+            });
+            apply_slice_frame(slice, &from);
+        }
+
+        if retain_leaving {
+            for (previous_index, previous_boundary) in previous_boundaries.iter().enumerate() {
+                if next_boundaries
+                    .iter()
+                    .any(|slice| slice.key == previous_boundary.key)
+                {
+                    continue;
+                }
+                let Some(previous) = self
+                    .slices
+                    .iter()
+                    .find(|slice| slice.key == previous_boundary.key)
+                else {
+                    continue;
+                };
+                let mut leaving = previous.clone();
+                let from = previous_boundary.frame.clone();
+                let collapse_angle = leaving_collapse_angle(
+                    previous_index,
+                    &previous_boundaries,
+                    &next_boundaries,
+                    from.end_angle,
+                );
+                let to = collapsed_frame(&from, collapse_angle);
+                leaving.entering = false;
+                leaving.leaving = true;
+                apply_slice_frame(&mut leaving, &from);
+                animations.push(PieSliceAnimation {
+                    key: leaving.key.clone(),
+                    from,
+                    to,
+                    delay_ms: 0,
+                    duration_ms,
+                    entering: false,
+                    leaving: true,
+                });
+                next.push(leaving);
             }
-            let mut leaving = previous.clone();
-            configure_leaving_slice(&mut leaving);
-            leaving.entering = false;
-            leaving.leaving = true;
-            next.push(leaving);
-            added = true;
         }
-        added
+
+        if animations.is_empty() {
+            self.clear_slice_animations();
+            return;
+        }
+        self.slice_animations = animations;
+        self.animating_slices = true;
+        self.update_hover_overlay_visibility();
+        self.animation_started_at_ms = now_ms();
+        self.start_slice_animation_loop();
     }
 
-    fn schedule_slice_animation_cleanup(&mut self, slice_count: usize) {
+    fn prepare_empty_slice_exit(&mut self) {
+        let duration_ms = animation_duration_ms(self.animation_duration);
+        if duration_ms == 0 || self.slices.is_empty() {
+            self.clear_slice_animations();
+            return;
+        }
+        let mut animations = Vec::new();
+        for slice in &mut self.slices {
+            let from = slice_frame(slice);
+            let to = collapsed_frame(&from, from.end_angle);
+            slice.entering = false;
+            slice.leaving = true;
+            animations.push(PieSliceAnimation {
+                key: slice.key.clone(),
+                from,
+                to,
+                delay_ms: 0,
+                duration_ms,
+                entering: false,
+                leaving: true,
+            });
+        }
+        self.slice_animations = animations;
+        self.animating_slices = true;
+        self.update_hover_overlay_visibility();
+        self.animation_started_at_ms = now_ms();
+        self.start_slice_animation_loop();
+    }
+
+    fn clear_slice_animations(&mut self) {
+        self.slice_animations.clear();
+        self.animating_slices = false;
+        self.update_hover_overlay_visibility();
+    }
+
+    fn start_slice_animation_loop(&mut self) {
         self.animation_generation = self.animation_generation.wrapping_add(1);
         let generation = self.animation_generation;
-        let delay = pie_animation_cleanup_delay_ms(self.animation_duration, slice_count);
         let me = pocopine::this::<Self>();
-        pocopine::timers::after_scoped(delay, move || {
-            me.update(|chart| chart.finish_slice_animations(generation));
+        pocopine::spawn_scoped(async move {
+            loop {
+                let now = pocopine::timers::next_frame().await;
+                if me.update(|chart| chart.tick_slice_animations(generation, now)) {
+                    break;
+                }
+            }
         });
+    }
+
+    fn tick_slice_animations(&mut self, generation: u32, now_ms: f64) -> bool {
+        if generation != self.animation_generation || self.slice_animations.is_empty() {
+            return true;
+        }
+
+        let animations = self.slice_animations.clone();
+        let elapsed_ms = (now_ms - self.animation_started_at_ms).max(0.0);
+        let easing = self.animation_easing.clone();
+        let complete = animations
+            .iter()
+            .all(|animation| slice_animation_progress(animation, elapsed_ms) >= 1.0);
+        let mut prune_leaving_keys = Vec::new();
+
+        for slice in &mut self.slices {
+            let Some(animation) = animations
+                .iter()
+                .find(|animation| animation.key == slice.key)
+            else {
+                configure_static_slice(slice);
+                continue;
+            };
+
+            let progress = slice_animation_progress(animation, elapsed_ms);
+            if animation.leaving && progress >= PIE_LEAVING_PRUNE_PROGRESS {
+                prune_leaving_keys.push(slice.key.clone());
+                continue;
+            }
+            let frame = interpolate_slice_frame(
+                &animation.from,
+                &animation.to,
+                easing_progress(progress, &easing),
+            );
+            apply_slice_frame(slice, &frame);
+            slice.entering = animation.entering && progress < 1.0;
+            slice.leaving = animation.leaving;
+        }
+
+        if !prune_leaving_keys.is_empty() {
+            self.slices.retain(|slice| {
+                !slice.leaving || !prune_leaving_keys.iter().any(|key| key == &slice.key)
+            });
+        }
+        self.sync_hover_slice();
+
+        if complete {
+            self.finish_slice_animations(generation);
+            return true;
+        }
+        false
     }
 
     fn finish_slice_animations(&mut self, generation: u32) {
         if generation != self.animation_generation {
             return;
         }
+        self.clear_slice_animations();
         self.slices.retain(|slice| !slice.leaving);
         self.slices.iter_mut().for_each(|slice| {
             configure_static_slice(slice);
         });
+        self.sync_hover_slice();
         if self.slices.is_empty() {
             self.clear_geometry();
             self.state_fields()
@@ -742,6 +948,7 @@ impl PinePieChart {
 
     fn clear_geometry(&mut self) {
         self.slices.clear();
+        self.clear_slice_animations();
         self.hover_slice = SvgPieSlice::default();
         self.legend_items.clear();
         self.center_x = 0.0;
@@ -807,12 +1014,25 @@ impl PinePieChart {
         self.hover_placement_x = update.placement.x.into();
         self.hover_placement_y = update.placement.y.into();
         self.hover_style = update.placement.style;
+        self.sync_hover_slice();
+        self.update_hover_overlay_visibility();
+    }
+
+    fn sync_hover_slice(&mut self) {
+        if self.hover_key.is_empty() {
+            self.hover_slice = SvgPieSlice::default();
+            return;
+        }
         self.hover_slice = self
             .slices
             .iter()
-            .find(|slice| slice.key == self.hover_key)
+            .find(|slice| !slice.leaving && slice.key == self.hover_key)
             .cloned()
             .unwrap_or_default();
+    }
+
+    fn update_hover_overlay_visibility(&mut self) {
+        self.hover_overlay_visible = self.hover_visible && !self.animating_slices;
     }
 
     fn reconcile_selection(&mut self) {
@@ -959,45 +1179,194 @@ fn configure_static_slice(slice: &mut SvgPieSlice) {
     slice.leaving = false;
 }
 
-fn configure_entering_slice(slice: &mut SvgPieSlice) {
-    slice.entering = true;
-    slice.leaving = false;
-}
-
-fn configure_leaving_slice(slice: &mut SvgPieSlice) {
-    slice.entering = false;
-    slice.leaving = true;
-}
-
-fn slice_animation_style(index: usize, start_angle: f64, end_angle: f64) -> String {
-    format!(
-        "--pine-chart-slice-delay: {}ms; --pine-chart-slice-enter-clip: {}; --pine-chart-slice-exit-clip: {};",
-        slice_delay_ms(index),
-        collapsed_clip_for_angle(start_angle),
-        collapsed_clip_for_angle(end_angle),
-    )
-}
-
-fn collapsed_clip_for_angle(angle: f64) -> &'static str {
-    let angle = angle.rem_euclid(FULL_CIRCLE_DEGREES);
-    if !(45.0..315.0).contains(&angle) {
-        "polygon(100% 0, 100% 0, 100% 100%, 100% 100%)"
-    } else if angle < 135.0 {
-        "polygon(0 100%, 100% 100%, 100% 100%, 0 100%)"
-    } else if angle < 225.0 {
-        "polygon(0 0, 0 0, 0 100%, 0 100%)"
-    } else {
-        "polygon(0 0, 100% 0, 100% 0, 0 0)"
+fn slice_frame(slice: &SvgPieSlice) -> PieSliceFrame {
+    PieSliceFrame {
+        center_x: slice.center_x,
+        center_y: slice.center_y,
+        outer_radius: slice.outer_radius,
+        inner_radius: slice.inner_radius,
+        start_angle: slice.start_angle,
+        end_angle: slice.end_angle,
     }
+}
+
+fn slice_boundaries(slices: &[SvgPieSlice]) -> Vec<PieSliceBoundary> {
+    slices
+        .iter()
+        .filter(|slice| !slice.leaving)
+        .map(|slice| PieSliceBoundary {
+            key: slice.key.clone(),
+            frame: slice_frame(slice),
+        })
+        .collect()
+}
+
+fn entering_collapse_angle(
+    next_index: usize,
+    next: &[PieSliceBoundary],
+    previous: &[PieSliceBoundary],
+    fallback: f64,
+) -> f64 {
+    let before = next
+        .get(..next_index)
+        .unwrap_or_default()
+        .iter()
+        .rev()
+        .find_map(|slice| boundary_frame(previous, &slice.key).map(|frame| frame.end_angle));
+    let after = next
+        .get(next_index + 1..)
+        .unwrap_or_default()
+        .iter()
+        .find_map(|slice| boundary_frame(previous, &slice.key).map(|frame| frame.start_angle));
+    collapse_angle(before, after, fallback)
+}
+
+fn leaving_collapse_angle(
+    previous_index: usize,
+    previous: &[PieSliceBoundary],
+    next: &[PieSliceBoundary],
+    fallback: f64,
+) -> f64 {
+    let before = previous
+        .get(..previous_index)
+        .unwrap_or_default()
+        .iter()
+        .rev()
+        .find_map(|slice| boundary_frame(next, &slice.key).map(|frame| frame.end_angle));
+    let after = previous
+        .get(previous_index + 1..)
+        .unwrap_or_default()
+        .iter()
+        .find_map(|slice| boundary_frame(next, &slice.key).map(|frame| frame.start_angle));
+    collapse_angle(before, after, fallback)
+}
+
+fn boundary_frame<'a>(boundaries: &'a [PieSliceBoundary], key: &str) -> Option<&'a PieSliceFrame> {
+    boundaries
+        .iter()
+        .find(|boundary| boundary.key == key)
+        .map(|boundary| &boundary.frame)
+}
+
+fn collapse_angle(before: Option<f64>, after: Option<f64>, fallback: f64) -> f64 {
+    match (before, after) {
+        (Some(before), Some(after)) => clean((before + after) * 0.5),
+        (Some(before), None) => before,
+        (None, Some(after)) => after,
+        (None, None) => fallback,
+    }
+}
+
+fn collapsed_frame(frame: &PieSliceFrame, angle: f64) -> PieSliceFrame {
+    PieSliceFrame {
+        center_x: frame.center_x,
+        center_y: frame.center_y,
+        outer_radius: frame.outer_radius,
+        inner_radius: frame.inner_radius,
+        start_angle: angle,
+        end_angle: angle,
+    }
+}
+
+fn apply_slice_frame(slice: &mut SvgPieSlice, frame: &PieSliceFrame) {
+    let center = Point {
+        x: frame.center_x,
+        y: frame.center_y,
+    };
+    if let Ok(path) = pie_slice_path(
+        center,
+        frame.outer_radius,
+        frame.inner_radius,
+        frame.start_angle,
+        frame.end_angle,
+    ) {
+        slice.d = path;
+    }
+    slice.center_x = frame.center_x;
+    slice.center_y = frame.center_y;
+    slice.outer_radius = frame.outer_radius;
+    slice.inner_radius = frame.inner_radius;
+    slice.start_angle = frame.start_angle;
+    slice.end_angle = frame.end_angle;
+    let label_point = polar_point(
+        center,
+        label_radius(frame.outer_radius, frame.inner_radius),
+        (frame.start_angle + frame.end_angle) * 0.5,
+    );
+    slice.label_x = label_point.x;
+    slice.label_y = label_point.y;
+}
+
+fn interpolate_slice_frame(
+    from: &PieSliceFrame,
+    to: &PieSliceFrame,
+    progress: f64,
+) -> PieSliceFrame {
+    PieSliceFrame {
+        center_x: lerp(from.center_x, to.center_x, progress),
+        center_y: lerp(from.center_y, to.center_y, progress),
+        outer_radius: lerp(from.outer_radius, to.outer_radius, progress),
+        inner_radius: lerp(from.inner_radius, to.inner_radius, progress),
+        start_angle: lerp(from.start_angle, to.start_angle, progress),
+        end_angle: lerp(from.end_angle, to.end_angle, progress),
+    }
+}
+
+fn frames_match(left: &PieSliceFrame, right: &PieSliceFrame) -> bool {
+    const EPSILON: f64 = 0.001;
+    (left.center_x - right.center_x).abs() <= EPSILON
+        && (left.center_y - right.center_y).abs() <= EPSILON
+        && (left.outer_radius - right.outer_radius).abs() <= EPSILON
+        && (left.inner_radius - right.inner_radius).abs() <= EPSILON
+        && (left.start_angle - right.start_angle).abs() <= EPSILON
+        && (left.end_angle - right.end_angle).abs() <= EPSILON
+}
+
+fn slice_animation_progress(animation: &PieSliceAnimation, elapsed_ms: f64) -> f64 {
+    let elapsed_ms = elapsed_ms - animation.delay_ms as f64;
+    if elapsed_ms <= 0.0 {
+        return 0.0;
+    }
+    if animation.duration_ms == 0 {
+        return 1.0;
+    }
+    (elapsed_ms / animation.duration_ms as f64).clamp(0.0, 1.0)
+}
+
+fn easing_progress(progress: f64, easing: &str) -> f64 {
+    let progress = progress.clamp(0.0, 1.0);
+    match easing.trim() {
+        "linear" => progress,
+        "ease-in" => progress * progress,
+        "ease-out" => 1.0 - (1.0 - progress).powi(2),
+        "ease-in-out" => {
+            if progress < 0.5 {
+                2.0 * progress * progress
+            } else {
+                1.0 - (-2.0 * progress + 2.0).powi(2) * 0.5
+            }
+        }
+        _ => progress * progress * (3.0 - 2.0 * progress),
+    }
+}
+
+fn lerp(from: f64, to: f64, progress: f64) -> f64 {
+    clean(from + (to - from) * progress)
+}
+
+fn slice_animation_style(index: usize) -> String {
+    format!("--pine-chart-slice-delay: {}ms;", slice_delay_ms(index))
 }
 
 fn slice_delay_ms(index: usize) -> u32 {
     index as u32 * PIE_SLICE_DELAY_MS
 }
 
-fn pie_animation_cleanup_delay_ms(duration_ms: f64, slice_count: usize) -> u32 {
-    let max_delay = slice_count.saturating_sub(1) as u32 * PIE_SLICE_DELAY_MS;
-    animation_duration_ms(duration_ms) + max_delay + PIE_ANIMATION_BUFFER_MS
+fn now_ms() -> f64 {
+    web_sys::window()
+        .and_then(|window| window.performance())
+        .map(|performance| performance.now())
+        .unwrap_or_else(js_sys::Date::now)
 }
 
 fn visible_arc_end(start_angle: f64, end_angle: f64) -> f64 {
@@ -1247,5 +1616,64 @@ mod tests {
         assert!(chart.center_visible);
         assert_eq!(chart.center_value_y, chart.center_y - 26.0);
         assert_eq!(chart.center_label_y, chart.center_y);
+    }
+
+    #[test]
+    fn entering_slice_collapses_at_old_neighbor_boundary() {
+        let previous = vec![boundary("a", -90.0, 180.0), boundary("b", 180.0, 270.0)];
+        let next = vec![
+            boundary("a", -90.0, 90.0),
+            boundary("b", 90.0, 150.0),
+            boundary("c", 150.0, 270.0),
+        ];
+
+        assert_eq!(
+            entering_collapse_angle(2, &next, &previous, next[2].frame.start_angle),
+            270.0
+        );
+    }
+
+    #[test]
+    fn entering_middle_slice_collapses_between_old_neighbors() {
+        let previous = vec![boundary("a", -90.0, 90.0), boundary("b", 90.0, 270.0)];
+        let next = vec![
+            boundary("a", -90.0, 54.0),
+            boundary("new", 54.0, 126.0),
+            boundary("b", 126.0, 270.0),
+        ];
+
+        assert_eq!(
+            entering_collapse_angle(1, &next, &previous, next[1].frame.start_angle),
+            90.0
+        );
+    }
+
+    #[test]
+    fn leaving_middle_slice_collapses_to_new_neighbor_boundary() {
+        let previous = vec![
+            boundary("one", -90.0, -54.0),
+            boundary("two", -54.0, -18.0),
+            boundary("three", -18.0, 270.0),
+        ];
+        let next = vec![
+            boundary("one", -90.0, -45.0),
+            boundary("three", -45.0, 270.0),
+        ];
+
+        assert_eq!(
+            leaving_collapse_angle(1, &previous, &next, previous[1].frame.end_angle),
+            -45.0
+        );
+    }
+
+    fn boundary(key: &str, start_angle: f64, end_angle: f64) -> PieSliceBoundary {
+        PieSliceBoundary {
+            key: key.into(),
+            frame: PieSliceFrame {
+                start_angle,
+                end_angle,
+                ..PieSliceFrame::default()
+            },
+        }
     }
 }

--- a/crates/pine-charts/src/pie/mod.rs
+++ b/crates/pine-charts/src/pie/mod.rs
@@ -4,7 +4,10 @@ use core::fmt::Write;
 use pocopine::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::animation::{animation_style, DEFAULT_ANIMATION_DURATION_MS, DEFAULT_ANIMATION_EASING};
+use crate::animation::{
+    animation_style, exit_animation_delay_ms, DEFAULT_ANIMATION_DURATION_MS,
+    DEFAULT_ANIMATION_EASING,
+};
 use crate::cartesian::{
     pointer_event_svg_point, step_key, CartesianHoverPlacement, ChartStateFields,
     DEFAULT_EMPTY_MESSAGE,
@@ -124,7 +127,7 @@ impl PieChartGeometry {
                 let percentage = slice.value / total * 100.0;
                 let percentage_label = format!("{}%", format_tick(percentage));
                 let value_label = format_tick(slice.value);
-                let label = slice_label(&slice.label, index);
+                let label = slice.label.clone();
                 let aria_label = format!("{label}: {value_label} ({percentage_label})");
                 let d = pie_slice_path(center, outer_radius, inner_radius, slice_start, slice_end)?;
                 let label_point = polar_point(
@@ -133,7 +136,7 @@ impl PieChartGeometry {
                     (slice_start + slice_end) * 0.5,
                 );
                 Ok(SvgPieSlice {
-                    key: format!("pie-slice-{index}-{label}"),
+                    key: slice.key.clone(),
                     label,
                     value: slice.value,
                     value_label,
@@ -149,6 +152,7 @@ impl PieChartGeometry {
                         "--pine-chart-slice-delay: {}ms;",
                         format_tick(index as f64 * 28.0)
                     ),
+                    leaving: false,
                 })
             })
             .collect::<ChartResult<Vec<_>>>()?;
@@ -198,6 +202,7 @@ pub struct SvgPieSlice {
     pub label_x: f64,
     pub label_y: f64,
     pub animation_style: String,
+    pub leaving: bool,
 }
 
 impl SvgPieSlice {
@@ -294,6 +299,7 @@ pub struct PinePieChart {
     #[prop]
     pub animation_easing: String,
     pub animation_style: String,
+    pub exit_generation: u32,
     pub state: String,
     pub view_box: String,
     pub slices: Vec<SvgPieSlice>,
@@ -352,6 +358,7 @@ impl Default for PinePieChart {
                 DEFAULT_ANIMATION_DURATION_MS,
                 DEFAULT_ANIMATION_EASING,
             ),
+            exit_generation: 0,
             state: "empty".into(),
             view_box: format!("0 0 {} {}", options.width, options.height),
             slices: Vec::new(),
@@ -411,7 +418,7 @@ impl PinePieChart {
 
     #[watch(data)]
     fn on_data(&mut self, _: Vec<ChartPieSlice>, _: Option<Vec<ChartPieSlice>>) {
-        self.recompute();
+        self.recompute_with_leaving();
     }
 
     #[watch(width)]
@@ -524,10 +531,22 @@ impl PinePieChart {
     }
 
     fn recompute(&mut self) {
+        self.recompute_inner(false);
+    }
+
+    fn recompute_with_leaving(&mut self) {
+        self.recompute_inner(self.animate);
+    }
+
+    fn recompute_inner(&mut self, retain_leaving: bool) {
         match PieChartGeometry::new(&self.data, &self.options()) {
             Ok(geometry) => {
                 self.view_box = geometry.view_box;
-                self.slices = geometry.slices;
+                let mut slices = geometry.slices;
+                if retain_leaving && self.merge_leaving_slices(&mut slices) {
+                    self.schedule_leaving_cleanup();
+                }
+                self.slices = slices;
                 self.legend_items = geometry.legend_items;
                 self.center_x = geometry.center.x;
                 self.center_y = geometry.center.y;
@@ -541,6 +560,19 @@ impl PinePieChart {
                 self.clear_hover();
             }
             Err(ChartError::EmptySeries) => {
+                if retain_leaving && !self.slices.is_empty() {
+                    self.slices.iter_mut().for_each(|slice| {
+                        slice.leaving = true;
+                    });
+                    self.legend_items = pie_legend_items(&self.data);
+                    self.clear_hover();
+                    self.clear_selection();
+                    self.error.clear();
+                    self.state_fields()
+                        .apply(crate::cartesian::CartesianChartState::Ready);
+                    self.schedule_leaving_cleanup();
+                    return;
+                }
                 self.clear_geometry();
                 self.clear_hover();
                 self.clear_selection();
@@ -556,6 +588,42 @@ impl PinePieChart {
                 self.state_fields()
                     .apply(crate::cartesian::CartesianChartState::Invalid);
             }
+        }
+    }
+
+    fn merge_leaving_slices(&self, next: &mut Vec<SvgPieSlice>) -> bool {
+        let mut added = false;
+        for previous in &self.slices {
+            if next.iter().any(|slice| slice.key == previous.key) {
+                continue;
+            }
+            let mut leaving = previous.clone();
+            leaving.leaving = true;
+            next.push(leaving);
+            added = true;
+        }
+        added
+    }
+
+    fn schedule_leaving_cleanup(&mut self) {
+        self.exit_generation = self.exit_generation.wrapping_add(1);
+        let generation = self.exit_generation;
+        let delay = exit_animation_delay_ms(self.animation_duration);
+        let me = pocopine::this::<Self>();
+        pocopine::timers::after_scoped(delay, move || {
+            me.update(|chart| chart.prune_leaving_slices(generation));
+        });
+    }
+
+    fn prune_leaving_slices(&mut self, generation: u32) {
+        if generation != self.exit_generation {
+            return;
+        }
+        self.slices.retain(|slice| !slice.leaving);
+        if self.slices.is_empty() {
+            self.clear_geometry();
+            self.state_fields()
+                .apply(crate::cartesian::CartesianChartState::Empty);
         }
     }
 
@@ -593,6 +661,7 @@ impl PinePieChart {
         let Some(update) = self
             .slices
             .iter()
+            .filter(|slice| !slice.leaving)
             .find(|slice| slice.contains(point, center, self.inner_radius_px, self.outer_radius_px))
             .map(|slice| slice.hover_update(plot, self.width, self.height))
         else {
@@ -605,7 +674,10 @@ impl PinePieChart {
 
     fn step_slice_focus(&mut self, step: isize) {
         if let Some(key) = step_key(
-            self.slices.iter().map(|slice| slice.key.as_str()),
+            self.slices
+                .iter()
+                .filter(|slice| !slice.leaving)
+                .map(|slice| slice.key.as_str()),
             &self.focused_key,
             step,
         ) {
@@ -614,13 +686,15 @@ impl PinePieChart {
     }
 
     fn has_slice_key(&self, key: &str) -> bool {
-        self.slices.iter().any(|slice| slice.key == key)
+        self.slices
+            .iter()
+            .any(|slice| !slice.leaving && slice.key == key)
     }
 
     fn selection_for_slice(&self, key: &str) -> Option<ChartSelection> {
         self.slices
             .iter()
-            .find(|slice| slice.key == key)
+            .find(|slice| !slice.leaving && slice.key == key)
             .map(SvgPieSlice::selection)
     }
 
@@ -725,6 +799,7 @@ impl PinePieChart {
 
 #[derive(Clone, Debug, PartialEq)]
 struct NormalizedPieSlice {
+    key: String,
     label: String,
     value: f64,
 }
@@ -746,8 +821,10 @@ fn normalize_slices(data: &[ChartPieSlice]) -> ChartResult<Vec<NormalizedPieSlic
         if value == 0.0 || !slice.visible {
             continue;
         }
+        let label = slice_label(&slice.label, index);
         output.push(NormalizedPieSlice {
-            label: slice_label(&slice.label, index),
+            key: format!("pie-slice-{index}-{label}"),
+            label,
             value,
         });
     }

--- a/crates/pine-charts/tests/charts.rs
+++ b/crates/pine-charts/tests/charts.rs
@@ -109,6 +109,19 @@ fn assert_svg_fills_frame_without_stretching(frame: &Element, svg: &Element) {
     assert_near(svg_rect.height(), svg_height, "svg rendered height");
 }
 
+fn assert_path_changed(actual: &str, previous: &str) {
+    assert_ne!(
+        actual, previous,
+        "expected SVG path to change during sector animation"
+    );
+}
+
+fn first_arc_radius(path: &str) -> f64 {
+    let (_, arc) = path.split_once('A').expect("expected SVG arc command");
+    let (radius, _) = arc.split_once(',').expect("expected SVG arc radius");
+    radius.parse().expect("expected numeric SVG arc radius")
+}
+
 fn direct_svg_layers(svg: &Element) -> Vec<String> {
     let groups = svg.query_selector_all(":scope > g[data-layer]").unwrap();
     (0..groups.length())
@@ -776,6 +789,192 @@ async fn line_chart_renders_svg_path_axes_and_grid() {
         y_axis_label.get_attribute("transform").as_deref(),
         Some("rotate(-90 12 50)")
     );
+
+    host.remove();
+}
+
+#[wasm_bindgen_test]
+async fn pie_chart_morphs_shape_without_svg_animate_nodes() {
+    let host = mount_fixture::<PieChartFixture>();
+    settle().await;
+
+    let first_slice = host
+        .query_selector(".pine-chart-pie-slice[data-label='Organic']")
+        .unwrap()
+        .unwrap();
+    let donut_path = first_slice.get_attribute("d").unwrap();
+
+    host.query_selector("button.show-pie")
+        .unwrap()
+        .unwrap()
+        .dyn_into::<HtmlElement>()
+        .unwrap()
+        .click();
+    sleep_ms(50).await;
+    settle().await;
+
+    let morphing_slice = host
+        .query_selector(".pine-chart-pie-slice[data-label='Organic']")
+        .unwrap()
+        .unwrap();
+    assert_ne!(
+        morphing_slice.get_attribute("d").as_deref(),
+        Some(donut_path.as_str())
+    );
+    assert!(morphing_slice.query_selector("animate").unwrap().is_none());
+    assert!(host
+        .query_selector(".pine-chart-pie-slice-reveal")
+        .unwrap()
+        .is_none());
+
+    sleep_ms(80).await;
+    settle().await;
+
+    let settled_slice = host
+        .query_selector(".pine-chart-pie-slice[data-label='Organic']")
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        settled_slice.get_attribute("data-entering").as_deref(),
+        Some("false")
+    );
+    assert_eq!(
+        settled_slice.get_attribute("data-leaving").as_deref(),
+        Some("false")
+    );
+
+    host.remove();
+}
+
+#[wasm_bindgen_test]
+async fn pie_chart_prunes_finished_leaving_slices_before_delayed_entries_finish() {
+    let host = mount_fixture::<PieChartFixture>();
+    settle().await;
+
+    host.query_selector("button.swap-latency")
+        .unwrap()
+        .unwrap()
+        .dyn_into::<HtmlElement>()
+        .unwrap()
+        .click();
+    sleep_ms(70).await;
+    settle().await;
+
+    assert!(host
+        .query_selector(".pine-chart-pie-slice[data-label='Organic']")
+        .unwrap()
+        .is_none());
+    assert!(host
+        .query_selector(".pine-chart-pie-slice[data-label='Referral']")
+        .unwrap()
+        .is_none());
+    assert_eq!(
+        host.query_selector_all(".pine-chart-pie-slices .pine-chart-pie-slice")
+            .unwrap()
+            .length(),
+        4
+    );
+    assert_eq!(
+        host.query_selector(".pine-chart-pie-slice[data-label='Idle']")
+            .unwrap()
+            .unwrap()
+            .get_attribute("data-entering")
+            .as_deref(),
+        Some("true")
+    );
+
+    host.remove();
+}
+
+#[wasm_bindgen_test]
+async fn pie_chart_animates_survivor_renormalization_when_middle_slice_is_removed() {
+    let host = mount_fixture::<PieChartFixture>();
+    settle().await;
+
+    host.query_selector("button.load-renormalize")
+        .unwrap()
+        .unwrap()
+        .dyn_into::<HtmlElement>()
+        .unwrap()
+        .click();
+    sleep_ms(160).await;
+    settle().await;
+
+    let one_before = host
+        .query_selector(".pine-chart-pie-slice[data-label='One']")
+        .unwrap()
+        .unwrap()
+        .get_attribute("d")
+        .unwrap();
+    let three_before = host
+        .query_selector(".pine-chart-pie-slice[data-label='Three']")
+        .unwrap()
+        .unwrap()
+        .get_attribute("d")
+        .unwrap();
+
+    host.query_selector("button.remove-middle")
+        .unwrap()
+        .unwrap()
+        .dyn_into::<HtmlElement>()
+        .unwrap()
+        .click();
+    settle().await;
+
+    let one_start = host
+        .query_selector(".pine-chart-pie-slice[data-label='One']")
+        .unwrap()
+        .unwrap()
+        .get_attribute("d")
+        .unwrap();
+    let three_start = host
+        .query_selector(".pine-chart-pie-slice[data-label='Three']")
+        .unwrap()
+        .unwrap()
+        .get_attribute("d")
+        .unwrap();
+    assert_path_changed(&one_start, &one_before);
+    assert_path_changed(&three_start, &three_before);
+
+    sleep_ms(24).await;
+    settle().await;
+
+    let one_mid = host
+        .query_selector(".pine-chart-pie-slice[data-label='One']")
+        .unwrap()
+        .unwrap()
+        .get_attribute("d")
+        .unwrap();
+    let three_mid = host
+        .query_selector(".pine-chart-pie-slice[data-label='Three']")
+        .unwrap()
+        .unwrap()
+        .get_attribute("d")
+        .unwrap();
+    assert_path_changed(&one_mid, &one_before);
+    assert_path_changed(&three_mid, &three_before);
+
+    sleep_ms(120).await;
+    settle().await;
+
+    assert!(host
+        .query_selector(".pine-chart-pie-slice[data-label='Two']")
+        .unwrap()
+        .is_none());
+    let one_done = host
+        .query_selector(".pine-chart-pie-slice[data-label='One']")
+        .unwrap()
+        .unwrap()
+        .get_attribute("d")
+        .unwrap();
+    let three_done = host
+        .query_selector(".pine-chart-pie-slice[data-label='Three']")
+        .unwrap()
+        .unwrap()
+        .get_attribute("d")
+        .unwrap();
+    assert_path_changed(&one_done, &one_before);
+    assert_path_changed(&three_done, &three_before);
 
     host.remove();
 }
@@ -1869,6 +2068,10 @@ async fn stacked_bar_chart_accumulates_segments() {
 <div>
   <button class="add-paid" @click="add_paid">Add paid</button>
   <button class="remove-referral" @click="remove_referral">Remove referral</button>
+  <button class="show-pie" @click="show_pie">Pie</button>
+  <button class="swap-latency" @click="swap_latency">Latency</button>
+  <button class="load-renormalize" @click="load_renormalize">Load renormalize</button>
+  <button class="remove-middle" @click="remove_middle">Remove middle</button>
   <pine-pie-chart class="share-chart"
                   label="Share"
                   animate="true"
@@ -1879,7 +2082,9 @@ async fn stacked_bar_chart_accumulates_segments() {
                   margin_right="0"
                   margin_bottom="0"
                   margin_left="0"
-                  inner_radius="0.5"
+                  pp-bind:inner_radius="inner_radius"
+                  pp-bind:start_angle="start_angle"
+                  pp-bind:end_angle="end_angle"
                   pp-bind:center_label="center_label"
                   pp-bind:center_value="center_value"
                   pp-bind:data="data"></pine-pie-chart>
@@ -1887,6 +2092,9 @@ async fn stacked_bar_chart_accumulates_segments() {
 "#)]
 struct PieChartFixture {
     data: Vec<ChartPieSlice>,
+    inner_radius: f64,
+    start_angle: f64,
+    end_angle: f64,
     center_label: String,
     center_value: String,
 }
@@ -1898,6 +2106,9 @@ impl Default for PieChartFixture {
                 ChartPieSlice::new("Organic", 3.0),
                 ChartPieSlice::new("Referral", 1.0),
             ],
+            inner_radius: 0.5,
+            start_angle: -90.0,
+            end_angle: 270.0,
             center_label: "Total".into(),
             center_value: "4".into(),
         }
@@ -1917,6 +2128,35 @@ impl PieChartFixture {
             slice.visible = false;
         }
     }
+
+    pub fn show_pie(&mut self) {
+        self.inner_radius = 0.0;
+        self.start_angle = -90.0;
+        self.end_angle = 270.0;
+    }
+
+    pub fn swap_latency(&mut self) {
+        self.data = vec![
+            ChartPieSlice::new("API", 38.0),
+            ChartPieSlice::new("Render", 29.0),
+            ChartPieSlice::new("Network", 21.0),
+            ChartPieSlice::new("Idle", 12.0),
+        ];
+    }
+
+    pub fn load_renormalize(&mut self) {
+        self.data = vec![
+            ChartPieSlice::new("One", 10.0),
+            ChartPieSlice::new("Two", 10.0),
+            ChartPieSlice::new("Three", 80.0),
+        ];
+    }
+
+    pub fn remove_middle(&mut self) {
+        if let Some(slice) = self.data.get_mut(1) {
+            slice.visible = false;
+        }
+    }
 }
 
 #[wasm_bindgen_test]
@@ -1931,6 +2171,7 @@ async fn pie_chart_renders_donut_slices_and_selection() {
     assert!(chart.has_attribute("data-donut"));
     assert_eq!(chart.get_attribute("tabindex").as_deref(), Some("0"));
     assert!(!chart.has_attribute("data-hover"));
+    assert!(!chart.has_attribute("data-slice-animating"));
 
     let slices = host
         .query_selector_all(".pine-chart-pie-slices .pine-chart-pie-slice")
@@ -1971,7 +2212,7 @@ async fn pie_chart_renders_donut_slices_and_selection() {
     dispatch_pointer_move(&svg, 50.0, 10.0);
     settle().await;
 
-    assert!(first.has_attribute("data-hovered"));
+    assert!(!first.has_attribute("data-hovered"));
     let hovered_key = first.get_attribute("data-key").unwrap();
     let hover_slice = host
         .query_selector(".pine-chart-pie-hover .pine-chart-pie-slice")
@@ -2060,18 +2301,42 @@ async fn pie_chart_marks_added_slice_as_entering_without_blocking_geometry_updat
         organic_after_add.get_attribute("data-entering").as_deref(),
         Some("false")
     );
-    assert_ne!(
-        organic_after_add.get_attribute("d").as_deref(),
-        Some(initial_organic_path.as_str())
-    );
     let paid = slices.get(2).unwrap().dyn_into::<Element>().unwrap();
     assert_eq!(paid.get_attribute("data-label").as_deref(), Some("Paid"));
     assert_eq!(paid.get_attribute("data-entering").as_deref(), Some("true"));
     let paid_style = paid.get_attribute("style").unwrap();
     assert!(paid_style.contains("--pine-chart-slice-delay: 56ms;"));
-    assert!(paid_style.contains("--pine-chart-slice-enter-clip:"));
-    assert!(paid_style.contains("--pine-chart-slice-exit-clip:"));
     assert!(paid.query_selector("animate").unwrap().is_none());
+    assert!(host
+        .query_selector(".pine-chart-pie-slice-reveal")
+        .unwrap()
+        .is_none());
+    let paid_animating_path = paid.get_attribute("d").unwrap();
+    assert!(
+        first_arc_radius(&paid_animating_path) > 1.0,
+        "expected entering slice to keep chart radius while the arc grows, got {paid_animating_path}"
+    );
+    let chart = host.query_selector(".pine-pie-chart").unwrap().unwrap();
+    let svg = host.query_selector("svg.pine-chart-svg").unwrap().unwrap();
+    dispatch_pointer_move(&svg, 50.0, 10.0);
+    settle().await;
+    assert!(chart.has_attribute("data-hover"));
+    assert!(chart.has_attribute("data-slice-animating"));
+    assert!(host
+        .query_selector(".pine-chart-pie-slices .pine-chart-pie-slice[data-hovered]")
+        .unwrap()
+        .is_some());
+    let hover_layer = host
+        .query_selector(".pine-chart-pie-hover")
+        .unwrap()
+        .unwrap();
+    assert!(
+        hover_layer
+            .get_attribute("style")
+            .unwrap_or_default()
+            .contains("display: none"),
+        "expected hover overlay to stay hidden while slices animate"
+    );
 
     sleep_ms(160).await;
     settle().await;
@@ -2085,6 +2350,18 @@ async fn pie_chart_marks_added_slice_as_entering_without_blocking_geometry_updat
         Some("false")
     );
     assert!(settled_paid.query_selector("animate").unwrap().is_none());
+    assert_ne!(
+        settled_paid.get_attribute("d").as_deref(),
+        Some(paid_animating_path.as_str())
+    );
+    let settled_organic = host
+        .query_selector(".pine-chart-pie-slice[data-label='Organic']")
+        .unwrap()
+        .unwrap();
+    assert_ne!(
+        settled_organic.get_attribute("d").as_deref(),
+        Some(initial_organic_path.as_str())
+    );
 
     host.remove();
 }
@@ -2127,10 +2404,6 @@ async fn pie_chart_marks_removed_slice_as_leaving_before_pruning() {
         organic.get_attribute("data-leaving").as_deref(),
         Some("false")
     );
-    assert_ne!(
-        organic.get_attribute("d").as_deref(),
-        Some(initial_organic_path.as_str())
-    );
     let referral = leaving_slices
         .get(1)
         .unwrap()
@@ -2145,6 +2418,28 @@ async fn pie_chart_marks_removed_slice_as_leaving_before_pruning() {
         Some("true")
     );
     assert!(referral.query_selector("animate").unwrap().is_none());
+    let referral_start_path = referral.get_attribute("d").unwrap();
+    let referral_start_radius = first_arc_radius(&referral_start_path);
+    assert!(host
+        .query_selector(".pine-chart-pie-slice-reveal")
+        .unwrap()
+        .is_none());
+
+    sleep_ms(34).await;
+    settle().await;
+
+    let shrinking_referral = host
+        .query_selector(".pine-chart-pie-slice[data-label='Referral']")
+        .unwrap()
+        .unwrap();
+    let shrinking_path = shrinking_referral.get_attribute("d").unwrap();
+    let shrinking_radius = first_arc_radius(&shrinking_path);
+    assert_path_changed(&shrinking_path, &referral_start_path);
+    assert_near(
+        shrinking_radius,
+        referral_start_radius,
+        "leaving slice radius",
+    );
 
     sleep_ms(120).await;
     settle().await;
@@ -2153,6 +2448,11 @@ async fn pie_chart_marks_removed_slice_as_leaving_before_pruning() {
         .query_selector_all(".pine-chart-pie-slices .pine-chart-pie-slice")
         .unwrap();
     assert_eq!(pruned_slices.length(), 1);
+    let pruned_organic = pruned_slices.get(0).unwrap().dyn_into::<Element>().unwrap();
+    assert_ne!(
+        pruned_organic.get_attribute("d").as_deref(),
+        Some(initial_organic_path.as_str())
+    );
 
     host.remove();
 }

--- a/crates/pine-charts/tests/charts.rs
+++ b/crates/pine-charts/tests/charts.rs
@@ -1010,8 +1010,11 @@ async fn scatter_chart_renders_points_axes_and_hover() {
 #[component(template_inline = r#"
 <div>
   <button class="add-area-forecast" @click="add_forecast">Add forecast</button>
+  <button class="remove-area-forecast" @click="remove_forecast">Remove forecast</button>
   <pine-area-chart class="multi-area-chart"
                    label="Area"
+                   animate="true"
+                   animation_duration="40"
                    width="100"
                    height="100"
                    margin_top="0"
@@ -1053,6 +1056,10 @@ impl AreaChartFixture {
             "Forecast",
             vec![ChartPoint::new(0.0, 0.5), ChartPoint::new(1.0, 0.8)],
         ));
+    }
+
+    pub fn remove_forecast(&mut self) {
+        self.series.retain(|series| series.label != "Forecast");
     }
 }
 
@@ -1231,6 +1238,57 @@ async fn line_chart_supports_marker_selection_and_keyboard_focus() {
     assert!(third.has_attribute("data-selected"));
     assert!(!second.has_attribute("data-selected"));
     assert_eq!(selected_label.borrow().as_deref(), Some("x 10, y 5"));
+
+    host.remove();
+}
+
+#[wasm_bindgen_test]
+async fn area_chart_marks_removed_series_as_leaving_before_pruning() {
+    let host = mount_fixture::<AreaChartFixture>();
+    settle().await;
+
+    host.query_selector("button.add-area-forecast")
+        .unwrap()
+        .unwrap()
+        .dyn_into::<HtmlElement>()
+        .unwrap()
+        .click();
+    settle().await;
+
+    let lines = host
+        .query_selector_all(".pine-area-chart .pine-chart-line")
+        .unwrap();
+    assert_eq!(lines.length(), 3);
+
+    host.query_selector("button.remove-area-forecast")
+        .unwrap()
+        .unwrap()
+        .dyn_into::<HtmlElement>()
+        .unwrap()
+        .click();
+    settle().await;
+
+    let leaving_lines = host
+        .query_selector_all(".pine-area-chart .pine-chart-line")
+        .unwrap();
+    assert_eq!(leaving_lines.length(), 3);
+    let forecast = leaving_lines.get(2).unwrap().dyn_into::<Element>().unwrap();
+    assert_eq!(
+        forecast.get_attribute("data-series").as_deref(),
+        Some("Forecast")
+    );
+    assert_eq!(
+        forecast.get_attribute("data-leaving").as_deref(),
+        Some("true")
+    );
+
+    sleep_ms(120).await;
+    settle().await;
+
+    let pruned_lines = host
+        .query_selector_all(".pine-area-chart .pine-chart-line")
+        .unwrap();
+    assert_eq!(pruned_lines.length(), 2);
 
     host.remove();
 }
@@ -1809,8 +1867,11 @@ async fn stacked_bar_chart_accumulates_segments() {
 #[derive(serde::Serialize, serde::Deserialize)]
 #[component(template_inline = r#"
 <div>
+  <button class="remove-referral" @click="remove_referral">Remove referral</button>
   <pine-pie-chart class="share-chart"
                   label="Share"
+                  animate="true"
+                  animation_duration="40"
                   width="100"
                   height="100"
                   margin_top="0"
@@ -1843,7 +1904,13 @@ impl Default for PieChartFixture {
 }
 
 #[handlers]
-impl PieChartFixture {}
+impl PieChartFixture {
+    pub fn remove_referral(&mut self) {
+        if let Some(slice) = self.data.get_mut(1) {
+            slice.visible = false;
+        }
+    }
+}
 
 #[wasm_bindgen_test]
 async fn pie_chart_renders_donut_slices_and_selection() {
@@ -1943,6 +2010,73 @@ async fn pie_chart_renders_donut_slices_and_selection() {
 
     assert!(second.has_attribute("data-selected"));
     assert!(!first.has_attribute("data-selected"));
+
+    host.remove();
+}
+
+#[wasm_bindgen_test]
+async fn pie_chart_marks_removed_slice_as_leaving_before_pruning() {
+    let host = mount_fixture::<PieChartFixture>();
+    settle().await;
+
+    let slices = host
+        .query_selector_all(".pine-chart-pie-slices .pine-chart-pie-slice")
+        .unwrap();
+    assert_eq!(slices.length(), 2);
+    let organic_key = slices
+        .get(0)
+        .unwrap()
+        .dyn_into::<Element>()
+        .unwrap()
+        .get_attribute("data-key")
+        .unwrap();
+
+    host.query_selector("button.remove-referral")
+        .unwrap()
+        .unwrap()
+        .dyn_into::<HtmlElement>()
+        .unwrap()
+        .click();
+    settle().await;
+
+    let leaving_slices = host
+        .query_selector_all(".pine-chart-pie-slices .pine-chart-pie-slice")
+        .unwrap();
+    assert_eq!(leaving_slices.length(), 2);
+    let organic = leaving_slices
+        .get(0)
+        .unwrap()
+        .dyn_into::<Element>()
+        .unwrap();
+    assert_eq!(
+        organic.get_attribute("data-key").as_deref(),
+        Some(organic_key.as_str())
+    );
+    assert_eq!(
+        organic.get_attribute("data-leaving").as_deref(),
+        Some("false")
+    );
+    let referral = leaving_slices
+        .get(1)
+        .unwrap()
+        .dyn_into::<Element>()
+        .unwrap();
+    assert_eq!(
+        referral.get_attribute("data-label").as_deref(),
+        Some("Referral")
+    );
+    assert_eq!(
+        referral.get_attribute("data-leaving").as_deref(),
+        Some("true")
+    );
+
+    sleep_ms(120).await;
+    settle().await;
+
+    let pruned_slices = host
+        .query_selector_all(".pine-chart-pie-slices .pine-chart-pie-slice")
+        .unwrap();
+    assert_eq!(pruned_slices.length(), 1);
 
     host.remove();
 }

--- a/crates/pine-charts/tests/charts.rs
+++ b/crates/pine-charts/tests/charts.rs
@@ -1867,6 +1867,7 @@ async fn stacked_bar_chart_accumulates_segments() {
 #[derive(serde::Serialize, serde::Deserialize)]
 #[component(template_inline = r#"
 <div>
+  <button class="add-paid" @click="add_paid">Add paid</button>
   <button class="remove-referral" @click="remove_referral">Remove referral</button>
   <pine-pie-chart class="share-chart"
                   label="Share"
@@ -1905,6 +1906,12 @@ impl Default for PieChartFixture {
 
 #[handlers]
 impl PieChartFixture {
+    pub fn add_paid(&mut self) {
+        if !self.data.iter().any(|slice| slice.label == "Paid") {
+            self.data.push(ChartPieSlice::new("Paid", 2.0));
+        }
+    }
+
     pub fn remove_referral(&mut self) {
         if let Some(slice) = self.data.get_mut(1) {
             slice.visible = false;
@@ -2015,6 +2022,77 @@ async fn pie_chart_renders_donut_slices_and_selection() {
 }
 
 #[wasm_bindgen_test]
+async fn pie_chart_animates_added_slice_as_segment_morph() {
+    let host = mount_fixture::<PieChartFixture>();
+    settle().await;
+
+    let initial_slices = host
+        .query_selector_all(".pine-chart-pie-slices .pine-chart-pie-slice")
+        .unwrap();
+    assert_eq!(initial_slices.length(), 2);
+    let organic = initial_slices
+        .get(0)
+        .unwrap()
+        .dyn_into::<Element>()
+        .unwrap();
+    let organic_animation = organic.query_selector("animate").unwrap().unwrap();
+    assert_eq!(
+        organic_animation.get_attribute("dur").as_deref(),
+        Some("0ms")
+    );
+
+    host.query_selector("button.add-paid")
+        .unwrap()
+        .unwrap()
+        .dyn_into::<HtmlElement>()
+        .unwrap()
+        .click();
+    settle().await;
+
+    let slices = host
+        .query_selector_all(".pine-chart-pie-slices .pine-chart-pie-slice")
+        .unwrap();
+    assert_eq!(slices.length(), 3);
+    let paid = slices.get(2).unwrap().dyn_into::<Element>().unwrap();
+    assert_eq!(paid.get_attribute("data-label").as_deref(), Some("Paid"));
+    assert_eq!(paid.get_attribute("data-entering").as_deref(), Some("true"));
+    let paid_animation = paid.query_selector("animate").unwrap().unwrap();
+    assert_eq!(
+        paid_animation.get_attribute("attributeName").as_deref(),
+        Some("d")
+    );
+    assert_eq!(paid_animation.get_attribute("dur").as_deref(), Some("40ms"));
+    assert_eq!(
+        paid_animation.get_attribute("begin").as_deref(),
+        Some("56ms")
+    );
+    assert_ne!(
+        paid_animation.get_attribute("from"),
+        paid_animation.get_attribute("to")
+    );
+    assert_eq!(paid_animation.get_attribute("to"), paid.get_attribute("d"));
+
+    sleep_ms(160).await;
+    settle().await;
+
+    let settled_paid = host
+        .query_selector(".pine-chart-pie-slice[data-label='Paid']")
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        settled_paid.get_attribute("data-entering").as_deref(),
+        Some("false")
+    );
+    let settled_animation = settled_paid.query_selector("animate").unwrap().unwrap();
+    assert_eq!(
+        settled_animation.get_attribute("dur").as_deref(),
+        Some("0ms")
+    );
+
+    host.remove();
+}
+
+#[wasm_bindgen_test]
 async fn pie_chart_marks_removed_slice_as_leaving_before_pruning() {
     let host = mount_fixture::<PieChartFixture>();
     settle().await;
@@ -2068,6 +2146,23 @@ async fn pie_chart_marks_removed_slice_as_leaving_before_pruning() {
     assert_eq!(
         referral.get_attribute("data-leaving").as_deref(),
         Some("true")
+    );
+    let referral_animation = referral.query_selector("animate").unwrap().unwrap();
+    assert_eq!(
+        referral_animation.get_attribute("attributeName").as_deref(),
+        Some("d")
+    );
+    assert_eq!(
+        referral_animation.get_attribute("dur").as_deref(),
+        Some("40ms")
+    );
+    assert_ne!(
+        referral_animation.get_attribute("from"),
+        referral_animation.get_attribute("to")
+    );
+    assert_eq!(
+        referral_animation.get_attribute("from"),
+        referral.get_attribute("d")
     );
 
     sleep_ms(120).await;

--- a/crates/pine-charts/tests/charts.rs
+++ b/crates/pine-charts/tests/charts.rs
@@ -2022,7 +2022,7 @@ async fn pie_chart_renders_donut_slices_and_selection() {
 }
 
 #[wasm_bindgen_test]
-async fn pie_chart_animates_added_slice_as_segment_morph() {
+async fn pie_chart_marks_added_slice_as_entering_without_blocking_geometry_updates() {
     let host = mount_fixture::<PieChartFixture>();
     settle().await;
 
@@ -2035,11 +2035,9 @@ async fn pie_chart_animates_added_slice_as_segment_morph() {
         .unwrap()
         .dyn_into::<Element>()
         .unwrap();
-    let organic_animation = organic.query_selector("animate").unwrap().unwrap();
-    assert_eq!(
-        organic_animation.get_attribute("dur").as_deref(),
-        Some("0ms")
-    );
+    let organic_key = organic.get_attribute("data-key").unwrap();
+    let initial_organic_path = organic.get_attribute("d").unwrap();
+    assert!(organic.query_selector("animate").unwrap().is_none());
 
     host.query_selector("button.add-paid")
         .unwrap()
@@ -2053,24 +2051,27 @@ async fn pie_chart_animates_added_slice_as_segment_morph() {
         .query_selector_all(".pine-chart-pie-slices .pine-chart-pie-slice")
         .unwrap();
     assert_eq!(slices.length(), 3);
+    let organic_after_add = slices.get(0).unwrap().dyn_into::<Element>().unwrap();
+    assert_eq!(
+        organic_after_add.get_attribute("data-key").as_deref(),
+        Some(organic_key.as_str())
+    );
+    assert_eq!(
+        organic_after_add.get_attribute("data-entering").as_deref(),
+        Some("false")
+    );
+    assert_ne!(
+        organic_after_add.get_attribute("d").as_deref(),
+        Some(initial_organic_path.as_str())
+    );
     let paid = slices.get(2).unwrap().dyn_into::<Element>().unwrap();
     assert_eq!(paid.get_attribute("data-label").as_deref(), Some("Paid"));
     assert_eq!(paid.get_attribute("data-entering").as_deref(), Some("true"));
-    let paid_animation = paid.query_selector("animate").unwrap().unwrap();
-    assert_eq!(
-        paid_animation.get_attribute("attributeName").as_deref(),
-        Some("d")
-    );
-    assert_eq!(paid_animation.get_attribute("dur").as_deref(), Some("40ms"));
-    assert_eq!(
-        paid_animation.get_attribute("begin").as_deref(),
-        Some("56ms")
-    );
-    assert_ne!(
-        paid_animation.get_attribute("from"),
-        paid_animation.get_attribute("to")
-    );
-    assert_eq!(paid_animation.get_attribute("to"), paid.get_attribute("d"));
+    let paid_style = paid.get_attribute("style").unwrap();
+    assert!(paid_style.contains("--pine-chart-slice-delay: 56ms;"));
+    assert!(paid_style.contains("--pine-chart-slice-enter-clip:"));
+    assert!(paid_style.contains("--pine-chart-slice-exit-clip:"));
+    assert!(paid.query_selector("animate").unwrap().is_none());
 
     sleep_ms(160).await;
     settle().await;
@@ -2083,11 +2084,7 @@ async fn pie_chart_animates_added_slice_as_segment_morph() {
         settled_paid.get_attribute("data-entering").as_deref(),
         Some("false")
     );
-    let settled_animation = settled_paid.query_selector("animate").unwrap().unwrap();
-    assert_eq!(
-        settled_animation.get_attribute("dur").as_deref(),
-        Some("0ms")
-    );
+    assert!(settled_paid.query_selector("animate").unwrap().is_none());
 
     host.remove();
 }
@@ -2101,13 +2098,9 @@ async fn pie_chart_marks_removed_slice_as_leaving_before_pruning() {
         .query_selector_all(".pine-chart-pie-slices .pine-chart-pie-slice")
         .unwrap();
     assert_eq!(slices.length(), 2);
-    let organic_key = slices
-        .get(0)
-        .unwrap()
-        .dyn_into::<Element>()
-        .unwrap()
-        .get_attribute("data-key")
-        .unwrap();
+    let initial_organic = slices.get(0).unwrap().dyn_into::<Element>().unwrap();
+    let organic_key = initial_organic.get_attribute("data-key").unwrap();
+    let initial_organic_path = initial_organic.get_attribute("d").unwrap();
 
     host.query_selector("button.remove-referral")
         .unwrap()
@@ -2134,6 +2127,10 @@ async fn pie_chart_marks_removed_slice_as_leaving_before_pruning() {
         organic.get_attribute("data-leaving").as_deref(),
         Some("false")
     );
+    assert_ne!(
+        organic.get_attribute("d").as_deref(),
+        Some(initial_organic_path.as_str())
+    );
     let referral = leaving_slices
         .get(1)
         .unwrap()
@@ -2147,23 +2144,7 @@ async fn pie_chart_marks_removed_slice_as_leaving_before_pruning() {
         referral.get_attribute("data-leaving").as_deref(),
         Some("true")
     );
-    let referral_animation = referral.query_selector("animate").unwrap().unwrap();
-    assert_eq!(
-        referral_animation.get_attribute("attributeName").as_deref(),
-        Some("d")
-    );
-    assert_eq!(
-        referral_animation.get_attribute("dur").as_deref(),
-        Some("40ms")
-    );
-    assert_ne!(
-        referral_animation.get_attribute("from"),
-        referral_animation.get_attribute("to")
-    );
-    assert_eq!(
-        referral_animation.get_attribute("from"),
-        referral.get_attribute("d")
-    );
+    assert!(referral.query_selector("animate").unwrap().is_none());
 
     sleep_ms(120).await;
     settle().await;

--- a/docs/charts/components.md
+++ b/docs/charts/components.md
@@ -448,16 +448,14 @@ The component emits stable hooks:
 - `--pine-chart-animation-duration`
 - `--pine-chart-animation-easing`
 - `--pine-chart-slice-delay`
-- `--pine-chart-slice-enter-clip`
-- `--pine-chart-slice-exit-clip`
 
 The default line paths use `stroke="currentColor"` and `fill="none"`, while bars
 use `fill="currentColor"`. Application CSS should own the final visual
 treatment. Pie/donut slices expose `data-entering` and `data-leaving` so CSS
-can animate the slice element itself. The renderer emits
-`--pine-chart-slice-enter-clip` and `--pine-chart-slice-exit-clip` for a
-CSS-only clip-path reveal. The real slice `d` attribute still updates directly,
-so interaction changes are never blocked by animation state.
+can style keyed mark changes. The chart owns pie/donut animation by
+interpolating sector geometry in component state, following the same broad
+model as Recharts' animated pie sectors. That keeps the rendered `d` attribute
+authoritative for interaction, donut radius changes, and half-donut morphs.
 
 ```css
 .pine-chart-root {
@@ -517,13 +515,6 @@ so interaction changes are never blocked by animation state.
   transform-origin: center bottom;
 }
 
-.pine-chart-root[data-animate="true"] .pine-chart-pie-slice[data-entering="true"] {
-  animation: chart-pie-segment-enter var(--pine-chart-animation-duration)
-    var(--pine-chart-animation-easing) var(--pine-chart-slice-delay, 0ms)
-    backwards;
-  will-change: clip-path, opacity;
-}
-
 .pine-chart-root[data-animate="true"] .pine-chart-area[data-leaving="true"] {
   animation: chart-fade-out var(--pine-chart-animation-duration)
     var(--pine-chart-animation-easing) forwards;
@@ -537,9 +528,6 @@ so interaction changes are never blocked by animation state.
 }
 
 .pine-chart-root[data-animate="true"] .pine-chart-pie-slice[data-leaving="true"] {
-  animation: chart-pie-segment-exit var(--pine-chart-animation-duration)
-    var(--pine-chart-animation-easing) forwards;
-  will-change: clip-path, opacity;
   pointer-events: none;
 }
 
@@ -560,28 +548,6 @@ so interaction changes are never blocked by animation state.
   from {
     opacity: 0;
     transform: scaleY(0);
-  }
-}
-
-@keyframes chart-pie-segment-enter {
-  from {
-    opacity: 0;
-    clip-path: var(--pine-chart-slice-enter-clip);
-  }
-  to {
-    opacity: 1;
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
-  }
-}
-
-@keyframes chart-pie-segment-exit {
-  from {
-    opacity: 1;
-    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
-  }
-  to {
-    opacity: 0;
-    clip-path: var(--pine-chart-slice-exit-clip);
   }
 }
 

--- a/docs/charts/components.md
+++ b/docs/charts/components.md
@@ -448,13 +448,16 @@ The component emits stable hooks:
 - `--pine-chart-animation-duration`
 - `--pine-chart-animation-easing`
 - `--pine-chart-slice-delay`
+- `--pine-chart-slice-enter-clip`
+- `--pine-chart-slice-exit-clip`
 
 The default line paths use `stroke="currentColor"` and `fill="none"`, while bars
 use `fill="currentColor"`. Application CSS should own the final visual
-treatment. Pie/donut slices animate their SVG path from a collapsed wedge to
-the final slice, so adding a slice reveals the new segment itself rather than
-scaling the whole chart from the center. Leaving area series and pie/donut
-slices use the same hooks in reverse.
+treatment. Pie/donut slices expose `data-entering` and `data-leaving` so CSS
+can animate the slice element itself. The renderer emits
+`--pine-chart-slice-enter-clip` and `--pine-chart-slice-exit-clip` for a
+CSS-only clip-path reveal. The real slice `d` attribute still updates directly,
+so interaction changes are never blocked by animation state.
 
 ```css
 .pine-chart-root {
@@ -514,6 +517,13 @@ slices use the same hooks in reverse.
   transform-origin: center bottom;
 }
 
+.pine-chart-root[data-animate="true"] .pine-chart-pie-slice[data-entering="true"] {
+  animation: chart-pie-segment-enter var(--pine-chart-animation-duration)
+    var(--pine-chart-animation-easing) var(--pine-chart-slice-delay, 0ms)
+    backwards;
+  will-change: clip-path, opacity;
+}
+
 .pine-chart-root[data-animate="true"] .pine-chart-area[data-leaving="true"] {
   animation: chart-fade-out var(--pine-chart-animation-duration)
     var(--pine-chart-animation-easing) forwards;
@@ -527,6 +537,9 @@ slices use the same hooks in reverse.
 }
 
 .pine-chart-root[data-animate="true"] .pine-chart-pie-slice[data-leaving="true"] {
+  animation: chart-pie-segment-exit var(--pine-chart-animation-duration)
+    var(--pine-chart-animation-easing) forwards;
+  will-change: clip-path, opacity;
   pointer-events: none;
 }
 
@@ -547,6 +560,28 @@ slices use the same hooks in reverse.
   from {
     opacity: 0;
     transform: scaleY(0);
+  }
+}
+
+@keyframes chart-pie-segment-enter {
+  from {
+    opacity: 0;
+    clip-path: var(--pine-chart-slice-enter-clip);
+  }
+  to {
+    opacity: 1;
+    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+  }
+}
+
+@keyframes chart-pie-segment-exit {
+  from {
+    opacity: 1;
+    clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+  }
+  to {
+    opacity: 0;
+    clip-path: var(--pine-chart-slice-exit-clip);
   }
 }
 

--- a/docs/charts/components.md
+++ b/docs/charts/components.md
@@ -367,6 +367,8 @@ CSS can keyframe newly inserted marks while existing marks remain stable during
 add/remove updates. If an application wants an existing mark to replay an entry
 animation after a data change, change that mark's key deliberately or use CSS
 transitions for the changed property.
+Area series and pie/donut slices also retain removed marks for one animation
+window and expose `data-leaving="true"` before pruning them from the DOM.
 
 ## Styling Hooks
 
@@ -438,6 +440,7 @@ The component emits stable hooks:
 - `data-hovered`
 - `data-focused`
 - `data-selected`
+- `data-leaving="true|false"`
 - `data-active`
 - `data-empty`
 - `data-invalid`
@@ -449,7 +452,8 @@ The default line paths use `stroke="currentColor"` and `fill="none"`, while bars
 use `fill="currentColor"`. Application CSS should own the final visual
 treatment. The example below animates keyed marks on entry: newly added lines
 draw in, bars grow from the baseline, and pie/donut slices use a clockwise
-sweep instead of a fade.
+sweep instead of a fade. Leaving area series and pie/donut slices use the same
+hooks in reverse.
 
 ```css
 .pine-chart-root {
@@ -517,8 +521,33 @@ sweep instead of a fade.
   transform-origin: center;
 }
 
+.pine-chart-root[data-animate="true"] .pine-chart-area[data-leaving="true"] {
+  animation: chart-fade-out var(--pine-chart-animation-duration)
+    var(--pine-chart-animation-easing) forwards;
+  pointer-events: none;
+}
+
+.pine-chart-root[data-animate="true"] .pine-chart-line[data-leaving="true"] {
+  animation: chart-line-exit var(--pine-chart-animation-duration)
+    var(--pine-chart-animation-easing) forwards;
+  pointer-events: none;
+}
+
+.pine-chart-root[data-animate="true"] .pine-chart-pie-slice[data-leaving="true"] {
+  animation: chart-pie-consume-out var(--pine-chart-animation-duration)
+    var(--pine-chart-animation-easing) forwards;
+  pointer-events: none;
+}
+
 @keyframes chart-line-draw {
   from {
+    stroke-dashoffset: 1;
+  }
+}
+
+@keyframes chart-line-exit {
+  to {
+    opacity: 0;
     stroke-dashoffset: 1;
   }
 }
@@ -530,9 +559,21 @@ sweep instead of a fade.
   }
 }
 
+@keyframes chart-fade-out {
+  to {
+    opacity: 0;
+  }
+}
+
 @keyframes chart-pie-sweep {
   from {
     transform: rotate(-18deg) scale(0.01);
+  }
+}
+
+@keyframes chart-pie-consume-out {
+  to {
+    transform: rotate(18deg) scale(0.01);
   }
 }
 

--- a/docs/charts/components.md
+++ b/docs/charts/components.md
@@ -440,6 +440,7 @@ The component emits stable hooks:
 - `data-hovered`
 - `data-focused`
 - `data-selected`
+- `data-entering="true|false"`
 - `data-leaving="true|false"`
 - `data-active`
 - `data-empty`
@@ -450,10 +451,10 @@ The component emits stable hooks:
 
 The default line paths use `stroke="currentColor"` and `fill="none"`, while bars
 use `fill="currentColor"`. Application CSS should own the final visual
-treatment. The example below animates keyed marks on entry: newly added lines
-draw in, bars grow from the baseline, and pie/donut slices use a clockwise
-sweep instead of a fade. Leaving area series and pie/donut slices use the same
-hooks in reverse.
+treatment. Pie/donut slices animate their SVG path from a collapsed wedge to
+the final slice, so adding a slice reveals the new segment itself rather than
+scaling the whole chart from the center. Leaving area series and pie/donut
+slices use the same hooks in reverse.
 
 ```css
 .pine-chart-root {
@@ -513,14 +514,6 @@ hooks in reverse.
   transform-origin: center bottom;
 }
 
-.pine-chart-root[data-animate="true"] .pine-chart-pie-slice {
-  animation: chart-pie-sweep var(--pine-chart-animation-duration)
-    var(--pine-chart-animation-easing) var(--pine-chart-slice-delay, 0ms)
-    backwards;
-  transform-box: view-box;
-  transform-origin: center;
-}
-
 .pine-chart-root[data-animate="true"] .pine-chart-area[data-leaving="true"] {
   animation: chart-fade-out var(--pine-chart-animation-duration)
     var(--pine-chart-animation-easing) forwards;
@@ -534,8 +527,6 @@ hooks in reverse.
 }
 
 .pine-chart-root[data-animate="true"] .pine-chart-pie-slice[data-leaving="true"] {
-  animation: chart-pie-consume-out var(--pine-chart-animation-duration)
-    var(--pine-chart-animation-easing) forwards;
   pointer-events: none;
 }
 
@@ -562,18 +553,6 @@ hooks in reverse.
 @keyframes chart-fade-out {
   to {
     opacity: 0;
-  }
-}
-
-@keyframes chart-pie-sweep {
-  from {
-    transform: rotate(-18deg) scale(0.01);
-  }
-}
-
-@keyframes chart-pie-consume-out {
-  to {
-    transform: rotate(18deg) scale(0.01);
   }
 }
 

--- a/docs/charts/interaction.md
+++ b/docs/charts/interaction.md
@@ -62,10 +62,12 @@ receives `data-hovered`, and the tooltip exposes `data-label`, `data-value`, and
 `data-percentage`. Applications can use that hook for a grow effect with CSS.
 Set `animate="true"` on the chart when those transitions should use the chart's
 animation variables. Keyframe entry animations should target keyed marks as they
-enter the DOM; add/remove updates then animate only the new line, area, bar,
-point, or slice instead of restarting the whole chart. Area series and
-pie/donut slices expose `data-leaving="true"` during their exit window so CSS
-can animate removal before the renderer prunes the mark.
+enter the DOM; add/remove updates then animate only the new line, area, bar, or
+point instead of restarting the whole chart. Pie/donut slices use an SVG path
+morph from a collapsed wedge to the final segment and expose
+`data-entering="true"` during that window. Area series and pie/donut slices
+expose `data-leaving="true"` during their exit window so CSS can animate
+removal before the renderer prunes the mark.
 
 Interactive legends are opt-in with `interactive="true"`. The legend then gives
 each item keyboard focus, toggles `data-active`, and emits

--- a/docs/charts/interaction.md
+++ b/docs/charts/interaction.md
@@ -63,7 +63,9 @@ receives `data-hovered`, and the tooltip exposes `data-label`, `data-value`, and
 Set `animate="true"` on the chart when those transitions should use the chart's
 animation variables. Keyframe entry animations should target keyed marks as they
 enter the DOM; add/remove updates then animate only the new line, area, bar,
-point, or slice instead of restarting the whole chart.
+point, or slice instead of restarting the whole chart. Area series and
+pie/donut slices expose `data-leaving="true"` during their exit window so CSS
+can animate removal before the renderer prunes the mark.
 
 Interactive legends are opt-in with `interactive="true"`. The legend then gives
 each item keyboard focus, toggles `data-active`, and emits

--- a/docs/charts/interaction.md
+++ b/docs/charts/interaction.md
@@ -62,12 +62,12 @@ receives `data-hovered`, and the tooltip exposes `data-label`, `data-value`, and
 `data-percentage`. Applications can use that hook for a grow effect with CSS.
 Set `animate="true"` on the chart when those transitions should use the chart's
 animation variables. Keyframe entry animations should target keyed marks as they
-enter the DOM; add/remove updates then animate only the new line, area, bar, or
-point instead of restarting the whole chart. Pie/donut slices use an SVG path
-morph from a collapsed wedge to the final segment and expose
-`data-entering="true"` during that window. Area series and pie/donut slices
-expose `data-leaving="true"` during their exit window so CSS can animate
-removal before the renderer prunes the mark.
+enter the DOM; add/remove updates then animate only the new line, area, bar,
+point, or pie segment instead of restarting the whole chart. Pie/donut slices
+expose `data-entering="true"` during that window and provide clip-path
+variables for a CSS-only segment reveal. Area series and pie/donut slices expose
+`data-leaving="true"` during their exit window so CSS can animate removal before
+the renderer prunes the mark.
 
 Interactive legends are opt-in with `interactive="true"`. The legend then gives
 each item keyboard focus, toggles `data-active`, and emits

--- a/docs/charts/interaction.md
+++ b/docs/charts/interaction.md
@@ -64,10 +64,12 @@ Set `animate="true"` on the chart when those transitions should use the chart's
 animation variables. Keyframe entry animations should target keyed marks as they
 enter the DOM; add/remove updates then animate only the new line, area, bar,
 point, or pie segment instead of restarting the whole chart. Pie/donut slices
-expose `data-entering="true"` during that window and provide clip-path
-variables for a CSS-only segment reveal. Area series and pie/donut slices expose
-`data-leaving="true"` during their exit window so CSS can animate removal before
-the renderer prunes the mark.
+expose `data-entering="true"` during that window. Pie/donut enter, exit, and
+shape changes are rendered by interpolating sector geometry in component state,
+so the visible path itself sweeps between sector angles and radii. Area series
+and pie/donut slices expose `data-leaving="true"` during their exit window so
+CSS or renderer-owned animation can show removal before the renderer prunes the
+mark.
 
 Interactive legends are opt-in with `interactive="true"`. The legend then gives
 each item keyboard focus, toggles `data-active`, and emits

--- a/examples/charts/index.html
+++ b/examples/charts/index.html
@@ -244,10 +244,6 @@
       transform-origin: center bottom;
     }
 
-    .pine-chart-root[data-animate="true"] .pine-chart-pie-slice:not(.pine-chart-pie-hover-slice) {
-      animation: pine-chart-pie-sweep var(--pine-chart-animation-duration) var(--pine-chart-animation-easing) var(--pine-chart-slice-delay, 0ms) backwards;
-    }
-
     .pine-chart-root[data-animate="true"] .pine-chart-area[data-leaving="true"],
     .pine-chart-root[data-animate="true"] .pine-chart-marker[data-leaving="true"],
     .pine-chart-root[data-animate="true"] .pine-chart-point[data-leaving="true"] {
@@ -262,7 +258,6 @@
     }
 
     .pine-chart-root[data-animate="true"] .pine-chart-pie-slice[data-leaving="true"] {
-      animation: pine-chart-pie-consume-out var(--pine-chart-animation-duration) var(--pine-chart-animation-easing) forwards;
       pointer-events: none;
     }
 
@@ -295,18 +290,6 @@
       from {
         opacity: 0;
         transform: scaleY(0);
-      }
-    }
-
-    @keyframes pine-chart-pie-sweep {
-      from {
-        transform: rotate(-18deg) scale(0.01);
-      }
-    }
-
-    @keyframes pine-chart-pie-consume-out {
-      to {
-        transform: rotate(18deg) scale(0.01);
       }
     }
 

--- a/examples/charts/index.html
+++ b/examples/charts/index.html
@@ -244,6 +244,11 @@
       transform-origin: center bottom;
     }
 
+    .pine-chart-root[data-animate="true"] .pine-chart-pie-slice[data-entering="true"]:not(.pine-chart-pie-hover-slice) {
+      animation: pine-chart-pie-segment-enter var(--pine-chart-animation-duration) var(--pine-chart-animation-easing) var(--pine-chart-slice-delay, 0ms) backwards;
+      will-change: clip-path, opacity;
+    }
+
     .pine-chart-root[data-animate="true"] .pine-chart-area[data-leaving="true"],
     .pine-chart-root[data-animate="true"] .pine-chart-marker[data-leaving="true"],
     .pine-chart-root[data-animate="true"] .pine-chart-point[data-leaving="true"] {
@@ -258,6 +263,8 @@
     }
 
     .pine-chart-root[data-animate="true"] .pine-chart-pie-slice[data-leaving="true"] {
+      animation: pine-chart-pie-segment-exit var(--pine-chart-animation-duration) var(--pine-chart-animation-easing) forwards;
+      will-change: clip-path, opacity;
       pointer-events: none;
     }
 
@@ -290,6 +297,28 @@
       from {
         opacity: 0;
         transform: scaleY(0);
+      }
+    }
+
+    @keyframes pine-chart-pie-segment-enter {
+      from {
+        opacity: 0;
+        clip-path: var(--pine-chart-slice-enter-clip);
+      }
+      to {
+        opacity: 1;
+        clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+      }
+    }
+
+    @keyframes pine-chart-pie-segment-exit {
+      from {
+        opacity: 1;
+        clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
+      }
+      to {
+        opacity: 0;
+        clip-path: var(--pine-chart-slice-exit-clip);
       }
     }
 

--- a/examples/charts/index.html
+++ b/examples/charts/index.html
@@ -244,11 +244,6 @@
       transform-origin: center bottom;
     }
 
-    .pine-chart-root[data-animate="true"] .pine-chart-pie-slice[data-entering="true"]:not(.pine-chart-pie-hover-slice) {
-      animation: pine-chart-pie-segment-enter var(--pine-chart-animation-duration) var(--pine-chart-animation-easing) var(--pine-chart-slice-delay, 0ms) backwards;
-      will-change: clip-path, opacity;
-    }
-
     .pine-chart-root[data-animate="true"] .pine-chart-area[data-leaving="true"],
     .pine-chart-root[data-animate="true"] .pine-chart-marker[data-leaving="true"],
     .pine-chart-root[data-animate="true"] .pine-chart-point[data-leaving="true"] {
@@ -263,8 +258,6 @@
     }
 
     .pine-chart-root[data-animate="true"] .pine-chart-pie-slice[data-leaving="true"] {
-      animation: pine-chart-pie-segment-exit var(--pine-chart-animation-duration) var(--pine-chart-animation-easing) forwards;
-      will-change: clip-path, opacity;
       pointer-events: none;
     }
 
@@ -297,28 +290,6 @@
       from {
         opacity: 0;
         transform: scaleY(0);
-      }
-    }
-
-    @keyframes pine-chart-pie-segment-enter {
-      from {
-        opacity: 0;
-        clip-path: var(--pine-chart-slice-enter-clip);
-      }
-      to {
-        opacity: 1;
-        clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
-      }
-    }
-
-    @keyframes pine-chart-pie-segment-exit {
-      from {
-        opacity: 1;
-        clip-path: polygon(0 0, 100% 0, 100% 100%, 0 100%);
-      }
-      to {
-        opacity: 0;
-        clip-path: var(--pine-chart-slice-exit-clip);
       }
     }
 

--- a/examples/charts/index.html
+++ b/examples/charts/index.html
@@ -248,14 +248,45 @@
       animation: pine-chart-pie-sweep var(--pine-chart-animation-duration) var(--pine-chart-animation-easing) var(--pine-chart-slice-delay, 0ms) backwards;
     }
 
+    .pine-chart-root[data-animate="true"] .pine-chart-area[data-leaving="true"],
+    .pine-chart-root[data-animate="true"] .pine-chart-marker[data-leaving="true"],
+    .pine-chart-root[data-animate="true"] .pine-chart-point[data-leaving="true"] {
+      animation: pine-chart-fade-out var(--pine-chart-animation-duration) var(--pine-chart-animation-easing) forwards;
+      pointer-events: none;
+    }
+
+    .pine-chart-root[data-animate="true"] .pine-chart-line[data-leaving="true"],
+    .pine-chart-root[data-animate="true"] .pine-layer-chart-line[data-leaving="true"] {
+      animation: pine-chart-line-exit var(--pine-chart-animation-duration) var(--pine-chart-animation-easing) forwards;
+      pointer-events: none;
+    }
+
+    .pine-chart-root[data-animate="true"] .pine-chart-pie-slice[data-leaving="true"] {
+      animation: pine-chart-pie-consume-out var(--pine-chart-animation-duration) var(--pine-chart-animation-easing) forwards;
+      pointer-events: none;
+    }
+
     @keyframes pine-chart-fade-in {
       from {
         opacity: 0;
       }
     }
 
+    @keyframes pine-chart-fade-out {
+      to {
+        opacity: 0;
+      }
+    }
+
     @keyframes pine-chart-line-draw {
       from {
+        stroke-dashoffset: 1;
+      }
+    }
+
+    @keyframes pine-chart-line-exit {
+      to {
+        opacity: 0;
         stroke-dashoffset: 1;
       }
     }
@@ -270,6 +301,12 @@
     @keyframes pine-chart-pie-sweep {
       from {
         transform: rotate(-18deg) scale(0.01);
+      }
+    }
+
+    @keyframes pine-chart-pie-consume-out {
+      to {
+        transform: rotate(18deg) scale(0.01);
       }
     }
 


### PR DESCRIPTION
## Summary
- add chart animation hooks for bars, lines, points, areas, and pie slices
- replace pie slice pop/fade behavior with RAF-driven sector interpolation
- fix pie/donut enter and exit sweep direction using neighboring arc boundaries
- hide the duplicate hover overlay while pie slices animate to avoid shimmer

## Verification
- `cargo test -p pine-charts`
- `wasm-pack test --firefox --headless crates/pine-charts`
- `cargo clippy -p pine-charts --all-targets -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- `cargo run -p pocopine-cli -- build --path examples/charts`
