### PR TITLE
Add SQLite-backed Keep sync example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2239,6 +2239,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "keep-example"
+version = "0.1.0"
+dependencies = [
+ "http-body-util",
+ "js-sys",
+ "pine",
+ "pine-icons",
+ "pine-motion",
+ "pocopine",
+ "pocopine-events",
+ "pocopine-live",
+ "pocopine-logging",
+ "pocopine-server",
+ "pocopine-sync",
+ "pocopine-sync-sqlite",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower",
+ "tracing",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "konst"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
     "examples/charts",
     "examples/counter",
     "examples/hn",
+    "examples/keep",
     "examples/live",
     "examples/observability-frontend",
     "examples/observability-smoke",

--- a/examples/keep/Cargo.toml
+++ b/examples/keep/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "keep-example"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[package.metadata.pocopine]
+bin = "server"
+port = 3022
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[[bin]]
+name = "server"
+path = "src/bin/server.rs"
+required-features = []
+
+[dependencies]
+pine = { path = "../../crates/pine" }
+pine-icons = { path = "../../crates/pine-icons" }
+pocopine = { path = "../../crates/pocopine" }
+pocopine-sync = { workspace = true }
+serde = { workspace = true }
+tracing = { workspace = true }
+wasm-bindgen = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+js-sys = { workspace = true }
+pine-motion = { path = "../../crates/pine-motion" }
+pocopine-sync-sqlite = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+pocopine-events = { workspace = true }
+pocopine-live = { workspace = true }
+pocopine-logging = { workspace = true }
+pocopine-server = { workspace = true }
+rusqlite = { version = "0.32", features = ["bundled"] }
+serde_json = { workspace = true }
+tokio = { version = "1", features = ["rt-multi-thread", "macros", "net"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+http-body-util = "0.1"
+serde_json = "1"
+tower = { version = "0.5", features = ["util"] }

--- a/examples/keep/DEVELOPMENT.md
+++ b/examples/keep/DEVELOPMENT.md
@@ -1,0 +1,473 @@
+# Building a Real Pocopine App
+
+This guide captures the development process behind the Keep example. It is
+not a feature tour. It is the set of practices that kept the example from
+turning into a tangle of duplicated state, brittle directives, and global CSS
+collisions.
+
+The short version:
+
+- design the data contract first,
+- keep durable UI state in one store,
+- keep small interaction state inside the component that owns it,
+- share semantic components instead of copying DOM,
+- keep directive expressions simple,
+- split CSS by owner, but remember that CSS is not scoped yet.
+
+## 1. Start With Data Contracts
+
+Before building the UI, define the synced payloads and streams. In this
+example those live in `src/model.rs`:
+
+- `KeepNote`
+- `KeepTodo`
+- `KeepTag`
+- `KEEP_STREAM` / `KEEP_COLLECTION`
+- `KEEP_TAGS_STREAM` / `KEEP_TAGS_COLLECTION`
+
+The payload shape should answer product questions before component questions:
+
+- Is a checklist a separate resource or part of a note?
+- Are labels just strings on notes, or queryable synced rows?
+- Does archive/pin belong to note state or view state?
+- Which fields need to survive refresh and sync to another browser?
+
+For Keep, todos are part of the note payload, but tags are a separate synced
+stream. That makes the sidebar queryable and durable even when a label has no
+visible notes in the current section.
+
+## 2. Use One Store as the App State Spine
+
+`KeepStore` owns durable app state:
+
+- synced note rows,
+- synced tag rows,
+- derived visible lists (`pinned_notes`, `other_notes`),
+- command/search state,
+- sidebar section state,
+- editor/composer open state,
+- selected note ids,
+- theme preference.
+
+The store is split by responsibility:
+
+- `store/mod.rs` contains the serialized state shape, defaults, and tests,
+- `store/actions.rs` contains UI-facing commands,
+- `store/mutations.rs` contains note/tag push plumbing,
+- `store/derived.rs` builds visible rows and label registries,
+- `store/labels.rs`, `store/theme.rs`, and `store/view.rs` hold pure helper
+  types and functions.
+
+Cross-cutting helpers live in `src/utils/`:
+
+- `utils/time.rs` owns timestamp helpers,
+- `utils/ui.rs` owns DOM focus and shared-layout transition helpers.
+
+This matters because Pocopine templates are easiest to reason about when
+views render already-shaped data. Avoid doing heavy filtering through nested
+`pp-for` plus `pp-if` in the template. Prefer deriving a list in the store,
+then rendering it directly:
+
+```rust
+store.rebuild_visible_notes();
+```
+
+Then the template can stay simple:
+
+```html
+<template pp-for="row in $store.keep.other_notes" pp-key="row.key">
+  <keep-note-card ...></keep-note-card>
+</template>
+```
+
+## 3. Keep Component State Local When It Is Truly Local
+
+Not every field belongs in `KeepStore`.
+
+Good local component state:
+
+- whether a card label popover is open,
+- the current query inside that card's label picker,
+- the current color popover open flag,
+- an active form edit buffer before save.
+
+Good store state:
+
+- the actual note list,
+- the actual label registry,
+- the active editor id,
+- whether the composer is open,
+- selected notes for multi-select,
+- command palette state.
+
+Rule of thumb: if another component needs to render or mutate it, put it in
+the store. If it only describes a tiny interaction inside one component, keep
+it local.
+
+## 4. Split Components by Ownership
+
+The current component split is intentional:
+
+| Component | Owns |
+| --- | --- |
+| `KeepBoard` | App shell, sync wiring, command dialog, sections, selection bar |
+| `KeepComposer` | Collapsed/expanded create-note shell |
+| `KeepEditor` | Modal shell and editor focus behavior |
+| `KeepNoteForm` | Shared active edit buffer and save/archive dispatch |
+| `KeepNoteBody` | Text body vs checklist body editing |
+| `KeepNoteCard` | One masonry card and its card-local actions |
+
+The important part is that `KeepComposer` and `KeepEditor` both use the same
+`KeepNoteForm`. They do not each define their own title field, body field,
+label picker, color picker, and toolbar.
+
+That avoids the classic bug where editing works in the modal but not the
+composer, or labels work in cards but not in the editor.
+
+## 5. Share Semantics, Not Layout Flags
+
+The shared form needs to know whether it is creating a draft or updating an
+existing note. That is semantic.
+
+It should not need to know whether it is currently displayed inside a modal
+or an inline composer. That is layout.
+
+Good:
+
+```rust
+KeepNoteFormContext { mode: "draft" }
+KeepNoteFormContext { mode: "editor" }
+```
+
+Avoid:
+
+```rust
+KeepNoteFormContext { surface: "modal" }
+KeepNoteFormContext { surface: "composer" }
+```
+
+The shell should provide size, placement, backdrop, and available scroll
+space. The form should provide the same fields and commands everywhere.
+
+## 6. Use Providers for Stable Semantic Context
+
+Providers are useful for static configuration at component setup time. In
+this example:
+
+- `KeepComposer` provides `mode = "draft"`,
+- `KeepEditor` provides `mode = "editor"`,
+- `KeepNoteForm` injects that mode once during setup.
+
+Do not use providers as a replacement for active payload updates. If the
+active note changes, use store watchers or props/models. The form watches
+`editor_open`, `editor_id`, and `editor_pinned` because those are live app
+state changes.
+
+## 7. Prefer One Edit Buffer
+
+The form owns one local edit buffer:
+
+- `title`
+- `body`
+- `kind`
+- `color`
+- `todos`
+- `labels`
+- `pinned`
+
+On save it emits a typed `KeepFormNote` into `KeepStore`.
+
+This is cleaner than binding every input directly to global store fields.
+Direct global binding makes cancel/rollback harder and tends to leak partial
+input state into unrelated UI.
+
+The flow is:
+
+1. Open composer or editor.
+2. Load the local form buffer.
+3. Let fields edit local component state.
+4. On save, collect a `KeepFormNote`.
+5. Let `KeepStore` create/update/archive and push the sync mutation.
+
+## 8. Keep Directive Expressions Small
+
+Pocopine directive expressions are Rust-oriented, not JavaScript template
+expressions. Keep complex logic in handlers and store methods.
+
+Prefer:
+
+```html
+<button @click="toggle_kind">...</button>
+```
+
+with Rust:
+
+```rust
+pub fn toggle_kind(&mut self) {
+    ...
+}
+```
+
+Avoid packing workflow logic into template expressions. It becomes harder to
+debug, harder to type-check mentally, and more likely to expose parser/runtime
+edge cases.
+
+## 9. Use `pp-model:value` With Pine Inputs
+
+Pine form primitives expose named component models. For `pine-input` and
+`pine-textarea`, bind their `value` model:
+
+```html
+<pine-input pp-model:value="title"></pine-input>
+<pine-textarea pp-model:value="body"></pine-textarea>
+```
+
+For native inputs inside a template, `pp-model` is still fine:
+
+```html
+<input pp-model="$store.keep.command_label_query">
+```
+
+If a form opens but fields are blank, inspect the rendered DOM and confirm
+that the actual native `input` or `textarea` exists and has the expected
+value. In this app, that caught several form-split mistakes quickly.
+
+## 10. Derive Lists Before Rendering
+
+The cards originally looked tempting to render as:
+
+```html
+<template pp-for="row in rows">
+  <template pp-if="row.value.pinned">...</template>
+</template>
+```
+
+That puts filtering, grouping, and rendering in the template. It also makes
+blank-list bugs harder to diagnose because a row may exist but fail an inner
+condition.
+
+The current pattern is better:
+
+- `KeepStore::rebuild_visible_notes` computes `pinned_notes` and
+  `other_notes`,
+- the template renders each list directly,
+- tests cover the section/archive/label filtering rules.
+
+## 11. Labels Must Be Data, Not Decorations
+
+Labels appear as chips on notes, but they are also navigation and search
+data. That means they cannot only live inside a note payload.
+
+The Keep example uses:
+
+- labels attached to notes,
+- a synced tag stream,
+- a registry rebuilt from both sources,
+- backfill for labels found on hydrated notes but missing from the tag stream.
+
+This prevents the sidebar from losing labels after a refresh.
+
+## 12. Local Storage Is for Preferences, SQLite Is for Sync Data
+
+Use typed `LocalStorage` for tiny preferences:
+
+- theme,
+- small UI preferences,
+- values that are safe to lose or reset.
+
+Use the sync local store for sync data:
+
+- rows,
+- cursors,
+- pending mutations,
+- durable offline state.
+
+Do not put synced rows in browser `localStorage`. Keep that path typed and
+small.
+
+## 13. CSS Split Pattern
+
+Use the same three-file component shape:
+
+```text
+components/note_card/
+  KeepNoteCard.poco
+  KeepNoteCard.css
+  mod.rs
+```
+
+Then point the component macro at the CSS:
+
+```rust
+#[component(style = "KeepNoteCard.css")]
+pub struct KeepNoteCard { ... }
+```
+
+Keep board-owned app styles in `components/board/KeepBoard.css`:
+
+- theme variables,
+- body/app shell,
+- topbar,
+- sidebar,
+- command dialog,
+- masonry grid,
+- selection bar,
+- shared utility classes.
+
+Move component-owned styles into component CSS:
+
+- composer chrome in `KeepComposer.css`,
+- form fields/toolbars in `KeepNoteForm.css`,
+- checklist/body editing in `KeepNoteBody.css`,
+- card layout/actions in `KeepNoteCard.css`,
+- modal shell in `KeepEditor.css`.
+
+## 14. CSS Is Split, Not Scoped
+
+Important: component CSS is not isolated today.
+
+`#[component(style = "...")]` injects a normal global `<style>` tag. Splitting
+CSS improves ownership, but selectors can still collide.
+
+Avoid generic component selectors:
+
+```css
+.button { ... }
+.title { ... }
+.body { ... }
+```
+
+Prefer component-specific classes:
+
+```css
+.note-form-foot { ... }
+.note-select { ... }
+.cmd-inline-input { ... }
+```
+
+or host-qualified selectors when that makes ownership clearer:
+
+```css
+keep-note-card .note-actions { ... }
+```
+
+Scoped component CSS is tracked separately in:
+
+- <https://github.com/mambisi/pocopine/issues/79>
+- `docs/poco/03-scoped-styles.md`
+
+Until that lands, CSS split is an organization tool, not a safety boundary.
+
+## 15. Popovers, Dropdowns, and Portals
+
+Pine popovers/dropdowns may render content through portals. Any selector that
+depends on the DOM ancestry of the trigger can break when content is portaled.
+
+Prefer styling portal content through stable classes on the content itself:
+
+```html
+<pine-popover-content class="label-pop">...</pine-popover-content>
+```
+
+and:
+
+```css
+.label-pop { ... }
+```
+
+This is another reason scoped CSS needs an explicit portal story before it
+becomes the default.
+
+## 16. Click-Through and Toolbar Rules
+
+Cards open on click, but toolbar buttons inside cards should not open the
+card. Use `@pointerdown.stop` and `@click.stop` on card toolbars and action
+buttons that should consume the event.
+
+The pattern is:
+
+```html
+<div class="note-actions" @pointerdown.stop @click.stop>
+  ...
+</div>
+```
+
+Use this for:
+
+- color picker buttons,
+- label picker buttons,
+- archive/delete actions,
+- multi-select controls.
+
+## 17. Verify With the Browser
+
+For this app, Rust checks are necessary but not enough. Several real bugs
+were only visible after mount:
+
+- blank editor fields after component extraction,
+- click-through from card toolbar buttons,
+- missing labels after refresh,
+- CSS selector misses after splitting Pine input/textarea styles,
+- OPFS failures without cross-origin isolation headers.
+
+Minimum verification after UI changes:
+
+```bash
+cargo check -p keep-example
+cargo check -p keep-example --target wasm32-unknown-unknown
+cargo test -p keep-example
+wasm-pack build --target web --dev
+```
+
+Then run the example:
+
+```bash
+cargo run -p pocopine-cli -- dev --path examples/keep
+```
+
+Browser smoke checklist:
+
+- create a text note,
+- create a checklist note,
+- open and close the editor,
+- verify title/body/todos populate,
+- change color,
+- add/remove a label,
+- refresh the page and confirm notes and labels remain,
+- open a second tab and confirm live wake-up pulls changes,
+- use the command dialog for search and inline label creation,
+- try multi-select actions,
+- inspect the console for wasm panics.
+
+## 18. When Something Goes Blank
+
+Use this order:
+
+1. Inspect the rendered DOM. Is the element missing, hidden, or empty?
+2. Check whether the store has the data.
+3. Check whether the component local buffer loaded from the store.
+4. Check whether the template binds the right model name.
+5. Check whether a `pp-if` destroyed and recreated the subtree.
+6. Check whether a CSS selector is targeting the custom element instead of
+   the native input rendered inside it, or the reverse.
+
+Do not guess from the Rust code alone. In Pocopine, the generated DOM is part
+of the truth.
+
+## 19. Commit Boundaries
+
+Good commit boundaries for an app like this:
+
+- data model and sync stream,
+- store state and derived lists,
+- component shells,
+- shared form extraction,
+- local persistence,
+- labels/tag stream,
+- command dialog,
+- multi-select,
+- CSS split,
+- docs.
+
+Keep each commit runnable. If a refactor breaks editor population or card
+rendering halfway through, finish the repair before committing.

--- a/examples/keep/README.md
+++ b/examples/keep/README.md
@@ -1,0 +1,63 @@
+# Keep Example
+
+Google Keep-style app showing Pocopine sync + the durable
+SQLite/OPFS local store in a real application shape.
+
+It demonstrates:
+
+- **durable browser local storage** through `pocopine-sync-sqlite`
+  (OPFS-backed SQLite); cached rows and pending mutations survive
+  page reloads,
+- a `KeepStore` `#[store]` that owns every durable UI field, paired
+  with small components (`KeepBoard`, `KeepComposer`, `KeepNoteForm`,
+  `KeepNoteBody`, `KeepNoteCard`, `KeepEditor`) and `pine-icons` for
+  every glyph,
+- optimistic sync pushes with live wake-up refreshes,
+- a mixed note/checklist payload on one sync stream plus a separate
+  synced tag stream for queryable labels. The sidebar registry is
+  rebuilt from the tag stream and any labels already attached to
+  hydrated notes, then missing labels are backfilled into the tag
+  stream so refreshes do not lose the navigation list,
+- a small memory-backed server stream so the example runs locally
+  without database setup.
+
+Run it with the CLI:
+
+```bash
+cargo run -p pocopine-cli -- dev --path examples/keep
+```
+
+Open the app in two browser tabs. Creating, pinning, archiving, or
+checking todo items in one tab wakes the other tab over SSE; the
+data itself is fetched from `__pocopine/sync/v1/pull`. Browser rows
+and pending mutations survive reloads through the SQLite OPFS local
+store.
+
+The server sets `Cross-Origin-Opener-Policy` and
+`Cross-Origin-Embedder-Policy` headers because SQLite's OPFS VFS
+needs a cross-origin-isolated browser context. If those headers are
+removed, the app still opens and network sync still works, but
+durable local SQLite hydration will fail with `no such vfs: opfs`.
+
+The server side uses a small rusqlite-backed stream source that stores
+rows, row versions, incremental changes, and accepted mutation ids in
+SQLite files under
+`${TMPDIR}/pocopine_keep_notes.sqlite3` and
+`${TMPDIR}/pocopine_keep_tags.sqlite3`. Restarting the bin rehydrates
+from those databases, so notes and user-created tags survive
+`cargo run` cycles and clients can keep using incremental cursors
+across server restarts. Set `POCOPINE_KEEP_NOTES_DB_PATH` and
+`POCOPINE_KEEP_TAGS_DB_PATH` when you want to isolate a dev or test
+run from those default databases.
+
+The development guide in [`DEVELOPMENT.md`](./DEVELOPMENT.md) explains
+the app-building process behind this example: state ownership,
+component boundaries, shared form extraction, directive pitfalls, CSS
+splitting, and browser verification.
+
+Checks:
+
+```bash
+cargo test -p keep-example
+cargo check -p keep-example --target wasm32-unknown-unknown
+```

--- a/examples/keep/build.rs
+++ b/examples/keep/build.rs
@@ -1,0 +1,9 @@
+fn main() {
+    println!("cargo:rustc-check-cfg=cfg(pocopine_browser)");
+    println!("cargo:rustc-check-cfg=cfg(pocopine_host)");
+
+    match std::env::var("CARGO_CFG_TARGET_ARCH").as_deref() {
+        Ok("wasm32") => println!("cargo:rustc-cfg=pocopine_browser"),
+        _ => println!("cargo:rustc-cfg=pocopine_host"),
+    }
+}

--- a/examples/keep/index.html
+++ b/examples/keep/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="icon" href="data:," />
+  <title>Pocopine Keep</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    rel="stylesheet"
+    href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap"
+  />
+</head>
+<body>
+  <div pp-app>
+    <keep-board></keep-board>
+  </div>
+  <script type="module">
+    import init from "/pkg/keep_example.js";
+    init();
+  </script>
+</body>
+</html>

--- a/examples/keep/src/app.rs
+++ b/examples/keep/src/app.rs
@@ -1,0 +1,79 @@
+use pocopine::prelude::*;
+
+use crate::{
+    KeepBoard, KeepComposer, KeepEditor, KeepNoteBody, KeepNoteCard, KeepNoteForm, KeepStore,
+};
+
+fn sync_client_plugin() -> pocopine_sync::SyncClientPlugin {
+    // Durable browser-side cache via OPFS-backed SQLite is the whole
+    // point of the keep example. No memory-store fallback — if the
+    // SQLite/OPFS path can't initialize, sync will surface the error
+    // rather than silently degrade to a non-durable store.
+    pocopine_sync::sync_plugin()
+        .with_live_wakeup(true)
+        .local_store(pocopine_sync_sqlite::SqliteLocalStore::new())
+}
+
+#[wasm_bindgen(start)]
+pub fn main() {
+    pine_icons::register_icons![
+        "menu-2",
+        "search",
+        "x",
+        "refresh",
+        "settings",
+        "moon",
+        "sun",
+        "tag",
+        "archive",
+        "copy",
+        "dots-vertical",
+        "pin",
+        filled / "pin",
+        "bulb",
+        filled / "bulb",
+        filled / "christmas-tree",
+        "palette",
+        "plus",
+        "check",
+        "list-check",
+        "notes",
+        "pencil",
+        "photo",
+        "trash",
+        "bell",
+        "user",
+        "corner-down-right",
+    ];
+    App::new()
+        .plugin(sync_client_plugin())
+        .store::<KeepStore>()
+        .register::<pine_icons::PineIcon>()
+        .register::<pine::PineCommandRoot>()
+        .register::<pine::PineCommandPortal>()
+        .register::<pine::PineCommandOverlay>()
+        .register::<pine::PineCommandContent>()
+        .register::<pine::PineCommandInput>()
+        .register::<pine::PineCommandList>()
+        .register::<pine::PineCommandItem>()
+        .register::<pine::PineCommandEmpty>()
+        .register::<pine::PineDropdownMenuRoot>()
+        .register::<pine::PineDropdownMenuTrigger>()
+        .register::<pine::PineDropdownMenuPortal>()
+        .register::<pine::PineDropdownMenuContent>()
+        .register::<pine::PineDropdownMenuItem>()
+        .register::<pine::PineDropdownMenuSeparator>()
+        .register::<pine::PineDropdownMenuLabel>()
+        .register::<pine::PineInput>()
+        .register::<pine::PinePopoverRoot>()
+        .register::<pine::PinePopoverTrigger>()
+        .register::<pine::PinePopoverPortal>()
+        .register::<pine::PinePopoverContent>()
+        .register::<KeepBoard>()
+        .register::<KeepComposer>()
+        .register::<KeepNoteCard>()
+        .register::<KeepEditor>()
+        .register::<KeepNoteForm>()
+        .register::<KeepNoteBody>()
+        .run();
+}

--- a/examples/keep/src/bin/server.rs
+++ b/examples/keep/src/bin/server.rs
@@ -1,0 +1,59 @@
+#[cfg(pocopine_host)]
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    use keep_example::{__reset_keep_notes_route, live_backend, sync_server};
+    use pocopine_live::{routes, LiveHub};
+    use pocopine_logging::init_default;
+    use pocopine_server::{axum, axum::Router, serve, static_files, Server};
+    use pocopine_sync::sync_server_plugin;
+
+    init_default().map_err(std::io::Error::other)?;
+
+    let sync = sync_server();
+    let sync_topics = sync.live_topics().map_err(std::io::Error::other)?;
+    let live_hub = LiveHub::new(live_backend())
+        .allow_topics(sync_topics.clone())
+        .default_topics(sync_topics);
+
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let router = Router::new()
+        .merge(routes(live_hub))
+        .fallback_service(static_files(manifest_dir))
+        .layer(axum::middleware::map_response(
+            cross_origin_isolation_headers,
+        ));
+    let router = Server::new(router)
+        .plugin(sync_server_plugin(sync))
+        .try_finalize()
+        .map_err(std::io::Error::other)?;
+    let router = __reset_keep_notes_route(router);
+
+    let addr = "127.0.0.1:3022";
+    tracing::info!(target: "pocopine.log", %addr, "serving keep example");
+    serve(router, addr).await
+}
+
+#[cfg(pocopine_browser)]
+fn main() {}
+
+#[cfg(pocopine_host)]
+async fn cross_origin_isolation_headers(
+    mut response: pocopine_server::axum::response::Response,
+) -> pocopine_server::axum::response::Response {
+    use pocopine_server::axum::http::header::{HeaderName, HeaderValue};
+
+    let headers = response.headers_mut();
+    headers.insert(
+        HeaderName::from_static("cross-origin-opener-policy"),
+        HeaderValue::from_static("same-origin"),
+    );
+    headers.insert(
+        HeaderName::from_static("cross-origin-embedder-policy"),
+        HeaderValue::from_static("require-corp"),
+    );
+    headers.insert(
+        HeaderName::from_static("cross-origin-resource-policy"),
+        HeaderValue::from_static("same-origin"),
+    );
+    response
+}

--- a/examples/keep/src/components/board/KeepBoard.css
+++ b/examples/keep/src/components/board/KeepBoard.css
@@ -1,0 +1,944 @@
+/* Keep — Notes & Todos */
+
+* { box-sizing: border-box; }
+
+:host,
+:root {
+  /* Keep's pastel palette (light) */
+  --c-default-bg: #ffffff;
+  --c-default-line: #e0e0e0;
+  --c-coral-bg:    #faafa8;
+  --c-peach-bg:    #f39f76;
+  --c-sand-bg:     #fff8b8;
+  --c-mint-bg:     #e2f6d3;
+  --c-sage-bg:     #b4ddd3;
+  --c-fog-bg:      #d4e4ed;
+  --c-storm-bg:    #aeccdc;
+  --c-dusk-bg:     #d3bfdb;
+  --c-blossom-bg: #f6e2dd;
+  --c-clay-bg:     #e9e3d4;
+  --c-chalk-bg:    #efeff1;
+
+  --bg-page: #fffbfa;
+  --fg: #202124;
+  --fg-2: #5f6368;
+  --fg-3: #80868b;
+  --line: #e8eaed;
+  --line-2: #dadce0;
+  --surface: #ffffff;
+  --surface-muted: #f1f3f4;
+  --surface-pop: #ffffff;
+  --hover: rgba(95,99,104,.12);
+  --scroll-thumb: rgba(95, 99, 104, .42);
+  --scroll-thumb-hover: rgba(95, 99, 104, .64);
+  --scrollbar-size: 8px;
+  --shadow-card: 0 0 0 1px rgba(0,0,0,.05);
+  --shadow-card-hover: 0 1px 2px 0 rgba(60,64,67,.30), 0 2px 6px 2px rgba(60,64,67,.15);
+  --shadow-pop: 0 2px 6px 2px rgba(60,64,67,.15), 0 1px 2px 0 rgba(60,64,67,.30);
+
+  /* Leaf-green accent — brand mark + selected sidebar pill. */
+  --accent: #34a853;
+  --accent-soft: #dcedc8;
+  --accent-on: #14532d;
+
+  /* Hover/chip overlays painted on top of a coloured card. Dark
+     pastels in light mode, light tints in dark mode. */
+  --card-overlay: rgba(0, 0, 0, .08);
+  --card-overlay-soft: rgba(0, 0, 0, .06);
+  --topbar-h: 64px;
+  --sb-w: 80px;
+  --sb-w-wide: 280px;
+  --r-card: 8px;
+  font-family:
+    "Geist", "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+}
+
+body {
+  margin: 0;
+  background: var(--bg-page);
+  color: var(--fg);
+  font-size: 14px;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body:has(.keep-app[data-theme="dark"]) {
+  --surface: #2b2c30;
+  --surface-muted: #303134;
+  --surface-pop: #25262a;
+  --fg: #e8eaed;
+  --fg-2: #bdc1c6;
+  --fg-3: #9aa0a6;
+  --line: #3c4043;
+  --line-2: #4b4f56;
+  --hover: rgba(232, 234, 237, .10);
+  --scroll-thumb: rgba(189, 193, 198, .42);
+  --scroll-thumb-hover: rgba(189, 193, 198, .66);
+  --shadow-pop: 0 8px 24px rgba(0, 0, 0, .35), 0 1px 2px rgba(0, 0, 0, .45);
+  --accent: #81c995;
+  --accent-soft: #1e3924;
+  --accent-on: #d7f3df;
+  background: #202124;
+  color: var(--fg);
+}
+
+.keep-app {
+  min-height: 100vh;
+  background: var(--bg-page);
+  color: var(--fg);
+}
+
+.keep-app[data-theme="dark"] {
+  --c-default-bg: #2b2c30;
+  --c-default-line: #4b4f56;
+  /* Keep's dark-mode palette — deeper, desaturated equivalents so
+     coloured cards, the composer, the editor modal, and the
+     swatch picker all read correctly on a dark page. The light
+     pastels otherwise pop blindingly off the dark background. */
+  --c-coral-bg:    #77172e;
+  --c-peach-bg:    #692b17;
+  --c-sand-bg:     #7c4a03;
+  --c-mint-bg:     #264d3b;
+  --c-sage-bg:     #0c625d;
+  --c-fog-bg:      #256377;
+  --c-storm-bg:    #284255;
+  --c-dusk-bg:     #472e5b;
+  --c-blossom-bg:  #6c394f;
+  --c-clay-bg:     #4b443a;
+  --c-chalk-bg:    #232427;
+  --bg-page: #202124;
+  --surface: #2b2c30;
+  --surface-muted: #303134;
+  --surface-pop: #25262a;
+  --fg: #e8eaed;
+  --fg-2: #bdc1c6;
+  --fg-3: #9aa0a6;
+  --line: #3c4043;
+  --line-2: #4b4f56;
+  --hover: rgba(232, 234, 237, .10);
+  --scroll-thumb: rgba(189, 193, 198, .42);
+  --scroll-thumb-hover: rgba(189, 193, 198, .66);
+  --card-overlay: rgba(255, 255, 255, .10);
+  --card-overlay-soft: rgba(255, 255, 255, .07);
+}
+
+.pine-command-list,
+.label-pop__list,
+.modal-note,
+.pine-textarea.note-body-input {
+  scrollbar-width: thin;
+  scrollbar-color: var(--scroll-thumb) transparent;
+}
+
+.pine-command-list::-webkit-scrollbar,
+.label-pop__list::-webkit-scrollbar,
+.modal-note::-webkit-scrollbar,
+.pine-textarea.note-body-input::-webkit-scrollbar {
+  width: var(--scrollbar-size);
+  height: var(--scrollbar-size);
+}
+
+.pine-command-list::-webkit-scrollbar-track,
+.label-pop__list::-webkit-scrollbar-track,
+.modal-note::-webkit-scrollbar-track,
+.pine-textarea.note-body-input::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.pine-command-list::-webkit-scrollbar-thumb,
+.label-pop__list::-webkit-scrollbar-thumb,
+.modal-note::-webkit-scrollbar-thumb,
+.pine-textarea.note-body-input::-webkit-scrollbar-thumb {
+  min-height: 32px;
+  border: 2px solid transparent;
+  border-radius: 999px;
+  background: var(--scroll-thumb);
+  background-clip: padding-box;
+}
+
+.pine-command-list::-webkit-scrollbar-thumb:hover,
+.label-pop__list::-webkit-scrollbar-thumb:hover,
+.modal-note::-webkit-scrollbar-thumb:hover,
+.pine-textarea.note-body-input::-webkit-scrollbar-thumb:hover {
+  background: var(--scroll-thumb-hover);
+  background-clip: padding-box;
+}
+
+.pine-command-list::-webkit-scrollbar-corner,
+.label-pop__list::-webkit-scrollbar-corner,
+.modal-note::-webkit-scrollbar-corner,
+.pine-textarea.note-body-input::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+/* Custom elements default to `display: inline`. Force block so they
+   honor `width: 100%` from their flex/masonry parents. */
+keep-composer,
+keep-editor,
+keep-note-form,
+keep-note-body,
+keep-note-card {
+  display: block;
+}
+keep-composer {
+  width: 100%;
+}
+keep-note-form,
+keep-note-body {
+  display: contents;
+}
+keep-note-card {
+  break-inside: avoid;
+  width: 100%;
+  margin: 0 0 16px;
+}
+
+button {
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  background: transparent;
+  border: 0;
+  padding: 0;
+}
+
+input,
+textarea {
+  font: inherit;
+  color: inherit;
+}
+
+/* ─── icon button ─── */
+
+.ic-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  color: var(--fg-2);
+  transition: background .12s, color .12s;
+}
+
+.ic-btn:hover {
+  background: var(--hover);
+  color: var(--fg);
+}
+
+.ic-btn.lg { width: 48px; height: 48px; }
+.ic-btn.sm { width: 32px; height: 32px; }
+
+/* ─── topbar ─── */
+
+.topbar {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  height: var(--topbar-h);
+  padding: 0 8px;
+  background: var(--surface);
+  border-bottom: 1px solid var(--line);
+}
+
+.tb-left {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: var(--sb-w);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 8px;
+  color: var(--fg-2);
+}
+
+.brand-mark {
+  display: inline-flex;
+  color: var(--accent);
+}
+
+.brand-word {
+  font-size: 22px;
+  font-weight: 500;
+  letter-spacing: .005em;
+  color: var(--fg-2);
+}
+
+.tb-command {
+  flex: 0 1 560px;
+  max-width: 560px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 6px 0 10px;
+  margin: 0 16px;
+  background: var(--surface-muted);
+  border: 1px solid transparent;
+  border-radius: 999px;
+  color: var(--fg-2);
+  text-align: left;
+  cursor: text;
+  transition:
+    background .15s ease,
+    border-color .15s ease,
+    box-shadow .15s ease,
+    color .15s ease;
+}
+
+.tb-command > pine-icon {
+  flex: 0 0 auto;
+  color: var(--fg-3);
+  transition: color .15s ease;
+}
+
+.tb-command:hover,
+.tb-command:focus-visible {
+  background: var(--surface);
+  border-color: var(--line-2);
+  box-shadow: 0 1px 2px 0 rgba(60, 64, 67, .12), 0 4px 12px -4px rgba(60, 64, 67, .12);
+  color: var(--fg);
+  outline: 0;
+}
+
+.tb-command:hover > pine-icon,
+.tb-command:focus-visible > pine-icon {
+  color: var(--accent);
+}
+
+.tb-command span {
+  flex: 0 1 auto;
+  min-width: 0;
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: .005em;
+  text-align: left;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tb-command kbd,
+.pine-command-shortcut {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  height: 24px;
+  margin-left: auto;
+  padding: 0 8px;
+  font: 600 11px/1 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  border-radius: 6px;
+  border: 1px solid var(--line-2);
+  background: var(--surface);
+  color: var(--fg-2);
+  letter-spacing: .04em;
+}
+
+.tb-right {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
+  padding-left: 8px;
+}
+
+.tb-divider {
+  width: 1px;
+  height: 24px;
+  background: var(--line);
+  margin: 0 8px;
+}
+
+.avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, #f6e2dd, #d3bfdb);
+  color: #5e2750;
+  font-weight: 600;
+  font-size: 15px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 6px;
+}
+
+.pine-dm-trigger {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border: 0;
+  border-radius: 50%;
+  padding: 0;
+  background: transparent;
+  color: var(--fg-2);
+  cursor: pointer;
+  transition: background .12s, color .12s;
+}
+
+.pine-dm-trigger:hover,
+.pine-dm-trigger:focus-visible,
+.pine-dm-trigger[data-state="open"] {
+  background: var(--hover);
+  color: var(--fg);
+  outline: 0;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.pine-dm-content {
+  z-index: 60;
+  min-width: 220px;
+  margin: 0;
+  padding: 6px;
+  list-style: none;
+  background: var(--surface-pop);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  box-shadow: var(--shadow-pop);
+  color: var(--fg);
+}
+
+.pine-dm-label {
+  padding: 8px 10px 6px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .7px;
+  text-transform: uppercase;
+  color: var(--fg-3);
+}
+
+.pine-dm-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 36px;
+  padding: 0 10px;
+  border-radius: 6px;
+  color: var(--fg);
+  cursor: pointer;
+  outline: 0;
+}
+
+.pine-dm-item:hover,
+.pine-dm-item:focus {
+  background: var(--hover);
+}
+
+.pine-dm-separator {
+  display: block;
+  height: 1px;
+  margin: 6px 4px;
+  background: var(--line);
+}
+
+.pine-dm-item.danger,
+.pine-command-item.danger {
+  color: #b42318;
+}
+
+.keep-app[data-theme="dark"] .pine-dm-item.danger,
+body:has(.keep-app[data-theme="dark"]) .pine-command-item.danger {
+  color: #fda29b;
+}
+
+.pine-command-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: rgba(32, 33, 36, .45);
+}
+
+pine-command-content {
+  position: fixed;
+  inset: 0;
+  z-index: 1001;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: 18vh 16px 0;
+  pointer-events: none;
+}
+
+.pine-command-content {
+  width: min(640px, 100%);
+  max-height: min(620px, 72vh);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  pointer-events: auto;
+  background: var(--surface-pop);
+  border: 1px solid var(--line);
+  border-radius: 12px;
+  box-shadow: 0 24px 48px rgba(0, 0, 0, .24);
+  color: var(--fg);
+}
+
+.pine-command-input {
+  width: 100%;
+  height: 58px;
+  border: 0;
+  border-bottom: 1px solid var(--line);
+  outline: 0;
+  padding: 0 18px;
+  background: transparent;
+  color: var(--fg);
+  font: inherit;
+  font-size: 16px;
+}
+
+.pine-command-input::placeholder {
+  color: var(--fg-3);
+}
+
+.pine-command-list {
+  list-style: none;
+  margin: 0;
+  padding: 8px;
+  overflow-y: auto;
+}
+
+.pine-command-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 14px;
+  min-height: 44px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  color: var(--fg);
+  cursor: pointer;
+  outline: 0;
+}
+
+.pine-command-item[data-disabled="true"] {
+  cursor: default;
+}
+
+.pine-command-item[data-highlighted="true"] {
+  background: var(--hover);
+}
+
+.cmd-row {
+  display: flex;
+  align-items: center;
+  min-width: 0;
+  gap: 12px;
+}
+
+.cmd-row > span {
+  flex: 1;
+  min-width: 0;
+}
+
+.cmd-kbd {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 22px;
+  height: 22px;
+  padding: 0 6px;
+  border: 1px solid var(--line-2);
+  border-radius: 5px;
+  background: var(--surface-pop);
+  color: var(--fg-2);
+  font: 600 11px/1 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  letter-spacing: .04em;
+}
+
+.cmd-note strong,
+.cmd-note small {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.cmd-note strong {
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.cmd-note small {
+  max-width: 460px;
+  margin-top: 2px;
+  color: var(--fg-3);
+  font-size: 12px;
+}
+
+.cmd-label-create {
+  width: 100%;
+}
+
+.cmd-label-create > span {
+  flex: 0 0 auto;
+  color: var(--fg-2);
+  font-weight: 600;
+}
+
+.cmd-inline-create {
+  padding: 0 10px 8px 40px;
+}
+
+.cmd-inline-create .cmd-label-create {
+  gap: 10px;
+}
+
+.cmd-inline-create .cmd-label-create > pine-icon {
+  color: var(--fg-3);
+}
+
+.cmd-inline-input {
+  flex: 1;
+  min-width: 120px;
+  height: 32px;
+  border: 1px solid var(--line-2);
+  border-radius: 6px;
+  outline: 0;
+  padding: 0 10px;
+  background: var(--surface);
+  color: var(--fg);
+  font: inherit;
+}
+
+.cmd-inline-input:focus {
+  border-color: #1a73e8;
+  box-shadow: 0 0 0 2px rgba(26, 115, 232, .16);
+}
+
+.cmd-inline-action {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 6px;
+  color: var(--fg-2);
+}
+
+.cmd-inline-action:hover,
+.cmd-inline-action:focus-visible {
+  background: var(--hover);
+  color: var(--fg);
+}
+
+.cmd-separator {
+  height: 1px;
+  margin: 8px 4px;
+  background: var(--line);
+}
+
+.pine-command-empty {
+  padding: 20px 12px;
+  color: var(--fg-3);
+  text-align: center;
+}
+
+/* ─── shell + sidebar ─── */
+
+.shell {
+  display: flex;
+  min-height: calc(100vh - var(--topbar-h));
+}
+
+.sidebar {
+  position: sticky;
+  top: var(--topbar-h);
+  flex-shrink: 0;
+  width: var(--sb-w);
+  height: calc(100vh - var(--topbar-h));
+  padding-top: 8px;
+  overflow: hidden;
+  transition: width .2s cubic-bezier(.4, 0, .2, 1);
+}
+
+.sidebar[data-wide="true"] { width: var(--sb-w-wide); }
+
+.sb-row {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 22px;
+  width: calc(var(--sb-w-wide) - 16px);
+  height: 48px;
+  padding: 0 29px;
+  border-radius: 0 24px 24px 0;
+  margin: 0 16px 4px 0;
+  color: var(--fg-2);
+  font-size: 14px;
+  font-weight: 500;
+  white-space: nowrap;
+  transition: color .12s;
+}
+
+.sb-row::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  border-radius: 50%;
+  background: transparent;
+  transition:
+    left .2s cubic-bezier(.4, 0, .2, 1),
+    width .2s cubic-bezier(.4, 0, .2, 1),
+    border-radius .2s cubic-bezier(.4, 0, .2, 1),
+    background .12s;
+}
+
+.sidebar[data-wide="true"] .sb-row::before {
+  left: 0;
+  width: 100%;
+  border-radius: 0 24px 24px 0;
+}
+
+.sidebar:not([data-wide="true"]) .sb-row::before {
+  left: 16px;
+  width: 48px;
+  border-radius: 50%;
+}
+
+.sb-row > * {
+  position: relative;
+  z-index: 1;
+}
+
+.sb-row:not([disabled]):hover {
+  color: var(--fg);
+}
+
+.sb-row:not([disabled]):hover::before { background: var(--hover); }
+
+.sb-row[disabled] {
+  cursor: default;
+  opacity: 0.7;
+}
+
+.sb-row[data-on="true"] {
+  color: var(--accent-on);
+}
+
+.sb-row[data-on="true"]::before { background: var(--accent-soft); }
+
+.sb-ic {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 22px;
+}
+
+.sb-lbl {
+  flex: 0 0 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-align: left;
+  opacity: 1;
+  transform: translateX(0);
+  transition:
+    opacity .12s,
+    transform .2s cubic-bezier(.4, 0, .2, 1);
+}
+
+.sidebar:not([data-wide="true"]) .sb-lbl {
+  opacity: 0;
+  transform: translateX(-8px);
+  pointer-events: none;
+}
+.sb-lbl--quiet { color: var(--fg-3); }
+
+/* ─── main ─── */
+
+.main {
+  flex: 1;
+  min-width: 0;
+  padding: 32px 16px 80px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.section-title {
+  width: 100%;
+  max-width: 1240px;
+  margin: 0 0 16px;
+  font-size: 22px;
+  font-weight: 500;
+  letter-spacing: -.005em;
+  color: var(--fg);
+  padding: 0 16px;
+}
+
+.error {
+  width: 100%;
+  max-width: 1240px;
+  margin: 0 auto 12px;
+  padding: 8px 14px;
+  border-radius: 8px;
+  background: #fff4f4;
+  border: 1px solid #f3c8c4;
+  color: #9a3412;
+  font-weight: 600;
+}
+
+/* ─── grid sections ─── */
+
+.grid-section {
+  width: 100%;
+  max-width: 1240px;
+  margin: 0 auto 24px;
+  padding: 0 16px;
+}
+
+.grid-h {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: .9px;
+  color: var(--fg-2);
+  text-transform: uppercase;
+  margin: 4px 0 14px;
+  padding: 0 4px;
+}
+
+/* CSS columns masonry */
+.masonry {
+  column-count: 4;
+  column-gap: 16px;
+}
+
+@media (max-width: 1380px) { .masonry { column-count: 3; } }
+@media (max-width: 1080px) { .masonry { column-count: 2; } }
+@media (max-width: 720px)  { .masonry { column-count: 1; } }
+
+/* ─── multi-select floating menu ─── */
+
+.selection-bar {
+  position: fixed;
+  left: 50%;
+  bottom: 24px;
+  z-index: 900;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-height: 52px;
+  padding: 6px 8px 6px 14px;
+  border: 1px solid color-mix(in srgb, var(--line-2) 80%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--surface-pop) 94%, transparent);
+  box-shadow:
+    0 18px 48px rgba(0, 0, 0, .22),
+    0 2px 8px rgba(0, 0, 0, .12);
+  color: var(--fg);
+  transform: translateX(-50%);
+  backdrop-filter: blur(14px);
+  animation: keep-selection-pop .16s cubic-bezier(.2, .9, .3, 1.05);
+}
+
+@keyframes keep-selection-pop {
+  from { opacity: 0; transform: translate(-50%, 8px) scale(.96); }
+  to   { opacity: 1; transform: translate(-50%, 0) scale(1); }
+}
+
+.selection-bar__count {
+  min-width: 82px;
+  padding: 0 8px 0 2px;
+  color: var(--fg-2);
+  font-size: 13px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.selection-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 38px;
+  height: 38px;
+  border-radius: 999px;
+  color: var(--fg-2);
+  transition: background .12s, color .12s;
+}
+
+.selection-action:hover {
+  background: var(--hover);
+  color: var(--fg);
+}
+
+.selection-action.danger {
+  color: #c2410c;
+}
+
+.keep-app[data-theme="dark"] .selection-action.danger {
+  color: #fca5a5;
+}
+
+.selection-divider {
+  width: 1px;
+  height: 24px;
+  margin: 0 4px;
+  background: var(--line-2);
+}
+
+/* ─── empty ─── */
+
+.empty {
+  margin: 80px auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  color: var(--fg-3);
+  gap: 12px;
+}
+
+.empty p {
+  font-size: 22px;
+  font-weight: 400;
+  margin: 0;
+}
+
+.empty svg {
+  color: var(--fg-3);
+  opacity: 0.45;
+}
+
+/* ─── prevent text selection on chrome ─── */
+
+.topbar,
+.sidebar,
+.note-actions,
+.selection-bar,
+.note-form-foot,
+.palette {
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+/* allow text selection inside editable surfaces */
+.pine-input.note-title-input,
+.pine-textarea.note-body-input,
+.cl-txt {
+  -webkit-user-select: text;
+  user-select: text;
+}

--- a/examples/keep/src/components/board/KeepBoard.poco
+++ b/examples/keep/src/components/board/KeepBoard.poco
@@ -1,0 +1,251 @@
+<div class="keep-app" :data-theme="$store.keep.theme">
+  <header class="topbar">
+    <div class="tb-left">
+      <button class="ic-btn lg" aria-label="Menu" @click="toggle_sidebar">
+        <pine-icon name="menu-2" size="22"></pine-icon>
+      </button>
+      <div class="brand">
+        <span class="brand-mark" aria-hidden="true">
+          <pine-icon name="christmas-tree" variant="filled" size="26"></pine-icon>
+        </span>
+        <span class="brand-word">Keep</span>
+      </div>
+    </div>
+
+    <button class="tb-command" type="button" aria-label="Search notes" @click="open_command">
+      <pine-icon name="search" size="20"></pine-icon>
+      <span>Search notes</span>
+      <kbd>⌘K</kbd>
+    </button>
+
+    <div class="tb-right">
+      <button class="ic-btn" aria-label="Pull" @click="refresh">
+        <pine-icon name="refresh" size="20"></pine-icon>
+      </button>
+      <pine-dropdown-menu-root>
+        <pine-dropdown-menu-trigger>
+          <pine-icon name="settings" size="20"></pine-icon>
+          <span class="sr-only">Settings</span>
+        </pine-dropdown-menu-trigger>
+        <pine-dropdown-menu-portal>
+          <pine-dropdown-menu-content class="keep-menu" side="bottom" align="end" side_offset="8">
+            <pine-dropdown-menu-label>Workspace</pine-dropdown-menu-label>
+            <pine-dropdown-menu-item @click="toggle_theme">
+              <pine-icon :name="$store.keep.theme == 'dark' ? 'sun' : 'moon'" size="18"></pine-icon>
+              <span pp-text="$store.keep.theme == 'dark' ? 'Change theme: light' : 'Change theme: dark'"></span>
+            </pine-dropdown-menu-item>
+            <pine-dropdown-menu-separator></pine-dropdown-menu-separator>
+            <pine-dropdown-menu-item class="danger" @click="delete_all_notes">
+              <pine-icon name="trash" size="18"></pine-icon>
+              <span>Reset database</span>
+            </pine-dropdown-menu-item>
+          </pine-dropdown-menu-content>
+        </pine-dropdown-menu-portal>
+      </pine-dropdown-menu-root>
+      <span class="avatar" aria-label="Account">M</span>
+    </div>
+  </header>
+
+  <pine-command-root shortcut="Mod+k" pp-model:open="command_open">
+    <pine-command-portal>
+      <pine-command-overlay></pine-command-overlay>
+      <pine-command-content class="keep-command" pp-transition="none">
+        <pine-command-input placeholder="Search notes or create…"></pine-command-input>
+        <pine-command-list>
+          <pine-command-item value="new note create text" @pp:command:select="cmd_new_note">
+            <span class="cmd-row">
+              <pine-icon name="pencil" size="18"></pine-icon>
+              <span>New note</span>
+              <kbd class="cmd-kbd">C</kbd>
+            </span>
+          </pine-command-item>
+          <pine-command-item value="new todo checklist list task" @pp:command:select="cmd_new_todo">
+            <span class="cmd-row">
+              <pine-icon name="list-check" size="18"></pine-icon>
+              <span>New todo</span>
+              <kbd class="cmd-kbd">L</kbd>
+            </span>
+          </pine-command-item>
+          <pine-command-item value="new label tag add label create" @pp:command:select.prevent="cmd_show_label_create">
+            <span class="cmd-row cmd-label-create">
+              <pine-icon name="tag" size="18"></pine-icon>
+              <span>Create new label</span>
+            </span>
+          </pine-command-item>
+
+          <div class="cmd-inline-create" pp-show="command_label_create_open" role="group" aria-label="Create new label">
+            <span class="cmd-row cmd-label-create">
+              <pine-icon name="corner-down-right" size="18"></pine-icon>
+              <input
+                class="cmd-inline-input"
+                placeholder="Label name"
+                pp-model="$store.keep.command_label_query"
+                @click.stop
+                @pointerdown.stop
+                @keydown.enter.prevent.stop="cmd_create_label_inline"
+              />
+              <button
+                class="cmd-inline-action"
+                aria-label="Create label"
+                @click.stop="cmd_create_label_inline"
+                @pointerdown.stop
+              >
+                <pine-icon name="plus" size="14"></pine-icon>
+              </button>
+            </span>
+          </div>
+
+          <div class="cmd-separator" role="separator" aria-hidden="true"></div>
+
+          <template pp-for="note in $store.keep.command_notes" pp-key="note.id">
+            <pine-command-item
+              :value="note.search_value"
+              @pp:command:select="cmd_open_note(note.id)"
+            >
+              <span class="cmd-row cmd-note">
+                <pine-icon :name="note.has_todos ? 'list-check' : 'notes'" size="18"></pine-icon>
+                <span>
+                  <strong pp-text="note.title || 'Untitled note'"></strong>
+                  <small pp-text="note.body"></small>
+                </span>
+              </span>
+            </pine-command-item>
+          </template>
+
+          <pine-command-empty>No matching notes or actions.</pine-command-empty>
+        </pine-command-list>
+      </pine-command-content>
+    </pine-command-portal>
+  </pine-command-root>
+
+  <div class="shell">
+    <aside class="sidebar" :data-wide="$store.keep.sidebar_expanded">
+      <button class="sb-row" :data-on="$store.keep.section_kind == 'notes'" @click="show_notes">
+        <span class="sb-ic" aria-hidden="true"><pine-icon name="bulb" size="22"></pine-icon></span>
+        <span class="sb-lbl">Notes</span>
+      </button>
+
+      <template pp-for="label in $store.keep.labels" pp-key="label">
+        <button
+          class="sb-row"
+          :data-on="$store.keep.section_kind == 'label' && $store.keep.section_label == label"
+          @click="show_label(label)"
+        >
+          <span class="sb-ic" aria-hidden="true"><pine-icon name="tag" size="22"></pine-icon></span>
+          <span class="sb-lbl" pp-text="label"></span>
+        </button>
+      </template>
+
+      <button class="sb-row" :data-on="$store.keep.section_kind == 'archive'" @click="show_archive">
+        <span class="sb-ic" aria-hidden="true"><pine-icon name="archive" size="22"></pine-icon></span>
+        <span class="sb-lbl">Archive</span>
+      </button>
+    </aside>
+
+    <main class="main">
+      <p class="error" pp-show="$store.keep.notes.error" pp-text="$store.keep.notes.error"></p>
+
+      <keep-composer pp-show="$store.keep.section_kind == 'notes'"></keep-composer>
+
+      <h2 class="section-title" pp-show="$store.keep.section_kind == 'archive'">Archive</h2>
+      <h2 class="section-title" pp-show="$store.keep.section_kind == 'label'" pp-text="$store.keep.section_label"></h2>
+
+      <section class="grid-section">
+        <div class="grid-h">PINNED</div>
+        <div class="masonry">
+          <template pp-for="row in $store.keep.pinned_notes" pp-key="row.key">
+            <keep-note-card
+              pp-bind:note-id="row.value.id"
+              pp-bind:title="row.value.title"
+              pp-bind:body="row.value.body"
+              pp-bind:color="row.value.color"
+              pp-bind:pinned="row.value.pinned"
+              pp-bind:archived="row.value.archived"
+              pp-bind:todos="row.value.todos"
+              pp-bind:labels="row.value.labels"
+              pp-bind:pending="row.pending"
+              pp-bind:conflict="row.conflict"
+              pp-bind:selected="row.selected"
+              pp-bind:selection-active="row.selection_active"
+            ></keep-note-card>
+          </template>
+        </div>
+      </section>
+
+      <section class="grid-section">
+        <div class="grid-h">OTHERS</div>
+        <div class="masonry">
+          <template pp-for="row in $store.keep.other_notes" pp-key="row.key">
+            <keep-note-card
+              pp-bind:note-id="row.value.id"
+              pp-bind:title="row.value.title"
+              pp-bind:body="row.value.body"
+              pp-bind:color="row.value.color"
+              pp-bind:pinned="row.value.pinned"
+              pp-bind:archived="row.value.archived"
+              pp-bind:todos="row.value.todos"
+              pp-bind:labels="row.value.labels"
+              pp-bind:pending="row.pending"
+              pp-bind:conflict="row.conflict"
+              pp-bind:selected="row.selected"
+              pp-bind:selection-active="row.selection_active"
+            ></keep-note-card>
+          </template>
+        </div>
+      </section>
+
+      <div class="empty" pp-show="!$store.keep.notes.loading && !$store.keep.pinned_notes.length && !$store.keep.other_notes.length">
+        <pine-icon name="bulb" size="120"></pine-icon>
+        <p>Notes you add appear here.</p>
+      </div>
+
+      <p class="empty" pp-show="$store.keep.notes.loading">Loading notes…</p>
+    </main>
+  </div>
+
+  <keep-editor></keep-editor>
+
+  <div class="selection-bar" pp-show="$store.keep.selected_note_ids.length" @pointerdown.stop @click.stop>
+    <span class="selection-bar__count" pp-text="$store.keep.selection_label"></span>
+
+    <button class="selection-action" aria-label="Pin selected" @click="pin_selected">
+      <pine-icon name="pin" size="18"></pine-icon>
+    </button>
+
+    <pine-popover-root pp-model:open="selection_color_open">
+      <pine-popover-trigger class="selection-action" aria-label="Background options">
+        <pine-icon name="palette" size="18"></pine-icon>
+      </pine-popover-trigger>
+      <pine-popover-portal>
+        <pine-popover-content class="palette palette--selection" side="top" align="center" side_offset="10">
+          <button class="sw sw-default" @click="pick_selected_color('default')" aria-label="Default"><span class="sw-x" aria-hidden="true">⊘</span></button>
+          <button class="sw sw-coral" @click="pick_selected_color('coral')" aria-label="Coral"></button>
+          <button class="sw sw-peach" @click="pick_selected_color('peach')" aria-label="Peach"></button>
+          <button class="sw sw-sand" @click="pick_selected_color('sand')" aria-label="Sand"></button>
+          <button class="sw sw-mint" @click="pick_selected_color('mint')" aria-label="Mint"></button>
+          <button class="sw sw-sage" @click="pick_selected_color('sage')" aria-label="Sage"></button>
+          <button class="sw sw-fog" @click="pick_selected_color('fog')" aria-label="Fog"></button>
+          <button class="sw sw-storm" @click="pick_selected_color('storm')" aria-label="Storm"></button>
+          <button class="sw sw-dusk" @click="pick_selected_color('dusk')" aria-label="Dusk"></button>
+          <button class="sw sw-blossom" @click="pick_selected_color('blossom')" aria-label="Blossom"></button>
+          <button class="sw sw-clay" @click="pick_selected_color('clay')" aria-label="Clay"></button>
+          <button class="sw sw-chalk" @click="pick_selected_color('chalk')" aria-label="Chalk"></button>
+        </pine-popover-content>
+      </pine-popover-portal>
+    </pine-popover-root>
+
+    <button class="selection-action" aria-label="Archive selected" @click="archive_selected">
+      <pine-icon name="archive" size="18"></pine-icon>
+    </button>
+
+    <button class="selection-action danger" aria-label="Delete selected" @click="delete_selected">
+      <pine-icon name="trash" size="18"></pine-icon>
+    </button>
+
+    <span class="selection-divider" aria-hidden="true"></span>
+
+    <button class="selection-action" aria-label="Clear selection" @click="clear_selection">
+      <pine-icon name="x" size="18"></pine-icon>
+    </button>
+  </div>
+</div>

--- a/examples/keep/src/components/board/mod.rs
+++ b/examples/keep/src/components/board/mod.rs
@@ -1,0 +1,294 @@
+//! `<keep-board>` — the top-level Keep app shell and sync wiring.
+
+use pine::{
+    PineCommandContent, PineCommandEmpty, PineCommandInput, PineCommandItem, PineCommandList,
+    PineCommandOverlay, PineCommandPortal, PineCommandRoot, PineDropdownMenuContent,
+    PineDropdownMenuItem, PineDropdownMenuLabel, PineDropdownMenuPortal, PineDropdownMenuRoot,
+    PineDropdownMenuSeparator, PineDropdownMenuTrigger, PineInput, PinePopoverContent,
+    PinePopoverPortal, PinePopoverRoot, PinePopoverTrigger, PineTextarea,
+};
+use pine_icons::PineIcon;
+use pocopine::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::components::{
+    composer::KeepComposer, editor::KeepEditor, note_body::KeepNoteBody, note_card::KeepNoteCard,
+    note_form::KeepNoteForm,
+};
+use crate::{focus_after_flush, KeepStore, KEEP_STREAM, KEEP_TAGS_STREAM};
+
+/// Top-level component. Owns nothing except the sync wiring; every
+/// piece of durable UI state lives in [`KeepStore`].
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    template = "KeepBoard.poco",
+    style = "KeepBoard.css",
+    role = "panel",
+    uses = [
+        PineIcon,
+        KeepComposer,
+        KeepNoteCard,
+        KeepEditor,
+        KeepNoteForm,
+        KeepNoteBody,
+        PineCommandRoot,
+        PineCommandPortal,
+        PineCommandOverlay,
+        PineCommandContent,
+        PineCommandInput,
+        PineCommandList,
+        PineCommandItem,
+        PineCommandEmpty,
+        PineDropdownMenuRoot,
+        PineDropdownMenuTrigger,
+        PineDropdownMenuPortal,
+        PineDropdownMenuContent,
+        PineDropdownMenuItem,
+        PineDropdownMenuSeparator,
+        PineDropdownMenuLabel,
+        PineInput,
+        PinePopoverRoot,
+        PinePopoverTrigger,
+        PinePopoverPortal,
+        PinePopoverContent,
+        PineTextarea,
+    ]
+)]
+pub struct KeepBoard {
+    pub command_open: bool,
+    pub command_label_create_open: bool,
+    pub selection_color_open: bool,
+}
+
+#[handlers]
+impl KeepBoard {
+    pub fn on_ready(&self, handle: pocopine::Handle<Self>) {
+        let command = handle.clone();
+        handle.watch_field::<bool, _>("command_open", move |open, prev| {
+            if !*open || prev.copied().unwrap_or(false) {
+                return;
+            }
+            command.update(|board| {
+                board.command_label_create_open = false;
+            });
+            pocopine::store::<KeepStore>().update(|s| s.command_label_query.clear());
+        });
+
+        // Global keyboard shortcuts, scope-bound to the KeepBoard
+        // mount via `pocopine::on!`: when the board unmounts the
+        // listener detaches automatically. Matches Keep's
+        // shortcuts — C for a new text note, L for a new todo —
+        // and bails out the moment an input / textarea /
+        // contenteditable surface is focused so typing isn't
+        // hijacked.
+        let Some(doc) = pocopine::dom::window().and_then(|w| w.document()) else {
+            return;
+        };
+        pocopine::on!(doc, keydown, |ev| {
+            if ev.ctrl_key() || ev.meta_key() || ev.alt_key() {
+                return;
+            }
+            if is_typing_target() {
+                return;
+            }
+            match ev.key().to_lowercase().as_str() {
+                "c" => {
+                    ev.prevent_default();
+                    pocopine::store::<KeepStore>().update(|s| {
+                        s.show_notes();
+                        s.expand_composer_text();
+                    });
+                    focus_after_flush(".composer.expanded textarea");
+                }
+                "l" => {
+                    ev.prevent_default();
+                    pocopine::store::<KeepStore>().update(|s| {
+                        s.show_notes();
+                        s.expand_composer_todo();
+                    });
+                    focus_after_flush(".composer.expanded .cl-add .cl-txt");
+                }
+                _ => {}
+            }
+        });
+    }
+
+    pub fn on_mount(&mut self) {
+        // Belt-and-suspenders: KeepStore::default() seeds section_kind /
+        // draft_kind / draft_color, but on_mount fires *after* the first
+        // template walk, so re-asserting via the store proxy here
+        // guarantees a change notification reaches every pp-if /
+        // pp-show subscriber even if the construct-time write didn't.
+        pocopine::store::<KeepStore>().update(|s| {
+            s.ensure_defaults();
+        });
+        pocopine::store::<KeepStore>().observe(KeepStore::tag_label_registry, |labels, _| {
+            let labels = labels.clone();
+            pocopine::store::<KeepStore>().update(move |s| {
+                s.remember_labels(labels.clone());
+            });
+        });
+        pocopine::store::<KeepStore>().observe(KeepStore::note_view_signature, |_, _| {
+            pocopine::store::<KeepStore>().update(KeepStore::rebuild_visible_notes);
+        });
+
+        // Hook sync to the store: notes lives on KeepStore, so the sync
+        // collection's selector mutably borrows the store, not the board.
+        let plugins = Plugins;
+        let Some(client) = plugins.get::<pocopine_sync::SyncClient>() else {
+            pocopine::store::<KeepStore>().update(|s| {
+                s.notes.set_error("sync plugin not installed");
+            });
+            return;
+        };
+        let notes_result = client
+            .collection(pocopine::store::<KeepStore>(), |s: &mut KeepStore| {
+                &mut s.notes
+            })
+            .stream(KEEP_STREAM)
+            .and_then(|c| c.open());
+        let tags_result = client
+            .collection(pocopine::store::<KeepStore>(), |s: &mut KeepStore| {
+                &mut s.tags
+            })
+            .stream(KEEP_TAGS_STREAM)
+            .and_then(|c| c.open());
+        if let Err(err) = notes_result {
+            pocopine::store::<KeepStore>().update(|s| {
+                s.status = "sync failed".into();
+                s.notes.set_error(err.to_string());
+            });
+        } else if let Err(err) = tags_result {
+            pocopine::store::<KeepStore>().update(|s| {
+                s.status = "sync failed".into();
+                s.notes.set_error(err.to_string());
+            });
+        }
+    }
+
+    pub fn toggle_sidebar(&mut self) {
+        pocopine::store::<KeepStore>().update(KeepStore::toggle_sidebar);
+    }
+
+    pub fn show_notes(&mut self) {
+        pocopine::store::<KeepStore>().update(KeepStore::show_notes);
+    }
+
+    pub fn show_archive(&mut self) {
+        pocopine::store::<KeepStore>().update(KeepStore::show_archive);
+    }
+
+    pub fn show_label(&mut self, label: String) {
+        pocopine::store::<KeepStore>().update(move |s| s.show_label(label));
+    }
+
+    pub fn clear_search(&mut self) {
+        pocopine::store::<KeepStore>().update(KeepStore::clear_search);
+    }
+
+    pub fn open_command(&mut self) {
+        self.command_open = true;
+        self.command_label_create_open = false;
+        pocopine::store::<KeepStore>().update(|s| s.command_label_query.clear());
+    }
+
+    pub fn cmd_new_note(&mut self) {
+        self.command_open = false;
+        self.command_label_create_open = false;
+        pocopine::store::<KeepStore>().update(|s| {
+            s.show_notes();
+            s.expand_composer_text();
+        });
+        focus_after_flush(".composer.expanded textarea");
+    }
+
+    pub fn cmd_new_todo(&mut self) {
+        self.command_open = false;
+        self.command_label_create_open = false;
+        pocopine::store::<KeepStore>().update(|s| {
+            s.show_notes();
+            s.expand_composer_todo();
+        });
+        focus_after_flush(".composer.expanded .cl-add .cl-txt");
+    }
+
+    pub fn cmd_show_label_create(&mut self) {
+        self.command_label_create_open = true;
+        focus_after_flush(".cmd-inline-input");
+    }
+
+    pub fn cmd_create_label_inline(&mut self) {
+        self.command_open = false;
+        self.command_label_create_open = false;
+        pocopine::store::<KeepStore>().update(KeepStore::create_command_label);
+    }
+
+    pub fn cmd_open_note(&mut self, note_id: String) {
+        self.command_open = false;
+        self.command_label_create_open = false;
+        pocopine::store::<KeepStore>().update(move |s| s.open_editor(note_id));
+    }
+
+    pub fn refresh(&mut self) {
+        pocopine::store::<KeepStore>().update(KeepStore::refresh);
+    }
+
+    pub fn resync(&mut self) {
+        pocopine::store::<KeepStore>().update(KeepStore::resync);
+    }
+
+    pub fn toggle_theme(&mut self) {
+        pocopine::store::<KeepStore>().update(KeepStore::toggle_theme);
+    }
+
+    pub fn delete_all_notes(&mut self) {
+        pocopine::store::<KeepStore>().update(KeepStore::reset);
+    }
+
+    pub fn clear_selection(&mut self) {
+        self.selection_color_open = false;
+        pocopine::store::<KeepStore>().update(KeepStore::clear_selection);
+    }
+
+    pub fn pin_selected(&mut self) {
+        self.selection_color_open = false;
+        pocopine::store::<KeepStore>().update(KeepStore::pin_selected);
+    }
+
+    pub fn archive_selected(&mut self) {
+        self.selection_color_open = false;
+        pocopine::store::<KeepStore>().update(KeepStore::archive_selected);
+    }
+
+    pub fn delete_selected(&mut self) {
+        self.selection_color_open = false;
+        pocopine::store::<KeepStore>().update(KeepStore::delete_selected);
+    }
+
+    pub fn pick_selected_color(&mut self, color: String) {
+        self.selection_color_open = false;
+        pocopine::store::<KeepStore>().update(move |s| s.set_selected_color(color));
+    }
+}
+
+/// True when the document's currently focused element is something
+/// the user is plausibly typing into, so shortcut keys should not
+/// fire and steal the keystroke. Host build returns false because
+/// there's no DOM to inspect; on_ready short-circuits earlier via
+/// the missing `window()`.
+fn is_typing_target() -> bool {
+    let Some(active) = pocopine::dom::window()
+        .and_then(|w| w.document())
+        .and_then(|d| d.active_element())
+    else {
+        return false;
+    };
+    let tag = active.tag_name().to_uppercase();
+    if matches!(tag.as_str(), "INPUT" | "TEXTAREA" | "SELECT") {
+        return true;
+    }
+    active
+        .get_attribute("contenteditable")
+        .map(|v| v != "false")
+        .unwrap_or(false)
+}

--- a/examples/keep/src/components/composer/KeepComposer.css
+++ b/examples/keep/src/components/composer/KeepComposer.css
@@ -1,0 +1,55 @@
+/* ─── composer ─── */
+
+.composer-wrap {
+  width: 100%;
+  max-width: 720px;
+  margin: 0 auto 32px;
+}
+
+.composer {
+  background: var(--c-default-bg);
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  box-shadow: 0 1px 2px 0 rgba(60, 64, 67, .30), 0 1px 3px 1px rgba(60, 64, 67, .15);
+  transition: background .15s, border-color .15s;
+}
+
+.composer.collapsed {
+  display: flex;
+  align-items: center;
+  height: 48px;
+  padding: 0 4px 0 16px;
+}
+
+.cmp-input {
+  flex: 1;
+  height: 100%;
+  text-align: left;
+  color: var(--fg-2);
+  font-size: 16px;
+  font-weight: 500;
+}
+
+.cmp-tools {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding-right: 4px;
+}
+
+.composer.expanded {
+  padding: 12px 16px 8px;
+}
+
+.composer.expanded[data-color="default"] { background: var(--c-default-bg); }
+.composer.expanded[data-color="coral"]   { background: var(--c-coral-bg); }
+.composer.expanded[data-color="peach"]   { background: var(--c-peach-bg); }
+.composer.expanded[data-color="sand"]    { background: var(--c-sand-bg); }
+.composer.expanded[data-color="mint"]    { background: var(--c-mint-bg); }
+.composer.expanded[data-color="sage"]    { background: var(--c-sage-bg); }
+.composer.expanded[data-color="fog"]     { background: var(--c-fog-bg); }
+.composer.expanded[data-color="storm"]   { background: var(--c-storm-bg); }
+.composer.expanded[data-color="dusk"]    { background: var(--c-dusk-bg); }
+.composer.expanded[data-color="blossom"] { background: var(--c-blossom-bg); }
+.composer.expanded[data-color="clay"]    { background: var(--c-clay-bg); }
+.composer.expanded[data-color="chalk"]   { background: var(--c-chalk-bg); }

--- a/examples/keep/src/components/composer/KeepComposer.poco
+++ b/examples/keep/src/components/composer/KeepComposer.poco
@@ -1,0 +1,21 @@
+<div class="composer-wrap">
+  <div class="composer collapsed" pp-show="!$store.keep.composer_open">
+    <button class="cmp-input" @click="expand_text">Take a note…</button>
+    <div class="cmp-tools">
+      <button class="ic-btn" aria-label="New list" @click="expand_todo">
+        <pine-icon name="list-check" size="20"></pine-icon>
+      </button>
+      <button class="ic-btn" aria-label="New text note" @click="expand_text">
+        <pine-icon name="pencil" size="20"></pine-icon>
+      </button>
+    </div>
+  </div>
+
+  <div
+    class="composer expanded"
+    pp-show="$store.keep.composer_open"
+    :data-color="$store.keep.draft_color"
+  >
+    <keep-note-form></keep-note-form>
+  </div>
+</div>

--- a/examples/keep/src/components/composer/mod.rs
+++ b/examples/keep/src/components/composer/mod.rs
@@ -1,0 +1,31 @@
+//! `<keep-composer>` — the inline "Take a note..." composer.
+//!
+//! Creation stays inline. The expanded note fields are delegated to
+//! `<keep-note-form>`, which is also used inside the modal editor.
+
+use pocopine::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::components::note_form::{KeepNoteFormContext, KEEP_NOTE_FORM_CONTEXT};
+use crate::store::KeepStore;
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(style = "KeepComposer.css")]
+pub struct KeepComposer {}
+
+#[handlers]
+impl KeepComposer {
+    pub fn on_setup(&mut self) {
+        KEEP_NOTE_FORM_CONTEXT.provide(KeepNoteFormContext::DRAFT_COMPOSER);
+    }
+
+    pub fn expand_text(&mut self) {
+        pocopine::store::<KeepStore>().update(KeepStore::expand_composer_text);
+        crate::focus_after_flush(".composer.expanded textarea");
+    }
+
+    pub fn expand_todo(&mut self) {
+        pocopine::store::<KeepStore>().update(KeepStore::expand_composer_todo);
+        crate::focus_after_flush(".composer.expanded .cl-add .cl-txt");
+    }
+}

