### PR TITLE
Add host analytics JSON-lines exporter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3122,6 +3122,7 @@ dependencies = [
  "pocopine-observe",
  "serde",
  "serde-wasm-bindgen 0.6.5",
+ "serde_json",
  "tracing",
  "wasm-bindgen",
 ]

--- a/crates/pocopine-analytics/Cargo.toml
+++ b/crates/pocopine-analytics/Cargo.toml
@@ -11,6 +11,9 @@ pocopine-observe = { workspace = true }
 serde = { workspace = true }
 tracing = { workspace = true }
 
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+serde_json = { workspace = true }
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = { workspace = true }
 serde-wasm-bindgen = { workspace = true }

--- a/crates/pocopine-analytics/src/lib.rs
+++ b/crates/pocopine-analytics/src/lib.rs
@@ -7,9 +7,15 @@
 #[cfg(not(target_arch = "wasm32"))]
 use std::collections::VecDeque;
 use std::fmt;
+#[cfg(not(target_arch = "wasm32"))]
+use std::fs::{File, OpenOptions};
+#[cfg(not(target_arch = "wasm32"))]
+use std::io::{self, Write};
 use std::panic::{catch_unwind, AssertUnwindSafe};
 #[cfg(not(target_arch = "wasm32"))]
-use std::sync::{Arc, Mutex};
+use std::path::Path;
+#[cfg(not(target_arch = "wasm32"))]
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use pocopine_observe::{
     emit_tracing, EventPriority, FieldPrivacy, ObserveContext, ObservedEvent, RedactionPolicy,
@@ -103,6 +109,82 @@ pub struct AnalyticsReport {
 impl AnalyticsReport {
     pub fn all_succeeded(&self) -> bool {
         self.failed == 0
+    }
+}
+
+/// Host-side JSON-lines analytics exporter.
+///
+/// Each accepted event is serialized as one JSON object followed by `\n`.
+/// This is useful for stdout/file pipelines consumed by AWS CloudWatch agents,
+/// Cloudflare log pipelines, container log collectors, or local tests.
+#[cfg(not(target_arch = "wasm32"))]
+pub struct JsonLinesAnalyticsSink<W> {
+    writer: Mutex<W>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<W> JsonLinesAnalyticsSink<W>
+where
+    W: Write + Send + 'static,
+{
+    pub fn new(writer: W) -> Self {
+        Self {
+            writer: Mutex::new(writer),
+        }
+    }
+
+    fn writer(&self) -> Result<MutexGuard<'_, W>, AnalyticsError> {
+        self.writer
+            .lock()
+            .map_err(|_| AnalyticsError::new("analytics json-lines writer lock poisoned"))
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl JsonLinesAnalyticsSink<io::Stdout> {
+    pub fn stdout() -> Self {
+        Self::new(io::stdout())
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl JsonLinesAnalyticsSink<io::Stderr> {
+    pub fn stderr() -> Self {
+        Self::new(io::stderr())
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl JsonLinesAnalyticsSink<File> {
+    pub fn file(path: impl AsRef<Path>) -> Result<Self, AnalyticsError> {
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .map_err(|err| AnalyticsError::new(format!("open analytics json-lines file: {err}")))?;
+        Ok(Self::new(file))
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl<W> AnalyticsSink for JsonLinesAnalyticsSink<W>
+where
+    W: Write + Send + 'static,
+{
+    fn emit(&self, event: &ObservedEvent) -> Result<(), AnalyticsError> {
+        let mut writer = self.writer()?;
+        serde_json::to_writer(&mut *writer, event)
+            .map_err(|err| AnalyticsError::new(format!("serialize analytics event: {err}")))?;
+        writer
+            .write_all(b"\n")
+            .map_err(|err| AnalyticsError::new(format!("write analytics event: {err}")))?;
+        Ok(())
+    }
+
+    fn flush(&self) -> Result<(), AnalyticsError> {
+        self.writer()?
+            .flush()
+            .map_err(|err| AnalyticsError::new(format!("flush analytics json-lines writer: {err}")))
     }
 }
 
@@ -545,12 +627,43 @@ pub mod web {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(not(target_arch = "wasm32"))]
+    use std::io::{self, Write};
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
 
     use pocopine_observe::{FieldPrivacy, RedactionPolicy};
 
     use super::*;
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[derive(Clone, Default)]
+    struct SharedBuffer {
+        bytes: Arc<Mutex<Vec<u8>>>,
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    impl SharedBuffer {
+        fn contents(&self) -> String {
+            String::from_utf8(self.bytes.lock().expect("buffer lock poisoned").clone())
+                .expect("analytics json-lines output is utf-8")
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    impl Write for SharedBuffer {
+        fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+            self.bytes
+                .lock()
+                .expect("buffer lock poisoned")
+                .extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
 
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
@@ -640,6 +753,37 @@ mod tests {
         assert_eq!(report.succeeded, 1);
         assert_eq!(report.failed, 0);
         assert!(report.all_succeeded());
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn json_lines_sink_writes_one_redacted_event_per_line() {
+        let output = SharedBuffer::default();
+        let sink = JsonLinesAnalyticsSink::new(output.clone());
+        let client = AnalyticsClient::new()
+            .without_tracing_events()
+            .with_redaction(RedactionPolicy::public_only())
+            .with_sink(sink);
+
+        let report = client.emit(
+            event("checkout")
+                .field("plan", "pro", FieldPrivacy::Public)
+                .field("email", "person@example.test", FieldPrivacy::Sensitive),
+        );
+        let flush = client.flush();
+
+        assert!(report.all_succeeded());
+        assert!(flush.all_succeeded());
+
+        let output = output.contents();
+        let lines = output.lines().collect::<Vec<_>>();
+        assert_eq!(lines.len(), 1);
+        let json: serde_json::Value =
+            serde_json::from_str(lines[0]).expect("analytics json-line is valid json");
+        assert_eq!(json["name"], "checkout");
+        assert_eq!(json["fields"]["plan"]["value"], "pro");
+        assert_eq!(json["fields"]["plan"]["privacy"], "public");
+        assert!(json["fields"].get("email").is_none());
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/docs/README.md
+++ b/docs/README.md
@@ -74,6 +74,6 @@ Example apps:
   with collection/query refetch callbacks.
 - [`examples/sync/`](../examples/sync/) — `pocopine-sync` cursor pulls
   with `pocopine-live` wake-ups.
-- [`examples/observability-smoke/`](../examples/observability-smoke/) — OTLP trace export smoke server.
+- [`examples/observability-smoke/`](../examples/observability-smoke/) — OTLP trace export and JSON-lines analytics exporter smoke paths.
 - [`examples/spa/`](../examples/spa/) — `App::route` + `<pp-outlet>` + `pp-route` + `$route`.
 - [`examples/site/`](../examples/site/) — the marketing page, dogfooded.

--- a/docs/logging-tracing-observer.md
+++ b/docs/logging-tracing-observer.md
@@ -502,9 +502,14 @@ events, rejects new events when full, and exposes counters for pending,
 enqueued, dropped, delivered, and failed operations:
 
 ```rust
-use pocopine::analytics::{AnalyticsClient, BoundedAnalyticsSink};
+use pocopine::analytics::{
+    AnalyticsClient, BoundedAnalyticsSink, JsonLinesAnalyticsSink,
+};
 
-let exporter = BoundedAnalyticsSink::new(my_exporter_sink, 1024);
+let exporter = BoundedAnalyticsSink::new(
+    JsonLinesAnalyticsSink::stdout(),
+    1024,
+);
 let metrics = exporter.clone();
 
 let analytics = AnalyticsClient::new()
@@ -525,6 +530,24 @@ if !report.all_succeeded() {
 Call `analytics.flush()` during graceful shutdown to drain the queued events
 into the wrapped sink. Flush keeps going after per-event exporter errors and
 counts those failures in the wrapper metrics.
+
+`JsonLinesAnalyticsSink` writes one `ObservedEvent` JSON object per line. When
+it is attached to `AnalyticsClient`, it receives the event after the client's
+redaction policy has run. This is the simplest host exporter for container
+logs, AWS CloudWatch log agents, Cloudflare-style log pipelines, and local
+smoke tests. Use
+`JsonLinesAnalyticsSink::stdout()`, `::stderr()`, `::file(path)`, or
+`::new(writer)` for a custom `std::io::Write`.
+
+Run the smoke binary:
+
+```sh
+cargo run -p observability-smoke --bin analytics_exporter
+```
+
+For OTLP, use the structured `tracing` fields described above and
+`pocopine-logging`'s `logging-otlp` feature. For JSON-log agents, consume the
+same `observed_context_*` and `observed_field_*` keys from the JSON formatter.
 
 ## Browser vendor bridges
 

--- a/examples/observability-smoke/Cargo.toml
+++ b/examples/observability-smoke/Cargo.toml
@@ -16,8 +16,12 @@ crate-type = ["rlib"]
 name = "server"
 path = "src/bin/server.rs"
 
+[[bin]]
+name = "analytics_exporter"
+path = "src/bin/analytics_exporter.rs"
+
 [dependencies]
-pocopine = { path = "../../crates/pocopine", features = ["logging-otlp"] }
+pocopine = { path = "../../crates/pocopine", features = ["analytics", "logging-otlp"] }
 serde = { workspace = true }
 tracing = { workspace = true }
 

--- a/examples/observability-smoke/README.md
+++ b/examples/observability-smoke/README.md
@@ -1,4 +1,4 @@
-# OTLP observability smoke example
+# Observability smoke example
 
 This example is a small host-side server that installs pocopine JSON logging and
 OTLP trace export, then exposes one `#[server(public)]` endpoint.
@@ -35,6 +35,19 @@ You should see spans named `pocopine.server_function` and
 
 The example intentionally does not log or export the raw message body.
 
+## Run the analytics JSON-lines exporter
+
+This binary emits a couple of redacted analytics events through
+`BoundedAnalyticsSink<JsonLinesAnalyticsSink<_>>`:
+
+```sh
+cargo run -p observability-smoke --bin analytics_exporter
+```
+
+The JSON-lines output is suitable for stdout/file log agents such as container
+logs, AWS CloudWatch agents, Cloudflare log pipelines, or local smoke tests.
+Exporter metrics are printed to stderr.
+
 ## CI smoke test
 
 The repository CI runs:
@@ -50,3 +63,12 @@ server-function route, and asserts:
 - `function`, `route`, `message_len`, and `service.name` metadata are present;
 - the raw request message is absent from exported telemetry;
 - local p95 request latency stays below a broad CI budget.
+
+The analytics exporter test can run without Docker or a collector:
+
+```sh
+bash scripts/ci/observability_exporters.sh
+```
+
+It asserts JSON-lines shape, redaction, bounded queue drops, delivery counts,
+and flush behavior through the public analytics API.

--- a/examples/observability-smoke/src/bin/analytics_exporter.rs
+++ b/examples/observability-smoke/src/bin/analytics_exporter.rs
@@ -1,0 +1,43 @@
+//! Host-side analytics exporter smoke binary.
+//!
+//! This writes redacted analytics events as JSON lines to stdout. It is meant
+//! to mirror container/AWS/Cloudflare-style log-agent ingestion without pulling
+//! a vendor SDK into the framework.
+
+#[cfg(not(target_arch = "wasm32"))]
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use pocopine::analytics::{
+        event, route_view, AnalyticsClient, BoundedAnalyticsSink, JsonLinesAnalyticsSink,
+    };
+    use pocopine::observe::FieldPrivacy;
+
+    let exporter = BoundedAnalyticsSink::new(JsonLinesAnalyticsSink::stdout(), 16);
+    let metrics = exporter.clone();
+    let analytics = AnalyticsClient::new()
+        .without_tracing_events()
+        .with_sink(exporter);
+
+    let route_report = analytics.emit(
+        route_view("/report/:id")
+            .field("surface", "observability-smoke", FieldPrivacy::Public)
+            .field("demo_user_hash", "demo-user", FieldPrivacy::Pseudonymous),
+    );
+    let timing_report = analytics.emit(
+        event("server_function_client_completed")
+            .field("function", "observe_echo", FieldPrivacy::Public)
+            .field("duration_ms", 18.4_f64, FieldPrivacy::Public),
+    );
+    let flush_report = analytics.flush();
+
+    eprintln!("analytics exporter metrics: {:?}", metrics.metrics());
+
+    if route_report.all_succeeded() && timing_report.all_succeeded() && flush_report.all_succeeded()
+    {
+        Ok(())
+    } else {
+        Err("analytics exporter smoke failed".into())
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn main() {}

--- a/examples/observability-smoke/tests/analytics_exporter.rs
+++ b/examples/observability-smoke/tests/analytics_exporter.rs
@@ -1,0 +1,91 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::io::{self, Write};
+use std::sync::{Arc, Mutex};
+
+use pocopine::analytics::{
+    event, AnalyticsClient, BoundedAnalyticsSink, ExporterMetrics, JsonLinesAnalyticsSink,
+};
+use pocopine::observe::{FieldPrivacy, RedactionPolicy};
+
+#[derive(Clone, Default)]
+struct SharedBuffer {
+    bytes: Arc<Mutex<Vec<u8>>>,
+}
+
+impl SharedBuffer {
+    fn lines(&self) -> Vec<serde_json::Value> {
+        let output = String::from_utf8(self.bytes.lock().expect("buffer lock poisoned").clone())
+            .expect("json-lines output is utf-8");
+        output
+            .lines()
+            .map(|line| serde_json::from_str(line).expect("valid analytics json-line"))
+            .collect()
+    }
+}
+
+impl Write for SharedBuffer {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.bytes
+            .lock()
+            .expect("buffer lock poisoned")
+            .extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn bounded_json_lines_exporter_redacts_and_counts_backpressure() {
+    let output = SharedBuffer::default();
+    let exporter = BoundedAnalyticsSink::new(JsonLinesAnalyticsSink::new(output.clone()), 2);
+    let metrics = exporter.clone();
+    let analytics = AnalyticsClient::new()
+        .without_tracing_events()
+        .with_redaction(RedactionPolicy::public_only())
+        .with_sink(exporter);
+
+    let first = analytics.emit(
+        event("route_view")
+            .field("route", "/settings", FieldPrivacy::Public)
+            .field("email", "person@example.test", FieldPrivacy::Sensitive),
+    );
+    let second = analytics.emit(
+        event("cta_clicked")
+            .field("cta", "upgrade", FieldPrivacy::Public)
+            .field("session", "session-123", FieldPrivacy::Pseudonymous),
+    );
+    let third = analytics.emit(event("overflow").field("route", "/overflow", FieldPrivacy::Public));
+
+    assert!(first.all_succeeded());
+    assert!(second.all_succeeded());
+    assert_eq!(third.attempted, 1);
+    assert_eq!(third.succeeded, 0);
+    assert_eq!(third.failed, 1);
+
+    let flush = analytics.flush();
+
+    assert!(flush.all_succeeded());
+    assert_eq!(
+        metrics.metrics(),
+        ExporterMetrics {
+            pending: 0,
+            enqueued: 2,
+            dropped: 1,
+            delivered: 2,
+            failed: 0,
+        }
+    );
+
+    let lines = output.lines();
+    assert_eq!(lines.len(), 2);
+    assert_eq!(lines[0]["name"], "route_view");
+    assert_eq!(lines[0]["fields"]["route"]["value"], "/settings");
+    assert!(lines[0]["fields"].get("email").is_none());
+    assert_eq!(lines[1]["name"], "cta_clicked");
+    assert_eq!(lines[1]["fields"]["cta"]["value"], "upgrade");
+    assert!(lines[1]["fields"].get("session").is_none());
+}

--- a/rfcs/rfc-069-observability.md
+++ b/rfcs/rfc-069-observability.md
@@ -78,6 +78,8 @@ ships:
 - panic isolation around sink calls;
 - a host-side bounded exporter wrapper with drop, delivery, and failure
   counters;
+- a host-side JSON-lines analytics sink for stdout, stderr, files, and
+  platform log agents;
 - wasm JS function sinks for user-supplied vendor bridges;
 - wasm Firebase and Google Analytics function adapters.
 
@@ -182,7 +184,8 @@ Later phases should add:
 - first-class route and server-function instrumentation points;
 - job observability export from the existing `pocopine-jobs` tracing events;
 - OpenTelemetry adapter;
-- AWS/Cloudflare host sinks;
+- vendor-specific AWS/Cloudflare host sinks on top of the JSON-lines and
+  bounded exporter primitives;
 - priority-aware async exporter queues;
 - metrics sink integration for exporter drop/failure counters;
 - devtools panel integration on top of the same event stream.

--- a/scripts/ci/observability_exporters.sh
+++ b/scripts/ci/observability_exporters.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cargo test -p pocopine-analytics
+cargo test -p observability-smoke --test analytics_exporter


### PR DESCRIPTION
## Summary
- add a host-only JsonLinesAnalyticsSink for stdout/stderr/file/custom writers
- add a bounded analytics exporter smoke binary and integration coverage
- document the JSON-lines exporter path in observability docs, the smoke example README, and RFC-069

## Verification
- cargo fmt --all
- cargo test -p pocopine-analytics
- cargo test -p observability-smoke --test analytics_exporter
- bash scripts/ci/observability_exporters.sh
- cargo check -p pocopine-analytics --target wasm32-unknown-unknown
- cargo clippy --workspace --all-targets --all-features -- -D warnings