### PR TITLE
Refactor chart interaction plumbing

### DIFF
--- a/crates/pine-charts/src/area/mod.rs
+++ b/crates/pine-charts/src/area/mod.rs
@@ -7,14 +7,13 @@ use crate::animation::{
 };
 use crate::cartesian::{
     centered_plot_y, chart_hover_payload, optional_domain, plot_rect_from_edges,
-    pointer_event_svg_point, step_key, tooltip_aria_hidden, tooltip_mode, CartesianChartState,
+    pointer_event_svg_point, step_key, sync_tooltip_fields, CartesianChartState,
     CartesianGuideFields, CartesianGuideUpdate, CartesianHoverFields, ChartStateFields,
     PlotEdgeFields, DEFAULT_EMPTY_MESSAGE,
 };
 use crate::error::{ChartError, ChartResult};
 use crate::events::{
-    ChartHoverEnd, ChartSelection, ChartSelectionEnd, CHART_HOVER_END_EVENT, CHART_HOVER_EVENT,
-    CHART_SELECT_END_EVENT, CHART_SELECT_EVENT,
+    ChartHoverEnd, ChartSelection, ChartSelectionKeys, CHART_HOVER_END_EVENT, CHART_HOVER_EVENT,
 };
 use crate::geometry::{ChartMargins, ChartRect, Point};
 use crate::legend::{series_label_or_default, series_legend_items_with_visibility};
