### PR TITLE
Add chart selection events

### DIFF
--- a/crates/pine-charts/src/area/PineAreaChart.poco
+++ b/crates/pine-charts/src/area/PineAreaChart.poco
@@ -9,7 +9,15 @@
       :data-animate="animate"
       :data-animation-duration="animation_duration"
       :data-animation-easing="animation_easing"
-      :style="animation_style">
+      :style="animation_style"
+      tabindex="0"
+      @keydown.arrow-right.prevent="focus_next_sample"
+      @keydown.arrow-down.prevent="focus_next_sample"
+      @keydown.arrow-left.prevent="focus_prev_sample"
+      @keydown.arrow-up.prevent="focus_prev_sample"
+      @keydown.enter.prevent="select_focused_sample"
+      @keydown.space.prevent="select_focused_sample"
+      @keydown.escape.prevent="clear_selection">
   <svg class="pine-chart-svg"
        :width="width"
        :height="height"
@@ -18,7 +26,8 @@
        aria-hidden="true"
        focusable="false"
        @pointermove="on_pointer_move"
-       @pointerleave="clear_hover">
+       @pointerleave="clear_hover"
+       @click="clear_selection">
     <g pp-show="ready"
        class="pine-chart-grid"
        data-layer="grid"
@@ -132,9 +141,16 @@
                 :cy="sample.y"
                 r="3"
                 fill="currentColor"
+                role="option"
+                :aria-label="sample.aria_label"
+                :aria-selected="sample.key == selected_key ? 'true' : 'false'"
+                :data-key="sample.key"
                 :data-x="sample.data_x"
                 :data-y="sample.data_y"
-                :data-series="sample.series_label"></circle>
+                :data-series="sample.series_label"
+                :data-focused="sample.key == focused_key"
+                :data-selected="sample.key == selected_key"
+                @click.stop="select_sample(sample.key)"></circle>
       </template>
     </g>
     <g pp-show="hover_visible"

--- a/crates/pine-charts/src/area/mod.rs
+++ b/crates/pine-charts/src/area/mod.rs
@@ -7,12 +7,15 @@ use crate::animation::{
 };
 use crate::cartesian::{
     centered_plot_y, chart_hover_payload, optional_domain, plot_rect_from_edges,
-    pointer_event_svg_point, tooltip_aria_hidden, tooltip_mode, CartesianChartState,
+    pointer_event_svg_point, step_key, tooltip_aria_hidden, tooltip_mode, CartesianChartState,
     CartesianGuideFields, CartesianGuideUpdate, CartesianHoverFields, ChartStateFields,
     PlotEdgeFields, DEFAULT_EMPTY_MESSAGE,
 };
 use crate::error::{ChartError, ChartResult};
-use crate::events::{ChartHoverEnd, CHART_HOVER_END_EVENT, CHART_HOVER_EVENT};
+use crate::events::{
+    ChartHoverEnd, ChartSelection, ChartSelectionEnd, CHART_HOVER_END_EVENT, CHART_HOVER_EVENT,
+    CHART_SELECT_END_EVENT, CHART_SELECT_EVENT,
+};
 use crate::geometry::{ChartMargins, ChartRect, Point};
 use crate::legend::{series_label_or_default, series_legend_items_with_visibility};
 use crate::line::{
@@ -230,6 +233,8 @@ pub struct PineAreaChart {
     pub hover_placement_x: String,
     pub hover_placement_y: String,
     pub hover_style: String,
+    pub focused_key: String,
+    pub selected_key: String,
     pub error: String,
     pub ready: bool,
     pub empty: bool,
@@ -296,6 +301,8 @@ impl Default for PineAreaChart {
             hover_placement_x: "right".into(),
             hover_placement_y: "above".into(),
             hover_style: String::new(),
+            focused_key: String::new(),
+            selected_key: String::new(),
             error: String::new(),
             ready: false,
             empty: true,
@@ -407,6 +414,37 @@ impl PineAreaChart {
             pocopine::emit(CHART_HOVER_END_EVENT, ChartHoverEnd::new("area"));
         }
     }
+
+    pub fn select_sample(&mut self, key: String) {
+        if let Some(selection) = self.selection_for_sample(&key) {
+            self.focused_key = key.clone();
+            self.selected_key = key;
+            pocopine::emit(CHART_SELECT_EVENT, selection);
+        }
+    }
+
+    pub fn focus_next_sample(&mut self) {
+        self.step_sample_focus(1);
+    }
+
+    pub fn focus_prev_sample(&mut self) {
+        self.step_sample_focus(-1);
+    }
+
+    pub fn select_focused_sample(&mut self) {
+        if self.focused_key.is_empty() {
+            self.step_sample_focus(1);
+        }
+        if let Some(selection) = self.selection_for_sample(&self.focused_key) {
+            self.selected_key = self.focused_key.clone();
+            pocopine::emit(CHART_SELECT_EVENT, selection);
+        }
+    }
+
+    pub fn clear_selection(&mut self) {
+        self.focused_key.clear();
+        self.clear_selected_key();
+    }
 }
 
 impl PineAreaChart {
@@ -457,6 +495,7 @@ impl PineAreaChart {
                 });
                 self.error.clear();
                 self.state_fields().apply(CartesianChartState::Ready);
+                self.reconcile_selection();
                 self.clear_hover();
             }
             Err(ChartError::EmptySeries) => {
@@ -466,6 +505,7 @@ impl PineAreaChart {
                     });
                     self.samples.clear();
                     self.clear_hover();
