### PR TITLE
Add chart event display helpers

### DIFF
--- a/crates/pine-charts/src/events.rs
+++ b/crates/pine-charts/src/events.rs
@@ -8,10 +8,57 @@ pub const CHART_HOVER_EVENT: &str = "pp:chart:hover";
 pub const CHART_HOVER_END_EVENT: &str = "pp:chart:hover-end";
 pub const LEGEND_TOGGLE_EVENT: &str = "pp:chart:legend-toggle";
 
+const KIND_XY: &str = "xy";
+const KIND_CATEGORY: &str = "category";
+const KIND_SHARE: &str = "share";
+
 #[cfg(target_arch = "wasm32")]
 fn from_event_detail<T: DeserializeOwned>(event: wasm_bindgen::JsValue) -> Option<T> {
     let detail = js_sys::Reflect::get(&event, &wasm_bindgen::JsValue::from_str("detail")).ok()?;
     pocopine::__private::serde_wasm_bindgen::from_value(detail).ok()
+}
+
+fn non_empty_or<'a>(value: &'a str, fallback: &'a str) -> &'a str {
+    if value.is_empty() {
+        fallback
+    } else {
+        value
+    }
+}
+
+fn pair_display_value(first: &str, second: &str, separator: &str, fallback: &str) -> String {
+    match (first.is_empty(), second.is_empty()) {
+        (false, false) => format!("{first}{separator}{second}"),
+        (false, true) => first.into(),
+        (true, false) => second.into(),
+        (true, true) => fallback.into(),
+    }
+}
+
+fn parenthetical_display_value(value: &str, qualifier: &str, fallback: &str) -> String {
+    match (value.is_empty(), qualifier.is_empty()) {
+        (false, false) => format!("{value} ({qualifier})"),
+        (false, true) => value.into(),
+        (true, false) => qualifier.into(),
+        (true, true) => fallback.into(),
+    }
+}
+
+fn interaction_display_value(
+    kind: &str,
+    label: &str,
+    category: &str,
+    x_label: &str,
+    y_label: &str,
+    value_label: &str,
+    percentage_label: &str,
+) -> String {
+    match kind {
+        KIND_XY => pair_display_value(x_label, y_label, ": ", label),
+        KIND_CATEGORY => pair_display_value(category, value_label, ": ", label),
+        KIND_SHARE => parenthetical_display_value(value_label, percentage_label, label),
+        _ => label.into(),
+    }
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
@@ -123,6 +170,34 @@ impl ChartSelection {
             value_label: value_label.into(),
             percentage_label: percentage_label.into(),
         }
+    }
+
+    /// Returns the series label when present, otherwise the chart kind.
+    ///
+    /// This is useful for custom tooltip/detail headings while keeping the
+    /// actual mark label available through `label`.
+    pub fn series_or_chart(&self) -> &str {
+        non_empty_or(&self.series, &self.chart)
+    }
+
+    /// Formats the populated value fields according to `kind`.
+    ///
+    /// - `xy` becomes `<x_label>: <y_label>`.
+    /// - `category` becomes `<category>: <value_label>`.
+    /// - `share` becomes `<value_label> (<percentage_label>)`.
+    ///
+    /// If a payload is incomplete, this falls back to the populated side, then
+    /// to `label`.
+    pub fn display_value(&self) -> String {
+        interaction_display_value(
+            &self.kind,
+            &self.label,
+            &self.category,
+            &self.x_label,
+            &self.y_label,
+            &self.value_label,
+            &self.percentage_label,
+        )
     }
 
     #[cfg(target_arch = "wasm32")]
@@ -356,6 +431,34 @@ impl ChartHover {
         }
     }
 