@@ -417,9 +416,7 @@ impl PineAreaChart {
 
     pub fn select_sample(&mut self, key: String) {
         if let Some(selection) = self.selection_for_sample(&key) {
-            self.focused_key = key.clone();
-            self.selected_key = key;
-            pocopine::emit(CHART_SELECT_EVENT, selection);
+            self.selection_keys().select(key, selection);
         }
     }
 
@@ -435,15 +432,14 @@ impl PineAreaChart {
         if self.focused_key.is_empty() {
             self.step_sample_focus(1);
         }
-        if let Some(selection) = self.selection_for_sample(&self.focused_key) {
-            self.selected_key = self.focused_key.clone();
-            pocopine::emit(CHART_SELECT_EVENT, selection);
+        let key = self.focused_key.clone();
+        if let Some(selection) = self.selection_for_sample(&key) {
+            self.selection_keys().select(key, selection);
         }
     }
 
     pub fn clear_selection(&mut self) {
-        self.focused_key.clear();
-        self.clear_selected_key();
+        self.selection_keys().clear();
     }
 }
 
@@ -453,9 +449,12 @@ impl PineAreaChart {
     }
 
     fn sync_tooltip_state(&mut self) {
-        self.tooltip_mode = tooltip_mode(&self.tooltip).into();
-        self.tooltip_aria_hidden =
-            tooltip_aria_hidden(&self.tooltip_mode, self.hover_visible).into();
+        sync_tooltip_fields(
+            &self.tooltip,
+            self.hover_visible,
+            &mut self.tooltip_mode,
+            &mut self.tooltip_aria_hidden,
+        );
     }
 
     fn recompute(&mut self) {
@@ -665,19 +664,13 @@ impl PineAreaChart {
     }
 
     fn reconcile_selection(&mut self) {
-        if !self.has_sample_key(&self.focused_key) {
-            self.focused_key.clear();
-        }
-        if !self.has_sample_key(&self.selected_key) {
-            self.clear_selected_key();
-        }
+        let has_focused = self.has_sample_key(&self.focused_key);
+        let has_selected = self.has_sample_key(&self.selected_key);
+        self.selection_keys().reconcile(has_focused, has_selected);
     }
 
-    fn clear_selected_key(&mut self) {
-        let key = std::mem::take(&mut self.selected_key);
-        if !key.is_empty() {
-            pocopine::emit(CHART_SELECT_END_EVENT, ChartSelectionEnd::new("area", key));
-        }
+    fn selection_keys(&mut self) -> ChartSelectionKeys<'_> {
+        ChartSelectionKeys::new("area", &mut self.focused_key, &mut self.selected_key)
     }
 
     fn hover_fields(&mut self) -> CartesianHoverFields<'_> {

--- a/crates/pine-charts/src/bar/mod.rs
+++ b/crates/pine-charts/src/bar/mod.rs
@@ -4,15 +4,14 @@ use serde::{Deserialize, Serialize};
 use crate::animation::{animation_style, DEFAULT_ANIMATION_DURATION_MS, DEFAULT_ANIMATION_EASING};
 use crate::cartesian::{
     expanded_domain, grid_lines_for_y, optional_domain, plot_rect_from_edges,
-    pointer_event_svg_point, step_key, tick_labels_for_y, tooltip_aria_hidden, tooltip_mode,
-    x_axis_label, y_axis_label, CartesianChartState, CartesianHoverPlacement,
-    CategoricalGuideFields, CategoricalGuideUpdate, ChartStateFields, PlotEdgeFields,
-    DEFAULT_EMPTY_MESSAGE,
+    pointer_event_svg_point, step_key, sync_tooltip_fields, tick_labels_for_y, x_axis_label,
+    y_axis_label, CartesianChartState, CartesianHoverPlacement, CategoricalGuideFields,
+    CategoricalGuideUpdate, ChartStateFields, PlotEdgeFields, DEFAULT_EMPTY_MESSAGE,
 };
 use crate::error::{finite, ChartError, ChartResult};
 use crate::events::{
-    ChartHover, ChartHoverEnd, ChartSelection, ChartSelectionEnd, CHART_HOVER_END_EVENT,
-    CHART_HOVER_EVENT, CHART_SELECT_END_EVENT, CHART_SELECT_EVENT,
+    ChartHover, ChartHoverEnd, ChartSelection, ChartSelectionKeys, CHART_HOVER_END_EVENT,
+    CHART_HOVER_EVENT,
 };
 use crate::geometry::{ChartMargins, ChartRect, Point};
 use crate::legend::{series_label_or_default, series_legend_items_with_visibility, LegendItem};
@@ -823,9 +822,7 @@ impl PineBarChart {
 
     pub fn select_bar(&mut self, key: String) {
         if let Some(selection) = self.selection_for_bar(&key) {
-            self.focused_key = key.clone();
-            self.selected_key = key;
-            pocopine::emit(CHART_SELECT_EVENT, selection);
+            self.selection_keys().select(key, selection);
         }
     }
 
@@ -841,15 +838,14 @@ impl PineBarChart {
         if self.focused_key.is_empty() {
             self.step_bar_focus(1);
         }
-        if let Some(selection) = self.selection_for_bar(&self.focused_key) {
-            self.selected_key = self.focused_key.clone();
-            pocopine::emit(CHART_SELECT_EVENT, selection);
+        let key = self.focused_key.clone();
+        if let Some(selection) = self.selection_for_bar(&key) {
+            self.selection_keys().select(key, selection);
         }
     }
 
     pub fn clear_selection(&mut self) {
-        self.focused_key.clear();
-        self.clear_selected_key();
+        self.selection_keys().clear();
     }
 }
 
@@ -859,9 +855,12 @@ impl PineBarChart {
     }
 
     fn sync_tooltip_state(&mut self) {
-        self.tooltip_mode = tooltip_mode(&self.tooltip).into();
-        self.tooltip_aria_hidden =
-            tooltip_aria_hidden(&self.tooltip_mode, self.hover_visible).into();
+        sync_tooltip_fields(
+            &self.tooltip,
+            self.hover_visible,
+            &mut self.tooltip_mode,
+            &mut self.tooltip_aria_hidden,
+        );
     }
 
     fn recompute(&mut self) {
@@ -1051,19 +1050,13 @@ impl PineBarChart {
     }
 
     fn reconcile_selection(&mut self) {
-        if !self.has_bar_key(&self.focused_key) {
-            self.focused_key.clear();
-        }
-        if !self.has_bar_key(&self.selected_key) {
-            self.clear_selected_key();
-        }
+        let has_focused = self.has_bar_key(&self.focused_key);
+        let has_selected = self.has_bar_key(&self.selected_key);
+        self.selection_keys().reconcile(has_focused, has_selected);
     }
 
-    fn clear_selected_key(&mut self) {
-        let key = std::mem::take(&mut self.selected_key);
-        if !key.is_empty() {
-            pocopine::emit(CHART_SELECT_END_EVENT, ChartSelectionEnd::new("bar", key));
-        }
+    fn selection_keys(&mut self) -> ChartSelectionKeys<'_> {
+        ChartSelectionKeys::new("bar", &mut self.focused_key, &mut self.selected_key)
     }
 }
 

--- a/crates/pine-charts/src/cartesian.rs
+++ b/crates/pine-charts/src/cartesian.rs
@@ -207,6 +207,17 @@ pub(crate) fn tooltip_aria_hidden(mode: &str, hover_visible: bool) -> &'static s
     }
 }
 
+pub(crate) fn sync_tooltip_fields(
+    tooltip: &str,
+    hover_visible: bool,
+    mode: &mut String,
+    aria_hidden: &mut String,
+) {
+    let next_mode = tooltip_mode(tooltip);
+    *mode = next_mode.into();
+    *aria_hidden = tooltip_aria_hidden(next_mode, hover_visible).into();
+}
+
 pub(crate) struct CartesianHoverFields<'a> {
     pub visible: &'a mut bool,
     pub x: &'a mut f64,

--- a/crates/pine-charts/src/events.rs
+++ b/crates/pine-charts/src/events.rs
@@ -162,6 +162,56 @@ impl ChartSelectionEnd {
     }
 }
 