+                    self.clear_selection();
                     self.error.clear();
                     self.state_fields().apply(CartesianChartState::Ready);
                     self.schedule_leaving_cleanup();
@@ -476,6 +516,7 @@ impl PineAreaChart {
                 self.plot_edges().clear();
                 self.guides().clear();
                 self.clear_hover();
+                self.clear_selection();
                 self.error.clear();
                 self.state_fields().apply(CartesianChartState::Empty);
             }
@@ -485,6 +526,7 @@ impl PineAreaChart {
                 self.plot_edges().clear();
                 self.guides().clear();
                 self.clear_hover();
+                self.clear_selection();
                 self.error = error.to_string();
                 self.state_fields().apply(CartesianChartState::Invalid);
             }
@@ -598,6 +640,43 @@ impl PineAreaChart {
             ready: &mut self.ready,
             empty: &mut self.empty,
             invalid: &mut self.invalid,
+        }
+    }
+
+    fn step_sample_focus(&mut self, step: isize) {
+        if let Some(key) = step_key(
+            self.samples.iter().map(|sample| sample.key.as_str()),
+            &self.focused_key,
+            step,
+        ) {
+            self.focused_key = key;
+        }
+    }
+
+    fn has_sample_key(&self, key: &str) -> bool {
+        self.samples.iter().any(|sample| sample.key == key)
+    }
+
+    fn selection_for_sample(&self, key: &str) -> Option<ChartSelection> {
+        self.samples
+            .iter()
+            .find(|sample| sample.key == key)
+            .map(|sample| sample.selection("area"))
+    }
+
+    fn reconcile_selection(&mut self) {
+        if !self.has_sample_key(&self.focused_key) {
+            self.focused_key.clear();
+        }
+        if !self.has_sample_key(&self.selected_key) {
+            self.clear_selected_key();
+        }
+    }
+
+    fn clear_selected_key(&mut self) {
+        let key = std::mem::take(&mut self.selected_key);
+        if !key.is_empty() {
+            pocopine::emit(CHART_SELECT_END_EVENT, ChartSelectionEnd::new("area", key));
         }
     }
 

--- a/crates/pine-charts/src/bar/PineBarChart.poco
+++ b/crates/pine-charts/src/bar/PineBarChart.poco
@@ -16,7 +16,8 @@
       @keydown.arrow-left.prevent="focus_prev_bar"
       @keydown.arrow-up.prevent="focus_prev_bar"
       @keydown.enter.prevent="select_focused_bar"
-      @keydown.space.prevent="select_focused_bar">
+      @keydown.space.prevent="select_focused_bar"
+      @keydown.escape.prevent="clear_selection">
   <svg class="pine-chart-svg"
        :width="width"
        :height="height"
@@ -25,7 +26,8 @@
        aria-hidden="true"
        focusable="false"
        @pointermove="on_pointer_move"
-       @pointerleave="clear_hover">
+       @pointerleave="clear_hover"
+       @click="clear_selection">
     <g pp-show="ready"
        class="pine-chart-grid"
        data-layer="grid"

--- a/crates/pine-charts/src/bar/mod.rs
+++ b/crates/pine-charts/src/bar/mod.rs
@@ -11,8 +11,8 @@ use crate::cartesian::{
 };
 use crate::error::{finite, ChartError, ChartResult};
 use crate::events::{
-    ChartHover, ChartHoverEnd, ChartSelection, CHART_HOVER_END_EVENT, CHART_HOVER_EVENT,
-    CHART_SELECT_EVENT,
+    ChartHover, ChartHoverEnd, ChartSelection, ChartSelectionEnd, CHART_HOVER_END_EVENT,
+    CHART_HOVER_EVENT, CHART_SELECT_END_EVENT, CHART_SELECT_EVENT,
 };
 use crate::geometry::{ChartMargins, ChartRect, Point};
 use crate::legend::{series_label_or_default, series_legend_items_with_visibility, LegendItem};
@@ -242,9 +242,11 @@ impl SvgBar {
             "bar",
             self.key.clone(),
             self.aria_label.clone(),
+            self.aria_label.clone(),
             self.category_label.clone(),
             display_series_label(&self.series_label),
             self.value,
+            format_tick(self.value),
         )
     }
 
@@ -844,6 +846,11 @@ impl PineBarChart {
             pocopine::emit(CHART_SELECT_EVENT, selection);
         }
     }
