### PR TITLE
Add chart hover events and custom tooltip hooks

### DIFF
--- a/crates/pine-charts/src/area/PineAreaChart.poco
+++ b/crates/pine-charts/src/area/PineAreaChart.poco
@@ -5,7 +5,7 @@
       :data-empty="empty"
       :data-invalid="invalid"
       :data-hover="hover_visible"
-      :data-tooltip="tooltip"
+      :data-tooltip="tooltip_mode"
       :data-animate="animate"
       :data-animation-duration="animation_duration"
       :data-animation-easing="animation_easing"
@@ -162,10 +162,10 @@
     </g>
   </svg>
   <div class="pine-chart-tooltip"
-       :aria-hidden="hover_visible && tooltip != 'none' ? 'false' : 'true'"
+       :aria-hidden="tooltip_aria_hidden"
        role="status"
        :aria-label="hover_aria_label"
-       :style="hover_visible && tooltip != 'none' ? hover_style : (tooltip == 'none' ? 'display: none;' : '')"
+       :style="hover_style"
        :data-tooltip-x="hover_placement_x"
        :data-tooltip-y="hover_placement_y"
        :data-x="hover_data_x"

--- a/crates/pine-charts/src/area/PineAreaChart.poco
+++ b/crates/pine-charts/src/area/PineAreaChart.poco
@@ -5,6 +5,7 @@
       :data-empty="empty"
       :data-invalid="invalid"
       :data-hover="hover_visible"
+      :data-tooltip="tooltip"
       :data-animate="animate"
       :data-animation-duration="animation_duration"
       :data-animation-easing="animation_easing"
@@ -161,10 +162,10 @@
     </g>
   </svg>
   <div class="pine-chart-tooltip"
-       :aria-hidden="hover_visible ? 'false' : 'true'"
+       :aria-hidden="hover_visible && tooltip != 'none' ? 'false' : 'true'"
        role="status"
        :aria-label="hover_aria_label"
-       :style="hover_style"
+       :style="hover_visible && tooltip != 'none' ? hover_style : (tooltip == 'none' ? 'display: none;' : '')"
        :data-tooltip-x="hover_placement_x"
        :data-tooltip-y="hover_placement_y"
        :data-x="hover_data_x"

--- a/crates/pine-charts/src/area/mod.rs
+++ b/crates/pine-charts/src/area/mod.rs
@@ -7,8 +7,9 @@ use crate::animation::{
 };
 use crate::cartesian::{
     centered_plot_y, chart_hover_payload, optional_domain, plot_rect_from_edges,
-    pointer_event_svg_point, CartesianChartState, CartesianGuideFields, CartesianGuideUpdate,
-    CartesianHoverFields, ChartStateFields, PlotEdgeFields, DEFAULT_EMPTY_MESSAGE,
+    pointer_event_svg_point, tooltip_aria_hidden, tooltip_mode, CartesianChartState,
+    CartesianGuideFields, CartesianGuideUpdate, CartesianHoverFields, ChartStateFields,
+    PlotEdgeFields, DEFAULT_EMPTY_MESSAGE,
 };
 use crate::error::{ChartError, ChartResult};
 use crate::events::{ChartHoverEnd, CHART_HOVER_END_EVENT, CHART_HOVER_EVENT};
