### PR TITLE
Add sync mutation push flow

### DIFF
--- a/crates/pocopine-sync/src/client.rs
+++ b/crates/pocopine-sync/src/client.rs
@@ -281,6 +281,7 @@ where
             stream,
             mutation,
             optimistic,
+            !self.live_wakeup,
         );
         Ok(())
     }
@@ -543,6 +544,7 @@ fn start_push<C, T, M>(
     stream: SyncStreamName,
     mutation: ClientMutation<M>,
     optimistic: Option<SyncRow<T>>,
+    pull_after_accept: bool,
 ) where
     C: 'static,
     T: Clone + serde::de::DeserializeOwned + 'static,
@@ -580,7 +582,7 @@ fn start_push<C, T, M>(
             }
         });
 
-        if should_pull {
+        if should_pull && pull_after_accept {
             start_pull(
                 scope_id,
                 handle,

--- a/crates/pocopine-sync/src/client.rs
+++ b/crates/pocopine-sync/src/client.rs
@@ -3,13 +3,14 @@ use std::marker::PhantomData;
 use pocopine_core::{App, AppPlugin, Handle};
 
 use crate::{
-    CollectionState, SyncCursor, SyncError, SyncReason, SyncResult, SyncStreamName,
-    SYNC_ENDPOINT_PREFIX,
+    ClientMutation, CollectionState, SyncCursor, SyncError, SyncReason, SyncResult, SyncRow,
+    SyncStreamName, SYNC_ENDPOINT_PREFIX,
 };
 
 #[cfg(target_arch = "wasm32")]
 use crate::{
     sync_stream_tag, SyncOpenRequest, SyncOpenResponse, SyncPullRequest, SyncPullResponse,
+    SyncPushRequest, SyncPushResponse,
 };
 
 /// Selector from an app-owned component/store into one sync collection field.
@@ -171,6 +172,20 @@ where
         self.pull_impl(SyncReason::Manual, false)
     }
 
+    /// Push one client mutation and apply an optional optimistic row while
+    /// the server confirms, rejects, or conflicts the write.
+    pub fn push<M>(
+        self,
+        mutation: ClientMutation<M>,
+        optimistic: Option<SyncRow<T>>,
+    ) -> SyncResult<()>
+    where
+        T: Clone + serde::de::DeserializeOwned,
+        M: serde::Serialize + 'static,
+    {
+        self.push_impl(mutation, optimistic)
+    }
+
     fn stream_value(&self) -> SyncResult<SyncStreamName> {
         self.stream
             .clone()
@@ -242,6 +257,33 @@ where
         );
         Ok(())
     }
+
+    fn push_impl<M>(
+        self,
+        mutation: ClientMutation<M>,
+        optimistic: Option<SyncRow<T>>,
+    ) -> SyncResult<()>
+    where
+        T: Clone + serde::de::DeserializeOwned + 'static,
+        M: serde::Serialize + 'static,
+    {
+        let stream = self.stream_value()?;
+        let scope_id = pocopine_core::current_scope_id().ok_or_else(|| {
+            SyncError::client(
+                "SyncCollection::push used outside a component handler/lifecycle hook",
+            )
+        })?;
+        start_push(
+            scope_id,
+            self.handle,
+            self.selector,
+            self.endpoint,
+            stream,
+            mutation,
+            optimistic,
+        );
+        Ok(())
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -259,6 +301,21 @@ where
     fn pull_impl(self, _reason: SyncReason, _live_event: bool) -> SyncResult<()> {
         self.touch_host_fields();
         let _ = self.stream_value()?;
+        Ok(())
+    }
+
+    fn push_impl<M>(
+        self,
+        mutation: ClientMutation<M>,
+        optimistic: Option<SyncRow<T>>,
+    ) -> SyncResult<()>
+    where
+        T: Clone + serde::de::DeserializeOwned + 'static,
+        M: serde::Serialize + 'static,
+    {
+        self.touch_host_fields();
+        let _ = self.stream_value()?;
+        let _ = (mutation, optimistic);
         Ok(())
     }
 }
@@ -474,6 +531,67 @@ fn start_pull<C, T>(
                 }
             }
         });
+    });
+}
+
+#[cfg(target_arch = "wasm32")]
+fn start_push<C, T, M>(
+    scope_id: pocopine_core::ScopeId,
+    handle: Handle<C>,
+    selector: CollectionSelector<C, T>,
+    endpoint: String,
+    stream: SyncStreamName,
+    mutation: ClientMutation<M>,
+    optimistic: Option<SyncRow<T>>,
+) where
+    C: 'static,
+    T: Clone + serde::de::DeserializeOwned + 'static,
+    M: serde::Serialize + 'static,
+{
+    let push_url = endpoint_path(&endpoint, "push");
+    let pull_endpoint = endpoint.clone();
+    let mutation_id = mutation.id.clone();
+    let mutation_op = mutation.op;
+    let mutation_key = mutation.key.clone();
+
+    pocopine_core::spawn_for_scope(scope_id, async move {
+        handle.update(|state| {
+            selector(state).apply_optimistic_mutation(
+                mutation_id,
+                mutation_op,
+                mutation_key,
+                optimistic,
+            );
+        });
+
+        let request = SyncPushRequest::new(stream.clone(), [mutation]);
+        let result = pocopine_core::fetch::call::<SyncPushRequest<M>, SyncPushResponse<T>>(
+            &push_url, &request,
+        )
+        .await;
+        let should_pull = handle.update(|state| {
+            let collection = selector(state);
+            match result {
+                Ok(response) => collection.apply_push(response),
+                Err(err) => {
+                    collection.set_error(err.to_string());
+                    false
+                }
+            }
+        });
+
+        if should_pull {
+            start_pull(
+                scope_id,
+                handle,
+                selector,
+                pull_endpoint,
+                stream,
+                None,
+                SyncReason::Push,
+                false,
+            );
+        }
     });
 }
 

--- a/crates/pocopine-sync/src/lib.rs
+++ b/crates/pocopine-sync/src/lib.rs
@@ -20,8 +20,8 @@ pub use protocol::{
     sync_stream_tag, ClientMutation, MutationId, RowKey, RowVersion, SyncChange,
     SyncCollectionName, SyncConflict, SyncCursor, SyncOp, SyncOpenRequest, SyncOpenResponse,
     SyncOpenStream, SyncPullMode, SyncPullRequest, SyncPullResponse, SyncPushRequest,
-    SyncPushResponse, SyncRow, SyncStreamName, MAX_SYNC_TOKEN_LEN, SYNC_ENDPOINT_PREFIX,
-    SYNC_OPEN_PATH, SYNC_PROTOCOL_V1, SYNC_PULL_PATH, SYNC_PUSH_PATH,
+    SyncPushResponse, SyncRejectedMutation, SyncRow, SyncStreamName, MAX_SYNC_TOKEN_LEN,
+    SYNC_ENDPOINT_PREFIX, SYNC_OPEN_PATH, SYNC_PROTOCOL_V1, SYNC_PULL_PATH, SYNC_PUSH_PATH,
 };
 pub use state::{CollectionState, SyncReason, SyncRequest};
 

--- a/crates/pocopine-sync/src/lib.rs
+++ b/crates/pocopine-sync/src/lib.rs
@@ -23,7 +23,7 @@ pub use protocol::{
     SyncPushResponse, SyncRejectedMutation, SyncRow, SyncStreamName, MAX_SYNC_TOKEN_LEN,
     SYNC_ENDPOINT_PREFIX, SYNC_OPEN_PATH, SYNC_PROTOCOL_V1, SYNC_PULL_PATH, SYNC_PUSH_PATH,
 };
-pub use state::{CollectionState, SyncReason, SyncRequest};
+pub use state::{CollectionState, PendingMutation, SyncReason, SyncRequest};
 
 pub use client::{sync_plugin, SyncClient, SyncClientPlugin, SyncCollection};
 

--- a/crates/pocopine-sync/src/memory.rs
+++ b/crates/pocopine-sync/src/memory.rs
@@ -19,6 +19,8 @@ struct Inner<T> {
     version: u64,
     rows: BTreeMap<String, SyncRow<T>>,
     changes: Vec<SyncChange<T>>,
+    // Unbounded by design for the reference source. Durable adapters should
+    // persist mutation ids with an explicit retention policy.
     accepted_mutations: BTreeSet<String>,
 }
 
