### PR TITLE
Document chart interaction composition

### DIFF
--- a/crates/pine-charts/src/area/PineAreaChart.poco
+++ b/crates/pine-charts/src/area/PineAreaChart.poco
@@ -27,7 +27,7 @@
        focusable="false"
        @pointermove="on_pointer_move"
        @pointerleave="clear_hover"
-       @click="clear_selection">
+       @click="select_hovered_or_clear">
     <g pp-show="ready"
        class="pine-chart-grid"
        data-layer="grid"

--- a/crates/pine-charts/src/area/mod.rs
+++ b/crates/pine-charts/src/area/mod.rs
@@ -420,6 +420,25 @@ impl PineAreaChart {
         }
     }
 
+    pub fn select_hovered_or_clear(&mut self) {
+        if self.hover_visible {
+            let key = nearest_line_sample_at(
+                &self.samples,
+                Point {
+                    x: self.hover_x,
+                    y: self.hover_y,
+                },
+            )
+            .map(|sample| sample.key.clone());
+            if let Some(key) = key {
+                self.select_sample(key);
+                return;
+            }
+        }
+
+        self.clear_selection();
+    }
+
     pub fn focus_next_sample(&mut self) {
         self.step_sample_focus(1);
     }

--- a/crates/pine-charts/src/line/PineLineChart.poco
+++ b/crates/pine-charts/src/line/PineLineChart.poco
@@ -27,7 +27,7 @@
        focusable="false"
        @pointermove="on_pointer_move"
        @pointerleave="clear_hover"
-       @click="clear_selection">
+       @click="select_hovered_or_clear">
     <g pp-show="ready"
        class="pine-chart-grid"
        data-layer="grid"

--- a/crates/pine-charts/src/line/mod.rs
+++ b/crates/pine-charts/src/line/mod.rs
@@ -605,6 +605,25 @@ impl PineLineChart {
         }
     }
 
+    pub fn select_hovered_or_clear(&mut self) {
+        if self.hover_visible {
+            let key = nearest_line_sample_at(
+                &self.samples,
+                Point {
+                    x: self.hover_x,
+                    y: self.hover_y,
+                },
+            )
+            .map(|sample| sample.key.clone());
+            if let Some(key) = key {
+                self.select_sample(key);
+                return;
+            }
+        }
+
+        self.clear_selection();
+    }
+
     pub fn focus_next_sample(&mut self) {
         self.step_sample_focus(1);
     }

--- a/crates/pine-charts/tests/charts.rs
+++ b/crates/pine-charts/tests/charts.rs
@@ -1389,6 +1389,21 @@ async fn area_chart_renders_fills_lines_and_hover_metadata() {
     let selected_kind = listen_string_field(&chart, CHART_SELECT_EVENT, "kind");
     let selected_label = listen_string_field(&chart, CHART_SELECT_EVENT, "label");
     let selected_x = listen_string_field(&chart, CHART_SELECT_EVENT, "x_label");
+    dispatch_click(&svg);
+    settle().await;
+
+    let hovered_marker = host
+        .query_selector(".pine-area-chart .pine-chart-marker[data-selected]")
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        hovered_marker.get_attribute("data-series").as_deref(),
+        Some("Target")
+    );
+    assert_eq!(selected_kind.borrow().as_deref(), Some("xy"));
+    assert_eq!(selected_label.borrow().as_deref(), Some("Target: x 1, y 0"));
+    assert_eq!(selected_x.borrow().as_deref(), Some("1"));
+
     let first_marker = markers.get(0).unwrap().dyn_into::<Element>().unwrap();
     dispatch_click(&first_marker);
     settle().await;