+pub(crate) struct ChartSelectionKeys<'a> {
+    chart: &'static str,
+    focused: &'a mut String,
+    selected: &'a mut String,
+}
+
+impl<'a> ChartSelectionKeys<'a> {
+    pub(crate) fn new(
+        chart: &'static str,
+        focused: &'a mut String,
+        selected: &'a mut String,
+    ) -> Self {
+        Self {
+            chart,
+            focused,
+            selected,
+        }
+    }
+
+    pub(crate) fn select(&mut self, key: String, selection: ChartSelection) {
+        *self.focused = key.clone();
+        *self.selected = key;
+        pocopine::emit(CHART_SELECT_EVENT, selection);
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.focused.clear();
+        self.clear_selected();
+    }
+
+    pub(crate) fn reconcile(&mut self, has_focused: bool, has_selected: bool) {
+        if !has_focused {
+            self.focused.clear();
+        }
+        if !has_selected {
+            self.clear_selected();
+        }
+    }
+
+    pub(crate) fn clear_selected(&mut self) {
+        let key = std::mem::take(self.selected);
+        if !key.is_empty() {
+            pocopine::emit(
+                CHART_SELECT_END_EVENT,
+                ChartSelectionEnd::new(self.chart, key),
+            );
+        }
+    }
+}
+
 /// Payload for `pp:chart:hover`.
 ///
 /// `kind` determines which value fields are populated:

--- a/crates/pine-charts/src/line/mod.rs
+++ b/crates/pine-charts/src/line/mod.rs
@@ -4,15 +4,14 @@ use serde::{Deserialize, Serialize};
 use crate::animation::{animation_style, DEFAULT_ANIMATION_DURATION_MS, DEFAULT_ANIMATION_EASING};
 use crate::cartesian::{
     centered_plot_y, chart_hover_payload, nearest_sample_by_point, nearest_sample_by_x,
-    optional_domain, plot_rect_from_edges, pointer_event_svg_point, step_key, tooltip_aria_hidden,
-    tooltip_mode, CartesianChartState, CartesianGuideFields, CartesianGuideUpdate,
-    CartesianHoverFields, CartesianHoverSample, CartesianHoverUpdate, CartesianLayout,
-    ChartStateFields, PlotEdgeFields, DEFAULT_EMPTY_MESSAGE,
+    optional_domain, plot_rect_from_edges, pointer_event_svg_point, step_key, sync_tooltip_fields,
+    CartesianChartState, CartesianGuideFields, CartesianGuideUpdate, CartesianHoverFields,
+    CartesianHoverSample, CartesianHoverUpdate, CartesianLayout, ChartStateFields, PlotEdgeFields,
+    DEFAULT_EMPTY_MESSAGE,
 };
 use crate::error::{finite, ChartError, ChartResult};
 use crate::events::{
-    ChartHoverEnd, ChartSelection, ChartSelectionEnd, CHART_HOVER_END_EVENT, CHART_HOVER_EVENT,
-    CHART_SELECT_END_EVENT, CHART_SELECT_EVENT,
+    ChartHoverEnd, ChartSelection, ChartSelectionKeys, CHART_HOVER_END_EVENT, CHART_HOVER_EVENT,
 };
 use crate::geometry::{ChartMargins, ChartRect, Point};
 use crate::legend::{series_label_or_default, series_legend_items_with_visibility};