+    /// Returns the series label when present, otherwise the chart kind.
+    ///
+    /// This is useful for custom tooltip/detail headings while keeping the
+    /// actual mark label available through `label`.
+    pub fn series_or_chart(&self) -> &str {
+        non_empty_or(&self.series, &self.chart)
+    }
+
+    /// Formats the populated value fields according to `kind`.
+    ///
+    /// - `xy` becomes `<x_label>: <y_label>`.
+    /// - `category` becomes `<category>: <value_label>`.
+    /// - `share` becomes `<value_label> (<percentage_label>)`.
+    ///
+    /// If a payload is incomplete, this falls back to the populated side, then
+    /// to `label`.
+    pub fn display_value(&self) -> String {
+        interaction_display_value(
+            &self.kind,
+            &self.label,
+            &self.category,
+            &self.x_label,
+            &self.y_label,
+            &self.value_label,
+            &self.percentage_label,
+        )
+    }
+
     #[cfg(target_arch = "wasm32")]
     pub fn from_event_value(event: wasm_bindgen::JsValue) -> Option<Self> {
         from_event_detail(event)
@@ -408,5 +511,111 @@ impl LegendToggle {
     #[cfg(not(target_arch = "wasm32"))]
     pub fn from_event_value(_: wasm_bindgen::JsValue) -> Option<Self> {
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chart_hover_formats_display_values_by_kind() {
+        let xy = ChartHover::xy(
+            "area",
+            "point",
+            "x 2, y 49",
+            "API: x 2, y 49",
+            "API",
+            2.0,
+            49.0,
+            "2",
+            "49",
+            "right",
+            "above",
+            "",
+        );
+        assert_eq!(xy.series_or_chart(), "API");
+        assert_eq!(xy.display_value(), "2: 49");
+
+        let category = ChartHover::category(
+            "bar",
+            "bar-a",
+            "Bucket A",
+            "Bucket A: 42",
+            "Bucket A",
+            "Actual",
+            42.0,
+            "42",
+            "right",
+            "above",
+            "",
+        );
+        assert_eq!(category.series_or_chart(), "Actual");
+        assert_eq!(category.display_value(), "Bucket A: 42");
+
+        let share = ChartHover::share(
+            "pie",
+            "organic",
+            "Organic",
+            "Organic: 30 (60%)",
+            30.0,
+            "30",
+            60.0,
+            "60%",
+            "right",
+            "above",
+            "",
+        );
+        assert_eq!(share.series_or_chart(), "pie");
+        assert_eq!(share.display_value(), "30 (60%)");
+    }
+
+    #[test]
+    fn chart_selection_formats_display_values_by_kind() {
+        let xy = ChartSelection::xy(
+            "line",
+            "point",
+            "x 1, y 10",
+            "x 1, y 10",
+            "",
+            1.0,
+            10.0,
+            "1",
+            "10",
+        );
+        assert_eq!(xy.series_or_chart(), "line");
+        assert_eq!(xy.display_value(), "1: 10");
+
+        let category =
+            ChartSelection::category("bar", "bar-a", "A", "A: 5", "A", "Actual", 5.0, "5");
+        assert_eq!(category.series_or_chart(), "Actual");
+        assert_eq!(category.display_value(), "A: 5");
+
+        let share = ChartSelection::share(
+            "pie",
+            "organic",
+            "Organic",
+            "Organic: 8 (80%)",
+            8.0,
+            "8",
+            80.0,
+            "80%",
+        );
+        assert_eq!(share.series_or_chart(), "pie");
+        assert_eq!(share.display_value(), "8 (80%)");
+    }
+
+    #[test]
+    fn display_value_handles_partial_payloads() {
+        let mut hover = ChartHover {
+            kind: KIND_CATEGORY.into(),
+            label: "Fallback".into(),
+            value_label: "42".into(),
+            ..ChartHover::default()
+        };
+        assert_eq!(hover.display_value(), "42");
+
+        hover.value_label.clear();
+        assert_eq!(hover.display_value(), "Fallback");
     }
 }

--- a/docs/charts/cookbook.md
+++ b/docs/charts/cookbook.md
@@ -141,7 +141,7 @@ pub fn show_latency_tooltip(&mut self, event: JsValue) {
     };
 
     self.tooltip_visible = true;
-    self.tooltip_value = format!("{}: {}", hover.x_label, hover.y_label);
+    self.tooltip_value = hover.display_value();
     self.tooltip_meta = hover.aria_label;
     self.tooltip_style = hover.tooltip_style;
 }
@@ -156,12 +156,7 @@ pub fn show_latency_detail(&mut self, event: JsValue) {
     };
 
     self.detail_visible = true;
-    self.detail_value = match selection.kind.as_str() {
-        "xy" => format!("{}: {}", selection.x_label, selection.y_label),
-        "category" => format!("{}: {}", selection.category, selection.value_label),
-        "share" => format!("{} ({})", selection.value_label, selection.percentage_label),
-        _ => selection.label,
-    };
+    self.detail_value = selection.display_value();
     self.detail_meta = format!("Selected {}", selection.key);
 }
 

--- a/docs/charts/events.md
+++ b/docs/charts/events.md
@@ -92,6 +92,15 @@ Payload fields:
 `label` for concise custom UI and `aria_label` when mirroring the chart's
 accessible announcement.
 
