### PR TITLE
Add sync foundation crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,9 @@ jobs:
           - name: pine
             crate: crates/pine
             args: ""
+          - name: pocopine-sync-client
+            crate: crates/pocopine-sync
+            args: --test client_browser
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@master
@@ -312,6 +315,7 @@ jobs:
           - examples/hn
           - examples/site
           - examples/spa
+          - examples/sync
           - examples/tailwind
           - examples/todo
           - examples/website

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4581,6 +4581,7 @@ dependencies = [
 name = "sync-example"
 version = "0.1.0"
 dependencies = [
+ "http-body-util",
  "pocopine",
  "pocopine-events",
  "pocopine-live",
@@ -4588,7 +4589,10 @@ dependencies = [
  "pocopine-server",
  "pocopine-sync",
  "serde",
+ "serde_json",
  "tokio",
+ "tower",
+ "tracing",
  "wasm-bindgen",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3346,6 +3346,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pocopine-sync"
+version = "0.1.0"
+dependencies = [
+ "http-body-util",
+ "pocopine-core",
+ "pocopine-events",
+ "pocopine-live",
+ "pocopine-server",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower",
+ "tracing",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4559,6 +4575,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "sync-example"
+version = "0.1.0"
+dependencies = [
+ "pocopine",
+ "pocopine-events",
+ "pocopine-live",
+ "pocopine-logging",
+ "pocopine-server",
+ "pocopine-sync",
+ "serde",
+ "tokio",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3350,6 +3350,8 @@ name = "pocopine-sync"
 version = "0.1.0"
 dependencies = [
  "http-body-util",
+ "js-sys",
+ "pocopine",
  "pocopine-core",
  "pocopine-events",
  "pocopine-live",
@@ -3359,6 +3361,10 @@ dependencies = [
  "tokio",
  "tower",
  "tracing",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "crates/pocopine-macros",
     "crates/pocopine-observe",
     "crates/pocopine-server",
+    "crates/pocopine-sync",
     "examples/blog",
     "examples/charts",
     "examples/counter",
@@ -37,6 +38,7 @@ members = [
     "examples/website",
     "examples/site",
     "examples/spa",
+    "examples/sync",
     "examples/tailwind",
     "examples/todo",
 ]
@@ -73,6 +75,7 @@ pocopine-logging = { path = "crates/pocopine-logging", version = "0.1.0" }
 pocopine-macros = { path = "crates/pocopine-macros", version = "0.1.0" }
 pocopine-observe = { path = "crates/pocopine-observe", version = "0.1.0" }
 pocopine-server = { path = "crates/pocopine-server", version = "0.1.0" }
+pocopine-sync = { path = "crates/pocopine-sync", version = "0.1.0" }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"

--- a/crates/pocopine-sync/Cargo.toml
+++ b/crates/pocopine-sync/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "pocopine-sync"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Sync protocol and plugin extension for Pocopine apps."
+
+[dependencies]
+pocopine-core = { workspace = true, default-features = false }
+pocopine-live = { workspace = true }
+serde = { workspace = true }
+serde_json = "1"
+tracing = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+pocopine-events = { workspace = true }
+pocopine-server = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+http-body-util = "0.1"
+tokio = { version = "1", features = ["macros", "rt"] }
+tower = { version = "0.5", features = ["util"] }

--- a/crates/pocopine-sync/Cargo.toml
+++ b/crates/pocopine-sync/Cargo.toml
@@ -21,3 +21,11 @@ pocopine-server = { workspace = true }
 http-body-util = "0.1"
 tokio = { version = "1", features = ["macros", "rt"] }
 tower = { version = "0.5", features = ["util"] }
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+js-sys = { workspace = true }
+pocopine = { path = "../pocopine" }
+wasm-bindgen = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
+wasm-bindgen-test = "0.3"
+web-sys = { version = "0.3", features = ["Document", "Element", "HtmlInputElement", "Window"] }

--- a/crates/pocopine-sync/src/client.rs
+++ b/crates/pocopine-sync/src/client.rs
@@ -314,23 +314,23 @@ fn start_pull<C, T>(
     C: 'static,
     T: serde::de::DeserializeOwned + 'static,
 {
-    let request_token = handle.update(|state| {
-        let collection = selector(state);
-        let cursor = cursor.or_else(|| collection.cursor.clone());
-        let request = SyncPullRequest::new(shape.clone()).cursor(cursor);
-        let token = if live_event {
-            collection.begin_live_pull(reason)
-        } else if collection.version == 0 {
-            collection.begin_initial()
-        } else {
-            collection.begin_pull(reason)
-        };
-        (request, token)
-    });
-    let (request, token) = request_token;
     let pull_url = endpoint_path(&endpoint, "pull");
 
     pocopine_core::spawn_for_scope(scope_id, async move {
+        let request_token = handle.update(|state| {
+            let collection = selector(state);
+            let cursor = cursor.or_else(|| collection.cursor.clone());
+            let request = SyncPullRequest::new(shape.clone()).cursor(cursor);
+            let token = if live_event {
+                collection.begin_live_pull(reason)
+            } else if collection.version == 0 {
+                collection.begin_initial()
+            } else {
+                collection.begin_pull(reason)
+            };
+            (request, token)
+        });
+        let (request, token) = request_token;
         let result =
             pocopine_core::fetch::call::<SyncPullRequest, SyncPullResponse<T>>(&pull_url, &request)
                 .await;

--- a/crates/pocopine-sync/src/client.rs
+++ b/crates/pocopine-sync/src/client.rs
@@ -1,0 +1,354 @@
+use std::marker::PhantomData;
+
+use pocopine_core::{App, AppPlugin, Handle};
+
+use crate::{
+    CollectionState, SyncCursor, SyncError, SyncReason, SyncResult, SyncShapeName,
+    SYNC_ENDPOINT_PREFIX,
+};
+
+#[cfg(target_arch = "wasm32")]
+use crate::{sync_shape_tag, SyncPullRequest, SyncPullResponse};
+
+/// Selector from an app-owned component/store into one sync collection field.
+pub type CollectionSelector<C, T> = for<'a> fn(&'a mut C) -> &'a mut CollectionState<T>;
+
+/// App plugin that provides [`SyncClient`] to components.
+#[derive(Clone, Debug)]
+pub struct SyncClientPlugin {
+    endpoint: String,
+    live_endpoint: Option<String>,
+    live_wakeup: bool,
+    with_credentials: bool,
+}
+
+impl Default for SyncClientPlugin {
+    fn default() -> Self {
+        Self {
+            endpoint: SYNC_ENDPOINT_PREFIX.to_string(),
+            live_endpoint: None,
+            live_wakeup: false,
+            with_credentials: false,
+        }
+    }
+}
+
+/// Build the sync app plugin.
+///
+/// The plugin is explicit: apps that do not install it do not get a
+/// [`SyncClient`] service. Live wake-up is opt-in so apps can use sync
+/// without also mounting `pocopine-live`.
+pub fn sync_plugin() -> SyncClientPlugin {
+    SyncClientPlugin::default()
+}
+
+impl SyncClientPlugin {
+    /// Override the sync HTTP endpoint prefix.
+    pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.endpoint = endpoint.into();
+        self
+    }
+
+    /// Enable or disable live wake-up integration.
+    pub fn with_live_wakeup(mut self, enabled: bool) -> Self {
+        self.live_wakeup = enabled;
+        self
+    }
+
+    /// Override the live stream endpoint when live wake-up is enabled.
+    pub fn live_endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.live_endpoint = Some(endpoint.into());
+        self
+    }
+
+    /// Set browser credentials mode for sync fetches and live wake-ups.
+    pub fn with_credentials(mut self, enabled: bool) -> Self {
+        self.with_credentials = enabled;
+        self
+    }
+}
+
+impl AppPlugin for SyncClientPlugin {
+    fn name(&self) -> &'static str {
+        "pocopine-sync"
+    }
+
+    fn install(self, app: App) -> App {
+        app.provide_plugin(SyncClient {
+            endpoint: self.endpoint,
+            live_endpoint: self.live_endpoint,
+            live_wakeup: self.live_wakeup,
+            with_credentials: self.with_credentials,
+        })
+    }
+}
+
+/// Runtime sync client service installed by [`sync_plugin`].
+#[derive(Clone, Debug)]
+pub struct SyncClient {
+    endpoint: String,
+    live_endpoint: Option<String>,
+    live_wakeup: bool,
+    with_credentials: bool,
+}
+
+impl SyncClient {
+    /// Build a collection runner bound to a component or store handle.
+    pub fn collection<C, T>(
+        &self,
+        handle: Handle<C>,
+        selector: CollectionSelector<C, T>,
+    ) -> SyncCollection<C, T>
+    where
+        C: 'static,
+        T: 'static,
+    {
+        SyncCollection {
+            handle,
+            selector,
+            endpoint: self.endpoint.clone(),
+            live_endpoint: self.live_endpoint.clone(),
+            live_wakeup: self.live_wakeup,
+            with_credentials: self.with_credentials,
+            shape: None,
+            cursor: None,
+            _marker: PhantomData,
+        }
+    }
+}
+
+/// Scope-bound sync collection runner.
+pub struct SyncCollection<C: 'static, T> {
+    handle: Handle<C>,
+    selector: CollectionSelector<C, T>,
+    endpoint: String,
+    live_endpoint: Option<String>,
+    live_wakeup: bool,
+    with_credentials: bool,
+    shape: Option<SyncShapeName>,
+    cursor: Option<SyncCursor>,
+    _marker: PhantomData<fn(C) -> T>,
+}
+
+impl<C, T> SyncCollection<C, T>
+where
+    C: 'static,
+    T: 'static,
+{
+    /// Set the server-registered shape to pull.
+    pub fn shape(mut self, shape: impl Into<String>) -> SyncResult<Self> {
+        self.shape = Some(SyncShapeName::new(shape.into())?);
+        Ok(self)
+    }
+
+    /// Resume from a previously stored sync cursor.
+    pub fn cursor(mut self, cursor: impl Into<String>) -> SyncResult<Self> {
+        self.cursor = Some(SyncCursor::new(cursor.into())?);
+        Ok(self)
+    }
+
+    /// Override live wake-up for this collection.
+    pub fn with_live_wakeup(mut self, enabled: bool) -> Self {
+        self.live_wakeup = enabled;
+        self
+    }
+
+    /// Pull initial data and, when configured, open a live wake-up stream.
+    pub fn open(self) -> SyncResult<()>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        self.open_impl()
+    }
+
+    /// Trigger a manual pull.
+    pub fn pull(self) -> SyncResult<()>
+    where
+        T: serde::de::DeserializeOwned,
+    {
+        self.pull_impl(SyncReason::Manual, false)
+    }
+
+    fn shape_value(&self) -> SyncResult<SyncShapeName> {
+        self.shape
+            .clone()
+            .ok_or_else(|| SyncError::invalid_value("shape", "<missing>"))
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn touch_host_fields(&self) {
+        let _ = (
+            &self.handle,
+            self.selector,
+            &self.endpoint,
+            &self.live_endpoint,
+            self.live_wakeup,
+            self.with_credentials,
+        );
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl<C, T> SyncCollection<C, T>
+where
+    C: 'static,
+    T: serde::de::DeserializeOwned + 'static,
+{
+    fn open_impl(self) -> SyncResult<()> {
+        let shape = self.shape_value()?;
+        let scope_id = pocopine_core::current_scope_id().ok_or_else(|| {
+            SyncError::client(
+                "SyncCollection::open used outside a component handler/lifecycle hook",
+            )
+        })?;
+
+        let handle = self.handle.clone();
+        let selector = self.selector;
+        start_pull(
+            scope_id,
+            handle.clone(),
+            selector,
+            self.endpoint.clone(),
+            shape.clone(),
+            self.cursor.clone(),
+            SyncReason::Initial,
+            false,
+        );
+
+        if !self.live_wakeup {
+            return Ok(());
+        }
+
+        let live_tag = sync_shape_tag(shape.as_str());
+        let endpoint = self.endpoint.clone();
+        let mut refresh = pocopine_live::LiveRefresh::scoped()
+            .query_tag(live_tag, move |event| {
+                let reason = if matches!(event.live_event, pocopine_live::LiveEvent::Gap { .. }) {
+                    SyncReason::Gap
+                } else {
+                    SyncReason::Live
+                };
+                start_pull(
+                    scope_id,
+                    handle.clone(),
+                    selector,
+                    endpoint.clone(),
+                    shape.clone(),
+                    None,
+                    reason,
+                    true,
+                );
+            })
+            .on_error({
+                let handle = self.handle.clone();
+                let selector = self.selector;
+                move |event| {
+                    handle.update(|state| {
+                        selector(state)
+                            .set_error(format!("live wake-up failed: {:?}", event.target));
+                    });
+                }
+            })
+            .with_credentials(self.with_credentials);
+
+        if let Some(live_endpoint) = self.live_endpoint {
+            refresh = refresh.endpoint(live_endpoint);
+        }
+
+        refresh
+            .open()
+            .map_err(|err| SyncError::client(err.to_string()))
+    }
+
+    fn pull_impl(self, reason: SyncReason, live_event: bool) -> SyncResult<()> {
+        let shape = self.shape_value()?;
+        let scope_id = pocopine_core::current_scope_id().ok_or_else(|| {
+            SyncError::client(
+                "SyncCollection::pull used outside a component handler/lifecycle hook",
+            )
+        })?;
+        start_pull(
+            scope_id,
+            self.handle,
+            self.selector,
+            self.endpoint,
+            shape,
+            self.cursor,
+            reason,
+            live_event,
+        );
+        Ok(())
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<C, T> SyncCollection<C, T>
+where
+    C: 'static,
+    T: 'static,
+{
+    fn open_impl(self) -> SyncResult<()> {
+        self.touch_host_fields();
+        let _ = self.shape_value()?;
+        Ok(())
+    }
+
+    fn pull_impl(self, _reason: SyncReason, _live_event: bool) -> SyncResult<()> {
+        self.touch_host_fields();
+        let _ = self.shape_value()?;
+        Ok(())
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn start_pull<C, T>(
+    scope_id: pocopine_core::ScopeId,
+    handle: Handle<C>,
+    selector: CollectionSelector<C, T>,
+    endpoint: String,
+    shape: SyncShapeName,
+    cursor: Option<SyncCursor>,
+    reason: SyncReason,
+    live_event: bool,
+) where
+    C: 'static,
+    T: serde::de::DeserializeOwned + 'static,
+{
+    let request_token = handle.update(|state| {
+        let collection = selector(state);
+        let cursor = cursor.or_else(|| collection.cursor.clone());
+        let request = SyncPullRequest::new(shape.clone()).cursor(cursor);
+        let token = if live_event {
+            collection.begin_live_pull(reason)
+        } else if collection.version == 0 {
+            collection.begin_initial()
+        } else {
+            collection.begin_pull(reason)
+        };
+        (request, token)
+    });
+    let (request, token) = request_token;
+    let pull_url = endpoint_path(&endpoint, "pull");
+
+    pocopine_core::spawn_for_scope(scope_id, async move {
+        let result =
+            pocopine_core::fetch::call::<SyncPullRequest, SyncPullResponse<T>>(&pull_url, &request)
+                .await;
+        handle.update(|state| {
+            let collection = selector(state);
+            match result {
+                Ok(response) => {
+                    collection.apply_pull(token, response);
+                }
+                Err(err) => {
+                    collection.apply_error(token, err);
+                }
+            }
+        });
+    });
+}
+
+#[cfg(target_arch = "wasm32")]
+fn endpoint_path(endpoint: &str, suffix: &str) -> String {
+    format!("{}/{}", endpoint.trim_end_matches('/'), suffix)
+}

--- a/crates/pocopine-sync/src/client.rs
+++ b/crates/pocopine-sync/src/client.rs
@@ -8,7 +8,7 @@ use crate::{
 };
 
 #[cfg(target_arch = "wasm32")]
-use crate::{sync_shape_tag, SyncPullRequest, SyncPullResponse};
+use crate::{sync_shape_tag, SyncOpenRequest, SyncOpenResponse, SyncPullRequest, SyncPullResponse};
 
 /// Selector from an app-owned component/store into one sync collection field.
 pub type CollectionSelector<C, T> = for<'a> fn(&'a mut C) -> &'a mut CollectionState<T>;
@@ -204,7 +204,11 @@ where
 
         let handle = self.handle.clone();
         let selector = self.selector;
-        start_pull(
+        let live_wakeup = self.live_wakeup.then(|| LiveWakeupOptions {
+            live_endpoint: self.live_endpoint.clone(),
+            with_credentials: self.with_credentials,
+        });
+        start_open_then_pull(
             scope_id,
             handle.clone(),
             selector,
@@ -212,52 +216,9 @@ where
             shape.clone(),
             self.cursor.clone(),
             SyncReason::Initial,
-            false,
+            live_wakeup,
         );
-
-        if !self.live_wakeup {
-            return Ok(());
-        }
-
-        let live_tag = sync_shape_tag(shape.as_str());
-        let endpoint = self.endpoint.clone();
-        let mut refresh = pocopine_live::LiveRefresh::scoped()
-            .query_tag(live_tag, move |event| {
-                let reason = if matches!(event.live_event, pocopine_live::LiveEvent::Gap { .. }) {
-                    SyncReason::Gap
-                } else {
-                    SyncReason::Live
-                };
-                start_pull(
-                    scope_id,
-                    handle.clone(),
-                    selector,
-                    endpoint.clone(),
-                    shape.clone(),
-                    None,
-                    reason,
-                    true,
-                );
-            })
-            .on_error({
-                let handle = self.handle.clone();
-                let selector = self.selector;
-                move |event| {
-                    handle.update(|state| {
-                        selector(state)
-                            .set_error(format!("live wake-up failed: {:?}", event.target));
-                    });
-                }
-            })
-            .with_credentials(self.with_credentials);
-
-        if let Some(live_endpoint) = self.live_endpoint {
-            refresh = refresh.endpoint(live_endpoint);
-        }
-
-        refresh
-            .open()
-            .map_err(|err| SyncError::client(err.to_string()))
+        Ok(())
     }
 
     fn pull_impl(self, reason: SyncReason, live_event: bool) -> SyncResult<()> {
@@ -297,6 +258,165 @@ where
         self.touch_host_fields();
         let _ = self.shape_value()?;
         Ok(())
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+struct LiveWakeupOptions {
+    live_endpoint: Option<String>,
+    with_credentials: bool,
+}
+
+#[cfg(target_arch = "wasm32")]
+fn start_open_then_pull<C, T>(
+    scope_id: pocopine_core::ScopeId,
+    handle: Handle<C>,
+    selector: CollectionSelector<C, T>,
+    endpoint: String,
+    shape: SyncShapeName,
+    cursor: Option<SyncCursor>,
+    reason: SyncReason,
+    live_wakeup: Option<LiveWakeupOptions>,
+) where
+    C: 'static,
+    T: serde::de::DeserializeOwned + 'static,
+{
+    let open_url = endpoint_path(&endpoint, "open");
+    let pull_url = endpoint_path(&endpoint, "pull");
+
+    pocopine_core::spawn_for_scope(scope_id, async move {
+        let request_token = handle.update(|state| {
+            let collection = selector(state);
+            let cursor = cursor.or_else(|| collection.cursor.clone());
+            let token = if collection.version == 0 {
+                collection.begin_initial()
+            } else {
+                collection.begin_pull(reason)
+            };
+            (cursor, token)
+        });
+        let (cursor, token) = request_token;
+
+        let open_request = SyncOpenRequest::new([shape.clone()]);
+        let open_result = pocopine_core::fetch::call::<SyncOpenRequest, SyncOpenResponse>(
+            &open_url,
+            &open_request,
+        )
+        .await;
+        if let Err(err) = open_result.and_then(|response| validate_open_response(response, &shape))
+        {
+            handle.update(|state| {
+                selector(state).apply_error(token, err);
+            });
+            return;
+        }
+
+        if let Some(live_wakeup) = live_wakeup {
+            open_live_wakeup(
+                scope_id,
+                handle.clone(),
+                selector,
+                endpoint.clone(),
+                shape.clone(),
+                live_wakeup,
+            );
+        }
+
+        let request = SyncPullRequest::new(shape).cursor(cursor);
+        let result =
+            pocopine_core::fetch::call::<SyncPullRequest, SyncPullResponse<T>>(&pull_url, &request)
+                .await;
+        handle.update(|state| {
+            let collection = selector(state);
+            match result {
+                Ok(response) => {
+                    collection.apply_pull(token, response);
+                }
+                Err(err) => {
+                    collection.apply_error(token, err);
+                }
+            }
+        });
+    });
+}
+
+#[cfg(target_arch = "wasm32")]
+fn open_live_wakeup<C, T>(
+    scope_id: pocopine_core::ScopeId,
+    handle: Handle<C>,
+    selector: CollectionSelector<C, T>,
+    endpoint: String,
+    shape: SyncShapeName,
+    options: LiveWakeupOptions,
+) where
+    C: 'static,
+    T: serde::de::DeserializeOwned + 'static,
+{
+    let live_tag = sync_shape_tag(shape.as_str());
+    let mut refresh = pocopine_live::LiveRefresh::scoped()
+        .query_tag(live_tag, {
+            let handle = handle.clone();
+            let endpoint = endpoint.clone();
+            let shape = shape.clone();
+            move |event| {
+                let reason = if matches!(event.live_event, pocopine_live::LiveEvent::Gap { .. }) {
+                    SyncReason::Gap
+                } else {
+                    SyncReason::Live
+                };
+                start_pull(
+                    scope_id,
+                    handle.clone(),
+                    selector,
+                    endpoint.clone(),
+                    shape.clone(),
+                    None,
+                    reason,
+                    true,
+                );
+            }
+        })
+        .on_error({
+            let handle = handle.clone();
+            move |event| {
+                handle.update(|state| {
+                    selector(state).set_error(format!("live wake-up failed: {:?}", event.target));
+                });
+            }
+        })
+        .with_credentials(options.with_credentials);
+
+    if let Some(live_endpoint) = options.live_endpoint {
+        refresh = refresh.endpoint(live_endpoint);
+    }
+
+    match refresh.open_unscoped() {
+        Ok(subscription) => {
+            pocopine_core::on_scope_unmount_for(scope_id, move || drop(subscription));
+        }
+        Err(err) => {
+            handle.update(|state| {
+                selector(state).set_error(format!("live wake-up failed: {err}"));
+            });
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn validate_open_response(
+    response: SyncOpenResponse,
+    shape: &SyncShapeName,
+) -> Result<(), pocopine_core::ServerError> {
+    if response
+        .shapes
+        .iter()
+        .any(|accepted| accepted.shape == *shape)
+    {
+        Ok(())
+    } else {
+        Err(pocopine_core::ServerError::Forbidden(format!(
+            "sync shape was not opened: {shape}"
+        )))
     }
 }
 

--- a/crates/pocopine-sync/src/client.rs
+++ b/crates/pocopine-sync/src/client.rs
@@ -407,6 +407,13 @@ fn validate_open_response(
     response: SyncOpenResponse,
     shape: &SyncShapeName,
 ) -> Result<(), pocopine_core::ServerError> {
+    if response.protocol != crate::SYNC_PROTOCOL_V1 {
+        return Err(pocopine_core::ServerError::BadRequest(format!(
+            "unsupported sync protocol: {}",
+            response.protocol
+        )));
+    }
+
     if response
         .shapes
         .iter()

--- a/crates/pocopine-sync/src/error.rs
+++ b/crates/pocopine-sync/src/error.rs
@@ -49,7 +49,9 @@ impl SyncError {
 impl fmt::Display for SyncError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::InvalidValue { field, value } => write!(f, "invalid sync {field}: {value:?}"),
+            Self::InvalidValue { field, value } => {
+                write!(f, "invalid sync {field}: {:?}", display_value(value))
+            }
             Self::UnknownShape(shape) => write!(f, "unknown sync shape: {shape}"),
             Self::Unsupported(msg) => write!(f, "unsupported sync operation: {msg}"),
             Self::Gap(cursor) => write!(f, "sync cursor is no longer resumable: {cursor}"),
@@ -66,4 +68,13 @@ impl From<serde_json::Error> for SyncError {
     fn from(err: serde_json::Error) -> Self {
         Self::Json(err)
     }
+}
+
+fn display_value(value: &str) -> String {
+    const MAX_DISPLAY_CHARS: usize = 80;
+    let mut preview = value.chars().take(MAX_DISPLAY_CHARS).collect::<String>();
+    if value.chars().count() > MAX_DISPLAY_CHARS {
+        preview.push_str("...");
+    }
+    preview
 }

--- a/crates/pocopine-sync/src/error.rs
+++ b/crates/pocopine-sync/src/error.rs
@@ -1,0 +1,69 @@
+use std::fmt;
+
+/// Result type used by the sync extension.
+pub type SyncResult<T> = Result<T, SyncError>;
+
+/// Errors produced by sync protocol validation and extension adapters.
+#[derive(Debug)]
+pub enum SyncError {
+    /// A protocol value was empty or malformed.
+    InvalidValue { field: &'static str, value: String },
+    /// A requested shape is not registered on the sync server.
+    UnknownShape(String),
+    /// The requested operation is not implemented by the current source.
+    Unsupported(String),
+    /// The server can no longer resume from the supplied cursor.
+    Gap(String),
+    /// JSON serialization or deserialization failed.
+    Json(serde_json::Error),
+    /// Browser, fetch, or runtime integration failed.
+    Client(String),
+    /// Host-side source or lock failure.
+    Backend(String),
+}
+
+impl SyncError {
+    pub(crate) fn invalid_value(field: &'static str, value: impl Into<String>) -> Self {
+        Self::InvalidValue {
+            field,
+            value: value.into(),
+        }
+    }
+
+    /// Build an unsupported-operation error.
+    pub fn unsupported(msg: impl Into<String>) -> Self {
+        Self::Unsupported(msg.into())
+    }
+
+    /// Build a client integration error.
+    pub fn client(msg: impl Into<String>) -> Self {
+        Self::Client(msg.into())
+    }
+
+    /// Build a backend/source error.
+    pub fn backend(msg: impl Into<String>) -> Self {
+        Self::Backend(msg.into())
+    }
+}
+
+impl fmt::Display for SyncError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidValue { field, value } => write!(f, "invalid sync {field}: {value:?}"),
+            Self::UnknownShape(shape) => write!(f, "unknown sync shape: {shape}"),
+            Self::Unsupported(msg) => write!(f, "unsupported sync operation: {msg}"),
+            Self::Gap(cursor) => write!(f, "sync cursor is no longer resumable: {cursor}"),
+            Self::Json(err) => write!(f, "sync json error: {err}"),
+            Self::Client(msg) => write!(f, "sync client error: {msg}"),
+            Self::Backend(msg) => write!(f, "sync backend error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for SyncError {}
+
+impl From<serde_json::Error> for SyncError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::Json(err)
+    }
+}

--- a/crates/pocopine-sync/src/lib.rs
+++ b/crates/pocopine-sync/src/lib.rs
@@ -1,0 +1,37 @@
+//! Sync protocol and plugin extension for Pocopine apps.
+//!
+//! `pocopine-sync` is an explicit extension crate. It is not re-exported
+//! from `pocopine` and it does not add feature flags to the framework core.
+//! Apps opt in by depending on this crate, registering the wasm app plugin,
+//! and installing the host server plugin.
+
+mod error;
+mod protocol;
+mod state;
+
+mod client;
+#[cfg(not(target_arch = "wasm32"))]
+mod memory;
+#[cfg(not(target_arch = "wasm32"))]
+mod server;
+
+pub use error::{SyncError, SyncResult};
+pub use protocol::{
+    sync_shape_tag, ClientMutation, MutationId, RowKey, RowVersion, SyncChange, SyncCollectionName,
+    SyncConflict, SyncCursor, SyncOp, SyncOpenRequest, SyncOpenResponse, SyncOpenShape,
+    SyncPullMode, SyncPullRequest, SyncPullResponse, SyncPushRequest, SyncPushResponse, SyncRow,
+    SyncShapeName, SYNC_ENDPOINT_PREFIX, SYNC_OPEN_PATH, SYNC_PROTOCOL_V1, SYNC_PULL_PATH,
+    SYNC_PUSH_PATH,
+};
+pub use state::{CollectionState, SyncReason, SyncRequest};
+
+pub use client::{sync_plugin, SyncClient, SyncClientPlugin, SyncCollection};
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use memory::{MemorySyncShape, MemorySyncState};
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use server::{
+    sync_server_plugin, SyncBoxFuture, SyncServer, SyncServerBuilder, SyncServerPlugin,
+    SyncShapeSource,
+};

--- a/crates/pocopine-sync/src/lib.rs
+++ b/crates/pocopine-sync/src/lib.rs
@@ -20,8 +20,8 @@ pub use protocol::{
     sync_shape_tag, ClientMutation, MutationId, RowKey, RowVersion, SyncChange, SyncCollectionName,
     SyncConflict, SyncCursor, SyncOp, SyncOpenRequest, SyncOpenResponse, SyncOpenShape,
     SyncPullMode, SyncPullRequest, SyncPullResponse, SyncPushRequest, SyncPushResponse, SyncRow,
-    SyncShapeName, SYNC_ENDPOINT_PREFIX, SYNC_OPEN_PATH, SYNC_PROTOCOL_V1, SYNC_PULL_PATH,
-    SYNC_PUSH_PATH,
+    SyncShapeName, MAX_SYNC_TOKEN_LEN, SYNC_ENDPOINT_PREFIX, SYNC_OPEN_PATH, SYNC_PROTOCOL_V1,
+    SYNC_PULL_PATH, SYNC_PUSH_PATH,
 };
 pub use state::{CollectionState, SyncReason, SyncRequest};
 

--- a/crates/pocopine-sync/src/memory.rs
+++ b/crates/pocopine-sync/src/memory.rs
@@ -29,6 +29,10 @@ impl<T> Default for Inner<T> {
 }
 
 /// In-memory source for tests, examples, and explicit single-process apps.
+///
+/// This source keeps an unbounded in-memory change log and serializes all
+/// access through one lock. It is a reference implementation, not a durable
+/// production backend.
 #[derive(Clone, Debug)]
 pub struct MemorySyncShape<T> {
     shape: SyncShapeName,
@@ -60,6 +64,8 @@ where
         let cursor = SyncCursor::new(version.to_string())?;
         let row = SyncRow::new(key.into(), value)?.version(format!("v{version}"))?;
         inner.rows.insert(row.key.as_str().to_string(), row.clone());
+        // Unbounded by design for the reference source; production adapters
+        // should retain changes according to their own cursor window policy.
         inner.changes.push(SyncChange {
             shape: self.shape.clone(),
             collection: self.collection.clone(),
@@ -129,20 +135,17 @@ where
             .as_str()
             .parse::<u64>()
             .map_err(|_| SyncError::Gap(after.to_string()))?;
-        let changes = inner
-            .changes
-            .iter()
-            .filter(|change| {
-                change
-                    .cursor
-                    .as_str()
-                    .parse::<u64>()
-                    .map(|cursor| cursor > after)
-                    .unwrap_or(true)
-            })
-            .cloned()
-            .map(change_to_value)
-            .collect::<SyncResult<Vec<_>>>()?;
+        let mut changes = Vec::new();
+        for change in &inner.changes {
+            let cursor = change
+                .cursor
+                .as_str()
+                .parse::<u64>()
+                .map_err(|_| SyncError::backend("memory sync change cursor is not numeric"))?;
+            if cursor > after {
+                changes.push(change_to_value(change.clone())?);
+            }
+        }
 
         Ok(SyncPullResponse::incremental(
             self.shape.clone(),
@@ -232,5 +235,43 @@ mod tests {
             second.changes[0].row.as_ref().unwrap().key.as_str(),
             "post_2"
         );
+    }
+
+    #[test]
+    fn memory_shape_returns_delete_and_reset_changes() {
+        let shape = MemorySyncShape::<String>::new("posts_for_tenant", "posts").unwrap();
+        shape.upsert("post_1", "one".to_string()).unwrap();
+        let first = shape
+            .pull_value(SyncPullRequest::new(
+                SyncShapeName::new("posts_for_tenant").unwrap(),
+            ))
+            .unwrap();
+
+        shape.delete("post_1").unwrap();
+        shape.reset().unwrap();
+
+        let second = shape
+            .pull_value(
+                SyncPullRequest::new(SyncShapeName::new("posts_for_tenant").unwrap())
+                    .cursor(first.cursor.clone()),
+            )
+            .unwrap();
+        assert_eq!(second.mode, SyncPullMode::Incremental);
+        assert_eq!(second.changes.len(), 2);
+        assert_eq!(second.changes[0].op, SyncOp::Delete);
+        assert_eq!(second.changes[0].key.as_ref().unwrap().as_str(), "post_1");
+        assert_eq!(second.changes[1].op, SyncOp::Reset);
+    }
+
+    #[test]
+    fn memory_shape_reports_gap_for_non_numeric_cursor() {
+        let shape = MemorySyncShape::<String>::new("posts_for_tenant", "posts").unwrap();
+        let err = shape
+            .pull_value(
+                SyncPullRequest::new(SyncShapeName::new("posts_for_tenant").unwrap())
+                    .cursor(Some(SyncCursor::new("not_numeric").unwrap())),
+            )
+            .unwrap_err();
+        assert!(matches!(err, SyncError::Gap(cursor) if cursor == "not_numeric"));
     }
 }

--- a/crates/pocopine-sync/src/memory.rs
+++ b/crates/pocopine-sync/src/memory.rs
@@ -1,0 +1,236 @@
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::{
+    SyncChange, SyncCollectionName, SyncCursor, SyncError, SyncOp, SyncPullRequest,
+    SyncPullResponse, SyncResult, SyncRow, SyncShapeName,
+};
+
+use super::server::{SyncBoxFuture, SyncShapeSource};
+
+#[derive(Debug)]
+struct Inner<T> {
+    version: u64,
+    rows: BTreeMap<String, SyncRow<T>>,
+    changes: Vec<SyncChange<T>>,
+}
+
+impl<T> Default for Inner<T> {
+    fn default() -> Self {
+        Self {
+            version: 0,
+            rows: BTreeMap::new(),
+            changes: Vec::new(),
+        }
+    }
+}
+
+/// In-memory source for tests, examples, and explicit single-process apps.
+#[derive(Clone, Debug)]
+pub struct MemorySyncShape<T> {
+    shape: SyncShapeName,
+    collection: SyncCollectionName,
+    inner: Arc<Mutex<Inner<T>>>,
+}
+
+/// Cloneable handle to the in-memory state backing a shape.
+pub type MemorySyncState<T> = MemorySyncShape<T>;
+
+impl<T> MemorySyncShape<T>
+where
+    T: Clone + Serialize + Send + Sync + 'static,
+{
+    /// Create an empty in-memory shape.
+    pub fn new(shape: impl Into<String>, collection: impl Into<String>) -> SyncResult<Self> {
+        Ok(Self {
+            shape: SyncShapeName::new(shape.into())?,
+            collection: SyncCollectionName::new(collection.into())?,
+            inner: Arc::new(Mutex::new(Inner::default())),
+        })
+    }
+
+    /// Insert or replace one row.
+    pub fn upsert(&self, key: impl Into<String>, value: T) -> SyncResult<SyncCursor> {
+        let mut inner = self.lock()?;
+        inner.version = inner.version.saturating_add(1);
+        let version = inner.version;
+        let cursor = SyncCursor::new(version.to_string())?;
+        let row = SyncRow::new(key.into(), value)?.version(format!("v{version}"))?;
+        inner.rows.insert(row.key.as_str().to_string(), row.clone());
+        inner.changes.push(SyncChange {
+            shape: self.shape.clone(),
+            collection: self.collection.clone(),
+            key: None,
+            op: SyncOp::Upsert,
+            row: Some(row),
+            cursor: cursor.clone(),
+        });
+        Ok(cursor)
+    }
+
+    /// Delete one row.
+    pub fn delete(&self, key: impl Into<String>) -> SyncResult<SyncCursor> {
+        let key = crate::RowKey::new(key.into())?;
+        let mut inner = self.lock()?;
+        inner.version = inner.version.saturating_add(1);
+        let cursor = SyncCursor::new(inner.version.to_string())?;
+        inner.rows.remove(key.as_str());
+        inner.changes.push(SyncChange {
+            shape: self.shape.clone(),
+            collection: self.collection.clone(),
+            key: Some(key),
+            op: SyncOp::Delete,
+            row: None,
+            cursor: cursor.clone(),
+        });
+        Ok(cursor)
+    }
+
+    /// Remove all rows and force clients to resnapshot.
+    pub fn reset(&self) -> SyncResult<SyncCursor> {
+        let mut inner = self.lock()?;
+        inner.version = inner.version.saturating_add(1);
+        let cursor = SyncCursor::new(inner.version.to_string())?;
+        inner.rows.clear();
+        inner.changes.push(SyncChange {
+            shape: self.shape.clone(),
+            collection: self.collection.clone(),
+            key: None,
+            op: SyncOp::Reset,
+            row: None,
+            cursor: cursor.clone(),
+        });
+        Ok(cursor)
+    }
+
+    fn pull_value(&self, request: SyncPullRequest) -> SyncResult<SyncPullResponse<Value>> {
+        let inner = self.lock()?;
+        let cursor = Some(SyncCursor::new(inner.version.to_string())?);
+
+        let Some(after) = request.cursor else {
+            let rows = inner
+                .rows
+                .values()
+                .cloned()
+                .map(row_to_value)
+                .collect::<SyncResult<Vec<_>>>()?;
+            return Ok(SyncPullResponse::snapshot(
+                self.shape.clone(),
+                self.collection.clone(),
+                rows,
+                cursor,
+            ));
+        };
+
+        let after = after
+            .as_str()
+            .parse::<u64>()
+            .map_err(|_| SyncError::Gap(after.to_string()))?;
+        let changes = inner
+            .changes
+            .iter()
+            .filter(|change| {
+                change
+                    .cursor
+                    .as_str()
+                    .parse::<u64>()
+                    .map(|cursor| cursor > after)
+                    .unwrap_or(true)
+            })
+            .cloned()
+            .map(change_to_value)
+            .collect::<SyncResult<Vec<_>>>()?;
+
+        Ok(SyncPullResponse::incremental(
+            self.shape.clone(),
+            self.collection.clone(),
+            changes,
+            cursor,
+        ))
+    }
+
+    fn lock(&self) -> SyncResult<std::sync::MutexGuard<'_, Inner<T>>> {
+        self.inner
+            .lock()
+            .map_err(|_| SyncError::backend("memory sync shape lock poisoned"))
+    }
+}
+
+impl<T> SyncShapeSource for MemorySyncShape<T>
+where
+    T: Clone + Serialize + Send + Sync + 'static,
+{
+    fn shape(&self) -> &SyncShapeName {
+        &self.shape
+    }
+
+    fn collection(&self) -> &SyncCollectionName {
+        &self.collection
+    }
+
+    fn current_cursor(&self) -> Option<SyncCursor> {
+        let inner = self.inner.lock().ok()?;
+        SyncCursor::new(inner.version.to_string()).ok()
+    }
+
+    fn pull<'a>(&'a self, request: SyncPullRequest) -> SyncBoxFuture<'a, SyncPullResponse<Value>> {
+        Box::pin(async move { self.pull_value(request) })
+    }
+}
+
+fn row_to_value<T: Serialize>(row: SyncRow<T>) -> SyncResult<SyncRow<Value>> {
+    Ok(SyncRow {
+        key: row.key,
+        version: row.version,
+        value: serde_json::to_value(row.value)?,
+        pending: row.pending,
+        conflict: row.conflict,
+    })
+}
+
+fn change_to_value<T: Serialize>(change: SyncChange<T>) -> SyncResult<SyncChange<Value>> {
+    Ok(SyncChange {
+        shape: change.shape,
+        collection: change.collection,
+        key: change.key,
+        op: change.op,
+        row: change.row.map(row_to_value).transpose()?,
+        cursor: change.cursor,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::SyncPullMode;
+
+    #[test]
+    fn memory_shape_returns_snapshot_then_incremental_changes() {
+        let shape = MemorySyncShape::<String>::new("posts_for_tenant", "posts").unwrap();
+        shape.upsert("post_1", "one".to_string()).unwrap();
+        let first = shape
+            .pull_value(SyncPullRequest::new(
+                SyncShapeName::new("posts_for_tenant").unwrap(),
+            ))
+            .unwrap();
+        assert_eq!(first.mode, SyncPullMode::Snapshot);
+        assert_eq!(first.rows.len(), 1);
+
+        shape.upsert("post_2", "two".to_string()).unwrap();
+        let second = shape
+            .pull_value(
+                SyncPullRequest::new(SyncShapeName::new("posts_for_tenant").unwrap())
+                    .cursor(first.cursor.clone()),
+            )
+            .unwrap();
+        assert_eq!(second.mode, SyncPullMode::Incremental);
+        assert_eq!(second.changes.len(), 1);
+        assert_eq!(
+            second.changes[0].row.as_ref().unwrap().key.as_str(),
+            "post_2"
+        );
+    }
+}

--- a/crates/pocopine-sync/src/protocol.rs
+++ b/crates/pocopine-sync/src/protocol.rs
@@ -1,24 +1,36 @@
 use std::fmt;
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::{SyncError, SyncResult};
 
 /// Current sync protocol identifier.
 pub const SYNC_PROTOCOL_V1: &str = "pocopine.sync.v1";
+/// Maximum length, in bytes, accepted for protocol token strings.
+pub const MAX_SYNC_TOKEN_LEN: usize = 1024;
+
+macro_rules! sync_path {
+    ($suffix:literal) => {
+        concat!("/__pocopine/sync/v1", $suffix)
+    };
+}
 
 /// Default sync endpoint prefix mounted by the server plugin.
-pub const SYNC_ENDPOINT_PREFIX: &str = "/__pocopine/sync/v1";
+pub const SYNC_ENDPOINT_PREFIX: &str = sync_path!("");
 /// Open endpoint path.
-pub const SYNC_OPEN_PATH: &str = "/__pocopine/sync/v1/open";
+pub const SYNC_OPEN_PATH: &str = sync_path!("/open");
 /// Pull endpoint path.
-pub const SYNC_PULL_PATH: &str = "/__pocopine/sync/v1/pull";
+pub const SYNC_PULL_PATH: &str = sync_path!("/pull");
 /// Push endpoint path.
-pub const SYNC_PUSH_PATH: &str = "/__pocopine/sync/v1/push";
+pub const SYNC_PUSH_PATH: &str = sync_path!("/push");
 
 fn validate_token(field: &'static str, value: String) -> SyncResult<String> {
     let trimmed = value.trim();
-    if trimmed.is_empty() || trimmed != value || value.chars().any(char::is_control) {
+    if value.len() > MAX_SYNC_TOKEN_LEN
+        || trimmed.is_empty()
+        || trimmed != value
+        || value.chars().any(char::is_control)
+    {
         return Err(SyncError::invalid_value(field, value));
     }
     Ok(value)
@@ -27,8 +39,7 @@ fn validate_token(field: &'static str, value: String) -> SyncResult<String> {
 macro_rules! opaque_string_type {
     ($name:ident, $field:literal, $doc:literal) => {
         #[doc = $doc]
-        #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
-        #[serde(transparent)]
+        #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
         pub struct $name(String);
 
         impl $name {
@@ -46,6 +57,25 @@ macro_rules! opaque_string_type {
         impl fmt::Display for $name {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
                 f.write_str(self.as_str())
+            }
+        }
+
+        impl Serialize for $name {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                serializer.serialize_str(self.as_str())
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let value = String::deserialize(deserializer)?;
+                Self::new(value).map_err(serde::de::Error::custom)
             }
         }
 
@@ -333,6 +363,15 @@ mod tests {
         assert!(SyncShapeName::new("").is_err());
         assert!(SyncShapeName::new(" posts").is_err());
         assert!(SyncShapeName::new("posts\nbad").is_err());
+        assert!(SyncShapeName::new("x".repeat(MAX_SYNC_TOKEN_LEN + 1)).is_err());
+    }
+
+    #[test]
+    fn deserializes_tokens_through_validation() {
+        let shape: SyncShapeName = serde_json::from_str("\"posts_for_tenant\"").unwrap();
+        assert_eq!(shape.as_str(), "posts_for_tenant");
+        assert!(serde_json::from_str::<SyncShapeName>("\" posts\"").is_err());
+        assert!(serde_json::from_str::<SyncShapeName>("\"posts\\nbad\"").is_err());
     }
 
     #[test]
@@ -341,5 +380,15 @@ mod tests {
             sync_shape_tag("posts_for_tenant"),
             "sync:shape:posts_for_tenant"
         );
+    }
+
+    #[test]
+    fn endpoint_paths_share_prefix() {
+        assert!(SYNC_OPEN_PATH.starts_with(SYNC_ENDPOINT_PREFIX));
+        assert!(SYNC_OPEN_PATH.ends_with("/open"));
+        assert!(SYNC_PULL_PATH.starts_with(SYNC_ENDPOINT_PREFIX));
+        assert!(SYNC_PULL_PATH.ends_with("/pull"));
+        assert!(SYNC_PUSH_PATH.starts_with(SYNC_ENDPOINT_PREFIX));
+        assert!(SYNC_PUSH_PATH.ends_with("/push"));
     }
 }

--- a/crates/pocopine-sync/src/protocol.rs
+++ b/crates/pocopine-sync/src/protocol.rs
@@ -1,0 +1,345 @@
+use std::fmt;
+
+use serde::{Deserialize, Serialize};
+
+use crate::{SyncError, SyncResult};
+
+/// Current sync protocol identifier.
+pub const SYNC_PROTOCOL_V1: &str = "pocopine.sync.v1";
+
+/// Default sync endpoint prefix mounted by the server plugin.
+pub const SYNC_ENDPOINT_PREFIX: &str = "/__pocopine/sync/v1";
+/// Open endpoint path.
+pub const SYNC_OPEN_PATH: &str = "/__pocopine/sync/v1/open";
+/// Pull endpoint path.
+pub const SYNC_PULL_PATH: &str = "/__pocopine/sync/v1/pull";
+/// Push endpoint path.
+pub const SYNC_PUSH_PATH: &str = "/__pocopine/sync/v1/push";
+
+fn validate_token(field: &'static str, value: String) -> SyncResult<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() || trimmed != value || value.chars().any(char::is_control) {
+        return Err(SyncError::invalid_value(field, value));
+    }
+    Ok(value)
+}
+
+macro_rules! opaque_string_type {
+    ($name:ident, $field:literal, $doc:literal) => {
+        #[doc = $doc]
+        #[derive(Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+        #[serde(transparent)]
+        pub struct $name(String);
+
+        impl $name {
+            /// Build a validated value.
+            pub fn new(value: impl Into<String>) -> SyncResult<Self> {
+                validate_token($field, value.into()).map(Self)
+            }
+
+            /// Borrow the string value.
+            pub fn as_str(&self) -> &str {
+                self.0.as_str()
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(self.as_str())
+            }
+        }
+
+        impl TryFrom<&str> for $name {
+            type Error = SyncError;
+
+            fn try_from(value: &str) -> Result<Self, Self::Error> {
+                Self::new(value)
+            }
+        }
+
+        impl TryFrom<String> for $name {
+            type Error = SyncError;
+
+            fn try_from(value: String) -> Result<Self, Self::Error> {
+                Self::new(value)
+            }
+        }
+    };
+}
+
+opaque_string_type!(SyncShapeName, "shape", "Server-registered sync shape name.");
+opaque_string_type!(
+    SyncCollectionName,
+    "collection",
+    "Public collection name exposed to the client."
+);
+opaque_string_type!(SyncCursor, "cursor", "Opaque server-issued sync cursor.");
+opaque_string_type!(
+    RowKey,
+    "row key",
+    "Public row identity inside one sync shape."
+);
+opaque_string_type!(
+    RowVersion,
+    "row version",
+    "Opaque server-issued row version."
+);
+opaque_string_type!(
+    MutationId,
+    "mutation id",
+    "Client-generated mutation idempotency key."
+);
+
+/// Live query tag used to wake clients for a sync shape.
+pub fn sync_shape_tag(shape: &str) -> String {
+    format!("sync:shape:{shape}")
+}
+
+/// Operation attached to a sync change.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SyncOp {
+    Upsert,
+    Delete,
+    Reset,
+}
+
+/// Whether a pull response is a full replacement or incremental batch.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SyncPullMode {
+    Snapshot,
+    Incremental,
+}
+
+/// Row payload plus sync metadata.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(bound(serialize = "T: Serialize", deserialize = "T: Deserialize<'de>"))]
+pub struct SyncRow<T> {
+    pub key: RowKey,
+    pub version: Option<RowVersion>,
+    pub value: T,
+    #[serde(default)]
+    pub pending: bool,
+    #[serde(default)]
+    pub conflict: bool,
+}
+
+impl<T> SyncRow<T> {
+    pub fn new(key: impl Into<String>, value: T) -> SyncResult<Self> {
+        Ok(Self {
+            key: RowKey::new(key)?,
+            version: None,
+            value,
+            pending: false,
+            conflict: false,
+        })
+    }
+
+    pub fn version(mut self, version: impl Into<String>) -> SyncResult<Self> {
+        self.version = Some(RowVersion::new(version)?);
+        Ok(self)
+    }
+}
+
+/// One ordered change in a sync stream.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(bound(serialize = "T: Serialize", deserialize = "T: Deserialize<'de>"))]
+pub struct SyncChange<T> {
+    pub shape: SyncShapeName,
+    pub collection: SyncCollectionName,
+    pub key: Option<RowKey>,
+    pub op: SyncOp,
+    pub row: Option<SyncRow<T>>,
+    pub cursor: SyncCursor,
+}
+
+/// Open one or more shapes.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SyncOpenRequest {
+    pub protocol: String,
+    #[serde(default)]
+    pub client_id: Option<String>,
+    pub shapes: Vec<SyncShapeName>,
+}
+
+impl SyncOpenRequest {
+    pub fn new(shapes: impl IntoIterator<Item = SyncShapeName>) -> Self {
+        Self {
+            protocol: SYNC_PROTOCOL_V1.to_string(),
+            client_id: None,
+            shapes: shapes.into_iter().collect(),
+        }
+    }
+}
+
+/// Shape accepted by an open response.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SyncOpenShape {
+    pub shape: SyncShapeName,
+    pub collection: SyncCollectionName,
+    pub cursor: Option<SyncCursor>,
+}
+
+/// Open response.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SyncOpenResponse {
+    pub protocol: String,
+    pub shapes: Vec<SyncOpenShape>,
+}
+
+impl SyncOpenResponse {
+    pub fn new(shapes: Vec<SyncOpenShape>) -> Self {
+        Self {
+            protocol: SYNC_PROTOCOL_V1.to_string(),
+            shapes,
+        }
+    }
+}
+
+/// Pull request for one shape.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SyncPullRequest {
+    pub protocol: String,
+    pub shape: SyncShapeName,
+    pub cursor: Option<SyncCursor>,
+    pub limit: u32,
+}
+
+impl SyncPullRequest {
+    pub fn new(shape: SyncShapeName) -> Self {
+        Self {
+            protocol: SYNC_PROTOCOL_V1.to_string(),
+            shape,
+            cursor: None,
+            limit: 500,
+        }
+    }
+
+    pub fn cursor(mut self, cursor: Option<SyncCursor>) -> Self {
+        self.cursor = cursor;
+        self
+    }
+}
+
+/// Pull response for one shape.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(bound(serialize = "T: Serialize", deserialize = "T: Deserialize<'de>"))]
+pub struct SyncPullResponse<T> {
+    pub protocol: String,
+    pub shape: SyncShapeName,
+    pub collection: SyncCollectionName,
+    pub mode: SyncPullMode,
+    #[serde(default)]
+    pub rows: Vec<SyncRow<T>>,
+    #[serde(default)]
+    pub changes: Vec<SyncChange<T>>,
+    pub cursor: Option<SyncCursor>,
+    pub has_more: bool,
+}
+
+impl<T> SyncPullResponse<T> {
+    pub fn snapshot(
+        shape: SyncShapeName,
+        collection: SyncCollectionName,
+        rows: Vec<SyncRow<T>>,
+        cursor: Option<SyncCursor>,
+    ) -> Self {
+        Self {
+            protocol: SYNC_PROTOCOL_V1.to_string(),
+            shape,
+            collection,
+            mode: SyncPullMode::Snapshot,
+            rows,
+            changes: Vec::new(),
+            cursor,
+            has_more: false,
+        }
+    }
+
+    pub fn incremental(
+        shape: SyncShapeName,
+        collection: SyncCollectionName,
+        changes: Vec<SyncChange<T>>,
+        cursor: Option<SyncCursor>,
+    ) -> Self {
+        Self {
+            protocol: SYNC_PROTOCOL_V1.to_string(),
+            shape,
+            collection,
+            mode: SyncPullMode::Incremental,
+            rows: Vec::new(),
+            changes,
+            cursor,
+            has_more: false,
+        }
+    }
+}
+
+/// Client mutation envelope. The first slice defines the wire shape;
+/// concrete mutation application belongs to shape sources.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(bound(serialize = "M: Serialize", deserialize = "M: Deserialize<'de>"))]
+pub struct ClientMutation<M> {
+    pub id: MutationId,
+    pub key: Option<RowKey>,
+    pub op: SyncOp,
+    pub base_version: Option<RowVersion>,
+    pub payload: M,
+}
+
+/// Push request for one shape.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(bound(serialize = "M: Serialize", deserialize = "M: Deserialize<'de>"))]
+pub struct SyncPushRequest<M> {
+    pub protocol: String,
+    pub shape: SyncShapeName,
+    #[serde(default)]
+    pub mutations: Vec<ClientMutation<M>>,
+}
+
+/// Conflict returned by a push.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(bound(serialize = "T: Serialize", deserialize = "T: Deserialize<'de>"))]
+pub struct SyncConflict<T> {
+    pub mutation_id: MutationId,
+    pub key: Option<RowKey>,
+    pub server_row: Option<SyncRow<T>>,
+    pub reason: String,
+}
+
+/// Push response for one shape.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(bound(serialize = "T: Serialize", deserialize = "T: Deserialize<'de>"))]
+pub struct SyncPushResponse<T> {
+    pub protocol: String,
+    pub shape: SyncShapeName,
+    #[serde(default)]
+    pub accepted: Vec<MutationId>,
+    #[serde(default)]
+    pub rows: Vec<SyncRow<T>>,
+    #[serde(default)]
+    pub conflicts: Vec<SyncConflict<T>>,
+    pub cursor: Option<SyncCursor>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn validates_shape_names() {
+        assert!(SyncShapeName::new("posts_for_tenant").is_ok());
+        assert!(SyncShapeName::new("").is_err());
+        assert!(SyncShapeName::new(" posts").is_err());
+        assert!(SyncShapeName::new("posts\nbad").is_err());
+    }
+
+    #[test]
+    fn sync_shape_tag_is_stable() {
+        assert_eq!(
+            sync_shape_tag("posts_for_tenant"),
+            "sync:shape:posts_for_tenant"
+        );
+    }
+}

--- a/crates/pocopine-sync/src/server.rs
+++ b/crates/pocopine-sync/src/server.rs
@@ -1,0 +1,276 @@
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use pocopine_core::{ServerError, ServerResult};
+use pocopine_events::SharedEventBackend;
+use pocopine_server::axum::extract::State;
+use pocopine_server::axum::response::Json;
+use pocopine_server::axum::routing::post;
+use pocopine_server::{Server, ServerPlugin};
+use serde_json::Value;
+
+use crate::{
+    sync_shape_tag, SyncError, SyncOpenRequest, SyncOpenResponse, SyncOpenShape, SyncPullRequest,
+    SyncPullResponse, SyncPushRequest, SyncPushResponse, SyncResult, SYNC_OPEN_PATH,
+    SYNC_PULL_PATH, SYNC_PUSH_PATH,
+};
+
+/// Future returned by a shape source.
+pub type SyncBoxFuture<'a, T> = Pin<Box<dyn Future<Output = SyncResult<T>> + Send + 'a>>;
+
+/// Server-side source for one registered sync shape.
+pub trait SyncShapeSource: Send + Sync + 'static {
+    /// Server-registered shape name.
+    fn shape(&self) -> &crate::SyncShapeName;
+
+    /// Public collection name represented by this shape.
+    fn collection(&self) -> &crate::SyncCollectionName;
+
+    /// Current cursor, if the source can cheaply report it.
+    fn current_cursor(&self) -> Option<crate::SyncCursor> {
+        None
+    }
+
+    /// Pull changes or a snapshot for this shape.
+    fn pull<'a>(&'a self, request: SyncPullRequest) -> SyncBoxFuture<'a, SyncPullResponse<Value>>;
+
+    /// Push client mutations for this shape.
+    fn push<'a>(
+        &'a self,
+        request: SyncPushRequest<Value>,
+    ) -> SyncBoxFuture<'a, SyncPushResponse<Value>> {
+        let _ = request;
+        Box::pin(async {
+            Err(SyncError::unsupported(
+                "push is not implemented for this shape",
+            ))
+        })
+    }
+}
+
+#[derive(Clone)]
+struct SyncServerInner {
+    shapes: Arc<HashMap<String, Arc<dyn SyncShapeSource>>>,
+    events: Option<SharedEventBackend>,
+}
+
+/// Host-side sync server service.
+#[derive(Clone)]
+pub struct SyncServer {
+    inner: Arc<SyncServerInner>,
+}
+
+impl SyncServer {
+    /// Start building a sync server.
+    pub fn builder() -> SyncServerBuilder {
+        SyncServerBuilder::default()
+    }
+
+    /// Return the live query tags this server can publish for shapes.
+    pub fn live_query_tags(&self) -> Vec<String> {
+        self.inner
+            .shapes
+            .keys()
+            .map(|shape| sync_shape_tag(shape))
+            .collect()
+    }
+
+    /// Return the live topics this server can publish for shapes.
+    pub fn live_topics(&self) -> pocopine_events::EventResult<Vec<pocopine_events::Topic>> {
+        self.live_query_tags()
+            .into_iter()
+            .map(|tag| pocopine_live::query_tag_topic(&tag))
+            .collect()
+    }
+
+    /// Publish a live wake-up for one shape when an event backend is
+    /// attached. The sync data still moves through pull; this only wakes
+    /// browsers to pull with their current sync cursor.
+    pub async fn invalidate_shape(&self, shape: &str) -> SyncResult<()> {
+        let Some(events) = self.inner.events.as_ref() else {
+            return Ok(());
+        };
+        let tag = sync_shape_tag(shape);
+        let topic = pocopine_live::query_tag_topic(&tag)
+            .map_err(|err| SyncError::backend(err.to_string()))?;
+        let draft = pocopine_live::query_invalidated(topic, [tag])
+            .map_err(|err| SyncError::backend(err.to_string()))?;
+        events
+            .publish(draft)
+            .await
+            .map_err(|err| SyncError::backend(err.to_string()))?;
+        Ok(())
+    }
+
+    fn shape(&self, shape: &str) -> SyncResult<Arc<dyn SyncShapeSource>> {
+        self.inner
+            .shapes
+            .get(shape)
+            .cloned()
+            .ok_or_else(|| SyncError::UnknownShape(shape.to_string()))
+    }
+}
+
+/// Builder for [`SyncServer`].
+#[derive(Default)]
+pub struct SyncServerBuilder {
+    shapes: HashMap<String, Arc<dyn SyncShapeSource>>,
+    events: Option<SharedEventBackend>,
+}
+
+impl SyncServerBuilder {
+    /// Register one shape source.
+    pub fn shape<S>(mut self, shape: S) -> Self
+    where
+        S: SyncShapeSource,
+    {
+        self.shapes
+            .insert(shape.shape().as_str().to_string(), Arc::new(shape));
+        self
+    }
+
+    /// Attach the event backend shared with `pocopine-live`.
+    pub fn events(mut self, events: SharedEventBackend) -> Self {
+        self.events = Some(events);
+        self
+    }
+
+    /// Finish the sync server.
+    pub fn build(self) -> SyncServer {
+        SyncServer {
+            inner: Arc::new(SyncServerInner {
+                shapes: Arc::new(self.shapes),
+                events: self.events,
+            }),
+        }
+    }
+}
+
+/// Server plugin that mounts sync routes and provides [`SyncServer`].
+#[derive(Clone)]
+pub struct SyncServerPlugin {
+    sync: SyncServer,
+}
+
+/// Build a sync server plugin.
+pub fn sync_server_plugin(sync: SyncServer) -> SyncServerPlugin {
+    SyncServerPlugin { sync }
+}
+
+impl ServerPlugin for SyncServerPlugin {
+    fn name(&self) -> &'static str {
+        "pocopine-sync"
+    }
+
+    fn install(self, server: Server) -> Server {
+        let sync = self.sync;
+        server
+            .provide_plugin(sync.clone())
+            .route(SYNC_OPEN_PATH, post(open_handler).with_state(sync.clone()))
+            .route(SYNC_PULL_PATH, post(pull_handler).with_state(sync.clone()))
+            .route(SYNC_PUSH_PATH, post(push_handler).with_state(sync))
+    }
+}
+
+async fn open_handler(
+    State(sync): State<SyncServer>,
+    Json(request): Json<SyncOpenRequest>,
+) -> Json<ServerResult<SyncOpenResponse>> {
+    Json(open(sync, request).await.map_err(server_error))
+}
+
+async fn open(sync: SyncServer, request: SyncOpenRequest) -> SyncResult<SyncOpenResponse> {
+    let mut shapes = Vec::with_capacity(request.shapes.len());
+    for requested in request.shapes {
+        let shape = sync.shape(requested.as_str())?;
+        shapes.push(SyncOpenShape {
+            shape: shape.shape().clone(),
+            collection: shape.collection().clone(),
+            cursor: shape.current_cursor(),
+        });
+    }
+    Ok(SyncOpenResponse::new(shapes))
+}
+
+async fn pull_handler(
+    State(sync): State<SyncServer>,
+    Json(request): Json<SyncPullRequest>,
+) -> Json<ServerResult<SyncPullResponse<Value>>> {
+    let result = async {
+        let shape = sync.shape(request.shape.as_str())?;
+        shape.pull(request).await
+    }
+    .await;
+    Json(result.map_err(server_error))
+}
+
+async fn push_handler(
+    State(sync): State<SyncServer>,
+    Json(request): Json<SyncPushRequest<Value>>,
+) -> Json<ServerResult<SyncPushResponse<Value>>> {
+    let result = async {
+        let shape = sync.shape(request.shape.as_str())?;
+        shape.push(request).await
+    }
+    .await;
+    Json(result.map_err(server_error))
+}
+
+fn server_error(error: SyncError) -> ServerError {
+    match error {
+        SyncError::InvalidValue { .. } => ServerError::BadRequest(error.to_string()),
+        SyncError::UnknownShape(_) => ServerError::Forbidden(error.to_string()),
+        SyncError::Unsupported(_) => ServerError::BadRequest(error.to_string()),
+        SyncError::Gap(_) => ServerError::BadRequest(error.to_string()),
+        SyncError::Json(_) => ServerError::BadRequest(error.to_string()),
+        SyncError::Client(_) | SyncError::Backend(_) => ServerError::App(error.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use http_body_util::BodyExt;
+    use pocopine_server::axum::body::Body;
+    use pocopine_server::axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    use super::*;
+    use crate::{MemorySyncShape, SyncPullMode, SyncRow, SyncShapeName, SYNC_PROTOCOL_V1};
+
+    #[tokio::test]
+    async fn server_plugin_mounts_pull_route() {
+        pocopine_server::__reset_for_test();
+        let posts = MemorySyncShape::<String>::new("posts_for_tenant", "posts").unwrap();
+        posts.upsert("post_1", "hello".to_string()).unwrap();
+        let sync = SyncServer::builder().shape(posts).build();
+        let router = pocopine_server::Server::new(pocopine_server::axum::Router::new())
+            .plugin(sync_server_plugin(sync))
+            .try_finalize()
+            .unwrap();
+
+        let request = SyncPullRequest::new(SyncShapeName::new("posts_for_tenant").unwrap());
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(SYNC_PULL_PATH)
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&request).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let outer: ServerResult<SyncPullResponse<String>> = serde_json::from_slice(&bytes).unwrap();
+        let response = outer.unwrap();
+        assert_eq!(response.protocol, SYNC_PROTOCOL_V1);
+        assert_eq!(response.mode, SyncPullMode::Snapshot);
+        let mut expected = SyncRow::new("post_1", "hello".to_string()).unwrap();
+        expected.version = Some(crate::RowVersion::new("v1").unwrap());
+        assert_eq!(response.rows, vec![expected]);
+    }
+}

--- a/crates/pocopine-sync/src/server.rs
+++ b/crates/pocopine-sync/src/server.rs
@@ -21,6 +21,11 @@ use crate::{
 pub type SyncBoxFuture<'a, T> = Pin<Box<dyn Future<Output = SyncResult<T>> + Send + 'a>>;
 
 /// Server-side source for one registered sync shape.
+///
+/// Registered shapes are pullable through the sync routes. Until a source
+/// implements its own authorization or the host app mounts sync behind an
+/// auth boundary, `/open` is validation/discovery and `/pull` remains
+/// callable for any registered shape.
 pub trait SyncShapeSource: Send + Sync + 'static {
     /// Server-registered shape name.
     fn shape(&self) -> &crate::SyncShapeName;
@@ -149,6 +154,10 @@ impl SyncServerBuilder {
 }
 
 /// Server plugin that mounts sync routes and provides [`SyncServer`].
+///
+/// Installing this plugin exposes `/__pocopine/sync/v1/open`, `/pull`, and
+/// `/push` for every registered shape. Shape sources are responsible for
+/// tenant filtering, authorization, and cursor policy in this first slice.
 #[derive(Clone)]
 pub struct SyncServerPlugin {
     sync: SyncServer,
@@ -224,31 +233,33 @@ fn server_error(error: SyncError) -> ServerError {
         SyncError::UnknownShape(_) => ServerError::Forbidden(error.to_string()),
         SyncError::Unsupported(_) => ServerError::BadRequest(error.to_string()),
         SyncError::Gap(_) => ServerError::BadRequest(error.to_string()),
-        SyncError::Json(_) => ServerError::BadRequest(error.to_string()),
-        SyncError::Client(_) | SyncError::Backend(_) => ServerError::App(error.to_string()),
+        SyncError::Json(err) => {
+            tracing::error!(target: "pocopine.log", error = %err, "sync json error");
+            ServerError::App("sync internal error".to_string())
+        }
+        SyncError::Client(msg) | SyncError::Backend(msg) => {
+            tracing::error!(target: "pocopine.log", error = %msg, "sync backend error");
+            ServerError::App("sync internal error".to_string())
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use http_body_util::BodyExt;
+    use pocopine_core::ServerError;
     use pocopine_server::axum::body::Body;
     use pocopine_server::axum::http::{Request, StatusCode};
     use tower::ServiceExt;
 
     use super::*;
-    use crate::{MemorySyncShape, SyncPullMode, SyncRow, SyncShapeName, SYNC_PROTOCOL_V1};
+    use crate::{
+        MemorySyncShape, SyncPullMode, SyncPushRequest, SyncRow, SyncShapeName, SYNC_PROTOCOL_V1,
+    };
 
     #[tokio::test]
-    async fn server_plugin_mounts_pull_route() {
-        pocopine_server::__reset_for_test();
-        let posts = MemorySyncShape::<String>::new("posts_for_tenant", "posts").unwrap();
-        posts.upsert("post_1", "hello".to_string()).unwrap();
-        let sync = SyncServer::builder().shape(posts).build();
-        let router = pocopine_server::Server::new(pocopine_server::axum::Router::new())
-            .plugin(sync_server_plugin(sync))
-            .try_finalize()
-            .unwrap();
+    async fn pull_route_is_public_for_registered_shapes() {
+        let router = router_with_posts_shape();
 
         let request = SyncPullRequest::new(SyncShapeName::new("posts_for_tenant").unwrap());
         let response = router
@@ -272,5 +283,87 @@ mod tests {
         let mut expected = SyncRow::new("post_1", "hello".to_string()).unwrap();
         expected.version = Some(crate::RowVersion::new("v1").unwrap());
         assert_eq!(response.rows, vec![expected]);
+    }
+
+    #[tokio::test]
+    async fn pull_unknown_shape_returns_forbidden() {
+        let router = router_with_posts_shape();
+
+        let request = SyncPullRequest::new(SyncShapeName::new("unknown_shape").unwrap());
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(SYNC_PULL_PATH)
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&request).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let outer: ServerResult<SyncPullResponse<String>> = serde_json::from_slice(&bytes).unwrap();
+        assert!(matches!(
+            outer,
+            Err(ServerError::Forbidden(message)) if message.contains("unknown sync shape")
+        ));
+    }
+
+    #[tokio::test]
+    async fn default_push_returns_unsupported_bad_request() {
+        let router = router_with_posts_shape();
+
+        let request = SyncPushRequest::<String> {
+            protocol: SYNC_PROTOCOL_V1.to_string(),
+            shape: SyncShapeName::new("posts_for_tenant").unwrap(),
+            mutations: Vec::new(),
+        };
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(SYNC_PUSH_PATH)
+                    .header("content-type", "application/json")
+                    .body(Body::from(serde_json::to_string(&request).unwrap()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let outer: ServerResult<SyncPushResponse<String>> = serde_json::from_slice(&bytes).unwrap();
+        assert!(matches!(
+            outer,
+            Err(ServerError::BadRequest(message))
+                if message.contains("unsupported sync operation")
+        ));
+    }
+
+    #[test]
+    fn server_error_hides_internal_details() {
+        assert!(matches!(
+            server_error(SyncError::backend("lock poisoned with internal detail")),
+            ServerError::App(message) if message == "sync internal error"
+        ));
+
+        let json_err = serde_json::from_str::<serde_json::Value>("not-json").unwrap_err();
+        assert!(matches!(
+            server_error(SyncError::Json(json_err)),
+            ServerError::App(message) if message == "sync internal error"
+        ));
+    }
+
+    fn router_with_posts_shape() -> pocopine_server::axum::Router {
+        pocopine_server::__reset_for_test();
+        let posts = MemorySyncShape::<String>::new("posts_for_tenant", "posts").unwrap();
+        posts.upsert("post_1", "hello".to_string()).unwrap();
+        let sync = SyncServer::builder().shape(posts).build();
+        pocopine_server::Server::new(pocopine_server::axum::Router::new())
+            .plugin(sync_server_plugin(sync))
+            .try_finalize()
+            .unwrap()
     }
 }

--- a/crates/pocopine-sync/src/state.rs
+++ b/crates/pocopine-sync/src/state.rs
@@ -81,8 +81,22 @@ impl<T> CollectionState<T> {
     }
 
     pub fn begin_live_pull(&mut self, reason: SyncReason) -> SyncRequest {
+        if self.version == 0 {
+            self.live_event_count = self.live_event_count.saturating_add(1);
+            return self.begin(reason, true);
+        }
+
+        self.request_generation = self.request_generation.saturating_add(1);
+        self.refresh_count = self.refresh_count.saturating_add(1);
         self.live_event_count = self.live_event_count.saturating_add(1);
-        self.begin(reason, true)
+        self.last_reason = reason;
+        self.error.clear();
+        self.loading = false;
+        self.syncing = false;
+
+        SyncRequest {
+            generation: self.request_generation,
+        }
     }
 
     pub fn apply_pull(&mut self, request: SyncRequest, response: SyncPullResponse<T>) -> bool {
@@ -90,14 +104,13 @@ impl<T> CollectionState<T> {
             return false;
         }
 
-        match response.mode {
+        let rows_changed = match response.mode {
             SyncPullMode::Snapshot => {
                 self.rows = response.rows;
+                true
             }
-            SyncPullMode::Incremental => {
-                self.apply_changes(response.changes);
-            }
-        }
+            SyncPullMode::Incremental => self.apply_changes(response.changes),
+        };
 
         self.cursor = response.cursor;
         self.loading = false;
@@ -105,7 +118,9 @@ impl<T> CollectionState<T> {
         self.stale = false;
         self.error.clear();
         self.version = self.version.saturating_add(1);
-        self.recount_row_flags();
+        if rows_changed {
+            self.recount_row_flags();
+        }
         true
     }
 
@@ -161,7 +176,8 @@ impl<T> CollectionState<T> {
         }
     }
 
-    fn apply_changes(&mut self, changes: Vec<SyncChange<T>>) {
+    fn apply_changes(&mut self, changes: Vec<SyncChange<T>>) -> bool {
+        let mut rows_changed = false;
         for change in changes {
             match change.op {
                 SyncOp::Upsert => {
@@ -177,20 +193,32 @@ impl<T> CollectionState<T> {
                     } else {
                         self.rows.push(row);
                     }
+                    rows_changed = true;
                 }
                 SyncOp::Delete => {
-                    if let Some(key) = change.key {
-                        self.rows.retain(|row| row.key != key);
+                    let Some(key) = change.key else {
+                        continue;
+                    };
+                    if let Some(index) = self.rows.iter().position(|row| row.key == key) {
+                        self.rows.remove(index);
+                        rows_changed = true;
                     }
                 }
-                SyncOp::Reset => {
-                    self.rows.clear();
-                    if let Some(row) = change.row {
+                SyncOp::Reset => match change.row {
+                    Some(row) => {
+                        self.rows.clear();
                         self.rows.push(row);
+                        rows_changed = true;
                     }
-                }
+                    None if !self.rows.is_empty() => {
+                        self.rows.clear();
+                        rows_changed = true;
+                    }
+                    None => {}
+                },
             }
         }
+        rows_changed
     }
 
     fn recount_row_flags(&mut self) {
@@ -293,5 +321,76 @@ mod tests {
             ),
         ));
         assert_eq!(state.rows[0].value, "current");
+    }
+
+    #[test]
+    fn live_pull_after_initial_load_is_background_refresh() {
+        let mut state = CollectionState::<String>::default();
+        let initial = state.begin_initial();
+        state.apply_pull(
+            initial,
+            SyncPullResponse::snapshot(
+                SyncShapeName::new("posts").unwrap(),
+                SyncCollectionName::new("posts").unwrap(),
+                vec![SyncRow::new("post_1", "loaded".to_string()).unwrap()],
+                Some(SyncCursor::new("1").unwrap()),
+            ),
+        );
+
+        let request = state.begin_live_pull(SyncReason::Live);
+
+        assert_eq!(request.generation(), 2);
+        assert_eq!(state.refresh_count, 2);
+        assert_eq!(state.live_event_count, 1);
+        assert_eq!(state.last_reason, SyncReason::Live);
+        assert!(!state.loading);
+        assert!(!state.syncing);
+        assert!(!state.stale);
+        assert_eq!(state.rows[0].value, "loaded");
+    }
+
+    #[test]
+    fn initial_live_pull_still_shows_loading() {
+        let mut state = CollectionState::<String>::default();
+
+        state.begin_live_pull(SyncReason::Live);
+
+        assert!(state.loading);
+        assert!(!state.syncing);
+        assert!(state.stale);
+        assert_eq!(state.live_event_count, 1);
+    }
+
+    #[test]
+    fn empty_incremental_pull_keeps_existing_rows_visible() {
+        let mut state = CollectionState::<String>::default();
+        let initial = state.begin_initial();
+        state.apply_pull(
+            initial,
+            SyncPullResponse::snapshot(
+                SyncShapeName::new("posts").unwrap(),
+                SyncCollectionName::new("posts").unwrap(),
+                vec![SyncRow::new("post_1", "loaded".to_string()).unwrap()],
+                Some(SyncCursor::new("1").unwrap()),
+            ),
+        );
+
+        let request = state.begin_live_pull(SyncReason::Live);
+        assert!(state.apply_pull(
+            request,
+            SyncPullResponse::incremental(
+                SyncShapeName::new("posts").unwrap(),
+                SyncCollectionName::new("posts").unwrap(),
+                Vec::new(),
+                Some(SyncCursor::new("1").unwrap()),
+            ),
+        ));
+
+        assert_eq!(state.rows.len(), 1);
+        assert_eq!(state.rows[0].key.as_str(), "post_1");
+        assert_eq!(state.rows[0].value, "loaded");
+        assert!(!state.loading);
+        assert!(!state.syncing);
+        assert!(!state.stale);
     }
 }

--- a/crates/pocopine-sync/src/state.rs
+++ b/crates/pocopine-sync/src/state.rs
@@ -1,0 +1,297 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{SyncChange, SyncCursor, SyncOp, SyncPullMode, SyncPullResponse, SyncRow};
+
+/// Reason attached to the latest sync state transition.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SyncReason {
+    #[default]
+    Idle,
+    Initial,
+    Manual,
+    Live,
+    Gap,
+    Error,
+}
+
+/// Opaque generation token for one pull request.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct SyncRequest {
+    generation: u64,
+}
+
+impl SyncRequest {
+    pub fn generation(self) -> u64 {
+        self.generation
+    }
+}
+
+/// Serializable state for one synced collection.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+#[serde(bound(
+    serialize = "T: Serialize",
+    deserialize = "T: Default + Deserialize<'de>"
+))]
+pub struct CollectionState<T> {
+    pub rows: Vec<SyncRow<T>>,
+    pub loading: bool,
+    pub syncing: bool,
+    pub stale: bool,
+    pub error: String,
+    pub cursor: Option<SyncCursor>,
+    pub version: u64,
+    pub refresh_count: u64,
+    pub live_event_count: u64,
+    pub pending_count: u64,
+    pub conflict_count: u64,
+    pub last_reason: SyncReason,
+    #[serde(skip)]
+    request_generation: u64,
+}
+
+impl<T> Default for CollectionState<T> {
+    fn default() -> Self {
+        Self {
+            rows: Vec::new(),
+            loading: false,
+            syncing: false,
+            stale: false,
+            error: String::new(),
+            cursor: None,
+            version: 0,
+            refresh_count: 0,
+            live_event_count: 0,
+            pending_count: 0,
+            conflict_count: 0,
+            last_reason: SyncReason::Idle,
+            request_generation: 0,
+        }
+    }
+}
+
+impl<T> CollectionState<T> {
+    pub fn begin_initial(&mut self) -> SyncRequest {
+        self.begin(SyncReason::Initial, false)
+    }
+
+    pub fn begin_pull(&mut self, reason: SyncReason) -> SyncRequest {
+        self.begin(reason, false)
+    }
+
+    pub fn begin_live_pull(&mut self, reason: SyncReason) -> SyncRequest {
+        self.live_event_count = self.live_event_count.saturating_add(1);
+        self.begin(reason, true)
+    }
+
+    pub fn apply_pull(&mut self, request: SyncRequest, response: SyncPullResponse<T>) -> bool {
+        if !self.is_current(request) {
+            return false;
+        }
+
+        match response.mode {
+            SyncPullMode::Snapshot => {
+                self.rows = response.rows;
+            }
+            SyncPullMode::Incremental => {
+                self.apply_changes(response.changes);
+            }
+        }
+
+        self.cursor = response.cursor;
+        self.loading = false;
+        self.syncing = false;
+        self.stale = false;
+        self.error.clear();
+        self.version = self.version.saturating_add(1);
+        self.recount_row_flags();
+        true
+    }
+
+    pub fn apply_error(&mut self, request: SyncRequest, error: impl ToString) -> bool {
+        if !self.is_current(request) {
+            return false;
+        }
+        self.loading = false;
+        self.syncing = false;
+        self.stale = self.version > 0 || self.stale;
+        self.error = error.to_string();
+        self.last_reason = SyncReason::Error;
+        true
+    }
+
+    pub fn set_error(&mut self, error: impl Into<String>) {
+        self.loading = false;
+        self.syncing = false;
+        self.last_reason = SyncReason::Error;
+        self.error = error.into();
+    }
+
+    pub fn clear_error(&mut self) {
+        self.error.clear();
+    }
+
+    pub fn mark_stale(&mut self, reason: SyncReason) {
+        self.stale = true;
+        self.last_reason = reason;
+    }
+
+    pub fn is_current(&self, request: SyncRequest) -> bool {
+        self.request_generation == request.generation
+    }
+
+    fn begin(&mut self, reason: SyncReason, stale_during_sync: bool) -> SyncRequest {
+        self.request_generation = self.request_generation.saturating_add(1);
+        self.refresh_count = self.refresh_count.saturating_add(1);
+        self.last_reason = reason;
+        self.error.clear();
+        self.stale = stale_during_sync;
+
+        if self.version == 0 {
+            self.loading = true;
+            self.syncing = false;
+        } else {
+            self.loading = false;
+            self.syncing = true;
+        }
+
+        SyncRequest {
+            generation: self.request_generation,
+        }
+    }
+
+    fn apply_changes(&mut self, changes: Vec<SyncChange<T>>) {
+        for change in changes {
+            match change.op {
+                SyncOp::Upsert => {
+                    let Some(row) = change.row else {
+                        continue;
+                    };
+                    if let Some(existing) = self
+                        .rows
+                        .iter_mut()
+                        .find(|existing| existing.key == row.key)
+                    {
+                        *existing = row;
+                    } else {
+                        self.rows.push(row);
+                    }
+                }
+                SyncOp::Delete => {
+                    if let Some(key) = change.key {
+                        self.rows.retain(|row| row.key != key);
+                    }
+                }
+                SyncOp::Reset => {
+                    self.rows.clear();
+                    if let Some(row) = change.row {
+                        self.rows.push(row);
+                    }
+                }
+            }
+        }
+    }
+
+    fn recount_row_flags(&mut self) {
+        self.pending_count = self.rows.iter().filter(|row| row.pending).count() as u64;
+        self.conflict_count = self.rows.iter().filter(|row| row.conflict).count() as u64;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        RowKey, SyncChange, SyncCollectionName, SyncCursor, SyncPullResponse, SyncShapeName,
+    };
+
+    #[test]
+    fn initial_pull_replaces_rows_and_cursor() {
+        let mut state = CollectionState::<String>::default();
+        let request = state.begin_initial();
+        let response = SyncPullResponse::snapshot(
+            SyncShapeName::new("posts").unwrap(),
+            SyncCollectionName::new("posts").unwrap(),
+            vec![SyncRow::new("post_1", "hello".to_string()).unwrap()],
+            Some(SyncCursor::new("1").unwrap()),
+        );
+
+        assert!(state.apply_pull(request, response));
+        assert_eq!(state.rows.len(), 1);
+        assert_eq!(state.rows[0].value, "hello");
+        assert_eq!(state.cursor.as_ref().unwrap().as_str(), "1");
+        assert!(!state.loading);
+    }
+
+    #[test]
+    fn incremental_pull_upserts_and_deletes_by_key() {
+        let mut state = CollectionState::<String>::default();
+        let initial = state.begin_initial();
+        state.apply_pull(
+            initial,
+            SyncPullResponse::snapshot(
+                SyncShapeName::new("posts").unwrap(),
+                SyncCollectionName::new("posts").unwrap(),
+                vec![SyncRow::new("post_1", "old".to_string()).unwrap()],
+                Some(SyncCursor::new("1").unwrap()),
+            ),
+        );
+
+        let request = state.begin_pull(SyncReason::Manual);
+        let response = SyncPullResponse::incremental(
+            SyncShapeName::new("posts").unwrap(),
+            SyncCollectionName::new("posts").unwrap(),
+            vec![
+                SyncChange {
+                    shape: SyncShapeName::new("posts").unwrap(),
+                    collection: SyncCollectionName::new("posts").unwrap(),
+                    key: None,
+                    op: SyncOp::Upsert,
+                    row: Some(SyncRow::new("post_2", "new".to_string()).unwrap()),
+                    cursor: SyncCursor::new("2").unwrap(),
+                },
+                SyncChange {
+                    shape: SyncShapeName::new("posts").unwrap(),
+                    collection: SyncCollectionName::new("posts").unwrap(),
+                    key: Some(RowKey::new("post_1").unwrap()),
+                    op: SyncOp::Delete,
+                    row: None,
+                    cursor: SyncCursor::new("3").unwrap(),
+                },
+            ],
+            Some(SyncCursor::new("3").unwrap()),
+        );
+
+        assert!(state.apply_pull(request, response));
+        assert_eq!(state.rows.len(), 1);
+        assert_eq!(state.rows[0].key.as_str(), "post_2");
+    }
+
+    #[test]
+    fn stale_response_is_ignored() {
+        let mut state = CollectionState::<String>::default();
+        let stale = state.begin_initial();
+        let current = state.begin_pull(SyncReason::Manual);
+
+        assert!(!state.apply_pull(
+            stale,
+            SyncPullResponse::snapshot(
+                SyncShapeName::new("posts").unwrap(),
+                SyncCollectionName::new("posts").unwrap(),
+                vec![SyncRow::new("post_1", "stale".to_string()).unwrap()],
+                None,
+            ),
+        ));
+        assert!(state.apply_pull(
+            current,
+            SyncPullResponse::snapshot(
+                SyncShapeName::new("posts").unwrap(),
+                SyncCollectionName::new("posts").unwrap(),
+                vec![SyncRow::new("post_2", "current".to_string()).unwrap()],
+                None,
+            ),
+        ));
+        assert_eq!(state.rows[0].value, "current");
+    }
+}

--- a/crates/pocopine-sync/src/state.rs
+++ b/crates/pocopine-sync/src/state.rs
@@ -30,10 +30,7 @@ impl SyncRequest {
 /// Serializable state for one synced collection.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(default)]
-#[serde(bound(
-    serialize = "T: Serialize",
-    deserialize = "T: Default + Deserialize<'de>"
-))]
+#[serde(bound(serialize = "T: Serialize", deserialize = "T: Deserialize<'de>"))]
 pub struct CollectionState<T> {
     pub rows: Vec<SyncRow<T>>,
     pub loading: bool,
@@ -52,6 +49,7 @@ pub struct CollectionState<T> {
 }
 
 impl<T> Default for CollectionState<T> {
+    // Manual impl avoids the `T: Default` bound that `derive(Default)` would add.
     fn default() -> Self {
         Self {
             rows: Vec::new(),
@@ -177,6 +175,8 @@ impl<T> CollectionState<T> {
     }
 
     fn apply_changes(&mut self, changes: Vec<SyncChange<T>>) -> bool {
+        // Linear scans are deliberate for this first small-collection state
+        // container; larger local stores should move to an indexed backend.
         let mut rows_changed = false;
         for change in changes {
             match change.op {

--- a/crates/pocopine-sync/tests/client_browser.rs
+++ b/crates/pocopine-sync/tests/client_browser.rs
@@ -1,0 +1,183 @@
+//! Browser smoke test for the sync client.
+//!
+//! Run with:
+//!   `wasm-pack test --firefox --headless crates/pocopine-sync --test client_browser`
+
+#![cfg(target_arch = "wasm32")]
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use js_sys::Promise;
+use pocopine::prelude::*;
+use pocopine_sync::{
+    sync_plugin, CollectionState, SyncCollectionName, SyncOpenRequest, SyncOpenResponse,
+    SyncOpenShape, SyncPullRequest, SyncPullResponse, SyncRow, SyncShapeName, SYNC_OPEN_PATH,
+    SYNC_PULL_PATH,
+};
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::JsValue;
+use wasm_bindgen_futures::JsFuture;
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+use web_sys::window;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+const SHAPE: &str = "posts_for_browser";
+const COLLECTION: &str = "posts";
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+struct BrowserPost {
+    id: String,
+    title: String,
+}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "sync-browser-board",
+    template_inline = r#"
+    <section class="sync-browser-board">
+      <output class="row-count" pp-text="posts.rows.length"></output>
+      <p class="error" pp-text="posts.error"></p>
+      <ol class="posts">
+        <template pp-for="row in posts.rows" pp-key="row.key">
+          <li class="post" pp-text="row.value.title"></li>
+        </template>
+      </ol>
+    </section>
+    "#
+)]
+struct SyncBrowserBoard {
+    posts: CollectionState<BrowserPost>,
+}
+
+#[handlers]
+impl SyncBrowserBoard {
+    pub fn on_mount(&mut self) {
+        if let Err(err) = self
+            .plugin::<pocopine_sync::SyncClient>()
+            .collection(pocopine::this::<Self>(), |state: &mut Self| {
+                &mut state.posts
+            })
+            .shape(SHAPE)
+            .and_then(|collection| collection.open())
+        {
+            self.posts.set_error(err.to_string());
+        }
+    }
+}
+
+#[wasm_bindgen_test(async)]
+async fn open_validates_shape_then_pull_renders_snapshot() {
+    pocopine::fetch::__reset_middleware_chain_for_test();
+
+    let seen_urls = Rc::new(RefCell::new(Vec::<String>::new()));
+    let seen_urls_for_middleware = seen_urls.clone();
+    pocopine::fetch::install_middleware(
+        move |req: pocopine::fetch::FetchRequest, _next: pocopine::fetch::FetchNext| {
+            let seen_urls = seen_urls_for_middleware.clone();
+            async move {
+                seen_urls.borrow_mut().push(req.url.clone());
+                match req.url.as_str() {
+                    SYNC_OPEN_PATH => {
+                        let request: SyncOpenRequest = serde_json::from_str(&req.body).unwrap();
+                        assert_eq!(request.shapes[0].as_str(), SHAPE);
+                        let response = SyncOpenResponse::new(vec![SyncOpenShape {
+                            shape: SyncShapeName::new(SHAPE).unwrap(),
+                            collection: SyncCollectionName::new(COLLECTION).unwrap(),
+                            cursor: None,
+                        }]);
+                        Ok(json_response(response))
+                    }
+                    SYNC_PULL_PATH => {
+                        let request: SyncPullRequest = serde_json::from_str(&req.body).unwrap();
+                        assert_eq!(request.shape.as_str(), SHAPE);
+                        assert!(
+                            request.cursor.is_none(),
+                            "the /open cursor must not make a fresh client skip its snapshot"
+                        );
+                        let response = SyncPullResponse::snapshot(
+                            SyncShapeName::new(SHAPE).unwrap(),
+                            SyncCollectionName::new(COLLECTION).unwrap(),
+                            vec![SyncRow::new(
+                                "post_1",
+                                BrowserPost {
+                                    id: "post_1".to_string(),
+                                    title: "Loaded through sync".to_string(),
+                                },
+                            )
+                            .unwrap()],
+                            Some(pocopine_sync::SyncCursor::new("1").unwrap()),
+                        );
+                        Ok(json_response(response))
+                    }
+                    other => Err(pocopine::ServerError::Network(format!(
+                        "unexpected sync browser test request: {other}"
+                    ))),
+                }
+            }
+        },
+    );
+
+    let document = window().unwrap().document().unwrap();
+    let host = document.create_element("div").unwrap();
+    host.set_attribute("pp-app", "").unwrap();
+    host.set_inner_html("<sync-browser-board></sync-browser-board>");
+    document.body().unwrap().append_child(&host).unwrap();
+
+    App::new()
+        .plugin(sync_plugin().with_live_wakeup(false))
+        .register::<SyncBrowserBoard>()
+        .run();
+
+    settle().await;
+
+    assert_eq!(
+        &*seen_urls.borrow(),
+        &[SYNC_OPEN_PATH.to_string(), SYNC_PULL_PATH.to_string()],
+        "sync client should call /open before the first /pull"
+    );
+    let post = host
+        .query_selector(".post")
+        .unwrap()
+        .expect("synced post should render");
+    assert_eq!(
+        post.text_content().unwrap_or_default(),
+        "Loaded through sync"
+    );
+    assert_eq!(
+        host.query_selector(".row-count")
+            .unwrap()
+            .unwrap()
+            .text_content()
+            .unwrap_or_default(),
+        "1"
+    );
+
+    host.remove();
+    pocopine::fetch::__reset_middleware_chain_for_test();
+}
+
+fn json_response<T: Serialize>(value: T) -> pocopine::fetch::FetchResponse {
+    pocopine::fetch::FetchResponse {
+        status: 200,
+        body: serde_json::to_string(&Ok::<T, pocopine::ServerError>(value)).unwrap(),
+    }
+}
+
+async fn settle() {
+    for _ in 0..4 {
+        next_task().await;
+    }
+}
+
+async fn next_task() {
+    let promise = Promise::new(&mut |resolve, _reject| {
+        if let Some(window) = window() {
+            let _ = window.set_timeout_with_callback_and_timeout_and_arguments_0(&resolve, 0);
+        } else {
+            let _ = resolve.call0(&JsValue::UNDEFINED);
+        }
+    });
+    let _ = JsFuture::from(promise).await;
+}

--- a/crates/pocopine-sync/webdriver.json
+++ b/crates/pocopine-sync/webdriver.json
@@ -1,0 +1,13 @@
+{
+  "moz:firefoxOptions": {
+    "args": ["--headless"]
+  },
+  "goog:chromeOptions": {
+    "args": [
+      "--headless=new",
+      "--no-sandbox",
+      "--disable-gpu",
+      "--disable-dev-shm-usage"
+    ]
+  }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,9 @@ looks the way it does — the code itself tells you *what*.
 - [`live.md`](./live.md) — live invalidation tutorial: SSE streams,
   collection/query refresh callbacks, server topic policies, and the
   example/test files that must stay in sync with live API changes.
+- [`sync.md`](./sync.md) — sync tutorial: explicit `pocopine-sync`
+  extension setup, server shapes, cursor pulls, live wake-up wiring, and
+  the current memory-backed example.
 - [`logging-tracing-observer.md`](./logging-tracing-observer.md) —
   browser console logging, backend logging, structured observed
   events, analytics sinks, privacy labels, and target filtering.
@@ -69,6 +72,8 @@ Example apps:
 - [`examples/blog/`](../examples/blog/) — `App` + `#[server]` + axum server bin.
 - [`examples/live/`](../examples/live/) — `pocopine-live` SSE invalidation
   with collection/query refetch callbacks.
+- [`examples/sync/`](../examples/sync/) — `pocopine-sync` cursor pulls
+  with `pocopine-live` wake-ups.
 - [`examples/observability-smoke/`](../examples/observability-smoke/) — OTLP trace export smoke server.
 - [`examples/spa/`](../examples/spa/) — `App::route` + `<pp-outlet>` + `pp-route` + `$route`.
 - [`examples/site/`](../examples/site/) — the marketing page, dogfooded.

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -1,0 +1,310 @@
+# Sync Tutorial
+
+`pocopine-sync` is the framework extension for cursor-based data sync.
+The first implementation is intentionally small:
+
+- the server owns named sync shapes,
+- the browser pulls a snapshot, then incremental changes with a cursor,
+- `pocopine-live` is used only as a wake-up signal,
+- the data payload still moves through `POST /__pocopine/sync/v1/pull`.
+
+This is not the full offline store yet. IndexedDB persistence,
+optimistic mutation replay, SQLx-backed adapters, and CDC integrations
+remain future work. The current API gives us the protocol boundary and a
+browser state shape that those backends can plug into later.
+
+The runnable source of truth is [`examples/sync`](../examples/sync/).
+When the sync API changes, update this document and the example in the
+same PR.
+
+## What You Build
+
+A sync-enabled app needs five pieces:
+
+1. A stable shape name for the data the browser may sync.
+2. A host-side `SyncShapeSource` registered with `SyncServer`.
+3. Sync routes mounted through `sync_server_plugin(...)`.
+4. Optional live routes that allow the sync shape's wake-up topic.
+5. A browser component with `CollectionState<T>` and `sync_plugin()`.
+
+The example uses `MemorySyncShape<Post>` so the whole flow can run
+without a database. Production adapters should implement
+`SyncShapeSource` and keep the browser code unchanged.
+
+## 1. Enable The Extension Crate
+
+Sync is explicit. Do not enable a `pocopine` feature and do not import it
+through framework core:
+
+```toml
+[dependencies]
+pocopine = { path = "../../crates/pocopine" }
+pocopine-sync = { workspace = true }
+serde = { workspace = true }
+wasm-bindgen = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+pocopine-events = { workspace = true }
+pocopine-live = { workspace = true }
+pocopine-logging = { workspace = true }
+pocopine-server = { workspace = true }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net"] }
+tracing = { workspace = true }
+```
+
+`pocopine-sync` has target-specific modules internally. The browser gets
+the client plugin and protocol/state types. The host gets the server
+plugin and source traits.
+
+## 2. Define A Shape
+
+A shape is the server-approved subset of data the browser can sync. It
+is not a database table name or arbitrary browser filter.
+
+```rust
+pub const POSTS_SHAPE: &str = "posts_for_user";
+pub const POSTS_COLLECTION: &str = "posts";
+```
+
+The initial memory source is useful for examples, tests, and explicit
+single-process apps:
+
+```rust
+#[cfg(pocopine_host)]
+pub fn posts_shape() -> pocopine_sync::MemorySyncShape<Post> {
+    static POSTS_SYNC: std::sync::OnceLock<
+        pocopine_sync::MemorySyncShape<Post>,
+    > = std::sync::OnceLock::new();
+
+    POSTS_SYNC
+        .get_or_init(|| {
+            let shape =
+                pocopine_sync::MemorySyncShape::new(POSTS_SHAPE, POSTS_COLLECTION)
+                    .expect("shape names must be valid");
+            shape
+                .upsert("post_1", Post::seeded())
+                .expect("seed post should sync");
+            shape
+        })
+        .clone()
+}
+```
+
+Database-backed apps should hide authorization, tenant filters, delete
+privacy, and cursor validation inside their source implementation.
+Browsers only ask for registered shape names.
+
+## 3. Build The Sync Server
+
+`SyncServer` owns the registered shapes and optionally shares the live
+event backend so it can publish wake-ups after mutations commit:
+
+```rust
+#[cfg(pocopine_host)]
+pub fn sync_server() -> pocopine_sync::SyncServer {
+    static SYNC_SERVER: std::sync::OnceLock<pocopine_sync::SyncServer> =
+        std::sync::OnceLock::new();
+
+    SYNC_SERVER
+        .get_or_init(|| {
+            pocopine_sync::SyncServer::builder()
+                .shape(posts_shape())
+                .events(std::sync::Arc::new(live_backend()))
+                .build()
+        })
+        .clone()
+}
+```
+
+Publishing a sync invalidation does not send rows through SSE. It sends
+a query-tag wake-up that tells the browser to call `pull`:
+
+```rust
+#[cfg(pocopine_host)]
+async fn invalidate_posts() {
+    if let Err(err) = sync_server().invalidate_shape(POSTS_SHAPE).await {
+        tracing::warn!(
+            target: "pocopine.log",
+            error = %err,
+            "failed to publish sync posts invalidation"
+        );
+    }
+}
+```
+
+## 4. Mount Routes
+
+Mount sync routes with the host server plugin. If live wake-up is
+enabled, allow the topics reported by `sync.live_topics()`.
+
+```rust
+#[cfg(pocopine_host)]
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    use pocopine_live::{routes, LiveHub};
+    use pocopine_server::{axum::Router, serve, static_files, Server};
+    use pocopine_sync::sync_server_plugin;
+
+    pocopine_logging::init_default().map_err(std::io::Error::other)?;
+
+    let sync = sync_server();
+    let sync_topics = sync.live_topics().map_err(std::io::Error::other)?;
+    let live_hub = LiveHub::new(live_backend())
+        .allow_topics(sync_topics.clone())
+        .default_topics(sync_topics);
+
+    let router = Router::new()
+        .merge(routes(live_hub))
+        .fallback_service(static_files(env!("CARGO_MANIFEST_DIR")));
+
+    let router = Server::new(router)
+        .plugin(sync_server_plugin(sync))
+        .try_finalize()
+        .map_err(std::io::Error::other)?;
+
+    serve(router, "127.0.0.1:3021").await
+}
+```
+
+The default live topic policy is deny-all. `sync.live_topics()` returns
+only the wake-up topics for registered shapes.
+
+## 5. Install The Browser Plugin
+
+Install `sync_plugin()` in the app. Live wake-up is opt-in:
+
+```rust
+#[wasm_bindgen(start)]
+pub fn main() {
+    App::new()
+        .plugin(pocopine_sync::sync_plugin().with_live_wakeup(true))
+        .register::<SyncBoard>()
+        .run();
+}
+```
+
+Components store synced rows in `CollectionState<T>`:
+
+```rust
+#[derive(Default, serde::Serialize, serde::Deserialize)]
+#[component(style = "sync_board.css")]
+pub struct SyncBoard {
+    pub posts: pocopine_sync::CollectionState<Post>,
+    pub status: String,
+}
+```
+
+Open a collection from a lifecycle hook or handler:
+
+```rust
+#[handlers]
+impl SyncBoard {
+    pub fn on_mount(&mut self) {
+        let result = self
+            .plugin::<pocopine_sync::SyncClient>()
+            .collection(pocopine::this::<Self>(), |s: &mut Self| &mut s.posts)
+            .shape(POSTS_SHAPE)
+            .and_then(|collection| collection.open());
+
+        if let Err(err) = result {
+            self.posts.set_error(err.to_string());
+        }
+    }
+}
+```
+
+`open()` pulls once. When live wake-up is enabled, it also subscribes to
+the shape's wake-up topic and pulls again whenever the server invalidates
+that shape. `pull()` can be called manually for refresh buttons.
+
+Templates read `CollectionState<T>` directly:
+
+```html
+<p pp-show="posts.error">
+  <span pp-text="posts.error"></span>
+</p>
+<p pp-show="posts.loading">Loading snapshot.</p>
+<p pp-show="posts.syncing">Pulling changes.</p>
+
+<ol pp-show="posts.rows.length">
+  <template pp-for="row in posts.rows" pp-key="row.key">
+    <li>
+      <h2 pp-text="row.value.title"></h2>
+      <p pp-text="row.value.body"></p>
+    </li>
+  </template>
+</ol>
+```
+
+## 6. Mutate Then Invalidate
+
+Server functions can mutate the source and publish a wake-up after the
+write succeeds:
+
+```rust
+#[pocopine::server(public)]
+pub async fn create_post(title: String, body: String) -> ServerResult<Post> {
+    let post = insert_post(title, body)?;
+
+    posts_shape()
+        .upsert(post.id.clone(), post.clone())
+        .map_err(|err| ServerError::App(err.to_string()))?;
+
+    invalidate_posts().await;
+    Ok(post)
+}
+```
+
+Do not publish before the mutation commits. If wake-up publishing fails
+after a successful mutation, log it and return the mutation result; the
+next manual pull or page load should still see the committed data.
+
+## 7. Run The Example
+
+```bash
+cargo run -p pocopine-cli -- dev --path examples/sync
+```
+
+Open `http://127.0.0.1:3021` in two tabs. Create or reset posts in one
+tab. The other tab should receive a live wake-up and then pull the new
+sync changes.
+
+For a fast compile check:
+
+```bash
+cargo check -p sync-example
+cargo test -p pocopine-sync
+```
+
+## Protocol Boundary
+
+- `open` validates shape names and reports registered shape metadata.
+- `pull` returns either a full snapshot or incremental changes.
+- `push` exists in the protocol, but the memory shape rejects it until
+  optimistic mutations and conflict policy are implemented.
+- Cursors are opaque. Components should store and resend them, not parse
+  them.
+- A live wake-up is not a data packet. It is only a prompt to pull.
+
+## Failure Model
+
+- Pull responses are server-authoritative.
+- Duplicate live wake-ups are safe; the client pulls with its current
+  cursor and applies idempotent upsert/delete/reset changes.
+- A stale async response cannot overwrite a newer pull in
+  `CollectionState<T>`.
+- Memory backends are single-process. Multi-process sync needs shared
+  event and data-source backends.
+- Authorization belongs to the shape source and route policy. Do not
+  treat a cursor or browser-provided shape name as proof of access.
+
+## Future Backends
+
+Keep these as separate adapter crates:
+
+- `pocopine-sync-sqlx` for compile-time checked SQL shapes,
+- `pocopine-sync-indexeddb` for browser persistence,
+- `pocopine-sync-redis` for shared cursor/change storage.
+
+Those crates should implement the same protocol contracts rather than
+adding optional backend settings to framework core.

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -4,7 +4,8 @@
 The first implementation is intentionally small:
 
 - the server owns named sync shapes,
-- the browser pulls a snapshot, then incremental changes with a cursor,
+- the browser opens an authorized shape, then pulls a snapshot or
+  incremental changes with a cursor,
 - `pocopine-live` is used only as a wake-up signal,
 - the data payload still moves through `POST /__pocopine/sync/v1/pull`.
 
@@ -213,9 +214,13 @@ impl SyncBoard {
 }
 ```
 
-`open()` pulls once. When live wake-up is enabled, it also subscribes to
-the shape's wake-up topic and pulls again whenever the server invalidates
-that shape. `pull()` can be called manually for refresh buttons.
+`open()` first calls `/__pocopine/sync/v1/open` to validate the shape,
+then calls `/__pocopine/sync/v1/pull`. A fresh client still pulls
+without a cursor so it receives a snapshot; the server's current cursor
+from `open` is metadata, not permission to skip initial data. When live
+wake-up is enabled, `open()` also subscribes to the shape's wake-up topic
+and pulls again whenever the server invalidates that shape. `pull()` can
+be called manually for refresh buttons.
 
 Templates read `CollectionState<T>` directly:
 
@@ -269,16 +274,25 @@ Open `http://127.0.0.1:3021` in two tabs. Create or reset posts in one
 tab. The other tab should receive a live wake-up and then pull the new
 sync changes.
 
-For a fast compile check:
+For fast host checks:
 
 ```bash
 cargo check -p sync-example
 cargo test -p pocopine-sync
+cargo test -p sync-example
+```
+
+For the browser smoke test that mounts a real component in headless
+Firefox and verifies `open -> pull -> render`:
+
+```bash
+wasm-pack test --firefox --headless crates/pocopine-sync --test client_browser
 ```
 
 ## Protocol Boundary
 
 - `open` validates shape names and reports registered shape metadata.
+  The browser client calls it before the first `pull`.
 - `pull` returns either a full snapshot or incremental changes.
 - `push` exists in the protocol, but the memory shape rejects it until
   optimistic mutations and conflict policy are implemented.

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -95,6 +95,10 @@ Database-backed apps should hide authorization, tenant filters, delete
 privacy, and cursor validation inside their source implementation.
 Browsers only ask for registered shape names.
 
+`MemorySyncShape<T>` is not a production backend. It keeps an unbounded
+in-memory change log and uses one process-local lock. Use it for tests,
+examples, and explicit single-process demos.
+
 ## 3. Build The Sync Server
 
 `SyncServer` owns the registered shapes and optionally shares the live
@@ -170,6 +174,13 @@ async fn main() -> std::io::Result<()> {
 The default live topic policy is deny-all. `sync.live_topics()` returns
 only the wake-up topics for registered shapes.
 
+This first sync slice does not make `/open` a server-side session
+boundary. A registered shape is pullable through `/pull`; `/open`
+validates discovery and gives the client metadata before the first pull.
+Production shape sources must enforce auth, tenant filtering, and cursor
+policy themselves, or the host app must mount sync behind an auth
+boundary.
+
 ## 5. Install The Browser Plugin
 
 Install `sync_plugin()` in the app. Live wake-up is opt-in:
@@ -183,6 +194,10 @@ pub fn main() {
         .run();
 }
 ```
+
+`sync_plugin()` sends fetches without browser credentials by default. If
+an app opts into `.with_credentials(true)`, the server must provide the
+same CSRF protections it uses for any credentialed JSON POST endpoint.
 
 Components store synced rows in `CollectionState<T>`:
 

--- a/examples/sync/Cargo.toml
+++ b/examples/sync/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "sync-example"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[package.metadata.pocopine]
+bin = "server"
+port = 3021
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[[bin]]
+name = "server"
+path = "src/bin/server.rs"
+required-features = []
+
+[dependencies]
+pocopine = { path = "../../crates/pocopine" }
+pocopine-sync = { workspace = true }
+serde = { workspace = true }
+wasm-bindgen = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+pocopine-events = { workspace = true }
+pocopine-live = { workspace = true }
+pocopine-logging = { workspace = true }
+pocopine-server = { workspace = true }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net"] }

--- a/examples/sync/Cargo.toml
+++ b/examples/sync/Cargo.toml
@@ -21,6 +21,7 @@ required-features = []
 pocopine = { path = "../../crates/pocopine" }
 pocopine-sync = { workspace = true }
 serde = { workspace = true }
+tracing = { workspace = true }
 wasm-bindgen = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -29,3 +30,8 @@ pocopine-live = { workspace = true }
 pocopine-logging = { workspace = true }
 pocopine-server = { workspace = true }
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "net"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+http-body-util = "0.1"
+serde_json = "1"
+tower = { version = "0.5", features = ["util"] }

--- a/examples/sync/README.md
+++ b/examples/sync/README.md
@@ -3,7 +3,7 @@
 Small app showing the first sync protocol slice:
 
 - server functions mutate a process-local `MemorySyncShape<Post>`,
-- `pocopine-sync` serves snapshot and incremental pulls,
+- `pocopine-sync` opens the shape, then serves snapshot and incremental pulls,
 - `pocopine-live` sends only wake-up events,
 - the browser stores rows in `CollectionState<Post>` and pulls with its cursor.
 
@@ -20,3 +20,10 @@ wakes the other tab over SSE; the data itself is fetched from
 This example uses memory backends, so it is intentionally single-process.
 Future database adapters should keep this same browser shape while
 replacing the server-side source.
+
+Checks:
+
+```bash
+cargo test -p sync-example
+wasm-pack test --firefox --headless crates/pocopine-sync --test client_browser
+```

--- a/examples/sync/README.md
+++ b/examples/sync/README.md
@@ -1,0 +1,22 @@
+# Sync Example
+
+Small app showing the first sync protocol slice:
+
+- server functions mutate a process-local `MemorySyncShape<Post>`,
+- `pocopine-sync` serves snapshot and incremental pulls,
+- `pocopine-live` sends only wake-up events,
+- the browser stores rows in `CollectionState<Post>` and pulls with its cursor.
+
+Run it with the CLI:
+
+```bash
+cargo run -p pocopine-cli -- dev --path examples/sync
+```
+
+Open the app in two browser tabs. Creating or resetting posts in one tab
+wakes the other tab over SSE; the data itself is fetched from
+`/__pocopine/sync/v1/pull`.
+
+This example uses memory backends, so it is intentionally single-process.
+Future database adapters should keep this same browser shape while
+replacing the server-side source.

--- a/examples/sync/build.rs
+++ b/examples/sync/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    println!("cargo:rustc-check-cfg=cfg(pocopine_browser)");
+    println!("cargo:rustc-check-cfg=cfg(pocopine_host)");
+
+    match std::env::var("CARGO_CFG_TARGET_ARCH").as_deref() {
+        Ok("wasm32") => println!("cargo:rustc-cfg=pocopine_browser"),
+        _ => println!("cargo:rustc-cfg=pocopine_host"),
+    }
+}

--- a/examples/sync/index.html
+++ b/examples/sync/index.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" href="data:," />
   <title>pocopine sync example</title>
 </head>
 <body>

--- a/examples/sync/index.html
+++ b/examples/sync/index.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>pocopine sync example</title>
+</head>
+<body>
+  <div pp-app>
+    <sync-board></sync-board>
+  </div>
+  <script type="module">
+    import init from "/pkg/sync_example.js";
+    init();
+  </script>
+</body>
+</html>

--- a/examples/sync/src/SyncBoard.poco
+++ b/examples/sync/src/SyncBoard.poco
@@ -1,0 +1,51 @@
+<main class="sync-board">
+  <section class="composer" aria-labelledby="sync-title">
+    <div>
+      <p class="eyebrow">pocopine sync</p>
+      <h1 id="sync-title">Synced posts</h1>
+    </div>
+
+    <form class="composer__form" pp-on:submit.prevent="create">
+      <label>
+        <span>Title</span>
+        <input type="text" pp-model="title" autocomplete="off" />
+      </label>
+      <label>
+        <span>Body</span>
+        <textarea pp-model="body" rows="4"></textarea>
+      </label>
+      <div class="actions">
+        <button type="submit" pp-show="!saving">Create</button>
+        <button type="button" disabled pp-show="saving">Working</button>
+        <button type="button" class="secondary" pp-on:click="refresh">Pull</button>
+        <button type="button" class="secondary" pp-on:click="reset">Reset</button>
+      </div>
+    </form>
+  </section>
+
+  <section class="feed" aria-label="synced posts">
+    <div class="feed__bar">
+      <span class="status" pp-text="status"></span>
+      <span class="counter"><strong pp-text="posts.live_event_count"></strong> wake-ups</span>
+      <span class="counter"><strong pp-text="posts.refresh_count"></strong> pulls</span>
+    </div>
+
+    <p pp-show="posts.error" class="error"><span pp-text="posts.error"></span></p>
+    <p pp-show="posts.loading" class="empty">Loading snapshot.</p>
+    <p pp-show="posts.syncing" class="empty">Pulling changes.</p>
+    <p pp-show="!posts.loading && !posts.rows.length" class="empty">No synced posts.</p>
+
+    <ol class="posts" pp-show="posts.rows.length">
+      <template pp-for="row in posts.rows" pp-key="row.key">
+        <li class="post">
+          <div class="post__meta">
+            <span pp-text="row.key"></span>
+            <span pp-text="row.version"></span>
+          </div>
+          <h2 pp-text="row.value.title"></h2>
+          <p pp-text="row.value.body"></p>
+        </li>
+      </template>
+    </ol>
+  </section>
+</main>

--- a/examples/sync/src/bin/server.rs
+++ b/examples/sync/src/bin/server.rs
@@ -1,0 +1,18 @@
+#[cfg(pocopine_host)]
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    use pocopine_logging::init_default;
+    use pocopine_server::{axum::Router, serve, static_files};
+
+    init_default().map_err(std::io::Error::other)?;
+
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let router = Router::new().fallback_service(static_files(manifest_dir));
+
+    let addr = "127.0.0.1:3021";
+    tracing::info!(target: "pocopine.log", %addr, "serving sync example");
+    serve(router, addr).await
+}
+
+#[cfg(pocopine_browser)]
+fn main() {}

--- a/examples/sync/src/bin/server.rs
+++ b/examples/sync/src/bin/server.rs
@@ -1,13 +1,30 @@
 #[cfg(pocopine_host)]
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
+    use pocopine_live::{routes, LiveHub};
     use pocopine_logging::init_default;
-    use pocopine_server::{axum::Router, serve, static_files};
+    use pocopine_server::{axum::Router, serve, static_files, Server};
+    use pocopine_sync::sync_server_plugin;
+    use sync_example::{__create_post_route, __reset_posts_route, live_backend, sync_server};
 
     init_default().map_err(std::io::Error::other)?;
 
+    let sync = sync_server();
+    let sync_topics = sync.live_topics().map_err(std::io::Error::other)?;
+    let live_hub = LiveHub::new(live_backend())
+        .allow_topics(sync_topics.clone())
+        .default_topics(sync_topics);
+
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
-    let router = Router::new().fallback_service(static_files(manifest_dir));
+    let router = Router::new()
+        .merge(routes(live_hub))
+        .fallback_service(static_files(manifest_dir));
+    let router = Server::new(router)
+        .plugin(sync_server_plugin(sync))
+        .try_finalize()
+        .map_err(std::io::Error::other)?;
+    let router = __create_post_route(router);
+    let router = __reset_posts_route(router);
 
     let addr = "127.0.0.1:3021";
     tracing::info!(target: "pocopine.log", %addr, "serving sync example");

--- a/examples/sync/src/lib.rs
+++ b/examples/sync/src/lib.rs
@@ -1,0 +1,29 @@
+use pocopine::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct Post {
+    pub id: String,
+    pub title: String,
+}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component]
+pub struct SyncBoard {
+    pub posts: pocopine_sync::CollectionState<Post>,
+}
+
+#[handlers]
+impl SyncBoard {
+    pub fn on_mount(&mut self) {
+        // The sync example is fleshed out after the core protocol compiles.
+    }
+}
+
+#[wasm_bindgen(start)]
+pub fn main() {
+    App::new()
+        .plugin(pocopine_sync::sync_plugin().with_live_wakeup(true))
+        .register::<SyncBoard>()
+        .run();
+}

--- a/examples/sync/src/lib.rs
+++ b/examples/sync/src/lib.rs
@@ -1,22 +1,212 @@
 use pocopine::prelude::*;
 use serde::{Deserialize, Serialize};
 
+#[cfg(pocopine_host)]
+use {
+    pocopine_events::MemoryEventBackend,
+    pocopine_sync::{MemorySyncShape, SyncServer},
+    std::sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, OnceLock,
+    },
+};
+
+pub const POSTS_SHAPE: &str = "posts_for_user";
+pub const POSTS_COLLECTION: &str = "posts";
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct Post {
     pub id: String,
     pub title: String,
+    pub body: String,
 }
 
 #[derive(Default, Serialize, Deserialize)]
-#[component]
+#[component(style = "sync_board.css")]
 pub struct SyncBoard {
+    pub title: String,
+    pub body: String,
     pub posts: pocopine_sync::CollectionState<Post>,
+    pub saving: bool,
+    pub status: String,
+}
+
+#[cfg(pocopine_host)]
+static POSTS_SYNC: OnceLock<MemorySyncShape<Post>> = OnceLock::new();
+#[cfg(pocopine_host)]
+static LIVE_BACKEND: OnceLock<MemoryEventBackend> = OnceLock::new();
+#[cfg(pocopine_host)]
+static SYNC_SERVER: OnceLock<SyncServer> = OnceLock::new();
+#[cfg(pocopine_host)]
+static NEXT_POST_ID: AtomicU64 = AtomicU64::new(3);
+
+#[cfg(pocopine_host)]
+pub fn posts_shape() -> MemorySyncShape<Post> {
+    POSTS_SYNC
+        .get_or_init(|| {
+            let shape = MemorySyncShape::new(POSTS_SHAPE, POSTS_COLLECTION)
+                .expect("sync example shape names must be valid");
+            shape
+                .upsert(
+                    "post_1",
+                    Post {
+                        id: "post_1".to_string(),
+                        title: "Seeded sync row".to_string(),
+                        body: "This row was loaded through the sync pull endpoint.".to_string(),
+                    },
+                )
+                .expect("seed post should sync");
+            shape
+                .upsert(
+                    "post_2",
+                    Post {
+                        id: "post_2".to_string(),
+                        title: "Live wake-up".to_string(),
+                        body: "Create a post in another tab; SSE wakes the client, then sync pulls the change."
+                            .to_string(),
+                    },
+                )
+                .expect("seed post should sync");
+            shape
+        })
+        .clone()
+}
+
+#[cfg(pocopine_host)]
+pub fn live_backend() -> MemoryEventBackend {
+    LIVE_BACKEND.get_or_init(MemoryEventBackend::new).clone()
+}
+
+#[cfg(pocopine_host)]
+pub fn sync_server() -> SyncServer {
+    SYNC_SERVER
+        .get_or_init(|| {
+            SyncServer::builder()
+                .shape(posts_shape())
+                .events(Arc::new(live_backend()))
+                .build()
+        })
+        .clone()
+}
+
+#[cfg(pocopine_host)]
+async fn invalidate_posts() {
+    if let Err(err) = sync_server().invalidate_shape(POSTS_SHAPE).await {
+        tracing::warn!(
+            target: "pocopine.log",
+            error = %err,
+            "failed to publish sync posts invalidation"
+        );
+    }
+}
+
+#[pocopine::server(public)]
+pub async fn create_post(title: String, body: String) -> ServerResult<Post> {
+    let title = title.trim();
+    let body = body.trim();
+    if title.is_empty() || body.is_empty() {
+        return Err(ServerError::BadRequest(
+            "title and body are required".to_string(),
+        ));
+    }
+
+    let next_id = NEXT_POST_ID.fetch_add(1, Ordering::Relaxed);
+    let post = Post {
+        id: format!("post_{next_id}"),
+        title: title.to_string(),
+        body: body.to_string(),
+    };
+
+    posts_shape()
+        .upsert(post.id.clone(), post.clone())
+        .map_err(|err| ServerError::App(err.to_string()))?;
+    invalidate_posts().await;
+    Ok(post)
+}
+
+#[pocopine::server(public)]
+pub async fn reset_posts() -> ServerResult<()> {
+    posts_shape()
+        .reset()
+        .map_err(|err| ServerError::App(err.to_string()))?;
+    invalidate_posts().await;
+    Ok(())
 }
 
 #[handlers]
 impl SyncBoard {
     pub fn on_mount(&mut self) {
-        // The sync example is fleshed out after the core protocol compiles.
+        self.status = "opening sync shape".to_string();
+        let result = self
+            .plugin::<pocopine_sync::SyncClient>()
+            .collection(pocopine::this::<Self>(), |s: &mut Self| &mut s.posts)
+            .shape(POSTS_SHAPE)
+            .and_then(|collection| collection.open());
+
+        if let Err(err) = result {
+            self.status = "sync failed".to_string();
+            self.posts.set_error(err.to_string());
+        }
+    }
+
+    pub fn create(&mut self) {
+        if self.title.trim().is_empty() || self.body.trim().is_empty() {
+            self.posts.set_error("title and body are required");
+            return;
+        }
+
+        self.saving = true;
+        self.posts.clear_error();
+        self.status = "saving".to_string();
+        let title = self.title.clone();
+        let body = self.body.clone();
+
+        dispatch!(create_post(title, body).await, |s, result| {
+            s.saving = false;
+            match result {
+                Ok(_) => {
+                    s.title.clear();
+                    s.body.clear();
+                    s.status = "saved; waiting for sync wake-up".to_string();
+                }
+                Err(err) => {
+                    s.status = "save failed".to_string();
+                    s.posts.set_error(err.to_string());
+                }
+            }
+        });
+    }
+
+    pub fn refresh(&mut self) {
+        self.status = "pulling changes".to_string();
+        let result = self
+            .plugin::<pocopine_sync::SyncClient>()
+            .collection(pocopine::this::<Self>(), |s: &mut Self| &mut s.posts)
+            .shape(POSTS_SHAPE)
+            .and_then(|collection| collection.pull());
+
+        if let Err(err) = result {
+            self.status = "refresh failed".to_string();
+            self.posts.set_error(err.to_string());
+        }
+    }
+
+    pub fn reset(&mut self) {
+        self.saving = true;
+        self.posts.clear_error();
+        self.status = "resetting".to_string();
+        dispatch!(reset_posts().await, |s, result| {
+            s.saving = false;
+            match result {
+                Ok(()) => {
+                    s.status = "reset; waiting for sync wake-up".to_string();
+                }
+                Err(err) => {
+                    s.status = "reset failed".to_string();
+                    s.posts.set_error(err.to_string());
+                }
+            }
+        });
     }
 }
 

--- a/examples/sync/src/lib.rs
+++ b/examples/sync/src/lib.rs
@@ -167,7 +167,7 @@ impl SyncBoard {
                 Ok(_) => {
                     s.title.clear();
                     s.body.clear();
-                    s.status = "saved; waiting for sync wake-up".to_string();
+                    s.status = "saved".to_string();
                 }
                 Err(err) => {
                     s.status = "save failed".to_string();
@@ -199,7 +199,7 @@ impl SyncBoard {
             s.saving = false;
             match result {
                 Ok(()) => {
-                    s.status = "reset; waiting for sync wake-up".to_string();
+                    s.status = "reset".to_string();
                 }
                 Err(err) => {
                     s.status = "reset failed".to_string();

--- a/examples/sync/src/sync_board.css
+++ b/examples/sync/src/sync_board.css
@@ -1,0 +1,153 @@
+.sync-board {
+  min-height: 100vh;
+  display: grid;
+  grid-template-columns: minmax(280px, 360px) minmax(0, 1fr);
+  gap: 24px;
+  padding: 32px;
+  color: #182026;
+  background: #f6f8f7;
+  font-family:
+    Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+.composer,
+.feed {
+  min-width: 0;
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: #4d6b57;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 0 0 24px;
+  font-size: 2.25rem;
+  line-height: 1.05;
+}
+
+.composer__form {
+  display: grid;
+  gap: 14px;
+}
+
+label {
+  display: grid;
+  gap: 6px;
+  font-weight: 650;
+}
+
+input,
+textarea {
+  width: 100%;
+  box-sizing: border-box;
+  border: 1px solid #c9d4ce;
+  border-radius: 6px;
+  padding: 10px 12px;
+  color: #182026;
+  background: #fff;
+  font: inherit;
+}
+
+textarea {
+  resize: vertical;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+button {
+  border: 1px solid #1f5a42;
+  border-radius: 6px;
+  padding: 9px 13px;
+  color: #fff;
+  background: #1f5a42;
+  font: inherit;
+  font-weight: 700;
+  cursor: pointer;
+}
+
+button.secondary {
+  color: #1f5a42;
+  background: #fff;
+}
+
+button:disabled {
+  cursor: wait;
+  opacity: 0.65;
+}
+
+.feed__bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 14px;
+}
+
+.status,
+.counter {
+  border: 1px solid #d5ded9;
+  border-radius: 999px;
+  padding: 6px 10px;
+  background: #fff;
+  font-size: 0.88rem;
+}
+
+.error,
+.empty {
+  margin: 12px 0;
+  color: #73351f;
+  font-weight: 650;
+}
+
+.posts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 12px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.post {
+  min-width: 0;
+  border: 1px solid #dbe3df;
+  border-radius: 8px;
+  padding: 16px;
+  background: #fff;
+}
+
+.post__meta {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+  color: #60736a;
+  font-size: 0.8rem;
+}
+
+.post h2 {
+  margin: 0 0 8px;
+  font-size: 1.05rem;
+}
+
+.post p {
+  margin: 0;
+  color: #3e4a44;
+  line-height: 1.45;
+}
+
+@media (max-width: 760px) {
+  .sync-board {
+    grid-template-columns: 1fr;
+    padding: 20px;
+  }
+}

--- a/examples/sync/tests/sync_flow.rs
+++ b/examples/sync/tests/sync_flow.rs
@@ -1,0 +1,114 @@
+#![cfg(pocopine_host)]
+
+use http_body_util::BodyExt;
+use pocopine_live::{build_live_stream_url, routes, LiveHub, LIVE_STREAM_PATH};
+use pocopine_server::axum::body::Body;
+use pocopine_server::axum::http::{Request, StatusCode};
+use pocopine_server::Server;
+use pocopine_sync::{
+    sync_server_plugin, sync_shape_tag, SyncPullMode, SyncPullRequest, SyncPullResponse,
+    SyncShapeName, SYNC_PULL_PATH,
+};
+use sync_example::{create_post, live_backend, sync_server, Post, POSTS_SHAPE};
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn sync_pull_and_live_wakeup_share_the_shape_topic() {
+    pocopine_server::__reset_for_test();
+    let sync = sync_server();
+    let sync_topics = sync.live_topics().unwrap();
+    let app = Server::new(routes(
+        LiveHub::new(live_backend())
+            .allow_topics(sync_topics.clone())
+            .default_topics(sync_topics),
+    ))
+    .plugin(sync_server_plugin(sync))
+    .try_finalize()
+    .unwrap();
+
+    let first = pull_posts(&app, None).await;
+    assert_eq!(first.mode, SyncPullMode::Snapshot);
+    assert!(first.rows.iter().any(|row| row.key.as_str() == "post_1"));
+
+    let stream_url = build_live_stream_url(
+        LIVE_STREAM_PATH,
+        &[],
+        &[format!("query:{}", sync_shape_tag(POSTS_SHAPE))],
+        None,
+    )
+    .unwrap();
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(stream_url)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let mut body = response.into_body();
+    let ready = read_sse_frame(&mut body).await;
+    assert!(ready.contains("event: ready"));
+    assert!(ready.contains("query:sync:shape:posts_for_user"));
+
+    create_post(
+        "CI sync wake-up".to_string(),
+        "incremental pull should receive this row".to_string(),
+    )
+    .await
+    .unwrap();
+
+    let invalidation = read_sse_frame(&mut body).await;
+    assert!(invalidation.contains("event: query.invalidated"));
+    assert!(invalidation.contains("sync:shape:posts_for_user"));
+
+    let second = pull_posts(&app, first.cursor).await;
+    assert_eq!(second.mode, SyncPullMode::Incremental);
+    assert!(second.changes.iter().any(|change| {
+        change
+            .row
+            .as_ref()
+            .map(|row| row.value.title == "CI sync wake-up")
+            .unwrap_or(false)
+    }));
+}
+
+async fn pull_posts(
+    app: &pocopine_server::axum::Router,
+    cursor: Option<pocopine_sync::SyncCursor>,
+) -> SyncPullResponse<Post> {
+    let request = SyncPullRequest::new(SyncShapeName::new(POSTS_SHAPE).unwrap()).cursor(cursor);
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(SYNC_PULL_PATH)
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&request).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let outer: pocopine::ServerResult<SyncPullResponse<Post>> =
+        serde_json::from_slice(&bytes).unwrap();
+    outer.unwrap()
+}
+
+async fn read_sse_frame(body: &mut Body) -> String {
+    let frame = tokio::time::timeout(std::time::Duration::from_secs(2), body.frame())
+        .await
+        .expect("timed out waiting for SSE frame")
+        .expect("SSE body ended before expected frame")
+        .expect("SSE body returned an error");
+    let data = frame.into_data().expect("SSE frame should contain data");
+    std::str::from_utf8(&data)
+        .expect("SSE data should be utf-8")
+        .to_string()
+}

--- a/rfcs/rfc-072-offline-sync-protocol.md
+++ b/rfcs/rfc-072-offline-sync-protocol.md
@@ -17,8 +17,10 @@ Initial implementation has started in `pocopine-sync`:
 - `/__pocopine/sync/v1/open`, `/pull`, and `/push` protocol routes,
 - `SyncServer`, `SyncShapeSource`, and `MemorySyncShape`,
 - browser `sync_plugin()`, `SyncClient`, and `CollectionState<T>`,
+- browser `SyncClient::open()` calls `/open` before the first `/pull`,
 - live wake-up integration through `pocopine-live` query-tag topics,
-- runnable memory-backed example in `examples/sync`.
+- runnable memory-backed example in `examples/sync`,
+- Firefox wasm smoke coverage for `open -> pull -> render`.
 
 Still future work: durable browser storage, optimistic mutation replay,
 conflict resolution UI, SQLx/database adapters, CDC sources, and

--- a/rfcs/rfc-072-offline-sync-protocol.md
+++ b/rfcs/rfc-072-offline-sync-protocol.md
@@ -22,9 +22,15 @@ Initial implementation has started in `pocopine-sync`:
 - runnable memory-backed example in `examples/sync`,
 - Firefox wasm smoke coverage for `open -> pull -> render`.
 
-Still future work: durable browser storage, optimistic mutation replay,
-conflict resolution UI, SQLx/database adapters, CDC sources, and
-query-driven shape parameters.
+Current limitation: registered shapes are pullable through `/pull`;
+`/open` is a discovery/validation step, not a server-side session grant.
+Shape-level guards remain part of the RFC target model and must be
+enforced inside shape sources or in front of the sync server until that
+follow-up lands.
+
+Still future work: shape auth/guards, durable browser storage,
+optimistic mutation replay, conflict resolution UI, SQLx/database
+adapters, CDC sources, and query-driven shape parameters.
 
 ## 1. Summary
 

--- a/rfcs/rfc-072-offline-sync-protocol.md
+++ b/rfcs/rfc-072-offline-sync-protocol.md
@@ -8,6 +8,22 @@
 | **Builds on** | [RFC 071](./rfc-071-event-spine-and-live-invalidation.md) |
 | **Related** | [RFC 002](./rfc-002-app-stores-servers.md), [RFC 069](./rfc-069-observability.md), [RFC 073](./rfc-073-yrs-collaboration.md) |
 
+## Implementation Status
+
+Initial implementation has started in `pocopine-sync`:
+
+- explicit extension crate, not a `pocopine` core feature,
+- target-specific browser and host modules in one crate,
+- `/__pocopine/sync/v1/open`, `/pull`, and `/push` protocol routes,
+- `SyncServer`, `SyncShapeSource`, and `MemorySyncShape`,
+- browser `sync_plugin()`, `SyncClient`, and `CollectionState<T>`,
+- live wake-up integration through `pocopine-live` query-tag topics,
+- runnable memory-backed example in `examples/sync`.
+
+Still future work: durable browser storage, optimistic mutation replay,
+conflict resolution UI, SQLx/database adapters, CDC sources, and
+query-driven shape parameters.
+
 ## 1. Summary
 
 Pocopine should treat sync as a protocol, not just a notification stream.


### PR DESCRIPTION
## Summary
- add the explicit `pocopine-sync` extension crate with protocol types, `SyncClient`, `SyncServer`, `SyncShapeSource`, `CollectionState`, and an in-memory shape source
- wire `/__pocopine/sync/v1/open`, `/pull`, and `/push`; browser `open()` validates the shape before the first pull and subscribes to live wake-ups only after open succeeds
- add a memory-backed `examples/sync` app, tutorial docs, RFC 072 status update, and CI coverage for the sync browser smoke test/example build

## Verification
- [x] `cargo fmt --check`
- [x] `cargo test -p pocopine-sync`
- [x] `cargo test -p sync-example`
- [x] `cargo clippy -p pocopine-sync -p sync-example --all-targets -- -D warnings`
- [x] `wasm-pack test --firefox --headless crates/pocopine-sync --test client_browser`
- [x] `wasm-pack build --release --target web examples/sync`

## Not included yet
- shape auth/guard integration
- push/optimistic mutations and conflict handling
- durable browser storage / IndexedDB
- SQLx, Redis, or CDC adapter crates