@@ -1569,6 +1584,17 @@ async fn line_chart_supports_marker_selection_and_keyboard_focus() {
     assert!(!third.has_attribute("data-selected"));
     let third_key = third.get_attribute("data-key");
     assert_eq!(cleared_key.borrow().as_deref(), third_key.as_deref());
+
+    let svg = host.query_selector("svg.pine-chart-svg").unwrap().unwrap();
+    let second_x = second.get_attribute("cx").unwrap().parse::<f64>().unwrap();
+    let second_y = second.get_attribute("cy").unwrap().parse::<f64>().unwrap();
+    dispatch_pointer_move(&svg, second_x, second_y);
+    settle().await;
+    dispatch_click(&svg);
+    settle().await;
+
+    assert!(second.has_attribute("data-selected"));
+    assert_eq!(selected_label.borrow().as_deref(), Some("x 5, y 10"));
 
     host.remove();
 }

--- a/docs/charts/README.md
+++ b/docs/charts/README.md
@@ -17,6 +17,30 @@ Higher level components build on those primitives instead of hiding them. That
 keeps charts useful for simple dashboards while still giving application authors
 a path to custom marks, axes, interaction, and styling.
 
+## Design Model
+
+Pine Charts is a block system, not a full dashboard framework. The crate should
+make the hard chart behavior reusable without taking over the application's
+layout or product decisions.
+
+Pine owns:
+
+- geometry, scales, SVG paths, and responsive measurement,
+- hit testing, hover state, keyboard selection, and event payloads,
+- accessibility metadata, stable classes, and `data-*` hooks,
+- validation errors for malformed data and unsupported options.
+
+Applications own:
+
+- cards, panels, dashboard grids, and page layout,
+- color, typography, spacing, animation timing, and visual emphasis,
+- filtering policy, custom tooltips, selection detail panels, and drilldown,
+- routing, persistence, analytics, and domain-specific labels.
+
+That boundary keeps the public API low-to-high: use the ready-made line, bar,
+area, scatter, pie, and Cartesian components when they fit; drop to layered SVG
+blocks when the visualization needs custom marks.
+
 ## Styling Contract
 
 Pine Charts does not ship a theme. Components must expose semantic classes such

--- a/docs/charts/cookbook.md
+++ b/docs/charts/cookbook.md
@@ -88,6 +88,112 @@ The important rule is that the responsive component owns the chart pixel box.
 Application CSS can decorate the panel, but should not force the SVG to
 `width: 100%; height: 100%`; doing so can stretch text and circular marks.
 
+## Custom Tooltip And Drilldown
+
+Use `tooltip="none"` when the built-in tooltip is too small for the product UI.
+The chart still owns hit testing, crosshair placement, hover markers, keyboard
+selection, and typed event payloads. The application owns the HTML surface.
+
+```html
+<section class="metric-card">
+  <pine-chart-responsive aspect_ratio="1.7" min_height="220">
+    <pine-area-chart
+      label="Render latency"
+      pp-bind:series="latency_series"
+      x_label="Week"
+      y_label="Latency"
+      show_markers="true"
+      tooltip="none"
+      @pp:chart:hover="show_latency_tooltip"
+      @pp:chart:hover-end="hide_latency_tooltip"
+      @pp:chart:select="show_latency_detail"
+      @pp:chart:select-end="hide_latency_detail"></pine-area-chart>
+  </pine-chart-responsive>
+
+  <div
+    class="metric-tooltip"
+    role="status"
+    aria-live="polite"
+    :data-visible="tooltip_visible"
+    :style="tooltip_visible ? tooltip_style : ''">
+    <strong pp-text="tooltip_value"></strong>
+    <span pp-text="tooltip_meta"></span>
+  </div>
+
+  <aside
+    class="metric-detail"
+    role="status"
+    aria-live="polite"
+    :data-visible="detail_visible">
+    <strong pp-text="detail_value"></strong>
+    <span pp-text="detail_meta"></span>
+  </aside>
+</section>
+```
+
+```rust
+use pine_charts::{ChartHover, ChartSelection};
+use pocopine::prelude::JsValue;
+
+pub fn show_latency_tooltip(&mut self, event: JsValue) {
+    let Some(hover) = ChartHover::from_event_value(event) else {
+        return;
+    };
+
+    self.tooltip_visible = true;
+    self.tooltip_value = format!("{}: {}", hover.x_label, hover.y_label);
+    self.tooltip_meta = hover.aria_label;
+    self.tooltip_style = hover.tooltip_style;
+}
+
+pub fn hide_latency_tooltip(&mut self) {
+    self.tooltip_visible = false;
+}
+
+pub fn show_latency_detail(&mut self, event: JsValue) {
+    let Some(selection) = ChartSelection::from_event_value(event) else {
+        return;
+    };
+
+    self.detail_visible = true;
+    self.detail_value = match selection.kind.as_str() {
+        "xy" => format!("{}: {}", selection.x_label, selection.y_label),
+        "category" => format!("{}: {}", selection.category, selection.value_label),
+        "share" => format!("{} ({})", selection.value_label, selection.percentage_label),
+        _ => selection.label,
+    };
+    self.detail_meta = format!("Selected {}", selection.key);
+}
+
+pub fn hide_latency_detail(&mut self) {
+    self.detail_visible = false;
+}
+```
+
+```css
+.metric-card {
+  position: relative;
+}
+
+.pine-chart-root[data-tooltip="none"] .pine-chart-tooltip {
+  display: none;
+}
+
+.metric-tooltip {
+  left: var(--pine-chart-tooltip-x);
+  opacity: 0;
+  position: absolute;
+  top: var(--pine-chart-tooltip-y);
+  transform: translate(10px, calc(-100% - 10px));
+  visibility: hidden;
+}
+
+.metric-tooltip[data-visible="true"] {
+  opacity: 1;
+  visibility: visible;
+}
+```
+
 ## Half Donut Progress
 
 Half donuts use the same `PinePieChart` component as full donuts. The angle

