### PR TITLE
Add guarded sync streams

### DIFF
--- a/crates/pocopine-sync/src/client.rs
+++ b/crates/pocopine-sync/src/client.rs
@@ -3,12 +3,14 @@ use std::marker::PhantomData;
 use pocopine_core::{App, AppPlugin, Handle};
 
 use crate::{
-    CollectionState, SyncCursor, SyncError, SyncReason, SyncResult, SyncShapeName,
+    CollectionState, SyncCursor, SyncError, SyncReason, SyncResult, SyncStreamName,
     SYNC_ENDPOINT_PREFIX,
 };
 
 #[cfg(target_arch = "wasm32")]
-use crate::{sync_shape_tag, SyncOpenRequest, SyncOpenResponse, SyncPullRequest, SyncPullResponse};
+use crate::{
+    sync_stream_tag, SyncOpenRequest, SyncOpenResponse, SyncPullRequest, SyncPullResponse,
+};
 
 /// Selector from an app-owned component/store into one sync collection field.
 pub type CollectionSelector<C, T> = for<'a> fn(&'a mut C) -> &'a mut CollectionState<T>;
@@ -110,7 +112,7 @@ impl SyncClient {
             live_endpoint: self.live_endpoint.clone(),
             live_wakeup: self.live_wakeup,
             with_credentials: self.with_credentials,
-            shape: None,
+            stream: None,
             cursor: None,
             _marker: PhantomData,
         }
@@ -125,7 +127,7 @@ pub struct SyncCollection<C: 'static, T> {
     live_endpoint: Option<String>,
     live_wakeup: bool,
     with_credentials: bool,
-    shape: Option<SyncShapeName>,
+    stream: Option<SyncStreamName>,
     cursor: Option<SyncCursor>,
     _marker: PhantomData<fn(C) -> T>,
 }
