### PR TITLE
Add sync local store foundation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -954,6 +966,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1557,6 +1581,15 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
@@ -1569,6 +1602,15 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
 
 [[package]]
 name = "heck"
@@ -2340,6 +2382,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3078,6 +3131,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3366,6 +3425,15 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
+]
+
+[[package]]
+name = "pocopine-sync-sqlite"
+version = "0.1.0"
+dependencies = [
+ "pocopine-sync",
+ "rusqlite",
+ "serde_json",
 ]
 
 [[package]]
@@ -3935,6 +4003,20 @@ dependencies = [
  "syn 2.0.117",
  "syn_derive",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags 2.11.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -5329,6 +5411,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21,6 +27,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -447,6 +468,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfa8873f51c92e232f9bac4065cddef41b714152812bfc5f7672ba16d6ef8cd9"
 
 [[package]]
+name = "brotli"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "874bb8112abecc98cbd6d81ea4fa7e94fb9449648c93cc89aa40c81c24d7de03"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -730,6 +772,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "cron"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -999,6 +1050,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "fnv"
@@ -2550,10 +2611,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "minifier"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14f1541610994bba178cb36757e102d06a52a2d9612aa6d34c64b3b377c5d943"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -3431,9 +3511,15 @@ dependencies = [
 name = "pocopine-sync-sqlite"
 version = "0.1.0"
 dependencies = [
+ "futures",
+ "js-sys",
  "pocopine-sync",
  "rusqlite",
+ "serde-wasm-bindgen 0.6.5",
  "serde_json",
+ "sqlite-wasm",
+ "wasm-bindgen",
+ "wasm-bindgen-test",
 ]
 
 [[package]]
@@ -4471,6 +4557,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
 name = "simple_asn1"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4565,6 +4657,30 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sqlite-wasm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144960afca29eab9373477365b78ac82ea797e3cfc0fe64b37655c40abe5d18e"
+dependencies = [
+ "anyhow",
+ "base64",
+ "brotli",
+ "console_error_panic_hook",
+ "flate2",
+ "futures",
+ "futures-channel",
+ "js-sys",
+ "lazy_static",
+ "minifier",
+ "serde_json",
+ "tokio",
+ "uuid",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "crates/pocopine-observe",
     "crates/pocopine-server",
     "crates/pocopine-sync",
+    "crates/pocopine-sync-sqlite",
     "examples/blog",
     "examples/charts",
     "examples/counter",
@@ -76,6 +77,7 @@ pocopine-macros = { path = "crates/pocopine-macros", version = "0.1.0" }
 pocopine-observe = { path = "crates/pocopine-observe", version = "0.1.0" }
 pocopine-server = { path = "crates/pocopine-server", version = "0.1.0" }
 pocopine-sync = { path = "crates/pocopine-sync", version = "0.1.0" }
+pocopine-sync-sqlite = { path = "crates/pocopine-sync-sqlite", version = "0.1.0" }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"

--- a/crates/pocopine-sync-sqlite/Cargo.toml
+++ b/crates/pocopine-sync-sqlite/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "pocopine-sync-sqlite"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "SQLite local-store backend for Pocopine sync."
+
+[dependencies]
+pocopine-sync = { workspace = true }
+serde_json = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+rusqlite = { version = "0.32", features = ["bundled"] }

--- a/crates/pocopine-sync-sqlite/Cargo.toml
+++ b/crates/pocopine-sync-sqlite/Cargo.toml
@@ -12,3 +12,13 @@ serde_json = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rusqlite = { version = "0.32", features = ["bundled"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+futures = "0.3"
+js-sys = { workspace = true }
+serde-wasm-bindgen = { workspace = true }
+sqlite-wasm = "0.1.4"
+wasm-bindgen = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+wasm-bindgen-test = "0.3"

--- a/crates/pocopine-sync-sqlite/src/lib.rs
+++ b/crates/pocopine-sync-sqlite/src/lib.rs
@@ -1,0 +1,25 @@
+//! SQLite local-store backend for `pocopine-sync`.
+//!
+//! This is an explicit sync extension crate. It is not re-exported from
+//! `pocopine` core. The crate owns the SQLite schema and local-store
+//! semantics; browser OPFS support will use the same API once the SQLite
+//! WASM worker binding lands.
+
+mod schema;
+
+pub use schema::{
+    BOOTSTRAP_SQL, DELETE_MUTATION_SQL, DELETE_ROW_SQL, DELETE_STREAM_ROWS_SQL, META_DEVICE_ID,
+    META_NEXT_MUTATION_COUNTER, META_SCHEMA_VERSION, META_TABLE, MUTATIONS_TABLE, ROWS_TABLE,
+    SCHEMA_VERSION, SELECT_PENDING_MUTATIONS_SQL, SELECT_ROWS_SQL, SELECT_STREAM_SQL,
+    STREAMS_TABLE, UPDATE_ROW_CONFLICT_SQL, UPSERT_MUTATION_SQL, UPSERT_ROW_SQL, UPSERT_STREAM_SQL,
+};
+
+#[cfg(not(target_arch = "wasm32"))]
+mod native;
+#[cfg(target_arch = "wasm32")]
+mod wasm;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use native::SqliteLocalStore;
+#[cfg(target_arch = "wasm32")]
+pub use wasm::SqliteLocalStore;

--- a/crates/pocopine-sync-sqlite/src/lib.rs
+++ b/crates/pocopine-sync-sqlite/src/lib.rs
@@ -2,8 +2,8 @@
 //!
 //! This is an explicit sync extension crate. It is not re-exported from
 //! `pocopine` core. The crate owns the SQLite schema and local-store
-//! semantics; browser OPFS support will use the same API once the SQLite
-//! WASM worker binding lands.
+//! semantics. Native builds use `rusqlite`; browser builds use SQLite WASM
+//! with an OPFS worker through the same `SyncLocalStore` API.
 
 mod schema;
 

--- a/crates/pocopine-sync-sqlite/src/native.rs
+++ b/crates/pocopine-sync-sqlite/src/native.rs
@@ -771,6 +771,188 @@ mod tests {
             .contains("incompatible sync sqlite schema version"));
     }
 
+    #[test]
+    fn sqlite_store_save_snapshot_replaces_previous_rows() {
+        let store = SqliteLocalStore::open_in_memory().unwrap();
+        let stream = SyncStreamName::new("posts").unwrap();
+        let collection = SyncCollectionName::new("posts").unwrap();
+
+        block(store.save_snapshot(LocalSnapshotBatch::new(
+            stream.clone(),
+            collection.clone(),
+            vec![
+                SyncRow::new("post_1", serde_json::json!({"title": "Old1"})).unwrap(),
+                SyncRow::new("post_2", serde_json::json!({"title": "Old2"})).unwrap(),
+            ],
+            Some(SyncCursor::new("cursor_1").unwrap()),
+        )))
+        .unwrap();
+
+        let replacement =
+            SyncRow::new("post_3", serde_json::json!({"title": "Only survivor"})).unwrap();
+        block(store.save_snapshot(LocalSnapshotBatch::new(
+            stream.clone(),
+            collection,
+            vec![replacement.clone()],
+            Some(SyncCursor::new("cursor_2").unwrap()),
+        )))
+        .unwrap();
+
+        let snapshot = block(store.hydrate_stream(&stream)).unwrap();
+        assert_eq!(snapshot.rows, vec![replacement]);
+        assert_eq!(snapshot.cursor.unwrap().as_str(), "cursor_2");
+    }
+
+    #[test]
+    fn sqlite_store_apply_changes_reset_then_upsert_keeps_only_post_reset_rows() {
+        let store = SqliteLocalStore::open_in_memory().unwrap();
+        let stream = SyncStreamName::new("posts").unwrap();
+        let collection = SyncCollectionName::new("posts").unwrap();
+        block(store.save_snapshot(LocalSnapshotBatch::new(
+            stream.clone(),
+            collection.clone(),
+            vec![
+                SyncRow::new("old_1", serde_json::json!({"title": "Old1"})).unwrap(),
+                SyncRow::new("old_2", serde_json::json!({"title": "Old2"})).unwrap(),
+            ],
+            Some(SyncCursor::new("cursor_1").unwrap()),
+        )))
+        .unwrap();
+
+        let cursor = SyncCursor::new("cursor_2").unwrap();
+        let after_reset =
+            SyncRow::new("post_after", serde_json::json!({"title": "After"})).unwrap();
+        block(store.apply_changes(LocalChangeBatch::new(
+            stream.clone(),
+            collection.clone(),
+            vec![
+                SyncChange {
+                    stream: stream.clone(),
+                    collection: collection.clone(),
+                    key: Some(RowKey::new("ignored").unwrap()),
+                    op: SyncOp::Upsert,
+                    row: Some(
+                        SyncRow::new("ignored", serde_json::json!({"title": "Pre-reset"}))
+                            .unwrap(),
+                    ),
+                    cursor: cursor.clone(),
+                },
+                SyncChange {
+                    stream: stream.clone(),
+                    collection: collection.clone(),
+                    key: None,
+                    op: SyncOp::Reset,
+                    row: None,
+                    cursor: cursor.clone(),
+                },
+                SyncChange {
+                    stream: stream.clone(),
+                    collection,
+                    key: Some(after_reset.key.clone()),
+                    op: SyncOp::Upsert,
+                    row: Some(after_reset.clone()),
+                    cursor: cursor.clone(),
+                },
+            ],
+            Some(cursor),
+        )))
+        .unwrap();
+
+        let snapshot = block(store.hydrate_stream(&stream)).unwrap();
+        assert_eq!(snapshot.rows, vec![after_reset]);
+    }
+
+    #[test]
+    fn sqlite_store_mark_push_cursor_only_without_prior_meta_errors() {
+        let store = SqliteLocalStore::open_in_memory().unwrap();
+        let stream = SyncStreamName::new("posts").unwrap();
+
+        let err = block(store.mark_push_result(LocalPushResult {
+            stream: stream.clone(),
+            collection: None,
+            accepted: Vec::new(),
+            rejected: Vec::new(),
+            rows: Vec::new(),
+            conflicts: Vec::new(),
+            cursor: Some(SyncCursor::new("orphan_cursor").unwrap()),
+        }))
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("cannot persist sync push cursor"),
+            "expected error about missing stream metadata, got: {err}"
+        );
+    }
+
+    #[test]
+    fn sqlite_store_pending_mutations_preserve_enqueue_order() {
+        let store = SqliteLocalStore::open_in_memory().unwrap();
+        let stream = SyncStreamName::new("posts").unwrap();
+        for index in 1..=3 {
+            block(store.enqueue_mutation(
+                &stream,
+                ClientMutation {
+                    id: MutationId::new(format!("device_abc:{index}")).unwrap(),
+                    key: Some(RowKey::new(format!("post_{index}")).unwrap()),
+                    op: SyncOp::Upsert,
+                    base_version: None,
+                    payload: serde_json::json!({"index": index}),
+                },
+            ))
+            .unwrap();
+        }
+
+        let pending = block(store.pending_mutations(&stream)).unwrap();
+        let ids: Vec<_> = pending.iter().map(|m| m.id.as_str().to_string()).collect();
+        assert_eq!(ids, vec!["device_abc:1", "device_abc:2", "device_abc:3"]);
+    }
+
+    #[test]
+    fn sqlite_store_apply_changes_delete_missing_key_is_noop() {
+        let store = SqliteLocalStore::open_in_memory().unwrap();
+        let stream = SyncStreamName::new("posts").unwrap();
+        let collection = SyncCollectionName::new("posts").unwrap();
+        block(store.save_snapshot(LocalSnapshotBatch::new(
+            stream.clone(),
+            collection.clone(),
+            vec![SyncRow::new("post_1", serde_json::json!({"title": "Kept"})).unwrap()],
+            None,
+        )))
+        .unwrap();
+
+        let cursor = SyncCursor::new("cursor_2").unwrap();
+        block(store.apply_changes(LocalChangeBatch::new(
+            stream.clone(),
+            collection.clone(),
+            vec![SyncChange {
+                stream: stream.clone(),
+                collection,
+                key: Some(RowKey::new("never_existed").unwrap()),
+                op: SyncOp::Delete,
+                row: None,
+                cursor: cursor.clone(),
+            }],
+            Some(cursor),
+        )))
+        .unwrap();
+
+        let snapshot = block(store.hydrate_stream(&stream)).unwrap();
+        assert_eq!(snapshot.rows.len(), 1);
+        assert_eq!(snapshot.rows[0].key.as_str(), "post_1");
+    }
+
+    #[test]
+    fn sqlite_store_hydrate_returns_empty_for_unknown_stream() {
+        let store = SqliteLocalStore::open_in_memory().unwrap();
+        let stream = SyncStreamName::new("never_seen").unwrap();
+        let snapshot = block(store.hydrate_stream(&stream)).unwrap();
+        assert_eq!(snapshot.stream, stream);
+        assert!(snapshot.collection.is_none());
+        assert!(snapshot.cursor.is_none());
+        assert!(snapshot.rows.is_empty());
+        assert!(snapshot.pending_mutations.is_empty());
+    }
+
     fn block<T>(future: SyncLocalFuture<'_, T>) -> SyncResult<T> {
         let waker = std::task::Waker::noop();
         let mut cx = std::task::Context::from_waker(waker);

--- a/crates/pocopine-sync-sqlite/src/native.rs
+++ b/crates/pocopine-sync-sqlite/src/native.rs
@@ -2,7 +2,7 @@ use std::{
     future,
     path::Path,
     sync::{Arc, Mutex},
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
 use pocopine_sync::{
@@ -20,9 +20,6 @@ use crate::schema::{
 };
 
 /// SQLite-backed [`SyncLocalStore`] for host/native targets.
-///
-/// Browser builds expose the same type name but return a clear unsupported
-/// error until the SQLite WASM + OPFS worker binding lands.
 #[derive(Clone)]
 pub struct SqliteLocalStore {
     conn: Arc<Mutex<Connection>>,
@@ -36,11 +33,14 @@ impl SqliteLocalStore {
 
     /// Open or create a SQLite local store at `path`.
     pub fn open_path(path: impl AsRef<Path>) -> SyncResult<Self> {
-        Self::from_connection(Connection::open(path).map_err(sqlite_error)?)
+        let conn = Connection::open(path).map_err(sqlite_error)?;
+        configure_file_connection(&conn)?;
+        Self::from_connection(conn)
     }
 
     /// Build a store from an existing SQLite connection and bootstrap schema.
     pub fn from_connection(mut conn: Connection) -> SyncResult<Self> {
+        configure_connection(&conn)?;
         bootstrap_schema(&mut conn)?;
         Ok(Self {
             conn: Arc::new(Mutex::new(conn)),
@@ -109,8 +109,46 @@ fn bootstrap_schema(conn: &mut Connection) -> SyncResult<()> {
     for sql in BOOTSTRAP_SQL {
         tx.execute_batch(sql).map_err(sqlite_error)?;
     }
+    validate_schema_version(&tx)?;
     upsert_meta(&tx, META_SCHEMA_VERSION, &SCHEMA_VERSION.to_string())?;
     tx.commit().map_err(sqlite_error)
+}
+
+fn configure_connection(conn: &Connection) -> SyncResult<()> {
+    conn.busy_timeout(Duration::from_millis(5_000))
+        .map_err(sqlite_error)
+}
+
+fn configure_file_connection(conn: &Connection) -> SyncResult<()> {
+    configure_connection(conn)?;
+    conn.pragma_update(None, "journal_mode", "WAL")
+        .map_err(sqlite_error)
+}
+
+fn validate_schema_version(tx: &Transaction<'_>) -> SyncResult<()> {
+    let existing = tx
+        .query_row(
+            "select value from __pocopine_meta where key = ?1",
+            params![META_SCHEMA_VERSION],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(sqlite_error)?;
+
+    if let Some(existing) = existing {
+        let version = existing.parse::<u32>().map_err(|_| {
+            SyncError::backend(format!(
+                "invalid sync sqlite schema version in local store: {existing}"
+            ))
+        })?;
+        if version != SCHEMA_VERSION {
+            return Err(SyncError::backend(format!(
+                "incompatible sync sqlite schema version: found {version}, expected {SCHEMA_VERSION}"
+            )));
+        }
+    }
+
+    Ok(())
 }
 
 fn load_identity(conn: &mut Connection) -> SyncResult<Option<SyncLocalIdentity>> {
@@ -199,34 +237,36 @@ fn save_snapshot(conn: &mut Connection, snapshot: LocalSnapshotBatch) -> SyncRes
 fn apply_changes(conn: &mut Connection, changes: LocalChangeBatch) -> SyncResult<()> {
     let tx = conn.transaction().map_err(sqlite_error)?;
     let now = epoch_ms();
+    let stream = changes.stream;
     upsert_stream(
         &tx,
-        &changes.stream,
+        &stream,
         &changes.collection,
         changes.cursor.as_ref(),
         now,
     )?;
-    for change in changes.changes {
+    let changes = changes_after_last_reset(changes.changes);
+    if changes.had_reset {
+        tx.execute(DELETE_STREAM_ROWS_SQL, params![stream.as_str()])
+            .map_err(sqlite_error)?;
+    }
+
+    for change in changes.items {
         match change.op {
             SyncOp::Upsert => {
                 if let Some(row) = change.row {
-                    upsert_row(&tx, &changes.stream, &row, now)?;
+                    upsert_row(&tx, &stream, &row, now)?;
                 }
             }
             SyncOp::Delete => {
                 if let Some(key) = change.key {
-                    tx.execute(
-                        DELETE_ROW_SQL,
-                        params![changes.stream.as_str(), key.as_str()],
-                    )
-                    .map_err(sqlite_error)?;
+                    tx.execute(DELETE_ROW_SQL, params![stream.as_str(), key.as_str()])
+                        .map_err(sqlite_error)?;
                 }
             }
             SyncOp::Reset => {
-                tx.execute(DELETE_STREAM_ROWS_SQL, params![changes.stream.as_str()])
-                    .map_err(sqlite_error)?;
                 if let Some(row) = change.row {
-                    upsert_row(&tx, &changes.stream, &row, now)?;
+                    upsert_row(&tx, &stream, &row, now)?;
                 }
             }
         }
@@ -261,12 +301,21 @@ fn mark_push_result(conn: &mut Connection, result: LocalPushResult) -> SyncResul
     let tx = conn.transaction().map_err(sqlite_error)?;
     let now = epoch_ms();
 
-    if let Some(cursor) = result.cursor {
-        tx.execute(
-            "update __pocopine_streams set cursor = ?2, updated_at_ms = ?3 where stream = ?1",
-            params![result.stream.as_str(), cursor.as_str(), now],
-        )
-        .map_err(sqlite_error)?;
+    if let Some(collection) = result.collection.as_ref() {
+        upsert_stream(&tx, &result.stream, collection, result.cursor.as_ref(), now)?;
+    } else if let Some(cursor) = result.cursor.as_ref() {
+        let updated = tx
+            .execute(
+                "update __pocopine_streams set cursor = ?2, updated_at_ms = ?3 where stream = ?1",
+                params![result.stream.as_str(), cursor.as_str(), now],
+            )
+            .map_err(sqlite_error)?;
+        if updated == 0 {
+            return Err(SyncError::backend(format!(
+                "cannot persist sync push cursor for stream {} before stream metadata exists",
+                result.stream
+            )));
+        }
     }
 
     for id in result.accepted {
@@ -454,6 +503,30 @@ fn op_from_str(value: &str) -> SyncResult<SyncOp> {
     }
 }
 
+struct LocalChanges {
+    had_reset: bool,
+    items: Vec<pocopine_sync::SyncChange<serde_json::Value>>,
+}
+
+fn changes_after_last_reset(
+    changes: Vec<pocopine_sync::SyncChange<serde_json::Value>>,
+) -> LocalChanges {
+    let Some(index) = changes
+        .iter()
+        .rposition(|change| change.op == SyncOp::Reset)
+    else {
+        return LocalChanges {
+            had_reset: false,
+            items: changes,
+        };
+    };
+
+    LocalChanges {
+        had_reset: true,
+        items: changes.into_iter().skip(index).collect(),
+    }
+}
+
 fn epoch_ms() -> i64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -583,6 +656,7 @@ mod tests {
 
         block(store.mark_push_result(LocalPushResult {
             stream: stream.clone(),
+            collection: Some(SyncCollectionName::new("posts").unwrap()),
             accepted: vec![MutationId::new("device_abc:1").unwrap()],
             rejected: Vec::new(),
             rows: vec![SyncRow::new("post_1", serde_json::json!({"title": "Saved"})).unwrap()],
@@ -593,6 +667,31 @@ mod tests {
 
         assert!(block(store.pending_mutations(&stream)).unwrap().is_empty());
         assert_eq!(block(store.hydrate_stream(&stream)).unwrap().rows.len(), 1);
+    }
+
+    #[test]
+    fn sqlite_store_persists_push_cursor_before_snapshot_when_collection_is_present() {
+        let store = SqliteLocalStore::open_in_memory().unwrap();
+        let stream = SyncStreamName::new("posts").unwrap();
+
+        block(store.mark_push_result(LocalPushResult {
+            stream: stream.clone(),
+            collection: Some(SyncCollectionName::new("posts").unwrap()),
+            accepted: vec![MutationId::new("device_abc:1").unwrap()],
+            rejected: Vec::new(),
+            rows: vec![SyncRow::new("post_1", serde_json::json!({"title": "Saved"}))
+                .unwrap()
+                .version("row_1")
+                .unwrap()],
+            conflicts: Vec::new(),
+            cursor: Some(SyncCursor::new("cursor_1").unwrap()),
+        }))
+        .unwrap();
+
+        let snapshot = block(store.hydrate_stream(&stream)).unwrap();
+        assert_eq!(snapshot.collection.unwrap().as_str(), "posts");
+        assert_eq!(snapshot.cursor.unwrap().as_str(), "cursor_1");
+        assert_eq!(snapshot.rows.len(), 1);
     }
 
     #[test]
@@ -624,6 +723,7 @@ mod tests {
 
         block(store.mark_push_result(LocalPushResult {
             stream: stream.clone(),
+            collection: Some(SyncCollectionName::new("posts").unwrap()),
             accepted: Vec::new(),
             rejected: vec![SyncRejectedMutation {
                 mutation_id: MutationId::new("device_abc:1").unwrap(),
@@ -647,6 +747,28 @@ mod tests {
         assert!(block(store.pending_mutations(&stream)).unwrap().is_empty());
         assert_eq!(snapshot.rows.len(), 1);
         assert!(snapshot.rows[0].conflict);
+    }
+
+    #[test]
+    fn sqlite_store_rejects_incompatible_schema_version() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "create table __pocopine_meta (
+                key text primary key,
+                value text not null
+            );
+            insert into __pocopine_meta (key, value) values ('schema_version', '2');",
+        )
+        .unwrap();
+
+        let err = match SqliteLocalStore::from_connection(conn) {
+            Ok(_) => panic!("schema version mismatch should fail"),
+            Err(err) => err,
+        };
+
+        assert!(err
+            .to_string()
+            .contains("incompatible sync sqlite schema version"));
     }
 
     fn block<T>(future: SyncLocalFuture<'_, T>) -> SyncResult<T> {

--- a/crates/pocopine-sync-sqlite/src/native.rs
+++ b/crates/pocopine-sync-sqlite/src/native.rs
@@ -757,7 +757,7 @@ mod tests {
                 key text primary key,
                 value text not null
             );
-            insert into __pocopine_meta (key, value) values ('schema_version', '2');",
+            insert into __pocopine_meta (key, value) values ('schema_version', '999');",
         )
         .unwrap();
 
@@ -832,8 +832,7 @@ mod tests {
                     key: Some(RowKey::new("ignored").unwrap()),
                     op: SyncOp::Upsert,
                     row: Some(
-                        SyncRow::new("ignored", serde_json::json!({"title": "Pre-reset"}))
-                            .unwrap(),
+                        SyncRow::new("ignored", serde_json::json!({"title": "Pre-reset"})).unwrap(),
                     ),
                     cursor: cursor.clone(),
                 },
@@ -888,23 +887,30 @@ mod tests {
     fn sqlite_store_pending_mutations_preserve_enqueue_order() {
         let store = SqliteLocalStore::open_in_memory().unwrap();
         let stream = SyncStreamName::new("posts").unwrap();
-        for index in 1..=3 {
+        for id in ["device_abc:10", "device_abc:2", "device_abc:1"] {
             block(store.enqueue_mutation(
                 &stream,
                 ClientMutation {
-                    id: MutationId::new(format!("device_abc:{index}")).unwrap(),
-                    key: Some(RowKey::new(format!("post_{index}")).unwrap()),
+                    id: MutationId::new(id).unwrap(),
+                    key: Some(RowKey::new("post_1").unwrap()),
                     op: SyncOp::Upsert,
                     base_version: None,
-                    payload: serde_json::json!({"index": index}),
+                    payload: serde_json::json!({"id": id}),
                 },
             ))
             .unwrap();
         }
+        store
+            .with_conn(|conn| {
+                conn.execute("update __pocopine_mutations set created_at_ms = 42", [])
+                    .map_err(sqlite_error)?;
+                Ok(())
+            })
+            .unwrap();
 
         let pending = block(store.pending_mutations(&stream)).unwrap();
         let ids: Vec<_> = pending.iter().map(|m| m.id.as_str().to_string()).collect();
-        assert_eq!(ids, vec!["device_abc:1", "device_abc:2", "device_abc:3"]);
+        assert_eq!(ids, vec!["device_abc:10", "device_abc:2", "device_abc:1"]);
     }
 
     #[test]

--- a/crates/pocopine-sync-sqlite/src/native.rs
+++ b/crates/pocopine-sync-sqlite/src/native.rs
@@ -1,0 +1,663 @@
+use std::{
+    future,
+    path::Path,
+    sync::{Arc, Mutex},
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use pocopine_sync::{
+    ClientMutation, LocalChangeBatch, LocalPushResult, LocalSnapshotBatch, LocalStreamSnapshot,
+    RowKey, RowVersion, SyncCollectionName, SyncCursor, SyncDeviceId, SyncError, SyncLocalFuture,
+    SyncLocalIdentity, SyncLocalStore, SyncOp, SyncResult, SyncRow, SyncStreamName,
+};
+use rusqlite::{params, Connection, OptionalExtension, Transaction};
+
+use crate::schema::{
+    BOOTSTRAP_SQL, DELETE_MUTATION_SQL, DELETE_ROW_SQL, DELETE_STREAM_ROWS_SQL, META_DEVICE_ID,
+    META_NEXT_MUTATION_COUNTER, META_SCHEMA_VERSION, SCHEMA_VERSION, SELECT_PENDING_MUTATIONS_SQL,
+    SELECT_ROWS_SQL, SELECT_STREAM_SQL, UPDATE_ROW_CONFLICT_SQL, UPSERT_MUTATION_SQL,
+    UPSERT_ROW_SQL, UPSERT_STREAM_SQL,
+};
+
+/// SQLite-backed [`SyncLocalStore`] for host/native targets.
+///
+/// Browser builds expose the same type name but return a clear unsupported
+/// error until the SQLite WASM + OPFS worker binding lands.
+#[derive(Clone)]
+pub struct SqliteLocalStore {
+    conn: Arc<Mutex<Connection>>,
+}
+
+impl SqliteLocalStore {
+    /// Open an in-memory SQLite local store.
+    pub fn open_in_memory() -> SyncResult<Self> {
+        Self::from_connection(Connection::open_in_memory().map_err(sqlite_error)?)
+    }
+
+    /// Open or create a SQLite local store at `path`.
+    pub fn open_path(path: impl AsRef<Path>) -> SyncResult<Self> {
+        Self::from_connection(Connection::open(path).map_err(sqlite_error)?)
+    }
+
+    /// Build a store from an existing SQLite connection and bootstrap schema.
+    pub fn from_connection(mut conn: Connection) -> SyncResult<Self> {
+        bootstrap_schema(&mut conn)?;
+        Ok(Self {
+            conn: Arc::new(Mutex::new(conn)),
+        })
+    }
+
+    fn with_conn<T>(&self, f: impl FnOnce(&mut Connection) -> SyncResult<T>) -> SyncResult<T> {
+        let mut conn = self
+            .conn
+            .lock()
+            .map_err(|_| SyncError::backend("sqlite sync local store lock poisoned"))?;
+        f(&mut conn)
+    }
+
+    fn ready<T: 'static>(result: SyncResult<T>) -> SyncLocalFuture<'static, T> {
+        Box::pin(future::ready(result))
+    }
+}
+
+impl SyncLocalStore for SqliteLocalStore {
+    fn load_identity(&self) -> SyncLocalFuture<'_, Option<SyncLocalIdentity>> {
+        Self::ready(self.with_conn(load_identity))
+    }
+
+    fn save_identity(&self, identity: SyncLocalIdentity) -> SyncLocalFuture<'_, ()> {
+        Self::ready(self.with_conn(|conn| save_identity(conn, identity)))
+    }
+
+    fn hydrate_stream(&self, stream: &SyncStreamName) -> SyncLocalFuture<'_, LocalStreamSnapshot> {
+        let stream = stream.clone();
+        Self::ready(self.with_conn(|conn| hydrate_stream(conn, stream)))
+    }
+
+    fn save_snapshot(&self, snapshot: LocalSnapshotBatch) -> SyncLocalFuture<'_, ()> {
+        Self::ready(self.with_conn(|conn| save_snapshot(conn, snapshot)))
+    }
+
+    fn apply_changes(&self, changes: LocalChangeBatch) -> SyncLocalFuture<'_, ()> {
+        Self::ready(self.with_conn(|conn| apply_changes(conn, changes)))
+    }
+
+    fn enqueue_mutation(
+        &self,
+        stream: &SyncStreamName,
+        mutation: ClientMutation<serde_json::Value>,
+    ) -> SyncLocalFuture<'_, ()> {
+        let stream = stream.clone();
+        Self::ready(self.with_conn(|conn| enqueue_mutation(conn, stream, mutation)))
+    }
+
+    fn mark_push_result(&self, result: LocalPushResult) -> SyncLocalFuture<'_, ()> {
+        Self::ready(self.with_conn(|conn| mark_push_result(conn, result)))
+    }
+
+    fn pending_mutations(
+        &self,
+        stream: &SyncStreamName,
+    ) -> SyncLocalFuture<'_, Vec<ClientMutation<serde_json::Value>>> {
+        let stream = stream.clone();
+        Self::ready(self.with_conn(|conn| pending_mutations(conn, &stream)))
+    }
+}
+
+fn bootstrap_schema(conn: &mut Connection) -> SyncResult<()> {
+    let tx = conn.transaction().map_err(sqlite_error)?;
+    for sql in BOOTSTRAP_SQL {
+        tx.execute_batch(sql).map_err(sqlite_error)?;
+    }
+    upsert_meta(&tx, META_SCHEMA_VERSION, &SCHEMA_VERSION.to_string())?;
+    tx.commit().map_err(sqlite_error)
+}
+
+fn load_identity(conn: &mut Connection) -> SyncResult<Option<SyncLocalIdentity>> {
+    let Some(device_id) = select_meta(conn, META_DEVICE_ID)? else {
+        return Ok(None);
+    };
+    let next_counter = select_meta(conn, META_NEXT_MUTATION_COUNTER)?
+        .map(|value| {
+            value.parse::<u64>().map_err(|_| {
+                SyncError::backend(format!(
+                    "invalid sync next mutation counter in sqlite store: {value}"
+                ))
+            })
+        })
+        .transpose()?
+        .unwrap_or(1);
+
+    SyncLocalIdentity::with_next_counter(SyncDeviceId::new(device_id)?, next_counter).map(Some)
+}
+
+fn save_identity(conn: &mut Connection, identity: SyncLocalIdentity) -> SyncResult<()> {
+    let tx = conn.transaction().map_err(sqlite_error)?;
+    upsert_meta(&tx, META_DEVICE_ID, identity.device_id.as_str())?;
+    upsert_meta(
+        &tx,
+        META_NEXT_MUTATION_COUNTER,
+        &identity.next_mutation_counter.to_string(),
+    )?;
+    tx.commit().map_err(sqlite_error)
+}
+
+fn hydrate_stream(
+    conn: &mut Connection,
+    stream: SyncStreamName,
+) -> SyncResult<LocalStreamSnapshot> {
+    let stream_meta = conn
+        .query_row(SELECT_STREAM_SQL, params![stream.as_str()], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
+        })
+        .optional()
+        .map_err(sqlite_error)?;
+
+    let rows = load_rows(conn, &stream)?;
+    let pending_mutations = pending_mutations(conn, &stream)?;
+    let Some((collection, cursor)) = stream_meta else {
+        if rows.is_empty() && pending_mutations.is_empty() {
+            return Ok(LocalStreamSnapshot::empty(stream));
+        }
+
+        return Ok(LocalStreamSnapshot {
+            stream,
+            collection: None,
+            cursor: None,
+            rows,
+            pending_mutations,
+        });
+    };
+
+    Ok(LocalStreamSnapshot {
+        stream: stream.clone(),
+        collection: Some(SyncCollectionName::new(collection)?),
+        cursor: cursor.map(SyncCursor::new).transpose()?,
+        rows,
+        pending_mutations,
+    })
+}
+
+fn save_snapshot(conn: &mut Connection, snapshot: LocalSnapshotBatch) -> SyncResult<()> {
+    let tx = conn.transaction().map_err(sqlite_error)?;
+    let now = epoch_ms();
+    upsert_stream(
+        &tx,
+        &snapshot.stream,
+        &snapshot.collection,
+        snapshot.cursor.as_ref(),
+        now,
+    )?;
+    tx.execute(DELETE_STREAM_ROWS_SQL, params![snapshot.stream.as_str()])
+        .map_err(sqlite_error)?;
+    for row in snapshot.rows {
+        upsert_row(&tx, &snapshot.stream, &row, now)?;
+    }
+    tx.commit().map_err(sqlite_error)
+}
+
+fn apply_changes(conn: &mut Connection, changes: LocalChangeBatch) -> SyncResult<()> {
+    let tx = conn.transaction().map_err(sqlite_error)?;
+    let now = epoch_ms();
+    upsert_stream(
+        &tx,
+        &changes.stream,
+        &changes.collection,
+        changes.cursor.as_ref(),
+        now,
+    )?;
+    for change in changes.changes {
+        match change.op {
+            SyncOp::Upsert => {
+                if let Some(row) = change.row {
+                    upsert_row(&tx, &changes.stream, &row, now)?;
+                }
+            }
+            SyncOp::Delete => {
+                if let Some(key) = change.key {
+                    tx.execute(
+                        DELETE_ROW_SQL,
+                        params![changes.stream.as_str(), key.as_str()],
+                    )
+                    .map_err(sqlite_error)?;
+                }
+            }
+            SyncOp::Reset => {
+                tx.execute(DELETE_STREAM_ROWS_SQL, params![changes.stream.as_str()])
+                    .map_err(sqlite_error)?;
+                if let Some(row) = change.row {
+                    upsert_row(&tx, &changes.stream, &row, now)?;
+                }
+            }
+        }
+    }
+    tx.commit().map_err(sqlite_error)
+}
+
+fn enqueue_mutation(
+    conn: &mut Connection,
+    stream: SyncStreamName,
+    mutation: ClientMutation<serde_json::Value>,
+) -> SyncResult<()> {
+    let now = epoch_ms();
+    let payload = serde_json::to_string(&mutation.payload)?;
+    conn.execute(
+        UPSERT_MUTATION_SQL,
+        params![
+            stream.as_str(),
+            mutation.id.as_str(),
+            mutation.key.as_ref().map(RowKey::as_str),
+            mutation.base_version.as_ref().map(RowVersion::as_str),
+            op_to_str(mutation.op),
+            payload,
+            now,
+        ],
+    )
+    .map_err(sqlite_error)?;
+    Ok(())
+}
+
+fn mark_push_result(conn: &mut Connection, result: LocalPushResult) -> SyncResult<()> {
+    let tx = conn.transaction().map_err(sqlite_error)?;
+    let now = epoch_ms();
+
+    if let Some(cursor) = result.cursor {
+        tx.execute(
+            "update __pocopine_streams set cursor = ?2, updated_at_ms = ?3 where stream = ?1",
+            params![result.stream.as_str(), cursor.as_str(), now],
+        )
+        .map_err(sqlite_error)?;
+    }
+
+    for id in result.accepted {
+        delete_mutation(&tx, id.as_str())?;
+    }
+
+    for rejected in result.rejected {
+        delete_mutation(&tx, rejected.mutation_id.as_str())?;
+    }
+
+    for conflict in result.conflicts {
+        delete_mutation(&tx, conflict.mutation_id.as_str())?;
+        if let Some(mut row) = conflict.server_row {
+            row.pending = false;
+            row.conflict = true;
+            upsert_row(&tx, &result.stream, &row, now)?;
+        } else if let Some(key) = conflict.key {
+            tx.execute(
+                UPDATE_ROW_CONFLICT_SQL,
+                params![result.stream.as_str(), key.as_str(), now],
+            )
+            .map_err(sqlite_error)?;
+        }
+    }
+
+    for mut row in result.rows {
+        row.pending = false;
+        row.conflict = false;
+        upsert_row(&tx, &result.stream, &row, now)?;
+    }
+
+    tx.commit().map_err(sqlite_error)
+}
+
+fn pending_mutations(
+    conn: &mut Connection,
+    stream: &SyncStreamName,
+) -> SyncResult<Vec<ClientMutation<serde_json::Value>>> {
+    let mut stmt = conn
+        .prepare(SELECT_PENDING_MUTATIONS_SQL)
+        .map_err(sqlite_error)?;
+    let rows = stmt
+        .query_map(params![stream.as_str()], |row| {
+            let mutation_id: String = row.get(0)?;
+            let row_key: Option<String> = row.get(1)?;
+            let base_version: Option<String> = row.get(2)?;
+            let op: String = row.get(3)?;
+            let payload: Option<String> = row.get(4)?;
+            Ok((mutation_id, row_key, base_version, op, payload))
+        })
+        .map_err(sqlite_error)?;
+
+    let mut mutations = Vec::new();
+    for row in rows {
+        let (mutation_id, row_key, base_version, op, payload) = row.map_err(sqlite_error)?;
+        mutations.push(ClientMutation {
+            id: pocopine_sync::MutationId::new(mutation_id)?,
+            key: row_key.map(RowKey::new).transpose()?,
+            base_version: base_version.map(RowVersion::new).transpose()?,
+            op: op_from_str(&op)?,
+            payload: payload
+                .map(|payload| serde_json::from_str(&payload))
+                .transpose()?
+                .unwrap_or(serde_json::Value::Null),
+        });
+    }
+    Ok(mutations)
+}
+
+fn load_rows(
+    conn: &mut Connection,
+    stream: &SyncStreamName,
+) -> SyncResult<Vec<SyncRow<serde_json::Value>>> {
+    let mut stmt = conn.prepare(SELECT_ROWS_SQL).map_err(sqlite_error)?;
+    let rows = stmt
+        .query_map(params![stream.as_str()], |row| {
+            let row_key: String = row.get(0)?;
+            let version: Option<String> = row.get(1)?;
+            let payload: String = row.get(2)?;
+            let pending: i64 = row.get(3)?;
+            let conflict: i64 = row.get(4)?;
+            Ok((row_key, version, payload, pending, conflict))
+        })
+        .map_err(sqlite_error)?;
+
+    let mut out = Vec::new();
+    for row in rows {
+        let (row_key, version, payload, pending, conflict) = row.map_err(sqlite_error)?;
+        out.push(SyncRow {
+            key: RowKey::new(row_key)?,
+            version: version.map(RowVersion::new).transpose()?,
+            value: serde_json::from_str(&payload)?,
+            pending: pending != 0,
+            conflict: conflict != 0,
+        });
+    }
+    Ok(out)
+}
+
+fn upsert_stream(
+    tx: &Transaction<'_>,
+    stream: &SyncStreamName,
+    collection: &SyncCollectionName,
+    cursor: Option<&SyncCursor>,
+    updated_at_ms: i64,
+) -> SyncResult<()> {
+    tx.execute(
+        UPSERT_STREAM_SQL,
+        params![
+            stream.as_str(),
+            collection.as_str(),
+            cursor.map(SyncCursor::as_str),
+            SCHEMA_VERSION,
+            updated_at_ms,
+        ],
+    )
+    .map_err(sqlite_error)?;
+    Ok(())
+}
+
+fn upsert_row(
+    tx: &Transaction<'_>,
+    stream: &SyncStreamName,
+    row: &SyncRow<serde_json::Value>,
+    updated_at_ms: i64,
+) -> SyncResult<()> {
+    tx.execute(
+        UPSERT_ROW_SQL,
+        params![
+            stream.as_str(),
+            row.key.as_str(),
+            row.version.as_ref().map(RowVersion::as_str),
+            serde_json::to_string(&row.value)?,
+            i64::from(row.pending),
+            i64::from(row.conflict),
+            updated_at_ms,
+        ],
+    )
+    .map_err(sqlite_error)?;
+    Ok(())
+}
+
+fn upsert_meta(tx: &Transaction<'_>, key: &str, value: &str) -> SyncResult<()> {
+    tx.execute(
+        "insert into __pocopine_meta (key, value) values (?1, ?2)
+         on conflict(key) do update set value = excluded.value",
+        params![key, value],
+    )
+    .map_err(sqlite_error)?;
+    Ok(())
+}
+
+fn select_meta(conn: &Connection, key: &str) -> SyncResult<Option<String>> {
+    conn.query_row(
+        "select value from __pocopine_meta where key = ?1",
+        params![key],
+        |row| row.get(0),
+    )
+    .optional()
+    .map_err(sqlite_error)
+}
+
+fn delete_mutation(tx: &Transaction<'_>, mutation_id: &str) -> SyncResult<()> {
+    tx.execute(DELETE_MUTATION_SQL, params![mutation_id])
+        .map_err(sqlite_error)?;
+    Ok(())
+}
+
+fn op_to_str(op: SyncOp) -> &'static str {
+    match op {
+        SyncOp::Upsert => "upsert",
+        SyncOp::Delete => "delete",
+        SyncOp::Reset => "reset",
+    }
+}
+
+fn op_from_str(value: &str) -> SyncResult<SyncOp> {
+    match value {
+        "upsert" => Ok(SyncOp::Upsert),
+        "delete" => Ok(SyncOp::Delete),
+        "reset" => Ok(SyncOp::Reset),
+        other => Err(SyncError::backend(format!(
+            "invalid sync mutation op in sqlite store: {other}"
+        ))),
+    }
+}
+
+fn epoch_ms() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .min(i64::MAX as u128) as i64
+}
+
+fn sqlite_error(err: rusqlite::Error) -> SyncError {
+    SyncError::backend(err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use pocopine_sync::{
+        LocalSnapshotBatch, MutationId, SyncChange, SyncCollectionName, SyncConflict, SyncCursor,
+        SyncRejectedMutation,
+    };
+
+    #[test]
+    fn sqlite_store_persists_identity() {
+        let store = SqliteLocalStore::open_in_memory().unwrap();
+        let identity =
+            SyncLocalIdentity::with_next_counter(SyncDeviceId::new("device_abc").unwrap(), 9)
+                .unwrap();
+
+        assert!(block(store.load_identity()).unwrap().is_none());
+        block(store.save_identity(identity.clone())).unwrap();
+
+        assert_eq!(block(store.load_identity()).unwrap(), Some(identity));
+    }
+
+    #[test]
+    fn sqlite_store_saves_snapshot_and_hydrates_rows() {
+        let store = SqliteLocalStore::open_in_memory().unwrap();
+        let stream = SyncStreamName::new("posts").unwrap();
+        let collection = SyncCollectionName::new("posts").unwrap();
+        let row = SyncRow::new("post_1", serde_json::json!({"title": "Cached"}))
+            .unwrap()
+            .version("row_1")
+            .unwrap();
+
+        block(store.save_snapshot(LocalSnapshotBatch::new(
+            stream.clone(),
+            collection.clone(),
+            vec![row.clone()],
+            Some(SyncCursor::new("cursor_1").unwrap()),
+        )))
+        .unwrap();
+
+        let snapshot = block(store.hydrate_stream(&stream)).unwrap();
+
+        assert_eq!(snapshot.collection, Some(collection));
+        assert_eq!(snapshot.cursor.unwrap().as_str(), "cursor_1");
+        assert_eq!(snapshot.rows, vec![row]);
+    }
+
+    #[test]
+    fn sqlite_store_applies_changes_transactionally() {
+        let store = SqliteLocalStore::open_in_memory().unwrap();
+        let stream = SyncStreamName::new("posts").unwrap();
+        let collection = SyncCollectionName::new("posts").unwrap();
+        let row = SyncRow::new("post_1", serde_json::json!({"title": "Cached"})).unwrap();
+        block(store.save_snapshot(LocalSnapshotBatch::new(
+            stream.clone(),
+            collection.clone(),
+            vec![row],
+            Some(SyncCursor::new("cursor_1").unwrap()),
+        )))
+        .unwrap();
+
+        let updated = SyncRow::new("post_1", serde_json::json!({"title": "Updated"}))
+            .unwrap()
+            .version("row_2")
+            .unwrap();
+        let new_row = SyncRow::new("post_2", serde_json::json!({"title": "New"})).unwrap();
+        block(store.apply_changes(LocalChangeBatch::new(
+            stream.clone(),
+            collection,
+            vec![
+                SyncChange {
+                    stream: stream.clone(),
+                    collection: SyncCollectionName::new("posts").unwrap(),
+                    key: Some(RowKey::new("post_1").unwrap()),
+                    op: SyncOp::Upsert,
+                    row: Some(updated.clone()),
+                    cursor: SyncCursor::new("cursor_2").unwrap(),
+                },
+                SyncChange {
+                    stream: stream.clone(),
+                    collection: SyncCollectionName::new("posts").unwrap(),
+                    key: Some(RowKey::new("post_2").unwrap()),
+                    op: SyncOp::Upsert,
+                    row: Some(new_row.clone()),
+                    cursor: SyncCursor::new("cursor_2").unwrap(),
+                },
+            ],
+            Some(SyncCursor::new("cursor_2").unwrap()),
+        )))
+        .unwrap();
+
+        let snapshot = block(store.hydrate_stream(&stream)).unwrap();
+
+        assert_eq!(snapshot.cursor.unwrap().as_str(), "cursor_2");
+        assert_eq!(snapshot.rows, vec![updated, new_row]);
+    }
+
+    #[test]
+    fn sqlite_store_replays_pending_mutations_and_clears_acceptance() {
+        let store = SqliteLocalStore::open_in_memory().unwrap();
+        let stream = SyncStreamName::new("posts").unwrap();
+        let mutation = ClientMutation {
+            id: MutationId::new("device_abc:1").unwrap(),
+            key: Some(RowKey::new("post_1").unwrap()),
+            op: SyncOp::Upsert,
+            base_version: Some(RowVersion::new("row_1").unwrap()),
+            payload: serde_json::json!({"title": "Saved"}),
+        };
+
+        block(store.enqueue_mutation(&stream, mutation.clone())).unwrap();
+        assert_eq!(
+            block(store.pending_mutations(&stream)).unwrap(),
+            vec![mutation]
+        );
+
+        block(store.mark_push_result(LocalPushResult {
+            stream: stream.clone(),
+            accepted: vec![MutationId::new("device_abc:1").unwrap()],
+            rejected: Vec::new(),
+            rows: vec![SyncRow::new("post_1", serde_json::json!({"title": "Saved"})).unwrap()],
+            conflicts: Vec::new(),
+            cursor: Some(SyncCursor::new("cursor_2").unwrap()),
+        }))
+        .unwrap();
+
+        assert!(block(store.pending_mutations(&stream)).unwrap().is_empty());
+        assert_eq!(block(store.hydrate_stream(&stream)).unwrap().rows.len(), 1);
+    }
+
+    #[test]
+    fn sqlite_store_persists_rejections_and_conflicts_as_terminal_outcomes() {
+        let store = SqliteLocalStore::open_in_memory().unwrap();
+        let stream = SyncStreamName::new("posts").unwrap();
+        block(store.enqueue_mutation(
+            &stream,
+            ClientMutation {
+                id: MutationId::new("device_abc:1").unwrap(),
+                key: Some(RowKey::new("post_1").unwrap()),
+                op: SyncOp::Upsert,
+                base_version: None,
+                payload: serde_json::json!({"title": "Draft"}),
+            },
+        ))
+        .unwrap();
+        block(store.enqueue_mutation(
+            &stream,
+            ClientMutation {
+                id: MutationId::new("device_abc:2").unwrap(),
+                key: Some(RowKey::new("post_2").unwrap()),
+                op: SyncOp::Upsert,
+                base_version: None,
+                payload: serde_json::json!({"title": "Draft"}),
+            },
+        ))
+        .unwrap();
+
+        block(store.mark_push_result(LocalPushResult {
+            stream: stream.clone(),
+            accepted: Vec::new(),
+            rejected: vec![SyncRejectedMutation {
+                mutation_id: MutationId::new("device_abc:1").unwrap(),
+                key: Some(RowKey::new("post_1").unwrap()),
+                reason: "invalid".to_string(),
+            }],
+            rows: Vec::new(),
+            conflicts: vec![SyncConflict {
+                mutation_id: MutationId::new("device_abc:2").unwrap(),
+                key: Some(RowKey::new("post_2").unwrap()),
+                server_row: Some(
+                    SyncRow::new("post_2", serde_json::json!({"title": "Server"})).unwrap(),
+                ),
+                reason: "stale".to_string(),
+            }],
+            cursor: None,
+        }))
+        .unwrap();
+
+        let snapshot = block(store.hydrate_stream(&stream)).unwrap();
+        assert!(block(store.pending_mutations(&stream)).unwrap().is_empty());
+        assert_eq!(snapshot.rows.len(), 1);
+        assert!(snapshot.rows[0].conflict);
+    }
+
+    fn block<T>(future: SyncLocalFuture<'_, T>) -> SyncResult<T> {
+        let waker = std::task::Waker::noop();
+        let mut cx = std::task::Context::from_waker(waker);
+        let mut future = future;
+        match future.as_mut().poll(&mut cx) {
+            std::task::Poll::Ready(value) => value,
+            std::task::Poll::Pending => {
+                panic!("sqlite local store futures must be immediately ready on host")
+            }
+        }
+    }
+}

--- a/crates/pocopine-sync-sqlite/src/schema.rs
+++ b/crates/pocopine-sync-sqlite/src/schema.rs
@@ -1,0 +1,140 @@
+/// Current Pocopine sync SQLite schema version.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// Metadata table for device identity and internal settings.
+pub const META_TABLE: &str = "__pocopine_meta";
+/// Per-stream cursor and collection metadata.
+pub const STREAMS_TABLE: &str = "__pocopine_streams";
+/// Persisted stream rows.
+pub const ROWS_TABLE: &str = "__pocopine_rows";
+/// Durable client mutation queue.
+pub const MUTATIONS_TABLE: &str = "__pocopine_mutations";
+
+/// Metadata key used to persist the stable sync device id.
+pub const META_DEVICE_ID: &str = "device_id";
+/// Metadata key used to persist the next mutation counter.
+pub const META_NEXT_MUTATION_COUNTER: &str = "next_mutation_counter";
+/// Metadata key used to persist the schema version.
+pub const META_SCHEMA_VERSION: &str = "schema_version";
+
+/// SQL statements used to bootstrap the local sync schema.
+pub const BOOTSTRAP_SQL: &[&str] = &[
+    "create table if not exists __pocopine_meta (
+        key text primary key,
+        value text not null
+    )",
+    "create table if not exists __pocopine_streams (
+        stream text primary key,
+        collection text not null,
+        cursor text,
+        schema_version integer not null,
+        updated_at_ms integer not null
+    )",
+    "create table if not exists __pocopine_rows (
+        stream text not null,
+        row_key text not null,
+        version text,
+        payload text not null,
+        pending integer not null default 0,
+        conflict integer not null default 0,
+        updated_at_ms integer not null,
+        primary key (stream, row_key)
+    )",
+    "create table if not exists __pocopine_mutations (
+        stream text not null,
+        mutation_id text primary key,
+        row_key text,
+        base_version text,
+        op text not null,
+        payload text,
+        status text not null,
+        error text,
+        created_at_ms integer not null,
+        updated_at_ms integer not null
+    )",
+    "create index if not exists __pocopine_rows_by_stream
+        on __pocopine_rows (stream)",
+    "create index if not exists __pocopine_mutations_by_stream_status
+        on __pocopine_mutations (stream, status, created_at_ms)",
+];
+
+/// SQL upsert used for stream cursor metadata.
+pub const UPSERT_STREAM_SQL: &str = "insert into __pocopine_streams
+    (stream, collection, cursor, schema_version, updated_at_ms)
+    values (?1, ?2, ?3, ?4, ?5)
+    on conflict(stream) do update set
+        collection = excluded.collection,
+        cursor = excluded.cursor,
+        schema_version = excluded.schema_version,
+        updated_at_ms = excluded.updated_at_ms";
+
+/// SQL statements used to clear one stream before saving a replacement snapshot.
+pub const DELETE_STREAM_ROWS_SQL: &str = "delete from __pocopine_rows where stream = ?1";
+
+/// SQL upsert used for stream rows.
+pub const UPSERT_ROW_SQL: &str = "insert into __pocopine_rows
+    (stream, row_key, version, payload, pending, conflict, updated_at_ms)
+    values (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+    on conflict(stream, row_key) do update set
+        version = excluded.version,
+        payload = excluded.payload,
+        pending = excluded.pending,
+        conflict = excluded.conflict,
+        updated_at_ms = excluded.updated_at_ms";
+
+/// SQL delete used for one row in one stream.
+pub const DELETE_ROW_SQL: &str = "delete from __pocopine_rows where stream = ?1 and row_key = ?2";
+
+/// SQL update used when a conflict references an existing local row.
+pub const UPDATE_ROW_CONFLICT_SQL: &str =
+    "update __pocopine_rows set pending = 0, conflict = 1, updated_at_ms = ?3
+     where stream = ?1 and row_key = ?2";
+
+/// SQL upsert used for durable pending mutations.
+pub const UPSERT_MUTATION_SQL: &str = "insert into __pocopine_mutations
+    (stream, mutation_id, row_key, base_version, op, payload, status, error, created_at_ms, updated_at_ms)
+    values (?1, ?2, ?3, ?4, ?5, ?6, 'pending', null, ?7, ?7)
+    on conflict(mutation_id) do update set
+        stream = excluded.stream,
+        row_key = excluded.row_key,
+        base_version = excluded.base_version,
+        op = excluded.op,
+        payload = excluded.payload,
+        status = 'pending',
+        error = null,
+        updated_at_ms = excluded.updated_at_ms";
+
+/// SQL delete used when a mutation reaches a terminal server outcome.
+pub const DELETE_MUTATION_SQL: &str = "delete from __pocopine_mutations where mutation_id = ?1";
+
+/// SQL query used to load pending mutations for a stream in enqueue order.
+pub const SELECT_PENDING_MUTATIONS_SQL: &str =
+    "select mutation_id, row_key, base_version, op, payload
+    from __pocopine_mutations
+    where stream = ?1 and status = 'pending'
+    order by created_at_ms asc, mutation_id asc";
+
+/// SQL query used to hydrate rows for a stream.
+pub const SELECT_ROWS_SQL: &str = "select row_key, version, payload, pending, conflict
+    from __pocopine_rows
+    where stream = ?1
+    order by row_key asc";
+
+/// SQL query used to hydrate stream metadata.
+pub const SELECT_STREAM_SQL: &str =
+    "select collection, cursor from __pocopine_streams where stream = ?1";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bootstrap_sql_mentions_all_internal_tables() {
+        let joined = BOOTSTRAP_SQL.join("\n");
+
+        assert!(joined.contains(META_TABLE));
+        assert!(joined.contains(STREAMS_TABLE));
+        assert!(joined.contains(ROWS_TABLE));
+        assert!(joined.contains(MUTATIONS_TABLE));
+    }
+}

--- a/crates/pocopine-sync-sqlite/src/schema.rs
+++ b/crates/pocopine-sync-sqlite/src/schema.rs
@@ -1,5 +1,5 @@
 /// Current Pocopine sync SQLite schema version.
-pub const SCHEMA_VERSION: u32 = 1;
+pub const SCHEMA_VERSION: u32 = 2;
 
 /// Metadata table for device identity and internal settings.
 pub const META_TABLE: &str = "__pocopine_meta";
@@ -41,8 +41,9 @@ pub const BOOTSTRAP_SQL: &[&str] = &[
         primary key (stream, row_key)
     )",
     "create table if not exists __pocopine_mutations (
+        enqueue_seq integer primary key autoincrement,
         stream text not null,
-        mutation_id text primary key,
+        mutation_id text not null unique,
         row_key text,
         base_version text,
         op text not null,
@@ -55,7 +56,7 @@ pub const BOOTSTRAP_SQL: &[&str] = &[
     "create index if not exists __pocopine_rows_by_stream
         on __pocopine_rows (stream)",
     "create index if not exists __pocopine_mutations_by_stream_status
-        on __pocopine_mutations (stream, status, created_at_ms)",
+        on __pocopine_mutations (stream, status, enqueue_seq)",
 ];
 
 /// SQL upsert used for stream cursor metadata.
@@ -112,7 +113,7 @@ pub const SELECT_PENDING_MUTATIONS_SQL: &str =
     "select mutation_id, row_key, base_version, op, payload
     from __pocopine_mutations
     where stream = ?1 and status = 'pending'
-    order by created_at_ms asc, mutation_id asc";
+    order by enqueue_seq asc";
 
 /// SQL query used to hydrate rows for a stream.
 pub const SELECT_ROWS_SQL: &str = "select row_key, version, payload, pending, conflict

--- a/crates/pocopine-sync-sqlite/src/wasm.rs
+++ b/crates/pocopine-sync-sqlite/src/wasm.rs
@@ -1,0 +1,68 @@
+use pocopine_sync::{
+    ClientMutation, LocalChangeBatch, LocalPushResult, LocalSnapshotBatch, LocalStreamSnapshot,
+    SyncError, SyncLocalFuture, SyncLocalIdentity, SyncLocalStore, SyncStreamName,
+};
+
+/// Browser SQLite local-store placeholder.
+///
+/// The schema and trait contract are shared with the native implementation,
+/// but browser persistence requires a SQLite WASM + OPFS worker binding. Until
+/// that lands, this type compiles on wasm and returns a clear error instead of
+/// pretending that data is durable.
+#[derive(Clone, Debug, Default)]
+pub struct SqliteLocalStore;
+
+impl SqliteLocalStore {
+    pub fn new() -> Self {
+        Self
+    }
+
+    fn unsupported<T>() -> SyncLocalFuture<'static, T> {
+        Box::pin(async {
+            Err(SyncError::unsupported(
+                "pocopine-sync-sqlite browser OPFS backend is not implemented yet",
+            ))
+        })
+    }
+}
+
+impl SyncLocalStore for SqliteLocalStore {
+    fn load_identity(&self) -> SyncLocalFuture<'_, Option<SyncLocalIdentity>> {
+        Self::unsupported()
+    }
+
+    fn save_identity(&self, _identity: SyncLocalIdentity) -> SyncLocalFuture<'_, ()> {
+        Self::unsupported()
+    }
+
+    fn hydrate_stream(&self, _stream: &SyncStreamName) -> SyncLocalFuture<'_, LocalStreamSnapshot> {
+        Self::unsupported()
+    }
+
+    fn save_snapshot(&self, _snapshot: LocalSnapshotBatch) -> SyncLocalFuture<'_, ()> {
+        Self::unsupported()
+    }
+
+    fn apply_changes(&self, _changes: LocalChangeBatch) -> SyncLocalFuture<'_, ()> {
+        Self::unsupported()
+    }
+
+    fn enqueue_mutation(
+        &self,
+        _stream: &SyncStreamName,
+        _mutation: ClientMutation<serde_json::Value>,
+    ) -> SyncLocalFuture<'_, ()> {
+        Self::unsupported()
+    }
+
+    fn mark_push_result(&self, _result: LocalPushResult) -> SyncLocalFuture<'_, ()> {
+        Self::unsupported()
+    }
+
+    fn pending_mutations(
+        &self,
+        _stream: &SyncStreamName,
+    ) -> SyncLocalFuture<'_, Vec<ClientMutation<serde_json::Value>>> {
+        Self::unsupported()
+    }
+}

--- a/crates/pocopine-sync-sqlite/src/wasm.rs
+++ b/crates/pocopine-sync-sqlite/src/wasm.rs
@@ -1,68 +1,621 @@
+use std::{cell::RefCell, collections::BTreeSet, fmt, rc::Rc};
+
+use futures::lock::Mutex as AsyncMutex;
+use js_sys::{Array, Reflect};
 use pocopine_sync::{
     ClientMutation, LocalChangeBatch, LocalPushResult, LocalSnapshotBatch, LocalStreamSnapshot,
-    SyncError, SyncLocalFuture, SyncLocalIdentity, SyncLocalStore, SyncStreamName,
+    RowKey, RowVersion, SyncCollectionName, SyncCursor, SyncDeviceId, SyncError, SyncLocalFuture,
+    SyncLocalIdentity, SyncLocalStore, SyncOp, SyncResult, SyncRow, SyncStreamName,
+};
+use serde_json::Value;
+use wasm_bindgen::{JsCast, JsValue};
+
+use crate::schema::{
+    BOOTSTRAP_SQL, DELETE_MUTATION_SQL, DELETE_ROW_SQL, DELETE_STREAM_ROWS_SQL, META_DEVICE_ID,
+    META_NEXT_MUTATION_COUNTER, META_SCHEMA_VERSION, SCHEMA_VERSION, SELECT_PENDING_MUTATIONS_SQL,
+    SELECT_ROWS_SQL, SELECT_STREAM_SQL, UPDATE_ROW_CONFLICT_SQL, UPSERT_MUTATION_SQL,
+    UPSERT_ROW_SQL, UPSERT_STREAM_SQL,
 };
 
-/// Browser SQLite local-store placeholder.
+const DEFAULT_DATABASE_NAME: &str = "pocopine_sync.sqlite3";
+
+thread_local! {
+    static SQLITE_GATE: Rc<AsyncMutex<()>> = Rc::new(AsyncMutex::new(()));
+    static SQLITE_STARTED: RefCell<bool> = const { RefCell::new(false) };
+    static SQLITE_CURRENT_DATABASE: RefCell<Option<String>> = const { RefCell::new(None) };
+    static SQLITE_BOOTSTRAPPED: RefCell<BTreeSet<String>> = const { RefCell::new(BTreeSet::new()) };
+}
+
+/// SQLite-backed [`SyncLocalStore`] for browser targets.
 ///
-/// The schema and trait contract are shared with the native implementation,
-/// but browser persistence requires a SQLite WASM + OPFS worker binding. Until
-/// that lands, this type compiles on wasm and returns a clear error instead of
-/// pretending that data is durable.
-#[derive(Clone, Debug, Default)]
-pub struct SqliteLocalStore;
+/// This adapter uses the official SQLite WASM worker through the `sqlite-wasm`
+/// crate and opens a persistent OPFS database. SQLite WASM is a singleton in
+/// the page process, so Pocopine serializes adapter operations through a global
+/// browser-local gate before touching the worker.
+#[derive(Clone)]
+pub struct SqliteLocalStore {
+    database_name: String,
+}
 
 impl SqliteLocalStore {
+    /// Open the default browser OPFS database.
     pub fn new() -> Self {
-        Self
+        Self {
+            database_name: DEFAULT_DATABASE_NAME.to_string(),
+        }
     }
 
-    fn unsupported<T>() -> SyncLocalFuture<'static, T> {
-        Box::pin(async {
-            Err(SyncError::unsupported(
-                "pocopine-sync-sqlite browser OPFS backend is not implemented yet",
-            ))
+    /// Open a named browser OPFS database.
+    ///
+    /// The name is an OPFS filename, not a URL or path. Pocopine rejects empty,
+    /// slash-containing, and control-character names so an app cannot
+    /// accidentally select surprising storage.
+    pub fn with_database_name(database_name: impl Into<String>) -> SyncResult<Self> {
+        let database_name = validate_database_name(database_name.into())?;
+        Ok(Self { database_name })
+    }
+
+    /// The OPFS database filename used by this store.
+    pub fn database_name(&self) -> &str {
+        &self.database_name
+    }
+
+    fn run<T: 'static>(
+        &self,
+        task: impl std::future::Future<Output = SyncResult<T>> + 'static,
+    ) -> SyncLocalFuture<'static, T> {
+        let database_name = self.database_name.clone();
+        Box::pin(async move {
+            let gate = sqlite_gate();
+            let _guard = gate.lock().await;
+            ensure_database(&database_name).await?;
+            task.await
         })
+    }
+}
+
+impl Default for SqliteLocalStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Debug for SqliteLocalStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SqliteLocalStore")
+            .field("database_name", &self.database_name)
+            .finish()
     }
 }
 
 impl SyncLocalStore for SqliteLocalStore {
     fn load_identity(&self) -> SyncLocalFuture<'_, Option<SyncLocalIdentity>> {
-        Self::unsupported()
+        self.run(load_identity())
     }
 
-    fn save_identity(&self, _identity: SyncLocalIdentity) -> SyncLocalFuture<'_, ()> {
-        Self::unsupported()
+    fn save_identity(&self, identity: SyncLocalIdentity) -> SyncLocalFuture<'_, ()> {
+        self.run(save_identity(identity))
     }
 
