### PR TITLE
Harden observability exporter surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3326,7 +3326,9 @@ name = "pocopine-observe"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "serde_json",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,7 @@ wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.6"
+serde_json = "1"
 http = "1"
 inventory = "0.3"
 linkme = "0.3"
@@ -88,6 +89,7 @@ syn = { version = "2", features = ["full"] }
 strsim = "0.11"
 cron = "0.12"
 tracing = "0.1"
+tracing-subscriber = { version = "0.3", default-features = false }
 
 # RFC-058 Phase 6.5 — match Yew's release-profile knobs.
 # `opt-level = "z"` collapses size-vs-speed in favour of size;

--- a/crates/pocopine-analytics/src/lib.rs
+++ b/crates/pocopine-analytics/src/lib.rs
@@ -4,8 +4,12 @@
 //! redaction and fan-out rules, then lets apps attach Firebase,
 //! Google Analytics, Cloudflare, OpenTelemetry, or custom sinks.
 
+#[cfg(not(target_arch = "wasm32"))]
+use std::collections::VecDeque;
 use std::fmt;
 use std::panic::{catch_unwind, AssertUnwindSafe};
+#[cfg(not(target_arch = "wasm32"))]
+use std::sync::{Arc, Mutex};
 
 use pocopine_observe::{
     emit_tracing, EventPriority, FieldPrivacy, ObserveContext, ObservedEvent, RedactionPolicy,
@@ -99,6 +103,173 @@ pub struct AnalyticsReport {
 impl AnalyticsReport {
     pub fn all_succeeded(&self) -> bool {
         self.failed == 0
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ExporterMetrics {
+    /// Events currently waiting for this exporter to flush.
+    pub pending: usize,
+    /// Events accepted into the bounded queue.
+    pub enqueued: u64,
+    /// Events rejected because the bounded queue was full.
+    pub dropped: u64,
+    /// Queued events successfully delivered to the wrapped sink.
+    pub delivered: u64,
+    /// Queued events, sink flushes, or panics that failed during delivery.
+    pub failed: u64,
+}
+
+/// Bounded queue wrapper for exporter sinks.
+///
+/// This keeps exporter integrations honest: backpressure is bounded, drops are
+/// counted, and flush continues across per-event failures.
+#[cfg(not(target_arch = "wasm32"))]
+pub struct BoundedAnalyticsSink<S> {
+    inner: Arc<S>,
+    capacity: usize,
+    queue: Arc<Mutex<VecDeque<ObservedEvent>>>,
+    metrics: Arc<Mutex<ExporterMetrics>>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<S> BoundedAnalyticsSink<S>
+where
+    S: AnalyticsSink + 'static,
+{
+    pub fn new(inner: S, capacity: usize) -> Self {
+        Self {
+            inner: Arc::new(inner),
+            capacity,
+            queue: Arc::new(Mutex::new(VecDeque::with_capacity(capacity))),
+            metrics: Arc::new(Mutex::new(ExporterMetrics::default())),
+        }
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.capacity
+    }
+
+    pub fn pending(&self) -> usize {
+        self.queue
+            .lock()
+            .expect("analytics exporter queue lock poisoned")
+            .len()
+    }
+
+    pub fn metrics(&self) -> ExporterMetrics {
+        let pending = self.pending();
+        let mut metrics = self
+            .metrics
+            .lock()
+            .expect("analytics exporter metrics lock poisoned")
+            .clone();
+        metrics.pending = pending;
+        metrics
+    }
+
+    fn increment_dropped(&self) {
+        self.metrics
+            .lock()
+            .expect("analytics exporter metrics lock poisoned")
+            .dropped += 1;
+    }
+
+    fn increment_enqueued(&self) {
+        self.metrics
+            .lock()
+            .expect("analytics exporter metrics lock poisoned")
+            .enqueued += 1;
+    }
+
+    fn increment_delivered(&self) {
+        self.metrics
+            .lock()
+            .expect("analytics exporter metrics lock poisoned")
+            .delivered += 1;
+    }
+
+    fn increment_failed(&self) {
+        self.metrics
+            .lock()
+            .expect("analytics exporter metrics lock poisoned")
+            .failed += 1;
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<S> Clone for BoundedAnalyticsSink<S> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+            capacity: self.capacity,
+            queue: Arc::clone(&self.queue),
+            metrics: Arc::clone(&self.metrics),
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<S> AnalyticsSink for BoundedAnalyticsSink<S>
+where
+    S: AnalyticsSink + 'static,
+{
+    fn emit(&self, event: &ObservedEvent) -> Result<(), AnalyticsError> {
+        let mut queue = self
+            .queue
+            .lock()
+            .expect("analytics exporter queue lock poisoned");
+        if queue.len() >= self.capacity {
+            self.increment_dropped();
+            return Err(AnalyticsError::new(format!(
+                "analytics export queue full (capacity {})",
+                self.capacity
+            )));
+        }
+
+        queue.push_back(event.clone());
+        drop(queue);
+        self.increment_enqueued();
+        Ok(())
+    }
+
+    fn flush(&self) -> Result<(), AnalyticsError> {
+        let queued = {
+            let mut queue = self
+                .queue
+                .lock()
+                .expect("analytics exporter queue lock poisoned");
+            queue.drain(..).collect::<Vec<_>>()
+        };
+
+        let mut failed = 0usize;
+
+        for event in queued {
+            match catch_unwind(AssertUnwindSafe(|| self.inner.emit(&event))) {
+                Ok(Ok(())) => self.increment_delivered(),
+                Ok(Err(_)) | Err(_) => {
+                    failed += 1;
+                    self.increment_failed();
+                }
+            }
+        }
+
+        match catch_unwind(AssertUnwindSafe(|| self.inner.flush())) {
+            Ok(Ok(())) => {}
+            Ok(Err(_)) | Err(_) => {
+                failed += 1;
+                self.increment_failed();
+            }
+        }
+
+        if failed == 0 {
+            Ok(())
+        } else {
+            Err(AnalyticsError::new(format!(
+                "analytics exporter flush failed for {failed} operation(s)"
+            )))
+        }
     }
 }
 
@@ -479,5 +650,112 @@ mod tests {
         assert_eq!(report.succeeded, 1);
         assert_eq!(report.failed, 0);
         assert!(report.all_succeeded());
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn bounded_sink_counts_backpressure_and_flush_delivery() {
+        let delivered = Arc::new(AtomicUsize::new(0));
+        let delivered_sink = Arc::clone(&delivered);
+        let bounded = BoundedAnalyticsSink::new(
+            move |_: &ObservedEvent| {
+                delivered_sink.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            },
+            1,
+        );
+        let client = AnalyticsClient::new()
+            .without_tracing_events()
+            .with_sink(bounded.clone());
+
+        let first = client.emit(event("first"));
+        let second = client.emit(event("second"));
+
+        assert!(first.all_succeeded());
+        assert_eq!(second.attempted, 1);
+        assert_eq!(second.succeeded, 0);
+        assert_eq!(second.failed, 1);
+        assert_eq!(
+            second.errors[0].message(),
+            "analytics export queue full (capacity 1)"
+        );
+        assert_eq!(
+            bounded.metrics(),
+            ExporterMetrics {
+                pending: 1,
+                enqueued: 1,
+                dropped: 1,
+                delivered: 0,
+                failed: 0,
+            }
+        );
+
+        let flush = client.flush();
+
+        assert!(flush.all_succeeded());
+        assert_eq!(delivered.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            bounded.metrics(),
+            ExporterMetrics {
+                pending: 0,
+                enqueued: 1,
+                dropped: 1,
+                delivered: 1,
+                failed: 0,
+            }
+        );
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn bounded_sink_flush_counts_inner_errors_and_continues() {
+        let delivered = Arc::new(Mutex::new(Vec::new()));
+        let delivered_sink = Arc::clone(&delivered);
+        let bounded = BoundedAnalyticsSink::new(
+            move |event: &ObservedEvent| {
+                if event.name == "bad" {
+                    return Err(AnalyticsError::new("inner exporter rejected event"));
+                }
+                delivered_sink
+                    .lock()
+                    .expect("delivered lock poisoned")
+                    .push(event.name.clone());
+                Ok(())
+            },
+            4,
+        );
+        let client = AnalyticsClient::new()
+            .without_tracing_events()
+            .with_sink(bounded.clone());
+
+        assert!(client.emit(event("bad")).all_succeeded());
+        assert!(client.emit(event("good")).all_succeeded());
+
+        let report = client.flush();
+
+        assert_eq!(report.attempted, 1);
+        assert_eq!(report.succeeded, 0);
+        assert_eq!(report.failed, 1);
+        assert_eq!(
+            report.errors[0].message(),
+            "analytics exporter flush failed for 1 operation(s)"
+        );
+        assert_eq!(
+            delivered
+                .lock()
+                .expect("delivered lock poisoned")
+                .as_slice(),
+            ["good"]
+        );
+        assert_eq!(
+            bounded.metrics(),
+            ExporterMetrics {
+                pending: 0,
+                enqueued: 2,
+                dropped: 0,
+                delivered: 1,
+                failed: 1,
+            }
+        );
     }
 }

--- a/crates/pocopine-analytics/src/lib.rs
+++ b/crates/pocopine-analytics/src/lib.rs
@@ -158,43 +158,33 @@ where
             .len()
     }
 
+    /// Returns a best-effort point-in-time snapshot.
+    ///
+    /// Monotonic counters are exact, while `pending` reflects queue depth at
+    /// the moment the snapshot was read.
     pub fn metrics(&self) -> ExporterMetrics {
-        let pending = self.pending();
+        let queue = self
+            .queue
+            .lock()
+            .expect("analytics exporter queue lock poisoned");
         let mut metrics = self
             .metrics
             .lock()
             .expect("analytics exporter metrics lock poisoned")
             .clone();
-        metrics.pending = pending;
+        metrics.pending = queue.len();
         metrics
     }
 
-    fn increment_dropped(&self) {
-        self.metrics
+    fn add_metrics(&self, enqueued: u64, dropped: u64, delivered: u64, failed: u64) {
+        let mut metrics = self
+            .metrics
             .lock()
-            .expect("analytics exporter metrics lock poisoned")
-            .dropped += 1;
-    }
-
-    fn increment_enqueued(&self) {
-        self.metrics
-            .lock()
-            .expect("analytics exporter metrics lock poisoned")
-            .enqueued += 1;
-    }
-
-    fn increment_delivered(&self) {
-        self.metrics
-            .lock()
-            .expect("analytics exporter metrics lock poisoned")
-            .delivered += 1;
-    }
-
-    fn increment_failed(&self) {
-        self.metrics
-            .lock()
-            .expect("analytics exporter metrics lock poisoned")
-            .failed += 1;
+            .expect("analytics exporter metrics lock poisoned");
+        metrics.enqueued += enqueued;
+        metrics.dropped += dropped;
+        metrics.delivered += delivered;
+        metrics.failed += failed;
     }
 }
 
@@ -221,7 +211,7 @@ where
             .lock()
             .expect("analytics exporter queue lock poisoned");
         if queue.len() >= self.capacity {
-            self.increment_dropped();
+            self.add_metrics(0, 1, 0, 0);
             return Err(AnalyticsError::new(format!(
                 "analytics export queue full (capacity {})",
                 self.capacity
@@ -229,8 +219,7 @@ where
         }
 
         queue.push_back(event.clone());
-        drop(queue);
-        self.increment_enqueued();
+        self.add_metrics(1, 0, 0, 0);
         Ok(())
     }
 
@@ -243,14 +232,14 @@ where
             queue.drain(..).collect::<Vec<_>>()
         };
 
-        let mut failed = 0usize;
+        let mut delivered = 0u64;
+        let mut failed = 0u64;
 
         for event in queued {
             match catch_unwind(AssertUnwindSafe(|| self.inner.emit(&event))) {
-                Ok(Ok(())) => self.increment_delivered(),
+                Ok(Ok(())) => delivered += 1,
                 Ok(Err(_)) | Err(_) => {
                     failed += 1;
-                    self.increment_failed();
                 }
             }
         }
@@ -259,9 +248,10 @@ where
             Ok(Ok(())) => {}
             Ok(Err(_)) | Err(_) => {
                 failed += 1;
-                self.increment_failed();
             }
         }
+
+        self.add_metrics(0, 0, delivered, failed);
 
         if failed == 0 {
             Ok(())
@@ -752,6 +742,89 @@ mod tests {
             ExporterMetrics {
                 pending: 0,
                 enqueued: 2,
+                dropped: 0,
+                delivered: 1,
+                failed: 1,
+            }
+        );
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn bounded_sink_flush_counts_inner_emit_panic() {
+        let bounded = BoundedAnalyticsSink::new(
+            |_: &ObservedEvent| -> Result<(), AnalyticsError> { panic!("inner emit panic") },
+            2,
+        );
+        let client = AnalyticsClient::new()
+            .without_tracing_events()
+            .with_sink(bounded.clone());
+
+        assert!(client.emit(event("panic")).all_succeeded());
+
+        let report = client.flush();
+
+        assert_eq!(report.attempted, 1);
+        assert_eq!(report.succeeded, 0);
+        assert_eq!(report.failed, 1);
+        assert_eq!(
+            report.errors[0].message(),
+            "analytics exporter flush failed for 1 operation(s)"
+        );
+        assert_eq!(
+            bounded.metrics(),
+            ExporterMetrics {
+                pending: 0,
+                enqueued: 1,
+                dropped: 0,
+                delivered: 0,
+                failed: 1,
+            }
+        );
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn bounded_sink_flush_counts_inner_flush_panic_after_delivery() {
+        struct FlushPanicSink {
+            delivered: Arc<AtomicUsize>,
+        }
+
+        impl AnalyticsSink for FlushPanicSink {
+            fn emit(&self, _: &ObservedEvent) -> Result<(), AnalyticsError> {
+                self.delivered.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+
+            fn flush(&self) -> Result<(), AnalyticsError> {
+                panic!("inner flush panic")
+            }
+        }
+
+        let delivered = Arc::new(AtomicUsize::new(0));
+        let bounded = BoundedAnalyticsSink::new(
+            FlushPanicSink {
+                delivered: Arc::clone(&delivered),
+            },
+            2,
+        );
+        let client = AnalyticsClient::new()
+            .without_tracing_events()
+            .with_sink(bounded.clone());
+
+        assert!(client.emit(event("good")).all_succeeded());
+
+        let report = client.flush();
+
+        assert_eq!(report.attempted, 1);
+        assert_eq!(report.succeeded, 0);
+        assert_eq!(report.failed, 1);
+        assert_eq!(delivered.load(Ordering::SeqCst), 1);
+        assert_eq!(
+            bounded.metrics(),
+            ExporterMetrics {
+                pending: 0,
+                enqueued: 1,
                 dropped: 0,
                 delivered: 1,
                 failed: 1,

--- a/crates/pocopine-events/src/lib.rs
+++ b/crates/pocopine-events/src/lib.rs
@@ -1482,10 +1482,7 @@ return {id, tostring(now_ms)}
             }
 
             fn mark_seen(&mut self, stream_id: (u64, u64)) {
-                if self
-                    .last_seen
-                    .map_or(true, |last_seen| stream_id > last_seen)
-                {
+                if self.last_seen.is_none_or(|last_seen| stream_id > last_seen) {
                     self.last_seen = Some(stream_id);
                 }
             }

--- a/crates/pocopine-observe/Cargo.toml
+++ b/crates/pocopine-observe/Cargo.toml
@@ -9,3 +9,7 @@ description = "Shared observability event contract for pocopine logging, tracing
 [dependencies]
 serde = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+serde_json = "1"
+tracing-subscriber = { version = "0.3", features = ["fmt", "json", "registry", "std"] }

--- a/crates/pocopine-observe/Cargo.toml
+++ b/crates/pocopine-observe/Cargo.toml
@@ -11,5 +11,5 @@ serde = { workspace = true }
 tracing = { workspace = true }
 
 [dev-dependencies]
-serde_json = "1"
-tracing-subscriber = { version = "0.3", features = ["fmt", "json", "registry", "std"] }
+serde_json = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["fmt", "json", "registry", "std"] }

--- a/crates/pocopine-observe/src/lib.rs
+++ b/crates/pocopine-observe/src/lib.rs
@@ -383,69 +383,421 @@ impl Default for RedactionPolicy {
     }
 }
 
+const OBSERVED_TRACING_FIELD_SLOTS: usize = 8;
+
+#[derive(Clone, Copy, Debug)]
+struct ObservedTracingField<'a> {
+    present: bool,
+    name: &'a str,
+    privacy: &'static str,
+    kind: &'static str,
+    value_string: &'a str,
+    value_bool: bool,
+    value_i64: i64,
+    value_u64: u64,
+    value_f64: f64,
+}
+
+impl<'a> ObservedTracingField<'a> {
+    const EMPTY: Self = Self {
+        present: false,
+        name: "",
+        privacy: "",
+        kind: "",
+        value_string: "",
+        value_bool: false,
+        value_i64: 0,
+        value_u64: 0,
+        value_f64: 0.0,
+    };
+
+    fn from_field(name: &'a str, field: &'a ObservedField) -> Self {
+        let mut slot = Self {
+            present: true,
+            name,
+            privacy: field.privacy.as_str(),
+            ..Self::EMPTY
+        };
+
+        match &field.value {
+            FieldValue::String(value) => {
+                slot.kind = "string";
+                slot.value_string = value;
+            }
+            FieldValue::Bool(value) => {
+                slot.kind = "bool";
+                slot.value_bool = *value;
+            }
+            FieldValue::I64(value) => {
+                slot.kind = "i64";
+                slot.value_i64 = *value;
+            }
+            FieldValue::U64(value) => {
+                slot.kind = "u64";
+                slot.value_u64 = *value;
+            }
+            FieldValue::F64(value) => {
+                slot.kind = "f64";
+                slot.value_f64 = *value;
+            }
+        }
+
+        slot
+    }
+}
+
+#[derive(Clone, Debug)]
+struct ObservedTracing<'a> {
+    event: &'a ObservedEvent,
+    fields: [ObservedTracingField<'a>; OBSERVED_TRACING_FIELD_SLOTS],
+    field_count: u64,
+    field_overflowed: bool,
+}
+
+impl<'a> ObservedTracing<'a> {
+    fn new(event: &'a ObservedEvent) -> Self {
+        let mut fields = [ObservedTracingField::EMPTY; OBSERVED_TRACING_FIELD_SLOTS];
+
+        for (slot, (name, field)) in fields.iter_mut().zip(event.fields.iter()) {
+            *slot = ObservedTracingField::from_field(name, field);
+        }
+
+        Self {
+            event,
+            fields,
+            field_count: event.fields.len() as u64,
+            field_overflowed: event.fields.len() > OBSERVED_TRACING_FIELD_SLOTS,
+        }
+    }
+
+    fn event_name(&self) -> &str {
+        &self.event.name
+    }
+
+    fn event_class(&self) -> &'static str {
+        self.event.class.as_str()
+    }
+
+    fn event_priority(&self) -> &'static str {
+        self.event.priority.as_str()
+    }
+
+    fn event_privacy(&self) -> &'static str {
+        self.event.privacy.as_str()
+    }
+
+    fn service(&self) -> &str {
+        self.event.context.service.as_deref().unwrap_or("")
+    }
+
+    fn has_service(&self) -> bool {
+        self.event.context.service.is_some()
+    }
+
+    fn environment(&self) -> &str {
+        self.event.context.environment.as_deref().unwrap_or("")
+    }
+
+    fn has_environment(&self) -> bool {
+        self.event.context.environment.is_some()
+    }
+
+    fn route(&self) -> &str {
+        self.event.context.route.as_deref().unwrap_or("")
+    }
+
+    fn has_route(&self) -> bool {
+        self.event.context.route.is_some()
+    }
+
+    fn component(&self) -> &str {
+        self.event.context.component.as_deref().unwrap_or("")
+    }
+
+    fn has_component(&self) -> bool {
+        self.event.context.component.is_some()
+    }
+
+    fn trace_id(&self) -> &str {
+        self.event.context.trace_id.as_deref().unwrap_or("")
+    }
+
+    fn has_trace_id(&self) -> bool {
+        self.event.context.trace_id.is_some()
+    }
+
+    fn session_id(&self) -> &str {
+        self.event.context.session_id.as_deref().unwrap_or("")
+    }
+
+    fn has_session_id(&self) -> bool {
+        self.event.context.session_id.is_some()
+    }
+
+    fn user_id_hash(&self) -> &str {
+        self.event.context.user_id_hash.as_deref().unwrap_or("")
+    }
+
+    fn has_user_id_hash(&self) -> bool {
+        self.event.context.user_id_hash.is_some()
+    }
+
+    fn slot(&self, index: usize) -> ObservedTracingField<'a> {
+        self.fields[index]
+    }
+}
+
 pub fn emit_tracing(event: &ObservedEvent) {
+    let observed = ObservedTracing::new(event);
+
+    macro_rules! emit_at_level {
+        ($target:literal, $level:expr, $observed:expr) => {{
+            let f0 = $observed.slot(0);
+            let f1 = $observed.slot(1);
+            let f2 = $observed.slot(2);
+            let f3 = $observed.slot(3);
+            let f4 = $observed.slot(4);
+            let f5 = $observed.slot(5);
+            let f6 = $observed.slot(6);
+            let f7 = $observed.slot(7);
+
+            tracing::event!(
+                target: $target,
+                $level,
+                event_name = $observed.event_name(),
+                event_version = $observed.event.version,
+                event_class = $observed.event_class(),
+                event_priority = $observed.event_priority(),
+                event_privacy = $observed.event_privacy(),
+                observed_context_has_service = $observed.has_service(),
+                observed_context_service = $observed.service(),
+                observed_context_has_environment = $observed.has_environment(),
+                observed_context_environment = $observed.environment(),
+                observed_context_has_route = $observed.has_route(),
+                observed_context_route = $observed.route(),
+                observed_context_has_component = $observed.has_component(),
+                observed_context_component = $observed.component(),
+                observed_context_has_trace_id = $observed.has_trace_id(),
+                observed_context_trace_id = $observed.trace_id(),
+                observed_context_has_session_id = $observed.has_session_id(),
+                observed_context_session_id = $observed.session_id(),
+                observed_context_has_user_id_hash = $observed.has_user_id_hash(),
+                observed_context_user_id_hash = $observed.user_id_hash(),
+                observed_field_slots = OBSERVED_TRACING_FIELD_SLOTS as u64,
+                observed_field_count = $observed.field_count,
+                observed_field_overflowed = $observed.field_overflowed,
+                observed_field_0_present = f0.present,
+                observed_field_0_name = f0.name,
+                observed_field_0_privacy = f0.privacy,
+                observed_field_0_kind = f0.kind,
+                observed_field_0_value_string = f0.value_string,
+                observed_field_0_value_bool = f0.value_bool,
+                observed_field_0_value_i64 = f0.value_i64,
+                observed_field_0_value_u64 = f0.value_u64,
+                observed_field_0_value_f64 = f0.value_f64,
+                observed_field_1_present = f1.present,
+                observed_field_1_name = f1.name,
+                observed_field_1_privacy = f1.privacy,
+                observed_field_1_kind = f1.kind,
+                observed_field_1_value_string = f1.value_string,
+                observed_field_1_value_bool = f1.value_bool,
+                observed_field_1_value_i64 = f1.value_i64,
+                observed_field_1_value_u64 = f1.value_u64,
+                observed_field_1_value_f64 = f1.value_f64,
+                observed_field_2_present = f2.present,
+                observed_field_2_name = f2.name,
+                observed_field_2_privacy = f2.privacy,
+                observed_field_2_kind = f2.kind,
+                observed_field_2_value_string = f2.value_string,
+                observed_field_2_value_bool = f2.value_bool,
+                observed_field_2_value_i64 = f2.value_i64,
+                observed_field_2_value_u64 = f2.value_u64,
+                observed_field_2_value_f64 = f2.value_f64,
+                observed_field_3_present = f3.present,
+                observed_field_3_name = f3.name,
+                observed_field_3_privacy = f3.privacy,
+                observed_field_3_kind = f3.kind,
+                observed_field_3_value_string = f3.value_string,
+                observed_field_3_value_bool = f3.value_bool,
+                observed_field_3_value_i64 = f3.value_i64,
+                observed_field_3_value_u64 = f3.value_u64,
+                observed_field_3_value_f64 = f3.value_f64,
+                observed_field_4_present = f4.present,
+                observed_field_4_name = f4.name,
+                observed_field_4_privacy = f4.privacy,
+                observed_field_4_kind = f4.kind,
+                observed_field_4_value_string = f4.value_string,
+                observed_field_4_value_bool = f4.value_bool,
+                observed_field_4_value_i64 = f4.value_i64,
+                observed_field_4_value_u64 = f4.value_u64,
+                observed_field_4_value_f64 = f4.value_f64,
+                observed_field_5_present = f5.present,
+                observed_field_5_name = f5.name,
+                observed_field_5_privacy = f5.privacy,
+                observed_field_5_kind = f5.kind,
+                observed_field_5_value_string = f5.value_string,
+                observed_field_5_value_bool = f5.value_bool,
+                observed_field_5_value_i64 = f5.value_i64,
+                observed_field_5_value_u64 = f5.value_u64,
+                observed_field_5_value_f64 = f5.value_f64,
+                observed_field_6_present = f6.present,
+                observed_field_6_name = f6.name,
+                observed_field_6_privacy = f6.privacy,
+                observed_field_6_kind = f6.kind,
+                observed_field_6_value_string = f6.value_string,
+                observed_field_6_value_bool = f6.value_bool,
+                observed_field_6_value_i64 = f6.value_i64,
+                observed_field_6_value_u64 = f6.value_u64,
+                observed_field_6_value_f64 = f6.value_f64,
+                observed_field_7_present = f7.present,
+                observed_field_7_name = f7.name,
+                observed_field_7_privacy = f7.privacy,
+                observed_field_7_kind = f7.kind,
+                observed_field_7_value_string = f7.value_string,
+                observed_field_7_value_bool = f7.value_bool,
+                observed_field_7_value_i64 = f7.value_i64,
+                observed_field_7_value_u64 = f7.value_u64,
+                observed_field_7_value_f64 = f7.value_f64,
+            );
+        }};
+    }
+
     macro_rules! emit_for_target {
-        ($target:literal, $event:expr) => {
-            match $event.priority.level() {
-                Level::ERROR => tracing::event!(
-                    target: $target,
-                    Level::ERROR,
-                    event_name = %$event.name,
-                    event_version = $event.version,
-                    event_class = %$event.class,
-                    event_priority = %$event.priority,
-                    event_privacy = %$event.privacy,
-                    context = ?$event.context,
-                    fields = ?$event.fields,
-                ),
-                Level::WARN => tracing::event!(
-                    target: $target,
-                    Level::WARN,
-                    event_name = %$event.name,
-                    event_version = $event.version,
-                    event_class = %$event.class,
-                    event_priority = %$event.priority,
-                    event_privacy = %$event.privacy,
-                    context = ?$event.context,
-                    fields = ?$event.fields,
-                ),
-                Level::INFO => tracing::event!(
-                    target: $target,
-                    Level::INFO,
-                    event_name = %$event.name,
-                    event_version = $event.version,
-                    event_class = %$event.class,
-                    event_priority = %$event.priority,
-                    event_privacy = %$event.privacy,
-                    context = ?$event.context,
-                    fields = ?$event.fields,
-                ),
-                Level::DEBUG | Level::TRACE => tracing::event!(
-                    target: $target,
-                    Level::DEBUG,
-                    event_name = %$event.name,
-                    event_version = $event.version,
-                    event_class = %$event.class,
-                    event_priority = %$event.priority,
-                    event_privacy = %$event.privacy,
-                    context = ?$event.context,
-                    fields = ?$event.fields,
-                ),
+        ($target:literal, $observed:expr) => {
+            match $observed.event.priority.level() {
+                Level::ERROR => emit_at_level!($target, Level::ERROR, $observed),
+                Level::WARN => emit_at_level!($target, Level::WARN, $observed),
+                Level::INFO => emit_at_level!($target, Level::INFO, $observed),
+                Level::DEBUG | Level::TRACE => emit_at_level!($target, Level::DEBUG, $observed),
             }
         };
     }
 
     match event.class {
-        EventClass::Log => emit_for_target!("pocopine.log", event),
-        EventClass::Trace => emit_for_target!("pocopine.trace", event),
-        EventClass::Metric => emit_for_target!("pocopine.metric", event),
-        EventClass::Analytics => emit_for_target!("pocopine.analytics", event),
+        EventClass::Log => emit_for_target!("pocopine.log", observed),
+        EventClass::Trace => emit_for_target!("pocopine.trace", observed),
+        EventClass::Metric => emit_for_target!("pocopine.metric", observed),
+        EventClass::Analytics => emit_for_target!("pocopine.analytics", observed),
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::BTreeMap;
+    use std::io::{self, Write};
+    use std::sync::{Arc, Mutex};
+    use tracing::field::{Field, Visit};
+    use tracing_subscriber::fmt::MakeWriter;
+    use tracing_subscriber::layer::Context;
+    use tracing_subscriber::prelude::*;
+    use tracing_subscriber::Layer;
+
+    #[derive(Clone)]
+    struct SharedWriter(Arc<Mutex<Vec<u8>>>);
+
+    struct TestWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for TestWriter {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.0
+                .lock()
+                .expect("test writer lock")
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> MakeWriter<'a> for SharedWriter {
+        type Writer = TestWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            TestWriter(Arc::clone(&self.0))
+        }
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    enum CapturedValue {
+        Bool(bool),
+        I64(i64),
+        U64(u64),
+        F64(f64),
+        Str(String),
+        Debug(String),
+    }
+
+    #[derive(Clone, Debug, PartialEq)]
+    struct CapturedEvent {
+        target: String,
+        fields: BTreeMap<String, CapturedValue>,
+    }
+
+    #[derive(Clone, Default)]
+    struct CaptureLayer {
+        events: Arc<Mutex<Vec<CapturedEvent>>>,
+    }
+
+    impl<S> Layer<S> for CaptureLayer
+    where
+        S: tracing::Subscriber,
+    {
+        fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+            let mut visitor = CaptureVisitor::default();
+            event.record(&mut visitor);
+            self.events
+                .lock()
+                .expect("captured events lock")
+                .push(CapturedEvent {
+                    target: event.metadata().target().to_string(),
+                    fields: visitor.fields,
+                });
+        }
+    }
+
+    #[derive(Default)]
+    struct CaptureVisitor {
+        fields: BTreeMap<String, CapturedValue>,
+    }
+
+    impl Visit for CaptureVisitor {
+        fn record_bool(&mut self, field: &Field, value: bool) {
+            self.fields
+                .insert(field.name().to_string(), CapturedValue::Bool(value));
+        }
+
+        fn record_i64(&mut self, field: &Field, value: i64) {
+            self.fields
+                .insert(field.name().to_string(), CapturedValue::I64(value));
+        }
+
+        fn record_u64(&mut self, field: &Field, value: u64) {
+            self.fields
+                .insert(field.name().to_string(), CapturedValue::U64(value));
+        }
+
+        fn record_f64(&mut self, field: &Field, value: f64) {
+            self.fields
+                .insert(field.name().to_string(), CapturedValue::F64(value));
+        }
+
+        fn record_str(&mut self, field: &Field, value: &str) {
+            self.fields.insert(
+                field.name().to_string(),
+                CapturedValue::Str(value.to_string()),
+            );
+        }
+
+        fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+            self.fields.insert(
+                field.name().to_string(),
+                CapturedValue::Debug(format!("{value:?}")),
+            );
+        }
+    }
 
     #[test]
     fn redacts_non_public_fields_by_default() {
@@ -476,5 +828,100 @@ mod tests {
         assert!(redacted.fields.contains_key("route"));
         assert!(redacted.fields.contains_key("session"));
         assert!(!redacted.fields.contains_key("token"));
+    }
+
+    #[test]
+    fn emit_tracing_json_output_uses_structured_observed_fields() {
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry().with(
+            tracing_subscriber::fmt::layer()
+                .json()
+                .with_ansi(false)
+                .with_writer(SharedWriter(Arc::clone(&output))),
+        );
+        let event = ObservedEvent::metric("queue_depth")
+            .context(
+                ObserveContext::default()
+                    .with_service("worker")
+                    .with_route("/jobs"),
+            )
+            .field("active", true, FieldPrivacy::Public)
+            .field("depth", 42_u64, FieldPrivacy::Public)
+            .field("route", "/jobs", FieldPrivacy::Public);
+
+        tracing::subscriber::with_default(subscriber, || emit_tracing(&event));
+
+        let output = String::from_utf8(output.lock().expect("json output lock").clone())
+            .expect("json output is utf8");
+        let line = output.lines().next().expect("one json line");
+        let json: serde_json::Value = serde_json::from_str(line).expect("valid json log line");
+        let fields = json
+            .get("fields")
+            .and_then(serde_json::Value::as_object)
+            .expect("json event fields");
+
+        assert_eq!(fields.get("event_name").unwrap(), "queue_depth");
+        assert_eq!(fields.get("event_class").unwrap(), "metric");
+        assert_eq!(fields.get("observed_context_has_service").unwrap(), true);
+        assert_eq!(fields.get("observed_context_service").unwrap(), "worker");
+        assert_eq!(fields.get("observed_context_route").unwrap(), "/jobs");
+        assert_eq!(fields.get("observed_field_count").unwrap(), 3);
+        assert_eq!(fields.get("observed_field_0_name").unwrap(), "active");
+        assert_eq!(fields.get("observed_field_0_kind").unwrap(), "bool");
+        assert_eq!(fields.get("observed_field_0_value_bool").unwrap(), true);
+        assert_eq!(fields.get("observed_field_1_name").unwrap(), "depth");
+        assert_eq!(fields.get("observed_field_1_kind").unwrap(), "u64");
+        assert_eq!(fields.get("observed_field_1_value_u64").unwrap(), 42);
+        assert_eq!(fields.get("observed_field_2_name").unwrap(), "route");
+        assert_eq!(fields.get("observed_field_2_kind").unwrap(), "string");
+        assert_eq!(
+            fields.get("observed_field_2_value_string").unwrap(),
+            "/jobs"
+        );
+        assert!(!fields.contains_key("context"));
+        assert!(!fields.contains_key("fields"));
+    }
+
+    #[test]
+    fn emit_tracing_records_otlp_facing_typed_slots() {
+        let capture = CaptureLayer::default();
+        let events = Arc::clone(&capture.events);
+        let subscriber = tracing_subscriber::registry().with(capture);
+        let event = ObservedEvent::analytics("cta")
+            .field("clicks", 7_u64, FieldPrivacy::Public)
+            .field("ok", true, FieldPrivacy::Public)
+            .field("ratio", 0.5_f64, FieldPrivacy::Public);
+
+        tracing::subscriber::with_default(subscriber, || emit_tracing(&event));
+
+        let events = events.lock().expect("captured events lock");
+        let event = events.first().expect("captured event");
+        assert_eq!(event.target, ANALYTICS_TARGET);
+        assert!(!event.fields.contains_key("context"));
+        assert!(!event.fields.contains_key("fields"));
+        assert_eq!(
+            event.fields.get("observed_field_0_name"),
+            Some(&CapturedValue::Str("clicks".to_string()))
+        );
+        assert_eq!(
+            event.fields.get("observed_field_0_value_u64"),
+            Some(&CapturedValue::U64(7))
+        );
+        assert_eq!(
+            event.fields.get("observed_field_1_name"),
+            Some(&CapturedValue::Str("ok".to_string()))
+        );
+        assert_eq!(
+            event.fields.get("observed_field_1_value_bool"),
+            Some(&CapturedValue::Bool(true))
+        );
+        assert_eq!(
+            event.fields.get("observed_field_2_name"),
+            Some(&CapturedValue::Str("ratio".to_string()))
+        );
+        assert_eq!(
+            event.fields.get("observed_field_2_value_f64"),
+            Some(&CapturedValue::F64(0.5))
+        );
     }
 }

--- a/crates/pocopine-observe/src/lib.rs
+++ b/crates/pocopine-observe/src/lib.rs
@@ -7,6 +7,7 @@
 
 use std::collections::BTreeMap;
 use std::fmt;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use serde::{Deserialize, Serialize};
 use tracing::Level;
@@ -384,6 +385,7 @@ impl Default for RedactionPolicy {
 }
 
 const OBSERVED_TRACING_FIELD_SLOTS: usize = 8;
+static OBSERVED_TRACING_OVERFLOW_WARNED: AtomicBool = AtomicBool::new(false);
 
 #[derive(Clone, Copy, Debug)]
 struct ObservedTracingField<'a> {
@@ -547,8 +549,24 @@ impl<'a> ObservedTracing<'a> {
     }
 }
 
+/// Emits an observed event into `tracing`.
+///
+/// This function preserves the event exactly as supplied. It does not apply
+/// redaction; call [`ObservedEvent::redacted`] first, or emit through
+/// `pocopine-analytics`, when private fields must be stripped before export.
 pub fn emit_tracing(event: &ObservedEvent) {
     let observed = ObservedTracing::new(event);
+
+    if observed.field_overflowed && !OBSERVED_TRACING_OVERFLOW_WARNED.swap(true, Ordering::Relaxed)
+    {
+        tracing::warn!(
+            target: "pocopine.log",
+            event_name = observed.event_name(),
+            observed_field_count = observed.field_count,
+            observed_field_slots = OBSERVED_TRACING_FIELD_SLOTS as u64,
+            "observed event field slots overflowed; extra fields omitted from tracing output"
+        );
+    }
 
     macro_rules! emit_at_level {
         ($target:literal, $level:expr, $observed:expr) => {{

--- a/docs/logging-tracing-observer.md
+++ b/docs/logging-tracing-observer.md
@@ -417,6 +417,44 @@ Fixed tracing targets:
 | metric | `pocopine.metric` |
 | analytics | `pocopine.analytics` |
 
+When an `ObservedEvent` is emitted into `tracing`, the shared context and
+event fields are recorded as stable tracing fields instead of a single Debug
+blob. This is important for JSON logs, `tracing-opentelemetry`, and log agents
+that consume typed tracing values.
+
+Context fields use fixed names:
+
+```text
+observed_context_service
+observed_context_route
+observed_context_component
+observed_context_trace_id
+```
+
+Each optional context field also has an `observed_context_has_*` boolean so
+exporters can distinguish missing context from an intentionally empty string.
+
+User event fields are exported through fixed slots because `tracing` callsites
+require static field names. Slots preserve the original field name, privacy
+label, kind, and typed value:
+
+```text
+observed_field_count = 2
+observed_field_overflowed = false
+observed_field_0_name = "duration_ms"
+observed_field_0_privacy = "public"
+observed_field_0_kind = "f64"
+observed_field_0_value_f64 = 12.7
+observed_field_1_name = "route"
+observed_field_1_kind = "string"
+observed_field_1_value_string = "/settings"
+```
+
+The current tracing emission reserves eight slots. If an event carries more
+fields, `observed_field_count` still records the full count and
+`observed_field_overflowed` is set to `true`; keep framework events coarse and
+stable rather than shipping wide payloads.
+
 ## Analytics and telemetry
 
 Analytics is separate from logging. Logs are operational records. Analytics
@@ -451,6 +489,36 @@ stored in shared server state such as axum state. On wasm targets this bound is
 relaxed because browser SDK handles are usually JavaScript objects. The closure
 example above spells out `&pocopine::observe::ObservedEvent` so Rust can infer
 the host closure sink against that `Send + Sync` blanket implementation.
+
+Host exporters that buffer work should use a bounded queue. The built-in
+`BoundedAnalyticsSink` wraps another sink, accepts up to `capacity` redacted
+events, rejects new events when full, and exposes counters for pending,
+enqueued, dropped, delivered, and failed operations:
+
+```rust
+use pocopine::analytics::{AnalyticsClient, BoundedAnalyticsSink};
+
+let exporter = BoundedAnalyticsSink::new(my_exporter_sink, 1024);
+let metrics = exporter.clone();
+
+let analytics = AnalyticsClient::new()
+    .with_sink(exporter);
+
+let report = analytics.emit(pocopine::analytics::route_view("/settings"));
+if !report.all_succeeded() {
+    let snapshot = metrics.metrics();
+    tracing::warn!(
+        target: "pocopine.log",
+        dropped = snapshot.dropped,
+        failed = snapshot.failed,
+        "analytics exporter backpressure"
+    );
+}
+```
+
+Call `analytics.flush()` during graceful shutdown to drain the queued events
+into the wrapped sink. Flush keeps going after per-event exporter errors and
+counts those failures in the wrapper metrics.
 
 ## Browser vendor bridges
 
@@ -504,7 +572,10 @@ Observability must not change application behavior.
 - Analytics sink failure must not stop other sinks.
 - Analytics sinks receive redacted events, not raw debug fields.
 - Runtime/library crates do not install global subscribers.
-- Async exporters added later must use bounded queues and count drops.
+- Host exporters that buffer work should use `BoundedAnalyticsSink` or an
+  equivalent bounded queue and count drops.
+- Async exporters added later must preserve the same bounded-queue and
+  drop/error-counter contract.
 
 ## Common recipes
 

--- a/docs/logging-tracing-observer.md
+++ b/docs/logging-tracing-observer.md
@@ -453,7 +453,13 @@ observed_field_1_value_string = "/settings"
 The current tracing emission reserves eight slots. If an event carries more
 fields, `observed_field_count` still records the full count and
 `observed_field_overflowed` is set to `true`; keep framework events coarse and
-stable rather than shipping wide payloads.
+stable rather than shipping wide payloads. Pocopine also emits one warning per
+process the first time an event overflows the reserved slots.
+
+`pocopine::logging::log_event()` and `pocopine::observe::emit_tracing()` do not
+apply redaction. They emit the event as supplied. For analytics or telemetry
+sinks that must strip private fields, use `AnalyticsClient` or call
+`ObservedEvent::redacted(...)` before emitting.
 
 ## Analytics and telemetry
 

--- a/rfcs/rfc-069-observability.md
+++ b/rfcs/rfc-069-observability.md
@@ -76,6 +76,8 @@ ships:
 - redaction before dispatch;
 - continued delivery after individual sink errors;
 - panic isolation around sink calls;
+- a host-side bounded exporter wrapper with drop, delivery, and failure
+  counters;
 - wasm JS function sinks for user-supplied vendor bridges;
 - wasm Firebase and Google Analytics function adapters.
 
@@ -141,10 +143,11 @@ This keeps vendor APIs out of `pocopine-core` and out of
 - Telemetry/exporter failure must not fail app behavior.
 - Analytics fan-out continues after a sink returns an error.
 - Sink panics are caught and reported as analytics delivery failures.
-- Export queues must be bounded when asynchronous exporters are added.
-- Overflow should drop low-priority analytics before operational errors.
-- Exporters must expose dropped-event and export-error counters once metrics
-  sinks land.
+- Exporters that buffer work must use bounded queues and expose dropped-event
+  and export-error counters.
+- The initial bounded host wrapper rejects new events when full. Future
+  priority-aware async exporters may drop low-priority analytics before
+  operational errors.
 - Libraries do not install global subscribers.
 
 ## 5. Privacy Rules
@@ -180,6 +183,6 @@ Later phases should add:
 - job observability export from the existing `pocopine-jobs` tracing events;
 - OpenTelemetry adapter;
 - AWS/Cloudflare host sinks;
-- bounded async exporter queues;
-- metrics for drops and exporter failures;
+- priority-aware async exporter queues;
+- metrics sink integration for exporter drop/failure counters;
 - devtools panel integration on top of the same event stream.


### PR DESCRIPTION
## Summary

- emit ObservedEvent data into tracing as stable structured context/field slots instead of Debug blobs
- add JSON subscriber and tracing visitor tests for structured observed-event output
- add host-side BoundedAnalyticsSink with pending/enqueued/dropped/delivered/failed metrics
- document the structured field schema and bounded exporter contract
- fix one existing clippy lint in pocopine-events so full workspace clippy stays clean

## Verification

- cargo fmt --all
- cargo test -p pocopine-observe
- cargo test -p pocopine-analytics
- cargo test -p pocopine-logging --all-features
- cargo test -p observability-smoke --test otlp_smoke
- cargo test -p pocopine --all-features --test server_auth --test job_macro
- cargo clippy --workspace --all-targets --all-features -- -D warnings

Also attempted cargo test --workspace --all-features; it reached the Docker-backed Redis integration tests and failed because this sandbox cannot create testcontainers: Permission denied on container creation.