+
+    pub fn clear_selection(&mut self) {
+        self.focused_key.clear();
+        self.clear_selected_key();
+    }
 }
 
 impl PineBarChart {
@@ -1048,13 +1055,15 @@ impl PineBarChart {
             self.focused_key.clear();
         }
         if !self.has_bar_key(&self.selected_key) {
-            self.selected_key.clear();
+            self.clear_selected_key();
         }
     }
 
-    fn clear_selection(&mut self) {
-        self.focused_key.clear();
-        self.selected_key.clear();
+    fn clear_selected_key(&mut self) {
+        let key = std::mem::take(&mut self.selected_key);
+        if !key.is_empty() {
+            pocopine::emit(CHART_SELECT_END_EVENT, ChartSelectionEnd::new("bar", key));
+        }
     }
 }
 

--- a/crates/pine-charts/src/events.rs
+++ b/crates/pine-charts/src/events.rs
@@ -3,6 +3,7 @@ use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 
 pub const CHART_SELECT_EVENT: &str = "pp:chart:select";
+pub const CHART_SELECT_END_EVENT: &str = "pp:chart:select-end";
 pub const CHART_HOVER_EVENT: &str = "pp:chart:hover";
 pub const CHART_HOVER_END_EVENT: &str = "pp:chart:hover-end";
 pub const LEGEND_TOGGLE_EVENT: &str = "pp:chart:legend-toggle";