--- a/docs/charts/examples.md
+++ b/docs/charts/examples.md
@@ -10,6 +10,20 @@ cargo run -p pocopine-cli -- run --path examples/charts --port 8025
 Open `http://localhost:8025` and switch between the two datasets. The demo keeps
 all visual styling in `index.html` CSS so the chart crate can stay unstyled.
 
+## What The Demo Proves
+
+The demo is intentionally a composition test, not a theme showcase. It should
+prove that applications can assemble chart blocks into their own product UI:
+
+- combo Cartesian charts with bars, areas, lines, scatter points, and reference
+  marks sharing one scale system,
+- custom layered SVG scenes with explicit paint order,
+- app-owned custom tooltips driven by `pp:chart:hover`,
+- persistent selection details driven by `pp:chart:select`,
+- interactive legends that mutate application-owned visible data,
+- responsive wrappers that keep SVG text and circular marks unstretched,
+- empty states when filtering hides all visible data.
+
 The example intentionally uses the same public API an application would use:
 
 - `pine_charts::register_all()` at startup,
@@ -36,6 +50,10 @@ The example intentionally uses the same public API an application would use:
   the template,
 - `<pine-pie-chart pp-bind:data="pie_data">` in the template,
 - `x_label` and `y_label` attributes for chart axis labels,
+- `tooltip="none"` plus `pp:chart:hover` / `pp:chart:hover-end` handlers for an
+  app-owned tooltip,
+- `pp:chart:select` / `pp:chart:select-end` handlers for an app-owned detail
+  panel,
 - `<pine-chart-legend pp-bind:items="line_legend">`,
   `<pine-chart-legend pp-bind:items="scatter_legend">`,
   `<pine-chart-legend pp-bind:items="area_legend">`,

--- a/docs/charts/interaction.md
+++ b/docs/charts/interaction.md
@@ -1,17 +1,35 @@
 # Interaction
 
-The first interaction layer is intentionally narrow: `PineLineChart`,
-`PineScatterChart`, and `PineAreaChart` support nearest-point hover state. They
-render SVG crosshair lines, an SVG marker, and an HTML tooltip container.
-`PineBarChart` supports rect hit-testing hover and renders the same HTML
-tooltip container with bar-specific category/value metadata.
+Chart interaction is hook-first. Pine Charts owns the geometry, hit testing,
+keyboard focus, selection bookkeeping, and typed event payloads. Applications
+own the visible product behavior: the tooltip body, detail panel, drilldown,
+filtering policy, and any route or analytics side effects.
 