-    fn hydrate_stream(&self, _stream: &SyncStreamName) -> SyncLocalFuture<'_, LocalStreamSnapshot> {
-        Self::unsupported()
+    fn hydrate_stream(&self, stream: &SyncStreamName) -> SyncLocalFuture<'_, LocalStreamSnapshot> {
+        self.run(hydrate_stream(stream.clone()))
     }
 
-    fn save_snapshot(&self, _snapshot: LocalSnapshotBatch) -> SyncLocalFuture<'_, ()> {
-        Self::unsupported()
+    fn save_snapshot(&self, snapshot: LocalSnapshotBatch) -> SyncLocalFuture<'_, ()> {
+        self.run(save_snapshot(snapshot))
     }
 
-    fn apply_changes(&self, _changes: LocalChangeBatch) -> SyncLocalFuture<'_, ()> {
-        Self::unsupported()
+    fn apply_changes(&self, changes: LocalChangeBatch) -> SyncLocalFuture<'_, ()> {
+        self.run(apply_changes(changes))
     }
 
     fn enqueue_mutation(
         &self,
-        _stream: &SyncStreamName,
-        _mutation: ClientMutation<serde_json::Value>,
+        stream: &SyncStreamName,
+        mutation: ClientMutation<serde_json::Value>,
     ) -> SyncLocalFuture<'_, ()> {