@@ -16,77 +17,148 @@ fn from_event_detail<T: DeserializeOwned>(event: wasm_bindgen::JsValue) -> Optio
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
 pub struct ChartSelection {
     pub chart: String,
+    pub kind: String,
     pub key: String,
     pub label: String,
+    pub aria_label: String,
     pub series: String,
     pub category: String,
     pub x: Option<f64>,
     pub y: Option<f64>,
     pub value: Option<f64>,
     pub percentage: Option<f64>,
+    pub x_label: String,
+    pub y_label: String,
+    pub value_label: String,
+    pub percentage_label: String,
 }
 
 impl ChartSelection {
+    #[allow(clippy::too_many_arguments)]
     pub fn xy(
         chart: impl Into<String>,
         key: impl Into<String>,
         label: impl Into<String>,
+        aria_label: impl Into<String>,
         series: impl Into<String>,
         x: f64,
         y: f64,
+        x_label: impl Into<String>,
+        y_label: impl Into<String>,
     ) -> Self {
         Self {
             chart: chart.into(),
+            kind: "xy".into(),
             key: key.into(),
             label: label.into(),
+            aria_label: aria_label.into(),
             series: series.into(),
             category: String::new(),
             x: Some(x),
             y: Some(y),
             value: None,
             percentage: None,
+            x_label: x_label.into(),
+            y_label: y_label.into(),
+            value_label: String::new(),
+            percentage_label: String::new(),
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn category(
         chart: impl Into<String>,
         key: impl Into<String>,
         label: impl Into<String>,
+        aria_label: impl Into<String>,
         category: impl Into<String>,
         series: impl Into<String>,
         value: f64,
+        value_label: impl Into<String>,
     ) -> Self {
         Self {
             chart: chart.into(),
+            kind: "category".into(),
             key: key.into(),
             label: label.into(),
+            aria_label: aria_label.into(),
             series: series.into(),
             category: category.into(),
             x: None,
             y: None,
             value: Some(value),
             percentage: None,
+            x_label: String::new(),
+            y_label: String::new(),
+            value_label: value_label.into(),
+            percentage_label: String::new(),
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn share(
         chart: impl Into<String>,
         key: impl Into<String>,
         label: impl Into<String>,
+        aria_label: impl Into<String>,
         value: f64,
+        value_label: impl Into<String>,
         percentage: f64,
+        percentage_label: impl Into<String>,
     ) -> Self {
         Self {
             chart: chart.into(),
+            kind: "share".into(),
             key: key.into(),
             label: label.into(),
+            aria_label: aria_label.into(),
             series: String::new(),
             category: String::new(),
             x: None,
             y: None,
             value: Some(value),
             percentage: Some(percentage),
+            x_label: String::new(),
+            y_label: String::new(),
+            value_label: value_label.into(),
+            percentage_label: percentage_label.into(),
         }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub fn from_event_value(event: wasm_bindgen::JsValue) -> Option<Self> {
+        from_event_detail(event)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn from_event_value(_: wasm_bindgen::JsValue) -> Option<Self> {
+        None
+    }
+}
+
+/// Payload for `pp:chart:select-end`.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct ChartSelectionEnd {
+    pub chart: String,
+    pub key: String,
+}
+
+impl ChartSelectionEnd {
+    pub fn new(chart: impl Into<String>, key: impl Into<String>) -> Self {
+        Self {
+            chart: chart.into(),
+            key: key.into(),
+        }
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub fn from_event_value(event: wasm_bindgen::JsValue) -> Option<Self> {
+        from_event_detail(event)
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn from_event_value(_: wasm_bindgen::JsValue) -> Option<Self> {
+        None
     }
 }
 

--- a/crates/pine-charts/src/lib.rs
+++ b/crates/pine-charts/src/lib.rs
@@ -44,8 +44,9 @@ pub use cartesian_chart::{
 };
 pub use error::{ChartError, ChartResult};
 pub use events::{
-    ChartHover, ChartHoverEnd, ChartSelection, LegendToggle, CHART_HOVER_END_EVENT,
-    CHART_HOVER_EVENT, CHART_SELECT_EVENT, LEGEND_TOGGLE_EVENT,
+    ChartHover, ChartHoverEnd, ChartSelection, ChartSelectionEnd, LegendToggle,
+    CHART_HOVER_END_EVENT, CHART_HOVER_EVENT, CHART_SELECT_END_EVENT, CHART_SELECT_EVENT,
+    LEGEND_TOGGLE_EVENT,
 };
 pub use geometry::{ChartMargins, ChartRect, Point};
 pub use layered::{

--- a/crates/pine-charts/src/line/PineLineChart.poco
+++ b/crates/pine-charts/src/line/PineLineChart.poco
@@ -16,7 +16,8 @@
       @keydown.arrow-left.prevent="focus_prev_sample"
       @keydown.arrow-up.prevent="focus_prev_sample"
       @keydown.enter.prevent="select_focused_sample"
-      @keydown.space.prevent="select_focused_sample">
+      @keydown.space.prevent="select_focused_sample"
+      @keydown.escape.prevent="clear_selection">
   <svg class="pine-chart-svg"
        :width="width"
        :height="height"
@@ -25,7 +26,8 @@
        aria-hidden="true"
        focusable="false"
        @pointermove="on_pointer_move"
-       @pointerleave="clear_hover">
+       @pointerleave="clear_hover"
+       @click="clear_selection">
     <g pp-show="ready"
        class="pine-chart-grid"
        data-layer="grid"

--- a/crates/pine-charts/src/line/mod.rs
+++ b/crates/pine-charts/src/line/mod.rs
@@ -11,7 +11,8 @@ use crate::cartesian::{
 };
 use crate::error::{finite, ChartError, ChartResult};
 use crate::events::{
-    ChartHoverEnd, ChartSelection, CHART_HOVER_END_EVENT, CHART_HOVER_EVENT, CHART_SELECT_EVENT,
+    ChartHoverEnd, ChartSelection, ChartSelectionEnd, CHART_HOVER_END_EVENT, CHART_HOVER_EVENT,
+    CHART_SELECT_END_EVENT, CHART_SELECT_EVENT,
 };
 use crate::geometry::{ChartMargins, ChartRect, Point};
 use crate::legend::{series_label_or_default, series_legend_items_with_visibility};
@@ -258,9 +259,12 @@ impl LineChartSample {
             chart,
             self.key.clone(),
             self.aria_label.clone(),
+            self.aria_label.clone(),
             self.series_label.clone(),
             self.data_x,
             self.data_y,
+            self.x_label.clone(),
+            self.y_label.clone(),
         )
     }
 }
@@ -621,6 +625,11 @@ impl PineLineChart {
             pocopine::emit(CHART_SELECT_EVENT, selection);
         }
     }
+
+    pub fn clear_selection(&mut self) {
+        self.focused_key.clear();
+        self.clear_selected_key();
+    }
 }
 
 impl PineLineChart {
@@ -790,13 +799,15 @@ impl PineLineChart {
             self.focused_key.clear();
         }
         if !self.has_sample_key(&self.selected_key) {
-            self.selected_key.clear();
+            self.clear_selected_key();
         }
     }
 
-    fn clear_selection(&mut self) {
-        self.focused_key.clear();
-        self.selected_key.clear();
+    fn clear_selected_key(&mut self) {
+        let key = std::mem::take(&mut self.selected_key);
+        if !key.is_empty() {
+            pocopine::emit(CHART_SELECT_END_EVENT, ChartSelectionEnd::new("line", key));
+        }
     }
 
     fn hover_fields(&mut self) -> CartesianHoverFields<'_> {

--- a/crates/pine-charts/src/pie/PinePieChart.poco
+++ b/crates/pine-charts/src/pie/PinePieChart.poco
@@ -18,7 +18,8 @@
       @keydown.arrow-left.prevent="focus_prev_slice"
       @keydown.arrow-up.prevent="focus_prev_slice"
       @keydown.enter.prevent="select_focused_slice"
-      @keydown.space.prevent="select_focused_slice">
+      @keydown.space.prevent="select_focused_slice"
+      @keydown.escape.prevent="clear_selection">
   <svg class="pine-chart-svg"
        :width="width"
        :height="height"
@@ -27,7 +28,8 @@
        aria-hidden="true"
        focusable="false"
        @pointermove="on_pointer_move"
-       @pointerleave="clear_hover">
+       @pointerleave="clear_hover"
+       @click="clear_selection">
     <g class="pine-chart-pie-slices" data-layer="series">
       <template pp-for="slice in slices" pp-key="slice.key">
         <g class="pine-chart-pie-slice-group"

--- a/crates/pine-charts/src/pie/mod.rs
+++ b/crates/pine-charts/src/pie/mod.rs
@@ -13,8 +13,8 @@ use crate::cartesian::{
 };
 use crate::error::{finite, ChartError, ChartResult};
 use crate::events::{
-    ChartHover, ChartHoverEnd, ChartSelection, CHART_HOVER_END_EVENT, CHART_HOVER_EVENT,
-    CHART_SELECT_EVENT,
+    ChartHover, ChartHoverEnd, ChartSelection, ChartSelectionEnd, CHART_HOVER_END_EVENT,
+    CHART_HOVER_EVENT, CHART_SELECT_END_EVENT, CHART_SELECT_EVENT,
 };
 use crate::geometry::{ChartMargins, ChartRect, Point};
 use crate::legend::LegendItem;
@@ -222,8 +222,11 @@ impl SvgPieSlice {
             "pie",
             self.key.clone(),
             self.aria_label.clone(),
+            self.aria_label.clone(),
             self.value,
+            self.value_label.clone(),
             self.percentage,
+            self.percentage_label.clone(),
         )
     }
 
@@ -587,6 +590,11 @@ impl PinePieChart {
             self.selected_key = self.focused_key.clone();
             pocopine::emit(CHART_SELECT_EVENT, selection);
         }
+    }
+
+    pub fn clear_selection(&mut self) {
+        self.focused_key.clear();
+        self.clear_selected_key();
     }
 }
 
@@ -1082,13 +1090,15 @@ impl PinePieChart {
             self.focused_key.clear();
         }
         if !self.has_slice_key(&self.selected_key) {
-            self.selected_key.clear();
+            self.clear_selected_key();
         }
     }
 
-    fn clear_selection(&mut self) {
-        self.focused_key.clear();
-        self.selected_key.clear();
+    fn clear_selected_key(&mut self) {
+        let key = std::mem::take(&mut self.selected_key);
+        if !key.is_empty() {
+            pocopine::emit(CHART_SELECT_END_EVENT, ChartSelectionEnd::new("pie", key));
+        }
     }
 
     fn state_fields(&mut self) -> ChartStateFields<'_> {

--- a/crates/pine-charts/src/scatter/PineScatterChart.poco
+++ b/crates/pine-charts/src/scatter/PineScatterChart.poco
@@ -16,7 +16,8 @@
       @keydown.arrow-left.prevent="focus_prev_sample"
       @keydown.arrow-up.prevent="focus_prev_sample"
       @keydown.enter.prevent="select_focused_sample"
-      @keydown.space.prevent="select_focused_sample">
+      @keydown.space.prevent="select_focused_sample"
+      @keydown.escape.prevent="clear_selection">
   <svg class="pine-chart-svg"
        :width="width"
        :height="height"
@@ -25,7 +26,8 @@
        aria-hidden="true"
        focusable="false"
        @pointermove="on_pointer_move"
-       @pointerleave="clear_hover">
+       @pointerleave="clear_hover"
+       @click="clear_selection">
     <g pp-show="ready"
        class="pine-chart-grid"
        data-layer="grid"

--- a/crates/pine-charts/src/scatter/mod.rs
+++ b/crates/pine-charts/src/scatter/mod.rs
@@ -10,7 +10,8 @@ use crate::cartesian::{
 };
 use crate::error::{ChartError, ChartResult};
 use crate::events::{
-    ChartHoverEnd, ChartSelection, CHART_HOVER_END_EVENT, CHART_HOVER_EVENT, CHART_SELECT_EVENT,
+    ChartHoverEnd, ChartSelection, ChartSelectionEnd, CHART_HOVER_END_EVENT, CHART_HOVER_EVENT,
+    CHART_SELECT_END_EVENT, CHART_SELECT_EVENT,
 };
 use crate::geometry::{ChartMargins, ChartRect, Point};
 use crate::legend::{series_label_or_default, series_legend_items_with_visibility};
@@ -429,6 +430,11 @@ impl PineScatterChart {
             pocopine::emit(CHART_SELECT_EVENT, selection);
         }
     }
+
+    pub fn clear_selection(&mut self) {
+        self.focused_key.clear();
+        self.clear_selected_key();
+    }
 }
 
 impl PineScatterChart {
@@ -590,13 +596,18 @@ impl PineScatterChart {
             self.focused_key.clear();
         }
         if !self.has_sample_key(&self.selected_key) {
-            self.selected_key.clear();
+            self.clear_selected_key();
         }
     }
 