@@ -135,9 +137,9 @@ where
     C: 'static,
     T: 'static,
 {
-    /// Set the server-registered shape to pull.
-    pub fn shape(mut self, shape: impl Into<String>) -> SyncResult<Self> {
-        self.shape = Some(SyncShapeName::new(shape.into())?);
+    /// Set the server-registered stream to pull.
+    pub fn stream(mut self, stream: impl Into<String>) -> SyncResult<Self> {
+        self.stream = Some(SyncStreamName::new(stream.into())?);
         Ok(self)
     }
 
@@ -169,10 +171,10 @@ where
         self.pull_impl(SyncReason::Manual, false)
     }
 
-    fn shape_value(&self) -> SyncResult<SyncShapeName> {
-        self.shape
+    fn stream_value(&self) -> SyncResult<SyncStreamName> {
+        self.stream
             .clone()
-            .ok_or_else(|| SyncError::invalid_value("shape", "<missing>"))
+            .ok_or_else(|| SyncError::invalid_value("stream", "<missing>"))
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -195,7 +197,7 @@ where
     T: serde::de::DeserializeOwned + 'static,
 {
     fn open_impl(self) -> SyncResult<()> {
-        let shape = self.shape_value()?;
+        let stream = self.stream_value()?;
         let scope_id = pocopine_core::current_scope_id().ok_or_else(|| {
             SyncError::client(
                 "SyncCollection::open used outside a component handler/lifecycle hook",
@@ -213,7 +215,7 @@ where
             handle.clone(),
             selector,
             self.endpoint.clone(),
-            shape.clone(),
+            stream.clone(),
             self.cursor.clone(),
             SyncReason::Initial,
             live_wakeup,
@@ -222,7 +224,7 @@ where
     }
 
     fn pull_impl(self, reason: SyncReason, live_event: bool) -> SyncResult<()> {
-        let shape = self.shape_value()?;
+        let stream = self.stream_value()?;
         let scope_id = pocopine_core::current_scope_id().ok_or_else(|| {
             SyncError::client(
                 "SyncCollection::pull used outside a component handler/lifecycle hook",
@@ -233,7 +235,7 @@ where
             self.handle,
             self.selector,
             self.endpoint,
-            shape,
+            stream,
             self.cursor,
             reason,
             live_event,
@@ -250,13 +252,13 @@ where
 {
     fn open_impl(self) -> SyncResult<()> {
         self.touch_host_fields();
-        let _ = self.shape_value()?;
+        let _ = self.stream_value()?;
         Ok(())
     }
 
     fn pull_impl(self, _reason: SyncReason, _live_event: bool) -> SyncResult<()> {
         self.touch_host_fields();
-        let _ = self.shape_value()?;
+        let _ = self.stream_value()?;
         Ok(())
     }
 }
@@ -273,7 +275,7 @@ fn start_open_then_pull<C, T>(
     handle: Handle<C>,
     selector: CollectionSelector<C, T>,
     endpoint: String,
-    shape: SyncShapeName,
+    stream: SyncStreamName,
     cursor: Option<SyncCursor>,
     reason: SyncReason,
     live_wakeup: Option<LiveWakeupOptions>,
@@ -297,13 +299,13 @@ fn start_open_then_pull<C, T>(
         });
         let (cursor, token) = request_token;
 
-        let open_request = SyncOpenRequest::new([shape.clone()]);
+        let open_request = SyncOpenRequest::new([stream.clone()]);
         let open_result = pocopine_core::fetch::call::<SyncOpenRequest, SyncOpenResponse>(
             &open_url,
             &open_request,
         )
         .await;
-        if let Err(err) = open_result.and_then(|response| validate_open_response(response, &shape))
+        if let Err(err) = open_result.and_then(|response| validate_open_response(response, &stream))
         {
             handle.update(|state| {
                 selector(state).apply_error(token, err);
@@ -317,12 +319,12 @@ fn start_open_then_pull<C, T>(
                 handle.clone(),
                 selector,
                 endpoint.clone(),
-                shape.clone(),
+                stream.clone(),
                 live_wakeup,
             );
         }
 
-        let request = SyncPullRequest::new(shape).cursor(cursor);
+        let request = SyncPullRequest::new(stream).cursor(cursor);
         let result =
             pocopine_core::fetch::call::<SyncPullRequest, SyncPullResponse<T>>(&pull_url, &request)
                 .await;
@@ -346,18 +348,18 @@ fn open_live_wakeup<C, T>(
     handle: Handle<C>,
     selector: CollectionSelector<C, T>,
     endpoint: String,
-    shape: SyncShapeName,
+    stream: SyncStreamName,
     options: LiveWakeupOptions,
 ) where
     C: 'static,
     T: serde::de::DeserializeOwned + 'static,
 {
-    let live_tag = sync_shape_tag(shape.as_str());
+    let live_tag = sync_stream_tag(stream.as_str());
     let mut refresh = pocopine_live::LiveRefresh::scoped()
         .query_tag(live_tag, {
             let handle = handle.clone();
             let endpoint = endpoint.clone();
-            let shape = shape.clone();
+            let stream = stream.clone();
             move |event| {
                 let reason = if matches!(event.live_event, pocopine_live::LiveEvent::Gap { .. }) {
                     SyncReason::Gap
@@ -369,7 +371,7 @@ fn open_live_wakeup<C, T>(
                     handle.clone(),
                     selector,
                     endpoint.clone(),
-                    shape.clone(),
+                    stream.clone(),
                     None,
                     reason,
                     true,
@@ -405,7 +407,7 @@ fn open_live_wakeup<C, T>(
 #[cfg(target_arch = "wasm32")]
 fn validate_open_response(
     response: SyncOpenResponse,
-    shape: &SyncShapeName,
+    stream: &SyncStreamName,
 ) -> Result<(), pocopine_core::ServerError> {
     if response.protocol != crate::SYNC_PROTOCOL_V1 {
         return Err(pocopine_core::ServerError::BadRequest(format!(
@@ -415,14 +417,14 @@ fn validate_open_response(
     }
 
     if response
-        .shapes
+        .streams
         .iter()
-        .any(|accepted| accepted.shape == *shape)
+        .any(|accepted| accepted.stream == *stream)
     {
         Ok(())
     } else {
         Err(pocopine_core::ServerError::Forbidden(format!(
-            "sync shape was not opened: {shape}"
+            "sync stream was not opened: {stream}"
         )))
     }
 }
@@ -433,7 +435,7 @@ fn start_pull<C, T>(
     handle: Handle<C>,
     selector: CollectionSelector<C, T>,
     endpoint: String,
-    shape: SyncShapeName,
+    stream: SyncStreamName,
     cursor: Option<SyncCursor>,
     reason: SyncReason,
     live_event: bool,
@@ -447,7 +449,7 @@ fn start_pull<C, T>(
         let request_token = handle.update(|state| {
             let collection = selector(state);
             let cursor = cursor.or_else(|| collection.cursor.clone());
-            let request = SyncPullRequest::new(shape.clone()).cursor(cursor);
+            let request = SyncPullRequest::new(stream.clone()).cursor(cursor);
             let token = if live_event {
                 collection.begin_live_pull(reason)
             } else if collection.version == 0 {

--- a/crates/pocopine-sync/src/error.rs
+++ b/crates/pocopine-sync/src/error.rs
@@ -8,8 +8,8 @@ pub type SyncResult<T> = Result<T, SyncError>;
 pub enum SyncError {
     /// A protocol value was empty or malformed.
     InvalidValue { field: &'static str, value: String },
-    /// A requested shape is not registered on the sync server.
-    UnknownShape(String),
+    /// A requested stream is not registered on the sync server.
+    UnknownStream(String),
     /// The requested operation is not implemented by the current source.
     Unsupported(String),
     /// The server can no longer resume from the supplied cursor.
@@ -52,7 +52,7 @@ impl fmt::Display for SyncError {
             Self::InvalidValue { field, value } => {
                 write!(f, "invalid sync {field}: {:?}", display_value(value))
             }
-            Self::UnknownShape(shape) => write!(f, "unknown sync shape: {shape}"),
+            Self::UnknownStream(stream) => write!(f, "unknown sync stream: {stream}"),
             Self::Unsupported(msg) => write!(f, "unsupported sync operation: {msg}"),
             Self::Gap(cursor) => write!(f, "sync cursor is no longer resumable: {cursor}"),
             Self::Json(err) => write!(f, "sync json error: {err}"),

--- a/crates/pocopine-sync/src/lib.rs
+++ b/crates/pocopine-sync/src/lib.rs
@@ -32,6 +32,6 @@ pub use memory::{MemorySyncState, MemorySyncStream};
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use server::{
-    sync_server_plugin, SyncBoxFuture, SyncServer, SyncServerBuilder, SyncServerPlugin,
-    SyncStreamSource,
+    sync_server_plugin, SyncBoxFuture, SyncGuardFuture, SyncServer, SyncServerBuilder,
+    SyncServerPlugin, SyncStreamGuard, SyncStreamSource,
 };

--- a/crates/pocopine-sync/src/lib.rs
+++ b/crates/pocopine-sync/src/lib.rs
@@ -17,21 +17,21 @@ mod server;
 
 pub use error::{SyncError, SyncResult};
 pub use protocol::{
-    sync_shape_tag, ClientMutation, MutationId, RowKey, RowVersion, SyncChange, SyncCollectionName,
-    SyncConflict, SyncCursor, SyncOp, SyncOpenRequest, SyncOpenResponse, SyncOpenShape,
-    SyncPullMode, SyncPullRequest, SyncPullResponse, SyncPushRequest, SyncPushResponse, SyncRow,
-    SyncShapeName, MAX_SYNC_TOKEN_LEN, SYNC_ENDPOINT_PREFIX, SYNC_OPEN_PATH, SYNC_PROTOCOL_V1,
-    SYNC_PULL_PATH, SYNC_PUSH_PATH,
+    sync_stream_tag, ClientMutation, MutationId, RowKey, RowVersion, SyncChange,
+    SyncCollectionName, SyncConflict, SyncCursor, SyncOp, SyncOpenRequest, SyncOpenResponse,
+    SyncOpenStream, SyncPullMode, SyncPullRequest, SyncPullResponse, SyncPushRequest,
+    SyncPushResponse, SyncRow, SyncStreamName, MAX_SYNC_TOKEN_LEN, SYNC_ENDPOINT_PREFIX,
+    SYNC_OPEN_PATH, SYNC_PROTOCOL_V1, SYNC_PULL_PATH, SYNC_PUSH_PATH,
 };
 pub use state::{CollectionState, SyncReason, SyncRequest};
 
 pub use client::{sync_plugin, SyncClient, SyncClientPlugin, SyncCollection};
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use memory::{MemorySyncShape, MemorySyncState};
+pub use memory::{MemorySyncState, MemorySyncStream};
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use server::{
     sync_server_plugin, SyncBoxFuture, SyncServer, SyncServerBuilder, SyncServerPlugin,
-    SyncShapeSource,
+    SyncStreamSource,
 };

--- a/crates/pocopine-sync/src/memory.rs
+++ b/crates/pocopine-sync/src/memory.rs
@@ -6,10 +6,10 @@ use serde_json::Value;
 
 use crate::{
     SyncChange, SyncCollectionName, SyncCursor, SyncError, SyncOp, SyncPullRequest,
-    SyncPullResponse, SyncResult, SyncRow, SyncShapeName,
+    SyncPullResponse, SyncResult, SyncRow, SyncStreamName,
 };
 
-use super::server::{SyncBoxFuture, SyncShapeSource};
+use super::server::{SyncBoxFuture, SyncStreamSource};
 
 #[derive(Debug)]
 struct Inner<T> {
@@ -34,23 +34,23 @@ impl<T> Default for Inner<T> {
 /// access through one lock. It is a reference implementation, not a durable
 /// production backend.
 #[derive(Clone, Debug)]
-pub struct MemorySyncShape<T> {
-    shape: SyncShapeName,
+pub struct MemorySyncStream<T> {
+    stream: SyncStreamName,
     collection: SyncCollectionName,
     inner: Arc<Mutex<Inner<T>>>,
 }
 
-/// Cloneable handle to the in-memory state backing a shape.
-pub type MemorySyncState<T> = MemorySyncShape<T>;
+/// Cloneable handle to the in-memory state backing a stream.
+pub type MemorySyncState<T> = MemorySyncStream<T>;
 
-impl<T> MemorySyncShape<T>
+impl<T> MemorySyncStream<T>
 where
     T: Clone + Serialize + Send + Sync + 'static,
 {
-    /// Create an empty in-memory shape.
-    pub fn new(shape: impl Into<String>, collection: impl Into<String>) -> SyncResult<Self> {
+    /// Create an empty in-memory stream.
+    pub fn new(stream: impl Into<String>, collection: impl Into<String>) -> SyncResult<Self> {
         Ok(Self {
-            shape: SyncShapeName::new(shape.into())?,
+            stream: SyncStreamName::new(stream.into())?,
             collection: SyncCollectionName::new(collection.into())?,
             inner: Arc::new(Mutex::new(Inner::default())),
         })
@@ -67,7 +67,7 @@ where
         // Unbounded by design for the reference source; production adapters
         // should retain changes according to their own cursor window policy.
         inner.changes.push(SyncChange {
-            shape: self.shape.clone(),
+            stream: self.stream.clone(),
             collection: self.collection.clone(),
             key: None,
             op: SyncOp::Upsert,
@@ -85,7 +85,7 @@ where
         let cursor = SyncCursor::new(inner.version.to_string())?;
         inner.rows.remove(key.as_str());
         inner.changes.push(SyncChange {
-            shape: self.shape.clone(),
+            stream: self.stream.clone(),
             collection: self.collection.clone(),
             key: Some(key),
             op: SyncOp::Delete,
@@ -102,7 +102,7 @@ where
         let cursor = SyncCursor::new(inner.version.to_string())?;
         inner.rows.clear();
         inner.changes.push(SyncChange {
-            shape: self.shape.clone(),
+            stream: self.stream.clone(),
             collection: self.collection.clone(),
             key: None,
             op: SyncOp::Reset,
@@ -124,7 +124,7 @@ where
                 .map(row_to_value)
                 .collect::<SyncResult<Vec<_>>>()?;
             return Ok(SyncPullResponse::snapshot(
-                self.shape.clone(),
+                self.stream.clone(),
                 self.collection.clone(),
                 rows,
                 cursor,
@@ -148,7 +148,7 @@ where
         }
 
         Ok(SyncPullResponse::incremental(
-            self.shape.clone(),
+            self.stream.clone(),
             self.collection.clone(),
             changes,
             cursor,
@@ -158,16 +158,16 @@ where
     fn lock(&self) -> SyncResult<std::sync::MutexGuard<'_, Inner<T>>> {
         self.inner
             .lock()
-            .map_err(|_| SyncError::backend("memory sync shape lock poisoned"))
+            .map_err(|_| SyncError::backend("memory sync stream lock poisoned"))
     }
 }
 
-impl<T> SyncShapeSource for MemorySyncShape<T>
+impl<T> SyncStreamSource for MemorySyncStream<T>
 where
     T: Clone + Serialize + Send + Sync + 'static,
 {
-    fn shape(&self) -> &SyncShapeName {
-        &self.shape
+    fn stream(&self) -> &SyncStreamName {
+        &self.stream
     }
 
     fn collection(&self) -> &SyncCollectionName {
@@ -196,7 +196,7 @@ fn row_to_value<T: Serialize>(row: SyncRow<T>) -> SyncResult<SyncRow<Value>> {
 
 fn change_to_value<T: Serialize>(change: SyncChange<T>) -> SyncResult<SyncChange<Value>> {
     Ok(SyncChange {
-        shape: change.shape,
+        stream: change.stream,
         collection: change.collection,
         key: change.key,
         op: change.op,
@@ -211,21 +211,21 @@ mod tests {
     use crate::SyncPullMode;
 
     #[test]
-    fn memory_shape_returns_snapshot_then_incremental_changes() {
-        let shape = MemorySyncShape::<String>::new("posts_for_tenant", "posts").unwrap();
-        shape.upsert("post_1", "one".to_string()).unwrap();
-        let first = shape
+    fn memory_stream_returns_snapshot_then_incremental_changes() {
+        let stream = MemorySyncStream::<String>::new("posts_for_tenant", "posts").unwrap();
+        stream.upsert("post_1", "one".to_string()).unwrap();
+        let first = stream
             .pull_value(SyncPullRequest::new(
-                SyncShapeName::new("posts_for_tenant").unwrap(),
+                SyncStreamName::new("posts_for_tenant").unwrap(),
             ))
             .unwrap();
         assert_eq!(first.mode, SyncPullMode::Snapshot);
         assert_eq!(first.rows.len(), 1);
 
-        shape.upsert("post_2", "two".to_string()).unwrap();
-        let second = shape
+        stream.upsert("post_2", "two".to_string()).unwrap();
+        let second = stream
             .pull_value(
-                SyncPullRequest::new(SyncShapeName::new("posts_for_tenant").unwrap())
+                SyncPullRequest::new(SyncStreamName::new("posts_for_tenant").unwrap())
                     .cursor(first.cursor.clone()),
             )
             .unwrap();
@@ -238,21 +238,21 @@ mod tests {
     }
 
     #[test]
-    fn memory_shape_returns_delete_and_reset_changes() {
-        let shape = MemorySyncShape::<String>::new("posts_for_tenant", "posts").unwrap();
-        shape.upsert("post_1", "one".to_string()).unwrap();
-        let first = shape
+    fn memory_stream_returns_delete_and_reset_changes() {
+        let stream = MemorySyncStream::<String>::new("posts_for_tenant", "posts").unwrap();
+        stream.upsert("post_1", "one".to_string()).unwrap();
+        let first = stream
             .pull_value(SyncPullRequest::new(
-                SyncShapeName::new("posts_for_tenant").unwrap(),
+                SyncStreamName::new("posts_for_tenant").unwrap(),
             ))
             .unwrap();
 
-        shape.delete("post_1").unwrap();
-        shape.reset().unwrap();
+        stream.delete("post_1").unwrap();
+        stream.reset().unwrap();
 
-        let second = shape
+        let second = stream
             .pull_value(
-                SyncPullRequest::new(SyncShapeName::new("posts_for_tenant").unwrap())
+                SyncPullRequest::new(SyncStreamName::new("posts_for_tenant").unwrap())
                     .cursor(first.cursor.clone()),
             )
             .unwrap();
@@ -264,11 +264,11 @@ mod tests {
     }
 
     #[test]
-    fn memory_shape_reports_gap_for_non_numeric_cursor() {
-        let shape = MemorySyncShape::<String>::new("posts_for_tenant", "posts").unwrap();
-        let err = shape
+    fn memory_stream_reports_gap_for_non_numeric_cursor() {
+        let stream = MemorySyncStream::<String>::new("posts_for_tenant", "posts").unwrap();
+        let err = stream
             .pull_value(
-                SyncPullRequest::new(SyncShapeName::new("posts_for_tenant").unwrap())
+                SyncPullRequest::new(SyncStreamName::new("posts_for_tenant").unwrap())
                     .cursor(Some(SyncCursor::new("not_numeric").unwrap())),
             )
             .unwrap_err();

--- a/crates/pocopine-sync/src/memory.rs
+++ b/crates/pocopine-sync/src/memory.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 
+use pocopine_server::auth::RequestContext;
 use serde::Serialize;
 use serde_json::Value;
 
@@ -174,12 +175,18 @@ where
         &self.collection
     }
 
-    fn current_cursor(&self) -> Option<SyncCursor> {
+    fn current_cursor(&self, ctx: &RequestContext) -> Option<SyncCursor> {
+        let _ = ctx;
         let inner = self.inner.lock().ok()?;
         SyncCursor::new(inner.version.to_string()).ok()
     }
 
-    fn pull<'a>(&'a self, request: SyncPullRequest) -> SyncBoxFuture<'a, SyncPullResponse<Value>> {
+    fn pull<'a>(
+        &'a self,
+        ctx: RequestContext,
+        request: SyncPullRequest,
+    ) -> SyncBoxFuture<'a, SyncPullResponse<Value>> {
+        let _ = ctx;
         Box::pin(async move { self.pull_value(request) })
     }
 }

--- a/crates/pocopine-sync/src/protocol.rs
+++ b/crates/pocopine-sync/src/protocol.rs
@@ -310,7 +310,7 @@ impl<T> SyncPullResponse<T> {
     }
 }
 
-/// Client mutation envelope. The first slice defines the wire stream;
+/// Client mutation envelope. The first slice defines the wire format;
 /// concrete mutation application belongs to stream sources.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(bound(serialize = "M: Serialize", deserialize = "M: Deserialize<'de>"))]

--- a/crates/pocopine-sync/src/protocol.rs
+++ b/crates/pocopine-sync/src/protocol.rs
@@ -97,7 +97,11 @@ macro_rules! opaque_string_type {
     };
 }
 
-opaque_string_type!(SyncShapeName, "shape", "Server-registered sync shape name.");
+opaque_string_type!(
+    SyncStreamName,
+    "stream",
+    "Server-registered sync stream name."
+);
 opaque_string_type!(
     SyncCollectionName,
     "collection",
@@ -107,7 +111,7 @@ opaque_string_type!(SyncCursor, "cursor", "Opaque server-issued sync cursor.");
 opaque_string_type!(
     RowKey,
     "row key",
-    "Public row identity inside one sync shape."
+    "Public row identity inside one sync stream."
 );
 opaque_string_type!(
     RowVersion,
@@ -120,9 +124,9 @@ opaque_string_type!(
     "Client-generated mutation idempotency key."
 );
 
-/// Live query tag used to wake clients for a sync shape.
-pub fn sync_shape_tag(shape: &str) -> String {
-    format!("sync:shape:{shape}")
+/// Live query tag used to wake clients for a sync stream.
+pub fn sync_stream_tag(stream: &str) -> String {
+    format!("sync:stream:{stream}")
 }
 
 /// Operation attached to a sync change.
@@ -176,7 +180,7 @@ impl<T> SyncRow<T> {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(bound(serialize = "T: Serialize", deserialize = "T: Deserialize<'de>"))]
 pub struct SyncChange<T> {
-    pub shape: SyncShapeName,
+    pub stream: SyncStreamName,
     pub collection: SyncCollectionName,
     pub key: Option<RowKey>,
     pub op: SyncOp,
@@ -184,29 +188,29 @@ pub struct SyncChange<T> {
     pub cursor: SyncCursor,
 }
 
-/// Open one or more shapes.
+/// Open one or more streams.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SyncOpenRequest {
     pub protocol: String,
     #[serde(default)]
     pub client_id: Option<String>,
-    pub shapes: Vec<SyncShapeName>,
+    pub streams: Vec<SyncStreamName>,
 }
 
 impl SyncOpenRequest {
-    pub fn new(shapes: impl IntoIterator<Item = SyncShapeName>) -> Self {
+    pub fn new(streams: impl IntoIterator<Item = SyncStreamName>) -> Self {
         Self {
             protocol: SYNC_PROTOCOL_V1.to_string(),
             client_id: None,
-            shapes: shapes.into_iter().collect(),
+            streams: streams.into_iter().collect(),
         }
     }
 }
 
-/// Shape accepted by an open response.
+/// Stream accepted by an open response.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct SyncOpenShape {
-    pub shape: SyncShapeName,
+pub struct SyncOpenStream {
+    pub stream: SyncStreamName,
     pub collection: SyncCollectionName,
     pub cursor: Option<SyncCursor>,
 }
@@ -215,32 +219,32 @@ pub struct SyncOpenShape {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SyncOpenResponse {
     pub protocol: String,
-    pub shapes: Vec<SyncOpenShape>,
+    pub streams: Vec<SyncOpenStream>,
 }
 
 impl SyncOpenResponse {
-    pub fn new(shapes: Vec<SyncOpenShape>) -> Self {
+    pub fn new(streams: Vec<SyncOpenStream>) -> Self {
         Self {
             protocol: SYNC_PROTOCOL_V1.to_string(),
-            shapes,
+            streams,
         }
     }
 }
 
-/// Pull request for one shape.
+/// Pull request for one stream.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SyncPullRequest {
     pub protocol: String,
-    pub shape: SyncShapeName,
+    pub stream: SyncStreamName,
     pub cursor: Option<SyncCursor>,
     pub limit: u32,
 }
 
 impl SyncPullRequest {
-    pub fn new(shape: SyncShapeName) -> Self {
+    pub fn new(stream: SyncStreamName) -> Self {
         Self {
             protocol: SYNC_PROTOCOL_V1.to_string(),
-            shape,
+            stream,
             cursor: None,
             limit: 500,
         }
@@ -252,12 +256,12 @@ impl SyncPullRequest {
     }
 }
 
-/// Pull response for one shape.
+/// Pull response for one stream.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(bound(serialize = "T: Serialize", deserialize = "T: Deserialize<'de>"))]
 pub struct SyncPullResponse<T> {
     pub protocol: String,
-    pub shape: SyncShapeName,
+    pub stream: SyncStreamName,
     pub collection: SyncCollectionName,
     pub mode: SyncPullMode,
     #[serde(default)]
@@ -270,14 +274,14 @@ pub struct SyncPullResponse<T> {
 
 impl<T> SyncPullResponse<T> {
     pub fn snapshot(
-        shape: SyncShapeName,
+        stream: SyncStreamName,
         collection: SyncCollectionName,
         rows: Vec<SyncRow<T>>,
         cursor: Option<SyncCursor>,
     ) -> Self {
         Self {
             protocol: SYNC_PROTOCOL_V1.to_string(),
-            shape,
+            stream,
             collection,
             mode: SyncPullMode::Snapshot,
             rows,
@@ -288,14 +292,14 @@ impl<T> SyncPullResponse<T> {
     }
 
     pub fn incremental(
-        shape: SyncShapeName,
+        stream: SyncStreamName,
         collection: SyncCollectionName,
         changes: Vec<SyncChange<T>>,
         cursor: Option<SyncCursor>,
     ) -> Self {
         Self {
             protocol: SYNC_PROTOCOL_V1.to_string(),
-            shape,
+            stream,
             collection,
             mode: SyncPullMode::Incremental,
             rows: Vec::new(),
@@ -306,8 +310,8 @@ impl<T> SyncPullResponse<T> {
     }
 }
 
-/// Client mutation envelope. The first slice defines the wire shape;
-/// concrete mutation application belongs to shape sources.
+/// Client mutation envelope. The first slice defines the wire stream;
+/// concrete mutation application belongs to stream sources.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(bound(serialize = "M: Serialize", deserialize = "M: Deserialize<'de>"))]
 pub struct ClientMutation<M> {
@@ -318,12 +322,12 @@ pub struct ClientMutation<M> {
     pub payload: M,
 }
 
-/// Push request for one shape.
+/// Push request for one stream.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(bound(serialize = "M: Serialize", deserialize = "M: Deserialize<'de>"))]
 pub struct SyncPushRequest<M> {
     pub protocol: String,
-    pub shape: SyncShapeName,
+    pub stream: SyncStreamName,
     #[serde(default)]
     pub mutations: Vec<ClientMutation<M>>,
 }
@@ -338,12 +342,12 @@ pub struct SyncConflict<T> {
     pub reason: String,
 }
 
-/// Push response for one shape.
+/// Push response for one stream.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(bound(serialize = "T: Serialize", deserialize = "T: Deserialize<'de>"))]
 pub struct SyncPushResponse<T> {
     pub protocol: String,
-    pub shape: SyncShapeName,
+    pub stream: SyncStreamName,
     #[serde(default)]
     pub accepted: Vec<MutationId>,
     #[serde(default)]
@@ -358,27 +362,27 @@ mod tests {
     use super::*;
 
     #[test]
-    fn validates_shape_names() {
-        assert!(SyncShapeName::new("posts_for_tenant").is_ok());
-        assert!(SyncShapeName::new("").is_err());
-        assert!(SyncShapeName::new(" posts").is_err());
-        assert!(SyncShapeName::new("posts\nbad").is_err());
-        assert!(SyncShapeName::new("x".repeat(MAX_SYNC_TOKEN_LEN + 1)).is_err());
+    fn validates_stream_names() {
+        assert!(SyncStreamName::new("posts_for_tenant").is_ok());
+        assert!(SyncStreamName::new("").is_err());
+        assert!(SyncStreamName::new(" posts").is_err());
+        assert!(SyncStreamName::new("posts\nbad").is_err());
+        assert!(SyncStreamName::new("x".repeat(MAX_SYNC_TOKEN_LEN + 1)).is_err());
     }
 
     #[test]
     fn deserializes_tokens_through_validation() {
-        let shape: SyncShapeName = serde_json::from_str("\"posts_for_tenant\"").unwrap();
-        assert_eq!(shape.as_str(), "posts_for_tenant");
-        assert!(serde_json::from_str::<SyncShapeName>("\" posts\"").is_err());
-        assert!(serde_json::from_str::<SyncShapeName>("\"posts\\nbad\"").is_err());
+        let stream: SyncStreamName = serde_json::from_str("\"posts_for_tenant\"").unwrap();
+        assert_eq!(stream.as_str(), "posts_for_tenant");
+        assert!(serde_json::from_str::<SyncStreamName>("\" posts\"").is_err());
+        assert!(serde_json::from_str::<SyncStreamName>("\"posts\\nbad\"").is_err());
     }
 
     #[test]
-    fn sync_shape_tag_is_stable() {
+    fn sync_stream_tag_is_stable() {
         assert_eq!(
-            sync_shape_tag("posts_for_tenant"),
-            "sync:shape:posts_for_tenant"
+            sync_stream_tag("posts_for_tenant"),
+            "sync:stream:posts_for_tenant"
         );
     }
 

--- a/crates/pocopine-sync/src/server.rs
+++ b/crates/pocopine-sync/src/server.rs
@@ -12,25 +12,25 @@ use pocopine_server::{Server, ServerPlugin};
 use serde_json::Value;
 
 use crate::{
-    sync_shape_tag, SyncError, SyncOpenRequest, SyncOpenResponse, SyncOpenShape, SyncPullRequest,
+    sync_stream_tag, SyncError, SyncOpenRequest, SyncOpenResponse, SyncOpenStream, SyncPullRequest,
     SyncPullResponse, SyncPushRequest, SyncPushResponse, SyncResult, SYNC_OPEN_PATH,
     SYNC_PULL_PATH, SYNC_PUSH_PATH,
 };
 
-/// Future returned by a shape source.
+/// Future returned by a stream source.
 pub type SyncBoxFuture<'a, T> = Pin<Box<dyn Future<Output = SyncResult<T>> + Send + 'a>>;
 
-/// Server-side source for one registered sync shape.
+/// Server-side source for one registered sync stream.
 ///
-/// Registered shapes are pullable through the sync routes. Until a source
+/// Registered streams are pullable through the sync routes. Until a source
 /// implements its own authorization or the host app mounts sync behind an
 /// auth boundary, `/open` is validation/discovery and `/pull` remains
-/// callable for any registered shape.
-pub trait SyncShapeSource: Send + Sync + 'static {
-    /// Server-registered shape name.
-    fn shape(&self) -> &crate::SyncShapeName;
+/// callable for any registered stream.
+pub trait SyncStreamSource: Send + Sync + 'static {
+    /// Server-registered stream name.
+    fn stream(&self) -> &crate::SyncStreamName;
 
-    /// Public collection name represented by this shape.
+    /// Public collection name represented by this stream.
     fn collection(&self) -> &crate::SyncCollectionName;
 
     /// Current cursor, if the source can cheaply report it.
@@ -38,10 +38,10 @@ pub trait SyncShapeSource: Send + Sync + 'static {
         None
     }
 
-    /// Pull changes or a snapshot for this shape.
+    /// Pull changes or a snapshot for this stream.
     fn pull<'a>(&'a self, request: SyncPullRequest) -> SyncBoxFuture<'a, SyncPullResponse<Value>>;
 
-    /// Push client mutations for this shape.
+    /// Push client mutations for this stream.
     fn push<'a>(
         &'a self,
         request: SyncPushRequest<Value>,
@@ -49,7 +49,7 @@ pub trait SyncShapeSource: Send + Sync + 'static {
         let _ = request;
         Box::pin(async {
             Err(SyncError::unsupported(
-                "push is not implemented for this shape",
+                "push is not implemented for this stream",
             ))
         })
     }
@@ -57,7 +57,7 @@ pub trait SyncShapeSource: Send + Sync + 'static {
 
 #[derive(Clone)]
 struct SyncServerInner {
-    shapes: Arc<HashMap<String, Arc<dyn SyncShapeSource>>>,
+    streams: Arc<HashMap<String, Arc<dyn SyncStreamSource>>>,
     events: Option<SharedEventBackend>,
 }
 
@@ -73,16 +73,16 @@ impl SyncServer {
         SyncServerBuilder::default()
     }
 
-    /// Return the live query tags this server can publish for shapes.
+    /// Return the live query tags this server can publish for streams.
     pub fn live_query_tags(&self) -> Vec<String> {
         self.inner
-            .shapes
+            .streams
             .keys()
-            .map(|shape| sync_shape_tag(shape))
+            .map(|stream| sync_stream_tag(stream))
             .collect()
     }
 
-    /// Return the live topics this server can publish for shapes.
+    /// Return the live topics this server can publish for streams.
     pub fn live_topics(&self) -> pocopine_events::EventResult<Vec<pocopine_events::Topic>> {
         self.live_query_tags()
             .into_iter()
@@ -90,14 +90,14 @@ impl SyncServer {
             .collect()
     }
 
-    /// Publish a live wake-up for one shape when an event backend is
+    /// Publish a live wake-up for one stream when an event backend is
     /// attached. The sync data still moves through pull; this only wakes
     /// browsers to pull with their current sync cursor.
-    pub async fn invalidate_shape(&self, shape: &str) -> SyncResult<()> {
+    pub async fn invalidate_stream(&self, stream: &str) -> SyncResult<()> {
         let Some(events) = self.inner.events.as_ref() else {
             return Ok(());
         };
-        let tag = sync_shape_tag(shape);
+        let tag = sync_stream_tag(stream);
         let topic = pocopine_live::query_tag_topic(&tag)
             .map_err(|err| SyncError::backend(err.to_string()))?;
         let draft = pocopine_live::query_invalidated(topic, [tag])
@@ -109,30 +109,30 @@ impl SyncServer {
         Ok(())
     }
 
-    fn shape(&self, shape: &str) -> SyncResult<Arc<dyn SyncShapeSource>> {
+    fn stream(&self, stream: &str) -> SyncResult<Arc<dyn SyncStreamSource>> {
         self.inner
-            .shapes
-            .get(shape)
+            .streams
+            .get(stream)
             .cloned()
-            .ok_or_else(|| SyncError::UnknownShape(shape.to_string()))
+            .ok_or_else(|| SyncError::UnknownStream(stream.to_string()))
     }
 }
 
 /// Builder for [`SyncServer`].
 #[derive(Default)]
 pub struct SyncServerBuilder {
-    shapes: HashMap<String, Arc<dyn SyncShapeSource>>,
+    streams: HashMap<String, Arc<dyn SyncStreamSource>>,
     events: Option<SharedEventBackend>,
 }
 
 impl SyncServerBuilder {
-    /// Register one shape source.
-    pub fn shape<S>(mut self, shape: S) -> Self
+    /// Register one stream source.
+    pub fn stream<S>(mut self, stream: S) -> Self
     where
-        S: SyncShapeSource,
+        S: SyncStreamSource,
     {
-        self.shapes
-            .insert(shape.shape().as_str().to_string(), Arc::new(shape));
+        self.streams
+            .insert(stream.stream().as_str().to_string(), Arc::new(stream));
         self
     }
 
@@ -146,7 +146,7 @@ impl SyncServerBuilder {
     pub fn build(self) -> SyncServer {
         SyncServer {
             inner: Arc::new(SyncServerInner {
-                shapes: Arc::new(self.shapes),
+                streams: Arc::new(self.streams),
                 events: self.events,
             }),
         }
@@ -156,7 +156,7 @@ impl SyncServerBuilder {
 /// Server plugin that mounts sync routes and provides [`SyncServer`].
 ///
 /// Installing this plugin exposes `/__pocopine/sync/v1/open`, `/pull`, and
-/// `/push` for every registered shape. Shape sources are responsible for
+/// `/push` for every registered stream. Stream sources are responsible for
 /// tenant filtering, authorization, and cursor policy in this first slice.
 #[derive(Clone)]
 pub struct SyncServerPlugin {
@@ -191,16 +191,16 @@ async fn open_handler(
 }
 
 async fn open(sync: SyncServer, request: SyncOpenRequest) -> SyncResult<SyncOpenResponse> {
-    let mut shapes = Vec::with_capacity(request.shapes.len());
-    for requested in request.shapes {
-        let shape = sync.shape(requested.as_str())?;
-        shapes.push(SyncOpenShape {
-            shape: shape.shape().clone(),
-            collection: shape.collection().clone(),
-            cursor: shape.current_cursor(),
+    let mut streams = Vec::with_capacity(request.streams.len());
+    for requested in request.streams {
+        let stream = sync.stream(requested.as_str())?;
+        streams.push(SyncOpenStream {
+            stream: stream.stream().clone(),
+            collection: stream.collection().clone(),
+            cursor: stream.current_cursor(),
         });
     }
-    Ok(SyncOpenResponse::new(shapes))
+    Ok(SyncOpenResponse::new(streams))
 }
 
 async fn pull_handler(
@@ -208,8 +208,8 @@ async fn pull_handler(
     Json(request): Json<SyncPullRequest>,
 ) -> Json<ServerResult<SyncPullResponse<Value>>> {
     let result = async {
-        let shape = sync.shape(request.shape.as_str())?;
-        shape.pull(request).await
+        let stream = sync.stream(request.stream.as_str())?;
+        stream.pull(request).await
     }
     .await;
     Json(result.map_err(server_error))
@@ -220,8 +220,8 @@ async fn push_handler(
     Json(request): Json<SyncPushRequest<Value>>,
 ) -> Json<ServerResult<SyncPushResponse<Value>>> {
     let result = async {
-        let shape = sync.shape(request.shape.as_str())?;
-        shape.push(request).await
+        let stream = sync.stream(request.stream.as_str())?;
+        stream.push(request).await
     }
     .await;
     Json(result.map_err(server_error))
@@ -230,7 +230,7 @@ async fn push_handler(
 fn server_error(error: SyncError) -> ServerError {
     match error {
         SyncError::InvalidValue { .. } => ServerError::BadRequest(error.to_string()),
-        SyncError::UnknownShape(_) => ServerError::Forbidden(error.to_string()),
+        SyncError::UnknownStream(_) => ServerError::Forbidden(error.to_string()),
         SyncError::Unsupported(_) => ServerError::BadRequest(error.to_string()),
         SyncError::Gap(_) => ServerError::BadRequest(error.to_string()),
         SyncError::Json(err) => {
@@ -254,14 +254,14 @@ mod tests {
 
     use super::*;
     use crate::{
-        MemorySyncShape, SyncPullMode, SyncPushRequest, SyncRow, SyncShapeName, SYNC_PROTOCOL_V1,
+        MemorySyncStream, SyncPullMode, SyncPushRequest, SyncRow, SyncStreamName, SYNC_PROTOCOL_V1,
     };
 
     #[tokio::test]
-    async fn pull_route_is_public_for_registered_shapes() {
-        let router = router_with_posts_shape();
+    async fn pull_route_is_public_for_registered_streams() {
+        let router = router_with_posts_stream();
 
-        let request = SyncPullRequest::new(SyncShapeName::new("posts_for_tenant").unwrap());
+        let request = SyncPullRequest::new(SyncStreamName::new("posts_for_tenant").unwrap());
         let response = router
             .oneshot(
                 Request::builder()
@@ -286,10 +286,10 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn pull_unknown_shape_returns_forbidden() {
-        let router = router_with_posts_shape();
+    async fn pull_unknown_stream_returns_forbidden() {
+        let router = router_with_posts_stream();
 
-        let request = SyncPullRequest::new(SyncShapeName::new("unknown_shape").unwrap());
+        let request = SyncPullRequest::new(SyncStreamName::new("unknown_stream").unwrap());
         let response = router
             .oneshot(
                 Request::builder()
@@ -307,17 +307,17 @@ mod tests {
         let outer: ServerResult<SyncPullResponse<String>> = serde_json::from_slice(&bytes).unwrap();
         assert!(matches!(
             outer,
-            Err(ServerError::Forbidden(message)) if message.contains("unknown sync shape")
+            Err(ServerError::Forbidden(message)) if message.contains("unknown sync stream")
         ));
     }
 
     #[tokio::test]
     async fn default_push_returns_unsupported_bad_request() {
-        let router = router_with_posts_shape();
+        let router = router_with_posts_stream();
 
         let request = SyncPushRequest::<String> {
             protocol: SYNC_PROTOCOL_V1.to_string(),
-            shape: SyncShapeName::new("posts_for_tenant").unwrap(),
+            stream: SyncStreamName::new("posts_for_tenant").unwrap(),
             mutations: Vec::new(),
         };
         let response = router
@@ -356,11 +356,11 @@ mod tests {
         ));
     }
 
-    fn router_with_posts_shape() -> pocopine_server::axum::Router {
+    fn router_with_posts_stream() -> pocopine_server::axum::Router {
         pocopine_server::__reset_for_test();
-        let posts = MemorySyncShape::<String>::new("posts_for_tenant", "posts").unwrap();
+        let posts = MemorySyncStream::<String>::new("posts_for_tenant", "posts").unwrap();
         posts.upsert("post_1", "hello".to_string()).unwrap();
-        let sync = SyncServer::builder().shape(posts).build();
+        let sync = SyncServer::builder().stream(posts).build();
         pocopine_server::Server::new(pocopine_server::axum::Router::new())
             .plugin(sync_server_plugin(sync))
             .try_finalize()

--- a/crates/pocopine-sync/src/server.rs
+++ b/crates/pocopine-sync/src/server.rs
@@ -5,10 +5,14 @@ use std::sync::Arc;
 
 use pocopine_core::{ServerError, ServerResult};
 use pocopine_events::SharedEventBackend;
-use pocopine_server::axum::extract::State;
+use pocopine_server::auth::{Predicate, RequestContext};
+use pocopine_server::axum::body::Body;
+use pocopine_server::axum::extract::{FromRequest, State};
+use pocopine_server::axum::http::Request;
 use pocopine_server::axum::response::Json;
 use pocopine_server::axum::routing::post;
 use pocopine_server::{Server, ServerPlugin};
+use serde::de::DeserializeOwned;
 use serde_json::Value;
 
 use crate::{
@@ -20,12 +24,42 @@ use crate::{
 /// Future returned by a stream source.
 pub type SyncBoxFuture<'a, T> = Pin<Box<dyn Future<Output = SyncResult<T>> + Send + 'a>>;
 
+/// Future returned by a stream guard.
+pub type SyncGuardFuture<'a> = Pin<Box<dyn Future<Output = ServerResult<()>> + Send + 'a>>;
+
+/// Server-side access check for a sync stream.
+pub trait SyncStreamGuard: Send + Sync + 'static {
+    /// Authorize one request before the stream source runs.
+    fn check(&self, ctx: RequestContext) -> SyncGuardFuture<'_>;
+}
+
+impl<F, Fut> SyncStreamGuard for F
+where
+    F: Fn(RequestContext) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ServerResult<()>> + Send + 'static,
+{
+    fn check(&self, ctx: RequestContext) -> SyncGuardFuture<'_> {
+        Box::pin((self)(ctx))
+    }
+}
+
+struct PredicateStreamGuard<P>(P);
+
+impl<P> SyncStreamGuard for PredicateStreamGuard<P>
+where
+    P: Predicate,
+{
+    fn check(&self, ctx: RequestContext) -> SyncGuardFuture<'_> {
+        let result: ServerResult<()> = self.0.check(&ctx.user).into();
+        Box::pin(async move { result })
+    }
+}
+
 /// Server-side source for one registered sync stream.
 ///
-/// Registered streams are pullable through the sync routes. Until a source
-/// implements its own authorization or the host app mounts sync behind an
-/// auth boundary, `/open` is validation/discovery and `/pull` remains
-/// callable for any registered stream.
+/// The request context is passed into each source call after stream-level
+/// authorization has succeeded. Sources still own tenant filtering, cursor
+/// validation, and any per-row visibility rules.
 pub trait SyncStreamSource: Send + Sync + 'static {
     /// Server-registered stream name.
     fn stream(&self) -> &crate::SyncStreamName;
@@ -34,18 +68,25 @@ pub trait SyncStreamSource: Send + Sync + 'static {
     fn collection(&self) -> &crate::SyncCollectionName;
 
     /// Current cursor, if the source can cheaply report it.
-    fn current_cursor(&self) -> Option<crate::SyncCursor> {
+    fn current_cursor(&self, ctx: &RequestContext) -> Option<crate::SyncCursor> {
+        let _ = ctx;
         None
     }
 
     /// Pull changes or a snapshot for this stream.
-    fn pull<'a>(&'a self, request: SyncPullRequest) -> SyncBoxFuture<'a, SyncPullResponse<Value>>;
+    fn pull<'a>(
+        &'a self,
+        ctx: RequestContext,
+        request: SyncPullRequest,
+    ) -> SyncBoxFuture<'a, SyncPullResponse<Value>>;
 
     /// Push client mutations for this stream.
     fn push<'a>(
         &'a self,
+        ctx: RequestContext,
         request: SyncPushRequest<Value>,
     ) -> SyncBoxFuture<'a, SyncPushResponse<Value>> {
+        let _ = ctx;
         let _ = request;
         Box::pin(async {
             Err(SyncError::unsupported(
@@ -56,8 +97,24 @@ pub trait SyncStreamSource: Send + Sync + 'static {
 }
 
 #[derive(Clone)]
+struct RegisteredSyncStream {
+    source: Arc<dyn SyncStreamSource>,
+    guard: Option<Arc<dyn SyncStreamGuard>>,
+}
+
+impl RegisteredSyncStream {
+    async fn authorize(&self, ctx: RequestContext) -> ServerResult<()> {
+        if let Some(guard) = &self.guard {
+            guard.check(ctx).await
+        } else {
+            Ok(())
+        }
+    }
+}
+
+#[derive(Clone)]
 struct SyncServerInner {
-    streams: Arc<HashMap<String, Arc<dyn SyncStreamSource>>>,
+    streams: Arc<HashMap<String, Arc<RegisteredSyncStream>>>,
     events: Option<SharedEventBackend>,
 }
 
@@ -109,7 +166,7 @@ impl SyncServer {
         Ok(())
     }
 
-    fn stream(&self, stream: &str) -> SyncResult<Arc<dyn SyncStreamSource>> {
+    fn stream(&self, stream: &str) -> SyncResult<Arc<RegisteredSyncStream>> {
         self.inner
             .streams
             .get(stream)
@@ -121,18 +178,37 @@ impl SyncServer {
 /// Builder for [`SyncServer`].
 #[derive(Default)]
 pub struct SyncServerBuilder {
-    streams: HashMap<String, Arc<dyn SyncStreamSource>>,
+    streams: HashMap<String, Arc<RegisteredSyncStream>>,
     events: Option<SharedEventBackend>,
 }
 
 impl SyncServerBuilder {
-    /// Register one stream source.
-    pub fn stream<S>(mut self, stream: S) -> Self
+    /// Register one explicitly public stream source.
+    pub fn public_stream<S>(mut self, stream: S) -> Self
     where
         S: SyncStreamSource,
     {
-        self.streams
-            .insert(stream.stream().as_str().to_string(), Arc::new(stream));
+        self.insert_stream(stream, None);
+        self
+    }
+
+    /// Register one stream guarded by a sync auth predicate.
+    pub fn guarded_stream<S, P>(mut self, stream: S, predicate: P) -> Self
+    where
+        S: SyncStreamSource,
+        P: Predicate,
+    {
+        self.insert_stream(stream, Some(Arc::new(PredicateStreamGuard(predicate))));
+        self
+    }
+
+    /// Register one stream guarded by an async request-context guard.
+    pub fn guarded_stream_with<S, G>(mut self, stream: S, guard: G) -> Self
+    where
+        S: SyncStreamSource,
+        G: SyncStreamGuard,
+    {
+        self.insert_stream(stream, Some(Arc::new(guard)));
         self
     }
 
@@ -151,13 +227,26 @@ impl SyncServerBuilder {
             }),
         }
     }
+
+    fn insert_stream<S>(&mut self, stream: S, guard: Option<Arc<dyn SyncStreamGuard>>)
+    where
+        S: SyncStreamSource,
+    {
+        self.streams.insert(
+            stream.stream().as_str().to_string(),
+            Arc::new(RegisteredSyncStream {
+                source: Arc::new(stream),
+                guard,
+            }),
+        );
+    }
 }
 
 /// Server plugin that mounts sync routes and provides [`SyncServer`].
 ///
 /// Installing this plugin exposes `/__pocopine/sync/v1/open`, `/pull`, and
-/// `/push` for every registered stream. Stream sources are responsible for
-/// tenant filtering, authorization, and cursor policy in this first slice.
+/// `/push` for every registered stream. Streams must be registered as either
+/// explicitly public or guarded; there is no implicit public registration.
 #[derive(Clone)]
 pub struct SyncServerPlugin {
     sync: SyncServer,
@@ -185,19 +274,30 @@ impl ServerPlugin for SyncServerPlugin {
 
 async fn open_handler(
     State(sync): State<SyncServer>,
-    Json(request): Json<SyncOpenRequest>,
+    request: Request<Body>,
 ) -> Json<ServerResult<SyncOpenResponse>> {
-    Json(open(sync, request).await.map_err(server_error))
+    Json(
+        async {
+            let (ctx, request) = parse_json_request::<SyncOpenRequest>(request).await?;
+            open(sync, ctx, request).await
+        }
+        .await,
+    )
 }
 
-async fn open(sync: SyncServer, request: SyncOpenRequest) -> SyncResult<SyncOpenResponse> {
+async fn open(
+    sync: SyncServer,
+    ctx: RequestContext,
+    request: SyncOpenRequest,
+) -> ServerResult<SyncOpenResponse> {
     let mut streams = Vec::with_capacity(request.streams.len());
     for requested in request.streams {
-        let stream = sync.stream(requested.as_str())?;
+        let stream = sync.stream(requested.as_str()).map_err(server_error)?;
+        stream.authorize(ctx.clone()).await?;
         streams.push(SyncOpenStream {
-            stream: stream.stream().clone(),
-            collection: stream.collection().clone(),
-            cursor: stream.current_cursor(),
+            stream: stream.source.stream().clone(),
+            collection: stream.source.collection().clone(),
+            cursor: stream.source.current_cursor(&ctx),
         });
     }
     Ok(SyncOpenResponse::new(streams))
@@ -205,26 +305,48 @@ async fn open(sync: SyncServer, request: SyncOpenRequest) -> SyncResult<SyncOpen
 
 async fn pull_handler(
     State(sync): State<SyncServer>,
-    Json(request): Json<SyncPullRequest>,
+    request: Request<Body>,
 ) -> Json<ServerResult<SyncPullResponse<Value>>> {
     let result = async {
-        let stream = sync.stream(request.stream.as_str())?;
-        stream.pull(request).await
+        let (ctx, request) = parse_json_request::<SyncPullRequest>(request).await?;
+        let stream = sync.stream(request.stream.as_str()).map_err(server_error)?;
+        stream.authorize(ctx.clone()).await?;
+        stream.source.pull(ctx, request).await.map_err(server_error)
     }
     .await;
-    Json(result.map_err(server_error))
+    Json(result)
 }
 
 async fn push_handler(
     State(sync): State<SyncServer>,
-    Json(request): Json<SyncPushRequest<Value>>,
+    request: Request<Body>,
 ) -> Json<ServerResult<SyncPushResponse<Value>>> {
     let result = async {
-        let stream = sync.stream(request.stream.as_str())?;
-        stream.push(request).await
+        let (ctx, request) = parse_json_request::<SyncPushRequest<Value>>(request).await?;
+        let stream = sync.stream(request.stream.as_str()).map_err(server_error)?;
+        stream.authorize(ctx.clone()).await?;
+        stream.source.push(ctx, request).await.map_err(server_error)
     }
     .await;
-    Json(result.map_err(server_error))
+    Json(result)
+}
+
+async fn parse_json_request<T>(request: Request<Body>) -> ServerResult<(RequestContext, T)>
+where
+    T: DeserializeOwned + Send + 'static,
+{
+    let (parts, body) = request.into_parts();
+    let ctx = RequestContext::from_parts(
+        parts.method.clone(),
+        parts.uri.clone(),
+        parts.headers.clone(),
+        parts.extensions.clone(),
+    );
+    let request = Request::from_parts(parts, body);
+    let Json(payload) = Json::<T>::from_request(request, &())
+        .await
+        .map_err(|err| ServerError::BadRequest(err.to_string()))?;
+    Ok((ctx, payload))
 }
 
 fn server_error(error: SyncError) -> ServerError {
@@ -246,15 +368,25 @@ fn server_error(error: SyncError) -> ServerError {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Mutex};
+
     use http_body_util::BodyExt;
     use pocopine_core::ServerError;
+    use pocopine_server::auth::{
+        require_auth, require_role, AuthUser, Predicate, Principal, RequestContext, Role,
+    };
     use pocopine_server::axum::body::Body;
     use pocopine_server::axum::http::{Request, StatusCode};
+    use pocopine_server::axum::Router;
+    use serde::de::DeserializeOwned;
+    use serde::Serialize;
+    use serde_json::{json, Value};
     use tower::ServiceExt;
 
     use super::*;
     use crate::{
-        MemorySyncStream, SyncPullMode, SyncPushRequest, SyncRow, SyncStreamName, SYNC_PROTOCOL_V1,
+        MemorySyncStream, SyncCollectionName, SyncOpenRequest, SyncPullMode, SyncPushRequest,
+        SyncRow, SyncStreamName, SYNC_PROTOCOL_V1,
     };
 
     #[tokio::test]
@@ -262,21 +394,8 @@ mod tests {
         let router = router_with_posts_stream();
 
         let request = SyncPullRequest::new(SyncStreamName::new("posts_for_tenant").unwrap());
-        let response = router
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri(SYNC_PULL_PATH)
-                    .header("content-type", "application/json")
-                    .body(Body::from(serde_json::to_string(&request).unwrap()))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), StatusCode::OK);
-        let bytes = response.into_body().collect().await.unwrap().to_bytes();
-        let outer: ServerResult<SyncPullResponse<String>> = serde_json::from_slice(&bytes).unwrap();
+        let outer: ServerResult<SyncPullResponse<String>> =
+            post_json(router, SYNC_PULL_PATH, &request, None).await;
         let response = outer.unwrap();
         assert_eq!(response.protocol, SYNC_PROTOCOL_V1);
         assert_eq!(response.mode, SyncPullMode::Snapshot);
@@ -290,21 +409,8 @@ mod tests {
         let router = router_with_posts_stream();
 
         let request = SyncPullRequest::new(SyncStreamName::new("unknown_stream").unwrap());
-        let response = router
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri(SYNC_PULL_PATH)
-                    .header("content-type", "application/json")
-                    .body(Body::from(serde_json::to_string(&request).unwrap()))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), StatusCode::OK);
-        let bytes = response.into_body().collect().await.unwrap().to_bytes();
-        let outer: ServerResult<SyncPullResponse<String>> = serde_json::from_slice(&bytes).unwrap();
+        let outer: ServerResult<SyncPullResponse<String>> =
+            post_json(router, SYNC_PULL_PATH, &request, None).await;
         assert!(matches!(
             outer,
             Err(ServerError::Forbidden(message)) if message.contains("unknown sync stream")
@@ -320,26 +426,88 @@ mod tests {
             stream: SyncStreamName::new("posts_for_tenant").unwrap(),
             mutations: Vec::new(),
         };
-        let response = router
-            .oneshot(
-                Request::builder()
-                    .method("POST")
-                    .uri(SYNC_PUSH_PATH)
-                    .header("content-type", "application/json")
-                    .body(Body::from(serde_json::to_string(&request).unwrap()))
-                    .unwrap(),
-            )
-            .await
-            .unwrap();
-
-        assert_eq!(response.status(), StatusCode::OK);
-        let bytes = response.into_body().collect().await.unwrap().to_bytes();
-        let outer: ServerResult<SyncPushResponse<String>> = serde_json::from_slice(&bytes).unwrap();
+        let outer: ServerResult<SyncPushResponse<String>> =
+            post_json(router, SYNC_PUSH_PATH, &request, None).await;
         assert!(matches!(
             outer,
             Err(ServerError::BadRequest(message))
                 if message.contains("unsupported sync operation")
         ));
+    }
+
+    #[tokio::test]
+    async fn guarded_stream_denies_anonymous_open_and_pull() {
+        let router = router_with_guarded_posts_stream(require_auth());
+
+        let open = SyncOpenRequest::new([SyncStreamName::new("posts_for_tenant").unwrap()]);
+        let opened: ServerResult<SyncOpenResponse> =
+            post_json(router.clone(), SYNC_OPEN_PATH, &open, None).await;
+        assert!(matches!(opened, Err(ServerError::Unauthorized(_))));
+
+        let pull = SyncPullRequest::new(SyncStreamName::new("posts_for_tenant").unwrap());
+        let pulled: ServerResult<SyncPullResponse<String>> =
+            post_json(router, SYNC_PULL_PATH, &pull, None).await;
+        assert!(matches!(pulled, Err(ServerError::Unauthorized(_))));
+    }
+
+    #[tokio::test]
+    async fn guarded_stream_allows_authenticated_principal() {
+        let router = router_with_guarded_posts_stream(require_auth());
+        let principal = Principal::from_user(AuthUser::new("user_1"));
+
+        let pull = SyncPullRequest::new(SyncStreamName::new("posts_for_tenant").unwrap());
+        let pulled: ServerResult<SyncPullResponse<String>> =
+            post_json(router, SYNC_PULL_PATH, &pull, Some(principal)).await;
+
+        assert!(pulled.is_ok());
+    }
+
+    #[tokio::test]
+    async fn role_guard_checks_authenticated_principal_roles() {
+        let router = router_with_guarded_posts_stream(require_role("admin"));
+        let viewer = Principal::from_user(AuthUser::new("viewer").with_role(Role::user()));
+        let admin = Principal::from_user(AuthUser::new("admin").with_role(Role::admin()));
+        let pull = SyncPullRequest::new(SyncStreamName::new("posts_for_tenant").unwrap());
+
+        let denied: ServerResult<SyncPullResponse<String>> =
+            post_json(router.clone(), SYNC_PULL_PATH, &pull, Some(viewer)).await;
+        assert!(matches!(denied, Err(ServerError::Forbidden(_))));
+
+        let allowed: ServerResult<SyncPullResponse<String>> =
+            post_json(router, SYNC_PULL_PATH, &pull, Some(admin)).await;
+        assert!(allowed.is_ok());
+    }
+
+    #[tokio::test]
+    async fn source_receives_request_context_after_guard_passes() {
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let sync = SyncServer::builder()
+            .public_stream(ContextCaptureStream::new(seen.clone()))
+            .build();
+        let router = finalize(sync);
+        let principal = Principal::from_user(AuthUser::new("ctx_user"));
+        let pull = SyncPullRequest::new(SyncStreamName::new("context_stream").unwrap());
+
+        let pulled: ServerResult<SyncPullResponse<String>> =
+            post_json(router, SYNC_PULL_PATH, &pull, Some(principal)).await;
+
+        assert!(pulled.is_ok());
+        assert_eq!(seen.lock().unwrap().as_slice(), &["ctx_user".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn guarded_stream_denies_push_before_default_unsupported() {
+        let router = router_with_guarded_posts_stream(require_auth());
+        let request = SyncPushRequest::<String> {
+            protocol: SYNC_PROTOCOL_V1.to_string(),
+            stream: SyncStreamName::new("posts_for_tenant").unwrap(),
+            mutations: Vec::new(),
+        };
+
+        let pushed: ServerResult<SyncPushResponse<String>> =
+            post_json(router, SYNC_PUSH_PATH, &request, None).await;
+
+        assert!(matches!(pushed, Err(ServerError::Unauthorized(_))));
     }
 
     #[test]
@@ -357,13 +525,113 @@ mod tests {
     }
 
     fn router_with_posts_stream() -> pocopine_server::axum::Router {
-        pocopine_server::__reset_for_test();
         let posts = MemorySyncStream::<String>::new("posts_for_tenant", "posts").unwrap();
         posts.upsert("post_1", "hello".to_string()).unwrap();
-        let sync = SyncServer::builder().stream(posts).build();
+        let sync = SyncServer::builder().public_stream(posts).build();
+        finalize(sync)
+    }
+
+    fn router_with_guarded_posts_stream<P>(predicate: P) -> Router
+    where
+        P: Predicate,
+    {
+        let posts = MemorySyncStream::<String>::new("posts_for_tenant", "posts").unwrap();
+        posts.upsert("post_1", "hello".to_string()).unwrap();
+        let sync = SyncServer::builder()
+            .guarded_stream(posts, predicate)
+            .build();
+        finalize(sync)
+    }
+
+    fn finalize(sync: SyncServer) -> Router {
+        pocopine_server::__reset_for_test();
         pocopine_server::Server::new(pocopine_server::axum::Router::new())
             .plugin(sync_server_plugin(sync))
             .try_finalize()
             .unwrap()
+    }
+
+    async fn post_json<T, R>(
+        router: Router,
+        uri: &str,
+        payload: &T,
+        principal: Option<Principal>,
+    ) -> ServerResult<R>
+    where
+        T: Serialize,
+        R: DeserializeOwned,
+    {
+        let response = router
+            .oneshot(sync_request(uri, payload, principal))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    fn sync_request<T>(uri: &str, payload: &T, principal: Option<Principal>) -> Request<Body>
+    where
+        T: Serialize,
+    {
+        let mut builder = Request::builder()
+            .method("POST")
+            .uri(uri)
+            .header("content-type", "application/json");
+        if let Some(principal) = principal {
+            builder = builder.extension(principal);
+        }
+        builder
+            .body(Body::from(serde_json::to_string(payload).unwrap()))
+            .unwrap()
+    }
+
+    struct ContextCaptureStream {
+        stream: SyncStreamName,
+        collection: SyncCollectionName,
+        seen: Arc<Mutex<Vec<String>>>,
+    }
+
+    impl ContextCaptureStream {
+        fn new(seen: Arc<Mutex<Vec<String>>>) -> Self {
+            Self {
+                stream: SyncStreamName::new("context_stream").unwrap(),
+                collection: SyncCollectionName::new("context").unwrap(),
+                seen,
+            }
+        }
+    }
+
+    impl SyncStreamSource for ContextCaptureStream {
+        fn stream(&self) -> &SyncStreamName {
+            &self.stream
+        }
+
+        fn collection(&self) -> &SyncCollectionName {
+            &self.collection
+        }
+
+        fn pull<'a>(
+            &'a self,
+            ctx: RequestContext,
+            request: SyncPullRequest,
+        ) -> SyncBoxFuture<'a, SyncPullResponse<Value>> {
+            let _ = request;
+            let user_id = ctx
+                .user
+                .user()
+                .map(|user| user.id.clone())
+                .unwrap_or_else(|| "anonymous".to_string());
+            self.seen.lock().unwrap().push(user_id.clone());
+            Box::pin(async move {
+                Ok(SyncPullResponse::snapshot(
+                    SyncStreamName::new("context_stream").unwrap(),
+                    SyncCollectionName::new("context").unwrap(),
+                    vec![SyncRow::new("ctx", json!(user_id))?],
+                    None,
+                ))
+            })
+        }
     }
 }

--- a/crates/pocopine-sync/src/state.rs
+++ b/crates/pocopine-sync/src/state.rs
@@ -231,7 +231,7 @@ impl<T> CollectionState<T> {
 mod tests {
     use super::*;
     use crate::{
-        RowKey, SyncChange, SyncCollectionName, SyncCursor, SyncPullResponse, SyncShapeName,
+        RowKey, SyncChange, SyncCollectionName, SyncCursor, SyncPullResponse, SyncStreamName,
     };
 
     #[test]
@@ -239,7 +239,7 @@ mod tests {
         let mut state = CollectionState::<String>::default();
         let request = state.begin_initial();
         let response = SyncPullResponse::snapshot(
-            SyncShapeName::new("posts").unwrap(),
+            SyncStreamName::new("posts").unwrap(),
             SyncCollectionName::new("posts").unwrap(),
             vec![SyncRow::new("post_1", "hello".to_string()).unwrap()],
             Some(SyncCursor::new("1").unwrap()),
@@ -259,7 +259,7 @@ mod tests {
         state.apply_pull(
             initial,
             SyncPullResponse::snapshot(
-                SyncShapeName::new("posts").unwrap(),
+                SyncStreamName::new("posts").unwrap(),
                 SyncCollectionName::new("posts").unwrap(),
                 vec![SyncRow::new("post_1", "old".to_string()).unwrap()],
                 Some(SyncCursor::new("1").unwrap()),
@@ -268,11 +268,11 @@ mod tests {
 
         let request = state.begin_pull(SyncReason::Manual);
         let response = SyncPullResponse::incremental(
-            SyncShapeName::new("posts").unwrap(),
+            SyncStreamName::new("posts").unwrap(),
             SyncCollectionName::new("posts").unwrap(),
             vec![
                 SyncChange {
-                    shape: SyncShapeName::new("posts").unwrap(),
+                    stream: SyncStreamName::new("posts").unwrap(),
                     collection: SyncCollectionName::new("posts").unwrap(),
                     key: None,
                     op: SyncOp::Upsert,
@@ -280,7 +280,7 @@ mod tests {
                     cursor: SyncCursor::new("2").unwrap(),
                 },
                 SyncChange {
-                    shape: SyncShapeName::new("posts").unwrap(),
+                    stream: SyncStreamName::new("posts").unwrap(),
                     collection: SyncCollectionName::new("posts").unwrap(),
                     key: Some(RowKey::new("post_1").unwrap()),
                     op: SyncOp::Delete,
@@ -305,7 +305,7 @@ mod tests {
         assert!(!state.apply_pull(
             stale,
             SyncPullResponse::snapshot(
-                SyncShapeName::new("posts").unwrap(),
+                SyncStreamName::new("posts").unwrap(),
                 SyncCollectionName::new("posts").unwrap(),
                 vec![SyncRow::new("post_1", "stale".to_string()).unwrap()],
                 None,
@@ -314,7 +314,7 @@ mod tests {
         assert!(state.apply_pull(
             current,
             SyncPullResponse::snapshot(
-                SyncShapeName::new("posts").unwrap(),
+                SyncStreamName::new("posts").unwrap(),
                 SyncCollectionName::new("posts").unwrap(),
                 vec![SyncRow::new("post_2", "current".to_string()).unwrap()],
                 None,
@@ -330,7 +330,7 @@ mod tests {
         state.apply_pull(
             initial,
             SyncPullResponse::snapshot(
-                SyncShapeName::new("posts").unwrap(),
+                SyncStreamName::new("posts").unwrap(),
                 SyncCollectionName::new("posts").unwrap(),
                 vec![SyncRow::new("post_1", "loaded".to_string()).unwrap()],
                 Some(SyncCursor::new("1").unwrap()),
@@ -368,7 +368,7 @@ mod tests {
         state.apply_pull(
             initial,
             SyncPullResponse::snapshot(
-                SyncShapeName::new("posts").unwrap(),
+                SyncStreamName::new("posts").unwrap(),
                 SyncCollectionName::new("posts").unwrap(),
                 vec![SyncRow::new("post_1", "loaded".to_string()).unwrap()],
                 Some(SyncCursor::new("1").unwrap()),
@@ -379,7 +379,7 @@ mod tests {
         assert!(state.apply_pull(
             request,
             SyncPullResponse::incremental(
-                SyncShapeName::new("posts").unwrap(),
+                SyncStreamName::new("posts").unwrap(),
                 SyncCollectionName::new("posts").unwrap(),
                 Vec::new(),
                 Some(SyncCursor::new("1").unwrap()),

--- a/crates/pocopine-sync/tests/client_browser.rs
+++ b/crates/pocopine-sync/tests/client_browser.rs
@@ -12,7 +12,7 @@ use js_sys::Promise;
 use pocopine::prelude::*;
 use pocopine_sync::{
     sync_plugin, CollectionState, SyncCollectionName, SyncOpenRequest, SyncOpenResponse,
-    SyncOpenShape, SyncPullRequest, SyncPullResponse, SyncRow, SyncShapeName, SYNC_OPEN_PATH,
+    SyncOpenStream, SyncPullRequest, SyncPullResponse, SyncRow, SyncStreamName, SYNC_OPEN_PATH,
     SYNC_PULL_PATH,
 };
 use serde::{Deserialize, Serialize};
@@ -23,7 +23,7 @@ use web_sys::window;
 
 wasm_bindgen_test_configure!(run_in_browser);
 
-const SHAPE: &str = "posts_for_browser";
+const STREAM: &str = "posts_for_browser";
 const COLLECTION: &str = "posts";
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -59,7 +59,7 @@ impl SyncBrowserBoard {
             .collection(pocopine::this::<Self>(), |state: &mut Self| {
                 &mut state.posts
             })
-            .shape(SHAPE)
+            .stream(STREAM)
             .and_then(|collection| collection.open())
         {
             self.posts.set_error(err.to_string());
@@ -68,7 +68,7 @@ impl SyncBrowserBoard {
 }
 
 #[wasm_bindgen_test(async)]
-async fn open_validates_shape_then_pull_renders_snapshot() {
+async fn open_validates_stream_then_pull_renders_snapshot() {
     pocopine::fetch::__reset_middleware_chain_for_test();
 
     let seen_urls = Rc::new(RefCell::new(Vec::<String>::new()));
@@ -81,9 +81,9 @@ async fn open_validates_shape_then_pull_renders_snapshot() {
                 match req.url.as_str() {
                     SYNC_OPEN_PATH => {
                         let request: SyncOpenRequest = serde_json::from_str(&req.body).unwrap();
-                        assert_eq!(request.shapes[0].as_str(), SHAPE);
-                        let response = SyncOpenResponse::new(vec![SyncOpenShape {
-                            shape: SyncShapeName::new(SHAPE).unwrap(),
+                        assert_eq!(request.streams[0].as_str(), STREAM);
+                        let response = SyncOpenResponse::new(vec![SyncOpenStream {
+                            stream: SyncStreamName::new(STREAM).unwrap(),
                             collection: SyncCollectionName::new(COLLECTION).unwrap(),
                             cursor: None,
                         }]);
@@ -91,13 +91,13 @@ async fn open_validates_shape_then_pull_renders_snapshot() {
                     }
                     SYNC_PULL_PATH => {
                         let request: SyncPullRequest = serde_json::from_str(&req.body).unwrap();
-                        assert_eq!(request.shape.as_str(), SHAPE);
+                        assert_eq!(request.stream.as_str(), STREAM);
                         assert!(
                             request.cursor.is_none(),
                             "the /open cursor must not make a fresh client skip its snapshot"
                         );
                         let response = SyncPullResponse::snapshot(
-                            SyncShapeName::new(SHAPE).unwrap(),
+                            SyncStreamName::new(STREAM).unwrap(),
                             SyncCollectionName::new(COLLECTION).unwrap(),
                             vec![SyncRow::new(
                                 "post_1",

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -12,7 +12,7 @@ The first implementation is intentionally small:
 This is not the full offline store yet. IndexedDB persistence,
 optimistic mutation replay, SQLx-backed adapters, and CDC integrations
 remain future work. The current API gives us the protocol boundary and a
-browser state stream that those backends can plug into later.
+browser state model that those backends can plug into later.
 
 The runnable source of truth is [`examples/sync`](../examples/sync/).
 When the sync API changes, update this document and the example in the
@@ -45,6 +45,7 @@ serde = { workspace = true }
 wasm-bindgen = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+pocopine-auth = { workspace = true }
 pocopine-events = { workspace = true }
 pocopine-live = { workspace = true }
 pocopine-logging = { workspace = true }
@@ -59,8 +60,9 @@ plugin and source traits.
 
 ## 2. Define A Stream
 
-A stream is the server-approved subset of data the browser can sync. It
-is not a database table name or arbitrary browser filter.
+A stream is the server-approved flow of sync state the browser can open
+and pull. It is not a database table name, arbitrary browser filter, or
+SSE/WebSocket transport.
 
 ```rust
 pub const POSTS_STREAM: &str = "posts_for_user";
@@ -91,9 +93,10 @@ pub fn posts_stream() -> pocopine_sync::MemorySyncStream<Post> {
 }
 ```
 
-Database-backed apps should hide authorization, tenant filters, delete
-privacy, and cursor validation inside their source implementation.
-Browsers only ask for registered stream names.
+Browsers only ask for registered stream names. Stream guards decide
+whether the request may use that stream; database-backed sources still
+own tenant filters, delete privacy, cursor validation, and per-row
+visibility.
 
 `MemorySyncStream<T>` is not a production backend. It keeps an unbounded
 in-memory change log and uses one process-local lock. Use it for tests,
@@ -102,7 +105,17 @@ examples, and explicit single-process demos.
 ## 3. Build The Sync Server
 
 `SyncServer` owns the registered streams and optionally shares the live
-event backend so it can publish wake-ups after mutations commit:
+event backend so it can publish wake-ups after mutations commit.
+
+Every stream registration is explicit:
+
+- `public_stream(...)` is for public demo or globally readable data.
+- `guarded_stream(..., predicate)` accepts `pocopine-auth` predicates
+  such as `require_auth()` or `require_role("admin")`.
+- `guarded_stream_with(..., guard)` accepts an async guard that receives
+  the same `RequestContext` used by server-function guards.
+
+The example is intentionally public so it can run without an auth setup:
 
 ```rust
 #[cfg(pocopine_host)]
@@ -113,12 +126,41 @@ pub fn sync_server() -> pocopine_sync::SyncServer {
     SYNC_SERVER
         .get_or_init(|| {
             pocopine_sync::SyncServer::builder()
-                .stream(posts_stream())
+                .public_stream(posts_stream())
                 .events(std::sync::Arc::new(live_backend()))
                 .build()
         })
         .clone()
 }
+```
+
+A protected app should register guarded streams instead:
+
+```rust
+use pocopine_auth::{require_auth, require_role};
+
+let sync = pocopine_sync::SyncServer::builder()
+    .guarded_stream(user_posts_stream(), require_auth())
+    .guarded_stream(admin_posts_stream(), require_role("admin"))
+    .guarded_stream_with(tenant_posts_stream(), |ctx| async move {
+        let user = ctx.require_user()?;
+        ensure_tenant_access(user)?;
+        Ok(())
+    })
+    .build();
+```
+
+Each `/open`, `/pull`, and `/push` request runs the stream guard before
+the stream source is called. `SyncStreamSource` receives the
+`RequestContext` after the guard passes, so sources can filter rows for
+the authenticated user or tenant:
+
+```rust
+fn pull<'a>(
+    &'a self,
+    ctx: pocopine_auth::RequestContext,
+    request: pocopine_sync::SyncPullRequest,
+) -> pocopine_sync::SyncBoxFuture<'a, pocopine_sync::SyncPullResponse<serde_json::Value>>;
 ```
 
 Publishing a sync invalidation does not send rows through SSE. It sends
@@ -174,12 +216,10 @@ async fn main() -> std::io::Result<()> {
 The default live topic policy is deny-all. `sync.live_topics()` returns
 only the wake-up topics for registered streams.
 
-This first sync slice does not make `/open` a server-side session
-boundary. A registered stream is pullable through `/pull`; `/open`
-validates discovery and gives the client metadata before the first pull.
-Production stream sources must enforce auth, tenant filtering, and cursor
-policy themselves, or the host app must mount sync behind an auth
-boundary.
+`/open` is not a session token. It validates discovery and gives the
+client metadata before the first pull, but `/pull` and `/push` still run
+the stream guard independently. A client that skips `/open` does not
+bypass access control.
 
 ## 5. Install The Browser Plugin
 
@@ -324,8 +364,9 @@ wasm-pack test --firefox --headless crates/pocopine-sync --test client_browser
   `CollectionState<T>`.
 - Memory backends are single-process. Multi-process sync needs shared
   event and data-source backends.
-- Authorization belongs to the stream source and route policy. Do not
-  treat a cursor or browser-provided stream name as proof of access.
+- Authorization belongs to stream guards plus the stream source's
+  row-level policy. Do not treat a cursor or browser-provided stream name
+  as proof of access.
 
 ## Future Backends
 

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -3,8 +3,8 @@
 `pocopine-sync` is the framework extension for cursor-based data sync.
 The first implementation is intentionally small:
 
-- the server owns named sync shapes,
-- the browser opens an authorized shape, then pulls a snapshot or
+- the server owns named sync streams,
+- the browser opens an authorized stream, then pulls a snapshot or
   incremental changes with a cursor,
 - `pocopine-live` is used only as a wake-up signal,
 - the data payload still moves through `POST /__pocopine/sync/v1/pull`.
@@ -12,7 +12,7 @@ The first implementation is intentionally small:
 This is not the full offline store yet. IndexedDB persistence,
 optimistic mutation replay, SQLx-backed adapters, and CDC integrations
 remain future work. The current API gives us the protocol boundary and a
-browser state shape that those backends can plug into later.
+browser state stream that those backends can plug into later.
 
 The runnable source of truth is [`examples/sync`](../examples/sync/).
 When the sync API changes, update this document and the example in the
@@ -22,15 +22,15 @@ same PR.
 
 A sync-enabled app needs five pieces:
 
-1. A stable shape name for the data the browser may sync.
-2. A host-side `SyncShapeSource` registered with `SyncServer`.
+1. A stable stream name for the data the browser may sync.
+2. A host-side `SyncStreamSource` registered with `SyncServer`.
 3. Sync routes mounted through `sync_server_plugin(...)`.
-4. Optional live routes that allow the sync shape's wake-up topic.
+4. Optional live routes that allow the sync stream's wake-up topic.
 5. A browser component with `CollectionState<T>` and `sync_plugin()`.
 
-The example uses `MemorySyncShape<Post>` so the whole flow can run
+The example uses `MemorySyncStream<Post>` so the whole flow can run
 without a database. Production adapters should implement
-`SyncShapeSource` and keep the browser code unchanged.
+`SyncStreamSource` and keep the browser code unchanged.
 
 ## 1. Enable The Extension Crate
 
@@ -57,13 +57,13 @@ tracing = { workspace = true }
 the client plugin and protocol/state types. The host gets the server
 plugin and source traits.
 
-## 2. Define A Shape
+## 2. Define A Stream
 
-A shape is the server-approved subset of data the browser can sync. It
+A stream is the server-approved subset of data the browser can sync. It
 is not a database table name or arbitrary browser filter.
 
 ```rust
-pub const POSTS_SHAPE: &str = "posts_for_user";
+pub const POSTS_STREAM: &str = "posts_for_user";
 pub const POSTS_COLLECTION: &str = "posts";
 ```
 
@@ -72,20 +72,20 @@ single-process apps:
 
 ```rust
 #[cfg(pocopine_host)]
-pub fn posts_shape() -> pocopine_sync::MemorySyncShape<Post> {
+pub fn posts_stream() -> pocopine_sync::MemorySyncStream<Post> {
     static POSTS_SYNC: std::sync::OnceLock<
-        pocopine_sync::MemorySyncShape<Post>,
+        pocopine_sync::MemorySyncStream<Post>,
     > = std::sync::OnceLock::new();
 
     POSTS_SYNC
         .get_or_init(|| {
-            let shape =
-                pocopine_sync::MemorySyncShape::new(POSTS_SHAPE, POSTS_COLLECTION)
-                    .expect("shape names must be valid");
-            shape
+            let stream =
+                pocopine_sync::MemorySyncStream::new(POSTS_STREAM, POSTS_COLLECTION)
+                    .expect("stream names must be valid");
+            stream
                 .upsert("post_1", Post::seeded())
                 .expect("seed post should sync");
-            shape
+            stream
         })
         .clone()
 }
@@ -93,15 +93,15 @@ pub fn posts_shape() -> pocopine_sync::MemorySyncShape<Post> {
 
 Database-backed apps should hide authorization, tenant filters, delete
 privacy, and cursor validation inside their source implementation.
-Browsers only ask for registered shape names.
+Browsers only ask for registered stream names.
 
-`MemorySyncShape<T>` is not a production backend. It keeps an unbounded
+`MemorySyncStream<T>` is not a production backend. It keeps an unbounded
 in-memory change log and uses one process-local lock. Use it for tests,
 examples, and explicit single-process demos.
 
 ## 3. Build The Sync Server
 
-`SyncServer` owns the registered shapes and optionally shares the live
+`SyncServer` owns the registered streams and optionally shares the live
 event backend so it can publish wake-ups after mutations commit:
 
 ```rust
@@ -113,7 +113,7 @@ pub fn sync_server() -> pocopine_sync::SyncServer {
     SYNC_SERVER
         .get_or_init(|| {
             pocopine_sync::SyncServer::builder()
-                .shape(posts_shape())
+                .stream(posts_stream())
                 .events(std::sync::Arc::new(live_backend()))
                 .build()
         })
@@ -127,7 +127,7 @@ a query-tag wake-up that tells the browser to call `pull`:
 ```rust
 #[cfg(pocopine_host)]
 async fn invalidate_posts() {
-    if let Err(err) = sync_server().invalidate_shape(POSTS_SHAPE).await {
+    if let Err(err) = sync_server().invalidate_stream(POSTS_STREAM).await {
         tracing::warn!(
             target: "pocopine.log",
             error = %err,
@@ -172,12 +172,12 @@ async fn main() -> std::io::Result<()> {
 ```
 
 The default live topic policy is deny-all. `sync.live_topics()` returns
-only the wake-up topics for registered shapes.
+only the wake-up topics for registered streams.
 
 This first sync slice does not make `/open` a server-side session
-boundary. A registered shape is pullable through `/pull`; `/open`
+boundary. A registered stream is pullable through `/pull`; `/open`
 validates discovery and gives the client metadata before the first pull.
-Production shape sources must enforce auth, tenant filtering, and cursor
+Production stream sources must enforce auth, tenant filtering, and cursor
 policy themselves, or the host app must mount sync behind an auth
 boundary.
 
@@ -219,7 +219,7 @@ impl SyncBoard {
         let result = self
             .plugin::<pocopine_sync::SyncClient>()
             .collection(pocopine::this::<Self>(), |s: &mut Self| &mut s.posts)
-            .shape(POSTS_SHAPE)
+            .stream(POSTS_STREAM)
             .and_then(|collection| collection.open());
 
         if let Err(err) = result {
@@ -229,12 +229,12 @@ impl SyncBoard {
 }
 ```
 
-`open()` first calls `/__pocopine/sync/v1/open` to validate the shape,
+`open()` first calls `/__pocopine/sync/v1/open` to validate the stream,
 then calls `/__pocopine/sync/v1/pull`. A fresh client still pulls
 without a cursor so it receives a snapshot; the server's current cursor
 from `open` is metadata, not permission to skip initial data. When live
-wake-up is enabled, `open()` also subscribes to the shape's wake-up topic
-and pulls again whenever the server invalidates that shape. `pull()` can
+wake-up is enabled, `open()` also subscribes to the stream's wake-up topic
+and pulls again whenever the server invalidates that stream. `pull()` can
 be called manually for refresh buttons.
 
 Templates read `CollectionState<T>` directly:
@@ -266,7 +266,7 @@ write succeeds:
 pub async fn create_post(title: String, body: String) -> ServerResult<Post> {
     let post = insert_post(title, body)?;
 
-    posts_shape()
+    posts_stream()
         .upsert(post.id.clone(), post.clone())
         .map_err(|err| ServerError::App(err.to_string()))?;
 
@@ -306,10 +306,10 @@ wasm-pack test --firefox --headless crates/pocopine-sync --test client_browser
 
 ## Protocol Boundary
 
-- `open` validates shape names and reports registered shape metadata.
+- `open` validates stream names and reports registered stream metadata.
   The browser client calls it before the first `pull`.
 - `pull` returns either a full snapshot or incremental changes.
-- `push` exists in the protocol, but the memory shape rejects it until
+- `push` exists in the protocol, but the memory stream rejects it until
   optimistic mutations and conflict policy are implemented.
 - Cursors are opaque. Components should store and resend them, not parse
   them.
@@ -324,14 +324,14 @@ wasm-pack test --firefox --headless crates/pocopine-sync --test client_browser
   `CollectionState<T>`.
 - Memory backends are single-process. Multi-process sync needs shared
   event and data-source backends.
-- Authorization belongs to the shape source and route policy. Do not
-  treat a cursor or browser-provided shape name as proof of access.
+- Authorization belongs to the stream source and route policy. Do not
+  treat a cursor or browser-provided stream name as proof of access.
 
 ## Future Backends
 
 Keep these as separate adapter crates:
 
-- `pocopine-sync-sqlx` for compile-time checked SQL shapes,
+- `pocopine-sync-sqlx` for compile-time checked SQL streams,
 - `pocopine-sync-indexeddb` for browser persistence,
 - `pocopine-sync-redis` for shared cursor/change storage.
 

--- a/examples/sync/README.md
+++ b/examples/sync/README.md
@@ -18,6 +18,9 @@ wakes the other tab over SSE; the data itself is fetched from
 `/__pocopine/sync/v1/pull`.
 
 This example uses memory backends, so it is intentionally single-process.
+It registers its stream with `public_stream(...)` to avoid bundling an
+auth setup into the demo; production apps should use `guarded_stream(...)`
+or `guarded_stream_with(...)`.
 Future database adapters should keep this same browser stream while
 replacing the server-side source.
 

--- a/examples/sync/README.md
+++ b/examples/sync/README.md
@@ -2,8 +2,8 @@
 
 Small app showing the first sync protocol slice:
 
-- server functions mutate a process-local `MemorySyncShape<Post>`,
-- `pocopine-sync` opens the shape, then serves snapshot and incremental pulls,
+- server functions mutate a process-local `MemorySyncStream<Post>`,
+- `pocopine-sync` opens the stream, then serves snapshot and incremental pulls,
 - `pocopine-live` sends only wake-up events,
 - the browser stores rows in `CollectionState<Post>` and pulls with its cursor.
 
@@ -18,7 +18,7 @@ wakes the other tab over SSE; the data itself is fetched from
 `/__pocopine/sync/v1/pull`.
 
 This example uses memory backends, so it is intentionally single-process.
-Future database adapters should keep this same browser shape while
+Future database adapters should keep this same browser stream while
 replacing the server-side source.
 
 Checks:

--- a/examples/sync/src/lib.rs
+++ b/examples/sync/src/lib.rs
@@ -4,14 +4,14 @@ use serde::{Deserialize, Serialize};
 #[cfg(pocopine_host)]
 use {
     pocopine_events::MemoryEventBackend,
-    pocopine_sync::{MemorySyncShape, SyncServer},
+    pocopine_sync::{MemorySyncStream, SyncServer},
     std::sync::{
         atomic::{AtomicU64, Ordering},
         Arc, OnceLock,
     },
 };
 
-pub const POSTS_SHAPE: &str = "posts_for_user";
+pub const POSTS_STREAM: &str = "posts_for_user";
 pub const POSTS_COLLECTION: &str = "posts";
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
@@ -32,7 +32,7 @@ pub struct SyncBoard {
 }
 
 #[cfg(pocopine_host)]
-static POSTS_SYNC: OnceLock<MemorySyncShape<Post>> = OnceLock::new();
+static POSTS_SYNC: OnceLock<MemorySyncStream<Post>> = OnceLock::new();
 #[cfg(pocopine_host)]
 static LIVE_BACKEND: OnceLock<MemoryEventBackend> = OnceLock::new();
 #[cfg(pocopine_host)]
@@ -41,12 +41,12 @@ static SYNC_SERVER: OnceLock<SyncServer> = OnceLock::new();
 static NEXT_POST_ID: AtomicU64 = AtomicU64::new(3);
 
 #[cfg(pocopine_host)]
-pub fn posts_shape() -> MemorySyncShape<Post> {
+pub fn posts_stream() -> MemorySyncStream<Post> {
     POSTS_SYNC
         .get_or_init(|| {
-            let shape = MemorySyncShape::new(POSTS_SHAPE, POSTS_COLLECTION)
-                .expect("sync example shape names must be valid");
-            shape
+            let stream = MemorySyncStream::new(POSTS_STREAM, POSTS_COLLECTION)
+                .expect("sync example stream names must be valid");
+            stream
                 .upsert(
                     "post_1",
                     Post {
@@ -56,7 +56,7 @@ pub fn posts_shape() -> MemorySyncShape<Post> {
                     },
                 )
                 .expect("seed post should sync");
-            shape
+            stream
                 .upsert(
                     "post_2",
                     Post {
@@ -67,7 +67,7 @@ pub fn posts_shape() -> MemorySyncShape<Post> {
                     },
                 )
                 .expect("seed post should sync");
-            shape
+            stream
         })
         .clone()
 }
@@ -82,7 +82,7 @@ pub fn sync_server() -> SyncServer {
     SYNC_SERVER
         .get_or_init(|| {
             SyncServer::builder()
-                .shape(posts_shape())
+                .stream(posts_stream())
                 .events(Arc::new(live_backend()))
                 .build()
         })
@@ -91,7 +91,7 @@ pub fn sync_server() -> SyncServer {
 
 #[cfg(pocopine_host)]
 async fn invalidate_posts() {
-    if let Err(err) = sync_server().invalidate_shape(POSTS_SHAPE).await {
+    if let Err(err) = sync_server().invalidate_stream(POSTS_STREAM).await {
         tracing::warn!(
             target: "pocopine.log",
             error = %err,
@@ -117,7 +117,7 @@ pub async fn create_post(title: String, body: String) -> ServerResult<Post> {
         body: body.to_string(),
     };
 
-    posts_shape()
+    posts_stream()
         .upsert(post.id.clone(), post.clone())
         .map_err(|err| ServerError::App(err.to_string()))?;
     invalidate_posts().await;
@@ -126,7 +126,7 @@ pub async fn create_post(title: String, body: String) -> ServerResult<Post> {
 
 #[pocopine::server(public)]
 pub async fn reset_posts() -> ServerResult<()> {
-    posts_shape()
+    posts_stream()
         .reset()
         .map_err(|err| ServerError::App(err.to_string()))?;
     invalidate_posts().await;
@@ -136,11 +136,11 @@ pub async fn reset_posts() -> ServerResult<()> {
 #[handlers]
 impl SyncBoard {
     pub fn on_mount(&mut self) {
-        self.status = "opening sync shape".to_string();
+        self.status = "opening sync stream".to_string();
         let result = self
             .plugin::<pocopine_sync::SyncClient>()
             .collection(pocopine::this::<Self>(), |s: &mut Self| &mut s.posts)
-            .shape(POSTS_SHAPE)
+            .stream(POSTS_STREAM)
             .and_then(|collection| collection.open());
 
         if let Err(err) = result {
@@ -182,7 +182,7 @@ impl SyncBoard {
         let result = self
             .plugin::<pocopine_sync::SyncClient>()
             .collection(pocopine::this::<Self>(), |s: &mut Self| &mut s.posts)
-            .shape(POSTS_SHAPE)
+            .stream(POSTS_STREAM)
             .and_then(|collection| collection.pull());
 
         if let Err(err) = result {

--- a/examples/sync/src/lib.rs
+++ b/examples/sync/src/lib.rs
@@ -82,7 +82,7 @@ pub fn sync_server() -> SyncServer {
     SYNC_SERVER
         .get_or_init(|| {
             SyncServer::builder()
-                .stream(posts_stream())
+                .public_stream(posts_stream())
                 .events(Arc::new(live_backend()))
                 .build()
         })

--- a/examples/sync/tests/sync_flow.rs
+++ b/examples/sync/tests/sync_flow.rs
@@ -6,14 +6,14 @@ use pocopine_server::axum::body::Body;
 use pocopine_server::axum::http::{Request, StatusCode};
 use pocopine_server::Server;
 use pocopine_sync::{
-    sync_server_plugin, sync_shape_tag, SyncPullMode, SyncPullRequest, SyncPullResponse,
-    SyncShapeName, SYNC_PULL_PATH,
+    sync_server_plugin, sync_stream_tag, SyncPullMode, SyncPullRequest, SyncPullResponse,
+    SyncStreamName, SYNC_PULL_PATH,
 };
-use sync_example::{create_post, live_backend, sync_server, Post, POSTS_SHAPE};
+use sync_example::{create_post, live_backend, sync_server, Post, POSTS_STREAM};
 use tower::ServiceExt;
 
 #[tokio::test]
-async fn sync_pull_and_live_wakeup_share_the_shape_topic() {
+async fn sync_pull_and_live_wakeup_share_the_stream_topic() {
     pocopine_server::__reset_for_test();
     let sync = sync_server();
     let sync_topics = sync.live_topics().unwrap();
@@ -33,7 +33,7 @@ async fn sync_pull_and_live_wakeup_share_the_shape_topic() {
     let stream_url = build_live_stream_url(
         LIVE_STREAM_PATH,
         &[],
-        &[format!("query:{}", sync_shape_tag(POSTS_SHAPE))],
+        &[format!("query:{}", sync_stream_tag(POSTS_STREAM))],
         None,
     )
     .unwrap();
@@ -52,7 +52,7 @@ async fn sync_pull_and_live_wakeup_share_the_shape_topic() {
     let mut body = response.into_body();
     let ready = read_sse_frame(&mut body).await;
     assert!(ready.contains("event: ready"));
-    assert!(ready.contains("query:sync:shape:posts_for_user"));
+    assert!(ready.contains("query:sync:stream:posts_for_user"));
 
     create_post(
         "CI sync wake-up".to_string(),
@@ -63,7 +63,7 @@ async fn sync_pull_and_live_wakeup_share_the_shape_topic() {
 
     let invalidation = read_sse_frame(&mut body).await;
     assert!(invalidation.contains("event: query.invalidated"));
-    assert!(invalidation.contains("sync:shape:posts_for_user"));
+    assert!(invalidation.contains("sync:stream:posts_for_user"));
 
     let second = pull_posts(&app, first.cursor).await;
     assert_eq!(second.mode, SyncPullMode::Incremental);
@@ -80,7 +80,7 @@ async fn pull_posts(
     app: &pocopine_server::axum::Router,
     cursor: Option<pocopine_sync::SyncCursor>,
 ) -> SyncPullResponse<Post> {
-    let request = SyncPullRequest::new(SyncShapeName::new(POSTS_SHAPE).unwrap()).cursor(cursor);
+    let request = SyncPullRequest::new(SyncStreamName::new(POSTS_STREAM).unwrap()).cursor(cursor);
     let response = app
         .clone()
         .oneshot(

--- a/rfcs/rfc-072-offline-sync-protocol.md
+++ b/rfcs/rfc-072-offline-sync-protocol.md
@@ -15,22 +15,22 @@ Initial implementation has started in `pocopine-sync`:
 - explicit extension crate, not a `pocopine` core feature,
 - target-specific browser and host modules in one crate,
 - `/__pocopine/sync/v1/open`, `/pull`, and `/push` protocol routes,
-- `SyncServer`, `SyncShapeSource`, and `MemorySyncShape`,
+- `SyncServer`, `SyncStreamSource`, and `MemorySyncStream`,
 - browser `sync_plugin()`, `SyncClient`, and `CollectionState<T>`,
 - browser `SyncClient::open()` calls `/open` before the first `/pull`,
 - live wake-up integration through `pocopine-live` query-tag topics,
 - runnable memory-backed example in `examples/sync`,
 - Firefox wasm smoke coverage for `open -> pull -> render`.
 
-Current limitation: registered shapes are pullable through `/pull`;
+Current limitation: registered streams are pullable through `/pull`;
 `/open` is a discovery/validation step, not a server-side session grant.
-Shape-level guards remain part of the RFC target model and must be
-enforced inside shape sources or in front of the sync server until that
+Stream-level guards remain part of the RFC target model and must be
+enforced inside stream sources or in front of the sync server until that
 follow-up lands.
 
-Still future work: shape auth/guards, durable browser storage,
+Still future work: stream auth/guards, durable browser storage,
 optimistic mutation replay, conflict resolution UI, SQLx/database
-adapters, CDC sources, and query-driven shape parameters.
+adapters, CDC sources, and query-driven stream parameters.
 
 ## 1. Summary
 
@@ -68,7 +68,7 @@ the fact. They need a stable protocol boundary.
   SQL without making SQLx a framework-wide dependency.
 - Support initial snapshots, incremental pulls, mutation pushes, and
   cursor-based resume.
-- Make sync shapes explicit and guarded.
+- Make sync streams explicit and guarded.
 - Let components query normalized local data instead of forcing
   view-specific server endpoints.
 - Provide safe defaults for conflict handling.
@@ -85,12 +85,12 @@ the fact. They need a stable protocol boundary.
 
 ## 5. Core Concepts
 
-### 5.1 Shape
+### 5.1 Stream
 
-A shape is a named, authorized subset of application data:
+A stream is a named, authorized subset of application data:
 
 ```rust
-pocopine::sync_shape! {
+pocopine::sync_stream! {
     posts_for_tenant {
         collection: posts;
         key: PostId;
@@ -101,7 +101,7 @@ pocopine::sync_shape! {
 }
 ```
 
-The client subscribes to shape names. It does not send table names, SQL
+The client subscribes to stream names. It does not send table names, SQL
 fragments, or raw database filters.
 
 ### 5.2 Cursor
@@ -111,7 +111,7 @@ such as a Redis stream id, database LSN, sequence id, or framework
 logical clock. Clients must not parse it.
 
 If a cursor expires or is no longer available, the server returns `gap`
-and the client must resnapshot the shape.
+and the client must resnapshot the stream.
 
 ### 5.3 Change
 
@@ -119,7 +119,7 @@ The sync protocol has a stable change envelope:
 
 ```rust
 pub struct SyncChange {
-    pub shape: String,
+    pub stream: String,
     pub key: serde_json::Value,
     pub op: SyncOp,
     pub version: RowVersion,
@@ -155,7 +155,7 @@ let posts = sync.collection::<PostSyncView>("posts_for_tenant");
 
 Collections may be populated by:
 
-- sync shapes from this RFC,
+- sync streams from this RFC,
 - ordinary server-function/query fetches,
 - local-only browser state,
 - direct framework writes from live events or CDC adapters.
@@ -206,7 +206,7 @@ storage.
 ### 6.3 Query-driven sync
 
 For large datasets, the observed frontend query should be able to drive
-which server shape subset is loaded:
+which server stream subset is loaded:
 
 ```rust
 let products = sync.collection::<ProductView>("products");
@@ -220,8 +220,8 @@ let results = sync.live_query(|q| {
 ```
 
 The client does not send arbitrary executable filters. The framework maps
-supported query predicates onto registered shape parameters. Unsupported
-predicates run locally after the authorized shape subset is loaded.
+supported query predicates onto registered stream parameters. Unsupported
+predicates run locally after the authorized stream subset is loaded.
 
 This gives the desired "query the local store from components" workflow
 without creating a raw database query API in the browser.
@@ -314,7 +314,7 @@ Request:
 
 ```json
 {
-  "shapes": ["posts_for_tenant"],
+  "streams": ["posts_for_tenant"],
   "client_id": "device_abc",
   "known_cursors": {}
 }
@@ -325,7 +325,7 @@ Response:
 ```json
 {
   "session_id": "sync_sess_123",
-  "shapes": [
+  "streams": [
     {
       "name": "posts_for_tenant",
       "snapshot_url": "/__pocopine/sync/v1/snapshot/snap_123",
@@ -341,7 +341,7 @@ Response:
 POST /__pocopine/sync/v1/pull
 ```
 
-The client sends shape cursors. The server returns ordered changes and a
+The client sends stream cursors. The server returns ordered changes and a
 new cursor. Pull responses may be empty.
 
 ### 7.3 Push
@@ -358,7 +358,7 @@ The client sends mutations:
   "mutations": [
     {
       "mutation_id": "device_abc:42",
-      "shape": "posts_for_tenant",
+      "stream": "posts_for_tenant",
       "key": "post_123",
       "base_version": "row:v7",
       "op": "update",
@@ -397,7 +397,7 @@ Later phases can add CDC adapters:
 
 ```rust
 pub trait ChangeSource {
-    async fn snapshot(&self, shape: ShapeRequest) -> SyncResult<Snapshot>;
+    async fn snapshot(&self, stream: StreamRequest) -> SyncResult<Snapshot>;
     async fn changes_since(&self, cursor: SyncCursor) -> SyncResult<ChangeBatch>;
 }
 ```
@@ -426,10 +426,10 @@ sqlx = { version = "0.8", features = [
 ] }
 ```
 
-Inline checked SQL should be the default authoring path for small shapes:
+Inline checked SQL should be the default authoring path for small streams:
 
 ```rust
-pocopine::sync_shape! {
+pocopine::sync_stream! {
     posts_for_tenant {
         collection: posts;
         key: PostId;
@@ -470,17 +470,17 @@ sqlx::query_file_as!(
 The adapter contract:
 
 - SQL remains normal SQL, not a Pocopine ORM DSL.
-- Inline `query!`/`query_as!` is preferred for simple shapes.
+- Inline `query!`/`query_as!` is preferred for simple streams.
 - `query_file!`/`query_file_as!` is supported for large or shared SQL.
 - Compile-time checking requires `DATABASE_URL` at build time or checked
   in SQLx offline metadata under `.sqlx`.
 - CI for SQLx-enabled apps should run `cargo sqlx prepare --check`.
-- Frontend query predicates must map to declared shape parameters. They
+- Frontend query predicates must map to declared stream parameters. They
   must not produce unchecked SQL string concatenation.
 
-SQLx checks query shape and database/Rust types for supported macros. It
+SQLx checks query stream and database/Rust types for supported macros. It
 does not prove tenant isolation, authorization, conflict correctness, or
-delete privacy. Pocopine still owns those safety checks through shape
+delete privacy. Pocopine still owns those safety checks through stream
 guards, server-side mutation policy, cursor validation, and tombstone
 rules.
 
@@ -489,8 +489,8 @@ rules.
 Sync does not need to keep a long-running bidirectional socket open for
 the first version. The client can use `pocopine-live` as a wake-up path:
 
-1. open the sync shape and load the snapshot,
-2. listen for `shape.invalidated`,
+1. open the sync stream and load the snapshot,
+2. listen for `stream.invalidated`,
 3. call `pull` with the current cursor,
 4. apply returned changes to the local store.
 
@@ -498,15 +498,15 @@ If the live stream drops, the next pull is still authoritative.
 
 ## 11. Security Model
 
-- Every shape must have a guard.
-- Shape filters run on the server.
+- Every stream must have a guard.
+- Stream filters run on the server.
 - Clients cannot invent new filters.
 - Pushes execute through typed server mutations, not direct table writes.
 - Tombstones reveal only keys unless explicitly configured.
 - Cursor tokens must not grant access by themselves; access is checked on
   every open, pull, and push.
-- Frontend query predicates may narrow an authorized shape but must not
-  expand it beyond the server-registered shape guard.
+- Frontend query predicates may narrow an authorized stream but must not
+  expand it beyond the server-registered stream guard.
 - SQLx compile-time checks, when enabled, are query/type checks only.
   They are not authorization proofs.
 
@@ -526,21 +526,21 @@ Mutation payloads and row payloads are not logged.
 
 ### Phase A - Manual source, HTTP protocol
 
-- Add sync shape registration and guarded open/pull/push endpoints.
+- Add sync stream registration and guarded open/pull/push endpoints.
 - Use application-published changes as the source.
 - Add memory frontend collection store.
 - Add basic live queries with conservative recomputation.
 
 ### Phase B - Live wake-up
 
-- Emit `shape.invalidated` through RFC 071.
+- Emit `stream.invalidated` through RFC 071.
 - Add browser helper that pulls on invalidation.
 - Apply server changes directly to synced collections.
 
 ### Phase C - CDC adapters
 
 - Add Postgres adapter using logical replication or Supabase ETL.
-- Map database changes into shape changes.
+- Map database changes into stream changes.
 - Add tests for delete privacy and cursor gaps.
 
 ### Phase D - Local store helpers
@@ -556,7 +556,7 @@ Mutation payloads and row payloads are not logged.
 
 ### Phase F - Query-driven sync
 
-- Map supported frontend predicates to shape parameters.
+- Map supported frontend predicates to stream parameters.
 - Add request coalescing and subset expansion.
 - Keep unsupported predicates as local-only filters.
 
@@ -574,7 +574,7 @@ Mutation payloads and row payloads are not logged.
 - Local-first software paper: https://www.inkandswitch.com/essay/local-first/
 - Automerge sync protocol: https://automerge.org/automerge/automerge/sync/index.html
 - CouchDB replication protocol: https://docs.couchdb.org/en/stable/replication/protocol.html
-- ElectricSQL sync engine and shapes: https://electric-sql.com/product/sync
+- ElectricSQL sync engine and streams: https://electric-sql.com/product/sync
 - PostgreSQL logical replication: https://www.postgresql.org/docs/current/logical-replication.html
 - Supabase ETL: https://supabase.github.io/etl/
 - TanStack DB overview: https://tanstack.com/db/latest/docs/overview

--- a/rfcs/rfc-072-offline-sync-protocol.md
+++ b/rfcs/rfc-072-offline-sync-protocol.md
@@ -16,21 +16,24 @@ Initial implementation has started in `pocopine-sync`:
 - target-specific browser and host modules in one crate,
 - `/__pocopine/sync/v1/open`, `/pull`, and `/push` protocol routes,
 - `SyncServer`, `SyncStreamSource`, and `MemorySyncStream`,
+- explicit `public_stream`, `guarded_stream`, and
+  `guarded_stream_with` registration,
+- stream guards run on `/open`, `/pull`, and `/push`,
+- `SyncStreamSource::pull` / `push` receive `RequestContext` after the
+  stream guard passes,
 - browser `sync_plugin()`, `SyncClient`, and `CollectionState<T>`,
 - browser `SyncClient::open()` calls `/open` before the first `/pull`,
 - live wake-up integration through `pocopine-live` query-tag topics,
 - runnable memory-backed example in `examples/sync`,
 - Firefox wasm smoke coverage for `open -> pull -> render`.
 
-Current limitation: registered streams are pullable through `/pull`;
-`/open` is a discovery/validation step, not a server-side session grant.
-Stream-level guards remain part of the RFC target model and must be
-enforced inside stream sources or in front of the sync server until that
-follow-up lands.
+Current model: `/open` is discovery/validation, not a session grant.
+Every `/open`, `/pull`, and `/push` request runs the stream guard
+independently, so skipping `/open` does not bypass access control.
 
-Still future work: stream auth/guards, durable browser storage,
-optimistic mutation replay, conflict resolution UI, SQLx/database
-adapters, CDC sources, and query-driven stream parameters.
+Still future work: durable browser storage, optimistic mutation replay,
+conflict resolution UI, SQLx/database adapters, CDC sources, and
+query-driven stream parameters.
 
 ## 1. Summary
 
@@ -103,6 +106,24 @@ pocopine::sync_stream! {
 
 The client subscribes to stream names. It does not send table names, SQL
 fragments, or raw database filters.
+
+Streams are registered explicitly:
+
+```rust
+SyncServer::builder()
+    .public_stream(public_posts_stream())
+    .guarded_stream(user_posts_stream(), require_auth())
+    .guarded_stream(admin_posts_stream(), require_role("admin"))
+    .guarded_stream_with(tenant_posts_stream(), |ctx| async move {
+        let user = ctx.require_user()?;
+        ensure_tenant_access(user)?;
+        Ok(())
+    })
+    .build();
+```
+
+There is no implicit public registration. Public streams are an explicit
+author choice.
 
 ### 5.2 Cursor
 
@@ -478,7 +499,7 @@ The adapter contract:
 - Frontend query predicates must map to declared stream parameters. They
   must not produce unchecked SQL string concatenation.
 
-SQLx checks query stream and database/Rust types for supported macros. It
+SQLx checks query structure and database/Rust types for supported macros. It
 does not prove tenant isolation, authorization, conflict correctness, or
 delete privacy. Pocopine still owns those safety checks through stream
 guards, server-side mutation policy, cursor validation, and tombstone
@@ -498,13 +519,16 @@ If the live stream drops, the next pull is still authoritative.
 
 ## 11. Security Model
 
-- Every stream must have a guard.
+- Every stream must be explicitly registered as public or guarded.
 - Stream filters run on the server.
 - Clients cannot invent new filters.
 - Pushes execute through typed server mutations, not direct table writes.
 - Tombstones reveal only keys unless explicitly configured.
 - Cursor tokens must not grant access by themselves; access is checked on
   every open, pull, and push.
+- `SyncStreamSource` receives `RequestContext` after stream-level access
+  passes so the source can apply user/tenant filters before producing
+  rows or accepting mutations.
 - Frontend query predicates may narrow an authorized stream but must not
   expand it beyond the server-registered stream guard.
 - SQLx compile-time checks, when enabled, are query/type checks only.


### PR DESCRIPTION
## Summary
- rename the sync boundary from shape to stream across `pocopine-sync`, the sync example, docs, RFC 072, and browser tests
- replace implicit server registration with explicit `public_stream`, `guarded_stream`, and `guarded_stream_with`
- run stream guards on `/open`, `/pull`, and `/push`, and pass `RequestContext` into stream sources after access passes
- document public vs guarded streams and keep the sync example intentionally public

## Verification
- [x] `cargo fmt --check`
- [x] `cargo test -p pocopine-sync`
- [x] `cargo test -p sync-example`
- [x] `cargo clippy -p pocopine-sync -p sync-example --all-targets -- -D warnings`
- [x] `wasm-pack test --firefox --headless crates/pocopine-sync --test client_browser`
- [x] `wasm-pack build --release --target web examples/sync`