@@ -197,6 +198,8 @@ pub struct PineAreaChart {
     pub animation_easing: String,
     #[prop]
     pub tooltip: String,
+    pub tooltip_mode: String,
+    pub tooltip_aria_hidden: String,
     pub animation_style: String,
     pub exit_generation: u32,
     pub state: String,
@@ -258,6 +261,8 @@ impl Default for PineAreaChart {
             animation_duration: DEFAULT_ANIMATION_DURATION_MS,
             animation_easing: DEFAULT_ANIMATION_EASING.into(),
             tooltip: "default".into(),
+            tooltip_mode: "default".into(),
+            tooltip_aria_hidden: "true".into(),
             animation_style: animation_style(
                 DEFAULT_ANIMATION_DURATION_MS,
                 DEFAULT_ANIMATION_EASING,
@@ -303,6 +308,7 @@ impl Default for PineAreaChart {
 impl PineAreaChart {
     fn on_setup(&mut self) {
         self.update_animation_style();
+        self.sync_tooltip_state();
         self.recompute();
     }
 
@@ -319,6 +325,11 @@ impl PineAreaChart {
     #[watch(animation_easing)]
     fn on_animation_easing(&mut self, _: String, _: Option<String>) {
         self.update_animation_style();
+    }
+
+    #[watch(tooltip)]
+    fn on_tooltip(&mut self, _: String, _: Option<String>) {
+        self.sync_tooltip_state();
     }
 
     #[watch(points)]
@@ -391,6 +402,7 @@ impl PineAreaChart {
     pub fn clear_hover(&mut self) {
         let was_visible = self.hover_visible;
         self.hover_fields().clear();
+        self.sync_tooltip_state();
         if was_visible {
             pocopine::emit(CHART_HOVER_END_EVENT, ChartHoverEnd::new("area"));
         }
@@ -400,6 +412,12 @@ impl PineAreaChart {
 impl PineAreaChart {
     fn update_animation_style(&mut self) {
         self.animation_style = animation_style(self.animation_duration, &self.animation_easing);
+    }
+
+    fn sync_tooltip_state(&mut self) {
+        self.tooltip_mode = tooltip_mode(&self.tooltip).into();
+        self.tooltip_aria_hidden =
+            tooltip_aria_hidden(&self.tooltip_mode, self.hover_visible).into();
     }
 
     fn recompute(&mut self) {
@@ -544,6 +562,7 @@ impl PineAreaChart {
         let update = sample.hover_update(self.plot_rect(), self.width, self.height);
         let hover = chart_hover_payload("area", &update);
         self.hover_fields().apply(update);
+        self.sync_tooltip_state();
         pocopine::emit(CHART_HOVER_EVENT, hover);
     }
 

--- a/crates/pine-charts/src/area/mod.rs
+++ b/crates/pine-charts/src/area/mod.rs
@@ -6,11 +6,12 @@ use crate::animation::{
     DEFAULT_ANIMATION_EASING,
 };
 use crate::cartesian::{
-    centered_plot_y, optional_domain, plot_rect_from_edges, pointer_event_svg_point,
-    CartesianChartState, CartesianGuideFields, CartesianGuideUpdate, CartesianHoverFields,
-    ChartStateFields, PlotEdgeFields, DEFAULT_EMPTY_MESSAGE,
+    centered_plot_y, chart_hover_payload, optional_domain, plot_rect_from_edges,
+    pointer_event_svg_point, CartesianChartState, CartesianGuideFields, CartesianGuideUpdate,
+    CartesianHoverFields, ChartStateFields, PlotEdgeFields, DEFAULT_EMPTY_MESSAGE,
 };
 use crate::error::{ChartError, ChartResult};
+use crate::events::{ChartHoverEnd, CHART_HOVER_END_EVENT, CHART_HOVER_EVENT};
 use crate::geometry::{ChartMargins, ChartRect, Point};
 use crate::legend::{series_label_or_default, series_legend_items_with_visibility};
 use crate::line::{
@@ -194,6 +195,8 @@ pub struct PineAreaChart {
     pub animation_duration: f64,
     #[prop]
     pub animation_easing: String,
+    #[prop]
+    pub tooltip: String,
     pub animation_style: String,
     pub exit_generation: u32,
     pub state: String,
@@ -254,6 +257,7 @@ impl Default for PineAreaChart {
             animate: false,
             animation_duration: DEFAULT_ANIMATION_DURATION_MS,
             animation_easing: DEFAULT_ANIMATION_EASING.into(),
+            tooltip: "default".into(),
             animation_style: animation_style(
                 DEFAULT_ANIMATION_DURATION_MS,
                 DEFAULT_ANIMATION_EASING,
@@ -385,7 +389,11 @@ impl PineAreaChart {
     }
 
     pub fn clear_hover(&mut self) {
+        let was_visible = self.hover_visible;
         self.hover_fields().clear();
+        if was_visible {
+            pocopine::emit(CHART_HOVER_END_EVENT, ChartHoverEnd::new("area"));
+        }
     }
 }
 
@@ -534,7 +542,9 @@ impl PineAreaChart {
             return;
         };
         let update = sample.hover_update(self.plot_rect(), self.width, self.height);
+        let hover = chart_hover_payload("area", &update);
         self.hover_fields().apply(update);
+        pocopine::emit(CHART_HOVER_EVENT, hover);
     }
 
     fn plot_rect(&self) -> ChartRect {

--- a/crates/pine-charts/src/bar/PineBarChart.poco
+++ b/crates/pine-charts/src/bar/PineBarChart.poco
@@ -5,7 +5,7 @@
       :data-empty="empty"
       :data-invalid="invalid"
       :data-hover="hover_visible"
-      :data-tooltip="tooltip"
+      :data-tooltip="tooltip_mode"
       :data-animate="animate"
       :data-animation-duration="animation_duration"
       :data-animation-easing="animation_easing"
@@ -118,10 +118,10 @@
     </g>
   </svg>
   <div class="pine-chart-tooltip pine-chart-bar-tooltip"
-       :aria-hidden="hover_visible && tooltip != 'none' ? 'false' : 'true'"
+       :aria-hidden="tooltip_aria_hidden"
        role="status"
        :aria-label="hover_aria_label"
-       :style="hover_visible && tooltip != 'none' ? hover_style : (tooltip == 'none' ? 'display: none;' : '')"
+       :style="hover_style"
        :data-tooltip-x="hover_placement_x"
        :data-tooltip-y="hover_placement_y"
        :data-category="hover_category"

--- a/crates/pine-charts/src/bar/PineBarChart.poco
+++ b/crates/pine-charts/src/bar/PineBarChart.poco
@@ -5,6 +5,7 @@
       :data-empty="empty"
       :data-invalid="invalid"
       :data-hover="hover_visible"
+      :data-tooltip="tooltip"
       :data-animate="animate"
       :data-animation-duration="animation_duration"
       :data-animation-easing="animation_easing"
@@ -117,10 +118,10 @@
     </g>
   </svg>
   <div class="pine-chart-tooltip pine-chart-bar-tooltip"
-       :aria-hidden="hover_visible ? 'false' : 'true'"
+       :aria-hidden="hover_visible && tooltip != 'none' ? 'false' : 'true'"
        role="status"
        :aria-label="hover_aria_label"
-       :style="hover_style"
+       :style="hover_visible && tooltip != 'none' ? hover_style : (tooltip == 'none' ? 'display: none;' : '')"
        :data-tooltip-x="hover_placement_x"
        :data-tooltip-y="hover_placement_y"
        :data-category="hover_category"

--- a/crates/pine-charts/src/bar/mod.rs
+++ b/crates/pine-charts/src/bar/mod.rs
@@ -4,9 +4,10 @@ use serde::{Deserialize, Serialize};
 use crate::animation::{animation_style, DEFAULT_ANIMATION_DURATION_MS, DEFAULT_ANIMATION_EASING};
 use crate::cartesian::{
     expanded_domain, grid_lines_for_y, optional_domain, plot_rect_from_edges,
-    pointer_event_svg_point, step_key, tick_labels_for_y, x_axis_label, y_axis_label,
-    CartesianChartState, CartesianHoverPlacement, CategoricalGuideFields, CategoricalGuideUpdate,
-    ChartStateFields, PlotEdgeFields, DEFAULT_EMPTY_MESSAGE,
+    pointer_event_svg_point, step_key, tick_labels_for_y, tooltip_aria_hidden, tooltip_mode,
+    x_axis_label, y_axis_label, CartesianChartState, CartesianHoverPlacement,
+    CategoricalGuideFields, CategoricalGuideUpdate, ChartStateFields, PlotEdgeFields,
+    DEFAULT_EMPTY_MESSAGE,
 };
 use crate::error::{finite, ChartError, ChartResult};
 use crate::events::{
@@ -592,6 +593,8 @@ pub struct PineBarChart {
     pub animation_easing: String,
     #[prop]
     pub tooltip: String,
+    pub tooltip_mode: String,
+    pub tooltip_aria_hidden: String,
     pub animation_style: String,
     pub state: String,
     pub view_box: String,
@@ -652,6 +655,8 @@ impl Default for PineBarChart {
             animation_duration: DEFAULT_ANIMATION_DURATION_MS,
             animation_easing: DEFAULT_ANIMATION_EASING.into(),
             tooltip: "default".into(),
+            tooltip_mode: "default".into(),
+            tooltip_aria_hidden: "true".into(),
             animation_style: animation_style(
                 DEFAULT_ANIMATION_DURATION_MS,
                 DEFAULT_ANIMATION_EASING,
@@ -695,6 +700,7 @@ impl Default for PineBarChart {
 impl PineBarChart {
     fn on_setup(&mut self) {
         self.update_animation_style();
+        self.sync_tooltip_state();
         self.recompute();
     }
 
@@ -711,6 +717,11 @@ impl PineBarChart {
     #[watch(animation_easing)]
     fn on_animation_easing(&mut self, _: String, _: Option<String>) {
         self.update_animation_style();
+    }
+
+    #[watch(tooltip)]
+    fn on_tooltip(&mut self, _: String, _: Option<String>) {
+        self.sync_tooltip_state();
     }
 
     #[watch(data)]
@@ -802,6 +813,7 @@ impl PineBarChart {
         self.hover_placement_x = "right".into();
         self.hover_placement_y = "above".into();
         self.hover_style.clear();
+        self.sync_tooltip_state();
         if was_visible {
             pocopine::emit(CHART_HOVER_END_EVENT, ChartHoverEnd::new("bar"));
         }
@@ -837,6 +849,12 @@ impl PineBarChart {
 impl PineBarChart {
     fn update_animation_style(&mut self) {
         self.animation_style = animation_style(self.animation_duration, &self.animation_easing);
+    }
+
+    fn sync_tooltip_state(&mut self) {
+        self.tooltip_mode = tooltip_mode(&self.tooltip).into();
+        self.tooltip_aria_hidden =
+            tooltip_aria_hidden(&self.tooltip_mode, self.hover_visible).into();
     }
 
     fn recompute(&mut self) {
@@ -966,6 +984,7 @@ impl PineBarChart {
         self.hover_placement_x = update.placement.x.into();
         self.hover_placement_y = update.placement.y.into();
         self.hover_style = update.placement.style;
+        self.sync_tooltip_state();
         pocopine::emit(CHART_HOVER_EVENT, hover);
     }
 

--- a/crates/pine-charts/src/bar/mod.rs
+++ b/crates/pine-charts/src/bar/mod.rs
@@ -9,7 +9,10 @@ use crate::cartesian::{
     ChartStateFields, PlotEdgeFields, DEFAULT_EMPTY_MESSAGE,
 };
 use crate::error::{finite, ChartError, ChartResult};
-use crate::events::{ChartSelection, CHART_SELECT_EVENT};
+use crate::events::{
+    ChartHover, ChartHoverEnd, ChartSelection, CHART_HOVER_END_EVENT, CHART_HOVER_EVENT,
+    CHART_SELECT_EVENT,
+};
 use crate::geometry::{ChartMargins, ChartRect, Point};
 use crate::legend::{series_label_or_default, series_legend_items_with_visibility, LegendItem};
 use crate::scale::{BandScale, LinearScale};
@@ -587,6 +590,8 @@ pub struct PineBarChart {
     pub animation_duration: f64,
     #[prop]
     pub animation_easing: String,
+    #[prop]
+    pub tooltip: String,
     pub animation_style: String,
     pub state: String,
     pub view_box: String,
@@ -646,6 +651,7 @@ impl Default for PineBarChart {
             animate: false,
             animation_duration: DEFAULT_ANIMATION_DURATION_MS,
             animation_easing: DEFAULT_ANIMATION_EASING.into(),
+            tooltip: "default".into(),
             animation_style: animation_style(
                 DEFAULT_ANIMATION_DURATION_MS,
                 DEFAULT_ANIMATION_EASING,
@@ -785,6 +791,7 @@ impl PineBarChart {
     }
 
     pub fn clear_hover(&mut self) {
+        let was_visible = self.hover_visible;
         self.hover_visible = false;
         self.hover_key.clear();
         self.hover_category.clear();
@@ -795,6 +802,9 @@ impl PineBarChart {
         self.hover_placement_x = "right".into();
         self.hover_placement_y = "above".into();
         self.hover_style.clear();
+        if was_visible {
+            pocopine::emit(CHART_HOVER_END_EVENT, ChartHoverEnd::new("bar"));
+        }
     }
 
     pub fn select_bar(&mut self, key: String) {
@@ -933,6 +943,19 @@ impl PineBarChart {
     }
 
     fn apply_hover(&mut self, update: BarHoverUpdate) {
+        let hover = ChartHover::category(
+            "bar",
+            update.key.clone(),
+            update.category.clone(),
+            update.aria_label.clone(),
+            update.category.clone(),
+            update.series.clone(),
+            update.value,
+            update.value_label.clone(),
+            update.placement.x,
+            update.placement.y,
+            update.placement.style.clone(),
+        );
         self.hover_visible = true;
         self.hover_key = update.key;
         self.hover_category = update.category;
@@ -943,6 +966,7 @@ impl PineBarChart {
         self.hover_placement_x = update.placement.x.into();
         self.hover_placement_y = update.placement.y.into();
         self.hover_style = update.placement.style;
+        pocopine::emit(CHART_HOVER_EVENT, hover);
     }
 
     fn plot_rect(&self) -> ChartRect {

--- a/crates/pine-charts/src/cartesian.rs
+++ b/crates/pine-charts/src/cartesian.rs
@@ -174,10 +174,11 @@ impl CartesianHoverUpdate {
 }
 
 pub(crate) fn chart_hover_payload(chart: &str, update: &CartesianHoverUpdate) -> ChartHover {
+    let label = format!("x {}, y {}", update.sample.x_label, update.sample.y_label);
     ChartHover::xy(
         chart,
         update.sample.key.clone(),
-        update.sample.aria_label.clone(),
+        label,
         update.sample.aria_label.clone(),
         update.sample.series.clone(),
         update.sample.data_x,
@@ -188,6 +189,22 @@ pub(crate) fn chart_hover_payload(chart: &str, update: &CartesianHoverUpdate) ->
         update.placement.y,
         update.placement.style.clone(),
     )
+}
+
+pub(crate) fn tooltip_mode(value: &str) -> &'static str {
+    if value.trim().eq_ignore_ascii_case("none") {
+        "none"
+    } else {
+        "default"
+    }
+}
+
+pub(crate) fn tooltip_aria_hidden(mode: &str, hover_visible: bool) -> &'static str {
+    if hover_visible && mode != "none" {
+        "false"
+    } else {
+        "true"
+    }
 }
 
 pub(crate) struct CartesianHoverFields<'a> {

--- a/crates/pine-charts/src/cartesian.rs
+++ b/crates/pine-charts/src/cartesian.rs
@@ -1,6 +1,7 @@
 use wasm_bindgen::JsCast;
 
 use crate::error::{finite, ChartError, ChartResult};
+use crate::events::ChartHover;
 use crate::geometry::{ChartMargins, ChartRect, Point};
 use crate::scale::LinearScale;
 use crate::svg::{format_tick, SvgAxisLabel, SvgLine, SvgTickLabel};
@@ -147,6 +148,7 @@ pub(crate) enum CartesianChartState {
 
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct CartesianHoverSample {
+    pub key: String,
     pub point: Point,
     pub data_x: f64,
     pub data_y: f64,
@@ -169,6 +171,23 @@ impl CartesianHoverUpdate {
             sample,
         }
     }
+}
+
+pub(crate) fn chart_hover_payload(chart: &str, update: &CartesianHoverUpdate) -> ChartHover {
+    ChartHover::xy(
+        chart,
+        update.sample.key.clone(),
+        update.sample.aria_label.clone(),
+        update.sample.aria_label.clone(),
+        update.sample.series.clone(),
+        update.sample.data_x,
+        update.sample.data_y,
+        update.sample.x_label.clone(),
+        update.sample.y_label.clone(),
+        update.placement.x,
+        update.placement.y,
+        update.placement.style.clone(),
+    )
 }
 
 pub(crate) struct CartesianHoverFields<'a> {

--- a/crates/pine-charts/src/events.rs
+++ b/crates/pine-charts/src/events.rs
@@ -1,7 +1,17 @@
+#[cfg(target_arch = "wasm32")]
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
 pub const CHART_SELECT_EVENT: &str = "pp:chart:select";
+pub const CHART_HOVER_EVENT: &str = "pp:chart:hover";
+pub const CHART_HOVER_END_EVENT: &str = "pp:chart:hover-end";
 pub const LEGEND_TOGGLE_EVENT: &str = "pp:chart:legend-toggle";
+
+#[cfg(target_arch = "wasm32")]
+fn from_event_detail<T: DeserializeOwned>(event: wasm_bindgen::JsValue) -> Option<T> {
+    let detail = js_sys::Reflect::get(&event, &wasm_bindgen::JsValue::from_str("detail")).ok()?;
+    pocopine::__private::serde_wasm_bindgen::from_value(detail).ok()
+}
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct ChartSelection {
@@ -81,6 +91,173 @@ impl ChartSelection {
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct ChartHover {
+    pub chart: String,
+    pub kind: String,
+    pub key: String,
+    pub label: String,
+    pub aria_label: String,
+    pub series: String,
+    pub category: String,
+    pub x: Option<f64>,
+    pub y: Option<f64>,
+    pub value: Option<f64>,
+    pub percentage: Option<f64>,
+    pub x_label: String,
+    pub y_label: String,
+    pub value_label: String,
+    pub percentage_label: String,
+    pub tooltip_x: String,
+    pub tooltip_y: String,
+    pub tooltip_style: String,
+}
+
+impl ChartHover {
+    #[allow(clippy::too_many_arguments)]
+    pub fn xy(
+        chart: impl Into<String>,
+        key: impl Into<String>,
+        label: impl Into<String>,
+        aria_label: impl Into<String>,
+        series: impl Into<String>,
+        x: f64,
+        y: f64,
+        x_label: impl Into<String>,
+        y_label: impl Into<String>,
+        tooltip_x: impl Into<String>,
+        tooltip_y: impl Into<String>,
+        tooltip_style: impl Into<String>,
+    ) -> Self {
+        Self {
+            chart: chart.into(),
+            kind: "xy".into(),
+            key: key.into(),
+            label: label.into(),
+            aria_label: aria_label.into(),
+            series: series.into(),
+            category: String::new(),
+            x: Some(x),
+            y: Some(y),
+            value: None,
+            percentage: None,
+            x_label: x_label.into(),
+            y_label: y_label.into(),
+            value_label: String::new(),
+            percentage_label: String::new(),
+            tooltip_x: tooltip_x.into(),
+            tooltip_y: tooltip_y.into(),
+            tooltip_style: tooltip_style.into(),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn category(
+        chart: impl Into<String>,
+        key: impl Into<String>,
+        label: impl Into<String>,
+        aria_label: impl Into<String>,
+        category: impl Into<String>,
+        series: impl Into<String>,
+        value: f64,
+        value_label: impl Into<String>,
+        tooltip_x: impl Into<String>,
+        tooltip_y: impl Into<String>,
+        tooltip_style: impl Into<String>,
+    ) -> Self {
+        let category = category.into();
+        Self {
+            chart: chart.into(),
+            kind: "category".into(),
+            key: key.into(),
+            label: label.into(),
+            aria_label: aria_label.into(),
+            series: series.into(),
+            category,
+            x: None,
+            y: None,
+            value: Some(value),
+            percentage: None,
+            x_label: String::new(),
+            y_label: String::new(),
+            value_label: value_label.into(),
+            percentage_label: String::new(),
+            tooltip_x: tooltip_x.into(),
+            tooltip_y: tooltip_y.into(),
+            tooltip_style: tooltip_style.into(),
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn share(
+        chart: impl Into<String>,
+        key: impl Into<String>,
+        label: impl Into<String>,
+        aria_label: impl Into<String>,
+        value: f64,
+        value_label: impl Into<String>,
+        percentage: f64,
+        percentage_label: impl Into<String>,
+        tooltip_x: impl Into<String>,
+        tooltip_y: impl Into<String>,
+        tooltip_style: impl Into<String>,
+    ) -> Self {
+        Self {
+            chart: chart.into(),
+            kind: "share".into(),
+            key: key.into(),
+            label: label.into(),
+            aria_label: aria_label.into(),
+            series: String::new(),
+            category: String::new(),
+            x: None,
+            y: None,
+            value: Some(value),
+            percentage: Some(percentage),
+            x_label: String::new(),
+            y_label: String::new(),
+            value_label: value_label.into(),
+            percentage_label: percentage_label.into(),
+            tooltip_x: tooltip_x.into(),
+            tooltip_y: tooltip_y.into(),
+            tooltip_style: tooltip_style.into(),
+        }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub fn from_event_value(event: wasm_bindgen::JsValue) -> Option<Self> {
+        from_event_detail(event)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn from_event_value(_: wasm_bindgen::JsValue) -> Option<Self> {
+        None
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct ChartHoverEnd {
+    pub chart: String,
+}
+
+impl ChartHoverEnd {
+    pub fn new(chart: impl Into<String>) -> Self {
+        Self {
+            chart: chart.into(),
+        }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub fn from_event_value(event: wasm_bindgen::JsValue) -> Option<Self> {
+        from_event_detail(event)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn from_event_value(_: wasm_bindgen::JsValue) -> Option<Self> {
+        None
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct LegendToggle {
     pub key: String,
     pub label: String,
@@ -91,9 +268,7 @@ pub struct LegendToggle {
 impl LegendToggle {
     #[cfg(target_arch = "wasm32")]
     pub fn from_event_value(event: wasm_bindgen::JsValue) -> Option<Self> {
-        let detail =
-            js_sys::Reflect::get(&event, &wasm_bindgen::JsValue::from_str("detail")).ok()?;
-        pocopine::__private::serde_wasm_bindgen::from_value(detail).ok()
+        from_event_detail(event)
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/crates/pine-charts/src/events.rs
+++ b/crates/pine-charts/src/events.rs
@@ -90,6 +90,17 @@ impl ChartSelection {
     }
 }
 
+/// Payload for `pp:chart:hover`.
+///
+/// `kind` determines which value fields are populated:
+/// - `xy`: line, scatter, and area hovers populate `x`, `y`, `x_label`, and
+///   `y_label`.
+/// - `category`: bar hovers populate `category`, `value`, and `value_label`.
+/// - `share`: pie/donut hovers populate `value`, `value_label`, `percentage`,
+///   and `percentage_label`.
+///
+/// `label` is the concise label suitable for custom UI. `aria_label` mirrors
+/// the rendered mark's accessible label.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct ChartHover {
     pub chart: String,
@@ -234,6 +245,7 @@ impl ChartHover {
     }
 }
 
+/// Payload for `pp:chart:hover-end`.
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct ChartHoverEnd {
     pub chart: String,

--- a/crates/pine-charts/src/lib.rs
+++ b/crates/pine-charts/src/lib.rs
@@ -43,7 +43,10 @@ pub use cartesian_chart::{
     PineChartGrid, PineLineSeries, PineScatterSeries, PineXAxis, PineYAxis,
 };
 pub use error::{ChartError, ChartResult};
-pub use events::{ChartSelection, LegendToggle, CHART_SELECT_EVENT, LEGEND_TOGGLE_EVENT};
+pub use events::{
+    ChartHover, ChartHoverEnd, ChartSelection, LegendToggle, CHART_HOVER_END_EVENT,
+    CHART_HOVER_EVENT, CHART_SELECT_EVENT, LEGEND_TOGGLE_EVENT,
+};
 pub use geometry::{ChartMargins, ChartRect, Point};
 pub use layered::{
     render_layer_chart, ChartLayerGuide, ChartLayerIcon, ChartLayerLabel, ChartLayerLine,

--- a/crates/pine-charts/src/line/PineLineChart.poco
+++ b/crates/pine-charts/src/line/PineLineChart.poco
@@ -5,7 +5,7 @@
       :data-empty="empty"
       :data-invalid="invalid"
       :data-hover="hover_visible"
-      :data-tooltip="tooltip"
+      :data-tooltip="tooltip_mode"
       :data-animate="animate"
       :data-animation-duration="animation_duration"
       :data-animation-easing="animation_easing"
@@ -162,10 +162,10 @@
     </g>
   </svg>
   <div class="pine-chart-tooltip"
-       :aria-hidden="hover_visible && tooltip != 'none' ? 'false' : 'true'"
+       :aria-hidden="tooltip_aria_hidden"
        role="status"
        :aria-label="hover_aria_label"
-       :style="hover_visible && tooltip != 'none' ? hover_style : (tooltip == 'none' ? 'display: none;' : '')"
+       :style="hover_style"
        :data-tooltip-x="hover_placement_x"
        :data-tooltip-y="hover_placement_y"
        :data-x="hover_data_x"

--- a/crates/pine-charts/src/line/PineLineChart.poco
+++ b/crates/pine-charts/src/line/PineLineChart.poco
@@ -5,6 +5,7 @@
       :data-empty="empty"
       :data-invalid="invalid"
       :data-hover="hover_visible"
+      :data-tooltip="tooltip"
       :data-animate="animate"
       :data-animation-duration="animation_duration"
       :data-animation-easing="animation_easing"
@@ -161,10 +162,10 @@
     </g>
   </svg>
   <div class="pine-chart-tooltip"
-       :aria-hidden="hover_visible ? 'false' : 'true'"
+       :aria-hidden="hover_visible && tooltip != 'none' ? 'false' : 'true'"
        role="status"
        :aria-label="hover_aria_label"
-       :style="hover_style"
+       :style="hover_visible && tooltip != 'none' ? hover_style : (tooltip == 'none' ? 'display: none;' : '')"
        :data-tooltip-x="hover_placement_x"
        :data-tooltip-y="hover_placement_y"
        :data-x="hover_data_x"

--- a/crates/pine-charts/src/line/mod.rs
+++ b/crates/pine-charts/src/line/mod.rs
@@ -4,9 +4,10 @@ use serde::{Deserialize, Serialize};
 use crate::animation::{animation_style, DEFAULT_ANIMATION_DURATION_MS, DEFAULT_ANIMATION_EASING};
 use crate::cartesian::{
     centered_plot_y, chart_hover_payload, nearest_sample_by_point, nearest_sample_by_x,
-    optional_domain, plot_rect_from_edges, pointer_event_svg_point, step_key, CartesianChartState,
-    CartesianGuideFields, CartesianGuideUpdate, CartesianHoverFields, CartesianHoverSample,
-    CartesianHoverUpdate, CartesianLayout, ChartStateFields, PlotEdgeFields, DEFAULT_EMPTY_MESSAGE,
+    optional_domain, plot_rect_from_edges, pointer_event_svg_point, step_key, tooltip_aria_hidden,
+    tooltip_mode, CartesianChartState, CartesianGuideFields, CartesianGuideUpdate,
+    CartesianHoverFields, CartesianHoverSample, CartesianHoverUpdate, CartesianLayout,
+    ChartStateFields, PlotEdgeFields, DEFAULT_EMPTY_MESSAGE,
 };
 use crate::error::{finite, ChartError, ChartResult};
 use crate::events::{
@@ -381,6 +382,8 @@ pub struct PineLineChart {
     pub animation_easing: String,
     #[prop]
     pub tooltip: String,
+    pub tooltip_mode: String,
+    pub tooltip_aria_hidden: String,
     pub animation_style: String,
     pub state: String,
     pub view_box: String,
@@ -443,6 +446,8 @@ impl Default for PineLineChart {
             animation_duration: DEFAULT_ANIMATION_DURATION_MS,
             animation_easing: DEFAULT_ANIMATION_EASING.into(),
             tooltip: "default".into(),
+            tooltip_mode: "default".into(),
+            tooltip_aria_hidden: "true".into(),
             animation_style: animation_style(
                 DEFAULT_ANIMATION_DURATION_MS,
                 DEFAULT_ANIMATION_EASING,
@@ -491,6 +496,7 @@ impl Default for PineLineChart {
 impl PineLineChart {
     fn on_setup(&mut self) {
         self.update_animation_style();
+        self.sync_tooltip_state();
         self.recompute();
     }
 
@@ -507,6 +513,11 @@ impl PineLineChart {
     #[watch(animation_easing)]
     fn on_animation_easing(&mut self, _: String, _: Option<String>) {
         self.update_animation_style();
+    }
+
+    #[watch(tooltip)]
+    fn on_tooltip(&mut self, _: String, _: Option<String>) {
+        self.sync_tooltip_state();
     }
 
     #[watch(points)]
@@ -579,6 +590,7 @@ impl PineLineChart {
     pub fn clear_hover(&mut self) {
         let was_visible = self.hover_visible;
         self.hover_fields().clear();
+        self.sync_tooltip_state();
         if was_visible {
             pocopine::emit(CHART_HOVER_END_EVENT, ChartHoverEnd::new("line"));
         }
@@ -614,6 +626,12 @@ impl PineLineChart {
 impl PineLineChart {
     fn update_animation_style(&mut self) {
         self.animation_style = animation_style(self.animation_duration, &self.animation_easing);
+    }
+
+    fn sync_tooltip_state(&mut self) {
+        self.tooltip_mode = tooltip_mode(&self.tooltip).into();
+        self.tooltip_aria_hidden =
+            tooltip_aria_hidden(&self.tooltip_mode, self.hover_visible).into();
     }
 
     fn recompute(&mut self) {
@@ -707,6 +725,7 @@ impl PineLineChart {
         let update = sample.hover_update(self.plot_rect(), self.width, self.height);
         let hover = chart_hover_payload("line", &update);
         self.hover_fields().apply(update);
+        self.sync_tooltip_state();
         pocopine::emit(CHART_HOVER_EVENT, hover);
     }
 

--- a/crates/pine-charts/src/line/mod.rs
+++ b/crates/pine-charts/src/line/mod.rs
@@ -3,13 +3,15 @@ use serde::{Deserialize, Serialize};
 
 use crate::animation::{animation_style, DEFAULT_ANIMATION_DURATION_MS, DEFAULT_ANIMATION_EASING};
 use crate::cartesian::{
-    centered_plot_y, nearest_sample_by_point, nearest_sample_by_x, optional_domain,
-    plot_rect_from_edges, pointer_event_svg_point, step_key, CartesianChartState,
+    centered_plot_y, chart_hover_payload, nearest_sample_by_point, nearest_sample_by_x,
+    optional_domain, plot_rect_from_edges, pointer_event_svg_point, step_key, CartesianChartState,
     CartesianGuideFields, CartesianGuideUpdate, CartesianHoverFields, CartesianHoverSample,
     CartesianHoverUpdate, CartesianLayout, ChartStateFields, PlotEdgeFields, DEFAULT_EMPTY_MESSAGE,
 };
 use crate::error::{finite, ChartError, ChartResult};
-use crate::events::{ChartSelection, CHART_SELECT_EVENT};
+use crate::events::{
+    ChartHoverEnd, ChartSelection, CHART_HOVER_END_EVENT, CHART_HOVER_EVENT, CHART_SELECT_EVENT,
+};
 use crate::geometry::{ChartMargins, ChartRect, Point};
 use crate::legend::{series_label_or_default, series_legend_items_with_visibility};
 use crate::path::line_path;
@@ -232,6 +234,7 @@ impl LineChartSample {
     ) -> CartesianHoverUpdate {
         CartesianHoverUpdate::new(
             CartesianHoverSample {
+                key: self.key.clone(),
                 point: Point {
                     x: self.x,
                     y: self.y,
@@ -376,6 +379,8 @@ pub struct PineLineChart {
     pub animation_duration: f64,
     #[prop]
     pub animation_easing: String,
+    #[prop]
+    pub tooltip: String,
     pub animation_style: String,
     pub state: String,
     pub view_box: String,
@@ -437,6 +442,7 @@ impl Default for PineLineChart {
             animate: false,
             animation_duration: DEFAULT_ANIMATION_DURATION_MS,
             animation_easing: DEFAULT_ANIMATION_EASING.into(),
+            tooltip: "default".into(),
             animation_style: animation_style(
                 DEFAULT_ANIMATION_DURATION_MS,
                 DEFAULT_ANIMATION_EASING,
@@ -571,7 +577,11 @@ impl PineLineChart {
     }
 
     pub fn clear_hover(&mut self) {
+        let was_visible = self.hover_visible;
         self.hover_fields().clear();
+        if was_visible {
+            pocopine::emit(CHART_HOVER_END_EVENT, ChartHoverEnd::new("line"));
+        }
     }
 
     pub fn select_sample(&mut self, key: String) {
@@ -695,7 +705,9 @@ impl PineLineChart {
             return;
         };
         let update = sample.hover_update(self.plot_rect(), self.width, self.height);
+        let hover = chart_hover_payload("line", &update);
         self.hover_fields().apply(update);
+        pocopine::emit(CHART_HOVER_EVENT, hover);
     }
 
     fn plot_rect(&self) -> ChartRect {

--- a/crates/pine-charts/src/pie/PinePieChart.poco
+++ b/crates/pine-charts/src/pie/PinePieChart.poco
@@ -6,7 +6,7 @@
       :data-invalid="invalid"
       :data-donut="inner_radius > 0"
       :data-hover="hover_visible"
-      :data-tooltip="tooltip"
+      :data-tooltip="tooltip_mode"
       :data-animate="animate"
       :data-slice-animating="animating_slices"
       :data-animation-duration="animation_duration"
@@ -85,10 +85,10 @@
     </g>
   </svg>
   <div class="pine-chart-tooltip pine-chart-pie-tooltip"
-       :aria-hidden="hover_visible && tooltip != 'none' ? 'false' : 'true'"
+       :aria-hidden="tooltip_aria_hidden"
        role="status"
        :aria-label="hover_aria_label"
-       :style="hover_visible && tooltip != 'none' ? hover_style : (tooltip == 'none' ? 'display: none;' : '')"
+       :style="hover_style"
        :data-tooltip-x="hover_placement_x"
        :data-tooltip-y="hover_placement_y"
        :data-label="hover_label"

--- a/crates/pine-charts/src/pie/PinePieChart.poco
+++ b/crates/pine-charts/src/pie/PinePieChart.poco
@@ -6,6 +6,7 @@
       :data-invalid="invalid"
       :data-donut="inner_radius > 0"
       :data-hover="hover_visible"
+      :data-tooltip="tooltip"
       :data-animate="animate"
       :data-slice-animating="animating_slices"
       :data-animation-duration="animation_duration"
@@ -84,10 +85,10 @@
     </g>
   </svg>
   <div class="pine-chart-tooltip pine-chart-pie-tooltip"
-       :aria-hidden="hover_visible ? 'false' : 'true'"
+       :aria-hidden="hover_visible && tooltip != 'none' ? 'false' : 'true'"
        role="status"
        :aria-label="hover_aria_label"
-       :style="hover_style"
+       :style="hover_visible && tooltip != 'none' ? hover_style : (tooltip == 'none' ? 'display: none;' : '')"
        :data-tooltip-x="hover_placement_x"
        :data-tooltip-y="hover_placement_y"
        :data-label="hover_label"

--- a/crates/pine-charts/src/pie/mod.rs
+++ b/crates/pine-charts/src/pie/mod.rs
@@ -8,8 +8,8 @@ use crate::animation::{
     animation_duration_ms, animation_style, DEFAULT_ANIMATION_DURATION_MS, DEFAULT_ANIMATION_EASING,
 };
 use crate::cartesian::{
-    pointer_event_svg_point, step_key, CartesianHoverPlacement, ChartStateFields,
-    DEFAULT_EMPTY_MESSAGE,
+    pointer_event_svg_point, step_key, tooltip_aria_hidden, tooltip_mode, CartesianHoverPlacement,
+    ChartStateFields, DEFAULT_EMPTY_MESSAGE,
 };
 use crate::error::{finite, ChartError, ChartResult};
 use crate::events::{
@@ -338,6 +338,8 @@ pub struct PinePieChart {
     pub animation_easing: String,
     #[prop]
     pub tooltip: String,
+    pub tooltip_mode: String,
+    pub tooltip_aria_hidden: String,
     pub animation_style: String,
     pub animation_generation: u32,
     pub animating_slices: bool,
@@ -399,6 +401,8 @@ impl Default for PinePieChart {
             animation_duration: DEFAULT_ANIMATION_DURATION_MS,
             animation_easing: DEFAULT_ANIMATION_EASING.into(),
             tooltip: "default".into(),
+            tooltip_mode: "default".into(),
+            tooltip_aria_hidden: "true".into(),
             animation_style: animation_style(
                 DEFAULT_ANIMATION_DURATION_MS,
                 DEFAULT_ANIMATION_EASING,
@@ -447,6 +451,7 @@ impl Default for PinePieChart {
 impl PinePieChart {
     fn on_setup(&mut self) {
         self.update_animation_style();
+        self.sync_tooltip_state();
         self.recompute();
     }
 
@@ -463,6 +468,11 @@ impl PinePieChart {
     #[watch(animation_easing)]
     fn on_animation_easing(&mut self, _: String, _: Option<String>) {
         self.update_animation_style();
+    }
+
+    #[watch(tooltip)]
+    fn on_tooltip(&mut self, _: String, _: Option<String>) {
+        self.sync_tooltip_state();
     }
 
     #[watch(data)]
@@ -547,6 +557,7 @@ impl PinePieChart {
         self.hover_placement_y = "above".into();
         self.hover_style.clear();
         self.hover_slice = SvgPieSlice::default();
+        self.sync_tooltip_state();
         if was_visible {
             pocopine::emit(CHART_HOVER_END_EVENT, ChartHoverEnd::new("pie"));
         }
@@ -582,6 +593,12 @@ impl PinePieChart {
 impl PinePieChart {
     fn update_animation_style(&mut self) {
         self.animation_style = animation_style(self.animation_duration, &self.animation_easing);
+    }
+
+    fn sync_tooltip_state(&mut self) {
+        self.tooltip_mode = tooltip_mode(&self.tooltip).into();
+        self.tooltip_aria_hidden =
+            tooltip_aria_hidden(&self.tooltip_mode, self.hover_visible).into();
     }
 
     fn recompute(&mut self) {
@@ -1039,6 +1056,7 @@ impl PinePieChart {
         self.hover_style = update.placement.style;
         self.sync_hover_slice();
         self.update_hover_overlay_visibility();
+        self.sync_tooltip_state();
         pocopine::emit(CHART_HOVER_EVENT, hover);
     }
 

--- a/crates/pine-charts/src/pie/mod.rs
+++ b/crates/pine-charts/src/pie/mod.rs
@@ -12,7 +12,10 @@ use crate::cartesian::{
     DEFAULT_EMPTY_MESSAGE,
 };
 use crate::error::{finite, ChartError, ChartResult};
-use crate::events::{ChartSelection, CHART_SELECT_EVENT};
+use crate::events::{
+    ChartHover, ChartHoverEnd, ChartSelection, CHART_HOVER_END_EVENT, CHART_HOVER_EVENT,
+    CHART_SELECT_EVENT,
+};
 use crate::geometry::{ChartMargins, ChartRect, Point};
 use crate::legend::LegendItem;
 use crate::svg::format_tick;
@@ -333,6 +336,8 @@ pub struct PinePieChart {
     pub animation_duration: f64,
     #[prop]
     pub animation_easing: String,
+    #[prop]
+    pub tooltip: String,
     pub animation_style: String,
     pub animation_generation: u32,
     pub animating_slices: bool,
@@ -393,6 +398,7 @@ impl Default for PinePieChart {
             animate: false,
             animation_duration: DEFAULT_ANIMATION_DURATION_MS,
             animation_easing: DEFAULT_ANIMATION_EASING.into(),
+            tooltip: "default".into(),
             animation_style: animation_style(
                 DEFAULT_ANIMATION_DURATION_MS,
                 DEFAULT_ANIMATION_EASING,
@@ -527,6 +533,7 @@ impl PinePieChart {
     }
 
     pub fn clear_hover(&mut self) {
+        let was_visible = self.hover_visible;
         self.hover_visible = false;
         self.hover_overlay_visible = false;
         self.hover_key.clear();
@@ -540,6 +547,9 @@ impl PinePieChart {
         self.hover_placement_y = "above".into();
         self.hover_style.clear();
         self.hover_slice = SvgPieSlice::default();
+        if was_visible {
+            pocopine::emit(CHART_HOVER_END_EVENT, ChartHoverEnd::new("pie"));
+        }
     }
 
     pub fn select_slice(&mut self, key: String) {
@@ -1003,6 +1013,19 @@ impl PinePieChart {
     }
 
     fn apply_hover(&mut self, update: PieHoverUpdate) {
+        let hover = ChartHover::share(
+            "pie",
+            update.key.clone(),
+            update.label.clone(),
+            update.aria_label.clone(),
+            update.value,
+            update.value_label.clone(),
+            update.percentage,
+            update.percentage_label.clone(),
+            update.placement.x,
+            update.placement.y,
+            update.placement.style.clone(),
+        );
         self.hover_visible = true;
         self.hover_key = update.key;
         self.hover_label = update.label;
@@ -1016,6 +1039,7 @@ impl PinePieChart {
         self.hover_style = update.placement.style;
         self.sync_hover_slice();
         self.update_hover_overlay_visibility();
+        pocopine::emit(CHART_HOVER_EVENT, hover);
     }
 
     fn sync_hover_slice(&mut self) {

--- a/crates/pine-charts/src/scatter/PineScatterChart.poco
+++ b/crates/pine-charts/src/scatter/PineScatterChart.poco
@@ -5,6 +5,7 @@
       :data-empty="empty"
       :data-invalid="invalid"
       :data-hover="hover_visible"
+      :data-tooltip="tooltip"
       :data-animate="animate"
       :data-animation-duration="animation_duration"
       :data-animation-easing="animation_easing"
@@ -151,10 +152,10 @@
     </g>
   </svg>
   <div class="pine-chart-tooltip"
-       :aria-hidden="hover_visible ? 'false' : 'true'"
+       :aria-hidden="hover_visible && tooltip != 'none' ? 'false' : 'true'"
        role="status"
        :aria-label="hover_aria_label"
-       :style="hover_style"
+       :style="hover_visible && tooltip != 'none' ? hover_style : (tooltip == 'none' ? 'display: none;' : '')"
        :data-tooltip-x="hover_placement_x"
        :data-tooltip-y="hover_placement_y"
        :data-x="hover_data_x"

--- a/crates/pine-charts/src/scatter/PineScatterChart.poco
+++ b/crates/pine-charts/src/scatter/PineScatterChart.poco
@@ -5,7 +5,7 @@
       :data-empty="empty"
       :data-invalid="invalid"
       :data-hover="hover_visible"
-      :data-tooltip="tooltip"
+      :data-tooltip="tooltip_mode"
       :data-animate="animate"
       :data-animation-duration="animation_duration"
       :data-animation-easing="animation_easing"
@@ -152,10 +152,10 @@
     </g>
   </svg>
   <div class="pine-chart-tooltip"
-       :aria-hidden="hover_visible && tooltip != 'none' ? 'false' : 'true'"
+       :aria-hidden="tooltip_aria_hidden"
        role="status"
        :aria-label="hover_aria_label"
-       :style="hover_visible && tooltip != 'none' ? hover_style : (tooltip == 'none' ? 'display: none;' : '')"
+       :style="hover_style"
        :data-tooltip-x="hover_placement_x"
        :data-tooltip-y="hover_placement_y"
        :data-x="hover_data_x"

--- a/crates/pine-charts/src/scatter/mod.rs
+++ b/crates/pine-charts/src/scatter/mod.rs
@@ -3,12 +3,15 @@ use serde::{Deserialize, Serialize};
 
 use crate::animation::{animation_style, DEFAULT_ANIMATION_DURATION_MS, DEFAULT_ANIMATION_EASING};
 use crate::cartesian::{
-    nearest_sample_by_point, optional_domain, plot_rect_from_edges, pointer_event_svg_point,
-    step_key, CartesianChartState, CartesianGuideFields, CartesianGuideUpdate,
-    CartesianHoverFields, ChartStateFields, PlotEdgeFields, DEFAULT_EMPTY_MESSAGE,
+    chart_hover_payload, nearest_sample_by_point, optional_domain, plot_rect_from_edges,
+    pointer_event_svg_point, step_key, CartesianChartState, CartesianGuideFields,
+    CartesianGuideUpdate, CartesianHoverFields, ChartStateFields, PlotEdgeFields,
+    DEFAULT_EMPTY_MESSAGE,
 };
 use crate::error::{ChartError, ChartResult};
-use crate::events::{ChartSelection, CHART_SELECT_EVENT};
+use crate::events::{
+    ChartHoverEnd, ChartSelection, CHART_HOVER_END_EVENT, CHART_HOVER_EVENT, CHART_SELECT_EVENT,
+};
 use crate::geometry::{ChartMargins, ChartRect, Point};
 use crate::legend::{series_label_or_default, series_legend_items_with_visibility};
 use crate::line::{ChartLineSeries, ChartPoint, LineChartGeometry, LineChartOptions};
@@ -187,6 +190,8 @@ pub struct PineScatterChart {
     pub animation_duration: f64,
     #[prop]
     pub animation_easing: String,
+    #[prop]
+    pub tooltip: String,
     pub animation_style: String,
     pub state: String,
     pub view_box: String,
@@ -248,6 +253,7 @@ impl Default for PineScatterChart {
             animate: false,
             animation_duration: DEFAULT_ANIMATION_DURATION_MS,
             animation_easing: DEFAULT_ANIMATION_EASING.into(),
+            tooltip: "default".into(),
             animation_style: animation_style(
                 DEFAULT_ANIMATION_DURATION_MS,
                 DEFAULT_ANIMATION_EASING,
@@ -380,7 +386,11 @@ impl PineScatterChart {
     }
 
     pub fn clear_hover(&mut self) {
+        let was_visible = self.hover_visible;
         self.hover_fields().clear();
+        if was_visible {
+            pocopine::emit(CHART_HOVER_END_EVENT, ChartHoverEnd::new("scatter"));
+        }
     }
 
     pub fn select_sample(&mut self, key: String) {
@@ -496,7 +506,9 @@ impl PineScatterChart {
             return;
         };
         let update = sample.hover_update(self.plot_rect(), self.width, self.height);
+        let hover = chart_hover_payload("scatter", &update);
         self.hover_fields().apply(update);
+        pocopine::emit(CHART_HOVER_EVENT, hover);
     }
 
     fn plot_rect(&self) -> ChartRect {

--- a/crates/pine-charts/src/scatter/mod.rs
+++ b/crates/pine-charts/src/scatter/mod.rs
@@ -4,9 +4,9 @@ use serde::{Deserialize, Serialize};
 use crate::animation::{animation_style, DEFAULT_ANIMATION_DURATION_MS, DEFAULT_ANIMATION_EASING};
 use crate::cartesian::{
     chart_hover_payload, nearest_sample_by_point, optional_domain, plot_rect_from_edges,
-    pointer_event_svg_point, step_key, CartesianChartState, CartesianGuideFields,
-    CartesianGuideUpdate, CartesianHoverFields, ChartStateFields, PlotEdgeFields,
-    DEFAULT_EMPTY_MESSAGE,
+    pointer_event_svg_point, step_key, tooltip_aria_hidden, tooltip_mode, CartesianChartState,
+    CartesianGuideFields, CartesianGuideUpdate, CartesianHoverFields, ChartStateFields,
+    PlotEdgeFields, DEFAULT_EMPTY_MESSAGE,
 };
 use crate::error::{ChartError, ChartResult};
 use crate::events::{
@@ -192,6 +192,8 @@ pub struct PineScatterChart {
     pub animation_easing: String,
     #[prop]
     pub tooltip: String,
+    pub tooltip_mode: String,
+    pub tooltip_aria_hidden: String,
     pub animation_style: String,
     pub state: String,
     pub view_box: String,
@@ -254,6 +256,8 @@ impl Default for PineScatterChart {
             animation_duration: DEFAULT_ANIMATION_DURATION_MS,
             animation_easing: DEFAULT_ANIMATION_EASING.into(),
             tooltip: "default".into(),
+            tooltip_mode: "default".into(),
+            tooltip_aria_hidden: "true".into(),
             animation_style: animation_style(
                 DEFAULT_ANIMATION_DURATION_MS,
                 DEFAULT_ANIMATION_EASING,
@@ -300,6 +304,7 @@ impl Default for PineScatterChart {
 impl PineScatterChart {
     fn on_setup(&mut self) {
         self.update_animation_style();
+        self.sync_tooltip_state();
         self.recompute();
     }
 
@@ -316,6 +321,11 @@ impl PineScatterChart {
     #[watch(animation_easing)]
     fn on_animation_easing(&mut self, _: String, _: Option<String>) {
         self.update_animation_style();
+    }
+
+    #[watch(tooltip)]
+    fn on_tooltip(&mut self, _: String, _: Option<String>) {
+        self.sync_tooltip_state();
     }
 
     #[watch(points)]
@@ -388,6 +398,7 @@ impl PineScatterChart {
     pub fn clear_hover(&mut self) {
         let was_visible = self.hover_visible;
         self.hover_fields().clear();
+        self.sync_tooltip_state();
         if was_visible {
             pocopine::emit(CHART_HOVER_END_EVENT, ChartHoverEnd::new("scatter"));
         }
@@ -423,6 +434,12 @@ impl PineScatterChart {
 impl PineScatterChart {
     fn update_animation_style(&mut self) {
         self.animation_style = animation_style(self.animation_duration, &self.animation_easing);
+    }
+
+    fn sync_tooltip_state(&mut self) {
+        self.tooltip_mode = tooltip_mode(&self.tooltip).into();
+        self.tooltip_aria_hidden =
+            tooltip_aria_hidden(&self.tooltip_mode, self.hover_visible).into();
     }
 
     fn recompute(&mut self) {
@@ -508,6 +525,7 @@ impl PineScatterChart {
         let update = sample.hover_update(self.plot_rect(), self.width, self.height);
         let hover = chart_hover_payload("scatter", &update);
         self.hover_fields().apply(update);
+        self.sync_tooltip_state();
         pocopine::emit(CHART_HOVER_EVENT, hover);
     }
 

--- a/crates/pine-charts/tests/charts.rs
+++ b/crates/pine-charts/tests/charts.rs
@@ -1203,6 +1203,9 @@ async fn scatter_chart_renders_points_axes_and_hover() {
 
     let axis_labels = host.query_selector_all(".pine-chart-axis-label").unwrap();
     assert_eq!(axis_labels.length(), 2);
+    let hover_chart = listen_string_field(&chart, CHART_HOVER_EVENT, "chart");
+    let hover_kind = listen_string_field(&chart, CHART_HOVER_EVENT, "kind");
+    let hover_label = listen_string_field(&chart, CHART_HOVER_EVENT, "label");
 
     let svg = host.query_selector("svg.pine-chart-svg").unwrap().unwrap();
     dispatch_pointer_move(&svg, 95.0, 95.0);
@@ -1224,6 +1227,9 @@ async fn scatter_chart_renders_points_axes_and_hover() {
         tooltip.get_attribute("aria-label").as_deref(),
         Some("Segment B: x 1, y 0")
     );
+    assert_eq!(hover_chart.borrow().as_deref(), Some("scatter"));
+    assert_eq!(hover_kind.borrow().as_deref(), Some("xy"));
+    assert_eq!(hover_label.borrow().as_deref(), Some("x 1, y 0"));
 
     let selected_label = listen_string_field(&chart, CHART_SELECT_EVENT, "label");
     dispatch_click(&first);
@@ -1350,6 +1356,9 @@ async fn area_chart_renders_fills_lines_and_hover_metadata() {
         .query_selector_all(".pine-area-chart .pine-chart-marker")
         .unwrap();
     assert_eq!(markers.length(), 4);
+    let hover_chart = listen_string_field(&chart, CHART_HOVER_EVENT, "chart");
+    let hover_kind = listen_string_field(&chart, CHART_HOVER_EVENT, "kind");
+    let hover_label = listen_string_field(&chart, CHART_HOVER_EVENT, "label");
 
     let svg = host.query_selector("svg.pine-chart-svg").unwrap().unwrap();
     let rect = svg.get_bounding_client_rect();
@@ -1372,6 +1381,9 @@ async fn area_chart_renders_fills_lines_and_hover_metadata() {
         tooltip.get_attribute("aria-label").as_deref(),
         Some("Target: x 1, y 0")
     );
+    assert_eq!(hover_chart.borrow().as_deref(), Some("area"));
+    assert_eq!(hover_kind.borrow().as_deref(), Some("xy"));
+    assert_eq!(hover_label.borrow().as_deref(), Some("x 1, y 0"));
 
     host.remove();
 }
@@ -1472,14 +1484,15 @@ async fn line_chart_emits_hover_events_and_allows_custom_tooltips() {
     settle().await;
 
     let tooltip = host.query_selector(".pine-chart-tooltip").unwrap().unwrap();
+    assert_eq!(chart.get_attribute("data-tooltip").as_deref(), Some("none"));
     assert_eq!(
         tooltip.get_attribute("aria-hidden").as_deref(),
         Some("true")
     );
-    assert_eq!(
-        tooltip.get_attribute("style").as_deref(),
-        Some("display: none;")
-    );
+    assert!(tooltip
+        .get_attribute("style")
+        .unwrap_or_default()
+        .contains("--pine-chart-tooltip-x: 50%"));
     assert_eq!(hover_chart.borrow().as_deref(), Some("line"));
     assert_eq!(hover_kind.borrow().as_deref(), Some("xy"));
     assert_eq!(hover_label.borrow().as_deref(), Some("x 5, y 10"));
@@ -2310,6 +2323,9 @@ async fn pie_chart_renders_donut_slices_and_selection() {
 
     let svg = host.query_selector("svg.pine-chart-svg").unwrap().unwrap();
     assert_eq!(direct_svg_layers(&svg), vec!["series", "hover", "labels"]);
+    let hover_chart = listen_string_field(&chart, CHART_HOVER_EVENT, "chart");
+    let hover_kind = listen_string_field(&chart, CHART_HOVER_EVENT, "kind");
+    let hover_label = listen_string_field(&chart, CHART_HOVER_EVENT, "label");
     dispatch_pointer_move(&svg, 50.0, 10.0);
     settle().await;
 
@@ -2339,6 +2355,9 @@ async fn pie_chart_renders_donut_slices_and_selection() {
         tooltip.get_attribute("data-percentage").as_deref(),
         Some("75")
     );
+    assert_eq!(hover_chart.borrow().as_deref(), Some("pie"));
+    assert_eq!(hover_kind.borrow().as_deref(), Some("share"));
+    assert_eq!(hover_label.borrow().as_deref(), Some("Organic"));
 
     let selected_label = listen_string_field(&chart, CHART_SELECT_EVENT, "label");
     dispatch_click(&first);

--- a/crates/pine-charts/tests/charts.rs
+++ b/crates/pine-charts/tests/charts.rs
@@ -9,7 +9,8 @@ use std::rc::Rc;
 use pine_charts::{
     line_legend_items, set_line_series_visible, ChartAreaSeries, ChartBar, ChartBarSeries,
     ChartLayerPoint, ChartLineSeries, ChartPieSlice, ChartPoint, ChartScatterSeries, LegendItem,
-    LegendToggle, CHART_SELECT_EVENT, LEGEND_TOGGLE_EVENT,
+    LegendToggle, CHART_HOVER_END_EVENT, CHART_HOVER_EVENT, CHART_SELECT_EVENT,
+    LEGEND_TOGGLE_EVENT,
 };
 use pocopine::prelude::*;
 use wasm_bindgen::closure::Closure;
@@ -179,6 +180,19 @@ fn listen_bool_field(
     seen
 }
 
+fn listen_event_count(target: &Element, event_name: &str) -> Rc<Cell<u32>> {
+    let seen = Rc::new(Cell::new(0_u32));
+    let seen_for_listener = seen.clone();
+    let cb = Closure::<dyn FnMut(web_sys::Event)>::new(move |_| {
+        seen_for_listener.set(seen_for_listener.get() + 1);
+    });
+    target
+        .add_event_listener_with_callback(event_name, cb.as_ref().unchecked_ref())
+        .unwrap();
+    cb.forget();
+    seen
+}
+
 #[derive(serde::Serialize, serde::Deserialize)]
 #[component(template_inline = r#"
 <div>
@@ -214,6 +228,41 @@ impl Default for LineChartFixture {
 
 #[handlers]
 impl LineChartFixture {}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+#[component(template_inline = r#"
+<div>
+  <pine-line-chart class="custom-tooltip-line"
+                   label="Sales"
+                   width="100"
+                   height="100"
+                   margin_top="0"
+                   margin_right="0"
+                   margin_bottom="0"
+                   margin_left="0"
+                   show_markers="true"
+                   tooltip="none"
+                   pp-bind:points="points"></pine-line-chart>
+</div>
+"#)]
+struct CustomTooltipLineChartFixture {
+    points: Vec<ChartPoint>,
+}
+
+impl Default for CustomTooltipLineChartFixture {
+    fn default() -> Self {
+        Self {
+            points: vec![
+                ChartPoint::new(0.0, 0.0),
+                ChartPoint::new(5.0, 10.0),
+                ChartPoint::new(10.0, 5.0),
+            ],
+        }
+    }
+}
+
+#[handlers]
+impl CustomTooltipLineChartFixture {}
 
 #[derive(serde::Serialize, serde::Deserialize)]
 #[component(template_inline = r##"
@@ -1403,6 +1452,50 @@ async fn line_chart_shows_crosshair_and_tooltip_on_pointer_move() {
 }
 
 #[wasm_bindgen_test]
+async fn line_chart_emits_hover_events_and_allows_custom_tooltips() {
+    let host = mount_fixture::<CustomTooltipLineChartFixture>();
+    settle().await;
+
+    let chart = host
+        .query_selector(".custom-tooltip-line")
+        .unwrap()
+        .unwrap();
+    let hover_chart = listen_string_field(&chart, CHART_HOVER_EVENT, "chart");
+    let hover_kind = listen_string_field(&chart, CHART_HOVER_EVENT, "kind");
+    let hover_label = listen_string_field(&chart, CHART_HOVER_EVENT, "label");
+    let hover_x = listen_string_field(&chart, CHART_HOVER_EVENT, "x_label");
+    let hover_y = listen_string_field(&chart, CHART_HOVER_EVENT, "y_label");
+    let hover_end_count = listen_event_count(&chart, CHART_HOVER_END_EVENT);
+
+    let svg = host.query_selector("svg.pine-chart-svg").unwrap().unwrap();
+    dispatch_pointer_move(&svg, 50.0, 50.0);
+    settle().await;
+
+    let tooltip = host.query_selector(".pine-chart-tooltip").unwrap().unwrap();
+    assert_eq!(
+        tooltip.get_attribute("aria-hidden").as_deref(),
+        Some("true")
+    );
+    assert_eq!(
+        tooltip.get_attribute("style").as_deref(),
+        Some("display: none;")
+    );
+    assert_eq!(hover_chart.borrow().as_deref(), Some("line"));
+    assert_eq!(hover_kind.borrow().as_deref(), Some("xy"));
+    assert_eq!(hover_label.borrow().as_deref(), Some("x 5, y 10"));
+    assert_eq!(hover_x.borrow().as_deref(), Some("5"));
+    assert_eq!(hover_y.borrow().as_deref(), Some("10"));
+
+    let leave = web_sys::PointerEvent::new("pointerleave").unwrap();
+    svg.dispatch_event(&leave).unwrap();
+    settle().await;
+
+    assert_eq!(hover_end_count.get(), 1);
+
+    host.remove();
+}
+
+#[wasm_bindgen_test]
 async fn line_chart_supports_marker_selection_and_keyboard_focus() {
     let host = mount_fixture::<LineChartFixture>();
     settle().await;
@@ -1827,6 +1920,10 @@ async fn bar_chart_shows_tooltip_on_pointer_move() {
     let chart = host.query_selector(".pine-bar-chart").unwrap().unwrap();
     assert!(!chart.has_attribute("data-hover"));
     let selected_label = listen_string_field(&chart, CHART_SELECT_EVENT, "label");
+    let hover_chart = listen_string_field(&chart, CHART_HOVER_EVENT, "chart");
+    let hover_kind = listen_string_field(&chart, CHART_HOVER_EVENT, "kind");
+    let hover_category = listen_string_field(&chart, CHART_HOVER_EVENT, "category");
+    let hover_value = listen_string_field(&chart, CHART_HOVER_EVENT, "value_label");
 
     let svg = host.query_selector("svg.pine-chart-svg").unwrap().unwrap();
     dispatch_pointer_move(&svg, 10.0, 90.0);
@@ -1854,6 +1951,10 @@ async fn bar_chart_shows_tooltip_on_pointer_move() {
         tooltip.get_attribute("data-tooltip-x").as_deref(),
         Some("right")
     );
+    assert_eq!(hover_chart.borrow().as_deref(), Some("bar"));
+    assert_eq!(hover_kind.borrow().as_deref(), Some("category"));
+    assert_eq!(hover_category.borrow().as_deref(), Some("A"));
+    assert_eq!(hover_value.borrow().as_deref(), Some("2"));
 
     dispatch_click(&first);
     settle().await;

--- a/docs/charts/components.md
+++ b/docs/charts/components.md
@@ -105,6 +105,8 @@ is mapped to the nearest sampled point in SVG space. For multi-series charts,
 that means nearest x/y distance, not just nearest x position. The component owns
 the nearest-point state and geometry variables, while the application owns
 tooltip placement and visual styling.
+Set `tooltip="none"` to suppress the built-in tooltip and render a custom block
+from the `pp:chart:hover` event payload instead.
 
 Set `show_markers="true"` when every sampled point should render as a visible
 SVG marker. Markers are opt-in so dense line charts do not accidentally produce
@@ -424,6 +426,7 @@ The component emits stable hooks:
 - `.pine-chart-status-empty`
 - `data-state="empty|ready|invalid"`
 - `data-hover`
+- `data-tooltip="default|none"`
 - `data-animate="true|false"`
 - `data-animation-duration`
 - `data-animation-easing`

--- a/docs/charts/components.md
+++ b/docs/charts/components.md
@@ -587,6 +587,10 @@ authoritative for interaction, donut radius changes, and half-donut morphs.
   visibility: visible;
 }
 
+.pine-chart-root[data-tooltip="none"] .pine-chart-tooltip {
+  display: none;
+}
+
 .pine-chart-tooltip[data-tooltip-x="left"] {
   transform: translate(calc(-100% - 10px), calc(-100% - 10px));
 }

--- a/docs/charts/events.md
+++ b/docs/charts/events.md
@@ -33,6 +33,61 @@ Template listeners use the event name directly:
   @pp:chart:select="show_detail"></pine-line-chart>
 ```
 
+## Hover
+
+Line, scatter, area, bar, and pie/donut charts emit `pp:chart:hover` while the
+pointer is over an interactive chart mark. Pointer exit emits
+`pp:chart:hover-end`. The hover payload is `ChartHover`:
+
+```rust
+use pine_charts::ChartHover;
+use pocopine::prelude::JsValue;
+```
+
+Payload fields:
+
+- `chart`: `"line"`, `"scatter"`, `"area"`, `"bar"`, or `"pie"`
+- `kind`: `"xy"`, `"category"`, or `"share"`
+- `key`
+- `label`
+- `aria_label`
+- `series`
+- `category`
+- `x` / `y`
+- `value`
+- `percentage`
+- `x_label` / `y_label`
+- `value_label`
+- `percentage_label`
+- `tooltip_x` / `tooltip_y`
+- `tooltip_style`
+
+The built-in tooltip remains the default. Set `tooltip="none"` on a chart to
+hide the built-in tooltip while keeping hover crosshairs, markers, data
+attributes, and hover events active. Applications can then render a custom
+tooltip block, overlay, or portal from the event payload:
+
+```html
+<pine-area-chart
+  pp-bind:series="series"
+  tooltip="none"
+  @pp:chart:hover="show_tooltip"
+  @pp:chart:hover-end="hide_tooltip"></pine-area-chart>
+```
+
+```rust
+use pine_charts::ChartHover;
+use pocopine::prelude::JsValue;
+
+pub fn show_tooltip(&mut self, event: JsValue) {
+    let Some(hover) = ChartHover::from_event_value(event) else {
+        return;
+    };
+    self.tooltip_title = hover.series;
+    self.tooltip_value = format!("{}: {}", hover.x_label, hover.y_label);
+}
+```
+
 ## Legend Toggles
 
 `PineChartLegend` can be made interactive with `interactive="true"`. Interactive

--- a/docs/charts/events.md
+++ b/docs/charts/events.md
@@ -83,7 +83,9 @@ accessible announcement.
 The built-in tooltip remains the default. Set `tooltip="none"` on a chart to
 hide the built-in tooltip while keeping hover crosshairs, markers, data
 attributes, and hover events active. Applications can then render a custom
-tooltip block, overlay, or portal from the event payload:
+tooltip block, overlay, or portal from the event payload. Because Pine Charts
+does not ship a stylesheet, include the `[data-tooltip="none"]` suppression rule
+from [Interaction](interaction.md) when styling the built-in tooltip.
 
 ```html
 <pine-area-chart

--- a/docs/charts/events.md
+++ b/docs/charts/events.md
@@ -37,7 +37,9 @@ Template listeners use the event name directly:
 
 Line, scatter, area, bar, and pie/donut charts emit `pp:chart:hover` while the
 pointer is over an interactive chart mark. Pointer exit emits
-`pp:chart:hover-end`. The hover payload is `ChartHover`:
+`pp:chart:hover-end`. Hover events are pointer-driven, so custom handlers should
+stay cheap and push expensive work outside the pointer path. The hover payload
+is `ChartHover`:
 
 ```rust
 use pine_charts::ChartHover;
@@ -61,6 +63,22 @@ Payload fields:
 - `percentage_label`
 - `tooltip_x` / `tooltip_y`
 - `tooltip_style`
+
+`kind` determines which fields are populated:
+
+- `xy`: line, scatter, and area hovers. `label` is the compact point label,
+  `series` is the series label when present, and `x`, `y`, `x_label`, and
+  `y_label` are populated.
+- `category`: bar hovers. `label` and `category` are the category label,
+  `series` is populated for grouped/stacked series, and `value` /
+  `value_label` are populated.
+- `share`: pie and donut hovers. `label` is the slice label, `value`,
+  `value_label`, `percentage`, and `percentage_label` are populated, and
+  `series` / `category` are empty.
+
+`aria_label` always matches the rendered mark's accessible label. Prefer
+`label` for concise custom UI and `aria_label` when mirroring the chart's
+accessible announcement.
 
 The built-in tooltip remains the default. Set `tooltip="none"` on a chart to
 hide the built-in tooltip while keeping hover crosshairs, markers, data
@@ -87,6 +105,10 @@ pub fn show_tooltip(&mut self, event: JsValue) {
     self.tooltip_value = format!("{}: {}", hover.x_label, hover.y_label);
 }
 ```
+
+When `tooltip="none"` is set, the application owns the replacement tooltip's
+accessibility. Use a status/live region such as `role="status"` and
+`aria-live="polite"` when the custom tooltip should be announced.
 
 ## Legend Toggles
 

--- a/docs/charts/interaction.md
+++ b/docs/charts/interaction.md
@@ -103,6 +103,10 @@ the hook for filtering or dimming series.
   visibility: visible;
 }
 
+.pine-chart-root[data-tooltip="none"] .pine-chart-tooltip {
+  display: none;
+}
+
 .pine-chart-tooltip[data-tooltip-x="left"] {
   transform: translate(calc(-100% - 10px), calc(-100% - 10px));
 }

--- a/docs/charts/interaction.md
+++ b/docs/charts/interaction.md
@@ -21,6 +21,7 @@ sampled point by SVG x/y distance and exposes:
 - `.pine-chart-tooltip-x`
 - `.pine-chart-tooltip-y`
 - `data-hover`
+- `data-tooltip="default|none"`
 - `data-tooltip-x="left|right"`
 - `data-tooltip-y="above|below"`
 - `data-x`
@@ -32,6 +33,9 @@ The chart owns sampled-point lookup, crosshair geometry, marker coordinates, and
 tooltip data attributes. Tooltip coordinates are emitted as percentages so they
 scale with responsive SVG sizing. Applications own colors, marker radius
 overrides, tooltip positioning, typography, borders, shadows, and transitions.
+Set `tooltip="none"` when the application should render its own tooltip from
+`pp:chart:hover` / `pp:chart:hover-end` events. That suppresses only the built-in
+HTML tooltip; hover markers, crosshairs, and data attributes still update.
 
 Bar charts use the same pointer coordinate conversion, but they select the
 painted SVG rect under the pointer instead of the nearest numeric sample. The

--- a/examples/charts/index.html
+++ b/examples/charts/index.html
@@ -530,6 +530,10 @@
       visibility: visible;
     }
 
+    .pine-chart-root[data-tooltip="none"] .pine-chart-tooltip {
+      display: none;
+    }
+
     .pine-chart-tooltip[data-tooltip-x="left"] {
       transform: translate(calc(-100% - 10px), calc(-100% - 10px));
     }

--- a/examples/charts/index.html
+++ b/examples/charts/index.html
@@ -144,27 +144,50 @@
       overflow: hidden;
     }
 
+    .chart-panel--custom-tooltip {
+      position: relative;
+    }
+
     .chart-card-legend {
       min-height: 22px;
     }
 
     .chart-custom-tooltip {
-      align-items: center;
-      background: #f7f9fb;
-      border: 1px solid #dde4ec;
+      background: white;
+      border: 1px solid #c7d0da;
       border-radius: 6px;
       display: grid;
       gap: 2px;
-      grid-template-columns: minmax(0, 1fr) auto;
-      min-height: 48px;
-      opacity: 0.72;
+      left: var(--pine-chart-tooltip-x);
+      max-width: min(220px, calc(100% - 24px));
+      min-width: 150px;
+      opacity: 0;
       padding: 8px 10px;
-      transition: border-color 140ms ease, opacity 140ms ease;
+      pointer-events: none;
+      position: absolute;
+      top: var(--pine-chart-tooltip-y);
+      transform: translate(10px, calc(-100% - 10px));
+      transition: opacity var(--pine-chart-animation-duration, 120ms) var(--pine-chart-animation-easing, ease);
+      visibility: hidden;
+      z-index: 4;
     }
 
     .chart-custom-tooltip[data-visible="true"] {
       border-color: #1d6fd8;
       opacity: 1;
+      visibility: visible;
+    }
+
+    .chart-custom-tooltip[data-tooltip-x="left"] {
+      transform: translate(calc(-100% - 10px), calc(-100% - 10px));
+    }
+
+    .chart-custom-tooltip[data-tooltip-y="below"] {
+      transform: translate(10px, 10px);
+    }
+
+    .chart-custom-tooltip[data-tooltip-x="left"][data-tooltip-y="below"] {
+      transform: translate(calc(-100% - 10px), 10px);
     }
 
     .chart-custom-tooltip-title {
@@ -178,17 +201,13 @@
     .chart-custom-tooltip-value {
       font-size: 14px;
       font-weight: 700;
-      grid-column: 1;
       min-width: 0;
     }
 
     .chart-custom-tooltip-meta {
       color: #526173;
       font-size: 12px;
-      grid-column: 2;
-      grid-row: 1 / span 2;
-      justify-self: end;
-      text-align: right;
+      min-width: 0;
     }
 
     .pine-chart-responsive-frame {

--- a/examples/charts/index.html
+++ b/examples/charts/index.html
@@ -148,6 +148,49 @@
       min-height: 22px;
     }
 
+    .chart-custom-tooltip {
+      align-items: center;
+      background: #f7f9fb;
+      border: 1px solid #dde4ec;
+      border-radius: 6px;
+      display: grid;
+      gap: 2px;
+      grid-template-columns: minmax(0, 1fr) auto;
+      min-height: 48px;
+      opacity: 0.72;
+      padding: 8px 10px;
+      transition: border-color 140ms ease, opacity 140ms ease;
+    }
+
+    .chart-custom-tooltip[data-visible="true"] {
+      border-color: #1d6fd8;
+      opacity: 1;
+    }
+
+    .chart-custom-tooltip-title {
+      color: #526173;
+      font-size: 12px;
+      font-weight: 600;
+      grid-column: 1;
+      min-width: 0;
+    }
+
+    .chart-custom-tooltip-value {
+      font-size: 14px;
+      font-weight: 700;
+      grid-column: 1;
+      min-width: 0;
+    }
+
+    .chart-custom-tooltip-meta {
+      color: #526173;
+      font-size: 12px;
+      grid-column: 2;
+      grid-row: 1 / span 2;
+      justify-self: end;
+      text-align: right;
+    }
+
     .pine-chart-responsive-frame {
       min-width: 0;
     }

--- a/examples/charts/src/ChartDemo.poco
+++ b/examples/charts/src/ChartDemo.poco
@@ -201,30 +201,35 @@
           </div>
         </div>
       </header>
-      <pine-chart-responsive class="chart-panel" aspect_ratio="1.55" min_height="220">
-        <pine-area-chart label="Trend area"
-                         pp-bind:series="area_series"
-                         x_label="Week"
-                         y_label="Volume"
-                         animate="true"
-                         animation_duration="180"
-                         animation_easing="ease-out"
-                         show_markers="true"
-                         tooltip="none"
-                         @pp:chart:hover="show_custom_tooltip"
-                         @pp:chart:hover-end="hide_custom_tooltip"></pine-area-chart>
-      </pine-chart-responsive>
+      <div class="chart-panel chart-panel--custom-tooltip">
+        <pine-chart-responsive aspect_ratio="1.55" min_height="220">
+          <pine-area-chart label="Trend area"
+                           pp-bind:series="area_series"
+                           x_label="Week"
+                           y_label="Volume"
+                           animate="true"
+                           animation_duration="180"
+                           animation_easing="ease-out"
+                           show_markers="true"
+                           tooltip="none"
+                           @pp:chart:hover="show_custom_tooltip"
+                           @pp:chart:hover-end="hide_custom_tooltip"></pine-area-chart>
+        </pine-chart-responsive>
 
-      <div class="chart-custom-tooltip"
-           role="status"
-           aria-live="polite"
-           :data-visible="custom_tooltip_visible">
-        <span class="chart-custom-tooltip-title"
-              pp-text="custom_tooltip_title"></span>
-        <strong class="chart-custom-tooltip-value"
-                pp-text="custom_tooltip_value"></strong>
-        <span class="chart-custom-tooltip-meta"
-              pp-text="custom_tooltip_meta"></span>
+        <div class="chart-custom-tooltip"
+             role="status"
+             aria-live="polite"
+             :data-visible="custom_tooltip_visible"
+             :data-tooltip-x="custom_tooltip_x"
+             :data-tooltip-y="custom_tooltip_y"
+             :style="custom_tooltip_visible ? custom_tooltip_style : ''">
+          <span class="chart-custom-tooltip-title"
+                pp-text="custom_tooltip_title"></span>
+          <strong class="chart-custom-tooltip-value"
+                  pp-text="custom_tooltip_value"></strong>
+          <span class="chart-custom-tooltip-meta"
+                pp-text="custom_tooltip_meta"></span>
+        </div>
       </div>
 
       <pine-chart-legend class="chart-card-legend"

--- a/examples/charts/src/ChartDemo.poco
+++ b/examples/charts/src/ChartDemo.poco
@@ -209,8 +209,23 @@
                          animate="true"
                          animation_duration="180"
                          animation_easing="ease-out"
-                         show_markers="true"></pine-area-chart>
+                         show_markers="true"
+                         tooltip="none"
+                         @pp:chart:hover="show_custom_tooltip"
+                         @pp:chart:hover-end="hide_custom_tooltip"></pine-area-chart>
       </pine-chart-responsive>
+
+      <div class="chart-custom-tooltip"
+           role="status"
+           aria-live="polite"
+           :data-visible="custom_tooltip_visible">
+        <span class="chart-custom-tooltip-title"
+              pp-text="custom_tooltip_title"></span>
+        <strong class="chart-custom-tooltip-value"
+                pp-text="custom_tooltip_value"></strong>
+        <span class="chart-custom-tooltip-meta"
+              pp-text="custom_tooltip_meta"></span>
+      </div>
 
       <pine-chart-legend class="chart-card-legend"
                          label="Trend area legend"

--- a/examples/charts/src/lib.rs
+++ b/examples/charts/src/lib.rs
@@ -52,6 +52,9 @@ pub struct ChartDemo {
     pub custom_tooltip_title: String,
     pub custom_tooltip_value: String,
     pub custom_tooltip_meta: String,
+    pub custom_tooltip_x: String,
+    pub custom_tooltip_y: String,
+    pub custom_tooltip_style: String,
 }
 
 impl Default for ChartDemo {
@@ -104,6 +107,9 @@ impl Default for ChartDemo {
             custom_tooltip_title: "Custom tooltip".into(),
             custom_tooltip_value: "Hover the trend area".into(),
             custom_tooltip_meta: "Built with pp:chart:hover".into(),
+            custom_tooltip_x: "right".into(),
+            custom_tooltip_y: "above".into(),
+            custom_tooltip_style: String::new(),
         }
     }
 }
@@ -286,6 +292,9 @@ impl ChartDemo {
         };
         self.custom_tooltip_value = format!("Week {}: {}", hover.x_label, hover.y_label);
         self.custom_tooltip_meta = hover.aria_label;
+        self.custom_tooltip_x = hover.tooltip_x;
+        self.custom_tooltip_y = hover.tooltip_y;
+        self.custom_tooltip_style = hover.tooltip_style;
     }
 
     pub fn hide_custom_tooltip(&mut self) {

--- a/examples/charts/src/lib.rs
+++ b/examples/charts/src/lib.rs
@@ -1,8 +1,9 @@
 use pine_charts::{
     area_legend_items, bar_legend_items, line_legend_items, scatter_legend_items,
     set_area_series_visible, set_bar_series_visible, set_pie_slice_visible,
-    set_scatter_series_visible, ChartAreaSeries, ChartBar, ChartBarSeries, ChartLayerPoint,
-    ChartLineSeries, ChartPieSlice, ChartPoint, ChartScatterSeries, LegendItem, LegendToggle,
+    set_scatter_series_visible, ChartAreaSeries, ChartBar, ChartBarSeries, ChartHover,
+    ChartLayerPoint, ChartLineSeries, ChartPieSlice, ChartPoint, ChartScatterSeries, LegendItem,
+    LegendToggle,
 };
 use pocopine::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -47,6 +48,10 @@ pub struct ChartDemo {
     pub pie_end_angle: f64,
     pub pie_center_label: String,
     pub pie_center_value: String,
+    pub custom_tooltip_visible: bool,
+    pub custom_tooltip_title: String,
+    pub custom_tooltip_value: String,
+    pub custom_tooltip_meta: String,
 }
 
 impl Default for ChartDemo {
@@ -95,6 +100,10 @@ impl Default for ChartDemo {
             pie_end_angle: 270.0,
             pie_center_label: "Total".into(),
             pie_center_value,
+            custom_tooltip_visible: false,
+            custom_tooltip_title: "Custom tooltip".into(),
+            custom_tooltip_value: "Hover the trend area".into(),
+            custom_tooltip_meta: "Built with pp:chart:hover".into(),
         }
     }
 }
@@ -263,6 +272,24 @@ impl ChartDemo {
             self.pie_legend = pine_charts::pie_legend_items(&self.pie_data);
             self.update_pie_center();
         }
+    }
+
+    pub fn show_custom_tooltip(&mut self, event: JsValue) {
+        let Some(hover) = ChartHover::from_event_value(event) else {
+            return;
+        };
+        self.custom_tooltip_visible = true;
+        self.custom_tooltip_title = if hover.series.is_empty() {
+            hover.chart
+        } else {
+            hover.series
+        };
+        self.custom_tooltip_value = format!("Week {}: {}", hover.x_label, hover.y_label);
+        self.custom_tooltip_meta = hover.aria_label;
+    }
+
+    pub fn hide_custom_tooltip(&mut self) {
+        self.custom_tooltip_visible = false;
     }
 }
 


### PR DESCRIPTION
## Summary
- Add typed ChartHover / ChartHoverEnd payloads and pp:chart:hover / pp:chart:hover-end events for line, area, scatter, bar, and pie charts.
- Add tooltip="none" to suppress built-in tooltip markup while preserving hover state, crosshairs, markers, and data attributes.
- Update the charts demo with a custom tooltip block and document the event-driven custom tooltip contract.

## Testing
- cargo check --workspace --all-targets
- cargo test -p pine-charts
- cargo clippy -p pine-charts --all-targets -- -D warnings
- cargo fmt --check
- wasm-pack test --firefox --headless crates/pine-charts
- cargo run -p pocopine-cli -- build --path examples/charts
- git diff --check