--- a/examples/keep/src/components/editor/KeepEditor.css
+++ b/examples/keep/src/components/editor/KeepEditor.css
@@ -1,0 +1,60 @@
+/* ─── editor modal (detail dialog) ─── */
+
+.modal-back {
+  position: fixed;
+  inset: 0;
+  background: rgba(32, 33, 36, .55);
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2.5vh 16px;
+  animation: keep-fade-in .15s ease-out;
+}
+
+@keyframes keep-fade-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+
+.modal-note {
+  position: relative;
+  width: 100%;
+  max-width: 600px;
+  max-height: 95vh;
+  overflow-y: auto;
+  background: var(--card-bg, var(--c-default-bg));
+  border-radius: 8px;
+  box-shadow:
+    0 24px 38px 3px rgba(0, 0, 0, .14),
+    0 9px 46px 8px rgba(0, 0, 0, .12),
+    0 11px 15px -7px rgba(0, 0, 0, .20);
+  padding: 12px 16px 8px;
+  display: flex;
+  flex-direction: column;
+  animation: keep-pop .18s cubic-bezier(.2, .9, .3, 1.05);
+}
+
+.modal-note[data-color="default"] { --card-bg: var(--c-default-bg); }
+.modal-note[data-color="coral"]   { --card-bg: var(--c-coral-bg); }
+.modal-note[data-color="peach"]   { --card-bg: var(--c-peach-bg); }
+.modal-note[data-color="sand"]    { --card-bg: var(--c-sand-bg); }
+.modal-note[data-color="mint"]    { --card-bg: var(--c-mint-bg); }
+.modal-note[data-color="sage"]    { --card-bg: var(--c-sage-bg); }
+.modal-note[data-color="fog"]     { --card-bg: var(--c-fog-bg); }
+.modal-note[data-color="storm"]   { --card-bg: var(--c-storm-bg); }
+.modal-note[data-color="dusk"]    { --card-bg: var(--c-dusk-bg); }
+.modal-note[data-color="blossom"] { --card-bg: var(--c-blossom-bg); }
+.modal-note[data-color="clay"]    { --card-bg: var(--c-clay-bg); }
+.modal-note[data-color="chalk"]   { --card-bg: var(--c-chalk-bg); }
+
+@keyframes keep-pop {
+  from { transform: scale(.95); opacity: 0; }
+  to   { transform: scale(1);   opacity: 1; }
+}
+
+.modal-note .note-pin {
+  opacity: 1;
+  top: 8px;
+  right: 8px;
+}