-    fn clear_selection(&mut self) {
-        self.focused_key.clear();
-        self.selected_key.clear();
+    fn clear_selected_key(&mut self) {
+        let key = std::mem::take(&mut self.selected_key);
+        if !key.is_empty() {
+            pocopine::emit(
+                CHART_SELECT_END_EVENT,
+                ChartSelectionEnd::new("scatter", key),
+            );
+        }
     }
 
     fn hover_fields(&mut self) -> CartesianHoverFields<'_> {

--- a/crates/pine-charts/tests/charts.rs
+++ b/crates/pine-charts/tests/charts.rs
@@ -9,8 +9,8 @@ use std::rc::Rc;
 use pine_charts::{
     line_legend_items, set_line_series_visible, ChartAreaSeries, ChartBar, ChartBarSeries,
     ChartLayerPoint, ChartLineSeries, ChartPieSlice, ChartPoint, ChartScatterSeries, LegendItem,
-    LegendToggle, CHART_HOVER_END_EVENT, CHART_HOVER_EVENT, CHART_SELECT_EVENT,
-    LEGEND_TOGGLE_EVENT,
+    LegendToggle, CHART_HOVER_END_EVENT, CHART_HOVER_EVENT, CHART_SELECT_END_EVENT,
+    CHART_SELECT_EVENT, LEGEND_TOGGLE_EVENT,
 };
 use pocopine::prelude::*;
 use wasm_bindgen::closure::Closure;
@@ -1385,6 +1385,20 @@ async fn area_chart_renders_fills_lines_and_hover_metadata() {
     assert_eq!(hover_kind.borrow().as_deref(), Some("xy"));
     assert_eq!(hover_label.borrow().as_deref(), Some("x 1, y 0"));
 
+    assert_eq!(chart.get_attribute("tabindex").as_deref(), Some("0"));
+    let selected_kind = listen_string_field(&chart, CHART_SELECT_EVENT, "kind");
+    let selected_label = listen_string_field(&chart, CHART_SELECT_EVENT, "label");
+    let selected_x = listen_string_field(&chart, CHART_SELECT_EVENT, "x_label");
+    let first_marker = markers.get(0).unwrap().dyn_into::<Element>().unwrap();
+    dispatch_click(&first_marker);
+    settle().await;
+
+    assert!(first_marker.has_attribute("data-focused"));
+    assert!(first_marker.has_attribute("data-selected"));
+    assert_eq!(selected_kind.borrow().as_deref(), Some("xy"));
+    assert_eq!(selected_label.borrow().as_deref(), Some("Actual: x 0, y 0"));
+    assert_eq!(selected_x.borrow().as_deref(), Some("0"));
+
     host.remove();
 }
 
@@ -1515,7 +1529,10 @@ async fn line_chart_supports_marker_selection_and_keyboard_focus() {
 
     let chart = host.query_selector(".pine-line-chart").unwrap().unwrap();
     assert_eq!(chart.get_attribute("tabindex").as_deref(), Some("0"));
+    let selected_kind = listen_string_field(&chart, CHART_SELECT_EVENT, "kind");
     let selected_label = listen_string_field(&chart, CHART_SELECT_EVENT, "label");
+    let selected_x = listen_string_field(&chart, CHART_SELECT_EVENT, "x_label");
+    let cleared_key = listen_string_field(&chart, CHART_SELECT_END_EVENT, "key");
 
     let markers = host.query_selector_all(".pine-chart-marker").unwrap();
     assert_eq!(markers.length(), 3);
@@ -1527,7 +1544,9 @@ async fn line_chart_supports_marker_selection_and_keyboard_focus() {
 
     assert!(second.has_attribute("data-focused"));
     assert!(second.has_attribute("data-selected"));
+    assert_eq!(selected_kind.borrow().as_deref(), Some("xy"));
     assert_eq!(selected_label.borrow().as_deref(), Some("x 5, y 10"));
+    assert_eq!(selected_x.borrow().as_deref(), Some("5"));
 
     dispatch_keydown(&chart, "ArrowRight");
     settle().await;
@@ -1543,6 +1562,13 @@ async fn line_chart_supports_marker_selection_and_keyboard_focus() {
     assert!(third.has_attribute("data-selected"));
     assert!(!second.has_attribute("data-selected"));
     assert_eq!(selected_label.borrow().as_deref(), Some("x 10, y 5"));
+
+    dispatch_keydown(&chart, "Escape");
+    settle().await;
+
+    assert!(!third.has_attribute("data-selected"));
+    let third_key = third.get_attribute("data-key");
+    assert_eq!(cleared_key.borrow().as_deref(), third_key.as_deref());
 
     host.remove();
 }

--- a/docs/charts/components.md
+++ b/docs/charts/components.md
@@ -199,7 +199,10 @@ let legend_items = area_legend_items(&series);
 ```
 
 Area fills close to the bottom of the plot rectangle. If an application needs a
-semantic zero baseline, set an explicit `y_min="0"` domain.
+semantic zero baseline, set an explicit `y_min="0"` domain. When
+`show_markers="true"` is set, area markers can be selected by click or by
+keyboard from the chart root and emit the same `pp:chart:select` /
+`pp:chart:select-end` events as line markers.
 
 ## Bar Chart
 

--- a/docs/charts/events.md
+++ b/docs/charts/events.md
@@ -5,24 +5,29 @@ usually connect to detail panels, filters, or route changes.
 
 ## Selection
 
-Line markers, scatter points, bars, and pie/donut slices emit
+Line markers, area markers, scatter points, bars, and pie/donut slices emit
 `pp:chart:select` when selected by pointer or keyboard. The event payload is
 `ChartSelection`:
 
 ```rust
-use pine_charts::ChartSelection;
+use pine_charts::{ChartSelection, ChartSelectionEnd};
 ```
 
 Payload fields:
 
-- `chart`: `"line"`, `"scatter"`, `"bar"`, or `"pie"`
+- `chart`: `"line"`, `"area"`, `"scatter"`, `"bar"`, or `"pie"`
+- `kind`: `"xy"`, `"category"`, or `"share"`
 - `key`: stable rendered mark key
-- `label`: human-readable mark label
+- `label`: human-readable selection label
+- `aria_label`: rendered mark accessibility label
 - `series`: series label when present
 - `category`: categorical label for bars
 - `x` / `y`: numeric coordinates for line and scatter charts
 - `value`: numeric value for bars and pie/donut slices
 - `percentage`: share percentage for pie/donut slices
+- `x_label` / `y_label`: formatted point coordinates for `xy` selections
+- `value_label`: formatted value for `category` and `share` selections
+- `percentage_label`: formatted percentage for `share` selections
 
 Template listeners use the event name directly:
 
@@ -32,6 +37,13 @@ Template listeners use the event name directly:
   show_markers="true"
   @pp:chart:select="show_detail"></pine-line-chart>
 ```
+
+Selection is persistent: the selected mark keeps `data-selected` and
+`aria-selected="true"` until another mark is selected or selection is cleared.
+Charts emit `pp:chart:select-end` with `ChartSelectionEnd { chart, key }` when
+selection is cleared by Escape, a background chart click, or a data update that
+removes the selected mark. Use `pp:chart:select` for drilldown/detail panels and
+`pp:chart:select-end` to close those panels.
 
 ## Hover
 

--- a/docs/charts/interaction.md
+++ b/docs/charts/interaction.md
@@ -44,12 +44,13 @@ hovered rect receives `data-hovered`; the tooltip exposes `data-category`,
 variables as line, scatter, and area charts. Bars do not render a crosshair by
 default because the rect itself is the hover target.
 
-Line markers, scatter points, bars, and pie/donut slices also expose a small
-selection contract. The chart root is keyboard focusable. Arrow keys move an
-internal focused item, and Enter or Space selects it. Pointer clicks select the
-clicked marker, point, bar, or slice. Selection emits a bubbling
-`pp:chart:select` event from the selected mark/root. Rendered selectable marks
-expose:
+Line markers, area markers, scatter points, bars, and pie/donut slices also
+expose a small selection contract. The chart root is keyboard focusable. Arrow
+keys move an internal focused item, Enter or Space selects it, and Escape clears
+selection. Pointer clicks select the clicked marker, point, bar, or slice;
+background chart clicks clear selection. Selection emits a bubbling
+`pp:chart:select` event, and clearing emits `pp:chart:select-end`. Rendered
+selectable marks expose:
 
 - `data-key`
 - `data-focused`
@@ -60,6 +61,8 @@ Line selection is marker-based, so visible point marks require
 `show_markers="true"`. Keyboard selection still tracks the sampled line data,
 but an application only gets visible selected/focused line marks when markers
 are rendered.
+
+Area selection follows the same marker-based model as line selection.
 
 Pie and donut hover follows the same hook-first model as bars: the hovered slice
 receives `data-hovered`, and the tooltip exposes `data-label`, `data-value`, and

--- a/examples/charts/index.html
+++ b/examples/charts/index.html
@@ -210,6 +210,45 @@
       min-width: 0;
     }
 
+    .chart-selection-detail {
+      align-items: center;
+      border: 1px solid #d6dee8;
+      border-radius: 6px;
+      display: grid;
+      gap: 4px 12px;
+      grid-template-columns: minmax(0, 1fr) auto;
+      margin-top: 10px;
+      min-height: 58px;
+      padding: 10px 12px;
+      transition: border-color var(--pine-chart-animation-duration, 120ms) var(--pine-chart-animation-easing, ease),
+                  background var(--pine-chart-animation-duration, 120ms) var(--pine-chart-animation-easing, ease);
+    }
+
+    .chart-selection-detail[data-visible="true"] {
+      background: #f8fbff;
+      border-color: #1d6fd8;
+    }
+
+    .chart-selection-detail-title {
+      color: #526173;
+      font-size: 12px;
+      font-weight: 700;
+      grid-column: 1 / -1;
+    }
+
+    .chart-selection-detail-value {
+      color: #0f172a;
+      font-size: 15px;
+      min-width: 0;
+    }
+
+    .chart-selection-detail-meta {
+      color: #526173;
+      font-size: 12px;
+      justify-self: end;
+      min-width: 0;
+    }
+
     .pine-chart-responsive-frame {
       min-width: 0;
     }

--- a/examples/charts/src/ChartDemo.poco
+++ b/examples/charts/src/ChartDemo.poco
@@ -213,7 +213,9 @@
                            show_markers="true"
                            tooltip="none"
                            @pp:chart:hover="show_custom_tooltip"
-                           @pp:chart:hover-end="hide_custom_tooltip"></pine-area-chart>
+                           @pp:chart:hover-end="hide_custom_tooltip"
+                           @pp:chart:select="show_selection_detail"
+                           @pp:chart:select-end="hide_selection_detail"></pine-area-chart>
         </pine-chart-responsive>
 
         <div class="chart-custom-tooltip"
@@ -230,6 +232,18 @@
           <span class="chart-custom-tooltip-meta"
                 pp-text="custom_tooltip_meta"></span>
         </div>
+      </div>
+
+      <div class="chart-selection-detail"
+           role="status"
+           aria-live="polite"
+           :data-visible="selection_visible">
+        <span class="chart-selection-detail-title"
+              pp-text="selection_title"></span>
+        <strong class="chart-selection-detail-value"
+                pp-text="selection_value"></strong>
+        <span class="chart-selection-detail-meta"
+              pp-text="selection_meta"></span>
       </div>
 
       <pine-chart-legend class="chart-card-legend"

--- a/examples/charts/src/lib.rs
+++ b/examples/charts/src/lib.rs
@@ -2,8 +2,8 @@ use pine_charts::{
     area_legend_items, bar_legend_items, line_legend_items, scatter_legend_items,
     set_area_series_visible, set_bar_series_visible, set_pie_slice_visible,
     set_scatter_series_visible, ChartAreaSeries, ChartBar, ChartBarSeries, ChartHover,
-    ChartLayerPoint, ChartLineSeries, ChartPieSlice, ChartPoint, ChartScatterSeries, LegendItem,
-    LegendToggle,
+    ChartLayerPoint, ChartLineSeries, ChartPieSlice, ChartPoint, ChartScatterSeries,
+    ChartSelection, LegendItem, LegendToggle,
 };
 use pocopine::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -55,6 +55,10 @@ pub struct ChartDemo {
     pub custom_tooltip_x: String,
     pub custom_tooltip_y: String,
     pub custom_tooltip_style: String,
+    pub selection_visible: bool,
+    pub selection_title: String,
+    pub selection_value: String,
+    pub selection_meta: String,
 }
 
 impl Default for ChartDemo {
@@ -110,6 +114,10 @@ impl Default for ChartDemo {
             custom_tooltip_x: "right".into(),
             custom_tooltip_y: "above".into(),
             custom_tooltip_style: String::new(),
+            selection_visible: false,
+            selection_title: "Select a point".into(),
+            selection_value: "Click a marker or use keyboard selection.".into(),
+            selection_meta: "Selection emits pp:chart:select".into(),
         }
     }
 }
@@ -299,6 +307,29 @@ impl ChartDemo {
 
     pub fn hide_custom_tooltip(&mut self) {
         self.custom_tooltip_visible = false;
+    }
+
+    pub fn show_selection_detail(&mut self, event: JsValue) {
+        let Some(selection) = ChartSelection::from_event_value(event) else {
+            return;
+        };
+        self.selection_visible = true;
+        self.selection_title = if selection.series.is_empty() {
+            selection.chart
+        } else {
+            selection.series
+        };
+        self.selection_value = match selection.kind.as_str() {
+            "xy" => format!("{}: {}", selection.x_label, selection.y_label),
+            "category" => format!("{}: {}", selection.category, selection.value_label),
+            "share" => format!("{} · {}", selection.value_label, selection.percentage_label),
+            _ => selection.label,
+        };
+        self.selection_meta = format!("Selected {}", selection.key);
+    }
+
+    pub fn hide_selection_detail(&mut self) {
+        self.selection_visible = false;
     }
 }
 


### PR DESCRIPTION
## Summary
- extends chart selection payloads with `kind`, accessibility, formatted labels, and JS parsing helpers
- adds `pp:chart:select-end` for clearing drilldown state, plus Escape/background-clear behavior
- wires area marker selection to match line/scatter/bar/pie and updates the charts demo with a persistent selection detail panel
- documents the selection/drilldown contract

## Verification
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`
- `cargo test -p pine-charts`
- `wasm-pack test --firefox --headless crates/pine-charts`
- `cargo run -p pocopine-cli -- build --path examples/charts`
- `git diff --check`