@@ -36,7 +38,8 @@ impl<T> Default for Inner<T> {
 /// In-memory source for tests, examples, and explicit single-process apps.
 ///
 /// This source keeps an unbounded in-memory change log and serializes all
-/// access through one lock. It is a reference implementation, not a durable
+/// access through one lock. Accepted mutation ids are also retained without
+/// bounds for idempotency. It is a reference implementation, not a durable
 /// production backend.
 #[derive(Clone, Debug)]
 pub struct MemorySyncStream<T> {

--- a/crates/pocopine-sync/src/memory.rs
+++ b/crates/pocopine-sync/src/memory.rs
@@ -1,13 +1,15 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, Mutex};
 
 use pocopine_server::auth::RequestContext;
+use serde::de::DeserializeOwned;
 use serde::Serialize;
 use serde_json::Value;
 
 use crate::{
-    SyncChange, SyncCollectionName, SyncCursor, SyncError, SyncOp, SyncPullRequest,
-    SyncPullResponse, SyncResult, SyncRow, SyncStreamName,
+    ClientMutation, SyncChange, SyncCollectionName, SyncConflict, SyncCursor, SyncError, SyncOp,
+    SyncPullRequest, SyncPullResponse, SyncPushRequest, SyncPushResponse, SyncRejectedMutation,
+    SyncResult, SyncRow, SyncStreamName,
 };
 
 use super::server::{SyncBoxFuture, SyncStreamSource};
@@ -17,6 +19,7 @@ struct Inner<T> {
     version: u64,
     rows: BTreeMap<String, SyncRow<T>>,
     changes: Vec<SyncChange<T>>,
+    accepted_mutations: BTreeSet<String>,
 }
 
 impl<T> Default for Inner<T> {
@@ -25,6 +28,7 @@ impl<T> Default for Inner<T> {
             version: 0,
             rows: BTreeMap::new(),
             changes: Vec::new(),
+            accepted_mutations: BTreeSet::new(),
         }
     }
 }
@@ -156,6 +160,189 @@ where
         ))
     }
 
+    fn push_value(&self, request: SyncPushRequest<Value>) -> SyncResult<SyncPushResponse<Value>>
+    where
+        T: DeserializeOwned,
+    {
+        let mut inner = self.lock()?;
+        let mut response = SyncPushResponse::new(self.stream.clone());
+
+        for mutation in request.mutations {
+            if inner.accepted_mutations.contains(mutation.id.as_str()) {
+                response.accepted.push(mutation.id);
+                continue;
+            }
+
+            let outcome = self.apply_mutation(&mut inner, mutation)?;
+            match outcome {
+                MemoryMutationOutcome::Accepted { id, row, cursor } => {
+                    inner.accepted_mutations.insert(id.as_str().to_string());
+                    response.accepted.push(id);
+                    if let Some(row) = row {
+                        response.rows.push(row_to_value(row)?);
+                    }
+                    response.cursor = Some(cursor);
+                }
+                MemoryMutationOutcome::Rejected(rejected) => {
+                    response.rejected.push(rejected);
+                }
+                MemoryMutationOutcome::Conflict(conflict) => {
+                    response.conflicts.push(conflict_to_value(conflict)?);
+                }
+            }
+        }
+
+        Ok(response)
+    }
+
+    fn apply_mutation(
+        &self,
+        inner: &mut Inner<T>,
+        mutation: ClientMutation<Value>,
+    ) -> SyncResult<MemoryMutationOutcome<T>>
+    where
+        T: DeserializeOwned,
+    {
+        match mutation.op {
+            SyncOp::Upsert => self.apply_upsert(inner, mutation),
+            SyncOp::Delete => self.apply_delete(inner, mutation),
+            SyncOp::Reset => self.apply_reset(inner, mutation),
+        }
+    }
+
+    fn apply_upsert(
+        &self,
+        inner: &mut Inner<T>,
+        mutation: ClientMutation<Value>,
+    ) -> SyncResult<MemoryMutationOutcome<T>>
+    where
+        T: DeserializeOwned,
+    {
+        let Some(key) = mutation.key.clone() else {
+            return Ok(MemoryMutationOutcome::Rejected(SyncRejectedMutation {
+                mutation_id: mutation.id,
+                key: None,
+                reason: "upsert requires a row key".to_string(),
+            }));
+        };
+
+        if let Some(conflict) = self.version_conflict(inner, &mutation, key.as_str()) {
+            return Ok(MemoryMutationOutcome::Conflict(conflict));
+        }
+
+        let value = match serde_json::from_value::<T>(mutation.payload) {
+            Ok(value) => value,
+            Err(err) => {
+                return Ok(MemoryMutationOutcome::Rejected(SyncRejectedMutation {
+                    mutation_id: mutation.id,
+                    key: Some(key),
+                    reason: format!("invalid mutation payload: {err}"),
+                }));
+            }
+        };
+
+        inner.version = inner.version.saturating_add(1);
+        let version = inner.version;
+        let cursor = SyncCursor::new(version.to_string())?;
+        let row = SyncRow::new(key.as_str().to_string(), value)?.version(format!("v{version}"))?;
+        inner.rows.insert(key.as_str().to_string(), row.clone());
+        inner.changes.push(SyncChange {
+            stream: self.stream.clone(),
+            collection: self.collection.clone(),
+            key: Some(key),
+            op: SyncOp::Upsert,
+            row: Some(row.clone()),
+            cursor: cursor.clone(),
+        });
+
+        Ok(MemoryMutationOutcome::Accepted {
+            id: mutation.id,
+            row: Some(row),
+            cursor,
+        })
+    }
+
+    fn apply_delete(
+        &self,
+        inner: &mut Inner<T>,
+        mutation: ClientMutation<Value>,
+    ) -> SyncResult<MemoryMutationOutcome<T>> {
+        let Some(key) = mutation.key.clone() else {
+            return Ok(MemoryMutationOutcome::Rejected(SyncRejectedMutation {
+                mutation_id: mutation.id,
+                key: None,
+                reason: "delete requires a row key".to_string(),
+            }));
+        };
+
+        if let Some(conflict) = self.version_conflict(inner, &mutation, key.as_str()) {
+            return Ok(MemoryMutationOutcome::Conflict(conflict));
+        }
+
+        inner.version = inner.version.saturating_add(1);
+        let cursor = SyncCursor::new(inner.version.to_string())?;
+        inner.rows.remove(key.as_str());
+        inner.changes.push(SyncChange {
+            stream: self.stream.clone(),
+            collection: self.collection.clone(),
+            key: Some(key),
+            op: SyncOp::Delete,
+            row: None,
+            cursor: cursor.clone(),
+        });
+
+        Ok(MemoryMutationOutcome::Accepted {
+            id: mutation.id,
+            row: None,
+            cursor,
+        })
+    }
+
+    fn apply_reset(
+        &self,
+        inner: &mut Inner<T>,
+        mutation: ClientMutation<Value>,
+    ) -> SyncResult<MemoryMutationOutcome<T>> {
+        inner.version = inner.version.saturating_add(1);
+        let cursor = SyncCursor::new(inner.version.to_string())?;
+        inner.rows.clear();
+        inner.changes.push(SyncChange {
+            stream: self.stream.clone(),
+            collection: self.collection.clone(),
+            key: None,
+            op: SyncOp::Reset,
+            row: None,
+            cursor: cursor.clone(),
+        });
+
+        Ok(MemoryMutationOutcome::Accepted {
+            id: mutation.id,
+            row: None,
+            cursor,
+        })
+    }
+
+    fn version_conflict(
+        &self,
+        inner: &Inner<T>,
+        mutation: &ClientMutation<Value>,
+        key: &str,
+    ) -> Option<SyncConflict<T>> {
+        let expected = mutation.base_version.as_ref()?;
+        let server_row = inner.rows.get(key).cloned();
+        let server_version = server_row.as_ref().and_then(|row| row.version.as_ref());
+        if server_version == Some(expected) {
+            return None;
+        }
+
+        Some(SyncConflict {
+            mutation_id: mutation.id.clone(),
+            key: mutation.key.clone(),
+            server_row,
+            reason: "base version is stale".to_string(),
+        })
+    }
+
     fn lock(&self) -> SyncResult<std::sync::MutexGuard<'_, Inner<T>>> {
         self.inner
             .lock()
@@ -165,7 +352,7 @@ where
 
 impl<T> SyncStreamSource for MemorySyncStream<T>
 where