--- a/examples/keep/src/components/editor/KeepEditor.poco
+++ b/examples/keep/src/components/editor/KeepEditor.poco
@@ -1,0 +1,9 @@
+<div class="modal-back" pp-show="$store.keep.editor_open">
+  <div class="modal-note" :data-color="$store.keep.editor_data.color" :data-pp-layout-id="'card-' + $store.keep.editor_data.id" @click.stop>
+    <button class="note-pin" :data-on="$store.keep.editor_data.pinned" aria-label="Pin" @click="toggle_pin">
+      <pine-icon name="pin" :variant="$store.keep.editor_data.pinned ? 'filled' : 'outline'" size="20"></pine-icon>
+    </button>
+
+    <keep-note-form></keep-note-form>
+  </div>
+</div>

--- a/examples/keep/src/components/editor/mod.rs
+++ b/examples/keep/src/components/editor/mod.rs
@@ -1,0 +1,43 @@
+//! `<keep-editor>` — the detail dialog shell. The shared inner fields
+//! and toolbar live in `<keep-note-form>`.
+
+use pocopine::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::components::note_form::{KeepNoteFormContext, KEEP_NOTE_FORM_CONTEXT};
+use crate::store::KeepStore;
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(style = "KeepEditor.css")]
+pub struct KeepEditor {}
+
+#[handlers]
+impl KeepEditor {
+    pub fn on_setup(&mut self) {
+        KEEP_NOTE_FORM_CONTEXT.provide(KeepNoteFormContext::EDITOR_MODAL);
+    }
+
+    pub fn on_ready(&self, _handle: pocopine::Handle<Self>) {
+        pocopine::store::<KeepStore>().watch_field::<bool, _>("editor_open", move |open, prev| {
+            if !*open || prev.copied().unwrap_or(false) {
+                return;
+            }
+            let selector = pocopine::store::<KeepStore>().with(|s| {
+                if s.editor_data.kind == "checklist" {
+                    ".note-body-checklist .cl-add .cl-txt"
+                } else {
+                    ".modal-note textarea"
+                }
+            });
+            crate::focus_after_flush(selector);
+        });
+    }
+
+    pub fn cancel(&mut self) {
+        crate::shared_layout_transition(KeepStore::cancel_editor);
+    }
+
+    pub fn toggle_pin(&mut self) {
+        pocopine::store::<KeepStore>().update(KeepStore::toggle_editor_pin);
+    }
+}

--- a/examples/keep/src/components/mod.rs
+++ b/examples/keep/src/components/mod.rs
@@ -1,0 +1,20 @@
+//! UI components for the Keep example.
+//!
+//! Long-lived app state lives in [`crate::KeepStore`]. Short-lived
+//! editing buffers live inside their form components so the inline
+//! composer and modal editor can share the same controls without
+//! duplicating template branches.
+
+pub mod board;
+pub mod composer;
+pub mod editor;
+pub mod note_body;
+pub mod note_card;
+pub mod note_form;
+
+pub use board::KeepBoard;
+pub use composer::KeepComposer;
+pub use editor::KeepEditor;
+pub use note_body::KeepNoteBody;
+pub use note_card::KeepNoteCard;
+pub use note_form::KeepNoteForm;

--- a/examples/keep/src/components/note_body/KeepNoteBody.css
+++ b/examples/keep/src/components/note_body/KeepNoteBody.css
@@ -1,0 +1,84 @@
+/* ─── checklist ─── */
+
+.note > .cl {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.cl { padding: 4px 0 0; }
+
+.cl-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 4px 0;
+  min-height: 24px;
+}
+
+.cl-row[data-done="true"] .cl-txt {
+  color: var(--fg-3);
+  text-decoration: line-through;
+}
+
+.cl-box {
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  border: 2px solid var(--fg-2);
+  border-radius: 2px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--fg-2);
+  background: transparent;
+  transition: background .12s, color .12s, border-color .12s;
+}
+
+.cl-box:hover {
+  border-color: var(--fg);
+  color: var(--fg);
+}
+
+.cl-row[data-done="true"] .cl-box {
+  background: var(--fg-2);
+  color: var(--card-bg);
+  border-color: var(--fg-2);
+}
+
+.cl-box.ghost { border-style: dashed; }
+
+.cl-txt {
+  flex: 1;
+  min-width: 0;
+  font-size: 14px;
+  line-height: 1.5;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  padding: 0;
+  word-break: break-word;
+}
+
+.note > .cl .cl-txt {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  word-break: normal;
+}
+
+.cl-x {
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  color: var(--fg-2);
+  opacity: 0;
+}
+
+.cl-row:hover .cl-x { opacity: 1; }
+.cl-x:hover { background: var(--card-overlay); color: var(--fg); }
+.cl-add { opacity: .65; }
+.cl-add:focus-within { opacity: 1; }

--- a/examples/keep/src/components/note_body/KeepNoteBody.poco
+++ b/examples/keep/src/components/note_body/KeepNoteBody.poco
@@ -1,0 +1,36 @@
+<div class="note-body-editor" :data-kind="kind">
+  <template pp-if="kind == 'text'">
+    <pine-textarea
+      class="note-body-input"
+      placeholder="Take a note…"
+      rows="3"
+      autosize
+      pp-model:value="body"
+    ></pine-textarea>
+  </template>
+
+  <div class="cl note-body-checklist" pp-show="kind == 'checklist'">
+    <template pp-for="todo in todos" pp-key="todo.id">
+      <div class="cl-row" :data-done="todo.done">
+        <button class="cl-box" aria-label="Toggle" @click="toggle_todo(todo.id)">
+          <template pp-if="todo.done">
+            <pine-icon name="check" size="14"></pine-icon>
+          </template>
+        </button>
+        <span class="cl-txt" pp-text="todo.text"></span>
+        <button class="cl-x" aria-label="Remove" @click="remove_todo(todo.id)">
+          <pine-icon name="x" size="14"></pine-icon>
+        </button>
+      </div>
+    </template>
+    <div class="cl-row cl-add">
+      <span class="cl-box ghost" aria-hidden="true"><pine-icon name="plus" size="14"></pine-icon></span>
+      <pine-input
+        class="cl-txt"
+        placeholder="List item"
+        pp-model:value="todo_text"
+        @keydown.enter="add_todo"
+      ></pine-input>
+    </div>
+  </div>
+</div>