@@ -602,9 +601,7 @@ impl PineLineChart {
 
     pub fn select_sample(&mut self, key: String) {
         if let Some(selection) = self.selection_for_sample(&key) {
-            self.focused_key = key.clone();
-            self.selected_key = key;
-            pocopine::emit(CHART_SELECT_EVENT, selection);
+            self.selection_keys().select(key, selection);
         }
     }
 
@@ -620,15 +617,14 @@ impl PineLineChart {
         if self.focused_key.is_empty() {
             self.step_sample_focus(1);
         }
-        if let Some(selection) = self.selection_for_sample(&self.focused_key) {
-            self.selected_key = self.focused_key.clone();
-            pocopine::emit(CHART_SELECT_EVENT, selection);
+        let key = self.focused_key.clone();
+        if let Some(selection) = self.selection_for_sample(&key) {
+            self.selection_keys().select(key, selection);
         }
     }
 
     pub fn clear_selection(&mut self) {
-        self.focused_key.clear();
-        self.clear_selected_key();
+        self.selection_keys().clear();
     }
 }
 
@@ -638,9 +634,12 @@ impl PineLineChart {
     }
 
     fn sync_tooltip_state(&mut self) {
-        self.tooltip_mode = tooltip_mode(&self.tooltip).into();
-        self.tooltip_aria_hidden =
-            tooltip_aria_hidden(&self.tooltip_mode, self.hover_visible).into();
+        sync_tooltip_fields(
+            &self.tooltip,
+            self.hover_visible,
+            &mut self.tooltip_mode,
+            &mut self.tooltip_aria_hidden,
+        );
     }
 
     fn recompute(&mut self) {
@@ -795,19 +794,13 @@ impl PineLineChart {
     }
 
     fn reconcile_selection(&mut self) {
-        if !self.has_sample_key(&self.focused_key) {
-            self.focused_key.clear();
-        }
-        if !self.has_sample_key(&self.selected_key) {
-            self.clear_selected_key();
-        }
+        let has_focused = self.has_sample_key(&self.focused_key);
+        let has_selected = self.has_sample_key(&self.selected_key);
+        self.selection_keys().reconcile(has_focused, has_selected);
     }
 
-    fn clear_selected_key(&mut self) {
-        let key = std::mem::take(&mut self.selected_key);
-        if !key.is_empty() {
-            pocopine::emit(CHART_SELECT_END_EVENT, ChartSelectionEnd::new("line", key));
-        }
+    fn selection_keys(&mut self) -> ChartSelectionKeys<'_> {
+        ChartSelectionKeys::new("line", &mut self.focused_key, &mut self.selected_key)
     }
 
     fn hover_fields(&mut self) -> CartesianHoverFields<'_> {

--- a/crates/pine-charts/src/pie/mod.rs
+++ b/crates/pine-charts/src/pie/mod.rs
@@ -8,13 +8,13 @@ use crate::animation::{
     animation_duration_ms, animation_style, DEFAULT_ANIMATION_DURATION_MS, DEFAULT_ANIMATION_EASING,
 };
 use crate::cartesian::{
-    pointer_event_svg_point, step_key, tooltip_aria_hidden, tooltip_mode, CartesianHoverPlacement,
+    pointer_event_svg_point, step_key, sync_tooltip_fields, CartesianHoverPlacement,
     ChartStateFields, DEFAULT_EMPTY_MESSAGE,
 };
 use crate::error::{finite, ChartError, ChartResult};
 use crate::events::{
-    ChartHover, ChartHoverEnd, ChartSelection, ChartSelectionEnd, CHART_HOVER_END_EVENT,
-    CHART_HOVER_EVENT, CHART_SELECT_END_EVENT, CHART_SELECT_EVENT,
+    ChartHover, ChartHoverEnd, ChartSelection, ChartSelectionKeys, CHART_HOVER_END_EVENT,
+    CHART_HOVER_EVENT,
 };
 use crate::geometry::{ChartMargins, ChartRect, Point};
 use crate::legend::LegendItem;
@@ -568,9 +568,7 @@ impl PinePieChart {
 
     pub fn select_slice(&mut self, key: String) {
         if let Some(selection) = self.selection_for_slice(&key) {
-            self.focused_key = key.clone();
-            self.selected_key = key;
-            pocopine::emit(CHART_SELECT_EVENT, selection);
+            self.selection_keys().select(key, selection);
         }
     }
 
@@ -586,15 +584,14 @@ impl PinePieChart {
         if self.focused_key.is_empty() {
             self.step_slice_focus(1);
         }
-        if let Some(selection) = self.selection_for_slice(&self.focused_key) {
-            self.selected_key = self.focused_key.clone();
-            pocopine::emit(CHART_SELECT_EVENT, selection);
+        let key = self.focused_key.clone();
+        if let Some(selection) = self.selection_for_slice(&key) {
+            self.selection_keys().select(key, selection);
         }
     }
 
     pub fn clear_selection(&mut self) {
-        self.focused_key.clear();
-        self.clear_selected_key();
+        self.selection_keys().clear();
     }
 }
 
@@ -604,9 +601,12 @@ impl PinePieChart {
     }
 
     fn sync_tooltip_state(&mut self) {
-        self.tooltip_mode = tooltip_mode(&self.tooltip).into();
-        self.tooltip_aria_hidden =
-            tooltip_aria_hidden(&self.tooltip_mode, self.hover_visible).into();
+        sync_tooltip_fields(
+            &self.tooltip,
+            self.hover_visible,
+            &mut self.tooltip_mode,
+            &mut self.tooltip_aria_hidden,
+        );
     }
 
     fn recompute(&mut self) {
@@ -1086,19 +1086,13 @@ impl PinePieChart {
     }
 
     fn reconcile_selection(&mut self) {
-        if !self.has_slice_key(&self.focused_key) {
-            self.focused_key.clear();
-        }
-        if !self.has_slice_key(&self.selected_key) {
-            self.clear_selected_key();
-        }
+        let has_focused = self.has_slice_key(&self.focused_key);
+        let has_selected = self.has_slice_key(&self.selected_key);
+        self.selection_keys().reconcile(has_focused, has_selected);
     }
 
-    fn clear_selected_key(&mut self) {
-        let key = std::mem::take(&mut self.selected_key);
-        if !key.is_empty() {
-            pocopine::emit(CHART_SELECT_END_EVENT, ChartSelectionEnd::new("pie", key));
-        }
+    fn selection_keys(&mut self) -> ChartSelectionKeys<'_> {
+        ChartSelectionKeys::new("pie", &mut self.focused_key, &mut self.selected_key)
     }
 
     fn state_fields(&mut self) -> ChartStateFields<'_> {

--- a/crates/pine-charts/src/scatter/mod.rs
+++ b/crates/pine-charts/src/scatter/mod.rs
@@ -4,14 +4,13 @@ use serde::{Deserialize, Serialize};
 use crate::animation::{animation_style, DEFAULT_ANIMATION_DURATION_MS, DEFAULT_ANIMATION_EASING};
 use crate::cartesian::{
     chart_hover_payload, nearest_sample_by_point, optional_domain, plot_rect_from_edges,
-    pointer_event_svg_point, step_key, tooltip_aria_hidden, tooltip_mode, CartesianChartState,
+    pointer_event_svg_point, step_key, sync_tooltip_fields, CartesianChartState,
     CartesianGuideFields, CartesianGuideUpdate, CartesianHoverFields, ChartStateFields,
     PlotEdgeFields, DEFAULT_EMPTY_MESSAGE,
 };
 use crate::error::{ChartError, ChartResult};
 use crate::events::{
-    ChartHoverEnd, ChartSelection, ChartSelectionEnd, CHART_HOVER_END_EVENT, CHART_HOVER_EVENT,
-    CHART_SELECT_END_EVENT, CHART_SELECT_EVENT,
+    ChartHoverEnd, ChartSelection, ChartSelectionKeys, CHART_HOVER_END_EVENT, CHART_HOVER_EVENT,
 };
 use crate::geometry::{ChartMargins, ChartRect, Point};
 use crate::legend::{series_label_or_default, series_legend_items_with_visibility};
@@ -407,9 +406,7 @@ impl PineScatterChart {
 
     pub fn select_sample(&mut self, key: String) {
         if let Some(selection) = self.selection_for_sample(&key) {
-            self.focused_key = key.clone();
-            self.selected_key = key;
-            pocopine::emit(CHART_SELECT_EVENT, selection);
+            self.selection_keys().select(key, selection);
         }
     }
 
@@ -425,15 +422,14 @@ impl PineScatterChart {
         if self.focused_key.is_empty() {
             self.step_sample_focus(1);
         }
-        if let Some(selection) = self.selection_for_sample(&self.focused_key) {
-            self.selected_key = self.focused_key.clone();
-            pocopine::emit(CHART_SELECT_EVENT, selection);
+        let key = self.focused_key.clone();
+        if let Some(selection) = self.selection_for_sample(&key) {
+            self.selection_keys().select(key, selection);
         }
     }
 
     pub fn clear_selection(&mut self) {
-        self.focused_key.clear();
-        self.clear_selected_key();
+        self.selection_keys().clear();
     }
 }
 
@@ -443,9 +439,12 @@ impl PineScatterChart {
     }
 
     fn sync_tooltip_state(&mut self) {
-        self.tooltip_mode = tooltip_mode(&self.tooltip).into();
-        self.tooltip_aria_hidden =
-            tooltip_aria_hidden(&self.tooltip_mode, self.hover_visible).into();
+        sync_tooltip_fields(
+            &self.tooltip,
+            self.hover_visible,
+            &mut self.tooltip_mode,
+            &mut self.tooltip_aria_hidden,
+        );
     }
 
     fn recompute(&mut self) {
@@ -592,22 +591,13 @@ impl PineScatterChart {
     }
 
     fn reconcile_selection(&mut self) {
-        if !self.has_sample_key(&self.focused_key) {
-            self.focused_key.clear();
-        }
-        if !self.has_sample_key(&self.selected_key) {
-            self.clear_selected_key();
-        }
+        let has_focused = self.has_sample_key(&self.focused_key);
+        let has_selected = self.has_sample_key(&self.selected_key);
+        self.selection_keys().reconcile(has_focused, has_selected);
     }
 
-    fn clear_selected_key(&mut self) {
-        let key = std::mem::take(&mut self.selected_key);
-        if !key.is_empty() {
-            pocopine::emit(
-                CHART_SELECT_END_EVENT,
-                ChartSelectionEnd::new("scatter", key),
-            );
-        }
+    fn selection_keys(&mut self) -> ChartSelectionKeys<'_> {
+        ChartSelectionKeys::new("scatter", &mut self.focused_key, &mut self.selected_key)
     }
 
     fn hover_fields(&mut self) -> CartesianHoverFields<'_> {


### PR DESCRIPTION
## Summary
- centralizes chart selection key handling and select-end emission in an internal helper
- centralizes tooltip mode / aria-hidden syncing without changing flat template fields
- removes repeated select, clear, and reconcile plumbing from line, area, scatter, bar, and pie charts

## Verification
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --check`
- `cargo test -p pine-charts`
- `wasm-pack test --firefox --headless crates/pine-charts`
- `cargo run -p pocopine-cli -- build --path examples/charts`
- `git diff --check`

Note: one browser run had a timer-sensitive pie pruning failure while clippy was compiling in parallel; the isolated rerun passed.