-        Self::unsupported()
+        self.run(enqueue_mutation(stream.clone(), mutation))
     }
 
-    fn mark_push_result(&self, _result: LocalPushResult) -> SyncLocalFuture<'_, ()> {
-        Self::unsupported()
+    fn mark_push_result(&self, result: LocalPushResult) -> SyncLocalFuture<'_, ()> {
+        self.run(mark_push_result(result))
     }
 
     fn pending_mutations(
         &self,
-        _stream: &SyncStreamName,
+        stream: &SyncStreamName,
     ) -> SyncLocalFuture<'_, Vec<ClientMutation<serde_json::Value>>> {
-        Self::unsupported()
+        self.run(pending_mutations(stream.clone()))
     }
+}
+
+async fn ensure_database(database_name: &str) -> SyncResult<()> {
+    let started = SQLITE_STARTED.with(|started| *started.borrow());
+    if !started {
+        sqlite_wasm::autostart_embedded().await.map_err(js_error)?;
+        SQLITE_STARTED.with(|started| *started.borrow_mut() = true);
+    }
+
+    let already_open = sqlite_wasm::is_open()
+        && SQLITE_CURRENT_DATABASE
+            .with(|current| current.borrow().as_deref() == Some(database_name));
+    if !already_open {
+        sqlite_wasm::open(database_name).await.map_err(js_error)?;
+        SQLITE_CURRENT_DATABASE
+            .with(|current| *current.borrow_mut() = Some(database_name.to_string()));
+    }
+
+    let bootstrapped = SQLITE_BOOTSTRAPPED.with(|names| names.borrow().contains(database_name));
+    if !bootstrapped {
+        bootstrap_schema().await?;
+        SQLITE_BOOTSTRAPPED.with(|names| {
+            names.borrow_mut().insert(database_name.to_string());
+        });
+    }
+
+    Ok(())
+}
+
+async fn bootstrap_schema() -> SyncResult<()> {
+    for sql in BOOTSTRAP_SQL {
+        exec(sql, Vec::new()).await?;
+    }
+    upsert_meta(META_SCHEMA_VERSION, &SCHEMA_VERSION.to_string()).await
+}
+
+async fn load_identity() -> SyncResult<Option<SyncLocalIdentity>> {
+    let Some(device_id) = select_meta(META_DEVICE_ID).await? else {
+        return Ok(None);
+    };
+    let next_counter = select_meta(META_NEXT_MUTATION_COUNTER)
+        .await?
+        .map(|value| {
+            value.parse::<u64>().map_err(|_| {
+                SyncError::backend(format!(
+                    "invalid sync next mutation counter in sqlite store: {value}"
+                ))
+            })
+        })
+        .transpose()?
+        .unwrap_or(1);
+
+    SyncLocalIdentity::with_next_counter(SyncDeviceId::new(device_id)?, next_counter).map(Some)
+}
+
+async fn save_identity(identity: SyncLocalIdentity) -> SyncResult<()> {
+    exec("BEGIN IMMEDIATE TRANSACTION", Vec::new()).await?;
+    let result = async {
+        upsert_meta(META_DEVICE_ID, identity.device_id.as_str()).await?;
+        upsert_meta(
+            META_NEXT_MUTATION_COUNTER,
+            &identity.next_mutation_counter.to_string(),
+        )
+        .await
+    }
+    .await;
+    finish_transaction(result).await
+}
+
+async fn hydrate_stream(stream: SyncStreamName) -> SyncResult<LocalStreamSnapshot> {
+    let stream_rows =
+        query_rows(SELECT_STREAM_SQL, vec![JsValue::from_str(stream.as_str())]).await?;
+    let stream_meta = stream_rows.first();
+    let rows = load_rows(&stream).await?;
+    let pending_mutations = pending_mutations(stream.clone()).await?;
+
+    let Some(meta) = stream_meta else {
+        if rows.is_empty() && pending_mutations.is_empty() {
+            return Ok(LocalStreamSnapshot::empty(stream));
+        }
+
+        return Ok(LocalStreamSnapshot {
+            stream,
+            collection: None,
+            cursor: None,
+            rows,
+            pending_mutations,
+        });
+    };
+
+    Ok(LocalStreamSnapshot {
+        stream: stream.clone(),
+        collection: Some(SyncCollectionName::new(required_string(
+            meta,
+            "collection",
+        )?)?),
+        cursor: optional_string(meta, "cursor")?
+            .map(SyncCursor::new)
+            .transpose()?,
+        rows,
+        pending_mutations,
+    })
+}
+
+async fn save_snapshot(snapshot: LocalSnapshotBatch) -> SyncResult<()> {
+    exec("BEGIN IMMEDIATE TRANSACTION", Vec::new()).await?;
+    let result = async {
+        let now = epoch_ms();
+        upsert_stream(
+            &snapshot.stream,
+            &snapshot.collection,
+            snapshot.cursor.as_ref(),
+            now,
+        )
+        .await?;
+        exec(
+            DELETE_STREAM_ROWS_SQL,
+            vec![JsValue::from_str(snapshot.stream.as_str())],
+        )
+        .await?;
+        for row in snapshot.rows {
+            upsert_row(&snapshot.stream, &row, now).await?;
+        }
+        Ok(())
+    }
+    .await;
+    finish_transaction(result).await
+}
+
+async fn apply_changes(changes: LocalChangeBatch) -> SyncResult<()> {
+    exec("BEGIN IMMEDIATE TRANSACTION", Vec::new()).await?;
+    let result = async {
+        let now = epoch_ms();
+        upsert_stream(
+            &changes.stream,
+            &changes.collection,
+            changes.cursor.as_ref(),
+            now,
+        )
+        .await?;
+        for change in changes.changes {
+            match change.op {
+                SyncOp::Upsert => {
+                    if let Some(row) = change.row {
+                        upsert_row(&changes.stream, &row, now).await?;
+                    }
+                }
+                SyncOp::Delete => {
+                    if let Some(key) = change.key {
+                        exec(
+                            DELETE_ROW_SQL,
+                            vec![
+                                JsValue::from_str(changes.stream.as_str()),
+                                JsValue::from_str(key.as_str()),
+                            ],
+                        )
+                        .await?;
+                    }
+                }
+                SyncOp::Reset => {
+                    exec(
+                        DELETE_STREAM_ROWS_SQL,
+                        vec![JsValue::from_str(changes.stream.as_str())],
+                    )
+                    .await?;
+                    if let Some(row) = change.row {
+                        upsert_row(&changes.stream, &row, now).await?;
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+    .await;
+    finish_transaction(result).await
+}
+
+async fn enqueue_mutation(
+    stream: SyncStreamName,
+    mutation: ClientMutation<serde_json::Value>,
+) -> SyncResult<()> {
+    exec(
+        UPSERT_MUTATION_SQL,
+        vec![
+            JsValue::from_str(stream.as_str()),
+            JsValue::from_str(mutation.id.as_str()),
+            optional_param(mutation.key.as_ref().map(RowKey::as_str)),
+            optional_param(mutation.base_version.as_ref().map(RowVersion::as_str)),
+            JsValue::from_str(op_to_str(mutation.op)),
+            JsValue::from_str(&serde_json::to_string(&mutation.payload)?),
+            JsValue::from_f64(epoch_ms() as f64),
+        ],
+    )
+    .await
+}
+
+async fn mark_push_result(result: LocalPushResult) -> SyncResult<()> {
+    exec("BEGIN IMMEDIATE TRANSACTION", Vec::new()).await?;
+    let tx_result = async {
+        let now = epoch_ms();
+
+        if let Some(cursor) = result.cursor {
+            exec(
+                "update __pocopine_streams set cursor = ?2, updated_at_ms = ?3 where stream = ?1",
+                vec![
+                    JsValue::from_str(result.stream.as_str()),
+                    JsValue::from_str(cursor.as_str()),
+                    JsValue::from_f64(now as f64),
+                ],
+            )
+            .await?;
+        }
+
+        for id in result.accepted {
+            delete_mutation(id.as_str()).await?;
+        }
+
+        for rejected in result.rejected {
+            delete_mutation(rejected.mutation_id.as_str()).await?;
+        }
+
+        for conflict in result.conflicts {
+            delete_mutation(conflict.mutation_id.as_str()).await?;
+            if let Some(mut row) = conflict.server_row {
+                row.pending = false;
+                row.conflict = true;
+                upsert_row(&result.stream, &row, now).await?;
+            } else if let Some(key) = conflict.key {
+                exec(
+                    UPDATE_ROW_CONFLICT_SQL,
+                    vec![
+                        JsValue::from_str(result.stream.as_str()),
+                        JsValue::from_str(key.as_str()),
+                        JsValue::from_f64(now as f64),
+                    ],
+                )
+                .await?;
+            }
+        }
+
+        for mut row in result.rows {
+            row.pending = false;
+            row.conflict = false;
+            upsert_row(&result.stream, &row, now).await?;
+        }
+
+        Ok(())
+    }
+    .await;
+    finish_transaction(tx_result).await
+}
+
+async fn pending_mutations(
+    stream: SyncStreamName,
+) -> SyncResult<Vec<ClientMutation<serde_json::Value>>> {
+    let rows = query_rows(
+        SELECT_PENDING_MUTATIONS_SQL,
+        vec![JsValue::from_str(stream.as_str())],
+    )
+    .await?;
+
+    let mut mutations = Vec::new();
+    for row in rows {
+        let payload = optional_string(&row, "payload")?
+            .map(|payload| serde_json::from_str(&payload))
+            .transpose()?
+            .unwrap_or(Value::Null);
+        mutations.push(ClientMutation {
+            id: pocopine_sync::MutationId::new(required_string(&row, "mutation_id")?)?,
+            key: optional_string(&row, "row_key")?
+                .map(RowKey::new)
+                .transpose()?,
+            base_version: optional_string(&row, "base_version")?
+                .map(RowVersion::new)
+                .transpose()?,
+            op: op_from_str(&required_string(&row, "op")?)?,
+            payload,
+        });
+    }
+    Ok(mutations)
+}
+
+async fn load_rows(stream: &SyncStreamName) -> SyncResult<Vec<SyncRow<serde_json::Value>>> {
+    let rows = query_rows(SELECT_ROWS_SQL, vec![JsValue::from_str(stream.as_str())]).await?;
+    let mut out = Vec::new();
+    for row in rows {
+        out.push(SyncRow {
+            key: RowKey::new(required_string(&row, "row_key")?)?,
+            version: optional_string(&row, "version")?
+                .map(RowVersion::new)
+                .transpose()?,
+            value: serde_json::from_str(&required_string(&row, "payload")?)?,
+            pending: bool_from_int(&row, "pending")?,
+            conflict: bool_from_int(&row, "conflict")?,
+        });
+    }
+    Ok(out)
+}
+
+async fn upsert_stream(
+    stream: &SyncStreamName,
+    collection: &SyncCollectionName,
+    cursor: Option<&SyncCursor>,
+    updated_at_ms: i64,
+) -> SyncResult<()> {
+    exec(
+        UPSERT_STREAM_SQL,
+        vec![
+            JsValue::from_str(stream.as_str()),
+            JsValue::from_str(collection.as_str()),
+            optional_param(cursor.map(SyncCursor::as_str)),
+            JsValue::from_f64(SCHEMA_VERSION as f64),
+            JsValue::from_f64(updated_at_ms as f64),
+        ],
+    )
+    .await
+}
+
+async fn upsert_row(
+    stream: &SyncStreamName,
+    row: &SyncRow<serde_json::Value>,
+    updated_at_ms: i64,
+) -> SyncResult<()> {
+    exec(
+        UPSERT_ROW_SQL,
+        vec![
+            JsValue::from_str(stream.as_str()),
+            JsValue::from_str(row.key.as_str()),
+            optional_param(row.version.as_ref().map(RowVersion::as_str)),
+            JsValue::from_str(&serde_json::to_string(&row.value)?),
+            JsValue::from_f64(i32::from(row.pending) as f64),
+            JsValue::from_f64(i32::from(row.conflict) as f64),
+            JsValue::from_f64(updated_at_ms as f64),
+        ],
+    )
+    .await
+}
+
+async fn upsert_meta(key: &str, value: &str) -> SyncResult<()> {
+    exec(
+        "insert into __pocopine_meta (key, value) values (?1, ?2)
+         on conflict(key) do update set value = excluded.value",
+        vec![JsValue::from_str(key), JsValue::from_str(value)],
+    )
+    .await
+}
+
+async fn select_meta(key: &str) -> SyncResult<Option<String>> {
+    let rows = query_rows(
+        "select value from __pocopine_meta where key = ?1",
+        vec![JsValue::from_str(key)],
+    )
+    .await?;
+    rows.first()
+        .map(|row| required_string(row, "value"))
+        .transpose()
+}
+
+async fn delete_mutation(mutation_id: &str) -> SyncResult<()> {
+    exec(DELETE_MUTATION_SQL, vec![JsValue::from_str(mutation_id)]).await
+}
+
+async fn finish_transaction(result: SyncResult<()>) -> SyncResult<()> {
+    match result {
+        Ok(()) => exec("COMMIT", Vec::new()).await,
+        Err(err) => {
+            let _ = exec("ROLLBACK", Vec::new()).await;
+            Err(err)
+        }
+    }
+}
+
+async fn exec(sql: &str, params: Vec<JsValue>) -> SyncResult<()> {
+    sqlite_wasm::exec(sql, params).await.map_err(js_error)?;
+    Ok(())
+}
+
+async fn query_rows(sql: &str, params: Vec<JsValue>) -> SyncResult<Vec<Value>> {
+    let result = sqlite_wasm::query(sql, params).await.map_err(js_error)?;
+    let result_obj = Reflect::get(&result, &JsValue::from_str("result")).map_err(js_error)?;
+    if result_obj.is_undefined() || result_obj.is_null() {
+        return Ok(Vec::new());
+    }
+    let rows = Reflect::get(&result_obj, &JsValue::from_str("resultRows")).map_err(js_error)?;
+    if rows.is_undefined() || rows.is_null() {
+        return Ok(Vec::new());
+    }
+
+    let rows = rows
+        .dyn_into::<Array>()
+        .map_err(|_| SyncError::backend("sqlite wasm query resultRows was not an array"))?;
+    let mut out = Vec::with_capacity(rows.length() as usize);
+    for index in 0..rows.length() {
+        let row = rows.get(index);
+        let value = serde_wasm_bindgen::from_value::<Value>(row)
+            .map_err(|err| SyncError::backend(format!("invalid sqlite wasm row: {err}")))?;
+        out.push(value);
+    }
+    Ok(out)
+}
+
+fn required_string(row: &Value, field: &'static str) -> SyncResult<String> {
+    optional_string(row, field)?.ok_or_else(|| {
+        SyncError::backend(format!("missing sqlite sync local-store field: {field}"))
+    })
+}
+
+fn optional_string(row: &Value, field: &'static str) -> SyncResult<Option<String>> {
+    match row.get(field) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(value)) => Ok(Some(value.clone())),
+        Some(other) => Err(SyncError::backend(format!(
+            "invalid sqlite sync local-store field {field}: expected string, got {other}"
+        ))),
+    }
+}
+
+fn bool_from_int(row: &Value, field: &'static str) -> SyncResult<bool> {
+    match row.get(field) {
+        Some(Value::Number(value)) => value
+            .as_i64()
+            .map(|value| value != 0)
+            .ok_or_else(|| SyncError::backend(format!("invalid integer field: {field}"))),
+        Some(other) => Err(SyncError::backend(format!(
+            "invalid sqlite sync local-store field {field}: expected integer, got {other}"
+        ))),
+        None => Err(SyncError::backend(format!(
+            "missing sqlite sync local-store field: {field}"
+        ))),
+    }
+}
+
+fn optional_param(value: Option<&str>) -> JsValue {
+    value.map(JsValue::from_str).unwrap_or(JsValue::NULL)
+}
+
+fn op_to_str(op: SyncOp) -> &'static str {
+    match op {
+        SyncOp::Upsert => "upsert",
+        SyncOp::Delete => "delete",
+        SyncOp::Reset => "reset",
+    }
+}
+
+fn op_from_str(value: &str) -> SyncResult<SyncOp> {
+    match value {
+        "upsert" => Ok(SyncOp::Upsert),
+        "delete" => Ok(SyncOp::Delete),
+        "reset" => Ok(SyncOp::Reset),
+        other => Err(SyncError::backend(format!(
+            "invalid sync mutation op in sqlite store: {other}"
+        ))),
+    }
+}
+
+fn validate_database_name(database_name: String) -> SyncResult<String> {
+    if database_name.trim() != database_name
+        || database_name.is_empty()
+        || database_name.len() > 255
+        || database_name
+            .chars()
+            .any(|ch| ch.is_control() || ch == '/' || ch == '\\')
+    {
+        return Err(SyncError::backend(format!(
+            "invalid sqlite local-store database name: {database_name:?}"
+        )));
+    }
+    Ok(database_name)
+}
+
+fn sqlite_gate() -> Rc<AsyncMutex<()>> {
+    SQLITE_GATE.with(Clone::clone)
+}
+
+fn epoch_ms() -> i64 {
+    js_sys::Date::now().min(i64::MAX as f64) as i64
+}
+
+fn js_error(err: JsValue) -> SyncError {
+    SyncError::client(js_value_to_string(err))
+}
+
+fn js_value_to_string(value: JsValue) -> String {
+    value
+        .as_string()
+        .or_else(|| {
+            js_sys::JSON::stringify(&value)
+                .ok()
+                .and_then(|text| text.as_string())
+        })
+        .unwrap_or_else(|| format!("{value:?}"))
 }

--- a/crates/pocopine-sync-sqlite/src/wasm.rs
+++ b/crates/pocopine-sync-sqlite/src/wasm.rs
@@ -136,10 +136,22 @@ async fn ensure_database(database_name: &str) -> SyncResult<()> {
         SQLITE_STARTED.with(|started| *started.borrow_mut() = true);
     }
 
-    let already_open = sqlite_wasm::is_open()
-        && SQLITE_CURRENT_DATABASE
-            .with(|current| current.borrow().as_deref() == Some(database_name));
-    if !already_open {
+    if sqlite_wasm::is_open() {
+        let current = SQLITE_CURRENT_DATABASE.with(|current| current.borrow().clone());
+        match current.as_deref() {
+            Some(current) if current == database_name => {}
+            Some(current) => {
+                return Err(SyncError::client(format!(
+                    "pocopine-sync-sqlite supports one open browser SQLite database per page; {current:?} is already open"
+                )));
+            }
+            None => {
+                return Err(SyncError::client(
+                    "pocopine-sync-sqlite cannot attach because another SQLite WASM database is already open",
+                ));
+            }
+        }
+    } else {
         sqlite_wasm::open(database_name).await.map_err(js_error)?;
         SQLITE_CURRENT_DATABASE
             .with(|current| *current.borrow_mut() = Some(database_name.to_string()));
@@ -160,6 +172,7 @@ async fn bootstrap_schema() -> SyncResult<()> {
     for sql in BOOTSTRAP_SQL {
         exec(sql, Vec::new()).await?;
     }
+    validate_schema_version().await?;
     upsert_meta(META_SCHEMA_VERSION, &SCHEMA_VERSION.to_string()).await
 }
 
@@ -180,6 +193,23 @@ async fn load_identity() -> SyncResult<Option<SyncLocalIdentity>> {
         .unwrap_or(1);
 
     SyncLocalIdentity::with_next_counter(SyncDeviceId::new(device_id)?, next_counter).map(Some)
+}
+
+async fn validate_schema_version() -> SyncResult<()> {
+    let Some(existing) = select_meta(META_SCHEMA_VERSION).await? else {
+        return Ok(());
+    };
+    let version = existing.parse::<u32>().map_err(|_| {
+        SyncError::backend(format!(
+            "invalid sync sqlite schema version in local store: {existing}"
+        ))
+    })?;
+    if version != SCHEMA_VERSION {
+        return Err(SyncError::backend(format!(
+            "incompatible sync sqlite schema version: found {version}, expected {SCHEMA_VERSION}"
+        )));
+    }
+    Ok(())
 }
 
 async fn save_identity(identity: SyncLocalIdentity) -> SyncResult<()> {
@@ -260,18 +290,22 @@ async fn apply_changes(changes: LocalChangeBatch) -> SyncResult<()> {
     exec("BEGIN IMMEDIATE TRANSACTION", Vec::new()).await?;
     let result = async {
         let now = epoch_ms();
-        upsert_stream(
-            &changes.stream,
-            &changes.collection,
-            changes.cursor.as_ref(),
-            now,
-        )
-        .await?;
-        for change in changes.changes {
+        let stream = changes.stream;
+        upsert_stream(&stream, &changes.collection, changes.cursor.as_ref(), now).await?;
+        let changes = changes_after_last_reset(changes.changes);
+        if changes.had_reset {
+            exec(
+                DELETE_STREAM_ROWS_SQL,
+                vec![JsValue::from_str(stream.as_str())],
+            )
+            .await?;
+        }
+
+        for change in changes.items {
             match change.op {
                 SyncOp::Upsert => {
                     if let Some(row) = change.row {
-                        upsert_row(&changes.stream, &row, now).await?;
+                        upsert_row(&stream, &row, now).await?;
                     }
                 }
                 SyncOp::Delete => {
@@ -279,7 +313,7 @@ async fn apply_changes(changes: LocalChangeBatch) -> SyncResult<()> {
                         exec(
                             DELETE_ROW_SQL,
                             vec![
-                                JsValue::from_str(changes.stream.as_str()),
+                                JsValue::from_str(stream.as_str()),
                                 JsValue::from_str(key.as_str()),
                             ],
                         )
@@ -287,13 +321,8 @@ async fn apply_changes(changes: LocalChangeBatch) -> SyncResult<()> {
                     }
                 }
                 SyncOp::Reset => {
-                    exec(
-                        DELETE_STREAM_ROWS_SQL,
-                        vec![JsValue::from_str(changes.stream.as_str())],
-                    )
-                    .await?;
                     if let Some(row) = change.row {
-                        upsert_row(&changes.stream, &row, now).await?;
+                        upsert_row(&stream, &row, now).await?;
                     }
                 }
             }
@@ -328,7 +357,9 @@ async fn mark_push_result(result: LocalPushResult) -> SyncResult<()> {
     let tx_result = async {
         let now = epoch_ms();
 
-        if let Some(cursor) = result.cursor {
+        if let Some(collection) = result.collection.as_ref() {
+            upsert_stream(&result.stream, collection, result.cursor.as_ref(), now).await?;
+        } else if let Some(cursor) = result.cursor.as_ref() {
             exec(
                 "update __pocopine_streams set cursor = ?2, updated_at_ms = ?3 where stream = ?1",
                 vec![
@@ -338,6 +369,12 @@ async fn mark_push_result(result: LocalPushResult) -> SyncResult<()> {
                 ],
             )
             .await?;
+            if stream_exists(&result.stream).await?.is_none() {
+                return Err(SyncError::backend(format!(
+                    "cannot persist sync push cursor for stream {} before stream metadata exists",
+                    result.stream
+                )));
+            }
         }
 
         for id in result.accepted {
@@ -485,6 +522,11 @@ async fn select_meta(key: &str) -> SyncResult<Option<String>> {
         .transpose()
 }
 
+async fn stream_exists(stream: &SyncStreamName) -> SyncResult<Option<()>> {
+    let rows = query_rows(SELECT_STREAM_SQL, vec![JsValue::from_str(stream.as_str())]).await?;
+    Ok(rows.first().map(|_| ()))
+}
+
 async fn delete_mutation(mutation_id: &str) -> SyncResult<()> {
     exec(DELETE_MUTATION_SQL, vec![JsValue::from_str(mutation_id)]).await
 }
@@ -546,6 +588,7 @@ fn optional_string(row: &Value, field: &'static str) -> SyncResult<Option<String
 
 fn bool_from_int(row: &Value, field: &'static str) -> SyncResult<bool> {
     match row.get(field) {
+        Some(Value::Bool(value)) => Ok(*value),
         Some(Value::Number(value)) => value
             .as_i64()
             .map(|value| value != 0)
@@ -579,6 +622,30 @@ fn op_from_str(value: &str) -> SyncResult<SyncOp> {
         other => Err(SyncError::backend(format!(
             "invalid sync mutation op in sqlite store: {other}"
         ))),
+    }
+}
+
+struct LocalChanges {
+    had_reset: bool,
+    items: Vec<pocopine_sync::SyncChange<serde_json::Value>>,
+}
+
+fn changes_after_last_reset(
+    changes: Vec<pocopine_sync::SyncChange<serde_json::Value>>,
+) -> LocalChanges {
+    let Some(index) = changes
+        .iter()
+        .rposition(|change| change.op == SyncOp::Reset)
+    else {
+        return LocalChanges {
+            had_reset: false,
+            items: changes,
+        };
+    };
+
+    LocalChanges {
+        had_reset: true,
+        items: changes.into_iter().skip(index).collect(),
     }
 }
 

--- a/crates/pocopine-sync-sqlite/tests/wasm_sqlite_store.rs
+++ b/crates/pocopine-sync-sqlite/tests/wasm_sqlite_store.rs
@@ -1,0 +1,91 @@
+#![cfg(target_arch = "wasm32")]
+
+use pocopine_sync::{
+    ClientMutation, LocalPushResult, LocalSnapshotBatch, MutationId, RowKey, SyncCollectionName,
+    SyncCursor, SyncDeviceId, SyncLocalIdentity, SyncLocalStore, SyncOp, SyncRow, SyncStreamName,
+};
+use pocopine_sync_sqlite::SqliteLocalStore;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+async fn sqlite_wasm_store_round_trips_cached_rows_and_pending_mutations() {
+    let store = SqliteLocalStore::with_database_name(test_database_name()).unwrap();
+    let identity =
+        SyncLocalIdentity::with_next_counter(SyncDeviceId::new("device_browser").unwrap(), 3)
+            .unwrap();
+    let stream = SyncStreamName::new("posts").unwrap();
+    let collection = SyncCollectionName::new("posts").unwrap();
+    let row = SyncRow::new("post_1", serde_json::json!({"title": "Cached"}))
+        .unwrap()
+        .version("row_1")
+        .unwrap();
+
+    store.save_identity(identity.clone()).await.unwrap();
+    assert_eq!(store.load_identity().await.unwrap(), Some(identity));
+
+    store
+        .save_snapshot(LocalSnapshotBatch::new(
+            stream.clone(),
+            collection.clone(),
+            vec![row.clone()],
+            Some(SyncCursor::new("cursor_1").unwrap()),
+        ))
+        .await
+        .unwrap();
+
+    let snapshot = store.hydrate_stream(&stream).await.unwrap();
+    assert_eq!(snapshot.collection, Some(collection));
+    assert_eq!(snapshot.cursor.unwrap().as_str(), "cursor_1");
+    assert_eq!(snapshot.rows, vec![row]);
+
+    let mutation = ClientMutation {
+        id: MutationId::new("device_browser:3").unwrap(),
+        key: Some(RowKey::new("post_1").unwrap()),
+        op: SyncOp::Upsert,
+        base_version: Some(pocopine_sync::RowVersion::new("row_1").unwrap()),
+        payload: serde_json::json!({"title": "Updated"}),
+    };
+    store
+        .enqueue_mutation(&stream, mutation.clone())
+        .await
+        .unwrap();
+    assert_eq!(
+        store.pending_mutations(&stream).await.unwrap(),
+        vec![mutation]
+    );
+
+    store
+        .mark_push_result(LocalPushResult {
+            stream: stream.clone(),
+            accepted: vec![MutationId::new("device_browser:3").unwrap()],
+            rejected: Vec::new(),
+            rows: vec![
+                SyncRow::new("post_1", serde_json::json!({"title": "Updated"}))
+                    .unwrap()
+                    .version("row_2")
+                    .unwrap(),
+            ],
+            conflicts: Vec::new(),
+            cursor: Some(SyncCursor::new("cursor_2").unwrap()),
+        })
+        .await
+        .unwrap();
+
+    assert!(store.pending_mutations(&stream).await.unwrap().is_empty());
+    let updated = store.hydrate_stream(&stream).await.unwrap();
+    assert_eq!(updated.cursor.unwrap().as_str(), "cursor_2");
+    assert_eq!(updated.rows[0].value["title"], "Updated");
+
+    let _ = sqlite_wasm::close().await;
+}
+
+fn test_database_name() -> String {
+    let random = (js_sys::Math::random() * 1_000_000_000.0) as u32;
+    format!(
+        "pocopine_sync_test_{}_{}.sqlite3",
+        js_sys::Date::now() as u64,
+        random
+    )
+}

--- a/crates/pocopine-sync-sqlite/tests/wasm_sqlite_store.rs
+++ b/crates/pocopine-sync-sqlite/tests/wasm_sqlite_store.rs
@@ -59,6 +59,7 @@ async fn sqlite_wasm_store_round_trips_cached_rows_and_pending_mutations() {
     store
         .mark_push_result(LocalPushResult {
             stream: stream.clone(),
+            collection: Some(SyncCollectionName::new("posts").unwrap()),
             accepted: vec![MutationId::new("device_browser:3").unwrap()],
             rejected: Vec::new(),
             rows: vec![
@@ -77,6 +78,29 @@ async fn sqlite_wasm_store_round_trips_cached_rows_and_pending_mutations() {
     let updated = store.hydrate_stream(&stream).await.unwrap();
     assert_eq!(updated.cursor.unwrap().as_str(), "cursor_2");
     assert_eq!(updated.rows[0].value["title"], "Updated");
+
+    let push_first_stream = SyncStreamName::new("push_first").unwrap();
+    store
+        .mark_push_result(LocalPushResult {
+            stream: push_first_stream.clone(),
+            collection: Some(SyncCollectionName::new("posts").unwrap()),
+            accepted: vec![MutationId::new("device_browser:4").unwrap()],
+            rejected: Vec::new(),
+            rows: vec![
+                SyncRow::new("post_2", serde_json::json!({"title": "Push first"}))
+                    .unwrap()
+                    .version("row_1")
+                    .unwrap(),
+            ],
+            conflicts: Vec::new(),
+            cursor: Some(SyncCursor::new("cursor_push_first").unwrap()),
+        })
+        .await
+        .unwrap();
+
+    let push_first = store.hydrate_stream(&push_first_stream).await.unwrap();
+    assert_eq!(push_first.cursor.unwrap().as_str(), "cursor_push_first");
+    assert_eq!(push_first.rows.len(), 1);
 
     let _ = sqlite_wasm::close().await;
 }

--- a/crates/pocopine-sync/src/client.rs
+++ b/crates/pocopine-sync/src/client.rs
@@ -1,28 +1,34 @@
-use std::marker::PhantomData;
+use std::{marker::PhantomData, rc::Rc};
 
 use pocopine_core::{App, AppPlugin, Handle};
+#[cfg(target_arch = "wasm32")]
+use serde_json::Value;
 
 use crate::{
-    ClientMutation, CollectionState, SyncCursor, SyncError, SyncReason, SyncResult, SyncRow,
-    SyncStreamName, SYNC_ENDPOINT_PREFIX,
+    ClientMutation, CollectionState, MemoryLocalStore, SyncCursor, SyncError, SyncLocalStore,
+    SyncReason, SyncResult, SyncRow, SyncStreamName, SYNC_ENDPOINT_PREFIX,
 };
 
 #[cfg(target_arch = "wasm32")]
 use crate::{
-    sync_stream_tag, SyncOpenRequest, SyncOpenResponse, SyncPullRequest, SyncPullResponse,
-    SyncPushRequest, SyncPushResponse,
+    sync_stream_tag, LocalChangeBatch, LocalPushResult, LocalSnapshotBatch, LocalStreamSnapshot,
+    SyncChange, SyncConflict, SyncOpenRequest, SyncOpenResponse, SyncPullMode, SyncPullRequest,
+    SyncPullResponse, SyncPushRequest, SyncPushResponse,
 };
 
 /// Selector from an app-owned component/store into one sync collection field.
 pub type CollectionSelector<C, T> = for<'a> fn(&'a mut C) -> &'a mut CollectionState<T>;
 
 /// App plugin that provides [`SyncClient`] to components.
-#[derive(Clone, Debug)]
+pub type SyncLocalStoreHandle = Rc<dyn SyncLocalStore>;
+
+#[derive(Clone)]
 pub struct SyncClientPlugin {
     endpoint: String,
     live_endpoint: Option<String>,
     live_wakeup: bool,
     with_credentials: bool,
+    local_store: SyncLocalStoreHandle,
 }
 
 impl Default for SyncClientPlugin {
@@ -32,6 +38,7 @@ impl Default for SyncClientPlugin {
             live_endpoint: None,
             live_wakeup: false,
             with_credentials: false,
+            local_store: Rc::new(MemoryLocalStore::new()),
         }
     }
 }
@@ -69,6 +76,21 @@ impl SyncClientPlugin {
         self.with_credentials = enabled;
         self
     }
+
+    /// Use a custom local sync store.
+    ///
+    /// The default store is [`MemoryLocalStore`], which is useful for tests
+    /// and demos but does not survive page reloads.
+    pub fn local_store(mut self, store: impl SyncLocalStore + 'static) -> Self {
+        self.local_store = Rc::new(store);
+        self
+    }
+
+    /// Use a shared local sync store handle.
+    pub fn shared_local_store(mut self, store: SyncLocalStoreHandle) -> Self {
+        self.local_store = store;
+        self
+    }
 }
 
 impl AppPlugin for SyncClientPlugin {
@@ -82,17 +104,19 @@ impl AppPlugin for SyncClientPlugin {
             live_endpoint: self.live_endpoint,
             live_wakeup: self.live_wakeup,
             with_credentials: self.with_credentials,
+            local_store: self.local_store,
         })
     }
 }
 
 /// Runtime sync client service installed by [`sync_plugin`].
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct SyncClient {
     endpoint: String,
     live_endpoint: Option<String>,
     live_wakeup: bool,
     with_credentials: bool,
+    local_store: SyncLocalStoreHandle,
 }
 
 impl SyncClient {
@@ -113,6 +137,7 @@ impl SyncClient {
             live_endpoint: self.live_endpoint.clone(),
             live_wakeup: self.live_wakeup,
             with_credentials: self.with_credentials,
+            local_store: self.local_store.clone(),
             stream: None,
             cursor: None,
             _marker: PhantomData,
@@ -128,6 +153,7 @@ pub struct SyncCollection<C: 'static, T> {
     live_endpoint: Option<String>,
     live_wakeup: bool,
     with_credentials: bool,
+    local_store: SyncLocalStoreHandle,
     stream: Option<SyncStreamName>,
     cursor: Option<SyncCursor>,
     _marker: PhantomData<fn(C) -> T>,
@@ -159,7 +185,7 @@ where
     /// Pull initial data and, when configured, open a live wake-up stream.
     pub fn open(self) -> SyncResult<()>
     where
-        T: serde::de::DeserializeOwned,
+        T: serde::de::DeserializeOwned + serde::Serialize,
     {
         self.open_impl()
     }
@@ -167,7 +193,7 @@ where
     /// Trigger a manual pull.
     pub fn pull(self) -> SyncResult<()>
     where
-        T: serde::de::DeserializeOwned,
+        T: serde::de::DeserializeOwned + serde::Serialize,
     {
         self.pull_impl(SyncReason::Manual, false)
     }
@@ -180,7 +206,7 @@ where
         optimistic: Option<SyncRow<T>>,
     ) -> SyncResult<()>
     where
-        T: Clone + serde::de::DeserializeOwned,
+        T: Clone + serde::de::DeserializeOwned + serde::Serialize,
         M: serde::Serialize + 'static,
     {
         self.push_impl(mutation, optimistic)
@@ -201,6 +227,7 @@ where
             &self.live_endpoint,
             self.live_wakeup,
             self.with_credentials,
+            &self.local_store,
         );
     }
 }
@@ -209,7 +236,7 @@ where
 impl<C, T> SyncCollection<C, T>
 where
     C: 'static,
-    T: serde::de::DeserializeOwned + 'static,
+    T: serde::de::DeserializeOwned + serde::Serialize + 'static,
 {
     fn open_impl(self) -> SyncResult<()> {
         let stream = self.stream_value()?;
@@ -230,6 +257,7 @@ where
             handle.clone(),
             selector,
             self.endpoint.clone(),
+            self.local_store.clone(),
             stream.clone(),
             self.cursor.clone(),
             SyncReason::Initial,
@@ -250,6 +278,7 @@ where
             self.handle,
             self.selector,
             self.endpoint,
+            self.local_store,
             stream,
             self.cursor,
             reason,
@@ -264,7 +293,7 @@ where
         optimistic: Option<SyncRow<T>>,
     ) -> SyncResult<()>
     where
-        T: Clone + serde::de::DeserializeOwned + 'static,
+        T: Clone + serde::de::DeserializeOwned + serde::Serialize + 'static,
         M: serde::Serialize + 'static,
     {
         let stream = self.stream_value()?;
@@ -278,6 +307,7 @@ where
             self.handle,
             self.selector,
             self.endpoint,
+            self.local_store,
             stream,
             mutation,
             optimistic,
@@ -311,7 +341,7 @@ where
         optimistic: Option<SyncRow<T>>,
     ) -> SyncResult<()>
     where
-        T: Clone + serde::de::DeserializeOwned + 'static,
+        T: Clone + serde::de::DeserializeOwned + serde::Serialize + 'static,
         M: serde::Serialize + 'static,
     {
         self.touch_host_fields();
@@ -333,21 +363,49 @@ fn start_open_then_pull<C, T>(
     handle: Handle<C>,
     selector: CollectionSelector<C, T>,
     endpoint: String,
+    local_store: SyncLocalStoreHandle,
     stream: SyncStreamName,
     cursor: Option<SyncCursor>,
     reason: SyncReason,
     live_wakeup: Option<LiveWakeupOptions>,
 ) where
     C: 'static,
-    T: serde::de::DeserializeOwned + 'static,
+    T: serde::de::DeserializeOwned + serde::Serialize + 'static,
 {
     let open_url = endpoint_path(&endpoint, "open");
     let pull_url = endpoint_path(&endpoint, "pull");
+    let push_url = endpoint_path(&endpoint, "push");
 
     pocopine_core::spawn_for_scope(scope_id, async move {
+        let mut local_cursor = None;
+        let mut pending_mutations = Vec::new();
+        let mut local_error = None;
+
+        match local_store.hydrate_stream(&stream).await {
+            Ok(snapshot) => {
+                local_cursor = snapshot.cursor.clone();
+                pending_mutations = snapshot.pending_mutations.clone();
+                match decode_local_snapshot(snapshot) {
+                    Ok((rows, cursor, pending_count)) => {
+                        handle.update(|state| {
+                            selector(state).apply_local_snapshot(rows, cursor, pending_count);
+                        });
+                    }
+                    Err(err) => {
+                        local_error = Some(format!("local sync cache decode failed: {err}"));
+                    }
+                }
+            }
+            Err(err) => {
+                local_error = Some(format!("local sync cache hydrate failed: {err}"));
+            }
+        }
+
         let request_token = handle.update(|state| {
             let collection = selector(state);
-            let cursor = cursor.or_else(|| collection.cursor.clone());
+            let cursor = cursor
+                .or_else(|| collection.cursor.clone())
+                .or(local_cursor);
             let token = if collection.version == 0 {
                 collection.begin_initial()
             } else {
@@ -377,20 +435,49 @@ fn start_open_then_pull<C, T>(
                 handle.clone(),
                 selector,
                 endpoint.clone(),
+                local_store.clone(),
                 stream.clone(),
                 live_wakeup,
             );
+        }
+
+        if !pending_mutations.is_empty() {
+            match replay_pending_mutations::<T>(
+                &local_store,
+                &push_url,
+                stream.clone(),
+                pending_mutations,
+            )
+            .await
+            {
+                Ok(()) => {}
+                Err(err) => {
+                    local_error = Some(format!("pending sync mutation replay failed: {err}"));
+                }
+            }
         }
 
         let request = SyncPullRequest::new(stream).cursor(cursor);
         let result =
             pocopine_core::fetch::call::<SyncPullRequest, SyncPullResponse<T>>(&pull_url, &request)
                 .await;
+        let result = match result {
+            Ok(response) => {
+                if let Err(err) = persist_pull_response(&local_store, &response).await {
+                    local_error = Some(format!("local sync cache persist failed: {err}"));
+                }
+                Ok(response)
+            }
+            Err(err) => Err(err),
+        };
         handle.update(|state| {
             let collection = selector(state);
             match result {
                 Ok(response) => {
                     collection.apply_pull(token, response);
+                    if let Some(error) = local_error {
+                        collection.set_error(error);
+                    }
                 }
                 Err(err) => {
                     collection.apply_error(token, err);
@@ -406,11 +493,12 @@ fn open_live_wakeup<C, T>(
     handle: Handle<C>,
     selector: CollectionSelector<C, T>,
     endpoint: String,
+    local_store: SyncLocalStoreHandle,
     stream: SyncStreamName,
     options: LiveWakeupOptions,
 ) where
     C: 'static,
-    T: serde::de::DeserializeOwned + 'static,
+    T: serde::de::DeserializeOwned + serde::Serialize + 'static,
 {
     let live_tag = sync_stream_tag(stream.as_str());
     let mut refresh = pocopine_live::LiveRefresh::scoped()
@@ -429,6 +517,7 @@ fn open_live_wakeup<C, T>(
                     handle.clone(),
                     selector,
                     endpoint.clone(),
+                    local_store.clone(),
                     stream.clone(),
                     None,
                     reason,
@@ -493,13 +582,14 @@ fn start_pull<C, T>(
     handle: Handle<C>,
     selector: CollectionSelector<C, T>,
     endpoint: String,
+    local_store: SyncLocalStoreHandle,
     stream: SyncStreamName,
     cursor: Option<SyncCursor>,
     reason: SyncReason,
     live_event: bool,
 ) where
     C: 'static,
-    T: serde::de::DeserializeOwned + 'static,
+    T: serde::de::DeserializeOwned + serde::Serialize + 'static,
 {
     let pull_url = endpoint_path(&endpoint, "pull");
 
@@ -521,11 +611,24 @@ fn start_pull<C, T>(
         let result =
             pocopine_core::fetch::call::<SyncPullRequest, SyncPullResponse<T>>(&pull_url, &request)
                 .await;
+        let mut local_error = None;
+        let result = match result {
+            Ok(response) => {
+                if let Err(err) = persist_pull_response(&local_store, &response).await {
+                    local_error = Some(format!("local sync cache persist failed: {err}"));
+                }
+                Ok(response)
+            }
+            Err(err) => Err(err),
+        };
         handle.update(|state| {
             let collection = selector(state);
             match result {
                 Ok(response) => {
                     collection.apply_pull(token, response);
+                    if let Some(error) = local_error {
+                        collection.set_error(error);
+                    }
                 }
                 Err(err) => {
                     collection.apply_error(token, err);
@@ -541,13 +644,14 @@ fn start_push<C, T, M>(
     handle: Handle<C>,
     selector: CollectionSelector<C, T>,
     endpoint: String,
+    local_store: SyncLocalStoreHandle,
     stream: SyncStreamName,
     mutation: ClientMutation<M>,
     optimistic: Option<SyncRow<T>>,
     pull_after_accept: bool,
 ) where
     C: 'static,
-    T: Clone + serde::de::DeserializeOwned + 'static,
+    T: Clone + serde::de::DeserializeOwned + serde::Serialize + 'static,
     M: serde::Serialize + 'static,
 {
     let push_url = endpoint_path(&endpoint, "push");
@@ -557,6 +661,22 @@ fn start_push<C, T, M>(
     let mutation_key = mutation.key.clone();
 
     pocopine_core::spawn_for_scope(scope_id, async move {
+        let local_mutation = match mutation_to_value(&mutation) {
+            Ok(mutation) => mutation,
+            Err(err) => {
+                handle.update(|state| {
+                    selector(state).set_error(format!("sync mutation encode failed: {err}"));
+                });
+                return;
+            }
+        };
+        if let Err(err) = local_store.enqueue_mutation(&stream, local_mutation).await {
+            handle.update(|state| {
+                selector(state).set_error(format!("local sync mutation enqueue failed: {err}"));
+            });
+            return;
+        }
+
         handle.update(|state| {
             selector(state).apply_optimistic_mutation(
                 mutation_id,
@@ -571,10 +691,34 @@ fn start_push<C, T, M>(
             &push_url, &request,
         )
         .await;
+        let mut local_error = None;
+        let result = match result {
+            Ok(response) => {
+                match local_push_result_from_response(&response) {
+                    Ok(result) => {
+                        if let Err(err) = local_store.mark_push_result(result).await {
+                            local_error =
+                                Some(format!("local sync push result persist failed: {err}"));
+                        }
+                    }
+                    Err(err) => {
+                        local_error = Some(format!("local sync push result encode failed: {err}"));
+                    }
+                }
+                Ok(response)
+            }
+            Err(err) => Err(err),
+        };
         let should_pull = handle.update(|state| {
             let collection = selector(state);
             match result {
-                Ok(response) => collection.apply_push(response),
+                Ok(response) => {
+                    let should_pull = collection.apply_push(response);
+                    if let Some(error) = local_error {
+                        collection.set_error(error);
+                    }
+                    should_pull
+                }
                 Err(err) => {
                     collection.set_error(err.to_string());
                     false
@@ -588,6 +732,7 @@ fn start_push<C, T, M>(
                 handle,
                 selector,
                 pull_endpoint,
+                local_store,
                 stream,
                 None,
                 SyncReason::Push,
@@ -595,6 +740,177 @@ fn start_push<C, T, M>(
             );
         }
     });
+}
+
+#[cfg(target_arch = "wasm32")]
+fn decode_local_snapshot<T>(
+    snapshot: LocalStreamSnapshot,
+) -> SyncResult<(Vec<SyncRow<T>>, Option<SyncCursor>, u64)>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let pending_count = snapshot.pending_mutations.len() as u64;
+    let rows = snapshot
+        .rows
+        .into_iter()
+        .map(row_from_value)
+        .collect::<SyncResult<Vec<_>>>()?;
+    Ok((rows, snapshot.cursor, pending_count))
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn replay_pending_mutations<T>(
+    local_store: &SyncLocalStoreHandle,
+    push_url: &str,
+    stream: SyncStreamName,
+    pending_mutations: Vec<ClientMutation<Value>>,
+) -> SyncResult<()>
+where
+    T: serde::de::DeserializeOwned + serde::Serialize + 'static,
+{
+    let request = SyncPushRequest::new(stream, pending_mutations);
+    let response = pocopine_core::fetch::call::<SyncPushRequest<Value>, SyncPushResponse<T>>(
+        push_url, &request,
+    )
+    .await
+    .map_err(|err| SyncError::client(err.to_string()))?;
+    let result = local_push_result_from_response(&response)?;
+    local_store.mark_push_result(result).await
+}
+
+#[cfg(target_arch = "wasm32")]
+async fn persist_pull_response<T>(
+    local_store: &SyncLocalStoreHandle,
+    response: &SyncPullResponse<T>,
+) -> SyncResult<()>
+where
+    T: serde::Serialize,
+{
+    match response.mode {
+        SyncPullMode::Snapshot => {
+            let rows = response
+                .rows
+                .iter()
+                .map(row_to_value)
+                .collect::<SyncResult<Vec<_>>>()?;
+            local_store
+                .save_snapshot(LocalSnapshotBatch::new(
+                    response.stream.clone(),
+                    response.collection.clone(),
+                    rows,
+                    response.cursor.clone(),
+                ))
+                .await
+        }
+        SyncPullMode::Incremental => {
+            let changes = response
+                .changes
+                .iter()
+                .map(change_to_value)
+                .collect::<SyncResult<Vec<_>>>()?;
+            local_store
+                .apply_changes(LocalChangeBatch::new(
+                    response.stream.clone(),
+                    response.collection.clone(),
+                    changes,
+                    response.cursor.clone(),
+                ))
+                .await
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn local_push_result_from_response<T>(response: &SyncPushResponse<T>) -> SyncResult<LocalPushResult>
+where
+    T: serde::Serialize,
+{
+    Ok(LocalPushResult {
+        stream: response.stream.clone(),
+        accepted: response.accepted.clone(),
+        rejected: response.rejected.clone(),
+        rows: response
+            .rows
+            .iter()
+            .map(row_to_value)
+            .collect::<SyncResult<Vec<_>>>()?,
+        conflicts: response
+            .conflicts
+            .iter()
+            .map(conflict_to_value)
+            .collect::<SyncResult<Vec<_>>>()?,
+        cursor: response.cursor.clone(),
+    })
+}
+
+#[cfg(target_arch = "wasm32")]
+fn mutation_to_value<M>(mutation: &ClientMutation<M>) -> SyncResult<ClientMutation<Value>>
+where
+    M: serde::Serialize,
+{
+    Ok(ClientMutation {
+        id: mutation.id.clone(),
+        key: mutation.key.clone(),
+        op: mutation.op,
+        base_version: mutation.base_version.clone(),
+        payload: serde_json::to_value(&mutation.payload)?,
+    })
+}
+
+#[cfg(target_arch = "wasm32")]
+fn row_to_value<T>(row: &SyncRow<T>) -> SyncResult<SyncRow<Value>>
+where
+    T: serde::Serialize,
+{
+    Ok(SyncRow {
+        key: row.key.clone(),
+        version: row.version.clone(),
+        value: serde_json::to_value(&row.value)?,
+        pending: row.pending,
+        conflict: row.conflict,
+    })
+}
+
+#[cfg(target_arch = "wasm32")]
+fn row_from_value<T>(row: SyncRow<Value>) -> SyncResult<SyncRow<T>>
+where
+    T: serde::de::DeserializeOwned,
+{
+    Ok(SyncRow {
+        key: row.key,
+        version: row.version,
+        value: serde_json::from_value(row.value)?,
+        pending: row.pending,
+        conflict: row.conflict,
+    })
+}
+
+#[cfg(target_arch = "wasm32")]
+fn change_to_value<T>(change: &SyncChange<T>) -> SyncResult<SyncChange<Value>>
+where
+    T: serde::Serialize,
+{
+    Ok(SyncChange {
+        stream: change.stream.clone(),
+        collection: change.collection.clone(),
+        key: change.key.clone(),
+        op: change.op,
+        row: change.row.as_ref().map(row_to_value).transpose()?,
+        cursor: change.cursor.clone(),
+    })
+}
+
+#[cfg(target_arch = "wasm32")]
+fn conflict_to_value<T>(conflict: &SyncConflict<T>) -> SyncResult<SyncConflict<Value>>
+where
+    T: serde::Serialize,
+{
+    Ok(SyncConflict {
+        mutation_id: conflict.mutation_id.clone(),
+        key: conflict.key.clone(),
+        server_row: conflict.server_row.as_ref().map(row_to_value).transpose()?,
+        reason: conflict.reason.clone(),
+    })
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/pocopine-sync/src/client.rs
+++ b/crates/pocopine-sync/src/client.rs
@@ -827,6 +827,7 @@ where
 {
     Ok(LocalPushResult {
         stream: response.stream.clone(),
+        collection: response.collection.clone(),
         accepted: response.accepted.clone(),
         rejected: response.rejected.clone(),
         rows: response

--- a/crates/pocopine-sync/src/lib.rs
+++ b/crates/pocopine-sync/src/lib.rs
@@ -6,6 +6,7 @@
 //! and installing the host server plugin.
 
 mod error;
+mod local_store;
 mod protocol;
 mod state;
 
@@ -16,12 +17,17 @@ mod memory;
 mod server;
 
 pub use error::{SyncError, SyncResult};
+pub use local_store::{
+    LocalChangeBatch, LocalPushResult, LocalSnapshotBatch, LocalStreamSnapshot,
+    MutationIdGenerator, SyncLocalFuture, SyncLocalIdentity, SyncLocalStore,
+};
 pub use protocol::{
     sync_stream_tag, ClientMutation, MutationId, RowKey, RowVersion, SyncChange,
-    SyncCollectionName, SyncConflict, SyncCursor, SyncOp, SyncOpenRequest, SyncOpenResponse,
-    SyncOpenStream, SyncPullMode, SyncPullRequest, SyncPullResponse, SyncPushRequest,
-    SyncPushResponse, SyncRejectedMutation, SyncRow, SyncStreamName, MAX_SYNC_TOKEN_LEN,
-    SYNC_ENDPOINT_PREFIX, SYNC_OPEN_PATH, SYNC_PROTOCOL_V1, SYNC_PULL_PATH, SYNC_PUSH_PATH,
+    SyncCollectionName, SyncConflict, SyncCursor, SyncDeviceId, SyncOp, SyncOpenRequest,
+    SyncOpenResponse, SyncOpenStream, SyncPullMode, SyncPullRequest, SyncPullResponse,
+    SyncPushRequest, SyncPushResponse, SyncRejectedMutation, SyncRow, SyncSessionId,
+    SyncStreamName, MAX_SYNC_TOKEN_LEN, SYNC_ENDPOINT_PREFIX, SYNC_OPEN_PATH, SYNC_PROTOCOL_V1,
+    SYNC_PULL_PATH, SYNC_PUSH_PATH,
 };
 pub use state::{CollectionState, PendingMutation, SyncReason, SyncRequest};
 

--- a/crates/pocopine-sync/src/lib.rs
+++ b/crates/pocopine-sync/src/lib.rs
@@ -33,7 +33,7 @@ pub use protocol::{
 };
 pub use state::{CollectionState, PendingMutation, SyncReason, SyncRequest};
 
-pub use client::{sync_plugin, SyncClient, SyncClientPlugin, SyncCollection};
+pub use client::{sync_plugin, SyncClient, SyncClientPlugin, SyncCollection, SyncLocalStoreHandle};
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use memory::{MemorySyncState, MemorySyncStream};

--- a/crates/pocopine-sync/src/lib.rs
+++ b/crates/pocopine-sync/src/lib.rs
@@ -6,6 +6,7 @@
 //! and installing the host server plugin.
 
 mod error;
+mod local_memory;
 mod local_store;
 mod protocol;
 mod state;
@@ -17,6 +18,7 @@ mod memory;
 mod server;
 
 pub use error::{SyncError, SyncResult};
+pub use local_memory::MemoryLocalStore;
 pub use local_store::{
     LocalChangeBatch, LocalPushResult, LocalSnapshotBatch, LocalStreamSnapshot,
     MutationIdGenerator, SyncLocalFuture, SyncLocalIdentity, SyncLocalStore,

--- a/crates/pocopine-sync/src/local_memory.rs
+++ b/crates/pocopine-sync/src/local_memory.rs
@@ -402,4 +402,258 @@ mod tests {
         assert!(snapshot.rows[0].conflict);
         assert!(!snapshot.rows[0].pending);
     }
+
+    #[tokio::test]
+    async fn memory_store_save_snapshot_replaces_previous_rows() {
+        let store = MemoryLocalStore::new();
+        let stream = SyncStreamName::new("posts").unwrap();
+        let collection = SyncCollectionName::new("posts").unwrap();
+
+        store
+            .save_snapshot(LocalSnapshotBatch::new(
+                stream.clone(),
+                collection.clone(),
+                vec![
+                    SyncRow::new("post_1", serde_json::json!({"title": "Old1"})).unwrap(),
+                    SyncRow::new("post_2", serde_json::json!({"title": "Old2"})).unwrap(),
+                ],
+                Some(SyncCursor::new("cursor_1").unwrap()),
+            ))
+            .await
+            .unwrap();
+
+        let replacement =
+            SyncRow::new("post_3", serde_json::json!({"title": "Only survivor"})).unwrap();
+        store
+            .save_snapshot(LocalSnapshotBatch::new(
+                stream.clone(),
+                collection,
+                vec![replacement.clone()],
+                Some(SyncCursor::new("cursor_2").unwrap()),
+            ))
+            .await
+            .unwrap();
+
+        let snapshot = store.hydrate_stream(&stream).await.unwrap();
+        assert_eq!(snapshot.rows, vec![replacement]);
+        assert_eq!(snapshot.cursor.unwrap().as_str(), "cursor_2");
+    }
+
+    #[tokio::test]
+    async fn memory_store_save_snapshot_preserves_pending_mutations() {
+        let store = MemoryLocalStore::new();
+        let stream = SyncStreamName::new("posts").unwrap();
+        let mutation = ClientMutation {
+            id: MutationId::new("device_abc:1").unwrap(),
+            key: Some(RowKey::new("post_1").unwrap()),
+            op: SyncOp::Upsert,
+            base_version: None,
+            payload: serde_json::json!({"title": "Local"}),
+        };
+        store
+            .enqueue_mutation(&stream, mutation.clone())
+            .await
+            .unwrap();
+
+        store
+            .save_snapshot(LocalSnapshotBatch::new(
+                stream.clone(),
+                SyncCollectionName::new("posts").unwrap(),
+                vec![SyncRow::new("post_1", serde_json::json!({"title": "Server"})).unwrap()],
+                Some(SyncCursor::new("cursor_1").unwrap()),
+            ))
+            .await
+            .unwrap();
+
+        let snapshot = store.hydrate_stream(&stream).await.unwrap();
+        assert_eq!(snapshot.pending_mutations, vec![mutation]);
+        assert_eq!(snapshot.rows.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn memory_store_apply_changes_delete_missing_key_is_noop() {
+        let store = MemoryLocalStore::new();
+        let stream = SyncStreamName::new("posts").unwrap();
+        let collection = SyncCollectionName::new("posts").unwrap();
+        store
+            .save_snapshot(LocalSnapshotBatch::new(
+                stream.clone(),
+                collection.clone(),
+                vec![SyncRow::new("post_1", serde_json::json!({"title": "Kept"})).unwrap()],
+                None,
+            ))
+            .await
+            .unwrap();
+
+        let cursor = SyncCursor::new("cursor_2").unwrap();
+        store
+            .apply_changes(LocalChangeBatch::new(
+                stream.clone(),
+                collection.clone(),
+                vec![SyncChange {
+                    stream: stream.clone(),
+                    collection,
+                    key: Some(RowKey::new("never_existed").unwrap()),
+                    op: SyncOp::Delete,
+                    row: None,
+                    cursor: cursor.clone(),
+                }],
+                Some(cursor),
+            ))
+            .await
+            .unwrap();
+
+        let snapshot = store.hydrate_stream(&stream).await.unwrap();
+        assert_eq!(snapshot.rows.len(), 1);
+        assert_eq!(snapshot.rows[0].key.as_str(), "post_1");
+        assert_eq!(snapshot.cursor.unwrap().as_str(), "cursor_2");
+    }
+
+    #[tokio::test]
+    async fn memory_store_apply_changes_reset_then_upsert_keeps_only_post_reset_rows() {
+        let store = MemoryLocalStore::new();
+        let stream = SyncStreamName::new("posts").unwrap();
+        let collection = SyncCollectionName::new("posts").unwrap();
+        store
+            .save_snapshot(LocalSnapshotBatch::new(
+                stream.clone(),
+                collection.clone(),
+                vec![
+                    SyncRow::new("old_1", serde_json::json!({"title": "Old1"})).unwrap(),
+                    SyncRow::new("old_2", serde_json::json!({"title": "Old2"})).unwrap(),
+                ],
+                Some(SyncCursor::new("cursor_1").unwrap()),
+            ))
+            .await
+            .unwrap();
+
+        let cursor = SyncCursor::new("cursor_2").unwrap();
+        let after_reset =
+            SyncRow::new("post_after", serde_json::json!({"title": "After"})).unwrap();
+        store
+            .apply_changes(LocalChangeBatch::new(
+                stream.clone(),
+                collection.clone(),
+                vec![
+                    SyncChange {
+                        stream: stream.clone(),
+                        collection: collection.clone(),
+                        key: Some(RowKey::new("ignored").unwrap()),
+                        op: SyncOp::Upsert,
+                        row: Some(
+                            SyncRow::new("ignored", serde_json::json!({"title": "Pre-reset"}))
+                                .unwrap(),
+                        ),
+                        cursor: cursor.clone(),
+                    },
+                    SyncChange {
+                        stream: stream.clone(),
+                        collection: collection.clone(),
+                        key: None,
+                        op: SyncOp::Reset,
+                        row: None,
+                        cursor: cursor.clone(),
+                    },
+                    SyncChange {
+                        stream: stream.clone(),
+                        collection,
+                        key: Some(after_reset.key.clone()),
+                        op: SyncOp::Upsert,
+                        row: Some(after_reset.clone()),
+                        cursor: cursor.clone(),
+                    },
+                ],
+                Some(cursor),
+            ))
+            .await
+            .unwrap();
+
+        let snapshot = store.hydrate_stream(&stream).await.unwrap();
+        assert_eq!(snapshot.rows, vec![after_reset]);
+    }
+
+    #[tokio::test]
+    async fn memory_store_conflict_with_key_only_marks_existing_row() {
+        let store = MemoryLocalStore::new();
+        let stream = SyncStreamName::new("posts").unwrap();
+        let collection = SyncCollectionName::new("posts").unwrap();
+        store
+            .save_snapshot(LocalSnapshotBatch::new(
+                stream.clone(),
+                collection,
+                vec![SyncRow::new("post_1", serde_json::json!({"title": "Local"})).unwrap()],
+                None,
+            ))
+            .await
+            .unwrap();
+
+        let mut response = SyncPushResponse::new(stream.clone());
+        response.conflicts.push(crate::SyncConflict {
+            mutation_id: MutationId::new("device_abc:1").unwrap(),
+            key: Some(RowKey::new("post_1").unwrap()),
+            server_row: None,
+            reason: "version mismatch".to_string(),
+        });
+
+        store
+            .mark_push_result(LocalPushResult::from_response(response))
+            .await
+            .unwrap();
+
+        let snapshot = store.hydrate_stream(&stream).await.unwrap();
+        assert_eq!(snapshot.rows.len(), 1);
+        assert!(snapshot.rows[0].conflict);
+        assert!(!snapshot.rows[0].pending);
+        assert_eq!(snapshot.rows[0].value, serde_json::json!({"title": "Local"}));
+    }
+
+    #[tokio::test]
+    async fn memory_store_hydrate_returns_empty_for_unknown_stream() {
+        let store = MemoryLocalStore::new();
+        let stream = SyncStreamName::new("never_seen").unwrap();
+        let snapshot = store.hydrate_stream(&stream).await.unwrap();
+        assert_eq!(snapshot.stream, stream);
+        assert!(snapshot.collection.is_none());
+        assert!(snapshot.cursor.is_none());
+        assert!(snapshot.rows.is_empty());
+        assert!(snapshot.pending_mutations.is_empty());
+    }
+
+    #[tokio::test]
+    async fn memory_store_pending_mutations_isolate_streams() {
+        let store = MemoryLocalStore::new();
+        let posts = SyncStreamName::new("posts").unwrap();
+        let comments = SyncStreamName::new("comments").unwrap();
+        let post_mutation = ClientMutation {
+            id: MutationId::new("device_abc:1").unwrap(),
+            key: Some(RowKey::new("post_1").unwrap()),
+            op: SyncOp::Upsert,
+            base_version: None,
+            payload: serde_json::json!({"title": "Post"}),
+        };
+        let comment_mutation = ClientMutation {
+            id: MutationId::new("device_abc:2").unwrap(),
+            key: Some(RowKey::new("comment_1").unwrap()),
+            op: SyncOp::Upsert,
+            base_version: None,
+            payload: serde_json::json!({"body": "Comment"}),
+        };
+        store
+            .enqueue_mutation(&posts, post_mutation.clone())
+            .await
+            .unwrap();
+        store
+            .enqueue_mutation(&comments, comment_mutation.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            store.pending_mutations(&posts).await.unwrap(),
+            vec![post_mutation]
+        );
+        assert_eq!(
+            store.pending_mutations(&comments).await.unwrap(),
+            vec![comment_mutation]
+        );
+    }
 }

--- a/crates/pocopine-sync/src/local_memory.rs
+++ b/crates/pocopine-sync/src/local_memory.rs
@@ -1,0 +1,375 @@
+use std::{
+    collections::BTreeMap,
+    future,
+    sync::{Arc, Mutex},
+};
+
+use crate::{
+    ClientMutation, LocalChangeBatch, LocalPushResult, LocalSnapshotBatch, LocalStreamSnapshot,
+    RowKey, SyncCollectionName, SyncError, SyncLocalFuture, SyncLocalIdentity, SyncLocalStore,
+    SyncOp, SyncResult, SyncRow, SyncStreamName,
+};
+
+/// In-memory [`SyncLocalStore`] implementation for tests and demos.
+///
+/// This store is process-local and not durable. It pins the local-store
+/// semantics before browser SQLite persistence is added.
+#[derive(Clone, Debug, Default)]
+pub struct MemoryLocalStore {
+    inner: Arc<Mutex<MemoryLocalStoreInner>>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct MemoryLocalStoreInner {
+    identity: Option<SyncLocalIdentity>,
+    streams: BTreeMap<SyncStreamName, MemoryStreamState>,
+}
+
+#[derive(Clone, Debug, Default)]
+struct MemoryStreamState {
+    collection: Option<SyncCollectionName>,
+    cursor: Option<crate::SyncCursor>,
+    rows: BTreeMap<RowKey, SyncRow<serde_json::Value>>,
+    pending: BTreeMap<crate::MutationId, ClientMutation<serde_json::Value>>,
+}
+
+impl MemoryLocalStore {
+    /// Build an empty in-memory local store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn with_inner<T>(
+        &self,
+        f: impl FnOnce(&mut MemoryLocalStoreInner) -> SyncResult<T>,
+    ) -> SyncResult<T> {
+        let mut inner = self
+            .inner
+            .lock()
+            .map_err(|_| SyncError::backend("memory local sync store lock poisoned"))?;
+        f(&mut inner)
+    }
+
+    fn ready<T: 'static>(result: SyncResult<T>) -> SyncLocalFuture<'static, T> {
+        Box::pin(future::ready(result))
+    }
+}
+
+impl SyncLocalStore for MemoryLocalStore {
+    fn load_identity(&self) -> SyncLocalFuture<'_, Option<SyncLocalIdentity>> {
+        Self::ready(self.with_inner(|inner| Ok(inner.identity.clone())))
+    }
+
+    fn save_identity(&self, identity: SyncLocalIdentity) -> SyncLocalFuture<'_, ()> {
+        Self::ready(self.with_inner(|inner| {
+            inner.identity = Some(identity);
+            Ok(())
+        }))
+    }
+
+    fn hydrate_stream(&self, stream: &SyncStreamName) -> SyncLocalFuture<'_, LocalStreamSnapshot> {
+        let stream = stream.clone();
+        Self::ready(self.with_inner(|inner| {
+            let Some(state) = inner.streams.get(&stream) else {
+                return Ok(LocalStreamSnapshot::empty(stream));
+            };
+            Ok(LocalStreamSnapshot {
+                stream,
+                collection: state.collection.clone(),
+                cursor: state.cursor.clone(),
+                rows: state.rows.values().cloned().collect(),
+                pending_mutations: state.pending.values().cloned().collect(),
+            })
+        }))
+    }
+
+    fn save_snapshot(&self, snapshot: LocalSnapshotBatch) -> SyncLocalFuture<'_, ()> {
+        Self::ready(self.with_inner(|inner| {
+            let state = inner.streams.entry(snapshot.stream).or_default();
+            state.collection = Some(snapshot.collection);
+            state.cursor = snapshot.cursor;
+            state.rows = snapshot
+                .rows
+                .into_iter()
+                .map(|row| (row.key.clone(), row))
+                .collect();
+            Ok(())
+        }))
+    }
+
+    fn apply_changes(&self, changes: LocalChangeBatch) -> SyncLocalFuture<'_, ()> {
+        Self::ready(self.with_inner(|inner| {
+            let state = inner.streams.entry(changes.stream).or_default();
+            state.collection = Some(changes.collection);
+            state.cursor = changes.cursor;
+
+            for change in changes.changes {
+                match change.op {
+                    SyncOp::Upsert => {
+                        if let Some(row) = change.row {
+                            state.rows.insert(row.key.clone(), row);
+                        }
+                    }
+                    SyncOp::Delete => {
+                        if let Some(key) = change.key {
+                            state.rows.remove(&key);
+                        }
+                    }
+                    SyncOp::Reset => {
+                        state.rows.clear();
+                        if let Some(row) = change.row {
+                            state.rows.insert(row.key.clone(), row);
+                        }
+                    }
+                }
+            }
+            Ok(())
+        }))
+    }
+
+    fn enqueue_mutation(
+        &self,
+        stream: &SyncStreamName,
+        mutation: ClientMutation<serde_json::Value>,
+    ) -> SyncLocalFuture<'_, ()> {
+        let stream = stream.clone();
+        Self::ready(self.with_inner(|inner| {
+            let state = inner.streams.entry(stream).or_default();
+            state.pending.insert(mutation.id.clone(), mutation);
+            Ok(())
+        }))
+    }
+
+    fn mark_push_result(&self, result: LocalPushResult) -> SyncLocalFuture<'_, ()> {
+        Self::ready(self.with_inner(|inner| {
+            let state = inner.streams.entry(result.stream).or_default();
+            state.cursor = result.cursor;
+
+            for id in result.accepted {
+                state.pending.remove(&id);
+            }
+
+            for rejected in result.rejected {
+                state.pending.remove(&rejected.mutation_id);
+            }
+
+            for conflict in result.conflicts {
+                state.pending.remove(&conflict.mutation_id);
+                if let Some(mut row) = conflict.server_row {
+                    row.pending = false;
+                    row.conflict = true;
+                    state.rows.insert(row.key.clone(), row);
+                } else if let Some(key) = conflict.key {
+                    if let Some(row) = state.rows.get_mut(&key) {
+                        row.pending = false;
+                        row.conflict = true;
+                    }
+                }
+            }
+
+            for mut row in result.rows {
+                row.pending = false;
+                row.conflict = false;
+                state.rows.insert(row.key.clone(), row);
+            }
+
+            Ok(())
+        }))
+    }
+
+    fn pending_mutations(
+        &self,
+        stream: &SyncStreamName,
+    ) -> SyncLocalFuture<'_, Vec<ClientMutation<serde_json::Value>>> {
+        let stream = stream.clone();
+        Self::ready(self.with_inner(|inner| {
+            Ok(inner
+                .streams
+                .get(&stream)
+                .map(|state| state.pending.values().cloned().collect())
+                .unwrap_or_default())
+        }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        LocalChangeBatch, LocalSnapshotBatch, MutationId, RowVersion, SyncChange,
+        SyncCollectionName, SyncCursor, SyncDeviceId, SyncPushResponse,
+    };
+
+    #[tokio::test]
+    async fn memory_store_persists_identity() {
+        let store = MemoryLocalStore::new();
+        let identity =
+            SyncLocalIdentity::with_next_counter(SyncDeviceId::new("device_abc").unwrap(), 7)
+                .unwrap();
+
+        assert!(store.load_identity().await.unwrap().is_none());
+        store.save_identity(identity.clone()).await.unwrap();
+
+        assert_eq!(store.load_identity().await.unwrap(), Some(identity));
+    }
+
+    #[tokio::test]
+    async fn memory_store_saves_snapshot_and_hydrates_rows() {
+        let store = MemoryLocalStore::new();
+        let stream = SyncStreamName::new("posts").unwrap();
+        let collection = SyncCollectionName::new("posts").unwrap();
+        let row = SyncRow::new("post_1", serde_json::json!({"title": "First"})).unwrap();
+
+        store
+            .save_snapshot(LocalSnapshotBatch::new(
+                stream.clone(),
+                collection.clone(),
+                vec![row.clone()],
+                Some(SyncCursor::new("cursor_1").unwrap()),
+            ))
+            .await
+            .unwrap();
+
+        let snapshot = store.hydrate_stream(&stream).await.unwrap();
+
+        assert_eq!(snapshot.stream, stream);
+        assert_eq!(snapshot.collection, Some(collection));
+        assert_eq!(snapshot.cursor.unwrap().as_str(), "cursor_1");
+        assert_eq!(snapshot.rows, vec![row]);
+    }
+
+    #[tokio::test]
+    async fn memory_store_applies_incremental_changes() {
+        let store = MemoryLocalStore::new();
+        let stream = SyncStreamName::new("posts").unwrap();
+        let collection = SyncCollectionName::new("posts").unwrap();
+        let row = SyncRow::new("post_1", serde_json::json!({"title": "First"})).unwrap();
+        store
+            .save_snapshot(LocalSnapshotBatch::new(
+                stream.clone(),
+                collection.clone(),
+                vec![row],
+                Some(SyncCursor::new("cursor_1").unwrap()),
+            ))
+            .await
+            .unwrap();
+
+        let updated = SyncRow::new("post_1", serde_json::json!({"title": "Updated"}))
+            .unwrap()
+            .version("row_2")
+            .unwrap();
+        let second = SyncRow::new("post_2", serde_json::json!({"title": "Second"})).unwrap();
+        let cursor = SyncCursor::new("cursor_2").unwrap();
+
+        store
+            .apply_changes(LocalChangeBatch::new(
+                stream.clone(),
+                collection,
+                vec![
+                    SyncChange {
+                        stream: stream.clone(),
+                        collection: SyncCollectionName::new("posts").unwrap(),
+                        key: Some(RowKey::new("post_1").unwrap()),
+                        op: SyncOp::Upsert,
+                        row: Some(updated.clone()),
+                        cursor: cursor.clone(),
+                    },
+                    SyncChange {
+                        stream: stream.clone(),
+                        collection: SyncCollectionName::new("posts").unwrap(),
+                        key: Some(RowKey::new("post_2").unwrap()),
+                        op: SyncOp::Upsert,
+                        row: Some(second.clone()),
+                        cursor: cursor.clone(),
+                    },
+                ],
+                Some(cursor),
+            ))
+            .await
+            .unwrap();
+
+        let snapshot = store.hydrate_stream(&stream).await.unwrap();
+
+        assert_eq!(snapshot.rows, vec![updated, second]);
+        assert_eq!(snapshot.cursor.unwrap().as_str(), "cursor_2");
+    }
+
+    #[tokio::test]
+    async fn memory_store_replays_pending_and_clears_push_outcomes() {
+        let store = MemoryLocalStore::new();
+        let stream = SyncStreamName::new("posts").unwrap();
+        let mutation = ClientMutation {
+            id: MutationId::new("device_abc:1").unwrap(),
+            key: Some(RowKey::new("post_1").unwrap()),
+            op: SyncOp::Upsert,
+            base_version: Some(RowVersion::new("row_1").unwrap()),
+            payload: serde_json::json!({"title": "Saved"}),
+        };
+
+        store
+            .enqueue_mutation(&stream, mutation.clone())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            store.pending_mutations(&stream).await.unwrap(),
+            vec![mutation]
+        );
+
+        let row = SyncRow::new("post_1", serde_json::json!({"title": "Saved"}))
+            .unwrap()
+            .version("row_2")
+            .unwrap();
+        let mut response = SyncPushResponse::new(stream.clone());
+        response
+            .accepted
+            .push(MutationId::new("device_abc:1").unwrap());
+        response.rows.push(row.clone());
+        response.cursor = Some(SyncCursor::new("cursor_2").unwrap());
+
+        store
+            .mark_push_result(LocalPushResult::from_response(response))
+            .await
+            .unwrap();
+
+        assert!(store.pending_mutations(&stream).await.unwrap().is_empty());
+        let snapshot = store.hydrate_stream(&stream).await.unwrap();
+        assert_eq!(snapshot.rows, vec![row]);
+        assert_eq!(snapshot.cursor.unwrap().as_str(), "cursor_2");
+    }
+
+    #[tokio::test]
+    async fn memory_store_marks_conflict_rows() {
+        let store = MemoryLocalStore::new();
+        let stream = SyncStreamName::new("posts").unwrap();
+        let collection = SyncCollectionName::new("posts").unwrap();
+        let row = SyncRow::new("post_1", serde_json::json!({"title": "Server"})).unwrap();
+        let mut response = SyncPushResponse::new(stream.clone());
+        response.conflicts.push(crate::SyncConflict {
+            mutation_id: MutationId::new("device_abc:1").unwrap(),
+            key: Some(RowKey::new("post_1").unwrap()),
+            server_row: Some(row),
+            reason: "base version is stale".to_string(),
+        });
+
+        store
+            .save_snapshot(LocalSnapshotBatch::new(
+                stream.clone(),
+                collection,
+                Vec::new(),
+                None,
+            ))
+            .await
+            .unwrap();
+        store
+            .mark_push_result(LocalPushResult::from_response(response))
+            .await
+            .unwrap();
+
+        let snapshot = store.hydrate_stream(&stream).await.unwrap();
+
+        assert_eq!(snapshot.rows.len(), 1);
+        assert!(snapshot.rows[0].conflict);
+        assert!(!snapshot.rows[0].pending);
+    }
+}

--- a/crates/pocopine-sync/src/local_memory.rs
+++ b/crates/pocopine-sync/src/local_memory.rs
@@ -30,7 +30,7 @@ struct MemoryStreamState {
     collection: Option<SyncCollectionName>,
     cursor: Option<crate::SyncCursor>,
     rows: BTreeMap<RowKey, SyncRow<serde_json::Value>>,
-    pending: BTreeMap<crate::MutationId, ClientMutation<serde_json::Value>>,
+    pending: Vec<ClientMutation<serde_json::Value>>,
 }
 
 impl MemoryLocalStore {
@@ -78,7 +78,7 @@ impl SyncLocalStore for MemoryLocalStore {
                 collection: state.collection.clone(),
                 cursor: state.cursor.clone(),
                 rows: state.rows.values().cloned().collect(),
-                pending_mutations: state.pending.values().cloned().collect(),
+                pending_mutations: state.pending.clone(),
             })
         }))
     }
@@ -138,7 +138,15 @@ impl SyncLocalStore for MemoryLocalStore {
         let stream = stream.clone();
         Self::ready(self.with_inner(|inner| {
             let state = inner.streams.entry(stream).or_default();
-            state.pending.insert(mutation.id.clone(), mutation);
+            if let Some(existing) = state
+                .pending
+                .iter_mut()
+                .find(|existing| existing.id == mutation.id)
+            {
+                *existing = mutation;
+            } else {
+                state.pending.push(mutation);
+            }
             Ok(())
         }))
     }
@@ -154,15 +162,19 @@ impl SyncLocalStore for MemoryLocalStore {
             }
 
             for id in result.accepted {
-                state.pending.remove(&id);
+                state.pending.retain(|mutation| mutation.id != id);
             }
 
             for rejected in result.rejected {
-                state.pending.remove(&rejected.mutation_id);
+                state
+                    .pending
+                    .retain(|mutation| mutation.id != rejected.mutation_id);
             }
 
             for conflict in result.conflicts {
-                state.pending.remove(&conflict.mutation_id);
+                state
+                    .pending
+                    .retain(|mutation| mutation.id != conflict.mutation_id);
                 if let Some(mut row) = conflict.server_row {
                     row.pending = false;
                     row.conflict = true;
@@ -194,7 +206,7 @@ impl SyncLocalStore for MemoryLocalStore {
             Ok(inner
                 .streams
                 .get(&stream)
-                .map(|state| state.pending.values().cloned().collect())
+                .map(|state| state.pending.clone())
                 .unwrap_or_default())
         }))
     }
@@ -366,6 +378,36 @@ mod tests {
         let snapshot = store.hydrate_stream(&stream).await.unwrap();
         assert_eq!(snapshot.rows, vec![row]);
         assert_eq!(snapshot.cursor.unwrap().as_str(), "cursor_2");
+    }
+
+    #[tokio::test]
+    async fn memory_store_pending_mutations_preserve_enqueue_order() {
+        let store = MemoryLocalStore::new();
+        let stream = SyncStreamName::new("posts").unwrap();
+
+        for id in ["device_abc:10", "device_abc:2", "device_abc:1"] {
+            store
+                .enqueue_mutation(
+                    &stream,
+                    ClientMutation {
+                        id: MutationId::new(id).unwrap(),
+                        key: Some(RowKey::new("post_1").unwrap()),
+                        op: SyncOp::Upsert,
+                        base_version: None,
+                        payload: serde_json::json!({ "id": id }),
+                    },
+                )
+                .await
+                .unwrap();
+        }
+
+        let pending = store.pending_mutations(&stream).await.unwrap();
+        let ids: Vec<_> = pending
+            .iter()
+            .map(|mutation| mutation.id.as_str())
+            .collect();
+
+        assert_eq!(ids, vec!["device_abc:10", "device_abc:2", "device_abc:1"]);
     }
 
     #[tokio::test]
@@ -604,7 +646,10 @@ mod tests {
         assert_eq!(snapshot.rows.len(), 1);
         assert!(snapshot.rows[0].conflict);
         assert!(!snapshot.rows[0].pending);
-        assert_eq!(snapshot.rows[0].value, serde_json::json!({"title": "Local"}));
+        assert_eq!(
+            snapshot.rows[0].value,
+            serde_json::json!({"title": "Local"})
+        );
     }
 
     #[tokio::test]

--- a/crates/pocopine-sync/src/local_memory.rs
+++ b/crates/pocopine-sync/src/local_memory.rs
@@ -102,8 +102,12 @@ impl SyncLocalStore for MemoryLocalStore {
             let state = inner.streams.entry(changes.stream).or_default();
             state.collection = Some(changes.collection);
             state.cursor = changes.cursor;
+            let changes = changes_after_last_reset(changes.changes);
+            if changes.had_reset {
+                state.rows.clear();
+            }
 
-            for change in changes.changes {
+            for change in changes.items {
                 match change.op {
                     SyncOp::Upsert => {
                         if let Some(row) = change.row {
@@ -116,7 +120,6 @@ impl SyncLocalStore for MemoryLocalStore {
                         }
                     }
                     SyncOp::Reset => {
-                        state.rows.clear();
                         if let Some(row) = change.row {
                             state.rows.insert(row.key.clone(), row);
                         }
@@ -143,7 +146,12 @@ impl SyncLocalStore for MemoryLocalStore {
     fn mark_push_result(&self, result: LocalPushResult) -> SyncLocalFuture<'_, ()> {
         Self::ready(self.with_inner(|inner| {
             let state = inner.streams.entry(result.stream).or_default();
-            state.cursor = result.cursor;
+            if let Some(collection) = result.collection {
+                state.collection = Some(collection);
+            }
+            if let Some(cursor) = result.cursor {
+                state.cursor = Some(cursor);
+            }
 
             for id in result.accepted {
                 state.pending.remove(&id);
@@ -189,6 +197,28 @@ impl SyncLocalStore for MemoryLocalStore {
                 .map(|state| state.pending.values().cloned().collect())
                 .unwrap_or_default())
         }))
+    }
+}
+
+struct LocalChanges {
+    had_reset: bool,
+    items: Vec<crate::SyncChange<serde_json::Value>>,
+}
+
+fn changes_after_last_reset(changes: Vec<crate::SyncChange<serde_json::Value>>) -> LocalChanges {
+    let Some(index) = changes
+        .iter()
+        .rposition(|change| change.op == SyncOp::Reset)
+    else {
+        return LocalChanges {
+            had_reset: false,
+            items: changes,
+        };
+    };
+
+    LocalChanges {
+        had_reset: true,
+        items: changes.into_iter().skip(index).collect(),
     }
 }
 

--- a/crates/pocopine-sync/src/local_memory.rs
+++ b/crates/pocopine-sync/src/local_memory.rs
@@ -192,7 +192,7 @@ impl SyncLocalStore for MemoryLocalStore {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
     use crate::{

--- a/crates/pocopine-sync/src/local_store.rs
+++ b/crates/pocopine-sync/src/local_store.rs
@@ -180,6 +180,7 @@ impl LocalChangeBatch {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct LocalPushResult {
     pub stream: SyncStreamName,
+    pub collection: Option<SyncCollectionName>,
     #[serde(default)]
     pub accepted: Vec<MutationId>,
     #[serde(default)]
@@ -195,6 +196,7 @@ impl LocalPushResult {
     pub fn from_response(response: SyncPushResponse<serde_json::Value>) -> Self {
         Self {
             stream: response.stream,
+            collection: response.collection,
             accepted: response.accepted,
             rejected: response.rejected,
             rows: response.rows,
@@ -209,6 +211,11 @@ impl LocalPushResult {
 /// Implementations must apply snapshot, change, mutation enqueue, and push
 /// result operations atomically. The local store improves durability and
 /// startup latency; it is not an authorization boundary.
+///
+/// `load_identity` and `save_identity` expose the durable identity slot used
+/// by apps or future Pocopine client helpers to allocate stable mutation ids.
+/// The current `SyncCollection::push` API remains id-explicit: callers still
+/// provide `ClientMutation::id` themselves.
 pub trait SyncLocalStore {
     /// Load the persisted client identity, if this store has one.
     fn load_identity(&self) -> SyncLocalFuture<'_, Option<SyncLocalIdentity>>;
@@ -233,6 +240,11 @@ pub trait SyncLocalStore {
     ) -> SyncLocalFuture<'_, ()>;
 
     /// Persist accepted, rejected, or conflicted mutation outcomes.
+    ///
+    /// Row `pending` flags persisted here describe the latest server outcome.
+    /// With stacked pending mutations for the same key, hydrated rows may
+    /// understate pending UI state until the client replays the queued
+    /// mutations.
     fn mark_push_result(&self, result: LocalPushResult) -> SyncLocalFuture<'_, ()>;
 
     /// Load pending mutations that should be replayed for one stream.

--- a/crates/pocopine-sync/src/local_store.rs
+++ b/crates/pocopine-sync/src/local_store.rs
@@ -1,0 +1,353 @@
+use std::{future::Future, pin::Pin};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    ClientMutation, MutationId, SyncChange, SyncCollectionName, SyncConflict, SyncCursor,
+    SyncDeviceId, SyncError, SyncPushResponse, SyncRejectedMutation, SyncResult, SyncRow,
+    SyncStreamName,
+};
+
+/// Boxed future returned by local sync store implementations.
+pub type SyncLocalFuture<'a, T> = Pin<Box<dyn Future<Output = SyncResult<T>> + 'a>>;
+
+/// Durable client identity persisted by a local sync store.
+///
+/// `next_mutation_counter` is the next counter to reserve for this device.
+/// It starts at `1`; stores should persist the increment before exposing a
+/// mutation id that may be sent to the server.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SyncLocalIdentity {
+    pub device_id: SyncDeviceId,
+    pub next_mutation_counter: u64,
+}
+
+impl SyncLocalIdentity {
+    /// Build an identity with the first mutation counter.
+    pub fn new(device_id: SyncDeviceId) -> Self {
+        Self {
+            device_id,
+            next_mutation_counter: 1,
+        }
+    }
+
+    /// Build an identity with a caller-supplied next mutation counter.
+    pub fn with_next_counter(
+        device_id: SyncDeviceId,
+        next_mutation_counter: u64,
+    ) -> SyncResult<Self> {
+        if next_mutation_counter == 0 {
+            return Err(SyncError::invalid_value("next mutation counter", "0"));
+        }
+        Ok(Self {
+            device_id,
+            next_mutation_counter,
+        })
+    }
+
+    /// Build a mutation id generator from this identity.
+    pub fn mutation_id_generator(&self) -> SyncResult<MutationIdGenerator> {
+        MutationIdGenerator::with_next_counter(self.device_id.clone(), self.next_mutation_counter)
+    }
+}
+
+/// Deterministic mutation id generator for one persisted device id.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MutationIdGenerator {
+    device_id: SyncDeviceId,
+    next_counter: u64,
+}
+
+impl MutationIdGenerator {
+    /// Start generating ids at counter `1`.
+    pub fn new(device_id: SyncDeviceId) -> Self {
+        Self {
+            device_id,
+            next_counter: 1,
+        }
+    }
+
+    /// Resume generation from a persisted next counter.
+    pub fn with_next_counter(device_id: SyncDeviceId, next_counter: u64) -> SyncResult<Self> {
+        if next_counter == 0 {
+            return Err(SyncError::invalid_value("next mutation counter", "0"));
+        }
+        Ok(Self {
+            device_id,
+            next_counter,
+        })
+    }
+
+    /// The device id this generator belongs to.
+    pub fn device_id(&self) -> &SyncDeviceId {
+        &self.device_id
+    }
+
+    /// The counter that will be used by the next generated id.
+    pub fn next_counter(&self) -> u64 {
+        self.next_counter
+    }
+
+    /// Generate the next mutation id and advance the in-memory counter.
+    pub fn next_mutation_id(&mut self) -> SyncResult<MutationId> {
+        let id = MutationId::new(format!("{}:{}", self.device_id, self.next_counter))?;
+        self.next_counter = self
+            .next_counter
+            .checked_add(1)
+            .ok_or_else(|| SyncError::invalid_value("next mutation counter", "overflow"))?;
+        Ok(id)
+    }
+}
+
+/// Locally cached rows and cursor for one stream.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct LocalStreamSnapshot {
+    pub stream: SyncStreamName,
+    pub collection: Option<SyncCollectionName>,
+    pub cursor: Option<SyncCursor>,
+    #[serde(default)]
+    pub rows: Vec<SyncRow<serde_json::Value>>,
+    #[serde(default)]
+    pub pending_mutations: Vec<ClientMutation<serde_json::Value>>,
+}
+
+impl LocalStreamSnapshot {
+    /// Empty local state for a stream that has not been persisted yet.
+    pub fn empty(stream: SyncStreamName) -> Self {
+        Self {
+            stream,
+            collection: None,
+            cursor: None,
+            rows: Vec::new(),
+            pending_mutations: Vec::new(),
+        }
+    }
+}
+
+/// Atomic snapshot replacement to persist for one stream.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct LocalSnapshotBatch {
+    pub stream: SyncStreamName,
+    pub collection: SyncCollectionName,
+    pub cursor: Option<SyncCursor>,
+    #[serde(default)]
+    pub rows: Vec<SyncRow<serde_json::Value>>,
+}
+
+impl LocalSnapshotBatch {
+    pub fn new(
+        stream: SyncStreamName,
+        collection: SyncCollectionName,
+        rows: Vec<SyncRow<serde_json::Value>>,
+        cursor: Option<SyncCursor>,
+    ) -> Self {
+        Self {
+            stream,
+            collection,
+            cursor,
+            rows,
+        }
+    }
+}
+
+/// Atomic incremental change batch to persist for one stream.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct LocalChangeBatch {
+    pub stream: SyncStreamName,
+    pub collection: SyncCollectionName,
+    pub cursor: Option<SyncCursor>,
+    #[serde(default)]
+    pub changes: Vec<SyncChange<serde_json::Value>>,
+}
+
+impl LocalChangeBatch {
+    pub fn new(
+        stream: SyncStreamName,
+        collection: SyncCollectionName,
+        changes: Vec<SyncChange<serde_json::Value>>,
+        cursor: Option<SyncCursor>,
+    ) -> Self {
+        Self {
+            stream,
+            collection,
+            cursor,
+            changes,
+        }
+    }
+}
+
+/// Push outcome persisted by the local store after the server responds.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct LocalPushResult {
+    pub stream: SyncStreamName,
+    #[serde(default)]
+    pub accepted: Vec<MutationId>,
+    #[serde(default)]
+    pub rejected: Vec<SyncRejectedMutation>,
+    #[serde(default)]
+    pub rows: Vec<SyncRow<serde_json::Value>>,
+    #[serde(default)]
+    pub conflicts: Vec<SyncConflict<serde_json::Value>>,
+    pub cursor: Option<SyncCursor>,
+}
+
+impl LocalPushResult {
+    pub fn from_response(response: SyncPushResponse<serde_json::Value>) -> Self {
+        Self {
+            stream: response.stream,
+            accepted: response.accepted,
+            rejected: response.rejected,
+            rows: response.rows,
+            conflicts: response.conflicts,
+            cursor: response.cursor,
+        }
+    }
+}
+
+/// Durable client-side storage contract for sync streams.
+///
+/// Implementations must apply snapshot, change, mutation enqueue, and push
+/// result operations atomically. The local store improves durability and
+/// startup latency; it is not an authorization boundary.
+pub trait SyncLocalStore {
+    /// Load the persisted client identity, if this store has one.
+    fn load_identity(&self) -> SyncLocalFuture<'_, Option<SyncLocalIdentity>>;
+
+    /// Persist the client identity and next mutation counter.
+    fn save_identity(&self, identity: SyncLocalIdentity) -> SyncLocalFuture<'_, ()>;
+
+    /// Hydrate locally cached rows and pending mutations for a stream.
+    fn hydrate_stream(&self, stream: &SyncStreamName) -> SyncLocalFuture<'_, LocalStreamSnapshot>;
+
+    /// Atomically replace the locally cached stream snapshot.
+    fn save_snapshot(&self, snapshot: LocalSnapshotBatch) -> SyncLocalFuture<'_, ()>;
+
+    /// Atomically apply incremental server changes for a stream.
+    fn apply_changes(&self, changes: LocalChangeBatch) -> SyncLocalFuture<'_, ()>;
+
+    /// Persist a mutation before it is sent to the server.
+    fn enqueue_mutation(
+        &self,
+        stream: &SyncStreamName,
+        mutation: ClientMutation<serde_json::Value>,
+    ) -> SyncLocalFuture<'_, ()>;
+
+    /// Persist accepted, rejected, or conflicted mutation outcomes.
+    fn mark_push_result(&self, result: LocalPushResult) -> SyncLocalFuture<'_, ()>;
+
+    /// Load pending mutations that should be replayed for one stream.
+    fn pending_mutations(
+        &self,
+        stream: &SyncStreamName,
+    ) -> SyncLocalFuture<'_, Vec<ClientMutation<serde_json::Value>>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{RowKey, SyncOp};
+
+    #[test]
+    fn local_identity_starts_at_first_mutation_counter() {
+        let identity = SyncLocalIdentity::new(SyncDeviceId::new("device_abc").unwrap());
+
+        assert_eq!(identity.device_id.as_str(), "device_abc");
+        assert_eq!(identity.next_mutation_counter, 1);
+    }
+
+    #[test]
+    fn local_identity_rejects_zero_next_counter() {
+        let err = SyncLocalIdentity::with_next_counter(SyncDeviceId::new("device_abc").unwrap(), 0)
+            .unwrap_err();
+
+        assert!(err.to_string().contains("next mutation counter"));
+    }
+
+    #[test]
+    fn mutation_id_generator_uses_device_id_and_monotonic_counter() {
+        let mut generator =
+            MutationIdGenerator::with_next_counter(SyncDeviceId::new("device_abc").unwrap(), 41)
+                .unwrap();
+
+        assert_eq!(
+            generator.next_mutation_id().unwrap().as_str(),
+            "device_abc:41"
+        );
+        assert_eq!(
+            generator.next_mutation_id().unwrap().as_str(),
+            "device_abc:42"
+        );
+        assert_eq!(generator.next_counter(), 43);
+    }
+
+    #[test]
+    fn mutation_id_generator_rejects_zero_next_counter() {
+        assert!(MutationIdGenerator::with_next_counter(
+            SyncDeviceId::new("device_abc").unwrap(),
+            0
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn local_snapshot_empty_has_no_rows_or_pending_mutations() {
+        let snapshot = LocalStreamSnapshot::empty(SyncStreamName::new("posts").unwrap());
+
+        assert_eq!(snapshot.stream.as_str(), "posts");
+        assert!(snapshot.collection.is_none());
+        assert!(snapshot.cursor.is_none());
+        assert!(snapshot.rows.is_empty());
+        assert!(snapshot.pending_mutations.is_empty());
+    }
+
+    #[test]
+    fn local_push_result_preserves_server_outcomes() {
+        let stream = SyncStreamName::new("posts").unwrap();
+        let row = SyncRow::new("post_1", serde_json::json!({"title": "Saved"})).unwrap();
+        let mut response = SyncPushResponse::new(stream.clone());
+        response
+            .accepted
+            .push(MutationId::new("device_abc:1").unwrap());
+        response.rejected.push(SyncRejectedMutation {
+            mutation_id: MutationId::new("device_abc:2").unwrap(),
+            key: Some(RowKey::new("post_2").unwrap()),
+            reason: "invalid title".to_string(),
+        });
+        response.rows.push(row);
+        response.cursor = Some(SyncCursor::new("cursor_2").unwrap());
+
+        let result = LocalPushResult::from_response(response);
+
+        assert_eq!(result.stream, stream);
+        assert_eq!(result.accepted[0].as_str(), "device_abc:1");
+        assert_eq!(result.rejected[0].reason, "invalid title");
+        assert_eq!(result.rows[0].key.as_str(), "post_1");
+        assert_eq!(result.cursor.unwrap().as_str(), "cursor_2");
+    }
+
+    #[test]
+    fn local_batches_preserve_stream_collection_and_cursor() {
+        let stream = SyncStreamName::new("posts").unwrap();
+        let collection = SyncCollectionName::new("posts").unwrap();
+        let cursor = Some(SyncCursor::new("cursor_1").unwrap());
+        let row = SyncRow::new("post_1", serde_json::json!({"title": "Saved"})).unwrap();
+        let snapshot = LocalSnapshotBatch::new(
+            stream.clone(),
+            collection.clone(),
+            vec![row.clone()],
+            cursor.clone(),
+        );
+        let change = SyncChange {
+            stream: stream.clone(),
+            collection: collection.clone(),
+            key: Some(row.key.clone()),
+            op: SyncOp::Upsert,
+            row: Some(row),
+            cursor: cursor.clone().unwrap(),
+        };
+        let changes = LocalChangeBatch::new(stream, collection, vec![change], cursor);
+
+        assert_eq!(snapshot.rows.len(), 1);
+        assert_eq!(changes.changes.len(), 1);
+    }
+}

--- a/crates/pocopine-sync/src/memory.rs
+++ b/crates/pocopine-sync/src/memory.rs
@@ -169,6 +169,7 @@ where
     {
         let mut inner = self.lock()?;
         let mut response = SyncPushResponse::new(self.stream.clone());
+        response.collection = Some(self.collection.clone());
 
         for mutation in request.mutations {
             if inner.accepted_mutations.contains(mutation.id.as_str()) {

--- a/crates/pocopine-sync/src/protocol.rs
+++ b/crates/pocopine-sync/src/protocol.rs
@@ -123,6 +123,16 @@ opaque_string_type!(
     "mutation id",
     "Client-generated mutation idempotency key."
 );
+opaque_string_type!(
+    SyncDeviceId,
+    "device id",
+    "Stable client device identity persisted by a local sync store."
+);
+opaque_string_type!(
+    SyncSessionId,
+    "session id",
+    "Ephemeral sync session identity for one running client instance."
+);
 
 /// Live query tag used to wake clients for a sync stream.
 pub fn sync_stream_tag(stream: &str) -> String {
@@ -193,7 +203,7 @@ pub struct SyncChange<T> {
 pub struct SyncOpenRequest {
     pub protocol: String,
     #[serde(default)]
-    pub client_id: Option<String>,
+    pub client_id: Option<SyncDeviceId>,
     pub streams: Vec<SyncStreamName>,
 }
 
@@ -204,6 +214,11 @@ impl SyncOpenRequest {
             client_id: None,
             streams: streams.into_iter().collect(),
         }
+    }
+
+    pub fn client_id(mut self, client_id: SyncDeviceId) -> Self {
+        self.client_id = Some(client_id);
+        self
     }
 }
 
@@ -405,6 +420,23 @@ mod tests {
         assert!(SyncStreamName::new(" posts").is_err());
         assert!(SyncStreamName::new("posts\nbad").is_err());
         assert!(SyncStreamName::new("x".repeat(MAX_SYNC_TOKEN_LEN + 1)).is_err());
+    }
+
+    #[test]
+    fn validates_device_and_session_ids() {
+        assert!(SyncDeviceId::new("device_abc").is_ok());
+        assert!(SyncSessionId::new("session_abc").is_ok());
+        assert!(SyncDeviceId::new("").is_err());
+        assert!(SyncSessionId::new("session bad\n").is_err());
+    }
+
+    #[test]
+    fn open_request_serializes_typed_client_id() {
+        let request = SyncOpenRequest::new([SyncStreamName::new("posts").unwrap()])
+            .client_id(SyncDeviceId::new("device_abc").unwrap());
+
+        let json = serde_json::to_value(request).unwrap();
+        assert_eq!(json["client_id"], "device_abc");
     }
 
     #[test]

--- a/crates/pocopine-sync/src/protocol.rs
+++ b/crates/pocopine-sync/src/protocol.rs
@@ -384,6 +384,8 @@ pub struct SyncRejectedMutation {
 pub struct SyncPushResponse<T> {
     pub protocol: String,
     pub stream: SyncStreamName,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub collection: Option<SyncCollectionName>,
     #[serde(default)]
     pub accepted: Vec<MutationId>,
     #[serde(default)]
@@ -400,6 +402,7 @@ impl<T> SyncPushResponse<T> {
         Self {
             protocol: SYNC_PROTOCOL_V1.to_string(),
             stream,
+            collection: None,
             accepted: Vec::new(),
             rejected: Vec::new(),
             rows: Vec::new(),

--- a/crates/pocopine-sync/src/server.rs
+++ b/crates/pocopine-sync/src/server.rs
@@ -325,11 +325,14 @@ async fn push_handler(
         let (ctx, request) = parse_json_request::<SyncPushRequest<Value>>(request).await?;
         let stream = sync.stream(request.stream.as_str()).map_err(server_error)?;
         stream.authorize(ctx.clone()).await?;
-        let response = stream
+        let mut response = stream
             .source
             .push(ctx, request)
             .await
             .map_err(server_error)?;
+        if response.collection.is_none() {
+            response.collection = Some(stream.source.collection().clone());
+        }
         if !response.accepted.is_empty() {
             if let Err(err) = sync.invalidate_stream(response.stream.as_str()).await {
                 tracing::warn!(

--- a/crates/pocopine-sync/src/state.rs
+++ b/crates/pocopine-sync/src/state.rs
@@ -146,6 +146,31 @@ impl<T> CollectionState<T> {
         true
     }
 
+    pub fn apply_local_snapshot(
+        &mut self,
+        rows: Vec<SyncRow<T>>,
+        cursor: Option<SyncCursor>,
+        pending_count: u64,
+    ) -> bool {
+        if rows.is_empty() && cursor.is_none() && pending_count == 0 {
+            return false;
+        }
+
+        self.rows = rows;
+        self.cursor = cursor;
+        self.loading = false;
+        self.syncing = false;
+        self.stale = true;
+        self.error.clear();
+        self.version = self.version.saturating_add(1);
+        self.last_reason = SyncReason::Initial;
+        self.recount_row_flags();
+        if pending_count > self.pending_count {
+            self.pending_count = pending_count;
+        }
+        true
+    }
+
     pub fn apply_error(&mut self, request: SyncRequest, error: impl ToString) -> bool {
         if !self.is_current(request) {
             return false;
@@ -468,6 +493,27 @@ mod tests {
         assert_eq!(state.rows[0].value, "hello");
         assert_eq!(state.cursor.as_ref().unwrap().as_str(), "1");
         assert!(!state.loading);
+    }
+
+    #[test]
+    fn local_snapshot_marks_rows_stale_until_network_pull() {
+        let mut state = CollectionState::<String>::default();
+        let row = SyncRow::new("post_1", "cached".to_string()).unwrap();
+
+        assert!(state.apply_local_snapshot(
+            vec![row.clone()],
+            Some(SyncCursor::new("cursor_1").unwrap()),
+            2,
+        ));
+
+        assert_eq!(state.rows, vec![row]);
+        assert_eq!(state.cursor.unwrap().as_str(), "cursor_1");
+        assert!(state.stale);
+        assert!(!state.loading);
+        assert!(!state.syncing);
+        assert_eq!(state.version, 1);
+        assert_eq!(state.pending_count, 2);
+        assert_eq!(state.last_reason, SyncReason::Initial);
     }
 
     #[test]

--- a/crates/pocopine-sync/tests/client_browser.rs
+++ b/crates/pocopine-sync/tests/client_browser.rs
@@ -11,7 +11,8 @@ use std::rc::Rc;
 use js_sys::Promise;
 use pocopine::prelude::*;
 use pocopine_sync::{
-    sync_plugin, CollectionState, SyncCollectionName, SyncOpenRequest, SyncOpenResponse,
+    sync_plugin, CollectionState, LocalSnapshotBatch, MemoryLocalStore, SyncChange,
+    SyncCollectionName, SyncCursor, SyncLocalStore, SyncOp, SyncOpenRequest, SyncOpenResponse,
     SyncOpenStream, SyncPullRequest, SyncPullResponse, SyncRow, SyncStreamName, SYNC_OPEN_PATH,
     SYNC_PULL_PATH,
 };
@@ -153,6 +154,120 @@ async fn open_validates_stream_then_pull_renders_snapshot() {
             .unwrap_or_default(),
         "1"
     );
+
+    host.remove();
+    pocopine::fetch::__reset_middleware_chain_for_test();
+}
+
+#[wasm_bindgen_test(async)]
+async fn open_hydrates_local_store_and_pulls_from_cached_cursor() {
+    pocopine::fetch::__reset_middleware_chain_for_test();
+
+    let store = MemoryLocalStore::new();
+    store
+        .save_snapshot(LocalSnapshotBatch::new(
+            SyncStreamName::new(STREAM).unwrap(),
+            SyncCollectionName::new(COLLECTION).unwrap(),
+            vec![SyncRow::new(
+                "post_1",
+                serde_json::json!({
+                    "id": "post_1",
+                    "title": "Cached locally"
+                }),
+            )
+            .unwrap()],
+            Some(SyncCursor::new("cached_cursor").unwrap()),
+        ))
+        .await
+        .unwrap();
+
+    let seen_pull_cursor = Rc::new(RefCell::new(None::<String>));
+    let seen_pull_cursor_for_middleware = seen_pull_cursor.clone();
+    pocopine::fetch::install_middleware(
+        move |req: pocopine::fetch::FetchRequest, _next: pocopine::fetch::FetchNext| {
+            let seen_pull_cursor = seen_pull_cursor_for_middleware.clone();
+            async move {
+                match req.url.as_str() {
+                    SYNC_OPEN_PATH => {
+                        let request: SyncOpenRequest = serde_json::from_str(&req.body).unwrap();
+                        assert_eq!(request.streams[0].as_str(), STREAM);
+                        let response = SyncOpenResponse::new(vec![SyncOpenStream {
+                            stream: SyncStreamName::new(STREAM).unwrap(),
+                            collection: SyncCollectionName::new(COLLECTION).unwrap(),
+                            cursor: None,
+                        }]);
+                        Ok(json_response(response))
+                    }
+                    SYNC_PULL_PATH => {
+                        let request: SyncPullRequest = serde_json::from_str(&req.body).unwrap();
+                        *seen_pull_cursor.borrow_mut() =
+                            request.cursor.as_ref().map(ToString::to_string);
+                        assert_eq!(request.cursor.as_ref().unwrap().as_str(), "cached_cursor");
+
+                        let response = SyncPullResponse::incremental(
+                            SyncStreamName::new(STREAM).unwrap(),
+                            SyncCollectionName::new(COLLECTION).unwrap(),
+                            vec![SyncChange {
+                                stream: SyncStreamName::new(STREAM).unwrap(),
+                                collection: SyncCollectionName::new(COLLECTION).unwrap(),
+                                key: Some(pocopine_sync::RowKey::new("post_2").unwrap()),
+                                op: SyncOp::Upsert,
+                                row: Some(
+                                    SyncRow::new(
+                                        "post_2",
+                                        BrowserPost {
+                                            id: "post_2".to_string(),
+                                            title: "Loaded incrementally".to_string(),
+                                        },
+                                    )
+                                    .unwrap(),
+                                ),
+                                cursor: SyncCursor::new("cursor_2").unwrap(),
+                            }],
+                            Some(SyncCursor::new("cursor_2").unwrap()),
+                        );
+                        Ok(json_response(response))
+                    }
+                    other => Err(pocopine::ServerError::Network(format!(
+                        "unexpected sync browser test request: {other}"
+                    ))),
+                }
+            }
+        },
+    );
+
+    let document = window().unwrap().document().unwrap();
+    let host = document.create_element("div").unwrap();
+    host.set_attribute("pp-app", "").unwrap();
+    host.set_inner_html("<sync-browser-board></sync-browser-board>");
+    document.body().unwrap().append_child(&host).unwrap();
+
+    App::new()
+        .plugin(
+            sync_plugin()
+                .with_live_wakeup(false)
+                .local_store(store.clone()),
+        )
+        .register::<SyncBrowserBoard>()
+        .run();
+
+    settle().await;
+
+    assert_eq!(seen_pull_cursor.borrow().as_deref(), Some("cached_cursor"));
+    assert_eq!(
+        host.query_selector(".row-count")
+            .unwrap()
+            .unwrap()
+            .text_content()
+            .unwrap_or_default(),
+        "2"
+    );
+    let persisted = store
+        .hydrate_stream(&SyncStreamName::new(STREAM).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(persisted.cursor.unwrap().as_str(), "cursor_2");
+    assert_eq!(persisted.rows.len(), 2);
 
     host.remove();
     pocopine::fetch::__reset_middleware_chain_for_test();

--- a/crates/pocopine-sync/tests/client_browser.rs
+++ b/crates/pocopine-sync/tests/client_browser.rs
@@ -318,13 +318,13 @@ async fn open_replays_pending_mutations_before_pull() {
             let pull_cursor_seen = pull_cursor_for_mw.clone();
             async move {
                 match req.url.as_str() {
-                    SYNC_OPEN_PATH => Ok(json_response(SyncOpenResponse::new(vec![
-                        SyncOpenStream {
+                    SYNC_OPEN_PATH => {
+                        Ok(json_response(SyncOpenResponse::new(vec![SyncOpenStream {
                             stream: SyncStreamName::new(STREAM).unwrap(),
                             collection: SyncCollectionName::new(COLLECTION).unwrap(),
                             cursor: None,
-                        },
-                    ]))),
+                        }])))
+                    }
                     SYNC_PUSH_PATH => {
                         *push_seen.borrow_mut() += 1;
                         let request: SyncPushRequest<serde_json::Value> =
@@ -339,8 +339,7 @@ async fn open_replays_pending_mutations_before_pull() {
                         let mut response = SyncPushResponse::<BrowserPost>::new(
                             SyncStreamName::new(STREAM).unwrap(),
                         );
-                        response.collection =
-                            Some(SyncCollectionName::new(COLLECTION).unwrap());
+                        response.collection = Some(SyncCollectionName::new(COLLECTION).unwrap());
                         response
                             .accepted
                             .push(MutationId::new("device_browser:42").unwrap());
@@ -359,8 +358,7 @@ async fn open_replays_pending_mutations_before_pull() {
                     }
                     SYNC_PULL_PATH => {
                         *pull_seen.borrow_mut() += 1;
-                        let request: SyncPullRequest =
-                            serde_json::from_str(&req.body).unwrap();
+                        let request: SyncPullRequest = serde_json::from_str(&req.body).unwrap();
                         *pull_cursor_seen.borrow_mut() =
                             request.cursor.as_ref().map(ToString::to_string);
                         let response = SyncPullResponse::<BrowserPost>::incremental(

--- a/crates/pocopine-sync/tests/client_browser.rs
+++ b/crates/pocopine-sync/tests/client_browser.rs
@@ -11,10 +11,10 @@ use std::rc::Rc;
 use js_sys::Promise;
 use pocopine::prelude::*;
 use pocopine_sync::{
-    sync_plugin, CollectionState, LocalSnapshotBatch, MemoryLocalStore, SyncChange,
-    SyncCollectionName, SyncCursor, SyncLocalStore, SyncOp, SyncOpenRequest, SyncOpenResponse,
-    SyncOpenStream, SyncPullRequest, SyncPullResponse, SyncRow, SyncStreamName, SYNC_OPEN_PATH,
-    SYNC_PULL_PATH,
+    sync_plugin, ClientMutation, CollectionState, LocalSnapshotBatch, MemoryLocalStore, MutationId,
+    RowKey, SyncChange, SyncCollectionName, SyncCursor, SyncLocalStore, SyncOp, SyncOpenRequest,
+    SyncOpenResponse, SyncOpenStream, SyncPullRequest, SyncPullResponse, SyncPushRequest,
+    SyncPushResponse, SyncRow, SyncStreamName, SYNC_OPEN_PATH, SYNC_PULL_PATH, SYNC_PUSH_PATH,
 };
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::JsValue;
@@ -268,6 +268,157 @@ async fn open_hydrates_local_store_and_pulls_from_cached_cursor() {
         .unwrap();
     assert_eq!(persisted.cursor.unwrap().as_str(), "cursor_2");
     assert_eq!(persisted.rows.len(), 2);
+
+    host.remove();
+    pocopine::fetch::__reset_middleware_chain_for_test();
+}
+
+#[wasm_bindgen_test(async)]
+async fn open_replays_pending_mutations_before_pull() {
+    pocopine::fetch::__reset_middleware_chain_for_test();
+
+    let store = MemoryLocalStore::new();
+    let stream = SyncStreamName::new(STREAM).unwrap();
+    let collection = SyncCollectionName::new(COLLECTION).unwrap();
+
+    store
+        .save_snapshot(LocalSnapshotBatch::new(
+            stream.clone(),
+            collection.clone(),
+            vec![SyncRow::new(
+                "post_1",
+                serde_json::json!({"id": "post_1", "title": "Cached"}),
+            )
+            .unwrap()],
+            Some(SyncCursor::new("cached_cursor").unwrap()),
+        ))
+        .await
+        .unwrap();
+
+    let pending = ClientMutation {
+        id: MutationId::new("device_browser:42").unwrap(),
+        key: Some(RowKey::new("post_2").unwrap()),
+        op: SyncOp::Upsert,
+        base_version: None,
+        payload: serde_json::json!({"id": "post_2", "title": "Pending"}),
+    };
+    store.enqueue_mutation(&stream, pending).await.unwrap();
+
+    let push_seen = Rc::new(RefCell::new(0u32));
+    let pull_seen = Rc::new(RefCell::new(0u32));
+    let pull_cursor_seen = Rc::new(RefCell::new(None::<String>));
+    let push_seen_for_mw = push_seen.clone();
+    let pull_seen_for_mw = pull_seen.clone();
+    let pull_cursor_for_mw = pull_cursor_seen.clone();
+
+    pocopine::fetch::install_middleware(
+        move |req: pocopine::fetch::FetchRequest, _next: pocopine::fetch::FetchNext| {
+            let push_seen = push_seen_for_mw.clone();
+            let pull_seen = pull_seen_for_mw.clone();
+            let pull_cursor_seen = pull_cursor_for_mw.clone();
+            async move {
+                match req.url.as_str() {
+                    SYNC_OPEN_PATH => Ok(json_response(SyncOpenResponse::new(vec![
+                        SyncOpenStream {
+                            stream: SyncStreamName::new(STREAM).unwrap(),
+                            collection: SyncCollectionName::new(COLLECTION).unwrap(),
+                            cursor: None,
+                        },
+                    ]))),
+                    SYNC_PUSH_PATH => {
+                        *push_seen.borrow_mut() += 1;
+                        let request: SyncPushRequest<serde_json::Value> =
+                            serde_json::from_str(&req.body).unwrap();
+                        assert_eq!(request.mutations.len(), 1);
+                        assert_eq!(request.mutations[0].id.as_str(), "device_browser:42");
+                        assert_eq!(
+                            request.mutations[0].key.as_ref().unwrap().as_str(),
+                            "post_2"
+                        );
+
+                        let mut response = SyncPushResponse::<BrowserPost>::new(
+                            SyncStreamName::new(STREAM).unwrap(),
+                        );
+                        response.collection =
+                            Some(SyncCollectionName::new(COLLECTION).unwrap());
+                        response
+                            .accepted
+                            .push(MutationId::new("device_browser:42").unwrap());
+                        response.rows.push(
+                            SyncRow::new(
+                                "post_2",
+                                BrowserPost {
+                                    id: "post_2".to_string(),
+                                    title: "Confirmed".to_string(),
+                                },
+                            )
+                            .unwrap(),
+                        );
+                        response.cursor = Some(SyncCursor::new("after_replay").unwrap());
+                        Ok(json_response(response))
+                    }
+                    SYNC_PULL_PATH => {
+                        *pull_seen.borrow_mut() += 1;
+                        let request: SyncPullRequest =
+                            serde_json::from_str(&req.body).unwrap();
+                        *pull_cursor_seen.borrow_mut() =
+                            request.cursor.as_ref().map(ToString::to_string);
+                        let response = SyncPullResponse::<BrowserPost>::incremental(
+                            SyncStreamName::new(STREAM).unwrap(),
+                            SyncCollectionName::new(COLLECTION).unwrap(),
+                            Vec::new(),
+                            Some(SyncCursor::new("after_pull").unwrap()),
+                        );
+                        Ok(json_response(response))
+                    }
+                    other => Err(pocopine::ServerError::Network(format!(
+                        "unexpected sync browser test request: {other}"
+                    ))),
+                }
+            }
+        },
+    );
+
+    let document = window().unwrap().document().unwrap();
+    let host = document.create_element("div").unwrap();
+    host.set_attribute("pp-app", "").unwrap();
+    host.set_inner_html("<sync-browser-board></sync-browser-board>");
+    document.body().unwrap().append_child(&host).unwrap();
+
+    App::new()
+        .plugin(
+            sync_plugin()
+                .with_live_wakeup(false)
+                .local_store(store.clone()),
+        )
+        .register::<SyncBrowserBoard>()
+        .run();
+
+    settle().await;
+
+    assert_eq!(
+        *push_seen.borrow(),
+        1,
+        "open should replay one pending mutation before pulling"
+    );
+    assert_eq!(*pull_seen.borrow(), 1, "pull runs once after replay");
+    assert_eq!(
+        pull_cursor_seen.borrow().as_deref(),
+        Some("cached_cursor"),
+        "pull continues from the cached cursor that was loaded before replay"
+    );
+
+    let persisted = store.hydrate_stream(&stream).await.unwrap();
+    assert!(
+        persisted.pending_mutations.is_empty(),
+        "accepted mutations should be cleared from the queue"
+    );
+    assert_eq!(persisted.cursor.unwrap().as_str(), "after_pull");
+    assert_eq!(
+        persisted.rows.len(),
+        2,
+        "local store should hold cached + replay-confirmed rows"
+    );
 
     host.remove();
     pocopine::fetch::__reset_middleware_chain_for_test();

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,9 @@ looks the way it does — the code itself tells you *what*.
 - [`sync.md`](./sync.md) — sync tutorial: explicit `pocopine-sync`
   extension setup, server shapes, cursor pulls, live wake-up wiring, and
   the current memory-backed example.
+- [`sync-local-store-plan.md`](./sync-local-store-plan.md) — next sync
+  phase plan: `SyncLocalStore`, durable client identity, SQLite-first
+  browser storage, and SQLx as a later host/server adapter.
 - [`logging-tracing-observer.md`](./logging-tracing-observer.md) —
   browser console logging, backend logging, structured observed
   events, analytics sinks, privacy labels, and target filtering.

--- a/docs/sync-local-store-plan.md
+++ b/docs/sync-local-store-plan.md
@@ -23,6 +23,11 @@ Do not route browser-local sync through SQLx. SQLx uses native database
 drivers and is excellent for server Rust, but browser SQLite uses the
 SQLite WASM/OPFS runtime shape.
 
+Current implementation status: the `SyncLocalStore` contract,
+`SyncLocalIdentity`, `MutationIdGenerator`, and `MemoryLocalStore` are in
+place. The client runtime does not yet hydrate from a store or replay
+stored mutations automatically.
+
 ## Crate Boundaries
 
 `pocopine-sync` owns the protocol and store-neutral client semantics:

--- a/docs/sync-local-store-plan.md
+++ b/docs/sync-local-store-plan.md
@@ -27,10 +27,9 @@ Current implementation status: the `SyncLocalStore` contract,
 `SyncLocalIdentity`, `MutationIdGenerator`, and `MemoryLocalStore` are in
 place. The client runtime hydrates cached rows before network pull,
 persists pull/push outcomes into the store, and replays stored pending
-mutations during `open()`. The store is still memory-backed until the
-SQLite WASM/OPFS crate lands. `pocopine-sync-sqlite` now contains the
-shared schema and a native SQLite implementation; the browser OPFS worker
-binding remains the next concrete storage step.
+mutations during `open()`. `pocopine-sync-sqlite` now contains the shared
+schema, a native SQLite implementation, and a browser SQLite WASM + OPFS
+worker implementation behind the same store trait.
 
 ## Crate Boundaries
 
@@ -324,13 +323,14 @@ Deliverables:
 - browser SQLite WASM + OPFS worker boundary,
 - schema migration bootstrap,
 - transactional local-store implementation,
-- fallback/error path when persistent storage is unavailable.
+- clear error path when persistent storage is unavailable.
 
 Tests:
 
 - native SQLite test for identity, snapshot, changes, pending replay, and
   push outcomes,
-- wasm browser test for open database and schema bootstrap,
+- wasm browser test for open database, schema bootstrap, rows, pending
+  mutation replay, and accepted push cleanup,
 - mutation queue persists across client recreation,
 - snapshot/change application is atomic,
 - private/incognito or storage-denied path reports a clear error.

--- a/docs/sync-local-store-plan.md
+++ b/docs/sync-local-store-plan.md
@@ -80,8 +80,9 @@ MutationId = "{device_id}:{counter}"
 ```
 
 `SyncDeviceId` is generated once and persisted by the local store.
-`SyncSessionId` is process/page-load scoped. Mutation counters are durable
-per device so retried writes keep stable idempotency keys.
+`SyncSessionId` is process/page-load scoped. The persisted local identity
+also stores the next mutation counter. Stores must advance that counter
+durably before exposing a mutation id that can be sent to the server.
 
 This keeps mutation ids stable across reloads and avoids the current
 example-only `post_local_{n}` pattern becoming a production habit.
@@ -93,42 +94,30 @@ should cover these operations:
 
 ```rust
 pub trait SyncLocalStore {
-    fn load_identity(&self) -> SyncBoxFuture<'_, Option<SyncDeviceId>>;
-    fn save_identity(&self, id: SyncDeviceId) -> SyncBoxFuture<'_, ()>;
+    fn load_identity(&self) -> SyncLocalFuture<'_, Option<SyncLocalIdentity>>;
+    fn save_identity(&self, identity: SyncLocalIdentity) -> SyncLocalFuture<'_, ()>;
 
     fn hydrate_stream(
         &self,
         stream: &SyncStreamName,
-    ) -> SyncBoxFuture<'_, LocalStreamSnapshot>;
+    ) -> SyncLocalFuture<'_, LocalStreamSnapshot>;
 
-    fn save_snapshot(
-        &self,
-        stream: &SyncStreamName,
-        snapshot: LocalSnapshotBatch,
-    ) -> SyncBoxFuture<'_, ()>;
+    fn save_snapshot(&self, snapshot: LocalSnapshotBatch) -> SyncLocalFuture<'_, ()>;
 
-    fn apply_changes(
-        &self,
-        stream: &SyncStreamName,
-        changes: LocalChangeBatch,
-    ) -> SyncBoxFuture<'_, ()>;
+    fn apply_changes(&self, changes: LocalChangeBatch) -> SyncLocalFuture<'_, ()>;
 
     fn enqueue_mutation(
         &self,
         stream: &SyncStreamName,
-        mutation: SyncMutation,
-    ) -> SyncBoxFuture<'_, ()>;
+        mutation: ClientMutation<serde_json::Value>,
+    ) -> SyncLocalFuture<'_, ()>;
 
-    fn mark_push_result(
-        &self,
-        stream: &SyncStreamName,
-        result: SyncPushResult,
-    ) -> SyncBoxFuture<'_, ()>;
+    fn mark_push_result(&self, result: LocalPushResult) -> SyncLocalFuture<'_, ()>;
 
     fn pending_mutations(
         &self,
         stream: &SyncStreamName,
-    ) -> SyncBoxFuture<'_, Vec<SyncMutation>>;
+    ) -> SyncLocalFuture<'_, Vec<ClientMutation<serde_json::Value>>>;
 }
 ```
 

--- a/docs/sync-local-store-plan.md
+++ b/docs/sync-local-store-plan.md
@@ -25,8 +25,10 @@ SQLite WASM/OPFS runtime shape.
 
 Current implementation status: the `SyncLocalStore` contract,
 `SyncLocalIdentity`, `MutationIdGenerator`, and `MemoryLocalStore` are in
-place. The client runtime does not yet hydrate from a store or replay
-stored mutations automatically.
+place. The client runtime hydrates cached rows before network pull,
+persists pull/push outcomes into the store, and replays stored pending
+mutations during `open()`. The store is still memory-backed until the
+SQLite WASM/OPFS crate lands.
 
 ## Crate Boundaries
 

--- a/docs/sync-local-store-plan.md
+++ b/docs/sync-local-store-plan.md
@@ -28,7 +28,9 @@ Current implementation status: the `SyncLocalStore` contract,
 place. The client runtime hydrates cached rows before network pull,
 persists pull/push outcomes into the store, and replays stored pending
 mutations during `open()`. The store is still memory-backed until the
-SQLite WASM/OPFS crate lands.
+SQLite WASM/OPFS crate lands. `pocopine-sync-sqlite` now contains the
+shared schema and a native SQLite implementation; the browser OPFS worker
+binding remains the next concrete storage step.
 
 ## Crate Boundaries
 
@@ -317,6 +319,8 @@ Files:
 Deliverables:
 
 - new extension crate,
+- shared SQLite schema and bootstrap SQL,
+- native SQLite implementation for tests and host/native apps,
 - browser SQLite WASM + OPFS worker boundary,
 - schema migration bootstrap,
 - transactional local-store implementation,
@@ -324,6 +328,8 @@ Deliverables:
 
 Tests:
 
+- native SQLite test for identity, snapshot, changes, pending replay, and
+  push outcomes,
 - wasm browser test for open database and schema bootstrap,
 - mutation queue persists across client recreation,
 - snapshot/change application is atomic,

--- a/docs/sync-local-store-plan.md
+++ b/docs/sync-local-store-plan.md
@@ -51,6 +51,10 @@ worker implementation behind the same store trait.
 - hydration from local rows before network pull,
 - pending mutation replay after reload.
 
+Browser SQLite is constrained to one open sync database per page because
+the current SQLite WASM wrapper exposes one process-wide worker/database
+handle. Apps should pick one database name for their sync store.
+
 `pocopine-sync-sqlx` is a later host/server adapter:
 
 - SQLx-backed `SyncStreamSource` implementations,
@@ -77,6 +81,11 @@ The local store is responsible for durable client-side sync state:
 The store is not trusted. Server guards, stream filters, and mutation
 policies still run on every `/open`, `/pull`, and `/push`.
 
+Persisted row flags are not a complete transaction UI model. They record
+the latest server outcome stored for a row; when several pending
+mutations target the same key, the client may need to replay the queued
+mutations before the hydrated row reflects every pending edit.
+
 ## Identity And Mutation Ids
 
 The next phase should add stable client identity:
@@ -94,6 +103,10 @@ durably before exposing a mutation id that can be sent to the server.
 
 This keeps mutation ids stable across reloads and avoids the current
 example-only `post_local_{n}` pattern becoming a production habit.
+
+The first client API remains explicit: apps pass `ClientMutation::id` to
+`SyncCollection::push`. Automatic id allocation from `SyncLocalIdentity`
+is a future helper layered on this storage slot.
 
 ## Store Contract Sketch
 

--- a/docs/sync-local-store-plan.md
+++ b/docs/sync-local-store-plan.md
@@ -1,0 +1,389 @@
+# Sync Local Store Plan
+
+This is the next sync phase after the guarded stream protocol and
+mutation push flow. The goal is to make Pocopine sync local-first without
+turning framework core into a database toolkit.
+
+The stable contract is a Pocopine sync store abstraction. SQLite is the
+first serious durable implementation. SQLx is a later host/server adapter,
+not the foundation of browser-local sync.
+
+## Decision
+
+Build the local store in this order:
+
+1. Add a `SyncLocalStore` contract to `pocopine-sync`.
+2. Add a memory implementation for tests and examples.
+3. Add `pocopine-sync-sqlite` for browser SQLite through SQLite WASM and
+   OPFS, behind a worker boundary.
+4. Add `pocopine-sync-sqlx` later for host/server `SyncStreamSource`
+   adapters and optional native SQLite use.
+
+Do not route browser-local sync through SQLx. SQLx uses native database
+drivers and is excellent for server Rust, but browser SQLite uses the
+SQLite WASM/OPFS runtime shape.
+
+## Crate Boundaries
+
+`pocopine-sync` owns the protocol and store-neutral client semantics:
+
+- sync wire types,
+- stream open/pull/push flow,
+- `CollectionState<T>`,
+- stable client/device/session identity types,
+- mutation id generation,
+- `SyncLocalStore` trait,
+- memory local store used by tests.
+
+`pocopine-sync-sqlite` owns durable local storage:
+
+- browser SQLite WASM + OPFS worker integration,
+- Pocopine internal tables,
+- transactional snapshot/change/mutation queue operations,
+- hydration from local rows before network pull,
+- pending mutation replay after reload.
+
+`pocopine-sync-sqlx` is a later host/server adapter:
+
+- SQLx-backed `SyncStreamSource` implementations,
+- compile-time checked snapshot and change queries,
+- Postgres/MySQL/SQLite host database support,
+- optional native-app local SQLite support if the same trait boundary fits.
+
+`pocopine-live` remains a wake-up channel only. It does not move sync
+rows and does not become the local database.
+
+## Local Store Responsibilities
+
+The local store is responsible for durable client-side sync state:
+
+- load cached stream rows before the network responds,
+- persist snapshots atomically,
+- apply incremental changes atomically,
+- persist the latest stream cursor,
+- enqueue mutations before sending them,
+- mark mutations accepted, rejected, or conflicted,
+- replay pending mutations after reload or reconnect,
+- store stable device/client identity.
+
+The store is not trusted. Server guards, stream filters, and mutation
+policies still run on every `/open`, `/pull`, and `/push`.
+
+## Identity And Mutation Ids
+
+The next phase should add stable client identity:
+
+```text
+SyncDeviceId
+SyncSessionId
+MutationId = "{device_id}:{counter}"
+```
+
+`SyncDeviceId` is generated once and persisted by the local store.
+`SyncSessionId` is process/page-load scoped. Mutation counters are durable
+per device so retried writes keep stable idempotency keys.
+
+This keeps mutation ids stable across reloads and avoids the current
+example-only `post_local_{n}` pattern becoming a production habit.
+
+## Store Contract Sketch
+
+The exact Rust shape can change during implementation, but the contract
+should cover these operations:
+
+```rust
+pub trait SyncLocalStore {
+    fn load_identity(&self) -> SyncBoxFuture<'_, Option<SyncDeviceId>>;
+    fn save_identity(&self, id: SyncDeviceId) -> SyncBoxFuture<'_, ()>;
+
+    fn hydrate_stream(
+        &self,
+        stream: &SyncStreamName,
+    ) -> SyncBoxFuture<'_, LocalStreamSnapshot>;
+
+    fn save_snapshot(
+        &self,
+        stream: &SyncStreamName,
+        snapshot: LocalSnapshotBatch,
+    ) -> SyncBoxFuture<'_, ()>;
+
+    fn apply_changes(
+        &self,
+        stream: &SyncStreamName,
+        changes: LocalChangeBatch,
+    ) -> SyncBoxFuture<'_, ()>;
+
+    fn enqueue_mutation(
+        &self,
+        stream: &SyncStreamName,
+        mutation: SyncMutation,
+    ) -> SyncBoxFuture<'_, ()>;
+
+    fn mark_push_result(
+        &self,
+        stream: &SyncStreamName,
+        result: SyncPushResult,
+    ) -> SyncBoxFuture<'_, ()>;
+
+    fn pending_mutations(
+        &self,
+        stream: &SyncStreamName,
+    ) -> SyncBoxFuture<'_, Vec<SyncMutation>>;
+}
+```
+
+The important invariant is transactional behavior. If a snapshot or push
+result partially applies, the client can render stale or impossible state.
+
+## Browser Flow
+
+Mounting a collection becomes local-first:
+
+```text
+component mounts
+  -> hydrate rows from SyncLocalStore
+  -> render cached rows immediately
+  -> open stream
+  -> pull snapshot or incremental changes
+  -> persist server changes transactionally
+  -> update CollectionState from the confirmed local view
+```
+
+Pushing a mutation becomes durable-before-network:
+
+```text
+user edits
+  -> allocate stable mutation id
+  -> enqueue mutation in SyncLocalStore
+  -> apply optimistic state
+  -> POST /push
+  -> persist accepted/rejected/conflict result
+  -> reconcile CollectionState
+  -> live wake-up or pull refreshes canonical rows
+```
+
+Reconnecting becomes anti-entropy:
+
+```text
+network returns
+  -> load pending mutations
+  -> replay pushes by mutation id
+  -> pull every open stream using stored cursor
+  -> resnapshot if the server reports a gap
+```
+
+## Initial SQLite Schema
+
+The first SQLite backend should store Pocopine metadata separately from
+application data:
+
+```sql
+create table __pocopine_meta (
+  key text primary key,
+  value text not null
+);
+
+create table __pocopine_streams (
+  stream text primary key,
+  collection text not null,
+  cursor text,
+  schema_version integer not null,
+  updated_at_ms integer not null
+);
+
+create table __pocopine_rows (
+  stream text not null,
+  row_key text not null,
+  version text,
+  payload text not null,
+  pending integer not null default 0,
+  conflict integer not null default 0,
+  updated_at_ms integer not null,
+  primary key (stream, row_key)
+);
+
+create table __pocopine_mutations (
+  stream text not null,
+  mutation_id text primary key,
+  row_key text,
+  base_version text,
+  op text not null,
+  payload text,
+  status text not null,
+  error text,
+  created_at_ms integer not null,
+  updated_at_ms integer not null
+);
+```
+
+This schema stores framework sync state. Later typed local query APIs may
+materialize app-specific tables or views, but the first phase should keep
+the persisted representation simple and correct.
+
+## Implementation Phases
+
+### Phase 1 - Store Contract
+
+Files:
+
+- `crates/pocopine-sync/src/lib.rs`
+- `crates/pocopine-sync/src/local_store.rs`
+- `crates/pocopine-sync/src/protocol.rs`
+- `crates/pocopine-sync/src/state.rs`
+- `docs/sync.md`
+
+Deliverables:
+
+- `SyncLocalStore` trait,
+- stable `SyncDeviceId`, `SyncSessionId`, and mutation id generator,
+- store-neutral result types for snapshots, changes, and push outcomes,
+- documentation of the durability model.
+
+Tests:
+
+- device id is generated once and reused,
+- mutation ids are monotonic for a device,
+- accepted push clears the queued mutation,
+- rejected push records rollback state,
+- conflict push records conflict metadata.
+
+Commit boundary:
+
+```text
+Define sync local-store contract
+```
+
+### Phase 2 - Memory Local Store
+
+Files:
+
+- `crates/pocopine-sync/src/local_memory.rs`
+- `crates/pocopine-sync/src/client.rs`
+- `crates/pocopine-sync/src/state.rs`
+
+Deliverables:
+
+- `MemoryLocalStore`,
+- hydration before network pull,
+- pending mutation replay through the existing push path,
+- client behavior still works without durable browser storage.
+
+Tests:
+
+- hydrate cached rows before the first pull,
+- snapshot replaces local rows,
+- incremental changes patch local rows,
+- queued mutation survives a recreated collection state,
+- pull gap clears old rows and applies the new snapshot.
+
+Commit boundary:
+
+```text
+Add memory-backed sync local store
+```
+
+### Phase 3 - Docs And Example
+
+Files:
+
+- `docs/sync.md`
+- `examples/sync/README.md`
+- `examples/sync/src/lib.rs`
+
+Deliverables:
+
+- tutorial updated for local-first flow,
+- example shows cached state and pending replay using the memory store,
+- docs clearly say memory is not production storage.
+
+Tests:
+
+- existing `pocopine-sync` tests,
+- existing `sync-example` tests,
+- browser smoke test if the example UI changes.
+
+Commit boundary:
+
+```text
+Document local-first sync store flow
+```
+
+### Phase 4 - SQLite Backend
+
+Files:
+
+- `crates/pocopine-sync-sqlite/Cargo.toml`
+- `crates/pocopine-sync-sqlite/src/lib.rs`
+- `crates/pocopine-sync-sqlite/src/worker.rs`
+- `crates/pocopine-sync-sqlite/src/schema.rs`
+- `docs/sync.md`
+
+Deliverables:
+
+- new extension crate,
+- browser SQLite WASM + OPFS worker boundary,
+- schema migration bootstrap,
+- transactional local-store implementation,
+- fallback/error path when persistent storage is unavailable.
+
+Tests:
+
+- wasm browser test for open database and schema bootstrap,
+- mutation queue persists across client recreation,
+- snapshot/change application is atomic,
+- private/incognito or storage-denied path reports a clear error.
+
+Commit boundary:
+
+```text
+Add SQLite-backed sync local store
+```
+
+### Phase 5 - SQLx Backend
+
+Files:
+
+- `crates/pocopine-sync-sqlx/Cargo.toml`
+- `crates/pocopine-sync-sqlx/src/lib.rs`
+- `docs/sync.md`
+
+Deliverables:
+
+- host/server-only adapter crate,
+- SQLx-backed `SyncStreamSource` helpers,
+- examples for inline `query!` / `query_as!`,
+- guidance for `.sqlx` offline metadata and CI.
+
+Tests:
+
+- host tests for snapshot and incremental source helpers,
+- SQLx offline metadata example or documented CI check,
+- authorization still proven outside SQLx query typing.
+
+Commit boundary:
+
+```text
+Add SQLx sync source adapter
+```
+
+## CI Strategy
+
+The store contract and memory backend should run in ordinary workspace
+tests. SQLite browser persistence needs a narrower CI shape:
+
+- keep pure protocol/store-state tests in `cargo test -p pocopine-sync`,
+- add wasm browser tests under `pocopine-sync-sqlite`,
+- run SQLite OPFS tests only where the browser supports persistent OPFS,
+- keep a memory fallback test so CI failures distinguish storage support
+  from sync semantic regressions.
+
+Do not require Redis, Postgres, or SQLx to test the local-store contract.
+Database adapter tests belong to their adapter crates.
+
+## Non-goals For The Next PR
+
+- No SQLx adapter in the local-store PR.
+- No CDC integration.
+- No CRDT document merge; that remains `pocopine-collab`.
+- No arbitrary browser SQL API exposed to app code.
+- No `pocopine` core feature that re-exports optional sync backends.

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -11,29 +11,31 @@ The first implementation is intentionally small:
 - `pocopine-live` is used only as a wake-up signal,
 - committed stream data still moves through `POST /__pocopine/sync/v1/pull`.
 
-This is not the full offline store yet. Durable browser storage,
-cross-reload mutation replay, SQLx-backed server adapters, and CDC
-integrations remain future work. The current API gives us the protocol
-boundary, server-confirmed mutations, and a browser state model that
-those backends can plug into later.
+This is not the full offline database system yet. The first durable local
+store exists as an explicit SQLite extension crate; SQLx-backed server
+adapters, CDC integrations, richer conflict UI, and query-driven streams
+remain future work. The current API gives us the protocol boundary,
+server-confirmed mutations, and a browser state model that those
+backends can plug into later.
 
 The planned local-first storage path is documented in
 [`sync-local-store-plan.md`](./sync-local-store-plan.md). The short
 version: add a Pocopine-owned `SyncLocalStore` contract first, ship a
 memory implementation to pin semantics, then add SQLite WASM/OPFS as the
-browser durable store. SQLx comes later as a host/server adapter, not as
+browser durable store. That SQLite store now lives in
+`pocopine-sync-sqlite`. SQLx comes later as a host/server adapter, not as
 the browser-local SQLite layer.
 
 The crate currently exposes `SyncLocalStore` and `MemoryLocalStore` so
 the storage contract can be tested without a browser database.
 `SyncCollection::open()` hydrates cached rows before the network pull and
-replays pending stored mutations. SQLite WASM/OPFS durability is the next
-implementation step.
+replays pending stored mutations.
 
-`pocopine-sync-sqlite` now owns the SQLite schema and includes a native
-SQLite implementation for tests and host/native apps. Browser builds
-compile against the same crate but return a clear unsupported error until
-the SQLite WASM + OPFS worker binding lands.
+`pocopine-sync-sqlite` owns the SQLite schema and includes both a native
+SQLite implementation for tests/host/native apps and a browser SQLite
+WASM + OPFS implementation. The browser adapter uses an embedded SQLite
+worker and serializes operations through a page-local gate because the
+underlying SQLite WASM worker is singleton-shaped.
 
 The runnable source of truth is [`examples/sync`](../examples/sync/).
 When the sync API changes, update this document and the example in the
@@ -78,6 +80,16 @@ tracing = { workspace = true }
 `pocopine-sync` has target-specific modules internally. The browser gets
 the client plugin and protocol/state types. The host gets the server
 plugin and source traits.
+
+For durable local storage, depend on the SQLite adapter directly:
+
+```toml
+[dependencies]
+pocopine-sync-sqlite = { workspace = true }
+```
+
+Do not route this through a `pocopine` core feature. Sync backends remain
+explicit extension crates.
 
 ## 2. Define A Stream
 
@@ -268,15 +280,27 @@ local-store contract active for tests and demos but does not survive page
 reloads. Apps can provide another store explicitly:
 
 ```rust
+let local_store = pocopine_sync_sqlite::SqliteLocalStore::new();
+
 App::new()
     .plugin(
         pocopine_sync::sync_plugin()
             .with_live_wakeup(true)
-            .local_store(my_store),
+            .local_store(local_store),
     )
     .register::<SyncBoard>()
     .run();
 ```
+
+Browser SQLite uses OPFS through an embedded SQLite worker. Apps may
+choose a database filename with
+`SqliteLocalStore::with_database_name("my_app_sync.sqlite3")`; names are
+validated as OPFS filenames rather than paths. If the browser denies
+persistent storage, the store reports a client error and the app can fall
+back to `MemoryLocalStore` or surface an offline-storage warning.
+
+Native apps can use the same crate with
+`SqliteLocalStore::open_path(path)` or `SqliteLocalStore::open_in_memory()`.
 
 Components store synced rows in `CollectionState<T>`:
 
@@ -320,8 +344,9 @@ stream's wake-up topic and pulls again whenever the server invalidates
 that stream. `pull()` can be called manually for refresh buttons.
 
 Pending mutations found in the local store are replayed after `open`
-passes and before the authoritative pull. This is the first anti-entropy
-hook; the durable SQLite backend will make it useful across reloads.
+passes and before the authoritative pull. With `MemoryLocalStore` this is
+useful inside one page lifetime. With `pocopine-sync-sqlite`, it also
+survives reloads in browsers that support OPFS.
 
 Templates read `CollectionState<T>` directly:
 
@@ -407,6 +432,12 @@ Firefox and verifies `open -> pull -> render`:
 wasm-pack test --firefox --headless crates/pocopine-sync --test client_browser
 ```
 
+For the SQLite OPFS browser smoke test:
+
+```bash
+wasm-pack test --firefox --headless crates/pocopine-sync-sqlite --test wasm_sqlite_store
+```
+
 ## Protocol Boundary
 
 - `open` validates stream names and reports registered stream metadata.
@@ -438,9 +469,8 @@ wasm-pack test --firefox --headless crates/pocopine-sync --test client_browser
 Keep these as separate adapter crates:
 
 - `pocopine-sync-sqlx` for compile-time checked SQL streams,
-- `pocopine-sync-sqlite` for SQLite local storage. The crate currently
-  ships the schema plus native SQLite implementation; browser durability
-  will use SQLite WASM/OPFS behind the same `SyncLocalStore` contract,
+- `pocopine-sync-sqlite` for SQLite local storage on native targets and
+  browser OPFS through SQLite WASM,
 - `pocopine-sync-redis` only if we need a shared server-side change log.
 
 Those crates should implement the same protocol contracts rather than

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -298,6 +298,8 @@ choose a database filename with
 validated as OPFS filenames rather than paths. If the browser denies
 persistent storage, the store reports a client error and the app can fall
 back to `MemoryLocalStore` or surface an offline-storage warning.
+Because the underlying SQLite WASM wrapper owns a singleton worker,
+Pocopine supports one open browser SQLite sync database per page.
 
 Native apps can use the same crate with
 `SqliteLocalStore::open_path(path)` or `SqliteLocalStore::open_in_memory()`.
@@ -347,6 +349,11 @@ Pending mutations found in the local store are replayed after `open`
 passes and before the authoritative pull. With `MemoryLocalStore` this is
 useful inside one page lifetime. With `pocopine-sync-sqlite`, it also
 survives reloads in browsers that support OPFS.
+
+`SyncLocalIdentity` and `MutationIdGenerator` are available for apps that
+want stable device-scoped mutation ids today. The current
+`SyncCollection::push` method still expects the app to provide
+`ClientMutation::id`; automatic id allocation is a follow-up API.
 
 Templates read `CollectionState<T>` directly:
 
@@ -406,6 +413,11 @@ same rule: do not emit a live wake-up until the mutation has committed.
 The example uses short client-local ids to keep the code readable.
 Production apps should use server-assigned ids or client-generated UUIDs
 to avoid row-key collisions across tabs and devices.
+
+Local-store row flags are a cached view of the latest server outcome. If
+an app stacks multiple pending mutations against the same row, a hydrated
+row may temporarily show `pending = false` until the client replays the
+stored mutation queue.
 
 ## 7. Run The Example
 

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -24,6 +24,11 @@ memory implementation to pin semantics, then add SQLite WASM/OPFS as the
 browser durable store. SQLx comes later as a host/server adapter, not as
 the browser-local SQLite layer.
 
+The crate currently exposes `SyncLocalStore` and `MemoryLocalStore` so
+the storage contract can be tested without a browser database. Automatic
+`SyncCollection` hydration, persisted mutation replay, and SQLite
+WASM/OPFS durability are the next implementation steps.
+
 The runnable source of truth is [`examples/sync`](../examples/sync/).
 When the sync API changes, update this document and the example in the
 same PR.

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -30,6 +30,11 @@ the storage contract can be tested without a browser database.
 replays pending stored mutations. SQLite WASM/OPFS durability is the next
 implementation step.
 
+`pocopine-sync-sqlite` now owns the SQLite schema and includes a native
+SQLite implementation for tests and host/native apps. Browser builds
+compile against the same crate but return a clear unsupported error until
+the SQLite WASM + OPFS worker binding lands.
+
 The runnable source of truth is [`examples/sync`](../examples/sync/).
 When the sync API changes, update this document and the example in the
 same PR.
@@ -433,7 +438,9 @@ wasm-pack test --firefox --headless crates/pocopine-sync --test client_browser
 Keep these as separate adapter crates:
 
 - `pocopine-sync-sqlx` for compile-time checked SQL streams,
-- `pocopine-sync-sqlite` for durable browser SQLite via SQLite WASM/OPFS,
+- `pocopine-sync-sqlite` for SQLite local storage. The crate currently
+  ships the schema plus native SQLite implementation; browser durability
+  will use SQLite WASM/OPFS behind the same `SyncLocalStore` contract,
 - `pocopine-sync-redis` only if we need a shared server-side change log.
 
 Those crates should implement the same protocol contracts rather than

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -11,11 +11,18 @@ The first implementation is intentionally small:
 - `pocopine-live` is used only as a wake-up signal,
 - committed stream data still moves through `POST /__pocopine/sync/v1/pull`.
 
-This is not the full offline store yet. IndexedDB durability,
-cross-reload mutation replay, SQLx-backed adapters, and CDC integrations
-remain future work. The current API gives us the protocol boundary,
-server-confirmed mutations, and a browser state model that those backends
-can plug into later.
+This is not the full offline store yet. Durable browser storage,
+cross-reload mutation replay, SQLx-backed server adapters, and CDC
+integrations remain future work. The current API gives us the protocol
+boundary, server-confirmed mutations, and a browser state model that
+those backends can plug into later.
+
+The planned local-first storage path is documented in
+[`sync-local-store-plan.md`](./sync-local-store-plan.md). The short
+version: add a Pocopine-owned `SyncLocalStore` contract first, ship a
+memory implementation to pin semantics, then add SQLite WASM/OPFS as the
+browser durable store. SQLx comes later as a host/server adapter, not as
+the browser-local SQLite layer.
 
 The runnable source of truth is [`examples/sync`](../examples/sync/).
 When the sync API changes, update this document and the example in the

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -25,9 +25,10 @@ browser durable store. SQLx comes later as a host/server adapter, not as
 the browser-local SQLite layer.
 
 The crate currently exposes `SyncLocalStore` and `MemoryLocalStore` so
-the storage contract can be tested without a browser database. Automatic
-`SyncCollection` hydration, persisted mutation replay, and SQLite
-WASM/OPFS durability are the next implementation steps.
+the storage contract can be tested without a browser database.
+`SyncCollection::open()` hydrates cached rows before the network pull and
+replays pending stored mutations. SQLite WASM/OPFS durability is the next
+implementation step.
 
 The runnable source of truth is [`examples/sync`](../examples/sync/).
 When the sync API changes, update this document and the example in the
@@ -257,6 +258,21 @@ When live wake-up is enabled, accepted pushes rely on the live
 invalidation to trigger the follow-up pull. Without live wake-up, the
 push path performs that pull directly.
 
+The plugin installs a `MemoryLocalStore` by default. That makes the
+local-store contract active for tests and demos but does not survive page
+reloads. Apps can provide another store explicitly:
+
+```rust
+App::new()
+    .plugin(
+        pocopine_sync::sync_plugin()
+            .with_live_wakeup(true)
+            .local_store(my_store),
+    )
+    .register::<SyncBoard>()
+    .run();
+```
+
 Components store synced rows in `CollectionState<T>`:
 
 ```rust
@@ -287,13 +303,20 @@ impl SyncBoard {
 }
 ```
 
-`open()` first calls `/__pocopine/sync/v1/open` to validate the stream,
-then calls `/__pocopine/sync/v1/pull`. A fresh client still pulls
-without a cursor so it receives a snapshot; the server's current cursor
-from `open` is metadata, not permission to skip initial data. When live
-wake-up is enabled, `open()` also subscribes to the stream's wake-up topic
-and pulls again whenever the server invalidates that stream. `pull()` can
-be called manually for refresh buttons.
+`open()` first hydrates rows and pending mutations from the local store.
+Cached rows render immediately with `stale = true`, then the client calls
+`/__pocopine/sync/v1/open` to validate the stream and
+`/__pocopine/sync/v1/pull` to reconcile with the server. If the local
+store has a cursor, that cursor is sent to `pull`; otherwise a fresh
+client pulls without a cursor so it receives a snapshot. The server's
+current cursor from `open` is metadata, not permission to skip initial
+data. When live wake-up is enabled, `open()` also subscribes to the
+stream's wake-up topic and pulls again whenever the server invalidates
+that stream. `pull()` can be called manually for refresh buttons.
+
+Pending mutations found in the local store are replayed after `open`
+passes and before the authoritative pull. This is the first anti-entropy
+hook; the durable SQLite backend will make it useful across reloads.
 
 Templates read `CollectionState<T>` directly:
 
@@ -316,11 +339,12 @@ Templates read `CollectionState<T>` directly:
 
 ## 6. Push Optimistic Mutations
 
-`SyncCollection::push` applies an optimistic row locally, sends a stable
-mutation id to `/__pocopine/sync/v1/push`, then applies the server's
-accepted, rejected, or conflict response. Accepted pushes also wake live
-listeners through the sync server's event backend, so other tabs pull the
-committed stream changes.
+`SyncCollection::push` first enqueues the mutation in the local store,
+then applies an optimistic row locally, sends a stable mutation id to
+`/__pocopine/sync/v1/push`, and applies the server's accepted, rejected,
+or conflict response. Accepted pushes also wake live listeners through
+the sync server's event backend, so other tabs pull the committed stream
+changes.
 
 ```rust
 pub fn create(&mut self) {
@@ -409,8 +433,8 @@ wasm-pack test --firefox --headless crates/pocopine-sync --test client_browser
 Keep these as separate adapter crates:
 
 - `pocopine-sync-sqlx` for compile-time checked SQL streams,
-- `pocopine-sync-indexeddb` for browser persistence,
-- `pocopine-sync-redis` for shared cursor/change storage.
+- `pocopine-sync-sqlite` for durable browser SQLite via SQLite WASM/OPFS,
+- `pocopine-sync-redis` only if we need a shared server-side change log.
 
 Those crates should implement the same protocol contracts rather than
 adding optional backend settings to framework core.

--- a/examples/sync/README.md
+++ b/examples/sync/README.md
@@ -27,12 +27,14 @@ or `guarded_stream_with(...)`.
 The create form uses short client-local ids for readability; production
 apps should use server-assigned ids or client-side UUIDs so multiple tabs
 and devices do not collide.
-Future database adapters should keep this same browser stream while
-replacing the server-side source.
+Durable browser local storage lives in `pocopine-sync-sqlite`; this
+example keeps the default memory local store so the demo has no storage
+requirements.
 
 Checks:
 
 ```bash
 cargo test -p sync-example
 wasm-pack test --firefox --headless crates/pocopine-sync --test client_browser
+wasm-pack test --firefox --headless crates/pocopine-sync-sqlite --test wasm_sqlite_store
 ```

--- a/rfcs/rfc-072-offline-sync-protocol.md
+++ b/rfcs/rfc-072-offline-sync-protocol.md
@@ -31,6 +31,8 @@ Initial implementation has started in `pocopine-sync`:
   stored mutations, and persists pull responses through `SyncLocalStore`,
 - `SyncCollection::push()` enqueues mutations before the network request
   and persists accepted/rejected/conflict outcomes,
+- `pocopine-sync-sqlite` owns the SQLite local-store schema and native
+  SQLite implementation for tests/host use,
 - `MemorySyncStream` accepts upsert/delete/reset pushes with stable
   mutation-id dedupe,
 - live wake-up integration through `pocopine-live` query-tag topics,
@@ -41,10 +43,10 @@ Current model: `/open` is discovery/validation, not a session grant.
 Every `/open`, `/pull`, and `/push` request runs the stream guard
 independently, so skipping `/open` does not bypass access control.
 
-Still future work: durable browser storage, cross-reload mutation replay
-with the SQLite backend, conflict resolution UI, SQLx/database adapters,
-CDC sources, and query-driven stream parameters. The local-store
-implementation plan is documented in
+Still future work: browser SQLite WASM/OPFS worker binding,
+cross-reload mutation replay in the browser, conflict resolution UI,
+SQLx/database adapters, CDC sources, and query-driven stream parameters.
+The local-store implementation plan is documented in
 [`docs/sync-local-store-plan.md`](../docs/sync-local-store-plan.md):
 SQLite-first local storage, with SQLx kept as a later host/server
 adapter.

--- a/rfcs/rfc-072-offline-sync-protocol.md
+++ b/rfcs/rfc-072-offline-sync-protocol.md
@@ -25,6 +25,8 @@ Initial implementation has started in `pocopine-sync`:
 - browser `SyncClient::open()` calls `/open` before the first `/pull`,
 - browser `SyncCollection::push()` applies optimistic rows and handles
   accepted, rejected, and conflict push outcomes,
+- `SyncLocalStore`, `SyncLocalIdentity`, `MutationIdGenerator`, and
+  `MemoryLocalStore` as the first local-store contract slice,
 - `MemorySyncStream` accepts upsert/delete/reset pushes with stable
   mutation-id dedupe,
 - live wake-up integration through `pocopine-live` query-tag topics,
@@ -35,10 +37,11 @@ Current model: `/open` is discovery/validation, not a session grant.
 Every `/open`, `/pull`, and `/push` request runs the stream guard
 independently, so skipping `/open` does not bypass access control.
 
-Still future work: the `SyncLocalStore` contract, durable browser
-storage, cross-reload mutation replay, conflict resolution UI,
-SQLx/database adapters, CDC sources, and query-driven stream parameters.
-The next implementation phase is documented in
+Still future work: wiring `SyncLocalStore` into `SyncCollection` runtime
+hydration/replay, durable browser storage, cross-reload mutation replay,
+conflict resolution UI, SQLx/database adapters, CDC sources, and
+query-driven stream parameters. The local-store implementation plan is
+documented in
 [`docs/sync-local-store-plan.md`](../docs/sync-local-store-plan.md):
 SQLite-first local storage, with SQLx kept as a later host/server
 adapter.

--- a/rfcs/rfc-072-offline-sync-protocol.md
+++ b/rfcs/rfc-072-offline-sync-protocol.md
@@ -27,6 +27,10 @@ Initial implementation has started in `pocopine-sync`:
   accepted, rejected, and conflict push outcomes,
 - `SyncLocalStore`, `SyncLocalIdentity`, `MutationIdGenerator`, and
   `MemoryLocalStore` as the first local-store contract slice,
+- `SyncCollection::open()` hydrates cached local rows, replays pending
+  stored mutations, and persists pull responses through `SyncLocalStore`,
+- `SyncCollection::push()` enqueues mutations before the network request
+  and persists accepted/rejected/conflict outcomes,
 - `MemorySyncStream` accepts upsert/delete/reset pushes with stable
   mutation-id dedupe,
 - live wake-up integration through `pocopine-live` query-tag topics,
@@ -37,11 +41,10 @@ Current model: `/open` is discovery/validation, not a session grant.
 Every `/open`, `/pull`, and `/push` request runs the stream guard
 independently, so skipping `/open` does not bypass access control.
 
-Still future work: wiring `SyncLocalStore` into `SyncCollection` runtime
-hydration/replay, durable browser storage, cross-reload mutation replay,
-conflict resolution UI, SQLx/database adapters, CDC sources, and
-query-driven stream parameters. The local-store implementation plan is
-documented in
+Still future work: durable browser storage, cross-reload mutation replay
+with the SQLite backend, conflict resolution UI, SQLx/database adapters,
+CDC sources, and query-driven stream parameters. The local-store
+implementation plan is documented in
 [`docs/sync-local-store-plan.md`](../docs/sync-local-store-plan.md):
 SQLite-first local storage, with SQLx kept as a later host/server
 adapter.

--- a/rfcs/rfc-072-offline-sync-protocol.md
+++ b/rfcs/rfc-072-offline-sync-protocol.md
@@ -31,21 +31,22 @@ Initial implementation has started in `pocopine-sync`:
   stored mutations, and persists pull responses through `SyncLocalStore`,
 - `SyncCollection::push()` enqueues mutations before the network request
   and persists accepted/rejected/conflict outcomes,
-- `pocopine-sync-sqlite` owns the SQLite local-store schema and native
-  SQLite implementation for tests/host use,
+- `pocopine-sync-sqlite` owns the SQLite local-store schema, native
+  SQLite implementation, and browser SQLite WASM/OPFS implementation,
 - `MemorySyncStream` accepts upsert/delete/reset pushes with stable
   mutation-id dedupe,
 - live wake-up integration through `pocopine-live` query-tag topics,
 - runnable memory-backed example in `examples/sync`,
-- Firefox wasm smoke coverage for `open -> pull -> render`.
+- Firefox wasm smoke coverage for `open -> pull -> render` and the
+  SQLite OPFS local store.
 
 Current model: `/open` is discovery/validation, not a session grant.
 Every `/open`, `/pull`, and `/push` request runs the stream guard
 independently, so skipping `/open` does not bypass access control.
 
-Still future work: browser SQLite WASM/OPFS worker binding,
-cross-reload mutation replay in the browser, conflict resolution UI,
-SQLx/database adapters, CDC sources, and query-driven stream parameters.
+Still future work: conflict resolution UI, SQLx/database adapters, CDC
+sources, query-driven stream parameters, and production guidance for
+storage-denied browser environments.
 The local-store implementation plan is documented in
 [`docs/sync-local-store-plan.md`](../docs/sync-local-store-plan.md):
 SQLite-first local storage, with SQLx kept as a later host/server
@@ -637,10 +638,13 @@ Mutation payloads and row payloads are not logged.
 
 ### Phase D2 - SQLite local store
 
-- Add `pocopine-sync-sqlite`.
+- Add `pocopine-sync-sqlite`. Implemented.
 - Use SQLite WASM + OPFS behind a worker boundary in browsers.
+  Implemented with an embedded worker and browser smoke coverage.
 - Persist stream cursors, rows, and pending mutations transactionally.
-- Hydrate collections from local SQLite before network pull.
+  Implemented for native SQLite and browser SQLite.
+- Hydrate collections from local SQLite before network pull. Implemented
+  through the `SyncLocalStore` client hook.
 
 ### Phase E - Advanced conflict handling
 

--- a/rfcs/rfc-072-offline-sync-protocol.md
+++ b/rfcs/rfc-072-offline-sync-protocol.md
@@ -46,7 +46,9 @@ independently, so skipping `/open` does not bypass access control.
 
 Still future work: conflict resolution UI, SQLx/database adapters, CDC
 sources, query-driven stream parameters, and production guidance for
-storage-denied browser environments.
+storage-denied browser environments. Automatic mutation-id allocation in
+the client is also future API work; this slice exposes the durable
+identity slot but keeps `SyncCollection::push` id-explicit.
 The local-store implementation plan is documented in
 [`docs/sync-local-store-plan.md`](../docs/sync-local-store-plan.md):
 SQLite-first local storage, with SQLx kept as a later host/server

--- a/rfcs/rfc-072-offline-sync-protocol.md
+++ b/rfcs/rfc-072-offline-sync-protocol.md
@@ -35,9 +35,13 @@ Current model: `/open` is discovery/validation, not a session grant.
 Every `/open`, `/pull`, and `/push` request runs the stream guard
 independently, so skipping `/open` does not bypass access control.
 
-Still future work: durable browser storage, cross-reload mutation replay,
-conflict resolution UI, SQLx/database adapters, CDC sources, and
-query-driven stream parameters.
+Still future work: the `SyncLocalStore` contract, durable browser
+storage, cross-reload mutation replay, conflict resolution UI,
+SQLx/database adapters, CDC sources, and query-driven stream parameters.
+The next implementation phase is documented in
+[`docs/sync-local-store-plan.md`](../docs/sync-local-store-plan.md):
+SQLite-first local storage, with SQLx kept as a later host/server
+adapter.
 
 ## 1. Summary
 
@@ -296,20 +300,30 @@ collection.apply_server_reset(snapshot, cursor);
 These operations update live queries immediately and reconcile any
 pending optimistic overlay for the same key.
 
-### 6.6 Storage adapters
+### 6.6 Local store adapters
 
-The frontend store starts with memory and IndexedDB adapters:
+The frontend store starts with a Pocopine-owned `SyncLocalStore`
+contract and a memory implementation for tests:
 
 ```rust
-pub trait ClientSyncStore {
-    async fn load_collection(&self, collection: &str) -> SyncResult<ClientSnapshot>;
-    async fn save_changes(&self, batch: ClientChangeBatch) -> SyncResult<()>;
-    async fn load_pending_mutations(&self) -> SyncResult<Vec<ClientMutation>>;
+pub trait SyncLocalStore {
+    async fn hydrate_stream(&self, stream: &str) -> SyncResult<ClientSnapshot>;
+    async fn save_snapshot(&self, batch: ClientSnapshotBatch) -> SyncResult<()>;
+    async fn apply_changes(&self, batch: ClientChangeBatch) -> SyncResult<()>;
+    async fn enqueue_mutation(&self, mutation: ClientMutation) -> SyncResult<()>;
+    async fn load_pending_mutations(&self, stream: &str) -> SyncResult<Vec<ClientMutation>>;
 }
 ```
 
-The memory adapter is valid for tests and ephemeral views. IndexedDB is
-the default browser persistence path for offline-capable apps.
+The memory adapter is valid for tests and ephemeral views. The durable
+browser implementation should be SQLite-first through SQLite WASM and
+OPFS, behind a worker boundary. IndexedDB may still be useful as a
+fallback or thin storage substrate, but it is not the primary query
+engine for the TanStack DB-like direction.
+
+SQLx is a separate host/server adapter. It should not sit underneath the
+browser local store, because browser SQLite uses the SQLite WASM/OPFS
+runtime shape rather than SQLx's native SQLite driver.
 
 ### 6.7 Framework integration
 
@@ -598,9 +612,17 @@ Mutation payloads and row payloads are not logged.
 
 ### Phase D - Local store helpers
 
-- Add IndexedDB browser persistence.
+- Add `SyncLocalStore` and a memory implementation.
+- Add stable device identity and durable mutation id generation.
 - Support optimistic writes with mutation id replay.
 - Add transaction state and conflict metadata exposed to components.
+
+### Phase D2 - SQLite local store
+
+- Add `pocopine-sync-sqlite`.
+- Use SQLite WASM + OPFS behind a worker boundary in browsers.
+- Persist stream cursors, rows, and pending mutations transactionally.
+- Hydrate collections from local SQLite before network pull.
 
 ### Phase E - Advanced conflict handling
 
@@ -633,5 +655,6 @@ Mutation payloads and row payloads are not logged.
 - TanStack DB overview: https://tanstack.com/db/latest/docs/overview
 - TanStack DB live queries: https://tanstack.com/db/latest/docs/guides/live-queries
 - TanStack DB mutations: https://tanstack.com/db/latest/docs/guides/mutations
+- SQLite WASM persistence and OPFS: https://sqlite.org/wasm/doc/trunk/persistence.md
 - SQLx repository and README: https://github.com/launchbadge/sqlx
 - SQLx `query!` macro and offline mode: https://docs.rs/sqlx/latest/sqlx/macro.query.html

--- a/rfcs/rfc-072-offline-sync-protocol.md
+++ b/rfcs/rfc-072-offline-sync-protocol.md
@@ -307,11 +307,21 @@ contract and a memory implementation for tests:
 
 ```rust
 pub trait SyncLocalStore {
-    async fn hydrate_stream(&self, stream: &str) -> SyncResult<ClientSnapshot>;
-    async fn save_snapshot(&self, batch: ClientSnapshotBatch) -> SyncResult<()>;
-    async fn apply_changes(&self, batch: ClientChangeBatch) -> SyncResult<()>;
-    async fn enqueue_mutation(&self, mutation: ClientMutation) -> SyncResult<()>;
-    async fn load_pending_mutations(&self, stream: &str) -> SyncResult<Vec<ClientMutation>>;
+    fn load_identity(&self) -> SyncLocalFuture<'_, Option<SyncLocalIdentity>>;
+    fn save_identity(&self, identity: SyncLocalIdentity) -> SyncLocalFuture<'_, ()>;
+    fn hydrate_stream(&self, stream: &SyncStreamName) -> SyncLocalFuture<'_, LocalStreamSnapshot>;
+    fn save_snapshot(&self, snapshot: LocalSnapshotBatch) -> SyncLocalFuture<'_, ()>;
+    fn apply_changes(&self, changes: LocalChangeBatch) -> SyncLocalFuture<'_, ()>;
+    fn enqueue_mutation(
+        &self,
+        stream: &SyncStreamName,
+        mutation: ClientMutation<serde_json::Value>,
+    ) -> SyncLocalFuture<'_, ()>;
+    fn mark_push_result(&self, result: LocalPushResult) -> SyncLocalFuture<'_, ()>;
+    fn pending_mutations(
+        &self,
+        stream: &SyncStreamName,
+    ) -> SyncLocalFuture<'_, Vec<ClientMutation<serde_json::Value>>>;
 }
 ```
 


### PR DESCRIPTION
## Summary
- add the `SyncLocalStore` contract, memory implementation, and sync client wiring for local hydration and pending mutation replay
- add `pocopine-sync-sqlite` with native SQLite and browser OPFS-backed SQLite stores
- persist push/pull results incrementally and preserve pending mutation enqueue order across reloads
- document the local-first sync plan and add example/test coverage

## Verification
- `cargo fmt`
- `cargo test -p pocopine-sync`
- `cargo test -p pocopine-sync-sqlite`
- `cargo check -p pocopine-sync-sqlite --target wasm32-unknown-unknown`
- `cargo clippy -p pocopine-sync -p pocopine-sync-sqlite --all-targets -- -D warnings`
- `git diff --check`