--- a/examples/keep/src/components/note_body/mod.rs
+++ b/examples/keep/src/components/note_body/mod.rs
@@ -1,0 +1,63 @@
+//! Body editor shared by the Keep composer and note dialog.
+//!
+//! The parent form owns the complete edit buffer. This component only
+//! edits the body-shaped fields through `pp-model`, keeping the text
+//! and checklist render paths in one place without deciding whether the
+//! final save creates or updates a note.
+
+use pocopine::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::KeepTodo;
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    template = "KeepNoteBody.poco",
+    style = "KeepNoteBody.css",
+    role = "panel",
+    display = "contents"
+)]
+pub struct KeepNoteBody {
+    #[prop]
+    pub kind: String,
+    #[model]
+    pub body: String,
+    #[model]
+    pub todos: Vec<KeepTodo>,
+    #[model]
+    pub todo_text: String,
+    pub next_todo_id: u64,
+}
+
+#[handlers]
+impl KeepNoteBody {
+    pub fn add_todo(&mut self) {
+        let text = self.todo_text.trim().to_string();
+        if text.is_empty() {
+            return;
+        }
+        self.push_todo(text, false);
+        self.todo_text.clear();
+    }
+
+    pub fn remove_todo(&mut self, todo_id: String) {
+        self.todos.retain(|todo| todo.id != todo_id);
+    }
+
+    pub fn toggle_todo(&mut self, todo_id: String) {
+        if let Some(todo) = self.todos.iter_mut().find(|todo| todo.id == todo_id) {
+            todo.done = !todo.done;
+        }
+    }
+}
+
+impl KeepNoteBody {
+    fn push_todo(&mut self, text: String, done: bool) {
+        self.next_todo_id = self.next_todo_id.saturating_add(1);
+        self.todos.push(KeepTodo {
+            id: format!("todo_{}_{}", crate::now_ms(), self.next_todo_id),
+            text,
+            done,
+        });
+    }
+}

--- a/examples/keep/src/components/note_card/KeepNoteCard.css
+++ b/examples/keep/src/components/note_card/KeepNoteCard.css
@@ -1,0 +1,400 @@
+/* ─── note card ─── */
+
+.note-shell {
+  position: relative;
+  width: 100%;
+  padding-top: 10px;
+}
+
+.note {
+  position: relative;
+  break-inside: avoid;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  max-height: 600px;
+  overflow: hidden;
+  margin: 0;
+  padding: 10px 12px 40px;
+  border-radius: 8px;
+  background: var(--card-bg, var(--c-default-bg));
+  box-shadow: var(--shadow-card);
+  transition: box-shadow .15s;
+  cursor: default;
+}
+
+.note:hover { box-shadow: var(--shadow-card-hover); }
+
+/* Hide the source card while the editor modal is open for it.
+   `visibility: hidden` keeps the masonry slot intact (so other
+   cards don't reflow) and pine-motion's snapshot still reads the
+   correct rect from getBoundingClientRect. */
+.note[data-shared="true"] {
+  visibility: hidden;
+}
+
+/* While pine-motion's projection is in flight the morphing
+   card gets translated across the page; without a stacking-
+   context bump it slides *under* its masonry siblings on the
+   way back to its slot. play_layout stamps
+   `data-pp-animating="true"` for the duration of the spring
+   and clears it on a settle-bound timeout. */
+.note[data-pp-animating="true"] {
+  /* Sit above the topbar (30), label-pop / command-content (60),
+     and any other in-page chrome the spring's translate could
+     drift the card across. Below the dropdown menu portal layer
+     (1000) since those should never be open during a card
+     transition anyway. */
+  z-index: 100;
+  pointer-events: none;
+}
+
+.note[data-color="default"] { --card-bg: var(--c-default-bg); box-shadow: 0 0 0 1px var(--line-2); }
+.note[data-color="default"]:hover { box-shadow: var(--shadow-card-hover); }
+.note[data-color="coral"]   { --card-bg: var(--c-coral-bg); }
+.note[data-color="peach"]   { --card-bg: var(--c-peach-bg); }
+.note[data-color="sand"]    { --card-bg: var(--c-sand-bg); }
+.note[data-color="mint"]    { --card-bg: var(--c-mint-bg); }
+.note[data-color="sage"]    { --card-bg: var(--c-sage-bg); }
+.note[data-color="fog"]     { --card-bg: var(--c-fog-bg); }
+.note[data-color="storm"]   { --card-bg: var(--c-storm-bg); }
+.note[data-color="dusk"]    { --card-bg: var(--c-dusk-bg); }
+.note[data-color="blossom"] { --card-bg: var(--c-blossom-bg); }
+.note[data-color="clay"]    { --card-bg: var(--c-clay-bg); }
+.note[data-color="chalk"]   { --card-bg: var(--c-chalk-bg); }
+
+.note[data-pending="true"] {
+  outline: 1px dashed rgba(60, 64, 67, .35);
+  outline-offset: -2px;
+}
+
+.note[data-conflict="true"] {
+  outline: 1px solid #c2410c;
+  outline-offset: -2px;
+}
+
+.note[data-selected="true"] {
+  box-shadow:
+    0 0 0 2px var(--accent),
+    var(--shadow-card-hover);
+}
+
+.note[data-selection-active="true"] {
+  cursor: pointer;
+}
+
+.note-pin {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 36px;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  color: var(--fg-2);
+  opacity: 0;
+  transition: opacity .12s, background .12s, color .12s;
+}
+
+.note:hover .note-pin,
+.note-pin[data-on="true"] { opacity: 1; }
+.note-pin:hover { background: var(--card-overlay); color: var(--fg); }
+
+.note-select {
+  position: absolute;
+  top: 0;
+  left: -10px;
+  z-index: 3;
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid rgba(255, 255, 255, .92);
+  border-radius: 999px;
+  background: rgba(32, 33, 36, .56);
+  color: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, .25);
+  opacity: 0;
+  transform: scale(.88);
+  transition: opacity .12s, transform .12s, background .12s, border-color .12s;
+}
+
+.note-select pine-icon {
+  opacity: 0;
+  transition: opacity .12s;
+}
+
+.note-shell:hover .note-select,
+.note-shell[data-selected="true"] .note-select,
+.note-shell[data-selection-active="true"] .note-select {
+  opacity: 1;
+  transform: scale(1);
+}
+
+.note-select[data-on="true"] {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--surface);
+}
+
+.note-select[data-on="true"] pine-icon {
+  opacity: 1;
+}
+
+.note-select:hover {
+  background: rgba(32, 33, 36, .72);
+}
+
+.note-select[data-on="true"]:hover {
+  background: var(--accent);
+}
+
+.note[data-selection-active="true"] .note-actions {
+  display: none;
+}
+
+.note-title {
+  flex: 0 0 auto;
+  margin: 4px 28px 8px 4px;
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -.003em;
+  word-break: break-word;
+  line-height: 1.35;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.note-body {
+  flex: 0 1 auto;
+  min-height: 0;
+  margin: 0 4px 4px;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--fg);
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 20;
+  -webkit-box-orient: vertical;
+  text-overflow: ellipsis;
+}
+
+.note-labels {
+  flex: 0 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin: 8px 4px 0;
+  max-height: 58px;
+  overflow: hidden;
+}
+
+.chip {
+  font-size: 11px;
+  line-height: 1;
+  padding: 5px 8px;
+  border-radius: 999px;
+  background: var(--card-overlay);
+  color: var(--fg);
+}
+
+.note[data-color="default"] .chip {
+  background: var(--card-overlay-soft);
+}
+
+.note-actions {
+  display: none;
+}
+
+.note-title {
+  flex: 0 0 auto;
+  margin: 4px 28px 8px 4px;
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -.003em;
+  word-break: break-word;
+  line-height: 1.35;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.note-body {
+  flex: 0 1 auto;
+  min-height: 0;
+  margin: 0 4px 4px;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--fg);
+  white-space: pre-wrap;
+  word-break: break-word;
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 20;
+  -webkit-box-orient: vertical;
+  text-overflow: ellipsis;
+}
+
+.note-labels {
+  flex: 0 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin: 8px 4px 0;
+  max-height: 58px;
+  overflow: hidden;
+}
+
+.chip {
+  font-size: 11px;
+  line-height: 1;
+  padding: 5px 8px;
+  border-radius: 999px;
+  background: var(--card-overlay);
+  color: var(--fg);
+}
+
+.note[data-color="default"] .chip {
+  background: var(--card-overlay-soft);
+}
+
+/* Editable label chips inside the composer + editor — chip with a
+   trailing × button. Reuse .chip's pill base. */
+.label-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin: 8px 0 0;
+}
+.label-chips .chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 4px 4px 10px;
+}
+.chip-x {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--fg-2);
+  cursor: pointer;
+}
+.chip-x:hover { background: var(--card-overlay); color: var(--fg); }
+
+/* Label-picker popover */
+.label-pop {
+  display: flex;
+  flex-direction: column;
+  width: 240px;
+  padding: 8px 0;
+  background: var(--surface-pop);
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  box-shadow: var(--shadow-pop);
+  color: var(--fg);
+  font-size: 13px;
+  z-index: 60;
+}
+
+.label-pop__h {
+  padding: 0 12px 6px;
+  color: var(--fg-2);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.label-pop__input {
+  margin: 0 12px 6px;
+  height: 32px;
+  padding: 0 8px;
+  border: 1px solid var(--line-2);
+  border-radius: 6px;
+  background: var(--surface);
+  color: var(--fg);
+  font: inherit;
+  outline: 0;
+}
+.label-pop__input:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 22%, transparent);
+}
+
+.label-pop__list {
+  max-height: 220px;
+  overflow-y: auto;
+  padding: 2px 0;
+}
+
+.label-pop__row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 12px;
+  cursor: pointer;
+  user-select: none;
+}
+.label-pop__row:hover { background: var(--hover); }
+.label-pop__row input[type="checkbox"] {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--accent);
+}
+
+.label-pop__create {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 4px 6px 0;
+  padding: 8px 10px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--fg);
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  text-align: left;
+}
+.label-pop__create:hover { background: var(--hover); }
+.label-pop__create pine-icon { color: var(--accent); }
+
+.note-actions {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  padding: 0 4px;
+  opacity: 0;
+  transition: opacity .12s;
+}
+
+.note:hover .note-actions { opacity: 1; }
+.note .note-actions .ic-btn,
+.note .note-actions .pine-dm-trigger {
+  width: 32px;
+  height: 32px;
+  color: var(--fg-2);
+}
+.note .note-actions .ic-btn:hover,
+.note .note-actions .pine-dm-trigger:hover,
+.note .note-actions .pine-dm-trigger:focus-visible,
+.note .note-actions .pine-dm-trigger[data-state="open"] {
+  background: var(--card-overlay);
+  color: var(--fg);
+}

--- a/examples/keep/src/components/note_card/KeepNoteCard.poco
+++ b/examples/keep/src/components/note_card/KeepNoteCard.poco
@@ -1,0 +1,144 @@
+<div
+  class="note-shell"
+  :data-selected="selected"
+  :data-selection-active="selection_active"
+>
+  <button
+    class="note-select"
+    :data-on="selected"
+    :aria-label="selected ? 'Deselect note' : 'Select note'"
+    @pointerdown.stop
+    @click.stop="toggle_selection"
+  >
+    <pine-icon name="check" size="13"></pine-icon>
+  </button>
+
+  <article
+    class="note"
+    :data-color="color"
+    :data-pinned="pinned"
+    :data-pending="pending"
+    :data-conflict="conflict"
+    :data-selected="selected"
+    :data-selection-active="selection_active"
+    :data-pp-layout-id="'card-' + note_id"
+    :data-shared="$store.keep.editor_open && $store.keep.editor_data.id == note_id"
+    @click="open"
+  >
+    <button class="note-pin" :data-on="pinned" aria-label="Pin" @pointerdown.stop @click.stop="pin">
+      <pine-icon name="pin" :variant="pinned ? 'filled' : 'outline'" size="18"></pine-icon>
+    </button>
+
+  <h3 class="note-title" pp-show="title" pp-text="title"></h3>
+  <p class="note-body" pp-show="body" pp-text="body"></p>
+
+  <div class="cl" pp-show="todos.length">
+    <template pp-for="todo in todos" pp-key="todo.id">
+      <div class="cl-row" :data-done="todo.done">
+        <button class="cl-box" aria-label="Toggle" @pointerdown.stop @click.stop="check_todo(todo.id)">
+          <template pp-if="todo.done">
+            <pine-icon name="check" size="14"></pine-icon>
+          </template>
+        </button>
+        <span class="cl-txt" pp-text="todo.text"></span>
+      </div>
+    </template>
+  </div>
+
+  <div class="note-labels" pp-show="labels.length">
+    <template pp-for="label in labels" pp-key="label">
+      <span class="chip" pp-text="label"></span>
+    </template>
+  </div>
+
+  <div class="note-actions" @pointerdown.stop @click.stop>
+    <pine-popover-root pp-model:open="label_picker_open">
+      <pine-popover-trigger class="ic-btn" aria-label="Labels" @pointerdown.stop>
+        <pine-icon name="tag" size="18"></pine-icon>
+      </pine-popover-trigger>
+      <pine-popover-portal>
+        <pine-popover-content class="label-pop" side="top" align="start" side_offset="6">
+          <div class="label-pop__h">Label note</div>
+          <input
+            class="label-pop__input"
+            placeholder="Enter label name"
+            pp-model="label_query"
+            @keydown.enter="create_label"
+          />
+          <div class="label-pop__list">
+            <template pp-for="label in label_options" pp-key="label.name">
+              <label class="label-pop__row" pp-show="label.visible">
+                <input
+                  type="checkbox"
+                  :checked="label.selected"
+                  @change="toggle_label(label.name)"
+                />
+                <span pp-text="label.name"></span>
+              </label>
+            </template>
+          </div>
+          <button
+            class="label-pop__create"
+            pp-show="label_can_create"
+            @click="create_label"
+          >
+            <pine-icon name="plus" size="14"></pine-icon>
+            <span>Create &ldquo;<span pp-text="label_query"></span>&rdquo;</span>
+          </button>
+        </pine-popover-content>
+      </pine-popover-portal>
+    </pine-popover-root>
+
+    <pine-popover-root pp-model:open="color_picker_open">
+      <pine-popover-trigger class="ic-btn" aria-label="Background options">
+        <pine-icon name="palette" size="18"></pine-icon>
+      </pine-popover-trigger>
+      <pine-popover-portal>
+        <pine-popover-content class="palette palette--popover" side="top" align="start" side_offset="6">
+          <button class="sw sw-default" :data-on="color == 'default'" @click="pick_color('default')" aria-label="Default"><span class="sw-x" aria-hidden="true">⊘</span></button>
+          <button class="sw sw-coral" :data-on="color == 'coral'" @click="pick_color('coral')" aria-label="Coral"></button>
+          <button class="sw sw-peach" :data-on="color == 'peach'" @click="pick_color('peach')" aria-label="Peach"></button>
+          <button class="sw sw-sand" :data-on="color == 'sand'" @click="pick_color('sand')" aria-label="Sand"></button>
+          <button class="sw sw-mint" :data-on="color == 'mint'" @click="pick_color('mint')" aria-label="Mint"></button>
+          <button class="sw sw-sage" :data-on="color == 'sage'" @click="pick_color('sage')" aria-label="Sage"></button>
+          <button class="sw sw-fog" :data-on="color == 'fog'" @click="pick_color('fog')" aria-label="Fog"></button>
+          <button class="sw sw-storm" :data-on="color == 'storm'" @click="pick_color('storm')" aria-label="Storm"></button>
+          <button class="sw sw-dusk" :data-on="color == 'dusk'" @click="pick_color('dusk')" aria-label="Dusk"></button>
+          <button class="sw sw-blossom" :data-on="color == 'blossom'" @click="pick_color('blossom')" aria-label="Blossom"></button>
+          <button class="sw sw-clay" :data-on="color == 'clay'" @click="pick_color('clay')" aria-label="Clay"></button>
+          <button class="sw sw-chalk" :data-on="color == 'chalk'" @click="pick_color('chalk')" aria-label="Chalk"></button>
+        </pine-popover-content>
+      </pine-popover-portal>
+    </pine-popover-root>
+    <button class="ic-btn" aria-label="Archive" @pointerdown.stop @click.stop="archive">
+      <pine-icon name="archive" size="18"></pine-icon>
+    </button>
+    <pine-dropdown-menu-root>
+      <pine-dropdown-menu-trigger aria-label="More" @pointerdown.stop>
+        <pine-icon name="dots-vertical" size="18"></pine-icon>
+      </pine-dropdown-menu-trigger>
+      <pine-dropdown-menu-portal>
+        <pine-dropdown-menu-content side="bottom" align="start" side_offset="6">
+          <pine-dropdown-menu-item class="danger" @click="delete">
+            <pine-icon name="trash" size="18"></pine-icon>
+            <span>Delete note</span>
+          </pine-dropdown-menu-item>
+          <pine-dropdown-menu-item @click="open_labels">
+            <pine-icon name="tag" size="18"></pine-icon>
+            <span>Add label</span>
+          </pine-dropdown-menu-item>
+          <pine-dropdown-menu-item @click="copy">
+            <pine-icon name="copy" size="18"></pine-icon>
+            <span>Make a copy</span>
+          </pine-dropdown-menu-item>
+          <pine-dropdown-menu-item @click="toggle_checkboxes">
+            <pine-icon name="list-check" size="18"></pine-icon>
+            <span pp-text="todos.length ? 'Hide checkboxes' : 'Show checkboxes'"></span>
+          </pine-dropdown-menu-item>
+        </pine-dropdown-menu-content>
+      </pine-dropdown-menu-portal>
+    </pine-dropdown-menu-root>
+  </div>
+
+  </article>
+</div>

--- a/examples/keep/src/components/note_card/mod.rs
+++ b/examples/keep/src/components/note_card/mod.rs
@@ -1,0 +1,209 @@
+//! `<keep-note-card>` — a single tile in the masonry. Takes scalar
+//! note props from the board loop so hydrated rows update directly and
+//! every click dispatches into [`KeepStore`] through the local handlers
+//! below. Local popover open state stays on the card instance.
+
+use pocopine::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    store::{can_create_label, label_picker_options_for, KeepLabelOption},
+    KeepStore, KeepTodo,
+};
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(style = "KeepNoteCard.css")]
+pub struct KeepNoteCard {
+    #[prop]
+    pub note_id: String,
+    #[prop]
+    pub title: String,
+    #[prop]
+    pub body: String,
+    #[prop]
+    pub color: String,
+    #[prop]
+    pub pinned: bool,
+    #[prop]
+    pub archived: bool,
+    #[prop]
+    pub todos: Vec<KeepTodo>,
+    #[prop]
+    pub labels: Vec<String>,
+    #[prop]
+    pub pending: bool,
+    #[prop]
+    pub conflict: bool,
+
+    pub label_picker_open: bool,
+    pub label_query: String,
+    pub label_options: Vec<KeepLabelOption>,
+    pub label_can_create: bool,
+    pub color_picker_open: bool,
+    #[prop]
+    pub selected: bool,
+    #[prop]
+    pub selection_active: bool,
+}
+
+#[handlers]
+impl KeepNoteCard {
+    pub fn on_ready(&self, handle: pocopine::Handle<Self>) {
+        let picker = handle.clone();
+        handle.watch_field::<bool, _>("label_picker_open", move |open, _| {
+            if *open {
+                picker.update(KeepNoteCard::rebuild_label_options);
+            }
+        });
+
+        let picker = handle.clone();
+        handle.watch_field::<String, _>("label_query", move |_, _| {
+            picker.update(KeepNoteCard::rebuild_label_options);
+        });
+    }
+
+    pub fn open(&mut self) {
+        let id = self.note_id.clone();
+        if id.is_empty() {
+            return;
+        }
+        if pocopine::store::<KeepStore>().with(|s| !s.selected_note_ids.is_empty()) {
+            pocopine::store::<KeepStore>().update(move |s| s.toggle_note_selection(id));
+            return;
+        }
+        crate::shared_layout_transition(move |s| s.open_editor(id));
+    }
+
+    pub fn toggle_selection(&mut self) {
+        let id = self.note_id.clone();
+        if id.is_empty() {
+            return;
+        }
+        pocopine::store::<KeepStore>().update(move |s| s.toggle_note_selection(id));
+    }
+
+    pub fn pin(&mut self) {
+        let id = self.note_id.clone();
+        if id.is_empty() {
+            return;
+        }
+        pocopine::store::<KeepStore>().update(move |s| s.toggle_pin(id));
+    }
+
+    pub fn archive(&mut self) {
+        let id = self.note_id.clone();
+        if id.is_empty() {
+            return;
+        }
+        pocopine::store::<KeepStore>().update(move |s| s.toggle_archive(id));
+    }
+
+    pub fn check_todo(&mut self, todo_id: String) {
+        let note_id = self.note_id.clone();
+        if note_id.is_empty() {
+            return;
+        }
+        pocopine::store::<KeepStore>().update(move |s| s.toggle_todo(note_id, todo_id));
+    }
+
+    pub fn pick_color(&mut self, color: String) {
+        let id = self.note_id.clone();
+        if id.is_empty() {
+            return;
+        }
+        self.color_picker_open = false;
+        pocopine::store::<KeepStore>().update(move |s| s.set_note_color(id, color));
+    }
+
+    pub fn open_labels(&mut self) {
+        self.rebuild_label_options();
+        self.label_picker_open = true;
+    }
+
+    pub fn toggle_label(&mut self, label: String) {
+        let id = self.note_id.clone();
+        if id.is_empty() {
+            return;
+        }
+        self.toggle_label_option(&label);
+        pocopine::store::<KeepStore>().update(move |s| s.toggle_note_label(id, label));
+    }
+
+    pub fn create_label(&mut self) {
+        let label = self.label_query.trim().to_string();
+        if label.is_empty() {
+            return;
+        }
+        let labels = pocopine::store::<KeepStore>().with(|s| s.labels.clone());
+        if !can_create_label(&labels, &label) {
+            return;
+        }
+        self.label_query.clear();
+        let id = self.note_id.clone();
+        if id.is_empty() {
+            return;
+        }
+        self.select_label_option(&label);
+        pocopine::store::<KeepStore>().update(move |s| s.toggle_note_label(id, label));
+    }
+
+    pub fn delete(&mut self) {
+        let id = self.note_id.clone();
+        if id.is_empty() {
+            return;
+        }
+        pocopine::store::<KeepStore>().update(move |s| s.delete_note(id));
+    }
+
+    pub fn copy(&mut self) {
+        let id = self.note_id.clone();
+        if id.is_empty() {
+            return;
+        }
+        pocopine::store::<KeepStore>().update(move |s| s.copy_note(id));
+    }
+
+    pub fn toggle_checkboxes(&mut self) {
+        let id = self.note_id.clone();
+        if id.is_empty() {
+            return;
+        }
+        pocopine::store::<KeepStore>().update(move |s| s.toggle_note_checklist(id));
+    }
+}
+
+impl KeepNoteCard {
+    fn rebuild_label_options(&mut self) {
+        let labels = pocopine::store::<KeepStore>().with(|s| s.labels.clone());
+        let (options, can_create) =
+            label_picker_options_for(&labels, &self.labels, &self.label_query);
+        self.label_options = options;
+        self.label_can_create = can_create;
+    }
+
+    fn toggle_label_option(&mut self, label: &str) {
+        if let Some(option) = self
+            .label_options
+            .iter_mut()
+            .find(|option| option.name == label)
+        {
+            option.selected = !option.selected;
+        }
+    }
+
+    fn select_label_option(&mut self, label: &str) {
+        if let Some(option) = self
+            .label_options
+            .iter_mut()
+            .find(|option| option.name == label)
+        {
+            option.selected = true;
+        } else {
+            self.label_options.push(KeepLabelOption {
+                name: label.to_string(),
+                selected: true,
+                visible: true,
+            });
+        }
+    }
+}