-## Contract
+## Ownership Contract
+
+| Pine Charts owns | Application owns |
+| --- | --- |
+| Pointer-to-SVG coordinate conversion | Card and dashboard layout |
+| Plot-bound hit testing | Tooltip markup and visual styling |
+| Crosshair, hover marker, and focused/selected mark state | Selection detail panels and drilldown |
+| `ChartHover`, `ChartSelection`, and `LegendToggle` payloads | Data filtering and domain-specific labels |
+| ARIA labels, `data-*` hooks, and keyboard affordances | Live-region copy when replacing the built-in tooltip |
+
+This keeps the primitives usable by default while still letting an application
+compose its own interaction surface around them.
+
+## Hover
 
 Pointer movement over the chart SVG is converted into SVG-space coordinates.
 Hover activates only while the pointer is inside the plot rectangle, not while
-it is over margins, axes, or tick labels. The component selects the nearest
-sampled point by SVG x/y distance and exposes:
+it is over margins, axes, or tick labels.
+
+Line, scatter, and area charts select the nearest sampled point by SVG distance.
+Bar charts select the painted SVG rect under the pointer. Pie and donut charts
+select the hovered slice. All of them emit `pp:chart:hover` while hover is
+visible and `pp:chart:hover-end` when it clears.
+
+The built-in hover surface exposes:
 
 - `.pine-chart-hover`
 - `.pine-chart-crosshair`
@@ -29,59 +47,185 @@ sampled point by SVG x/y distance and exposes:
 - `data-series`
 - CSS variables `--pine-chart-tooltip-x` and `--pine-chart-tooltip-y`
 
-The chart owns sampled-point lookup, crosshair geometry, marker coordinates, and
-tooltip data attributes. Tooltip coordinates are emitted as percentages so they
-scale with responsive SVG sizing. Applications own colors, marker radius
-overrides, tooltip positioning, typography, borders, shadows, and transitions.
 Set `tooltip="none"` when the application should render its own tooltip from
-`pp:chart:hover` / `pp:chart:hover-end` events. That suppresses only the built-in
-HTML tooltip; hover markers, crosshairs, and data attributes still update.
+events. That suppresses only the built-in HTML tooltip; hover markers,
+crosshairs, and data attributes still update. Because Pine Charts does not ship
+a stylesheet, application CSS must include the hide rule:
 
-Bar charts use the same pointer coordinate conversion, but they select the
-painted SVG rect under the pointer instead of the nearest numeric sample. The
-hovered rect receives `data-hovered`; the tooltip exposes `data-category`,
-`data-value`, optional `data-series`, and the same placement attributes and CSS
-variables as line, scatter, and area charts. Bars do not render a crosshair by
-default because the rect itself is the hover target.
+```css
+.pine-chart-root[data-tooltip="none"] .pine-chart-tooltip {
+  display: none;
+}
+```
 