-    T: Clone + Serialize + Send + Sync + 'static,
+    T: Clone + Serialize + DeserializeOwned + Send + Sync + 'static,
 {
     fn stream(&self) -> &SyncStreamName {
         &self.stream
@@ -189,6 +376,25 @@ where
         let _ = ctx;
         Box::pin(async move { self.pull_value(request) })
     }
+
+    fn push<'a>(
+        &'a self,
+        ctx: RequestContext,
+        request: SyncPushRequest<Value>,
+    ) -> SyncBoxFuture<'a, SyncPushResponse<Value>> {
+        let _ = ctx;
+        Box::pin(async move { self.push_value(request) })
+    }
+}
+
+enum MemoryMutationOutcome<T> {
+    Accepted {
+        id: crate::MutationId,
+        row: Option<SyncRow<T>>,
+        cursor: SyncCursor,
+    },
+    Rejected(SyncRejectedMutation),
+    Conflict(SyncConflict<T>),
 }
 
 fn row_to_value<T: Serialize>(row: SyncRow<T>) -> SyncResult<SyncRow<Value>> {
@@ -212,10 +418,19 @@ fn change_to_value<T: Serialize>(change: SyncChange<T>) -> SyncResult<SyncChange
     })
 }
 
+fn conflict_to_value<T: Serialize>(conflict: SyncConflict<T>) -> SyncResult<SyncConflict<Value>> {
+    Ok(SyncConflict {
+        mutation_id: conflict.mutation_id,
+        key: conflict.key,
+        server_row: conflict.server_row.map(row_to_value).transpose()?,
+        reason: conflict.reason,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::SyncPullMode;
+    use crate::{MutationId, RowKey, RowVersion, SyncPullMode};
 
     #[test]
     fn memory_stream_returns_snapshot_then_incremental_changes() {
@@ -280,5 +495,125 @@ mod tests {
             )
             .unwrap_err();
         assert!(matches!(err, SyncError::Gap(cursor) if cursor == "not_numeric"));
+    }
+
+    #[test]
+    fn memory_push_accepts_upsert_and_emits_incremental_change() {
+        let stream = MemorySyncStream::<String>::new("posts_for_tenant", "posts").unwrap();
+        let request = SyncPushRequest::new(
+            SyncStreamName::new("posts_for_tenant").unwrap(),
+            [ClientMutation {
+                id: MutationId::new("device_1:1").unwrap(),
+                key: Some(RowKey::new("post_1").unwrap()),
+                op: SyncOp::Upsert,
+                base_version: None,
+                payload: Value::String("hello".to_string()),
+            }],
+        );
+
+        let pushed = stream.push_value(request).unwrap();
+        assert_eq!(pushed.accepted[0].as_str(), "device_1:1");
+        assert!(pushed.rejected.is_empty());
+        assert!(pushed.conflicts.is_empty());
+        assert_eq!(pushed.rows[0].value, Value::String("hello".to_string()));
+
+        let pulled = stream
+            .pull_value(
+                SyncPullRequest::new(SyncStreamName::new("posts_for_tenant").unwrap())
+                    .cursor(Some(SyncCursor::new("0").unwrap())),
+            )
+            .unwrap();
+        assert_eq!(pulled.mode, SyncPullMode::Incremental);
+        assert_eq!(pulled.changes.len(), 1);
+        assert_eq!(pulled.changes[0].op, SyncOp::Upsert);
+    }
+
+    #[test]
+    fn memory_push_rejects_invalid_payload_without_advancing_cursor() {
+        let stream = MemorySyncStream::<String>::new("posts_for_tenant", "posts").unwrap();
+        let request = SyncPushRequest::new(
+            SyncStreamName::new("posts_for_tenant").unwrap(),
+            [ClientMutation {
+                id: MutationId::new("device_1:bad").unwrap(),
+                key: Some(RowKey::new("post_1").unwrap()),
+                op: SyncOp::Upsert,
+                base_version: None,
+                payload: serde_json::json!({"not": "a string"}),
+            }],
+        );
+
+        let pushed = stream.push_value(request).unwrap();
+        assert!(pushed.accepted.is_empty());
+        assert_eq!(pushed.rejected[0].mutation_id.as_str(), "device_1:bad");
+        assert!(pushed.cursor.is_none());
+
+        let pulled = stream
+            .pull_value(SyncPullRequest::new(
+                SyncStreamName::new("posts_for_tenant").unwrap(),
+            ))
+            .unwrap();
+        assert!(pulled.rows.is_empty());
+        assert_eq!(pulled.cursor.unwrap().as_str(), "0");
+    }
+
+    #[test]
+    fn memory_push_detects_stale_base_version_conflict() {
+        let stream = MemorySyncStream::<String>::new("posts_for_tenant", "posts").unwrap();
+        stream.upsert("post_1", "server".to_string()).unwrap();
+        let request = SyncPushRequest::new(
+            SyncStreamName::new("posts_for_tenant").unwrap(),
+            [ClientMutation {
+                id: MutationId::new("device_1:stale").unwrap(),
+                key: Some(RowKey::new("post_1").unwrap()),
+                op: SyncOp::Upsert,
+                base_version: Some(RowVersion::new("v0").unwrap()),
+                payload: Value::String("client".to_string()),
+            }],
+        );
+
+        let pushed = stream.push_value(request).unwrap();
+        assert!(pushed.accepted.is_empty());
+        assert!(pushed.rejected.is_empty());
+        assert_eq!(pushed.conflicts[0].mutation_id.as_str(), "device_1:stale");
+        assert_eq!(
+            pushed.conflicts[0].server_row.as_ref().unwrap().value,
+            Value::String("server".to_string())
+        );
+    }
+
+    #[test]
+    fn memory_push_dedupes_accepted_mutation_ids() {
+        let stream = MemorySyncStream::<String>::new("posts_for_tenant", "posts").unwrap();
+        let mutation = ClientMutation {
+            id: MutationId::new("device_1:dupe").unwrap(),
+            key: Some(RowKey::new("post_1").unwrap()),
+            op: SyncOp::Upsert,
+            base_version: None,
+            payload: Value::String("hello".to_string()),
+        };
+
+        stream
+            .push_value(SyncPushRequest::new(
+                SyncStreamName::new("posts_for_tenant").unwrap(),
+                [mutation.clone()],
+            ))
+            .unwrap();
+        let pushed_again = stream
+            .push_value(SyncPushRequest::new(
+                SyncStreamName::new("posts_for_tenant").unwrap(),
+                [mutation],
+            ))
+            .unwrap();
+
+        assert_eq!(pushed_again.accepted[0].as_str(), "device_1:dupe");
+        assert!(pushed_again.rows.is_empty());
+
+        let pulled = stream
+            .pull_value(
+                SyncPullRequest::new(SyncStreamName::new("posts_for_tenant").unwrap())
+                    .cursor(Some(SyncCursor::new("0").unwrap())),
+            )
+            .unwrap();
+        assert_eq!(pulled.changes.len(), 1);
     }
 }

--- a/crates/pocopine-sync/src/protocol.rs
+++ b/crates/pocopine-sync/src/protocol.rs
@@ -332,6 +332,19 @@ pub struct SyncPushRequest<M> {
     pub mutations: Vec<ClientMutation<M>>,
 }
 
+impl<M> SyncPushRequest<M> {
+    pub fn new(
+        stream: SyncStreamName,
+        mutations: impl IntoIterator<Item = ClientMutation<M>>,
+    ) -> Self {
+        Self {
+            protocol: SYNC_PROTOCOL_V1.to_string(),
+            stream,
+            mutations: mutations.into_iter().collect(),
+        }
+    }
+}
+
 /// Conflict returned by a push.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(bound(serialize = "T: Serialize", deserialize = "T: Deserialize<'de>"))]
@@ -339,6 +352,14 @@ pub struct SyncConflict<T> {
     pub mutation_id: MutationId,
     pub key: Option<RowKey>,
     pub server_row: Option<SyncRow<T>>,
+    pub reason: String,
+}
+
+/// Rejected mutation returned by a push.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SyncRejectedMutation {
+    pub mutation_id: MutationId,
+    pub key: Option<RowKey>,
     pub reason: String,
 }
 
@@ -351,10 +372,26 @@ pub struct SyncPushResponse<T> {
     #[serde(default)]
     pub accepted: Vec<MutationId>,
     #[serde(default)]
+    pub rejected: Vec<SyncRejectedMutation>,
+    #[serde(default)]
     pub rows: Vec<SyncRow<T>>,
     #[serde(default)]
     pub conflicts: Vec<SyncConflict<T>>,
     pub cursor: Option<SyncCursor>,
+}
+
+impl<T> SyncPushResponse<T> {
+    pub fn new(stream: SyncStreamName) -> Self {
+        Self {
+            protocol: SYNC_PROTOCOL_V1.to_string(),
+            stream,
+            accepted: Vec::new(),
+            rejected: Vec::new(),
+            rows: Vec::new(),
+            conflicts: Vec::new(),
+            cursor: None,
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/pocopine-sync/src/server.rs
+++ b/crates/pocopine-sync/src/server.rs
@@ -325,7 +325,22 @@ async fn push_handler(
         let (ctx, request) = parse_json_request::<SyncPushRequest<Value>>(request).await?;
         let stream = sync.stream(request.stream.as_str()).map_err(server_error)?;
         stream.authorize(ctx.clone()).await?;
-        stream.source.push(ctx, request).await.map_err(server_error)
+        let response = stream
+            .source
+            .push(ctx, request)
+            .await
+            .map_err(server_error)?;
+        if !response.accepted.is_empty() {
+            if let Err(err) = sync.invalidate_stream(response.stream.as_str()).await {
+                tracing::warn!(
+                    target: "pocopine.log",
+                    error = %err,
+                    stream = response.stream.as_str(),
+                    "failed to publish sync stream invalidation after push"
+                );
+            }
+        }
+        Ok(response)
     }
     .await;
     Json(result)
@@ -385,8 +400,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        MemorySyncStream, SyncCollectionName, SyncOpenRequest, SyncPullMode, SyncPushRequest,
-        SyncRow, SyncStreamName, SYNC_PROTOCOL_V1,
+        ClientMutation, MemorySyncStream, MutationId, RowKey, SyncCollectionName, SyncOp,
+        SyncOpenRequest, SyncPullMode, SyncPushRequest, SyncRow, SyncStreamName, SYNC_PROTOCOL_V1,
     };
 
     #[tokio::test]
@@ -418,21 +433,27 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn default_push_returns_unsupported_bad_request() {
+    async fn push_route_applies_memory_mutation_for_registered_streams() {
         let router = router_with_posts_stream();
 
-        let request = SyncPushRequest::<String> {
-            protocol: SYNC_PROTOCOL_V1.to_string(),
-            stream: SyncStreamName::new("posts_for_tenant").unwrap(),
-            mutations: Vec::new(),
-        };
+        let request = SyncPushRequest::new(
+            SyncStreamName::new("posts_for_tenant").unwrap(),
+            [ClientMutation {
+                id: MutationId::new("device_1:1").unwrap(),
+                key: Some(RowKey::new("post_2").unwrap()),
+                op: SyncOp::Upsert,
+                base_version: None,
+                payload: "from push".to_string(),
+            }],
+        );
         let outer: ServerResult<SyncPushResponse<String>> =
             post_json(router, SYNC_PUSH_PATH, &request, None).await;
-        assert!(matches!(
-            outer,
-            Err(ServerError::BadRequest(message))
-                if message.contains("unsupported sync operation")
-        ));
+        let response = outer.unwrap();
+        assert_eq!(response.accepted.len(), 1);
+        assert!(response.rejected.is_empty());
+        assert!(response.conflicts.is_empty());
+        assert_eq!(response.rows[0].key.as_str(), "post_2");
+        assert_eq!(response.rows[0].value, "from push");
     }
 
     #[tokio::test]

--- a/crates/pocopine-sync/src/state.rs
+++ b/crates/pocopine-sync/src/state.rs
@@ -1,6 +1,9 @@
 use serde::{Deserialize, Serialize};
 
-use crate::{SyncChange, SyncCursor, SyncOp, SyncPullMode, SyncPullResponse, SyncRow};
+use crate::{
+    MutationId, RowKey, SyncChange, SyncCursor, SyncOp, SyncPullMode, SyncPullResponse,
+    SyncPushResponse, SyncRow,
+};
 
 /// Reason attached to the latest sync state transition.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
@@ -11,6 +14,7 @@ pub enum SyncReason {
     Initial,
     Manual,
     Live,
+    Push,
     Gap,
     Error,
 }
@@ -25,6 +29,19 @@ impl SyncRequest {
     pub fn generation(self) -> u64 {
         self.generation
     }
+}
+
+/// Local mutation tracked until the server accepts, rejects, or conflicts it.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(bound(serialize = "T: Serialize", deserialize = "T: Deserialize<'de>"))]
+pub struct PendingMutation<T> {
+    pub id: MutationId,
+    pub op: SyncOp,
+    pub key: Option<RowKey>,
+    pub before: Option<SyncRow<T>>,
+    #[serde(default)]
+    pub before_rows: Vec<SyncRow<T>>,
+    pub optimistic: Option<SyncRow<T>>,
 }
 
 /// Serializable state for one synced collection.
@@ -43,6 +60,9 @@ pub struct CollectionState<T> {
     pub live_event_count: u64,
     pub pending_count: u64,
     pub conflict_count: u64,
+    pub rejected_count: u64,
+    #[serde(default)]
+    pub pending_mutations: Vec<PendingMutation<T>>,
     pub last_reason: SyncReason,
     #[serde(skip)]
     request_generation: u64,
@@ -63,6 +83,8 @@ impl<T> Default for CollectionState<T> {
             live_event_count: 0,
             pending_count: 0,
             conflict_count: 0,
+            rejected_count: 0,
+            pending_mutations: Vec::new(),
             last_reason: SyncReason::Idle,
             request_generation: 0,
         }
@@ -222,8 +244,181 @@ impl<T> CollectionState<T> {
     }
 
     fn recount_row_flags(&mut self) {
-        self.pending_count = self.rows.iter().filter(|row| row.pending).count() as u64;
+        let row_pending = self.rows.iter().filter(|row| row.pending).count() as u64;
+        self.pending_count = self.pending_mutations.len() as u64;
+        if row_pending > self.pending_count {
+            self.pending_count = row_pending;
+        }
         self.conflict_count = self.rows.iter().filter(|row| row.conflict).count() as u64;
+    }
+}
+
+impl<T> CollectionState<T>
+where
+    T: Clone,
+{
+    pub fn apply_optimistic_mutation(
+        &mut self,
+        id: MutationId,
+        op: SyncOp,
+        key: Option<RowKey>,
+        optimistic: Option<SyncRow<T>>,
+    ) {
+        let before = key.as_ref().and_then(|key| self.row_by_key(key).cloned());
+        let before_rows = if op == SyncOp::Reset {
+            self.rows.clone()
+        } else {
+            Vec::new()
+        };
+        self.pending_mutations.retain(|pending| pending.id != id);
+
+        match op {
+            SyncOp::Upsert => {
+                if let Some(mut row) = optimistic.clone() {
+                    row.pending = true;
+                    row.conflict = false;
+                    self.upsert_row(row);
+                }
+            }
+            SyncOp::Delete => {
+                if let Some(key) = &key {
+                    self.remove_row(key);
+                }
+            }
+            SyncOp::Reset => {
+                self.rows.clear();
+                if let Some(mut row) = optimistic.clone() {
+                    row.pending = true;
+                    row.conflict = false;
+                    self.rows.push(row);
+                }
+            }
+        }
+
+        self.pending_mutations.push(PendingMutation {
+            id,
+            op,
+            key,
+            before,
+            before_rows,
+            optimistic,
+        });
+        self.error.clear();
+        self.last_reason = SyncReason::Push;
+        self.recount_row_flags();
+    }
+
+    pub fn apply_push(&mut self, response: SyncPushResponse<T>) -> bool {
+        let has_accepted = !response.accepted.is_empty();
+
+        for rejected in response.rejected {
+            self.rollback_mutation(&rejected.mutation_id);
+            self.rejected_count = self.rejected_count.saturating_add(1);
+            self.error = rejected.reason;
+            self.last_reason = SyncReason::Error;
+        }
+
+        for conflict in response.conflicts {
+            self.complete_mutation(&conflict.mutation_id);
+            if let Some(mut row) = conflict.server_row {
+                row.pending = false;
+                row.conflict = true;
+                self.upsert_row(row);
+            } else if let Some(key) = conflict.key {
+                self.remove_row(&key);
+            }
+            self.error = conflict.reason;
+            self.last_reason = SyncReason::Error;
+        }
+
+        for id in response.accepted {
+            self.complete_mutation(&id);
+        }
+
+        for mut row in response.rows {
+            row.pending = false;
+            row.conflict = false;
+            self.upsert_row(row);
+        }
+
+        if let Some(cursor) = response.cursor {
+            self.cursor = Some(cursor);
+        }
+
+        self.loading = false;
+        self.syncing = false;
+        self.stale = has_accepted;
+        self.recount_row_flags();
+        has_accepted
+    }
+
+    fn rollback_mutation(&mut self, id: &MutationId) {
+        let Some(index) = self
+            .pending_mutations
+            .iter()
+            .position(|pending| &pending.id == id)
+        else {
+            return;
+        };
+        let pending = self.pending_mutations.remove(index);
+        match pending.op {
+            SyncOp::Upsert => {
+                if let Some(before) = pending.before {
+                    self.upsert_row(before);
+                } else if let Some(key) = pending.key {
+                    self.remove_row(&key);
+                }
+            }
+            SyncOp::Delete | SyncOp::Reset => {
+                if pending.op == SyncOp::Reset {
+                    self.rows = pending.before_rows;
+                } else if let Some(before) = pending.before {
+                    self.upsert_row(before);
+                }
+            }
+        }
+    }
+
+    fn complete_mutation(&mut self, id: &MutationId) {
+        let Some(index) = self
+            .pending_mutations
+            .iter()
+            .position(|pending| &pending.id == id)
+        else {
+            return;
+        };
+        let pending = self.pending_mutations.remove(index);
+        if let Some(key) = pending.key {
+            if let Some(row) = self.row_by_key_mut(&key) {
+                row.pending = false;
+            }
+        }
+    }
+
+    fn upsert_row(&mut self, row: SyncRow<T>) {
+        if let Some(existing) = self
+            .rows
+            .iter_mut()
+            .find(|existing| existing.key == row.key)
+        {
+            *existing = row;
+        } else {
+            self.rows.push(row);
+        }
+    }
+
+    fn remove_row(&mut self, key: &RowKey) {
+        if let Some(index) = self.rows.iter().position(|row| &row.key == key) {
+            self.rows.remove(index);
+        }
+    }
+
+    fn row_by_key(&self, key: &RowKey) -> Option<&SyncRow<T>> {
+        self.rows.iter().find(|row| &row.key == key)
+    }
+
+    fn row_by_key_mut(&mut self, key: &RowKey) -> Option<&mut SyncRow<T>> {
+        self.rows.iter_mut().find(|row| &row.key == key)
     }
 }
 
@@ -231,7 +426,8 @@ impl<T> CollectionState<T> {
 mod tests {
     use super::*;
     use crate::{
-        RowKey, SyncChange, SyncCollectionName, SyncCursor, SyncPullResponse, SyncStreamName,
+        MutationId, RowKey, RowVersion, SyncChange, SyncCollectionName, SyncConflict, SyncCursor,
+        SyncPullResponse, SyncPushResponse, SyncRejectedMutation, SyncStreamName,
     };
 
     #[test]
@@ -392,5 +588,107 @@ mod tests {
         assert!(!state.loading);
         assert!(!state.syncing);
         assert!(!state.stale);
+    }
+
+    #[test]
+    fn optimistic_upsert_marks_row_pending() {
+        let mut state = CollectionState::<String>::default();
+        let row = SyncRow::new("post_1", "draft".to_string()).unwrap();
+
+        state.apply_optimistic_mutation(
+            MutationId::new("device_1:1").unwrap(),
+            SyncOp::Upsert,
+            Some(RowKey::new("post_1").unwrap()),
+            Some(row),
+        );
+
+        assert_eq!(state.rows.len(), 1);
+        assert!(state.rows[0].pending);
+        assert_eq!(state.pending_count, 1);
+        assert_eq!(state.last_reason, SyncReason::Push);
+    }
+
+    #[test]
+    fn rejected_push_rolls_back_optimistic_upsert() {
+        let mut state = CollectionState::<String>::default();
+        state.apply_optimistic_mutation(
+            MutationId::new("device_1:1").unwrap(),
+            SyncOp::Upsert,
+            Some(RowKey::new("post_1").unwrap()),
+            Some(SyncRow::new("post_1", "draft".to_string()).unwrap()),
+        );
+        let mut response = SyncPushResponse::new(SyncStreamName::new("posts").unwrap());
+        response.rejected.push(SyncRejectedMutation {
+            mutation_id: MutationId::new("device_1:1").unwrap(),
+            key: Some(RowKey::new("post_1").unwrap()),
+            reason: "title is required".to_string(),
+        });
+
+        assert!(!state.apply_push(response));
+
+        assert!(state.rows.is_empty());
+        assert_eq!(state.pending_count, 0);
+        assert_eq!(state.rejected_count, 1);
+        assert_eq!(state.error, "title is required");
+    }
+
+    #[test]
+    fn accepted_push_applies_canonical_row_and_clears_pending() {
+        let mut state = CollectionState::<String>::default();
+        state.apply_optimistic_mutation(
+            MutationId::new("device_1:1").unwrap(),
+            SyncOp::Upsert,
+            Some(RowKey::new("post_1").unwrap()),
+            Some(SyncRow::new("post_1", "draft".to_string()).unwrap()),
+        );
+        let mut canonical = SyncRow::new("post_1", "saved".to_string())
+            .unwrap()
+            .version("v1")
+            .unwrap();
+        canonical.pending = true;
+        let mut response = SyncPushResponse::new(SyncStreamName::new("posts").unwrap());
+        response
+            .accepted
+            .push(MutationId::new("device_1:1").unwrap());
+        response.rows.push(canonical);
+        response.cursor = Some(SyncCursor::new("1").unwrap());
+
+        assert!(state.apply_push(response));
+
+        assert_eq!(state.rows[0].value, "saved");
+        assert!(!state.rows[0].pending);
+        assert_eq!(
+            state.rows[0].version.as_ref().unwrap(),
+            &RowVersion::new("v1").unwrap()
+        );
+        assert_eq!(state.pending_count, 0);
+        assert!(state.stale);
+        assert_eq!(state.cursor.as_ref().unwrap().as_str(), "1");
+    }
+
+    #[test]
+    fn conflict_push_marks_server_row_conflicted() {
+        let mut state = CollectionState::<String>::default();
+        state.apply_optimistic_mutation(
+            MutationId::new("device_1:1").unwrap(),
+            SyncOp::Upsert,
+            Some(RowKey::new("post_1").unwrap()),
+            Some(SyncRow::new("post_1", "local".to_string()).unwrap()),
+        );
+        let mut response = SyncPushResponse::new(SyncStreamName::new("posts").unwrap());
+        response.conflicts.push(SyncConflict {
+            mutation_id: MutationId::new("device_1:1").unwrap(),
+            key: Some(RowKey::new("post_1").unwrap()),
+            server_row: Some(SyncRow::new("post_1", "server".to_string()).unwrap()),
+            reason: "base version is stale".to_string(),
+        });
+
+        assert!(!state.apply_push(response));
+
+        assert_eq!(state.rows[0].value, "server");
+        assert!(!state.rows[0].pending);
+        assert!(state.rows[0].conflict);
+        assert_eq!(state.conflict_count, 1);
+        assert_eq!(state.error, "base version is stale");
     }
 }

--- a/crates/pocopine-sync/src/state.rs
+++ b/crates/pocopine-sync/src/state.rs
@@ -58,6 +58,8 @@ pub struct CollectionState<T> {
     pub version: u64,
     pub refresh_count: u64,
     pub live_event_count: u64,
+    /// Number of in-flight mutations or pending row flags. This includes
+    /// mutations like optimistic deletes where no pending row remains visible.
     pub pending_count: u64,
     pub conflict_count: u64,
     pub rejected_count: u64,
@@ -310,25 +312,33 @@ where
 
     pub fn apply_push(&mut self, response: SyncPushResponse<T>) -> bool {
         let has_accepted = !response.accepted.is_empty();
+        let rejected_total = response.rejected.len();
+        let conflict_total = response.conflicts.len();
+        let mut first_failure = None;
 
         for rejected in response.rejected {
+            if first_failure.is_none() {
+                first_failure = Some(rejected.reason.clone());
+            }
             self.rollback_mutation(&rejected.mutation_id);
             self.rejected_count = self.rejected_count.saturating_add(1);
-            self.error = rejected.reason;
-            self.last_reason = SyncReason::Error;
         }
 
         for conflict in response.conflicts {
+            if first_failure.is_none() {
+                first_failure = Some(conflict.reason.clone());
+            }
             self.complete_mutation(&conflict.mutation_id);
             if let Some(mut row) = conflict.server_row {
                 row.pending = false;
                 row.conflict = true;
                 self.upsert_row(row);
             } else if let Some(key) = conflict.key {
-                self.remove_row(&key);
+                if let Some(row) = self.row_by_key_mut(&key) {
+                    row.pending = false;
+                    row.conflict = true;
+                }
             }
-            self.error = conflict.reason;
-            self.last_reason = SyncReason::Error;
         }
 
         for id in response.accepted {
@@ -343,6 +353,11 @@ where
 
         if let Some(cursor) = response.cursor {
             self.cursor = Some(cursor);
+        }
+
+        if let Some(reason) = first_failure {
+            self.error = push_failure_message(rejected_total, conflict_total, reason);
+            self.last_reason = SyncReason::Error;
         }
 
         self.loading = false;
@@ -420,6 +435,13 @@ where
     fn row_by_key_mut(&mut self, key: &RowKey) -> Option<&mut SyncRow<T>> {
         self.rows.iter_mut().find(|row| &row.key == key)
     }
+}
+
+fn push_failure_message(rejected: usize, conflicted: usize, first_reason: String) -> String {
+    if rejected + conflicted == 1 {
+        return first_reason;
+    }
+    format!("{rejected} rejected, {conflicted} conflicted; first: {first_reason}")
 }
 
 #[cfg(test)]
@@ -690,5 +712,132 @@ mod tests {
         assert!(state.rows[0].conflict);
         assert_eq!(state.conflict_count, 1);
         assert_eq!(state.error, "base version is stale");
+    }
+
+    #[test]
+    fn conflict_without_server_row_keeps_local_row_visible() {
+        let mut state = CollectionState::<String>::default();
+        state.apply_optimistic_mutation(
+            MutationId::new("device_1:1").unwrap(),
+            SyncOp::Upsert,
+            Some(RowKey::new("post_1").unwrap()),
+            Some(SyncRow::new("post_1", "local".to_string()).unwrap()),
+        );
+        let mut response = SyncPushResponse::new(SyncStreamName::new("posts").unwrap());
+        response.conflicts.push(SyncConflict {
+            mutation_id: MutationId::new("device_1:1").unwrap(),
+            key: Some(RowKey::new("post_1").unwrap()),
+            server_row: None,
+            reason: "base version is stale".to_string(),
+        });
+
+        assert!(!state.apply_push(response));
+
+        assert_eq!(state.rows[0].value, "local");
+        assert!(!state.rows[0].pending);
+        assert!(state.rows[0].conflict);
+        assert_eq!(state.conflict_count, 1);
+    }
+
+    #[test]
+    fn multiple_push_failures_report_counts_and_first_reason() {
+        let mut state = CollectionState::<String>::default();
+        let mut response = SyncPushResponse::new(SyncStreamName::new("posts").unwrap());
+        response.rejected.push(SyncRejectedMutation {
+            mutation_id: MutationId::new("device_1:1").unwrap(),
+            key: Some(RowKey::new("post_1").unwrap()),
+            reason: "first rejection".to_string(),
+        });
+        response.rejected.push(SyncRejectedMutation {
+            mutation_id: MutationId::new("device_1:2").unwrap(),
+            key: Some(RowKey::new("post_2").unwrap()),
+            reason: "second rejection".to_string(),
+        });
+        response.conflicts.push(SyncConflict {
+            mutation_id: MutationId::new("device_1:3").unwrap(),
+            key: Some(RowKey::new("post_3").unwrap()),
+            server_row: None,
+            reason: "conflict".to_string(),
+        });
+
+        assert!(!state.apply_push(response));
+
+        assert_eq!(
+            state.error,
+            "2 rejected, 1 conflicted; first: first rejection"
+        );
+        assert_eq!(state.rejected_count, 2);
+    }
+
+    #[test]
+    fn rejected_delete_rolls_back_removed_row() {
+        let mut state = CollectionState::<String>::default();
+        let initial = state.begin_initial();
+        state.apply_pull(
+            initial,
+            SyncPullResponse::snapshot(
+                SyncStreamName::new("posts").unwrap(),
+                SyncCollectionName::new("posts").unwrap(),
+                vec![SyncRow::new("post_1", "loaded".to_string()).unwrap()],
+                Some(SyncCursor::new("1").unwrap()),
+            ),
+        );
+        state.apply_optimistic_mutation(
+            MutationId::new("device_1:delete").unwrap(),
+            SyncOp::Delete,
+            Some(RowKey::new("post_1").unwrap()),
+            None,
+        );
+        assert!(state.rows.is_empty());
+        assert_eq!(state.pending_count, 1);
+
+        let mut response = SyncPushResponse::new(SyncStreamName::new("posts").unwrap());
+        response.rejected.push(SyncRejectedMutation {
+            mutation_id: MutationId::new("device_1:delete").unwrap(),
+            key: Some(RowKey::new("post_1").unwrap()),
+            reason: "cannot delete".to_string(),
+        });
+        state.apply_push(response);
+
+        assert_eq!(state.rows[0].value, "loaded");
+        assert_eq!(state.pending_count, 0);
+    }
+
+    #[test]
+    fn rejected_reset_restores_previous_rows() {
+        let mut state = CollectionState::<String>::default();
+        let initial = state.begin_initial();
+        state.apply_pull(
+            initial,
+            SyncPullResponse::snapshot(
+                SyncStreamName::new("posts").unwrap(),
+                SyncCollectionName::new("posts").unwrap(),
+                vec![
+                    SyncRow::new("post_1", "one".to_string()).unwrap(),
+                    SyncRow::new("post_2", "two".to_string()).unwrap(),
+                ],
+                Some(SyncCursor::new("1").unwrap()),
+            ),
+        );
+        state.apply_optimistic_mutation(
+            MutationId::new("device_1:reset").unwrap(),
+            SyncOp::Reset,
+            None,
+            None,
+        );
+        assert!(state.rows.is_empty());
+
+        let mut response = SyncPushResponse::new(SyncStreamName::new("posts").unwrap());
+        response.rejected.push(SyncRejectedMutation {
+            mutation_id: MutationId::new("device_1:reset").unwrap(),
+            key: None,
+            reason: "cannot reset".to_string(),
+        });
+        state.apply_push(response);
+
+        assert_eq!(state.rows.len(), 2);
+        assert_eq!(state.rows[0].value, "one");
+        assert_eq!(state.rows[1].value, "two");
+        assert_eq!(state.pending_count, 0);
     }
 }

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -241,6 +241,9 @@ pub fn main() {
 `sync_plugin()` sends fetches without browser credentials by default. If
 an app opts into `.with_credentials(true)`, the server must provide the
 same CSRF protections it uses for any credentialed JSON POST endpoint.
+When live wake-up is enabled, accepted pushes rely on the live
+invalidation to trigger the follow-up pull. Without live wake-up, the
+push path performs that pull directly.
 
 Components store synced rows in `CollectionState<T>`:
 
@@ -333,6 +336,10 @@ source, invalid payloads are returned in `rejected`, stale
 `base_version` values are returned in `conflicts`, and accepted upserts
 append an incremental stream change. Production sources should keep the
 same rule: do not emit a live wake-up until the mutation has committed.
+
+The example uses short client-local ids to keep the code readable.
+Production apps should use server-assigned ids or client-generated UUIDs
+to avoid row-key collisions across tabs and devices.
 
 ## 7. Run The Example
 

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -349,8 +349,10 @@ wasm-pack test --firefox --headless crates/pocopine-sync --test client_browser
 - `open` validates stream names and reports registered stream metadata.
   The browser client calls it before the first `pull`.
 - `pull` returns either a full snapshot or incremental changes.
-- `push` exists in the protocol, but the memory stream rejects it until
-  optimistic mutations and conflict policy are implemented.
+- `push` sends client-generated mutation ids plus app payloads to the
+  stream source. Responses split mutations into `accepted`, `rejected`,
+  and `conflicts`; accepted mutations may include canonical rows and also
+  wake live listeners so clients can pull the committed stream changes.
 - Cursors are opaque. Components should store and resend them, not parse
   them.
 - A live wake-up is not a data packet. It is only a prompt to pull.

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -6,13 +6,16 @@ The first implementation is intentionally small:
 - the server owns named sync streams,
 - the browser opens an authorized stream, then pulls a snapshot or
   incremental changes with a cursor,
+- the browser can push server-confirmed optimistic mutations with stable
+  mutation ids,
 - `pocopine-live` is used only as a wake-up signal,
-- the data payload still moves through `POST /__pocopine/sync/v1/pull`.
+- committed stream data still moves through `POST /__pocopine/sync/v1/pull`.
 
-This is not the full offline store yet. IndexedDB persistence,
-optimistic mutation replay, SQLx-backed adapters, and CDC integrations
-remain future work. The current API gives us the protocol boundary and a
-browser state model that those backends can plug into later.
+This is not the full offline store yet. IndexedDB durability,
+cross-reload mutation replay, SQLx-backed adapters, and CDC integrations
+remain future work. The current API gives us the protocol boundary,
+server-confirmed mutations, and a browser state model that those backends
+can plug into later.
 
 The runnable source of truth is [`examples/sync`](../examples/sync/).
 When the sync API changes, update this document and the example in the
@@ -296,28 +299,40 @@ Templates read `CollectionState<T>` directly:
 </ol>
 ```
 
-## 6. Mutate Then Invalidate
+## 6. Push Optimistic Mutations
 
-Server functions can mutate the source and publish a wake-up after the
-write succeeds:
+`SyncCollection::push` applies an optimistic row locally, sends a stable
+mutation id to `/__pocopine/sync/v1/push`, then applies the server's
+accepted, rejected, or conflict response. Accepted pushes also wake live
+listeners through the sync server's event backend, so other tabs pull the
+committed stream changes.
 
 ```rust
-#[pocopine::server(public)]
-pub async fn create_post(title: String, body: String) -> ServerResult<Post> {
-    let post = insert_post(title, body)?;
+pub fn create(&mut self) {
+    let post = Post {
+        id: "post_local_1".to_string(),
+        title: self.title.clone(),
+        body: self.body.clone(),
+    };
+    let result = build_create_mutation(post)
+        .and_then(|(mutation, optimistic)| {
+            self.plugin::<pocopine_sync::SyncClient>()
+                .collection(pocopine::this::<Self>(), |s: &mut Self| &mut s.posts)
+                .stream(POSTS_STREAM)
+                .and_then(|collection| collection.push(mutation, Some(optimistic)))
+        });
 
-    posts_stream()
-        .upsert(post.id.clone(), post.clone())
-        .map_err(|err| ServerError::App(err.to_string()))?;
-
-    invalidate_posts().await;
-    Ok(post)
+    if let Err(err) = result {
+        self.posts.set_error(err.to_string());
+    }
 }
 ```
 
-Do not publish before the mutation commits. If wake-up publishing fails
-after a successful mutation, log it and return the mutation result; the
-next manual pull or page load should still see the committed data.
+Stream sources own validation and write policy. In the reference memory
+source, invalid payloads are returned in `rejected`, stale
+`base_version` values are returned in `conflicts`, and accepted upserts
+append an incremental stream change. Production sources should keep the
+same rule: do not emit a live wake-up until the mutation has committed.
 
 ## 7. Run The Example
 

--- a/examples/sync/README.md
+++ b/examples/sync/README.md
@@ -2,7 +2,8 @@
 
 Small app showing the first sync protocol slice:
 
-- server functions mutate a process-local `MemorySyncStream<Post>`,
+- browser create actions push optimistic mutations into a process-local
+  `MemorySyncStream<Post>`,
 - `pocopine-sync` opens the stream, then serves snapshot and incremental pulls,
 - `pocopine-live` sends only wake-up events,
 - the browser stores rows in `CollectionState<Post>` and pulls with its cursor.
@@ -15,7 +16,9 @@ cargo run -p pocopine-cli -- dev --path examples/sync
 
 Open the app in two browser tabs. Creating or resetting posts in one tab
 wakes the other tab over SSE; the data itself is fetched from
-`/__pocopine/sync/v1/pull`.
+`/__pocopine/sync/v1/pull`. Create uses
+`/__pocopine/sync/v1/push`; reset remains a small server-function helper
+that mutates the same memory stream.
 
 This example uses memory backends, so it is intentionally single-process.
 It registers its stream with `public_stream(...)` to avoid bundling an

--- a/examples/sync/README.md
+++ b/examples/sync/README.md
@@ -24,6 +24,9 @@ This example uses memory backends, so it is intentionally single-process.
 It registers its stream with `public_stream(...)` to avoid bundling an
 auth setup into the demo; production apps should use `guarded_stream(...)`
 or `guarded_stream_with(...)`.
+The create form uses short client-local ids for readability; production
+apps should use server-assigned ids or client-side UUIDs so multiple tabs
+and devices do not collide.
 Future database adapters should keep this same browser stream while
 replacing the server-side source.
 

--- a/examples/sync/src/SyncBoard.poco
+++ b/examples/sync/src/SyncBoard.poco
@@ -28,6 +28,8 @@
       <span class="status" pp-text="status"></span>
       <span class="counter"><strong pp-text="posts.live_event_count"></strong> wake-ups</span>
       <span class="counter"><strong pp-text="posts.refresh_count"></strong> pulls</span>
+      <span class="counter"><strong pp-text="posts.pending_count"></strong> pending</span>
+      <span class="counter"><strong pp-text="posts.conflict_count"></strong> conflicts</span>
     </div>
 
     <p pp-show="posts.error" class="error"><span pp-text="posts.error"></span></p>
@@ -41,6 +43,10 @@
           <div class="post__meta">
             <span pp-text="row.key"></span>
             <span pp-text="row.version"></span>
+          </div>
+          <div class="post__flags">
+            <span pp-show="row.pending">pending</span>
+            <span pp-show="row.conflict">conflict</span>
           </div>
           <h2 pp-text="row.value.title"></h2>
           <p pp-text="row.value.body"></p>

--- a/examples/sync/src/bin/server.rs
+++ b/examples/sync/src/bin/server.rs
@@ -5,7 +5,7 @@ async fn main() -> std::io::Result<()> {
     use pocopine_logging::init_default;
     use pocopine_server::{axum::Router, serve, static_files, Server};
     use pocopine_sync::sync_server_plugin;
-    use sync_example::{__create_post_route, __reset_posts_route, live_backend, sync_server};
+    use sync_example::{__reset_posts_route, live_backend, sync_server};
 
     init_default().map_err(std::io::Error::other)?;
 
@@ -23,7 +23,6 @@ async fn main() -> std::io::Result<()> {
         .plugin(sync_server_plugin(sync))
         .try_finalize()
         .map_err(std::io::Error::other)?;
-    let router = __create_post_route(router);
     let router = __reset_posts_route(router);
 
     let addr = "127.0.0.1:3021";

--- a/examples/sync/src/lib.rs
+++ b/examples/sync/src/lib.rs
@@ -5,10 +5,7 @@ use serde::{Deserialize, Serialize};
 use {
     pocopine_events::MemoryEventBackend,
     pocopine_sync::{MemorySyncStream, SyncServer},
-    std::sync::{
-        atomic::{AtomicU64, Ordering},
-        Arc, OnceLock,
-    },
+    std::sync::{Arc, OnceLock},
 };
 
 pub const POSTS_STREAM: &str = "posts_for_user";
@@ -29,6 +26,7 @@ pub struct SyncBoard {
     pub posts: pocopine_sync::CollectionState<Post>,
     pub saving: bool,
     pub status: String,
+    pub next_local_id: u64,
 }
 
 #[cfg(pocopine_host)]
@@ -37,8 +35,6 @@ static POSTS_SYNC: OnceLock<MemorySyncStream<Post>> = OnceLock::new();
 static LIVE_BACKEND: OnceLock<MemoryEventBackend> = OnceLock::new();
 #[cfg(pocopine_host)]
 static SYNC_SERVER: OnceLock<SyncServer> = OnceLock::new();
-#[cfg(pocopine_host)]
-static NEXT_POST_ID: AtomicU64 = AtomicU64::new(3);
 
 #[cfg(pocopine_host)]
 pub fn posts_stream() -> MemorySyncStream<Post> {
@@ -101,30 +97,6 @@ async fn invalidate_posts() {
 }
 
 #[pocopine::server(public)]
-pub async fn create_post(title: String, body: String) -> ServerResult<Post> {
-    let title = title.trim();
-    let body = body.trim();
-    if title.is_empty() || body.is_empty() {
-        return Err(ServerError::BadRequest(
-            "title and body are required".to_string(),
-        ));
-    }
-
-    let next_id = NEXT_POST_ID.fetch_add(1, Ordering::Relaxed);
-    let post = Post {
-        id: format!("post_{next_id}"),
-        title: title.to_string(),
-        body: body.to_string(),
-    };
-
-    posts_stream()
-        .upsert(post.id.clone(), post.clone())
-        .map_err(|err| ServerError::App(err.to_string()))?;
-    invalidate_posts().await;
-    Ok(post)
-}
-
-#[pocopine::server(public)]
 pub async fn reset_posts() -> ServerResult<()> {
     posts_stream()
         .reset()
@@ -150,31 +122,39 @@ impl SyncBoard {
     }
 
     pub fn create(&mut self) {
-        if self.title.trim().is_empty() || self.body.trim().is_empty() {
+        let title = self.title.trim().to_string();
+        let body = self.body.trim().to_string();
+        if title.is_empty() || body.is_empty() {
             self.posts.set_error("title and body are required");
             return;
         }
 
-        self.saving = true;
         self.posts.clear_error();
-        self.status = "saving".to_string();
-        let title = self.title.clone();
-        let body = self.body.clone();
+        self.next_local_id = self.next_local_id.saturating_add(1);
+        let post = Post {
+            id: format!("post_local_{}", self.next_local_id),
+            title,
+            body,
+        };
 
-        dispatch!(create_post(title, body).await, |s, result| {
-            s.saving = false;
-            match result {
-                Ok(_) => {
-                    s.title.clear();
-                    s.body.clear();
-                    s.status = "saved".to_string();
-                }
-                Err(err) => {
-                    s.status = "save failed".to_string();
-                    s.posts.set_error(err.to_string());
-                }
-            }
+        let result = build_create_mutation(post.clone()).and_then(|(mutation, optimistic)| {
+            self.plugin::<pocopine_sync::SyncClient>()
+                .collection(pocopine::this::<Self>(), |s: &mut Self| &mut s.posts)
+                .stream(POSTS_STREAM)
+                .and_then(|collection| collection.push(mutation, Some(optimistic)))
         });
+
+        match result {
+            Ok(()) => {
+                self.title.clear();
+                self.body.clear();
+                self.status = "ready".to_string();
+            }
+            Err(err) => {
+                self.status = "push failed".to_string();
+                self.posts.set_error(err.to_string());
+            }
+        }
     }
 
     pub fn refresh(&mut self) {
@@ -208,6 +188,24 @@ impl SyncBoard {
             }
         });
     }
+}
+
+fn build_create_mutation(
+    post: Post,
+) -> pocopine_sync::SyncResult<(
+    pocopine_sync::ClientMutation<Post>,
+    pocopine_sync::SyncRow<Post>,
+)> {
+    let key = pocopine_sync::RowKey::new(post.id.clone())?;
+    let mutation = pocopine_sync::ClientMutation {
+        id: pocopine_sync::MutationId::new(format!("create_post:{}", post.id))?,
+        key: Some(key),
+        op: pocopine_sync::SyncOp::Upsert,
+        base_version: None,
+        payload: post.clone(),
+    };
+    let optimistic = pocopine_sync::SyncRow::new(post.id.clone(), post)?;
+    Ok((mutation, optimistic))
 }
 
 #[wasm_bindgen(start)]

--- a/examples/sync/src/sync_board.css
+++ b/examples/sync/src/sync_board.css
@@ -134,6 +134,24 @@ button:disabled {
   font-size: 0.8rem;
 }
 
+.post__flags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  min-height: 22px;
+  margin-bottom: 8px;
+}
+
+.post__flags span {
+  border: 1px solid #d7b56d;
+  border-radius: 999px;
+  padding: 2px 8px;
+  color: #664b0f;
+  background: #fff7df;
+  font-size: 0.74rem;
+  font-weight: 700;
+}
+
 .post h2 {
   margin: 0 0 8px;
   font-size: 1.05rem;

--- a/examples/sync/tests/sync_flow.rs
+++ b/examples/sync/tests/sync_flow.rs
@@ -6,10 +6,11 @@ use pocopine_server::axum::body::Body;
 use pocopine_server::axum::http::{Request, StatusCode};
 use pocopine_server::Server;
 use pocopine_sync::{
-    sync_server_plugin, sync_stream_tag, SyncPullMode, SyncPullRequest, SyncPullResponse,
-    SyncStreamName, SYNC_PULL_PATH,
+    sync_server_plugin, sync_stream_tag, ClientMutation, MutationId, RowKey, SyncOp, SyncPullMode,
+    SyncPullRequest, SyncPullResponse, SyncPushRequest, SyncPushResponse, SyncStreamName,
+    SYNC_PULL_PATH, SYNC_PUSH_PATH,
 };
-use sync_example::{create_post, live_backend, sync_server, Post, POSTS_STREAM};
+use sync_example::{live_backend, sync_server, Post, POSTS_STREAM};
 use tower::ServiceExt;
 
 #[tokio::test]
@@ -54,12 +55,18 @@ async fn sync_pull_and_live_wakeup_share_the_stream_topic() {
     assert!(ready.contains("event: ready"));
     assert!(ready.contains("query:sync:stream:posts_for_user"));
 
-    create_post(
-        "CI sync wake-up".to_string(),
-        "incremental pull should receive this row".to_string(),
+    let pushed = push_post(
+        &app,
+        Post {
+            id: "post_from_push".to_string(),
+            title: "CI sync wake-up".to_string(),
+            body: "incremental pull should receive this row".to_string(),
+        },
     )
-    .await
-    .unwrap();
+    .await;
+    assert_eq!(pushed.accepted[0].as_str(), "ci:post_from_push");
+    assert!(pushed.rejected.is_empty());
+    assert!(pushed.conflicts.is_empty());
 
     let invalidation = read_sse_frame(&mut body).await;
     assert!(invalidation.contains("event: query.invalidated"));
@@ -74,6 +81,37 @@ async fn sync_pull_and_live_wakeup_share_the_stream_topic() {
             .map(|row| row.value.title == "CI sync wake-up")
             .unwrap_or(false)
     }));
+}
+
+async fn push_post(app: &pocopine_server::axum::Router, post: Post) -> SyncPushResponse<Post> {
+    let request = SyncPushRequest::new(
+        SyncStreamName::new(POSTS_STREAM).unwrap(),
+        [ClientMutation {
+            id: MutationId::new(format!("ci:{}", post.id)).unwrap(),
+            key: Some(RowKey::new(post.id.clone()).unwrap()),
+            op: SyncOp::Upsert,
+            base_version: None,
+            payload: post,
+        }],
+    );
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(SYNC_PUSH_PATH)
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&request).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let outer: pocopine::ServerResult<SyncPushResponse<Post>> =
+        serde_json::from_slice(&bytes).unwrap();
+    outer.unwrap()
 }
 
 async fn pull_posts(

--- a/rfcs/rfc-072-offline-sync-protocol.md
+++ b/rfcs/rfc-072-offline-sync-protocol.md
@@ -23,6 +23,10 @@ Initial implementation has started in `pocopine-sync`:
   stream guard passes,
 - browser `sync_plugin()`, `SyncClient`, and `CollectionState<T>`,
 - browser `SyncClient::open()` calls `/open` before the first `/pull`,
+- browser `SyncCollection::push()` applies optimistic rows and handles
+  accepted, rejected, and conflict push outcomes,
+- `MemorySyncStream` accepts upsert/delete/reset pushes with stable
+  mutation-id dedupe,
 - live wake-up integration through `pocopine-live` query-tag topics,
 - runnable memory-backed example in `examples/sync`,
 - Firefox wasm smoke coverage for `open -> pull -> render`.
@@ -31,7 +35,7 @@ Current model: `/open` is discovery/validation, not a session grant.
 Every `/open`, `/pull`, and `/push` request runs the stream guard
 independently, so skipping `/open` does not bypass access control.
 
-Still future work: durable browser storage, optimistic mutation replay,
+Still future work: durable browser storage, cross-reload mutation replay,
 conflict resolution UI, SQLx/database adapters, CDC sources, and
 query-driven stream parameters.
 

--- a/rfcs/rfc-072-offline-sync-protocol.md
+++ b/rfcs/rfc-072-offline-sync-protocol.md
@@ -375,14 +375,14 @@ The client sends mutations:
 
 ```json
 {
-  "client_id": "device_abc",
+  "protocol": "pocopine.sync.v1",
+  "stream": "posts_for_tenant",
   "mutations": [
     {
-      "mutation_id": "device_abc:42",
-      "stream": "posts_for_tenant",
+      "id": "device_abc:42",
       "key": "post_123",
       "base_version": "row:v7",
-      "op": "update",
+      "op": "upsert",
       "payload": {"title": "New title"}
     }
   ]
@@ -390,7 +390,32 @@ The client sends mutations:
 ```
 
 Mutation ids are idempotency keys. Replayed pushes must not apply twice.
-The server returns accepted, rejected, or conflict states per mutation.
+The server returns accepted, rejected, or conflict states per mutation:
+
+```json
+{
+  "protocol": "pocopine.sync.v1",
+  "stream": "posts_for_tenant",
+  "accepted": ["device_abc:42"],
+  "rejected": [],
+  "rows": [
+    {
+      "key": "post_123",
+      "version": "row:v8",
+      "value": {"title": "New title"},
+      "pending": false,
+      "conflict": false
+    }
+  ],
+  "conflicts": [],
+  "cursor": "sync:v1:cursor_124"
+}
+```
+
+`rejected` is for validation, authorization, or business-rule failures
+where retrying the same mutation as-is cannot succeed. `conflicts` is for
+stale `base_version` or concurrent-write cases where the server can return
+the current row and let the UI choose how to proceed.
 
 ## 8. Conflict Policy
 


### PR DESCRIPTION
## Summary
- adds explicit sync push outcomes for accepted, rejected, and conflict mutations
- implements MemorySyncStream push support with mutation-id dedupe, stale-version conflicts, and server-side live invalidation after accepted pushes
- adds optimistic CollectionState handling plus SyncCollection::push, then updates the sync example and docs to use /push for create

## Verification
- cargo fmt --check
- cargo test -p pocopine-sync
- cargo test -p sync-example
- cargo clippy -p pocopine-sync -p sync-example --all-targets -- -D warnings
- wasm-pack test --firefox --headless crates/pocopine-sync --test client_browser
- wasm-pack build --release --target web examples/sync