+`ChartHover` and `ChartSelection` also expose small formatting helpers for
+custom UI:
+
+- `series_or_chart()` returns the series label when present, otherwise the chart
+  kind.
+- `display_value()` formats the populated value fields for the payload kind:
+  `<x_label>: <y_label>`, `<category>: <value_label>`, or
+  `<value_label> (<percentage_label>)`.
+
 The built-in tooltip remains the default. Set `tooltip="none"` on a chart to
 hide the built-in tooltip while keeping hover crosshairs, markers, data
 attributes, and hover events active. Applications can then render a custom
@@ -115,8 +124,8 @@ pub fn show_tooltip(&mut self, event: JsValue) {
     let Some(hover) = ChartHover::from_event_value(event) else {
         return;
     };
-    self.tooltip_title = hover.series;
-    self.tooltip_value = format!("{}: {}", hover.x_label, hover.y_label);
+    self.tooltip_title = hover.series_or_chart().into();
+    self.tooltip_value = hover.display_value();
 }
 ```
 

--- a/docs/charts/interaction.md
+++ b/docs/charts/interaction.md
@@ -93,17 +93,8 @@ pub fn show_custom_tooltip(&mut self, event: JsValue) {
     };
 
     self.custom_tooltip_visible = true;
-    self.custom_tooltip_title = if hover.series.is_empty() {
-        hover.chart
-    } else {
-        hover.series
-    };
-    self.custom_tooltip_value = match hover.kind.as_str() {
-        "xy" => format!("{}: {}", hover.x_label, hover.y_label),
-        "category" => format!("{}: {}", hover.category, hover.value_label),
-        "share" => format!("{} ({})", hover.value_label, hover.percentage_label),
-        _ => hover.label,
-    };
+    self.custom_tooltip_title = hover.series_or_chart().into();
+    self.custom_tooltip_value = hover.display_value();
     self.custom_tooltip_x = hover.tooltip_x;
     self.custom_tooltip_y = hover.tooltip_y;
     self.custom_tooltip_style = hover.tooltip_style;
@@ -164,17 +155,8 @@ pub fn show_selection_detail(&mut self, event: JsValue) {
     };
 
     self.selection_visible = true;
-    self.selection_title = if selection.series.is_empty() {
-        selection.chart
-    } else {
-        selection.series
-    };
-    self.selection_value = match selection.kind.as_str() {
-        "xy" => format!("{}: {}", selection.x_label, selection.y_label),
-        "category" => format!("{}: {}", selection.category, selection.value_label),
-        "share" => format!("{} ({})", selection.value_label, selection.percentage_label),
-        _ => selection.label,
-    };
+    self.selection_title = selection.series_or_chart().into();
+    self.selection_value = selection.display_value();
     self.selection_meta = format!("Selected {}", selection.key);
 }
 

--- a/examples/charts/src/lib.rs
+++ b/examples/charts/src/lib.rs
@@ -293,12 +293,8 @@ impl ChartDemo {
             return;
         };
         self.custom_tooltip_visible = true;
-        self.custom_tooltip_title = if hover.series.is_empty() {
-            hover.chart
-        } else {
-            hover.series
-        };
-        self.custom_tooltip_value = format!("Week {}: {}", hover.x_label, hover.y_label);
+        self.custom_tooltip_title = hover.series_or_chart().into();
+        self.custom_tooltip_value = format!("Week {}", hover.display_value());
         self.custom_tooltip_meta = hover.aria_label;
         self.custom_tooltip_x = hover.tooltip_x;
         self.custom_tooltip_y = hover.tooltip_y;
@@ -314,17 +310,8 @@ impl ChartDemo {
             return;
         };
         self.selection_visible = true;
-        self.selection_title = if selection.series.is_empty() {
-            selection.chart
-        } else {
-            selection.series
-        };
-        self.selection_value = match selection.kind.as_str() {
-            "xy" => format!("{}: {}", selection.x_label, selection.y_label),
-            "category" => format!("{}: {}", selection.category, selection.value_label),
-            "share" => format!("{} · {}", selection.value_label, selection.percentage_label),
-            _ => selection.label,
-        };
+        self.selection_title = selection.series_or_chart().into();
+        self.selection_value = selection.display_value();
         self.selection_meta = format!("Selected {}", selection.key);
     }
 


### PR DESCRIPTION
## Summary
- Add `series_or_chart()` and `display_value()` helpers to `ChartHover` and `ChartSelection`
- Simplify the chart demo custom tooltip and selection handlers to use the helper API
- Update chart events, interaction, and cookbook docs to show the lower-boilerplate event pattern

## Verification
- `cargo fmt --check`
- `cargo test -p pine-charts events`
- `cargo run -p pocopine-cli -- build --path examples/charts`
- `wasm-pack test --firefox --headless crates/pine-charts`
- `cargo check --workspace --all-targets`
- `cargo clippy --workspace --all-targets -- -D warnings`