-Line markers, area markers, scatter points, bars, and pie/donut slices also
-expose a small selection contract. The chart root is keyboard focusable. Arrow
-keys move an internal focused item, Enter or Space selects it, and Escape clears
-selection. Pointer clicks select the clicked marker, point, bar, or slice;
-background chart clicks clear selection. Selection emits a bubbling
-`pp:chart:select` event, and clearing emits `pp:chart:select-end`. Rendered
-selectable marks expose:
+When `tooltip="none"` is used, the application is responsible for any live
+region used by the replacement tooltip.
+
+```html
+<pine-area-chart
+  label="Trend area"
+  pp-bind:series="area_series"
+  show_markers="true"
+  tooltip="none"
+  @pp:chart:hover="show_custom_tooltip"
+  @pp:chart:hover-end="hide_custom_tooltip"></pine-area-chart>
+
+<div
+  class="chart-custom-tooltip"
+  role="status"
+  aria-live="polite"
+  :data-visible="custom_tooltip_visible"
+  :data-tooltip-x="custom_tooltip_x"
+  :data-tooltip-y="custom_tooltip_y"
+  :style="custom_tooltip_visible ? custom_tooltip_style : ''">
+  <span pp-text="custom_tooltip_title"></span>
+  <strong pp-text="custom_tooltip_value"></strong>
+</div>
+```
+
+```rust
+use pine_charts::ChartHover;
+use pocopine::prelude::JsValue;
+
+pub fn show_custom_tooltip(&mut self, event: JsValue) {
+    let Some(hover) = ChartHover::from_event_value(event) else {
+        return;
+    };
+
+    self.custom_tooltip_visible = true;
+    self.custom_tooltip_title = if hover.series.is_empty() {
+        hover.chart
+    } else {
+        hover.series
+    };
+    self.custom_tooltip_value = match hover.kind.as_str() {
+        "xy" => format!("{}: {}", hover.x_label, hover.y_label),
+        "category" => format!("{}: {}", hover.category, hover.value_label),
+        "share" => format!("{} ({})", hover.value_label, hover.percentage_label),
+        _ => hover.label,
+    };
+    self.custom_tooltip_x = hover.tooltip_x;
+    self.custom_tooltip_y = hover.tooltip_y;
+    self.custom_tooltip_style = hover.tooltip_style;
+}
+
+pub fn hide_custom_tooltip(&mut self) {
+    self.custom_tooltip_visible = false;
+}
+```
+
+## Selection And Drilldown
+
+Line markers, area markers, scatter points, bars, and pie/donut slices expose a
+small selection contract. The chart root is keyboard focusable. Arrow keys move
+the focused item, Enter or Space selects it, and Escape clears selection. Line
+and area plot clicks select the current hovered sample. Scatter, bar, and pie
+clicks select the clicked point, bar, or slice. Background chart clicks clear
+selection when there is no hovered sample.
+
+Selection emits a bubbling `pp:chart:select` event, and clearing emits
+`pp:chart:select-end`. Rendered selectable marks expose:
 
 - `data-key`
 - `data-focused`
 - `data-selected`
 - `aria-selected="true|false"`
 
-Line selection is marker-based, so visible point marks require
-`show_markers="true"`. Keyboard selection still tracks the sampled line data,
-but an application only gets visible selected/focused line marks when markers
-are rendered.
+Line and area selection uses sampled data. Use `show_markers="true"` when the
+selected/focused sample should have a visible mark; keyboard selection still
+tracks sampled line data even when markers are hidden.
 