--- a/examples/keep/src/components/note_form/KeepNoteForm.css
+++ b/examples/keep/src/components/note_form/KeepNoteForm.css
@@ -1,0 +1,150 @@
+.note-form {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  width: 100%;
+  min-height: 0;
+  background: inherit;
+}
+
+.pine-input.note-title-input {
+  width: 100%;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  padding: 4px 32px 8px 4px;
+  margin-bottom: 4px;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.note-body-editor {
+  min-height: 0;
+}
+
+.pine-textarea.note-body-input {
+  width: 100%;
+  min-height: 96px;
+  max-height: calc(95vh - 170px);
+  overflow-y: auto;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  resize: none;
+  font-size: 14px;
+  line-height: 1.5;
+  padding: 4px;
+  font-family: inherit;
+  white-space: pre-wrap;
+}
+
+.note-body-checklist {
+  padding: 4px 0 8px;
+}
+
+.note-form-foot {
+  position: sticky;
+  bottom: 0;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin: 8px -16px -8px;
+  padding: 6px 16px 8px;
+  background: inherit;
+}
+
+.note-form-foot-tools {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-wrap: wrap;
+}
+
+.note-form-close {
+  height: 36px;
+  padding: 0 24px;
+  border-radius: 4px;
+  font-weight: 500;
+  font-size: 14px;
+  color: var(--fg);
+  transition: background .12s;
+}
+
+.note-form-close:hover { background: var(--hover); }
+
+
+
+/* ─── palette ─── */
+
+.palette {
+  display: grid;
+  grid-template-columns: repeat(6, 28px);
+  gap: 6px;
+}
+
+.palette--inline {
+  margin: 8px 0 4px;
+}
+
+.palette--popover {
+  padding: 8px;
+  background: var(--surface-pop);
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  box-shadow: var(--shadow-pop);
+  z-index: 60;
+}
+
+.palette--selection {
+  padding: 8px;
+  background: var(--surface-pop);
+  border: 1px solid var(--line-2);
+  border-radius: 8px;
+  box-shadow: var(--shadow-pop);
+  z-index: 1200;
+}
+
+.sw {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: 1.5px solid transparent;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  transition: border-color .12s;
+}
+
+.sw:hover { border-color: var(--fg-2); }
+
+.sw[data-on="true"] {
+  border-color: #1a73e8;
+  border-width: 2px;
+}
+
+.sw-default {
+  background: #fff;
+  border-color: var(--line-2);
+}
+
+.sw-x {
+  display: block;
+  font-size: 18px;
+  color: var(--fg-2);
+  line-height: 1;
+  transform: rotate(20deg);
+}
+
+.sw-coral   { background: #faafa8; }
+.sw-peach   { background: #f39f76; }
+.sw-sand    { background: #fff8b8; }
+.sw-mint    { background: #e2f6d3; }
+.sw-sage    { background: #b4ddd3; }
+.sw-fog     { background: #d4e4ed; }
+.sw-storm   { background: #aeccdc; }
+.sw-dusk    { background: #d3bfdb; }
+.sw-blossom { background: #f6e2dd; }
+.sw-clay    { background: #e9e3d4; }
+.sw-chalk   { background: #efeff1; }

--- a/examples/keep/src/components/note_form/KeepNoteForm.poco
+++ b/examples/keep/src/components/note_form/KeepNoteForm.poco
@@ -1,0 +1,108 @@
+<div
+  class="note-form"
+  :data-color="color"
+  data-pp-outside-exempt=".composer.collapsed,.modal-note .note-pin,.palette--popover,.label-pop"
+  @click.outside="save"
+>
+  <pine-input
+    class="note-title-input"
+    placeholder="Title"
+    pp-model:value="title"
+    @keydown.ctrl.enter="save"
+    @keydown.meta.enter="save"
+    @keydown.escape="cancel"
+  ></pine-input>
+
+  <keep-note-body
+    pp-bind:kind="kind"
+    pp-model:body="body"
+    pp-model:todos="todos"
+    pp-model:todo-text="todo_text"
+    @keydown.ctrl.enter="save"
+    @keydown.meta.enter="save"
+    @keydown.escape="cancel"
+  ></keep-note-body>
+
+  <div class="label-chips" pp-show="labels.length">
+    <template pp-for="lbl in labels" pp-key="lbl">
+      <span class="chip">
+        <span pp-text="lbl"></span>
+        <button class="chip-x" aria-label="Remove label" @click="toggle_label(lbl)">
+          <pine-icon name="x" size="12"></pine-icon>
+        </button>
+      </span>
+    </template>
+  </div>
+
+  <div class="note-form-foot">
+    <div class="note-form-foot-tools">
+      <button class="ic-btn" aria-label="Convert (text ↔ checklist)" @click="toggle_kind">
+        <pine-icon :name="kind == 'text' ? 'list-check' : 'notes'" size="18"></pine-icon>
+      </button>
+
+      <pine-popover-root pp-model:open="color_picker_open">
+        <pine-popover-trigger class="ic-btn" aria-label="Background options">
+          <pine-icon name="palette" size="18"></pine-icon>
+        </pine-popover-trigger>
+        <pine-popover-portal>
+          <pine-popover-content class="palette palette--popover" side="top" align="start" side_offset="6">
+            <button class="sw sw-default" :data-on="color == 'default'" @click="pick_color('default')" aria-label="Default"><span class="sw-x" aria-hidden="true">⊘</span></button>
+            <button class="sw sw-coral" :data-on="color == 'coral'" @click="pick_color('coral')" aria-label="Coral"></button>
+            <button class="sw sw-peach" :data-on="color == 'peach'" @click="pick_color('peach')" aria-label="Peach"></button>
+            <button class="sw sw-sand" :data-on="color == 'sand'" @click="pick_color('sand')" aria-label="Sand"></button>
+            <button class="sw sw-mint" :data-on="color == 'mint'" @click="pick_color('mint')" aria-label="Mint"></button>
+            <button class="sw sw-sage" :data-on="color == 'sage'" @click="pick_color('sage')" aria-label="Sage"></button>
+            <button class="sw sw-fog" :data-on="color == 'fog'" @click="pick_color('fog')" aria-label="Fog"></button>
+            <button class="sw sw-storm" :data-on="color == 'storm'" @click="pick_color('storm')" aria-label="Storm"></button>
+            <button class="sw sw-dusk" :data-on="color == 'dusk'" @click="pick_color('dusk')" aria-label="Dusk"></button>
+            <button class="sw sw-blossom" :data-on="color == 'blossom'" @click="pick_color('blossom')" aria-label="Blossom"></button>
+            <button class="sw sw-clay" :data-on="color == 'clay'" @click="pick_color('clay')" aria-label="Clay"></button>
+            <button class="sw sw-chalk" :data-on="color == 'chalk'" @click="pick_color('chalk')" aria-label="Chalk"></button>
+          </pine-popover-content>
+        </pine-popover-portal>
+      </pine-popover-root>
+
+      <pine-popover-root pp-model:open="label_picker_open">
+        <pine-popover-trigger class="ic-btn" aria-label="Labels">
+          <pine-icon name="tag" size="18"></pine-icon>
+        </pine-popover-trigger>
+        <pine-popover-portal>
+          <pine-popover-content class="label-pop" side="top" align="start" side_offset="6">
+            <div class="label-pop__h">Label note</div>
+            <pine-input
+              class="label-pop__input"
+              placeholder="Enter label name"
+              pp-model:value="label_query"
+              @keydown.enter="create_label"
+            ></pine-input>
+            <div class="label-pop__list">
+              <template pp-for="label in label_options" pp-key="label.name">
+                <label class="label-pop__row" pp-show="label.visible">
+                  <input
+                    type="checkbox"
+                    :checked="label.selected"
+                    @change="toggle_label(label.name)"
+                  />
+                  <span pp-text="label.name"></span>
+                </label>
+              </template>
+            </div>
+            <button
+              class="label-pop__create"
+              pp-show="label_can_create"
+              @click="create_label"
+            >
+              <pine-icon name="plus" size="14"></pine-icon>
+              <span>Create &ldquo;<span pp-text="label_query"></span>&rdquo;</span>
+            </button>
+          </pine-popover-content>
+        </pine-popover-portal>
+      </pine-popover-root>
+
+      <button class="ic-btn" pp-show="mode == 'editor'" aria-label="Archive" @click="archive">
+        <pine-icon name="archive" size="18"></pine-icon>
+      </button>
+    </div>
+    <button class="note-form-close" @click="save">Close</button>
+  </div>
+</div>

--- a/examples/keep/src/components/note_form/mod.rs
+++ b/examples/keep/src/components/note_form/mod.rs
@@ -1,0 +1,395 @@
+//! Shared note editor used by the inline composer and modal editor.
+//!
+//! The component owns one local edit buffer. Shells provide context
+//! (`draft` vs `editor`) and the form dispatches either a create or update
+//! when the buffer is saved.
+
+use pocopine::create_context;
+use pocopine::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::store::{
+    can_create_label, format_todo_line, label_picker_options_for, parse_todo_line, KeepEditorData,
+    KeepFormNote, KeepLabelOption, KeepStore,
+};
+use crate::KeepTodo;
+
+create_context!(pub(crate) KEEP_NOTE_FORM_CONTEXT: KeepNoteFormContext);
+
+#[derive(Clone, Copy)]
+pub(crate) struct KeepNoteFormContext {
+    pub mode: &'static str,
+}
+
+impl KeepNoteFormContext {
+    pub const DRAFT_COMPOSER: Self = Self { mode: "draft" };
+
+    pub const EDITOR_MODAL: Self = Self { mode: "editor" };
+}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(style = "KeepNoteForm.css")]
+pub struct KeepNoteForm {
+    pub mode: String,
+    pub note_id: String,
+    pub title: String,
+    pub body: String,
+    pub kind: String,
+    pub color: String,
+    pub todos: Vec<KeepTodo>,
+    pub labels: Vec<String>,
+    pub pinned: bool,
+    pub todo_text: String,
+    pub label_picker_open: bool,
+    pub label_query: String,
+    pub label_options: Vec<KeepLabelOption>,
+    pub label_can_create: bool,
+    pub color_picker_open: bool,
+    pub next_todo_id: u64,
+}
+
+#[handlers]
+impl KeepNoteForm {
+    pub fn on_setup(&mut self) {
+        let ctx = KEEP_NOTE_FORM_CONTEXT
+            .inject()
+            .unwrap_or(KeepNoteFormContext::DRAFT_COMPOSER);
+        self.mode = ctx.mode.into();
+        self.reset_draft("text");
+    }
+
+    pub fn on_ready(&self, handle: pocopine::Handle<Self>) {
+        if self.mode == "draft" {
+            let h = handle.clone();
+            pocopine::store::<KeepStore>().watch_field::<bool, _>(
+                "composer_open",
+                move |open, prev| {
+                    let was_open = prev.copied().unwrap_or(false);
+                    if *open && !was_open {
+                        schedule_prepare_draft(h.clone());
+                    } else if !*open && was_open {
+                        schedule_reset_draft(h.clone());
+                    }
+                },
+            );
+
+            let h = handle.clone();
+            pocopine::store::<KeepStore>().watch_field::<String, _>("draft_kind", move |_, _| {
+                schedule_prepare_draft(h.clone());
+            });
+        } else {
+            let h = handle.clone();
+            pocopine::store::<KeepStore>().watch_field::<bool, _>(
+                "editor_open",
+                move |open, prev| {
+                    let was_open = prev.copied().unwrap_or(false);
+                    if *open && !was_open {
+                        schedule_load_editor(h.clone());
+                    }
+                },
+            );
+
+            let h = handle.clone();
+            pocopine::store::<KeepStore>().watch_field::<KeepEditorData, _>(
+                "editor_data",
+                move |data, prev| {
+                    let previous = prev.cloned().unwrap_or_default();
+                    if data.id != previous.id {
+                        schedule_load_editor(h.clone());
+                    } else if data.pinned != previous.pinned {
+                        schedule_sync_editor_pin(h.clone());
+                    }
+                },
+            );
+        }
+
+        let picker = handle.clone();
+        handle.watch_field::<bool, _>("label_picker_open", move |open, _| {
+            if *open {
+                picker.update(KeepNoteForm::rebuild_label_options);
+            }
+        });
+
+        let picker = handle.clone();
+        handle.watch_field::<String, _>("label_query", move |_, _| {
+            picker.update(KeepNoteForm::rebuild_label_options);
+        });
+    }
+
+    pub fn save(&mut self) {
+        if !self.is_active() {
+            return;
+        }
+        self.close_popovers();
+        let form = self.collect_fields();
+        if self.mode == "editor" {
+            crate::shared_layout_transition(move |s| {
+                s.save_form_note(form);
+            });
+        } else {
+            pocopine::store::<KeepStore>().update(move |s| {
+                s.save_form_note(form);
+            });
+        }
+    }
+
+    pub fn cancel(&mut self) {
+        self.close_popovers();
+        if self.mode == "editor" {
+            crate::shared_layout_transition(KeepStore::cancel_editor);
+        } else {
+            self.reset_draft("text");
+            pocopine::store::<KeepStore>().update(KeepStore::cancel_composer);
+        }
+    }
+
+    pub fn toggle_kind(&mut self) {
+        if self.kind == "checklist" {
+            let mut lines: Vec<String> = self.todos.iter().map(format_todo_line).collect();
+            if !self.body.is_empty() {
+                lines.insert(0, self.body.clone());
+            }
+            self.body = lines.join("\n");
+            self.todos.clear();
+            self.kind = "text".into();
+        } else {
+            let lines: Vec<String> = self.body.lines().map(str::to_string).collect();
+            for line in lines {
+                let trimmed = line.trim();
+                if trimmed.is_empty() {
+                    continue;
+                }
+                let (text, done) = parse_todo_line(trimmed);
+                self.push_todo(text, done);
+            }
+            self.body.clear();
+            self.kind = "checklist".into();
+        }
+    }
+
+    pub fn pick_color(&mut self, color: String) {
+        self.color_picker_open = false;
+        self.color = color.clone();
+        if self.mode == "editor" {
+            pocopine::store::<KeepStore>().update(move |s| s.set_editor_color(color));
+        } else {
+            pocopine::store::<KeepStore>().update(move |s| s.set_draft_color(color));
+        }
+    }
+
+    pub fn archive(&mut self) {
+        if self.mode != "editor" || !self.is_active() {
+            return;
+        }
+        self.close_popovers();
+        let form = self.collect_fields();
+        crate::shared_layout_transition(move |s| {
+            s.archive_form_note(form);
+        });
+    }
+
+    pub fn toggle_label(&mut self, label: String) {
+        if let Some(pos) = self.labels.iter().position(|existing| existing == &label) {
+            self.labels.remove(pos);
+        } else {
+            self.labels.push(label.clone());
+            pocopine::store::<KeepStore>().update(move |s| s.add_label(label));
+        }
+        self.rebuild_label_options();
+    }
+
+    pub fn create_label(&mut self) {
+        let label = self.label_query.trim().to_string();
+        if label.is_empty() {
+            return;
+        }
+        let labels = pocopine::store::<KeepStore>().with(|s| s.labels.clone());
+        if !can_create_label(&labels, &label) {
+            return;
+        }
+        self.label_query.clear();
+        if !self.labels.iter().any(|existing| existing == &label) {
+            self.labels.push(label.clone());
+        }
+        self.select_label_option(&label);
+        pocopine::store::<KeepStore>().update(move |s| s.add_label(label));
+    }
+}
+
+fn schedule_prepare_draft(handle: pocopine::Handle<KeepNoteForm>) {
+    pocopine::tick::next(move || {
+        handle.update(KeepNoteForm::prepare_draft_from_store);
+    });
+}
+
+fn schedule_reset_draft(handle: pocopine::Handle<KeepNoteForm>) {
+    pocopine::tick::next(move || {
+        handle.update(|form| form.reset_draft("text"));
+    });
+}
+
+fn schedule_load_editor(handle: pocopine::Handle<KeepNoteForm>) {
+    pocopine::tick::next(move || {
+        handle.update(KeepNoteForm::load_editor_from_store);
+    });
+}
+
+fn schedule_sync_editor_pin(handle: pocopine::Handle<KeepNoteForm>) {
+    pocopine::tick::next(move || {
+        handle.update(KeepNoteForm::sync_editor_pin);
+    });
+}
+
+impl KeepNoteForm {
+    fn close_popovers(&mut self) {
+        self.color_picker_open = false;
+        self.label_picker_open = false;
+    }
+
+    fn is_active(&self) -> bool {
+        let mode = self.mode.clone();
+        pocopine::store::<KeepStore>().with(|s| {
+            if mode == "editor" {
+                s.editor_open
+            } else {
+                s.composer_open
+            }
+        })
+    }
+
+    fn prepare_draft_from_store(&mut self) {
+        if self.mode != "draft" {
+            return;
+        }
+        let Some(kind) = pocopine::store::<KeepStore>().with(|s| {
+            s.composer_open.then(|| {
+                if s.draft_kind == "checklist" {
+                    "checklist".to_string()
+                } else {
+                    "text".to_string()
+                }
+            })
+        }) else {
+            return;
+        };
+        self.reset_draft(&kind);
+    }
+
+    fn reset_draft(&mut self, kind: &str) {
+        self.note_id.clear();
+        self.title.clear();
+        self.body.clear();
+        self.kind = if kind == "checklist" {
+            "checklist".into()
+        } else {
+            "text".into()
+        };
+        self.color = "default".into();
+        self.todos.clear();
+        self.labels.clear();
+        self.pinned = false;
+        self.todo_text.clear();
+        self.label_query.clear();
+        self.label_options.clear();
+        self.label_can_create = false;
+        self.close_popovers();
+    }
+
+    fn load_editor_from_store(&mut self) {
+        if self.mode != "editor" {
+            return;
+        }
+        let Some(data) =
+            pocopine::store::<KeepStore>().with(|s| s.editor_open.then(|| s.editor_data.clone()))
+        else {
+            return;
+        };
+        self.note_id = data.id;
+        self.kind = if data.kind == "checklist" {
+            "checklist".into()
+        } else {
+            "text".into()
+        };
+        self.title = data.title;
+        self.body = data.body;
+        self.color = if data.color.is_empty() {
+            "default".into()
+        } else {
+            data.color
+        };
+        self.todos = data.todos;
+        self.labels = data.labels;
+        self.pinned = data.pinned;
+        self.todo_text.clear();
+        self.label_query.clear();
+        self.rebuild_label_options();
+        self.close_popovers();
+    }
+
+    fn sync_editor_pin(&mut self) {
+        if self.mode != "editor" {
+            return;
+        }
+        if let Some(pinned) =
+            pocopine::store::<KeepStore>().with(|s| s.editor_open.then_some(s.editor_data.pinned))
+        {
+            self.pinned = pinned;
+        }
+    }
+
+    fn collect_fields(&mut self) -> KeepFormNote {
+        let mut todos = self.todos.clone();
+        let inline = self.todo_text.trim().to_string();
+        if self.kind == "checklist" && !inline.is_empty() {
+            self.next_todo_id = self.next_todo_id.saturating_add(1);
+            todos.push(KeepTodo {
+                id: format!("todo_{}_{}", crate::now_ms(), self.next_todo_id),
+                text: inline,
+                done: false,
+            });
+            self.todo_text.clear();
+        }
+        KeepFormNote {
+            note_id: self.note_id.clone(),
+            title: self.title.clone(),
+            body: self.body.clone(),
+            color: self.color.clone(),
+            todos,
+            labels: self.labels.clone(),
+            pinned: self.pinned,
+        }
+    }
+
+    fn push_todo(&mut self, text: String, done: bool) {
+        self.next_todo_id = self.next_todo_id.saturating_add(1);
+        self.todos.push(KeepTodo {
+            id: format!("todo_{}_{}", crate::now_ms(), self.next_todo_id),
+            text,
+            done,
+        });
+    }
+
+    fn rebuild_label_options(&mut self) {
+        let labels = pocopine::store::<KeepStore>().with(|s| s.labels.clone());
+        let (options, can_create) =
+            label_picker_options_for(&labels, &self.labels, &self.label_query);
+        self.label_options = options;
+        self.label_can_create = can_create;
+    }
+
+    fn select_label_option(&mut self, label: &str) {
+        if let Some(option) = self
+            .label_options
+            .iter_mut()
+            .find(|option| option.name == label)
+        {
+            option.selected = true;
+        } else {
+            self.label_options.push(KeepLabelOption {
+                name: label.to_string(),
+                selected: true,
+                visible: true,
+            });
+        }
+    }
+}

--- a/examples/keep/src/lib.rs
+++ b/examples/keep/src/lib.rs
@@ -1,0 +1,34 @@
+//! Keep example — a Google-Keep-style sync demo.
+//!
+//! Code is split into:
+//!
+//! - [`KeepBoard`] — the only `#[component]` mounted in the DOM. It
+//!   hosts the layout shell and, on mount, hooks the sync client up to
+//!   the [`store::KeepStore`] singleton.
+//! - [`store::KeepStore`] — `#[store]` singleton that owns durable app
+//!   state: the synced `notes` collection, registered labels, sidebar
+//!   and search state, command state, and sync handlers.
+//! - [`components`] — UI components: board shell, composer shell,
+//!   shared note form, note body editor, note cards, and editor modal.
+//!   The shared form owns the active edit buffer locally and dispatches
+//!   a typed save payload back into [`store::KeepStore`].
+
+#[cfg(target_arch = "wasm32")]
+mod app;
+pub mod components;
+pub mod model;
+#[cfg(pocopine_host)]
+pub mod sqlite_stream;
+pub mod store;
+pub mod sync;
+pub mod utils;
+
+pub use components::{
+    KeepBoard, KeepComposer, KeepEditor, KeepNoteBody, KeepNoteCard, KeepNoteForm,
+};
+pub use model::*;
+pub use store::KeepStore;
+pub use sync::reset_keep_notes;
+#[cfg(pocopine_host)]
+pub use sync::{__reset_keep_notes_route, live_backend, sync_server};
+pub use utils::{focus_after_flush, now_ms, shared_layout_transition};

--- a/examples/keep/src/model.rs
+++ b/examples/keep/src/model.rs
@@ -1,0 +1,33 @@
+use serde::{Deserialize, Serialize};
+
+pub const KEEP_STREAM: &str = "keep_notes_for_user";
+pub const KEEP_COLLECTION: &str = "keep_notes";
+pub const KEEP_TAGS_STREAM: &str = "keep_tags_for_user";
+pub const KEEP_TAGS_COLLECTION: &str = "keep_tags";
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct KeepTodo {
+    pub id: String,
+    pub text: String,
+    pub done: bool,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct KeepNote {
+    pub id: String,
+    pub title: String,
+    pub body: String,
+    pub color: String,
+    pub pinned: bool,
+    pub archived: bool,
+    pub todos: Vec<KeepTodo>,
+    pub labels: Vec<String>,
+    pub updated_at_ms: u64,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct KeepTag {
+    pub id: String,
+    pub name: String,
+    pub updated_at_ms: u64,
+}

--- a/examples/keep/src/sqlite_stream.rs
+++ b/examples/keep/src/sqlite_stream.rs
@@ -1,0 +1,909 @@
+//! SQLite-backed sync streams for the Keep example server.
+//!
+//! This is intentionally small, but it is a real SQLite sync source:
+//! rows, row versions, incremental changes, and accepted mutation ids are
+//! all persisted in rusqlite. The browser still exercises the
+//! `pocopine-sync-sqlite` local cache; this module is the server-side
+//! authority for the example app.
+
+use std::fs;
+use std::marker::PhantomData;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+
+use pocopine_server::auth::RequestContext;
+use pocopine_sync::{
+    ClientMutation, RowKey, RowVersion, SyncBoxFuture, SyncChange, SyncCollectionName,
+    SyncConflict, SyncCursor, SyncError, SyncOp, SyncPullRequest, SyncPullResponse,
+    SyncPushRequest, SyncPushResponse, SyncRejectedMutation, SyncResult, SyncRow, SyncStreamName,
+    SyncStreamSource,
+};
+use rusqlite::{params, Connection, OptionalExtension, Transaction};
+use serde::{de::DeserializeOwned, Serialize};
+use serde_json::Value;
+
+use crate::{KeepNote, KeepTag};
+
+const SCHEMA_VERSION: &str = "2";
+const LEGACY_SCHEMA_VERSION: &str = "1";
+const META_SCHEMA_VERSION: &str = "schema_version";
+const META_CURSOR_VERSION: &str = "cursor_version";
+
+/// Where the keep example writes notes. Set `POCOPINE_KEEP_NOTES_DB_PATH` to
+/// isolate test/dev runs; otherwise the database sits under the system temp
+/// dir so it does not pollute the source tree but survives `cargo run` cycles.
+pub fn default_keep_notes_path() -> PathBuf {
+    default_keep_sqlite_path("POCOPINE_KEEP_NOTES_DB_PATH", "pocopine_keep_notes.sqlite3")
+}
+
+/// Where the keep example writes tags. Set `POCOPINE_KEEP_TAGS_DB_PATH` to
+/// isolate test/dev runs.
+pub fn default_keep_tags_path() -> PathBuf {
+    default_keep_sqlite_path("POCOPINE_KEEP_TAGS_DB_PATH", "pocopine_keep_tags.sqlite3")
+}
+
+fn default_keep_sqlite_path(env_key: &str, file_name: &str) -> PathBuf {
+    if let Some(path) = std::env::var_os(env_key)
+        .filter(|path| !path.is_empty())
+        .map(PathBuf::from)
+    {
+        return path;
+    }
+    std::env::temp_dir().join(file_name)
+}
+
+#[derive(Clone)]
+pub struct SqliteSyncStream<T> {
+    stream: SyncStreamName,
+    collection: SyncCollectionName,
+    path: PathBuf,
+    lock: Arc<Mutex<()>>,
+    _marker: PhantomData<fn() -> T>,
+}
+
+pub type SqliteKeepStream = SqliteSyncStream<KeepNote>;
+pub type SqliteKeepTagStream = SqliteSyncStream<KeepTag>;
+
+impl<T> SqliteSyncStream<T>
+where
+    T: DeserializeOwned + Serialize + Send + Sync + 'static,
+{
+    /// Create the stream and initialize the SQLite schema.
+    pub fn open(stream: &str, collection: &str, path: PathBuf) -> SyncResult<Self> {
+        let stream = SyncStreamName::new(stream)?;
+        let collection = SyncCollectionName::new(collection)?;
+        open_database(&path)?;
+
+        Ok(Self {
+            stream,
+            collection,
+            path,
+            lock: Arc::new(Mutex::new(())),
+            _marker: PhantomData,
+        })
+    }
+
+    pub fn upsert(&self, id: impl Into<String>, row: T) -> SyncResult<SyncCursor> {
+        let key = RowKey::new(id.into())?;
+        let payload = serde_json::to_value(row)?;
+        self.with_transaction(|tx| {
+            let version = next_version(tx)?;
+            let row = self.write_upsert(tx, key, version, payload)?;
+            Ok(row.cursor)
+        })
+    }
+
+    pub fn reset(&self) -> SyncResult<SyncCursor> {
+        self.with_transaction(|tx| {
+            let version = next_version(tx)?;
+            tx.execute("DELETE FROM keep_rows", [])
+                .map_err(sqlite_error)?;
+            self.insert_change(tx, version, None, SyncOp::Reset, None)?;
+            SyncCursor::new(version.to_string())
+        })
+    }
+
+    fn with_connection<R>(&self, f: impl FnOnce(&Connection) -> SyncResult<R>) -> SyncResult<R> {
+        let _guard = self
+            .lock
+            .lock()
+            .map_err(|_| SyncError::backend("keep sqlite stream lock poisoned"))?;
+        let conn = open_database(&self.path)?;
+        f(&conn)
+    }
+
+    fn with_transaction<R>(
+        &self,
+        f: impl FnOnce(&Transaction<'_>) -> SyncResult<R>,
+    ) -> SyncResult<R> {
+        let _guard = self
+            .lock
+            .lock()
+            .map_err(|_| SyncError::backend("keep sqlite stream lock poisoned"))?;
+        let mut conn = open_database(&self.path)?;
+        let tx = conn.transaction().map_err(sqlite_error)?;
+        let result = f(&tx)?;
+        tx.commit().map_err(sqlite_error)?;
+        Ok(result)
+    }
+
+    fn current_cursor_value(&self) -> SyncResult<SyncCursor> {
+        self.with_connection(|conn| SyncCursor::new(current_version(conn)?.to_string()))
+    }
+
+    fn pull_value(&self, request: SyncPullRequest) -> SyncResult<SyncPullResponse<Value>> {
+        self.with_connection(|conn| {
+            let cursor = Some(SyncCursor::new(current_version(conn)?.to_string())?);
+            let Some(after) = request.cursor else {
+                let rows = self.snapshot_rows(conn)?;
+                return Ok(SyncPullResponse::snapshot(
+                    self.stream.clone(),
+                    self.collection.clone(),
+                    rows,
+                    cursor,
+                ));
+            };
+
+            let after = after
+                .as_str()
+                .parse::<u64>()
+                .map_err(|_| SyncError::Gap(after.to_string()))?;
+            let changes = self.incremental_changes(conn, after)?;
+            Ok(SyncPullResponse::incremental(
+                self.stream.clone(),
+                self.collection.clone(),
+                changes,
+                cursor,
+            ))
+        })
+    }
+
+    fn push_value(&self, request: SyncPushRequest<Value>) -> SyncResult<SyncPushResponse<Value>> {
+        self.with_transaction(|tx| {
+            let mut response = SyncPushResponse::new(self.stream.clone());
+            response.collection = Some(self.collection.clone());
+
+            for mutation in request.mutations {
+                if mutation_was_accepted(tx, mutation.id.as_str())? {
+                    response.accepted.push(mutation.id);
+                    continue;
+                }
+
+                match self.apply_mutation(tx, mutation)? {
+                    SqliteMutationOutcome::Accepted {
+                        mutation_id,
+                        row,
+                        cursor,
+                    } => {
+                        record_accepted_mutation(tx, mutation_id.as_str())?;
+                        response.accepted.push(mutation_id);
+                        if let Some(row) = row {
+                            response.rows.push(row);
+                        }
+                        response.cursor = Some(cursor);
+                    }
+                    SqliteMutationOutcome::Rejected(rejected) => {
+                        response.rejected.push(rejected);
+                    }
+                    SqliteMutationOutcome::Conflict(conflict) => {
+                        response.conflicts.push(conflict);
+                    }
+                }
+            }
+
+            Ok(response)
+        })
+    }
+
+    fn apply_mutation(
+        &self,
+        tx: &Transaction<'_>,
+        mutation: ClientMutation<Value>,
+    ) -> SyncResult<SqliteMutationOutcome> {
+        match mutation.op {
+            SyncOp::Upsert => self.apply_upsert(tx, mutation),
+            SyncOp::Delete => self.apply_delete(tx, mutation),
+            SyncOp::Reset => self.apply_reset(tx, mutation),
+        }
+    }
+
+    fn apply_upsert(
+        &self,
+        tx: &Transaction<'_>,
+        mutation: ClientMutation<Value>,
+    ) -> SyncResult<SqliteMutationOutcome> {
+        let Some(key) = mutation.key.clone() else {
+            return Ok(SqliteMutationOutcome::Rejected(SyncRejectedMutation {
+                mutation_id: mutation.id,
+                key: None,
+                reason: "upsert requires a row key".to_string(),
+            }));
+        };
+
+        if let Some(conflict) = self.version_conflict(tx, &mutation, key.as_str())? {
+            return Ok(SqliteMutationOutcome::Conflict(conflict));
+        }
+
+        let value = match serde_json::from_value::<T>(mutation.payload.clone()) {
+            Ok(value) => value,
+            Err(err) => {
+                return Ok(SqliteMutationOutcome::Rejected(SyncRejectedMutation {
+                    mutation_id: mutation.id,
+                    key: Some(key),
+                    reason: format!("invalid mutation payload: {err}"),
+                }));
+            }
+        };
+        let payload = serde_json::to_value(value)?;
+        let version = next_version(tx)?;
+        let row = self.write_upsert(tx, key, version, payload)?;
+
+        Ok(SqliteMutationOutcome::Accepted {
+            mutation_id: mutation.id,
+            row: Some(row.row),
+            cursor: row.cursor,
+        })
+    }
+
+    fn apply_delete(
+        &self,
+        tx: &Transaction<'_>,
+        mutation: ClientMutation<Value>,
+    ) -> SyncResult<SqliteMutationOutcome> {
+        let Some(key) = mutation.key.clone() else {
+            return Ok(SqliteMutationOutcome::Rejected(SyncRejectedMutation {
+                mutation_id: mutation.id,
+                key: None,
+                reason: "delete requires a row key".to_string(),
+            }));
+        };
+
+        if let Some(conflict) = self.version_conflict(tx, &mutation, key.as_str())? {
+            return Ok(SqliteMutationOutcome::Conflict(conflict));
+        }
+
+        let version = next_version(tx)?;
+        tx.execute("DELETE FROM keep_rows WHERE row_key = ?1", [key.as_str()])
+            .map_err(sqlite_error)?;
+        self.insert_change(tx, version, Some(&key), SyncOp::Delete, None)?;
+
+        Ok(SqliteMutationOutcome::Accepted {
+            mutation_id: mutation.id,
+            row: None,
+            cursor: SyncCursor::new(version.to_string())?,
+        })
+    }
+
+    fn apply_reset(
+        &self,
+        tx: &Transaction<'_>,
+        mutation: ClientMutation<Value>,
+    ) -> SyncResult<SqliteMutationOutcome> {
+        let version = next_version(tx)?;
+        tx.execute("DELETE FROM keep_rows", [])
+            .map_err(sqlite_error)?;
+        self.insert_change(tx, version, None, SyncOp::Reset, None)?;
+
+        Ok(SqliteMutationOutcome::Accepted {
+            mutation_id: mutation.id,
+            row: None,
+            cursor: SyncCursor::new(version.to_string())?,
+        })
+    }
+
+    fn write_upsert(
+        &self,
+        tx: &Transaction<'_>,
+        key: RowKey,
+        version: u64,
+        payload: Value,
+    ) -> SyncResult<AppliedRow> {
+        let payload = serde_json::to_string(&payload)?;
+        tx.execute(
+            r#"
+            INSERT INTO keep_rows (row_key, version, payload)
+            VALUES (?1, ?2, ?3)
+            ON CONFLICT(row_key) DO UPDATE SET
+                version = excluded.version,
+                payload = excluded.payload
+            "#,
+            params![key.as_str(), version_to_i64(version)?, payload],
+        )
+        .map_err(sqlite_error)?;
+
+        let row = sync_row_from_parts(key.as_str().to_string(), version, payload)?;
+        self.insert_change(tx, version, Some(&key), SyncOp::Upsert, Some(&row))?;
+        Ok(AppliedRow {
+            row,
+            cursor: SyncCursor::new(version.to_string())?,
+        })
+    }
+
+    fn version_conflict(
+        &self,
+        tx: &Transaction<'_>,
+        mutation: &ClientMutation<Value>,
+        key: &str,
+    ) -> SyncResult<Option<SyncConflict<Value>>> {
+        let Some(expected) = mutation.base_version.as_ref() else {
+            return Ok(None);
+        };
+        let server_row = select_row(tx, key)?.map(sync_row_from_stored).transpose()?;
+        let server_version = server_row.as_ref().and_then(|row| row.version.as_ref());
+        if server_version == Some(expected) {
+            return Ok(None);
+        }
+
+        Ok(Some(SyncConflict {
+            mutation_id: mutation.id.clone(),
+            key: mutation.key.clone(),
+            server_row,
+            reason: "base version is stale".to_string(),
+        }))
+    }
+
+    fn snapshot_rows(&self, conn: &Connection) -> SyncResult<Vec<SyncRow<Value>>> {
+        let mut stmt = conn
+            .prepare("SELECT row_key, version, payload FROM keep_rows ORDER BY row_key")
+            .map_err(sqlite_error)?;
+        let rows = stmt
+            .query_map([], stored_row_from_sql)
+            .map_err(sqlite_error)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(sqlite_error)?;
+
+        rows.into_iter().map(sync_row_from_stored).collect()
+    }
+
+    fn incremental_changes(
+        &self,
+        conn: &Connection,
+        after: u64,
+    ) -> SyncResult<Vec<SyncChange<Value>>> {
+        let mut stmt = conn
+            .prepare(
+                r#"
+                SELECT cursor, row_key, op, row_version, payload
+                FROM keep_changes
+                WHERE cursor > ?1
+                ORDER BY cursor
+                "#,
+            )
+            .map_err(sqlite_error)?;
+        let changes = stmt
+            .query_map([version_to_i64(after)?], stored_change_from_sql)
+            .map_err(sqlite_error)?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(sqlite_error)?;
+
+        changes
+            .into_iter()
+            .map(|change| self.sync_change_from_stored(change))
+            .collect()
+    }
+
+    fn insert_change(
+        &self,
+        tx: &Transaction<'_>,
+        cursor: u64,
+        key: Option<&RowKey>,
+        op: SyncOp,
+        row: Option<&SyncRow<Value>>,
+    ) -> SyncResult<()> {
+        let payload = row
+            .map(|row| serde_json::to_string(&row.value))
+            .transpose()?;
+        let row_version = row
+            .and_then(|row| row.version.as_ref())
+            .map(|version| version.as_str().to_string());
+        tx.execute(
+            r#"
+            INSERT INTO keep_changes (cursor, row_key, op, row_version, payload)
+            VALUES (?1, ?2, ?3, ?4, ?5)
+            "#,
+            params![
+                version_to_i64(cursor)?,
+                key.map(RowKey::as_str),
+                op_to_db(op),
+                row_version,
+                payload
+            ],
+        )
+        .map_err(sqlite_error)?;
+        Ok(())
+    }
+
+    fn sync_change_from_stored(&self, change: StoredChange) -> SyncResult<SyncChange<Value>> {
+        let op = op_from_db(&change.op)?;
+        let key_value = change.key.clone();
+        let key = key_value.clone().map(RowKey::new).transpose()?;
+        let row = match (key_value.as_deref(), change.row_version, change.payload) {
+            (Some(key), Some(version), Some(payload)) => Some(sync_row_from_parts(
+                key.to_string(),
+                parse_row_version(&version)?,
+                payload,
+            )?),
+            _ => None,
+        };
+
+        Ok(SyncChange {
+            stream: self.stream.clone(),
+            collection: self.collection.clone(),
+            key,
+            op,
+            row,
+            cursor: SyncCursor::new(change.cursor.to_string())?,
+        })
+    }
+}
+
+impl<T> SyncStreamSource for SqliteSyncStream<T>
+where
+    T: DeserializeOwned + Serialize + Send + Sync + 'static,
+{
+    fn stream(&self) -> &SyncStreamName {
+        &self.stream
+    }
+
+    fn collection(&self) -> &SyncCollectionName {
+        &self.collection
+    }
+
+    fn current_cursor(&self, ctx: &RequestContext) -> Option<SyncCursor> {
+        let _ = ctx;
+        self.current_cursor_value().ok()
+    }
+
+    fn pull<'a>(
+        &'a self,
+        ctx: RequestContext,
+        request: SyncPullRequest,
+    ) -> SyncBoxFuture<'a, SyncPullResponse<Value>> {
+        let _ = ctx;
+        Box::pin(async move { self.pull_value(request) })
+    }
+
+    fn push<'a>(
+        &'a self,
+        ctx: RequestContext,
+        request: SyncPushRequest<Value>,
+    ) -> SyncBoxFuture<'a, SyncPushResponse<Value>> {
+        let _ = ctx;
+        Box::pin(async move { self.push_value(request) })
+    }
+}
+
+struct AppliedRow {
+    row: SyncRow<Value>,
+    cursor: SyncCursor,
+}
+
+enum SqliteMutationOutcome {
+    Accepted {
+        mutation_id: pocopine_sync::MutationId,
+        row: Option<SyncRow<Value>>,
+        cursor: SyncCursor,
+    },
+    Rejected(SyncRejectedMutation),
+    Conflict(SyncConflict<Value>),
+}
+
+struct StoredRow {
+    key: String,
+    version: u64,
+    payload: String,
+}
+
+struct StoredChange {
+    cursor: u64,
+    key: Option<String>,
+    op: String,
+    row_version: Option<String>,
+    payload: Option<String>,
+}
+
+fn open_database(path: &Path) -> SyncResult<Connection> {
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent).map_err(|err| SyncError::backend(err.to_string()))?;
+    }
+    let conn = Connection::open(path).map_err(sqlite_error)?;
+    conn.busy_timeout(std::time::Duration::from_secs(5))
+        .map_err(sqlite_error)?;
+    bootstrap_schema(&conn)?;
+    Ok(conn)
+}
+
+fn bootstrap_schema(conn: &Connection) -> SyncResult<()> {
+    conn.execute_batch(
+        r#"
+        CREATE TABLE IF NOT EXISTS keep_meta (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        );
+        "#,
+    )
+    .map_err(sqlite_error)?;
+
+    let existing: Option<String> = conn
+        .query_row(
+            "SELECT value FROM keep_meta WHERE key = ?1",
+            [META_SCHEMA_VERSION],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(sqlite_error)?;
+
+    match existing.as_deref() {
+        None => {
+            create_stream_tables(conn)?;
+            set_meta(conn, META_SCHEMA_VERSION, SCHEMA_VERSION)?;
+            set_meta(conn, META_CURSOR_VERSION, "0")?;
+        }
+        Some(LEGACY_SCHEMA_VERSION) => {
+            create_stream_tables(conn)?;
+            ensure_row_version_column(conn)?;
+            set_meta(conn, META_SCHEMA_VERSION, SCHEMA_VERSION)?;
+            set_meta(conn, META_CURSOR_VERSION, "0")?;
+        }
+        Some(SCHEMA_VERSION) => {
+            create_stream_tables(conn)?;
+            ensure_row_version_column(conn)?;
+            conn.execute(
+                "INSERT OR IGNORE INTO keep_meta (key, value) VALUES (?1, ?2)",
+                [META_CURSOR_VERSION, "0"],
+            )
+            .map_err(sqlite_error)?;
+        }
+        Some(other) => {
+            return Err(SyncError::backend(format!(
+                "incompatible keep sqlite schema version: {other}"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+fn create_stream_tables(conn: &Connection) -> SyncResult<()> {
+    conn.execute_batch(
+        r#"
+        CREATE TABLE IF NOT EXISTS keep_rows (
+            row_key TEXT PRIMARY KEY,
+            version INTEGER NOT NULL,
+            payload TEXT NOT NULL
+        );
+        CREATE TABLE IF NOT EXISTS keep_changes (
+            cursor INTEGER PRIMARY KEY,
+            row_key TEXT,
+            op TEXT NOT NULL,
+            row_version TEXT,
+            payload TEXT
+        );
+        CREATE TABLE IF NOT EXISTS keep_accepted_mutations (
+            mutation_id TEXT PRIMARY KEY
+        );
+        "#,
+    )
+    .map_err(sqlite_error)?;
+    Ok(())
+}
+
+fn ensure_row_version_column(conn: &Connection) -> SyncResult<()> {
+    let mut stmt = conn
+        .prepare("PRAGMA table_info(keep_rows)")
+        .map_err(sqlite_error)?;
+    let columns = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .map_err(sqlite_error)?
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(sqlite_error)?;
+    if !columns.iter().any(|column| column == "version") {
+        conn.execute(
+            "ALTER TABLE keep_rows ADD COLUMN version INTEGER NOT NULL DEFAULT 0",
+            [],
+        )
+        .map_err(sqlite_error)?;
+    }
+    Ok(())
+}
+
+fn set_meta(conn: &Connection, key: &str, value: &str) -> SyncResult<()> {
+    conn.execute(
+        r#"
+        INSERT INTO keep_meta (key, value) VALUES (?1, ?2)
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+        "#,
+        [key, value],
+    )
+    .map_err(sqlite_error)?;
+    Ok(())
+}
+
+fn current_version(conn: &Connection) -> SyncResult<u64> {
+    let value: String = conn
+        .query_row(
+            "SELECT value FROM keep_meta WHERE key = ?1",
+            [META_CURSOR_VERSION],
+            |row| row.get(0),
+        )
+        .map_err(sqlite_error)?;
+    value
+        .parse::<u64>()
+        .map_err(|_| SyncError::backend("keep sqlite cursor version is not numeric"))
+}
+
+fn next_version(tx: &Transaction<'_>) -> SyncResult<u64> {
+    let current = current_version(tx)?;
+    let next = current.saturating_add(1);
+    tx.execute(
+        "UPDATE keep_meta SET value = ?1 WHERE key = ?2",
+        params![next.to_string(), META_CURSOR_VERSION],
+    )
+    .map_err(sqlite_error)?;
+    Ok(next)
+}
+
+fn mutation_was_accepted(tx: &Transaction<'_>, mutation_id: &str) -> SyncResult<bool> {
+    let seen: Option<String> = tx
+        .query_row(
+            "SELECT mutation_id FROM keep_accepted_mutations WHERE mutation_id = ?1",
+            [mutation_id],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(sqlite_error)?;
+    Ok(seen.is_some())
+}
+
+fn record_accepted_mutation(tx: &Transaction<'_>, mutation_id: &str) -> SyncResult<()> {
+    tx.execute(
+        "INSERT INTO keep_accepted_mutations (mutation_id) VALUES (?1)",
+        [mutation_id],
+    )
+    .map_err(sqlite_error)?;
+    Ok(())
+}
+
+fn select_row(conn: &Connection, key: &str) -> SyncResult<Option<StoredRow>> {
+    conn.query_row(
+        "SELECT row_key, version, payload FROM keep_rows WHERE row_key = ?1",
+        [key],
+        stored_row_from_sql,
+    )
+    .optional()
+    .map_err(sqlite_error)
+}
+
+fn stored_row_from_sql(row: &rusqlite::Row<'_>) -> rusqlite::Result<StoredRow> {
+    Ok(StoredRow {
+        key: row.get(0)?,
+        version: i64_to_version(row.get::<_, i64>(1)?)?,
+        payload: row.get(2)?,
+    })
+}
+
+fn stored_change_from_sql(row: &rusqlite::Row<'_>) -> rusqlite::Result<StoredChange> {
+    Ok(StoredChange {
+        cursor: i64_to_version(row.get::<_, i64>(0)?)?,
+        key: row.get(1)?,
+        op: row.get(2)?,
+        row_version: row.get(3)?,
+        payload: row.get(4)?,
+    })
+}
+
+fn sync_row_from_stored(row: StoredRow) -> SyncResult<SyncRow<Value>> {
+    sync_row_from_parts(row.key, row.version, row.payload)
+}
+
+fn sync_row_from_parts(key: String, version: u64, payload: String) -> SyncResult<SyncRow<Value>> {
+    Ok(SyncRow {
+        key: RowKey::new(key)?,
+        value: serde_json::from_str(&payload)?,
+        version: Some(RowVersion::new(format!("v{version}"))?),
+        pending: false,
+        conflict: false,
+    })
+}
+
+fn parse_row_version(version: &str) -> SyncResult<u64> {
+    version
+        .strip_prefix('v')
+        .ok_or_else(|| SyncError::backend("keep sqlite row version is missing v prefix"))?
+        .parse::<u64>()
+        .map_err(|_| SyncError::backend("keep sqlite row version is not numeric"))
+}
+
+fn op_to_db(op: SyncOp) -> &'static str {
+    match op {
+        SyncOp::Upsert => "upsert",
+        SyncOp::Delete => "delete",
+        SyncOp::Reset => "reset",
+    }
+}
+
+fn op_from_db(op: &str) -> SyncResult<SyncOp> {
+    match op {
+        "upsert" => Ok(SyncOp::Upsert),
+        "delete" => Ok(SyncOp::Delete),
+        "reset" => Ok(SyncOp::Reset),
+        _ => Err(SyncError::backend(format!(
+            "unknown keep sqlite sync op: {op}"
+        ))),
+    }
+}
+
+fn version_to_i64(version: u64) -> SyncResult<i64> {
+    i64::try_from(version).map_err(|_| SyncError::backend("keep sqlite version overflow"))
+}
+
+fn i64_to_version(version: i64) -> rusqlite::Result<u64> {
+    u64::try_from(version).map_err(|err| {
+        rusqlite::Error::FromSqlConversionFailure(0, rusqlite::types::Type::Integer, Box::new(err))
+    })
+}
+
+fn sqlite_error(err: rusqlite::Error) -> SyncError {
+    SyncError::backend(format!("keep sqlite error: {err}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pocopine_server::axum::http::{HeaderMap, Method, Uri};
+    use pocopine_sync::{
+        ClientMutation, MutationId, SyncPullMode, SyncPullRequest, SyncPushRequest,
+    };
+
+    fn test_note(id: &str, title: &str) -> KeepNote {
+        KeepNote {
+            id: id.to_string(),
+            title: title.to_string(),
+            body: String::new(),
+            color: "default".to_string(),
+            pinned: false,
+            archived: false,
+            todos: Vec::new(),
+            labels: Vec::new(),
+            updated_at_ms: 0,
+        }
+    }
+
+    fn test_context() -> RequestContext {
+        RequestContext::new(Method::GET, Uri::from_static("/"), HeaderMap::new())
+    }
+
+    fn test_path(name: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "pocopine_keep_{name}_{}_{}.sqlite3",
+            std::process::id(),
+            crate::now_ms()
+        ))
+    }
+
+    #[tokio::test]
+    async fn sqlite_stream_rehydrates_persisted_rows() {
+        let path = test_path("rehydrates");
+        let _ = std::fs::remove_file(&path);
+
+        {
+            let stream =
+                SqliteKeepStream::open(crate::KEEP_STREAM, crate::KEEP_COLLECTION, path.clone())
+                    .unwrap();
+            stream
+                .upsert("note_1", test_note("note_1", "Persisted"))
+                .unwrap();
+        }
+
+        let stream =
+            SqliteKeepStream::open(crate::KEEP_STREAM, crate::KEEP_COLLECTION, path.clone())
+                .unwrap();
+        let request = SyncPullRequest::new(SyncStreamName::new(crate::KEEP_STREAM).unwrap());
+        let response = stream.pull(test_context(), request).await.unwrap();
+
+        assert_eq!(response.mode, SyncPullMode::Snapshot);
+        assert_eq!(response.rows.len(), 1);
+        assert_eq!(response.rows[0].value["id"], "note_1");
+        assert_eq!(response.rows[0].value["title"], "Persisted");
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn sqlite_stream_persists_incremental_changes() {
+        let path = test_path("incremental");
+        let _ = std::fs::remove_file(&path);
+
+        {
+            let stream =
+                SqliteKeepStream::open(crate::KEEP_STREAM, crate::KEEP_COLLECTION, path.clone())
+                    .unwrap();
+            stream
+                .upsert("note_1", test_note("note_1", "First"))
+                .unwrap();
+        }
+
+        let stream =
+            SqliteKeepStream::open(crate::KEEP_STREAM, crate::KEEP_COLLECTION, path.clone())
+                .unwrap();
+        let response = stream
+            .pull(
+                test_context(),
+                SyncPullRequest::new(SyncStreamName::new(crate::KEEP_STREAM).unwrap())
+                    .cursor(Some(SyncCursor::new("0").unwrap())),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.mode, SyncPullMode::Incremental);
+        assert_eq!(response.changes.len(), 1);
+        assert_eq!(response.changes[0].op, SyncOp::Upsert);
+        assert_eq!(
+            response.changes[0].row.as_ref().unwrap().value["title"],
+            "First"
+        );
+
+        let _ = std::fs::remove_file(path);
+    }
+
+    #[tokio::test]
+    async fn sqlite_stream_dedupes_accepted_mutations_in_sqlite() {
+        let path = test_path("dedupe");
+        let _ = std::fs::remove_file(&path);
+
+        let stream =
+            SqliteKeepStream::open(crate::KEEP_STREAM, crate::KEEP_COLLECTION, path.clone())
+                .unwrap();
+        let mutation = ClientMutation {
+            id: MutationId::new("device_1:dupe").unwrap(),
+            key: Some(RowKey::new("note_1").unwrap()),
+            op: SyncOp::Upsert,
+            base_version: None,
+            payload: serde_json::to_value(test_note("note_1", "First")).unwrap(),
+        };
+
+        stream
+            .push(
+                test_context(),
+                SyncPushRequest::new(
+                    SyncStreamName::new(crate::KEEP_STREAM).unwrap(),
+                    [mutation.clone()],
+                ),
+            )
+            .await
+            .unwrap();
+        stream
+            .upsert("note_1", test_note("note_1", "Server replacement"))
+            .unwrap();
+
+        let stream =
+            SqliteKeepStream::open(crate::KEEP_STREAM, crate::KEEP_COLLECTION, path.clone())
+                .unwrap();
+        let replayed = stream
+            .push(
+                test_context(),
+                SyncPushRequest::new(SyncStreamName::new(crate::KEEP_STREAM).unwrap(), [mutation]),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(replayed.accepted[0].as_str(), "device_1:dupe");
+        assert!(replayed.cursor.is_none());
+
+        let response = stream
+            .pull(
+                test_context(),
+                SyncPullRequest::new(SyncStreamName::new(crate::KEEP_STREAM).unwrap()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.rows.len(), 1);
+        assert_eq!(response.rows[0].value["title"], "Server replacement");
+
+        let _ = std::fs::remove_file(path);
+    }
+}

--- a/examples/keep/src/store/actions.rs
+++ b/examples/keep/src/store/actions.rs
@@ -1,0 +1,393 @@
+use pocopine::prelude::*;
+
+use crate::KeepTodo;
+
+use super::{
+    theme::{load_theme_preference, save_theme_preference},
+    view::{format_todo_line, parse_todo_line, KeepEditorData},
+    KeepStore,
+};
+
+#[handlers]
+impl KeepStore {
+    /// Re-assert the semantic defaults that need to be present at first
+    /// render. Default::default() already does this at construction;
+    /// calling it again from KeepBoard::on_mount is defensive — if the
+    /// store proxy's listeners haven't subscribed by the time the
+    /// constructor ran (e.g. the very first template walk), this
+    /// assignment fires another change notification.
+    pub fn ensure_defaults(&mut self) {
+        if self.section_kind.is_empty() {
+            self.section_kind = "notes".into();
+        }
+        if self.draft_kind.is_empty() {
+            self.draft_kind = "text".into();
+        }
+        if self.draft_color.is_empty() {
+            self.draft_color = "default".into();
+        }
+        self.theme = load_theme_preference();
+        self.labels = self.tag_label_registry();
+        self.rebuild_visible_notes();
+    }
+
+    // ─── shell ───
+
+    pub fn toggle_sidebar(&mut self) {
+        self.sidebar_expanded = !self.sidebar_expanded;
+    }
+
+    pub fn show_notes(&mut self) {
+        self.clear_selection();
+        self.section_kind = "notes".into();
+        self.section_label.clear();
+        self.rebuild_visible_notes();
+    }
+
+    pub fn show_archive(&mut self) {
+        self.clear_selection();
+        self.section_kind = "archive".into();
+        self.section_label.clear();
+        self.rebuild_visible_notes();
+    }
+
+    /// Filter the masonry to a single label. Empty `label` falls
+    /// back to the default Notes view.
+    pub fn show_label(&mut self, label: String) {
+        let label = label.trim();
+        if label.is_empty() {
+            self.clear_selection();
+            self.section_kind = "notes".into();
+            self.section_label.clear();
+            self.rebuild_visible_notes();
+            return;
+        }
+        self.clear_selection();
+        self.section_kind = "label".into();
+        self.section_label = label.to_string();
+        self.rebuild_visible_notes();
+    }
+
+    pub fn clear_search(&mut self) {
+        self.search_query.clear();
+    }
+
+    pub fn toggle_theme(&mut self) {
+        self.theme = self.theme.toggled();
+        save_theme_preference(self.theme);
+    }
+
+    pub fn add_label(&mut self, label: String) {
+        if self.remember_label(&label).is_some() {
+            self.sidebar_expanded = true;
+        }
+    }
+
+    pub fn create_command_label(&mut self) {
+        let label = self.command_label_query.trim().to_string();
+        if label.is_empty() {
+            return;
+        }
+        self.command_label_query.clear();
+        self.add_label(label);
+    }
+
+    pub fn refresh(&mut self) {
+        // If the local cache had a cursor but no rows (e.g. the
+        // server bin lost its in-memory state and the OPFS-cached
+        // cursor is now ahead of the server's), an incremental
+        // pull comes back empty and the masonry stays empty too.
+        // Drop the cursor in that case so the next request asks
+        // for a Snapshot and recovers all rows.
+        if self.notes.rows.is_empty() && self.notes.cursor.is_some() {
+            self.notes.cursor = None;
+        }
+        if self.tags.rows.is_empty() && self.tags.cursor.is_some() {
+            self.tags.cursor = None;
+        }
+        let plugins = Plugins;
+        let Some(client) = plugins.get::<pocopine_sync::SyncClient>() else {
+            self.notes.set_error("sync plugin not installed");
+            return;
+        };
+        let notes_result = client
+            .collection(pocopine::store::<Self>(), |s: &mut Self| &mut s.notes)
+            .stream(crate::KEEP_STREAM)
+            .and_then(|c| c.pull());
+        let tags_result = client
+            .collection(pocopine::store::<Self>(), |s: &mut Self| &mut s.tags)
+            .stream(crate::KEEP_TAGS_STREAM)
+            .and_then(|c| c.pull());
+        if let Err(err) = notes_result {
+            self.status = "refresh failed".into();
+            self.notes.set_error(err.to_string());
+        } else if let Err(err) = tags_result {
+            self.status = "refresh failed".into();
+            self.notes.set_error(err.to_string());
+        }
+    }
+
+    /// Force a Snapshot pull regardless of local state — wipes the
+    /// in-memory cursor so the next request hits the server with
+    /// `cursor: null`. Recovery action when the durable client
+    /// cache and the transient server cursor have drifted (rows
+    /// gone but a stale cursor still cached).
+    pub fn resync(&mut self) {
+        self.notes.cursor = None;
+        self.tags.cursor = None;
+        self.refresh();
+    }
+
+    pub fn reset(&mut self) {
+        self.resetting = true;
+        self.notes.clear_error();
+        self.tags.clear_error();
+        dispatch!(crate::reset_keep_notes().await, |s, result| {
+            s.resetting = false;
+            match result {
+                Ok(()) => {
+                    s.status.clear();
+                    s.notes.rows.clear();
+                    s.notes.cursor = None;
+                    s.tags.rows.clear();
+                    s.tags.cursor = None;
+                    s.labels.clear();
+                    s.clear_selection();
+                    s.rebuild_visible_notes();
+                }
+                Err(err) => {
+                    s.status = "reset failed".into();
+                    s.notes.set_error(err.to_string());
+                }
+            }
+        });
+    }
+
+    // ─── composer ───
+
+    pub fn expand_composer_text(&mut self) {
+        self.composer_open = true;
+        self.draft_kind = "text".into();
+    }
+
+    pub fn expand_composer_todo(&mut self) {
+        self.composer_open = true;
+        self.draft_kind = "checklist".into();
+    }
+
+    pub fn set_draft_color(&mut self, color: String) {
+        self.draft_color = color;
+    }
+
+    /// Discard the in-progress draft and close the composer without
+    /// persisting anything. Bound to Escape from the composer's
+    /// inputs.
+    pub fn cancel_composer(&mut self) {
+        self.composer_open = false;
+        self.draft_color = "default".into();
+        self.draft_kind = "text".into();
+    }
+
+    // ─── card actions ───
+
+    pub fn toggle_pin(&mut self, note_id: String) {
+        self.update_note(&note_id, "pin", |note| {
+            note.pinned = !note.pinned;
+            if note.pinned {
+                note.archived = false;
+            }
+        });
+    }
+
+    pub fn toggle_archive(&mut self, note_id: String) {
+        self.update_note(&note_id, "archive", |note| {
+            note.archived = !note.archived;
+            if note.archived {
+                note.pinned = false;
+            }
+        });
+    }
+
+    pub fn delete_note(&mut self, note_id: String) {
+        let Some((_, base_version)) = self.find_note(&note_id) else {
+            self.notes.set_error("note is not loaded yet");
+            return;
+        };
+        match self.push_delete(&note_id, base_version, "delete") {
+            Ok(()) => self.status.clear(),
+            Err(err) => {
+                self.status = "delete failed".into();
+                self.notes.set_error(err.to_string());
+            }
+        }
+    }
+
+    pub fn copy_note(&mut self, note_id: String) {
+        let Some((mut note, _)) = self.find_note(&note_id) else {
+            self.notes.set_error("note is not loaded yet");
+            return;
+        };
+        self.next_local_id = self.next_local_id.saturating_add(1);
+        note.id = format!("note_{}_copy_{}", crate::now_ms(), self.next_local_id);
+        note.pinned = false;
+        note.archived = false;
+        note.updated_at_ms = crate::now_ms();
+
+        match self.push_upsert(note, None, "copy") {
+            Ok(()) => self.status.clear(),
+            Err(err) => {
+                self.status = "copy failed".into();
+                self.notes.set_error(err.to_string());
+            }
+        }
+    }
+
+    pub fn toggle_note_label(&mut self, note_id: String, label: String) {
+        let Some(label) = self.remember_label(&label) else {
+            return;
+        };
+        self.update_note(&note_id, "label", move |note| {
+            if let Some(pos) = note.labels.iter().position(|existing| existing == &label) {
+                note.labels.remove(pos);
+            } else {
+                note.labels.push(label);
+            }
+        });
+    }
+
+    pub fn toggle_note_checklist(&mut self, note_id: String) {
+        self.update_note(&note_id, "checklist", |note| {
+            if note.todos.is_empty() {
+                note.todos = note
+                    .body
+                    .lines()
+                    .enumerate()
+                    .filter_map(|(index, line)| {
+                        let trimmed = line.trim();
+                        if trimmed.is_empty() {
+                            None
+                        } else {
+                            let (text, done) = parse_todo_line(trimmed);
+                            Some(KeepTodo {
+                                id: format!("todo_{}_{}", crate::now_ms(), index),
+                                text,
+                                done,
+                            })
+                        }
+                    })
+                    .collect();
+                note.body.clear();
+            } else {
+                let mut lines: Vec<String> = note.todos.iter().map(format_todo_line).collect();
+                if !note.body.is_empty() {
+                    lines.insert(0, note.body.clone());
+                }
+                note.body = lines.join("\n");
+                note.todos.clear();
+            }
+        });
+    }
+
+    pub fn toggle_todo(&mut self, note_id: String, todo_id: String) {
+        self.update_note(&note_id, "todo", |note| {
+            if let Some(todo) = note.todos.iter_mut().find(|t| t.id == todo_id) {
+                todo.done = !todo.done;
+            }
+        });
+    }
+
+    pub fn set_note_color(&mut self, note_id: String, color: String) {
+        self.update_note(&note_id, "color", |note| {
+            note.color = color;
+        });
+    }
+
+    // ─── multi-select ───
+
+    pub fn toggle_note_selection(&mut self, note_id: String) {
+        if note_id.is_empty() || self.find_note(&note_id).is_none() {
+            return;
+        }
+        if let Some(pos) = self.selected_note_ids.iter().position(|id| id == &note_id) {
+            self.selected_note_ids.remove(pos);
+        } else {
+            self.selected_note_ids.push(note_id);
+        }
+        self.update_selection_label();
+        self.rebuild_visible_notes();
+    }
+
+    pub fn clear_selection(&mut self) {
+        if self.selected_note_ids.is_empty() {
+            return;
+        }
+        self.selected_note_ids.clear();
+        self.selection_label.clear();
+        self.rebuild_visible_notes();
+    }
+
+    pub fn pin_selected(&mut self) {
+        let ids = self.selected_note_ids.clone();
+        for id in ids {
+            self.update_note(&id, "pin-selected", |note| {
+                note.pinned = true;
+                note.archived = false;
+            });
+        }
+        self.clear_selection();
+    }
+
+    pub fn archive_selected(&mut self) {
+        let ids = self.selected_note_ids.clone();
+        for id in ids {
+            self.update_note(&id, "archive-selected", |note| {
+                note.archived = true;
+                note.pinned = false;
+            });
+        }
+        self.clear_selection();
+    }
+
+    pub fn delete_selected(&mut self) {
+        let ids = self.selected_note_ids.clone();
+        for id in ids {
+            self.delete_note(id);
+        }
+        self.clear_selection();
+    }
+
+    pub fn set_selected_color(&mut self, color: String) {
+        let ids = self.selected_note_ids.clone();
+        for id in ids {
+            let color = color.clone();
+            self.update_note(&id, "color-selected", move |note| {
+                note.color = color;
+            });
+        }
+    }
+
+    // ─── editor (detail dialog) ───
+
+    pub fn open_editor(&mut self, note_id: String) {
+        self.clear_selection();
+        self.cancel_composer();
+        let Some(row) = self.notes.rows.iter().find(|r| r.value.id == note_id) else {
+            return;
+        };
+        self.editor_data = KeepEditorData::from_note(row.value.clone());
+        self.editor_open = true;
+    }
+
+    pub fn cancel_editor(&mut self) {
+        self.editor_open = false;
+        self.clear_editor_fields();
+    }
+
+    pub fn set_editor_color(&mut self, color: String) {
+        self.editor_data.color = color;
+    }
+
+    pub fn toggle_editor_pin(&mut self) {
+        self.editor_data.pinned = !self.editor_data.pinned;
+    }
+}

--- a/examples/keep/src/store/derived.rs
+++ b/examples/keep/src/store/derived.rs
@@ -1,0 +1,121 @@
+use crate::{KeepNote, KeepTag};
+
+use super::{
+    labels::{normalize_label, normalize_labels},
+    view::{card_row_for, command_note_for},
+    KeepStore,
+};
+
+impl KeepStore {
+    pub fn note_view_signature(
+        &self,
+    ) -> (
+        String,
+        String,
+        Vec<String>,
+        Vec<pocopine_sync::SyncRow<KeepNote>>,
+    ) {
+        (
+            self.section_kind.clone(),
+            self.section_label.clone(),
+            self.selected_note_ids.clone(),
+            self.notes.rows.clone(),
+        )
+    }
+
+    pub fn rebuild_visible_notes(&mut self) {
+        self.pinned_notes.clear();
+        self.other_notes.clear();
+        self.command_notes.clear();
+        let existing_ids: Vec<String> = self
+            .notes
+            .rows
+            .iter()
+            .map(|row| row.value.id.clone())
+            .collect();
+        self.selected_note_ids
+            .retain(|id| existing_ids.iter().any(|existing| existing == id));
+        self.update_selection_label();
+        let selection_active = !self.selected_note_ids.is_empty();
+
+        for row in &self.notes.rows {
+            self.command_notes.push(command_note_for(&row.value));
+            if !self.note_is_visible(&row.value) {
+                continue;
+            }
+            let view = card_row_for(row, &self.selected_note_ids, selection_active);
+            if row.value.pinned {
+                self.pinned_notes.push(view);
+            } else {
+                self.other_notes.push(view);
+            }
+        }
+    }
+
+    fn note_is_visible(&self, note: &KeepNote) -> bool {
+        match self.section_kind.as_str() {
+            "notes" => !note.archived,
+            "archive" => note.archived,
+            "label" => {
+                !note.archived && note.labels.iter().any(|label| label == &self.section_label)
+            }
+            _ => false,
+        }
+    }
+
+    pub fn remember_labels(&mut self, labels: Vec<String>) {
+        self.labels = normalize_labels(labels);
+        self.sync_missing_tag_rows();
+    }
+
+    pub(super) fn remember_label(&mut self, label: &str) -> Option<String> {
+        let label = normalize_label(label)?;
+        if !self.labels.iter().any(|existing| existing == &label) {
+            self.labels.push(label.clone());
+        }
+        if !self.tags.rows.iter().any(|row| row.value.name == label) {
+            self.next_local_id = self.next_local_id.saturating_add(1);
+            let tag = KeepTag {
+                id: label.clone(),
+                name: label.clone(),
+                updated_at_ms: crate::now_ms(),
+            };
+            if let Err(err) = self.push_tag_upsert(tag, "label") {
+                self.status = "label save failed".into();
+                self.notes.set_error(err.to_string());
+            }
+        }
+        Some(label)
+    }
+
+    pub fn tag_label_registry(&self) -> Vec<String> {
+        let mut labels = Vec::new();
+        labels.extend(self.tags.rows.iter().map(|row| row.value.name.clone()));
+        labels.extend(
+            self.notes
+                .rows
+                .iter()
+                .flat_map(|row| row.value.labels.iter().cloned()),
+        );
+        normalize_labels(labels)
+    }
+
+    fn sync_missing_tag_rows(&mut self) {
+        let labels = self.labels.clone();
+        for label in labels {
+            if self.tags.rows.iter().any(|row| row.value.name == label) {
+                continue;
+            }
+            self.next_local_id = self.next_local_id.saturating_add(1);
+            let tag = KeepTag {
+                id: label.clone(),
+                name: label,
+                updated_at_ms: crate::now_ms(),
+            };
+            if let Err(err) = self.push_tag_upsert(tag, "backfill") {
+                self.status = "label save failed".into();
+                self.notes.set_error(err.to_string());
+            }
+        }
+    }
+}

--- a/examples/keep/src/store/labels.rs
+++ b/examples/keep/src/store/labels.rs
@@ -1,0 +1,66 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct KeepLabelOption {
+    pub name: String,
+    pub selected: bool,
+    pub visible: bool,
+}
+
+pub(crate) fn normalize_label(label: &str) -> Option<String> {
+    let label = label.trim();
+    if label.is_empty() {
+        return None;
+    }
+    Some(label.to_string())
+}
+
+pub(crate) fn normalize_labels(labels: Vec<String>) -> Vec<String> {
+    let mut normalized = Vec::new();
+    for label in labels {
+        let Some(label) = normalize_label(&label) else {
+            continue;
+        };
+        if !normalized.iter().any(|existing| existing == &label) {
+            normalized.push(label);
+        }
+    }
+    normalized
+}
+
+pub fn label_options_for(labels: &[String], selected: &[String]) -> Vec<KeepLabelOption> {
+    label_picker_options_for(labels, selected, "").0
+}
+
+pub fn label_picker_options_for(
+    labels: &[String],
+    selected: &[String],
+    query: &str,
+) -> (Vec<KeepLabelOption>, bool) {
+    let labels = normalize_labels(labels.to_vec());
+    let query = query.trim();
+    let needle = query.to_lowercase();
+    let can_create = normalize_label(query).is_some()
+        && !labels.iter().any(|label| label.eq_ignore_ascii_case(query));
+
+    let options = labels
+        .into_iter()
+        .map(|name| {
+            let visible = needle.is_empty() || name.to_lowercase().contains(&needle);
+            KeepLabelOption {
+                selected: selected.iter().any(|label| label == &name),
+                visible,
+                name,
+            }
+        })
+        .collect();
+
+    (options, can_create)
+}
+
+pub fn can_create_label(labels: &[String], query: &str) -> bool {
+    normalize_labels(labels.to_vec())
+        .iter()
+        .all(|label| !label.eq_ignore_ascii_case(query.trim()))
+        && normalize_label(query).is_some()
+}

--- a/examples/keep/src/store/mod.rs
+++ b/examples/keep/src/store/mod.rs
@@ -1,0 +1,374 @@
+//! `KeepStore` — singleton owning durable Keep app state.
+//!
+//! Board state, synced rows, labels, command state, and persistence
+//! hooks live here. The active note form keeps its transient edit
+//! buffer locally and submits a typed save payload back to this store.
+
+use pocopine::prelude::*;
+use serde::{Deserialize, Serialize};
+
+use crate::{KeepNote, KeepTag};
+
+mod actions;
+mod derived;
+mod labels;
+mod mutations;
+mod theme;
+mod view;
+
+pub use labels::{can_create_label, label_options_for, label_picker_options_for, KeepLabelOption};
+use theme::load_theme_preference;
+pub use theme::KeepTheme;
+pub(crate) use view::{format_todo_line, parse_todo_line, KeepFormNote};
+pub use view::{KeepCommandNote, KeepEditorData, KeepNoteCardRow};
+
+#[derive(Serialize, Deserialize)]
+#[store(name = "keep")]
+pub struct KeepStore {
+    pub notes: pocopine_sync::CollectionState<KeepNote>,
+    pub tags: pocopine_sync::CollectionState<KeepTag>,
+    pub pinned_notes: Vec<KeepNoteCardRow>,
+    pub other_notes: Vec<KeepNoteCardRow>,
+    pub command_notes: Vec<KeepCommandNote>,
+
+    pub composer_open: bool,
+    pub draft_kind: String,
+    pub draft_color: String,
+
+    pub editor_open: bool,
+    pub editor_data: KeepEditorData,
+
+    pub sidebar_expanded: bool,
+    pub section_kind: String,
+    /// When `section_kind == "label"`, the active label name to
+    /// filter by. Empty otherwise.
+    pub section_label: String,
+    pub search_query: String,
+    pub command_label_query: String,
+    pub theme: KeepTheme,
+    pub labels: Vec<String>,
+    pub selected_note_ids: Vec<String>,
+    pub selection_label: String,
+
+    pub status: String,
+    pub next_local_id: u64,
+    pub resetting: bool,
+}
+
+impl Default for KeepStore {
+    fn default() -> Self {
+        // Hand-rolled so that String fields with semantic defaults
+        // ("notes", "text", "default") are correct at the very first
+        // template walk — before any handler has a chance to run.
+        // on_mount fires *after* the initial walk, so doing this in a
+        // handler leaves the first render with section_kind = "" and
+        // the PINNED/OTHERS filters evaluating to false.
+        Self {
+            notes: pocopine_sync::CollectionState::default(),
+            tags: pocopine_sync::CollectionState::default(),
+            pinned_notes: Vec::new(),
+            other_notes: Vec::new(),
+            command_notes: Vec::new(),
+
+            composer_open: false,
+            draft_kind: "text".to_string(),
+            draft_color: "default".to_string(),
+
+            editor_open: false,
+            editor_data: KeepEditorData::default(),
+
+            sidebar_expanded: false,
+            section_kind: "notes".to_string(),
+            section_label: String::new(),
+            search_query: String::new(),
+            command_label_query: String::new(),
+            theme: load_theme_preference(),
+            labels: Vec::new(),
+            selected_note_ids: Vec::new(),
+            selection_label: String::new(),
+
+            status: String::new(),
+            next_local_id: 0,
+            resetting: false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::KeepTodo;
+
+    fn note(id: &str, pinned: bool, archived: bool, labels: &[&str]) -> KeepNote {
+        KeepNote {
+            id: id.to_string(),
+            title: id.to_string(),
+            body: String::new(),
+            color: "default".to_string(),
+            pinned,
+            archived,
+            todos: Vec::new(),
+            labels: labels.iter().map(|label| label.to_string()).collect(),
+            updated_at_ms: 0,
+        }
+    }
+
+    fn push_row(store: &mut KeepStore, note: KeepNote) {
+        store
+            .notes
+            .rows
+            .push(pocopine_sync::SyncRow::new(note.id.clone(), note).unwrap());
+    }
+
+    fn row_ids(rows: &[KeepNoteCardRow]) -> Vec<String> {
+        rows.iter().map(|row| row.value.id.clone()).collect()
+    }
+
+    #[test]
+    fn default_store_has_no_placeholder_labels() {
+        assert!(KeepStore::default().labels.is_empty());
+    }
+
+    #[test]
+    fn add_label_trims_and_dedupes() {
+        let mut store = KeepStore::default();
+        store.add_label(" Work ".to_string());
+        store.add_label("Work".to_string());
+        store.add_label("   ".to_string());
+
+        assert_eq!(store.labels, vec!["Work"]);
+        assert!(store.sidebar_expanded);
+    }
+
+    #[test]
+    fn command_label_creation_uses_inline_query() {
+        let mut store = KeepStore {
+            command_label_query: " Ideas ".to_string(),
+            ..Default::default()
+        };
+
+        store.create_command_label();
+
+        assert_eq!(store.labels, vec!["Ideas"]);
+        assert!(store.command_label_query.is_empty());
+        assert!(store.sidebar_expanded);
+    }
+
+    #[test]
+    fn add_label_updates_registry_once() {
+        let mut store = KeepStore::default();
+
+        store.add_label("Ideas".to_string());
+        store.add_label("Ideas".to_string());
+
+        assert_eq!(store.labels, vec!["Ideas"]);
+    }
+
+    #[test]
+    fn label_options_mark_selected_labels() {
+        let labels = vec!["Work".to_string(), "Ideas".to_string()];
+        let selected = vec!["Ideas".to_string()];
+
+        assert_eq!(
+            label_options_for(&labels, &selected),
+            vec![
+                KeepLabelOption {
+                    name: "Work".to_string(),
+                    selected: false,
+                    visible: true,
+                },
+                KeepLabelOption {
+                    name: "Ideas".to_string(),
+                    selected: true,
+                    visible: true,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn label_picker_options_filter_and_hide_existing_create() {
+        let labels = vec!["Work".to_string(), "Ideas".to_string()];
+        let selected = vec!["Ideas".to_string()];
+
+        let (options, can_create) = label_picker_options_for(&labels, &selected, "work");
+        assert!(!can_create);
+        assert_eq!(
+            options,
+            vec![
+                KeepLabelOption {
+                    name: "Work".to_string(),
+                    selected: false,
+                    visible: true,
+                },
+                KeepLabelOption {
+                    name: "Ideas".to_string(),
+                    selected: true,
+                    visible: false,
+                },
+            ]
+        );
+
+        let (_, can_create) = label_picker_options_for(&labels, &selected, "Travel");
+        assert!(can_create);
+    }
+
+    #[test]
+    fn tag_registry_includes_labels_already_attached_to_notes() {
+        let mut store = KeepStore::default();
+        push_row(
+            &mut store,
+            note("labeled", false, false, &["Work", "Ideas"]),
+        );
+        store.tags.rows.push(
+            pocopine_sync::SyncRow::new(
+                "Travel",
+                KeepTag {
+                    id: "Travel".to_string(),
+                    name: "Travel".to_string(),
+                    updated_at_ms: 0,
+                },
+            )
+            .unwrap(),
+        );
+
+        assert_eq!(store.tag_label_registry(), vec!["Travel", "Work", "Ideas"]);
+    }
+
+    #[test]
+    fn command_notes_include_labels_in_search_value() {
+        let mut store = KeepStore::default();
+        push_row(
+            &mut store,
+            KeepNote {
+                id: "note-1".to_string(),
+                title: "Roadmap".to_string(),
+                body: "Polish command palette".to_string(),
+                color: "default".to_string(),
+                pinned: false,
+                archived: false,
+                todos: vec![KeepTodo {
+                    id: "todo-1".to_string(),
+                    text: "Ship".to_string(),
+                    done: false,
+                }],
+                labels: vec!["Work".to_string(), "Ideas".to_string()],
+                updated_at_ms: 0,
+            },
+        );
+
+        store.rebuild_visible_notes();
+
+        assert_eq!(store.command_notes.len(), 1);
+        assert_eq!(store.command_notes[0].id, "note-1");
+        assert!(store.command_notes[0].has_todos);
+        assert_eq!(
+            store.command_notes[0].search_value,
+            "Roadmap Polish command palette Work Ideas"
+        );
+    }
+
+    #[test]
+    fn visible_note_lists_track_active_section() {
+        let mut store = KeepStore::default();
+        push_row(&mut store, note("pinned", true, false, &[]));
+        push_row(&mut store, note("other", false, false, &[]));
+        push_row(&mut store, note("archived", false, true, &[]));
+        push_row(&mut store, note("work", false, false, &["Work"]));
+
+        store.rebuild_visible_notes();
+        assert_eq!(row_ids(&store.pinned_notes), vec!["pinned"]);
+        assert_eq!(row_ids(&store.other_notes), vec!["other", "work"]);
+
+        store.show_label("Work".to_string());
+        assert!(store.pinned_notes.is_empty());
+        assert_eq!(row_ids(&store.other_notes), vec!["work"]);
+
+        store.show_archive();
+        assert!(store.pinned_notes.is_empty());
+        assert_eq!(row_ids(&store.other_notes), vec!["archived"]);
+    }
+
+    #[test]
+    fn editor_data_populates_and_resets_as_one_value() {
+        let mut store = KeepStore::default();
+        push_row(
+            &mut store,
+            KeepNote {
+                id: "editor".to_string(),
+                title: "Draft title".to_string(),
+                body: String::new(),
+                color: "sand".to_string(),
+                pinned: true,
+                archived: false,
+                todos: vec![KeepTodo {
+                    id: "todo-1".to_string(),
+                    text: "Ship it".to_string(),
+                    done: false,
+                }],
+                labels: vec!["Work".to_string()],
+                updated_at_ms: 0,
+            },
+        );
+
+        store.open_editor("editor".to_string());
+
+        assert!(store.editor_open);
+        assert_eq!(store.editor_data.id, "editor");
+        assert_eq!(store.editor_data.kind, "checklist");
+        assert_eq!(store.editor_data.title, "Draft title");
+        assert_eq!(store.editor_data.color, "sand");
+        assert!(store.editor_data.pinned);
+        assert_eq!(store.editor_data.labels, vec!["Work"]);
+        assert_eq!(store.editor_data.todos.len(), 1);
+
+        store.cancel_editor();
+
+        assert!(!store.editor_open);
+        assert_eq!(store.editor_data, KeepEditorData::default());
+    }
+
+    #[test]
+    fn selection_toggles_and_formats_count() {
+        let mut store = KeepStore::default();
+        push_row(&mut store, note("one", false, false, &[]));
+        push_row(&mut store, note("two", false, false, &[]));
+
+        store.toggle_note_selection("one".to_string());
+        assert_eq!(store.selected_note_ids, vec!["one"]);
+        assert_eq!(store.selection_label, "1 selected");
+        assert!(store
+            .other_notes
+            .iter()
+            .find(|row| row.value.id == "one")
+            .is_some_and(|row| row.selected && row.selection_active));
+
+        store.toggle_note_selection("two".to_string());
+        assert_eq!(store.selected_note_ids, vec!["one", "two"]);
+        assert_eq!(store.selection_label, "2 selected");
+
+        store.toggle_note_selection("one".to_string());
+        assert_eq!(store.selected_note_ids, vec!["two"]);
+        assert_eq!(store.selection_label, "1 selected");
+
+        store.clear_selection();
+        assert!(store.selected_note_ids.is_empty());
+        assert!(store.selection_label.is_empty());
+    }
+
+    #[test]
+    fn rebuild_visible_notes_prunes_deleted_selection() {
+        let mut store = KeepStore::default();
+        push_row(&mut store, note("kept", false, false, &[]));
+        push_row(&mut store, note("deleted", false, false, &[]));
+
+        store.toggle_note_selection("kept".to_string());
+        store.toggle_note_selection("deleted".to_string());
+        store.notes.rows.retain(|row| row.value.id != "deleted");
+
+        store.rebuild_visible_notes();
+
+        assert_eq!(store.selected_note_ids, vec!["kept"]);
+        assert_eq!(store.selection_label, "1 selected");
+    }
+}

--- a/examples/keep/src/store/mutations.rs
+++ b/examples/keep/src/store/mutations.rs
@@ -1,0 +1,233 @@
+use pocopine::prelude::*;
+
+use crate::{KeepNote, KeepTag};
+
+use super::{labels::normalize_labels, view::KeepFormNote, KeepStore};
+
+impl KeepStore {
+    pub(crate) fn save_form_note(&mut self, form: KeepFormNote) {
+        let note_id = form.note_id;
+        let title = form.title.trim().to_string();
+        let body = form.body.trim().to_string();
+        let color = form.color;
+        let todos = form.todos;
+        let labels = normalize_labels(form.labels);
+        let pinned = form.pinned;
+        for label in labels.clone() {
+            self.remember_label(&label);
+        }
+
+        if note_id.is_empty() {
+            if title.is_empty() && body.is_empty() && todos.is_empty() {
+                self.composer_open = false;
+                return;
+            }
+
+            self.notes.clear_error();
+            self.next_local_id = self.next_local_id.saturating_add(1);
+            let id = format!("note_{}_{}", crate::now_ms(), self.next_local_id);
+            let note = KeepNote {
+                id: id.clone(),
+                title,
+                body,
+                color,
+                pinned: false,
+                archived: false,
+                todos,
+                labels,
+                updated_at_ms: crate::now_ms(),
+            };
+
+            match self.push_upsert(note, None, "create") {
+                Ok(()) => {
+                    self.composer_open = false;
+                    self.status.clear();
+                }
+                Err(err) => {
+                    self.status = "save failed".into();
+                    self.notes.set_error(err.to_string());
+                }
+            }
+            return;
+        }
+
+        self.editor_open = false;
+        self.clear_editor_fields();
+        self.update_note(&note_id, "edit", |note| {
+            note.title = title;
+            note.body = body;
+            note.color = color;
+            note.todos = todos;
+            note.labels = labels;
+            note.pinned = pinned;
+        });
+    }
+
+    pub(crate) fn archive_form_note(&mut self, form: KeepFormNote) {
+        let note_id = form.note_id;
+        if note_id.is_empty() {
+            return;
+        }
+        let title = form.title.trim().to_string();
+        let body = form.body.trim().to_string();
+        let color = form.color;
+        let todos = form.todos;
+        let labels = normalize_labels(form.labels);
+        for label in labels.clone() {
+            self.remember_label(&label);
+        }
+        self.editor_open = false;
+        self.clear_editor_fields();
+        self.update_note(&note_id, "archive", |note| {
+            note.title = title;
+            note.body = body;
+            note.color = color;
+            note.todos = todos;
+            note.labels = labels;
+            note.archived = true;
+            note.pinned = false;
+        });
+    }
+
+    pub(super) fn clear_editor_fields(&mut self) {
+        self.editor_data = Default::default();
+    }
+
+    pub(super) fn update_note(
+        &mut self,
+        note_id: &str,
+        action: &str,
+        f: impl FnOnce(&mut KeepNote),
+    ) {
+        let Some((mut note, base_version)) = self.find_note(note_id) else {
+            self.notes.set_error("note is not loaded yet");
+            return;
+        };
+        f(&mut note);
+        note.updated_at_ms = crate::now_ms();
+
+        match self.push_upsert(note, base_version, action) {
+            Ok(()) => self.status.clear(),
+            Err(err) => {
+                self.status = "save failed".into();
+                self.notes.set_error(err.to_string());
+            }
+        }
+    }
+
+    pub(super) fn find_note(
+        &self,
+        note_id: &str,
+    ) -> Option<(KeepNote, Option<pocopine_sync::RowVersion>)> {
+        self.notes
+            .rows
+            .iter()
+            .find(|row| row.value.id == note_id)
+            .map(|row| (row.value.clone(), row.version.clone()))
+    }
+
+    pub(super) fn update_selection_label(&mut self) {
+        let count = self.selected_note_ids.len();
+        self.selection_label = match count {
+            0 => String::new(),
+            1 => "1 selected".to_string(),
+            _ => format!("{count} selected"),
+        };
+    }
+
+    pub(super) fn push_upsert(
+        &mut self,
+        note: KeepNote,
+        base_version: Option<pocopine_sync::RowVersion>,
+        action: &str,
+    ) -> pocopine_sync::SyncResult<()> {
+        let plugins = Plugins;
+        let Some(client) = plugins.get::<pocopine_sync::SyncClient>() else {
+            return Err(pocopine_sync::SyncError::client(
+                "sync plugin not installed",
+            ));
+        };
+        let key = pocopine_sync::RowKey::new(note.id.clone())?;
+        let mutation = pocopine_sync::ClientMutation {
+            id: pocopine_sync::MutationId::new(format!(
+                "keep:{action}:{}:{}:{}",
+                note.id,
+                crate::now_ms(),
+                self.next_local_id
+            ))?,
+            key: Some(key),
+            op: pocopine_sync::SyncOp::Upsert,
+            base_version,
+            payload: note.clone(),
+        };
+        let optimistic = pocopine_sync::SyncRow::new(note.id.clone(), note)?;
+
+        client
+            .collection(pocopine::store::<Self>(), |s: &mut Self| &mut s.notes)
+            .stream(crate::KEEP_STREAM)
+            .and_then(|c| c.push(mutation, Some(optimistic)))
+    }
+
+    pub(super) fn push_delete(
+        &mut self,
+        note_id: &str,
+        base_version: Option<pocopine_sync::RowVersion>,
+        action: &str,
+    ) -> pocopine_sync::SyncResult<()> {
+        let plugins = Plugins;
+        let Some(client) = plugins.get::<pocopine_sync::SyncClient>() else {
+            return Err(pocopine_sync::SyncError::client(
+                "sync plugin not installed",
+            ));
+        };
+        let key = pocopine_sync::RowKey::new(note_id.to_string())?;
+        let mutation = pocopine_sync::ClientMutation {
+            id: pocopine_sync::MutationId::new(format!(
+                "keep:{action}:{note_id}:{}:{}",
+                crate::now_ms(),
+                self.next_local_id
+            ))?,
+            key: Some(key),
+            op: pocopine_sync::SyncOp::Delete,
+            base_version,
+            payload: (),
+        };
+
+        client
+            .collection(pocopine::store::<Self>(), |s: &mut Self| &mut s.notes)
+            .stream(crate::KEEP_STREAM)
+            .and_then(|c| c.push(mutation, None))
+    }
+
+    pub(super) fn push_tag_upsert(
+        &mut self,
+        tag: KeepTag,
+        action: &str,
+    ) -> pocopine_sync::SyncResult<()> {
+        let plugins = Plugins;
+        let Some(client) = plugins.get::<pocopine_sync::SyncClient>() else {
+            return Err(pocopine_sync::SyncError::client(
+                "sync plugin not installed",
+            ));
+        };
+        let key = pocopine_sync::RowKey::new(tag.id.clone())?;
+        let mutation = pocopine_sync::ClientMutation {
+            id: pocopine_sync::MutationId::new(format!(
+                "keep:tag:{action}:{}:{}:{}",
+                tag.id,
+                crate::now_ms(),
+                self.next_local_id
+            ))?,
+            key: Some(key),
+            op: pocopine_sync::SyncOp::Upsert,
+            base_version: None,
+            payload: tag.clone(),
+        };
+        let optimistic = pocopine_sync::SyncRow::new(tag.id.clone(), tag)?;
+
+        client
+            .collection(pocopine::store::<Self>(), |s: &mut Self| &mut s.tags)
+            .stream(crate::KEEP_TAGS_STREAM)
+            .and_then(|c| c.push(mutation, Some(optimistic)))
+    }
+}

--- a/examples/keep/src/store/theme.rs
+++ b/examples/keep/src/store/theme.rs
@@ -1,0 +1,32 @@
+use serde::{Deserialize, Serialize};
+
+const THEME_STORAGE_KEY: &str = "pocopine.keep.theme";
+
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum KeepTheme {
+    #[default]
+    Light,
+    Dark,
+}
+
+impl KeepTheme {
+    pub(crate) fn toggled(self) -> Self {
+        match self {
+            Self::Light => Self::Dark,
+            Self::Dark => Self::Light,
+        }
+    }
+}
+
+pub(crate) fn load_theme_preference() -> KeepTheme {
+    pocopine::storage::LocalStorage::<KeepTheme>::new(THEME_STORAGE_KEY)
+        .get()
+        .ok()
+        .flatten()
+        .unwrap_or_default()
+}
+
+pub(crate) fn save_theme_preference(theme: KeepTheme) {
+    let _ = pocopine::storage::LocalStorage::new(THEME_STORAGE_KEY).set(&theme);
+}

--- a/examples/keep/src/store/view.rs
+++ b/examples/keep/src/store/view.rs
@@ -1,0 +1,120 @@
+use serde::{Deserialize, Serialize};
+
+use crate::{KeepNote, KeepTodo};
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct KeepEditorData {
+    pub id: String,
+    pub kind: String,
+    pub title: String,
+    pub body: String,
+    pub color: String,
+    pub todos: Vec<KeepTodo>,
+    pub labels: Vec<String>,
+    pub pinned: bool,
+}
+
+impl KeepEditorData {
+    pub(crate) fn from_note(note: KeepNote) -> Self {
+        Self {
+            id: note.id,
+            kind: if note.todos.is_empty() {
+                "text".into()
+            } else {
+                "checklist".into()
+            },
+            title: note.title,
+            body: note.body,
+            color: note.color,
+            todos: note.todos,
+            labels: note.labels,
+            pinned: note.pinned,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub(crate) struct KeepFormNote {
+    pub note_id: String,
+    pub title: String,
+    pub body: String,
+    pub color: String,
+    pub todos: Vec<KeepTodo>,
+    pub labels: Vec<String>,
+    pub pinned: bool,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct KeepCommandNote {
+    pub id: String,
+    pub title: String,
+    pub body: String,
+    pub has_todos: bool,
+    pub search_value: String,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct KeepNoteCardRow {
+    pub key: String,
+    pub value: KeepNote,
+    pub pending: bool,
+    pub conflict: bool,
+    pub selected: bool,
+    pub selection_active: bool,
+}
+
+pub(crate) fn command_note_for(note: &KeepNote) -> KeepCommandNote {
+    let search_value = [
+        note.title.as_str(),
+        note.body.as_str(),
+        &note.labels.join(" "),
+    ]
+    .into_iter()
+    .filter(|part| !part.is_empty())
+    .collect::<Vec<_>>()
+    .join(" ");
+
+    KeepCommandNote {
+        id: note.id.clone(),
+        title: note.title.clone(),
+        body: note.body.clone(),
+        has_todos: !note.todos.is_empty(),
+        search_value,
+    }
+}
+
+pub(crate) fn card_row_for(
+    row: &pocopine_sync::SyncRow<KeepNote>,
+    selected_note_ids: &[String],
+    selection_active: bool,
+) -> KeepNoteCardRow {
+    KeepNoteCardRow {
+        key: row.key.to_string(),
+        value: row.value.clone(),
+        pending: row.pending,
+        conflict: row.conflict,
+        selected: selected_note_ids.iter().any(|id| id == &row.value.id),
+        selection_active,
+    }
+}
+
+pub(crate) fn format_todo_line(todo: &KeepTodo) -> String {
+    if todo.done {
+        format!("[x] {}", todo.text)
+    } else {
+        todo.text.clone()
+    }
+}
+
+pub(crate) fn parse_todo_line(line: &str) -> (String, bool) {
+    if let Some(rest) = line
+        .strip_prefix("[x] ")
+        .or_else(|| line.strip_prefix("[X] "))
+    {
+        (rest.trim().to_string(), true)
+    } else if let Some(rest) = line.strip_prefix("[ ] ") {
+        (rest.trim().to_string(), false)
+    } else {
+        (line.to_string(), false)
+    }
+}

--- a/examples/keep/src/sync.rs
+++ b/examples/keep/src/sync.rs
@@ -1,0 +1,113 @@
+use pocopine::prelude::*;
+
+#[cfg(pocopine_host)]
+use {
+    crate::{
+        sqlite_stream::{
+            default_keep_notes_path, default_keep_tags_path, SqliteKeepStream, SqliteKeepTagStream,
+        },
+        KEEP_COLLECTION, KEEP_STREAM, KEEP_TAGS_COLLECTION, KEEP_TAGS_STREAM,
+    },
+    pocopine_events::MemoryEventBackend,
+    pocopine_sync::SyncServer,
+    std::sync::{Arc, OnceLock},
+};
+
+#[cfg(pocopine_host)]
+static KEEP_SYNC: OnceLock<SqliteKeepStream> = OnceLock::new();
+#[cfg(pocopine_host)]
+static KEEP_TAGS_SYNC: OnceLock<SqliteKeepTagStream> = OnceLock::new();
+#[cfg(pocopine_host)]
+static LIVE_BACKEND: OnceLock<MemoryEventBackend> = OnceLock::new();
+#[cfg(pocopine_host)]
+static SYNC_SERVER: OnceLock<SyncServer> = OnceLock::new();
+
+#[cfg(pocopine_host)]
+pub fn keep_stream() -> SqliteKeepStream {
+    KEEP_SYNC
+        .get_or_init(|| {
+            let stream =
+                SqliteKeepStream::open(KEEP_STREAM, KEEP_COLLECTION, default_keep_notes_path())
+                    .expect("keep example stream names must be valid");
+            seed_keep_notes(&stream).expect("seed keep notes should sync");
+            stream
+        })
+        .clone()
+}
+
+#[cfg(pocopine_host)]
+pub fn keep_tags_stream() -> SqliteKeepTagStream {
+    KEEP_TAGS_SYNC
+        .get_or_init(|| {
+            SqliteKeepTagStream::open(
+                KEEP_TAGS_STREAM,
+                KEEP_TAGS_COLLECTION,
+                default_keep_tags_path(),
+            )
+            .expect("keep example tag stream names must be valid")
+        })
+        .clone()
+}
+
+#[cfg(pocopine_host)]
+pub fn live_backend() -> MemoryEventBackend {
+    LIVE_BACKEND.get_or_init(MemoryEventBackend::new).clone()
+}
+
+#[cfg(pocopine_host)]
+pub fn sync_server() -> SyncServer {
+    SYNC_SERVER
+        .get_or_init(|| {
+            SyncServer::builder()
+                .public_stream(keep_stream())
+                .public_stream(keep_tags_stream())
+                .events(Arc::new(live_backend()))
+                .build()
+        })
+        .clone()
+}
+
+#[cfg(pocopine_host)]
+fn seed_keep_notes(_stream: &SqliteKeepStream) -> pocopine_sync::SyncResult<()> {
+    // Intentionally empty: the keep example starts with a blank
+    // workspace so the user immediately sees the optimistic-insert +
+    // live-wakeup loop instead of a pre-baked demo.
+    Ok(())
+}
+
+#[cfg(pocopine_host)]
+async fn invalidate_keep_notes() {
+    invalidate_keep_stream(KEEP_STREAM).await;
+}
+
+#[cfg(pocopine_host)]
+async fn invalidate_keep_tags() {
+    invalidate_keep_stream(KEEP_TAGS_STREAM).await;
+}
+
+#[cfg(pocopine_host)]
+async fn invalidate_keep_stream(stream: &str) {
+    if let Err(err) = sync_server().invalidate_stream(stream).await {
+        tracing::warn!(
+            target: "pocopine.log",
+            stream,
+            error = %err,
+            "failed to publish keep sync invalidation"
+        );
+    }
+}
+
+#[pocopine::server(public)]
+pub async fn reset_keep_notes() -> ServerResult<()> {
+    let stream = keep_stream();
+    stream
+        .reset()
+        .map_err(|err| ServerError::App(err.to_string()))?;
+    let tags = keep_tags_stream();
+    tags.reset()
+        .map_err(|err| ServerError::App(err.to_string()))?;
+    seed_keep_notes(&stream).map_err(|err| ServerError::App(err.to_string()))?;
+    invalidate_keep_notes().await;
+    invalidate_keep_tags().await;
+    Ok(())
+}

--- a/examples/keep/src/utils/mod.rs
+++ b/examples/keep/src/utils/mod.rs
@@ -1,0 +1,5 @@
+pub mod time;
+pub mod ui;
+
+pub use time::now_ms;
+pub use ui::{focus_after_flush, shared_layout_transition};

--- a/examples/keep/src/utils/time.rs
+++ b/examples/keep/src/utils/time.rs
@@ -1,0 +1,14 @@
+#[cfg(target_arch = "wasm32")]
+pub fn now_ms() -> u64 {
+    js_sys::Date::now() as u64
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn now_ms() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}

--- a/examples/keep/src/utils/ui.rs
+++ b/examples/keep/src/utils/ui.rs
@@ -1,0 +1,52 @@
+use crate::KeepStore;
+
+/// Snapshot the document layout, run `action` against the
+/// `KeepStore` singleton, then before the very next browser paint
+/// replay the projection. Every data-pp-layout-id element that
+/// exists in both the before and after states animates from its
+/// old rect to its new one — card → editor on open, editor →
+/// card on close.
+///
+/// Scheduled with `tick::next_frame` (requestAnimationFrame), not
+/// `after_flush` (setTimeout 0), so the projection's first
+/// transform commits in the same paint as the DOM mutation —
+/// otherwise there's a one-frame flicker where the source card
+/// appears at its rest position before the WAAPI animation has a
+/// chance to apply its from-keyframe.
+///
+/// Wasm only because pine-motion goes through web_sys / DomRect;
+/// host build just dispatches the action.
+pub fn shared_layout_transition(action: impl FnOnce(&mut KeepStore) + 'static) {
+    #[cfg(target_arch = "wasm32")]
+    let snapshot = pocopine::dom::document_element()
+        .map(|root| (root.clone(), pine_motion::snapshot_layout(&root)));
+
+    pocopine::store::<KeepStore>().update(action);
+
+    #[cfg(target_arch = "wasm32")]
+    if let Some((root, snap)) = snapshot {
+        pocopine::tick::next_frame(move || {
+            // pine-motion stamps `data-pp-animating="true"` on
+            // every element it kicks an animation on, then clears
+            // it on a settle-bound timeout. The CSS rule on
+            // `.note[data-pp-animating="true"]` does the z-index
+            // lift; nothing else to wire here.
+            pine_motion::play_layout(&root, snap, pine_motion::Spring::gentle());
+        });
+    }
+}
+
+/// Focus the first element matching `selector`, deferred until
+/// after the next reactive flush so the target has actually
+/// mounted by the time we look it up. Used by the new-note
+/// shortcuts and the composer expand handlers.
+pub fn focus_after_flush(selector: &'static str) {
+    pocopine::tick::after_flush(move || {
+        let Some(el) =
+            pocopine::dom::document().and_then(|d| d.query_selector(selector).ok().flatten())
+        else {
+            return;
+        };
+        pocopine::focus::focus_element_no_scroll(&el);
+    });
+}

--- a/examples/keep/tests/keep_flow.rs
+++ b/examples/keep/tests/keep_flow.rs
@@ -1,0 +1,264 @@
+#![cfg(pocopine_host)]
+
+use http_body_util::BodyExt;
+use keep_example::{live_backend, sync_server, KeepNote, KeepTag, KEEP_STREAM, KEEP_TAGS_STREAM};
+use pocopine_live::{build_live_stream_url, routes, LiveHub, LIVE_STREAM_PATH};
+use pocopine_server::axum::body::Body;
+use pocopine_server::axum::http::{Request, StatusCode};
+use pocopine_server::Server;
+use pocopine_sync::{
+    sync_server_plugin, sync_stream_tag, ClientMutation, MutationId, RowKey, SyncOp, SyncPullMode,
+    SyncPullRequest, SyncPullResponse, SyncPushRequest, SyncPushResponse, SyncStreamName,
+    SYNC_PULL_PATH, SYNC_PUSH_PATH,
+};
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn keep_push_and_live_wakeup_share_the_stream_topic() {
+    pocopine_server::__reset_for_test();
+    let test_path =
+        std::env::temp_dir().join(format!("pocopine_keep_flow_{}.sqlite3", std::process::id()));
+    let test_tags_path = std::env::temp_dir().join(format!(
+        "pocopine_keep_tags_flow_{}.sqlite3",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_file(&test_path);
+    let _ = std::fs::remove_file(&test_tags_path);
+    std::env::set_var("POCOPINE_KEEP_NOTES_DB_PATH", &test_path);
+    std::env::set_var("POCOPINE_KEEP_TAGS_DB_PATH", &test_tags_path);
+
+    let sync = sync_server();
+    let sync_topics = sync.live_topics().unwrap();
+    let app = Server::new(routes(
+        LiveHub::new(live_backend())
+            .allow_topics(sync_topics.clone())
+            .default_topics(sync_topics),
+    ))
+    .plugin(sync_server_plugin(sync))
+    .try_finalize()
+    .unwrap();
+
+    let first = pull_notes(&app, None).await;
+    assert_eq!(first.mode, SyncPullMode::Snapshot);
+    assert!(
+        first.rows.is_empty(),
+        "the keep example seeds nothing — the demo workspace should start blank"
+    );
+    let first_tags = pull_tags(&app, None).await;
+    assert_eq!(first_tags.mode, SyncPullMode::Snapshot);
+    assert!(
+        first_tags.rows.is_empty(),
+        "the keep example should start with no placeholder tags"
+    );
+
+    let stream_url = build_live_stream_url(
+        LIVE_STREAM_PATH,
+        &[],
+        &[format!("query:{}", sync_stream_tag(KEEP_STREAM))],
+        None,
+    )
+    .unwrap();
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri(stream_url)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let mut body = response.into_body();
+    let ready = read_sse_frame(&mut body).await;
+    assert!(ready.contains("event: ready"));
+    assert!(ready.contains("query:sync:stream:keep_notes_for_user"));
+
+    let pushed = push_note(
+        &app,
+        KeepNote {
+            id: "note_from_push".to_string(),
+            title: "CI note".to_string(),
+            body: "incremental pull should receive this row".to_string(),
+            color: "sky".to_string(),
+            pinned: false,
+            archived: false,
+            todos: Vec::new(),
+            labels: vec!["ci".to_string()],
+            updated_at_ms: 9,
+        },
+    )
+    .await;
+    assert_eq!(pushed.accepted[0].as_str(), "ci:note_from_push");
+    assert!(pushed.rejected.is_empty());
+    assert!(pushed.conflicts.is_empty());
+
+    let invalidation = read_sse_frame(&mut body).await;
+    assert!(invalidation.contains("event: query.invalidated"));
+    assert!(invalidation.contains("sync:stream:keep_notes_for_user"));
+
+    let second = pull_notes(&app, first.cursor).await;
+    assert_eq!(second.mode, SyncPullMode::Incremental);
+    assert!(second.changes.iter().any(|change| {
+        change
+            .row
+            .as_ref()
+            .map(|row| row.value.title == "CI note")
+            .unwrap_or(false)
+    }));
+
+    let pushed_tag = push_tag(
+        &app,
+        KeepTag {
+            id: "ci".to_string(),
+            name: "ci".to_string(),
+            updated_at_ms: 10,
+        },
+    )
+    .await;
+    assert_eq!(pushed_tag.accepted[0].as_str(), "ci:tag:ci");
+    assert!(pushed_tag.rejected.is_empty());
+    assert!(pushed_tag.conflicts.is_empty());
+
+    let second_tags = pull_tags(&app, first_tags.cursor).await;
+    assert_eq!(second_tags.mode, SyncPullMode::Incremental);
+    assert!(second_tags.changes.iter().any(|change| {
+        change
+            .row
+            .as_ref()
+            .map(|row| row.value.name == "ci")
+            .unwrap_or(false)
+    }));
+
+    let _ = std::fs::remove_file(&test_path);
+    let _ = std::fs::remove_file(&test_tags_path);
+}
+
+async fn push_note(
+    app: &pocopine_server::axum::Router,
+    note: KeepNote,
+) -> SyncPushResponse<KeepNote> {
+    let request = SyncPushRequest::new(
+        SyncStreamName::new(KEEP_STREAM).unwrap(),
+        [ClientMutation {
+            id: MutationId::new(format!("ci:{}", note.id)).unwrap(),
+            key: Some(RowKey::new(note.id.clone()).unwrap()),
+            op: SyncOp::Upsert,
+            base_version: None,
+            payload: note,
+        }],
+    );
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(SYNC_PUSH_PATH)
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&request).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let outer: pocopine::ServerResult<SyncPushResponse<KeepNote>> =
+        serde_json::from_slice(&bytes).unwrap();
+    outer.unwrap()
+}
+
+async fn push_tag(app: &pocopine_server::axum::Router, tag: KeepTag) -> SyncPushResponse<KeepTag> {
+    let request = SyncPushRequest::new(
+        SyncStreamName::new(KEEP_TAGS_STREAM).unwrap(),
+        [ClientMutation {
+            id: MutationId::new(format!("ci:tag:{}", tag.id)).unwrap(),
+            key: Some(RowKey::new(tag.id.clone()).unwrap()),
+            op: SyncOp::Upsert,
+            base_version: None,
+            payload: tag,
+        }],
+    );
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(SYNC_PUSH_PATH)
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&request).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let outer: pocopine::ServerResult<SyncPushResponse<KeepTag>> =
+        serde_json::from_slice(&bytes).unwrap();
+    outer.unwrap()
+}
+
+async fn pull_notes(
+    app: &pocopine_server::axum::Router,
+    cursor: Option<pocopine_sync::SyncCursor>,
+) -> SyncPullResponse<KeepNote> {
+    let request = SyncPullRequest::new(SyncStreamName::new(KEEP_STREAM).unwrap()).cursor(cursor);
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(SYNC_PULL_PATH)
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&request).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let outer: pocopine::ServerResult<SyncPullResponse<KeepNote>> =
+        serde_json::from_slice(&bytes).unwrap();
+    outer.unwrap()
+}
+
+async fn pull_tags(
+    app: &pocopine_server::axum::Router,
+    cursor: Option<pocopine_sync::SyncCursor>,
+) -> SyncPullResponse<KeepTag> {
+    let request =
+        SyncPullRequest::new(SyncStreamName::new(KEEP_TAGS_STREAM).unwrap()).cursor(cursor);
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(SYNC_PULL_PATH)
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&request).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let outer: pocopine::ServerResult<SyncPullResponse<KeepTag>> =
+        serde_json::from_slice(&bytes).unwrap();
+    outer.unwrap()
+}
+
+async fn read_sse_frame(body: &mut Body) -> String {
+    let frame = tokio::time::timeout(std::time::Duration::from_secs(2), body.frame())
+        .await
+        .expect("timed out waiting for SSE frame")
+        .expect("SSE body ended before expected frame")
+        .expect("SSE body returned an error");
+    let data = frame.into_data().expect("SSE frame should contain data");
+    std::str::from_utf8(&data)
+        .expect("SSE data should be utf-8")
+        .to_string()
+}


### PR DESCRIPTION
## Summary

- Add a full Keep-style notes and todo example app using Pine components and Pocopine sync.
- Back the browser client with the SQLite local sync store and the server stream with rusqlite.
- Include labels, search command dialog, selection actions, editor/composer components, theme preference, and SQLite-backed sync flow tests.
- Document the example and the development lessons for building larger Pocopine apps.

## Verification

Run after rebasing onto merged `main`:

- `cargo fmt --check -p keep-example`
- `cargo check -p keep-example`
- `cargo test -p keep-example`
- `cargo check -p keep-example --target wasm32-unknown-unknown`
- `cargo clippy -p keep-example --all-targets -- -D warnings`