-Area selection follows the same marker-based model as line selection.
+```html
+<pine-area-chart
+  label="Trend area"
+  pp-bind:series="area_series"
+  show_markers="true"
+  @pp:chart:select="show_selection_detail"
+  @pp:chart:select-end="hide_selection_detail"></pine-area-chart>
 
-Pie and donut hover follows the same hook-first model as bars: the hovered slice
-receives `data-hovered`, and the tooltip exposes `data-label`, `data-value`, and
-`data-percentage`. Applications can use that hook for a grow effect with CSS.
-Set `animate="true"` on the chart when those transitions should use the chart's
+<aside
+  class="chart-selection-detail"
+  role="status"
+  aria-live="polite"
+  :data-visible="selection_visible">
+  <span pp-text="selection_title"></span>
+  <strong pp-text="selection_value"></strong>
+  <span pp-text="selection_meta"></span>
+</aside>
+```
+
+```rust
+use pine_charts::ChartSelection;
+use pocopine::prelude::JsValue;
+
+pub fn show_selection_detail(&mut self, event: JsValue) {
+    let Some(selection) = ChartSelection::from_event_value(event) else {
+        return;
+    };
+
+    self.selection_visible = true;
+    self.selection_title = if selection.series.is_empty() {
+        selection.chart
+    } else {
+        selection.series
+    };
+    self.selection_value = match selection.kind.as_str() {
+        "xy" => format!("{}: {}", selection.x_label, selection.y_label),
+        "category" => format!("{}: {}", selection.category, selection.value_label),
+        "share" => format!("{} ({})", selection.value_label, selection.percentage_label),
+        _ => selection.label,
+    };
+    self.selection_meta = format!("Selected {}", selection.key);
+}
+
+pub fn hide_selection_detail(&mut self) {
+    self.selection_visible = false;
+}
+```
+
+## Legend Filtering
+
+Interactive legends are opt-in with `interactive="true"`. The legend gives each
+item keyboard focus, toggles `data-active`, and emits
+`pp:chart:legend-toggle`. The chart data remains application-owned; the event is
+the hook for filtering, dimming, routing, or analytics.
+
+```html
+<pine-chart-legend
+  label="Trend area legend"
+  interactive="true"
+  pp-bind:items="area_legend"
+  @pp:chart:legend-toggle="toggle_area_series"></pine-chart-legend>
+```
+
+```rust
+use pine_charts::LegendToggle;
+use pocopine::prelude::JsValue;
+
+pub fn toggle_area_series(&mut self, event: JsValue) {
+    let Some(toggle) = LegendToggle::from_event_value(event) else {
+        return;
+    };
+
+    if set_area_series_visible(&mut self.area_series, &toggle.key, toggle.active) {
+        self.area_legend = area_legend_items(&self.area_series);
+    }
+}
+```
+
+## Animation Hooks
+
+Set `animate="true"` on a chart when CSS transitions should use the chart's
 animation variables. Keyframe entry animations should target keyed marks as they
 enter the DOM; add/remove updates then animate only the new line, area, bar,
-point, or pie segment instead of restarting the whole chart. Pie/donut slices
-expose `data-entering="true"` during that window. Pie/donut enter, exit, and
-shape changes are rendered by interpolating sector geometry in component state,
-so the visible path itself sweeps between sector angles and radii. Area series
-and pie/donut slices expose `data-leaving="true"` during their exit window so
-CSS or renderer-owned animation can show removal before the renderer prunes the
-mark.
+point, or pie segment instead of restarting the whole chart.
 
-Interactive legends are opt-in with `interactive="true"`. The legend then gives
-each item keyboard focus, toggles `data-active`, and emits
-`pp:chart:legend-toggle`. The chart data remains application-owned; the event is
-the hook for filtering or dimming series.
+Pie/donut slices expose `data-entering="true"` during entry. Area series and
+pie/donut slices expose `data-leaving="true"` during exit so CSS or
+renderer-owned animation can show removal before the renderer prunes the mark.
+Pie/donut enter, exit, and shape changes are rendered by interpolating sector
+geometry in component state, so the visible path itself sweeps between sector
+angles and radii.
 
 ## Styling
 
@@ -122,7 +266,8 @@ the hook for filtering or dimming series.
   transform: translate(calc(-100% - 10px), 10px);
 }
 
-.pine-chart-bar[data-hovered] {
+.pine-chart-bar[data-hovered],
+.pine-chart-pie-slice[data-hovered] {
   opacity: 1;
   stroke: currentColor;
 }
@@ -141,6 +286,3 @@ the hook for filtering or dimming series.
   stroke-width: 3;
 }
 ```
-
-This keeps the primitive useful by default without forcing a dashboard layout or
-theme onto the application.


### PR DESCRIPTION
## Summary
- Clarify Pine Charts as a block-and-events system rather than a full dashboard framework
- Expand interaction docs with hover, custom tooltip, selection/drilldown, legend filtering, and animation hook examples
- Make line/area plot clicks select the current hovered sample instead of requiring exact marker clicks
- Add cookbook/example guidance and keep the chart demo on the stable card grid

## Verification
- `cargo fmt --check`
- `cargo run -p pocopine-cli -- build --path examples/charts`
- `wasm-pack test --firefox --headless crates/pine-charts`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
- Live Firefox check: plot click in the Trend area demo selects a point and the card grid stays on the prior 8/4 + 4/4/4 layout
