### PR TITLE
Add automatic server function route registration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3501,6 +3501,7 @@ name = "pocopine-server"
 version = "0.1.0"
 dependencies = [
  "axum 0.7.9",
+ "inventory",
  "pocopine-auth",
  "serde",
  "serde_json",

--- a/crates/pocopine-core/src/server.rs
+++ b/crates/pocopine-core/src/server.rs
@@ -74,3 +74,53 @@ impl From<&str> for ServerError {
 
 /// Canonical `Result` alias for `#[server]` functions.
 pub type Result<T> = core::result::Result<T, ServerError>;
+
+const SERVER_FUNCTION_HASH_OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+const SERVER_FUNCTION_HASH_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+fn fnv1a64(bytes: &[u8]) -> u64 {
+    let mut hash = SERVER_FUNCTION_HASH_OFFSET;
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(SERVER_FUNCTION_HASH_PRIME);
+    }
+    hash
+}
+
+/// Returns the compiler-generated default route path for a server function.
+///
+/// The suffix is based on the Rust module path and function name so two
+/// modules can expose the same function name without colliding.
+#[doc(hidden)]
+pub fn server_function_default_path(module_path: &str, function: &str) -> String {
+    let mut key = String::with_capacity(module_path.len() + function.len() + 2);
+    key.push_str(module_path);
+    key.push_str("::");
+    key.push_str(function);
+    let hash = fnv1a64(key.as_bytes());
+
+    format!("/_pocopine/{function}_{hash:016x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::server_function_default_path;
+
+    #[test]
+    fn default_paths_are_scoped_by_module_path() {
+        let first = server_function_default_path("app::filters", "get_filter");
+        let second = server_function_default_path("app::admin", "get_filter");
+
+        assert_ne!(first, second);
+        assert!(first.starts_with("/_pocopine/get_filter_"));
+        assert!(second.starts_with("/_pocopine/get_filter_"));
+    }
+
+    #[test]
+    fn default_paths_are_stable() {
+        assert_eq!(
+            server_function_default_path("app::filters", "get_filter"),
+            "/_pocopine/get_filter_b0e2ae5de9927498"
+        );
+    }
+}

--- a/crates/pocopine-logging/src/lib.rs
+++ b/crates/pocopine-logging/src/lib.rs
@@ -394,6 +394,7 @@ mod server {
                     .priority(EventPriority::Low)
                     .context(self.context())
                     .field("function", event.function, FieldPrivacy::Public)
+                    .field("function_path", event.function_path, FieldPrivacy::Public)
                     .field("request_id", event.request_id, FieldPrivacy::Public),
             );
         }
@@ -405,6 +406,7 @@ mod server {
                 ObservedEvent::trace("server_function_completed")
                     .context(self.context())
                     .field("function", event.function, FieldPrivacy::Public)
+                    .field("function_path", event.function_path, FieldPrivacy::Public)
                     .field("request_id", event.request_id, FieldPrivacy::Public)
                     .field("duration_ms", event.duration_ms, FieldPrivacy::Public),
             );
@@ -418,6 +420,7 @@ mod server {
                     .priority(EventPriority::High)
                     .context(self.context())
                     .field("function", event.function, FieldPrivacy::Public)
+                    .field("function_path", event.function_path, FieldPrivacy::Public)
                     .field("request_id", event.request_id, FieldPrivacy::Public)
                     .field("status", event.status as u64, FieldPrivacy::Public)
                     .field("reason", event.reason, FieldPrivacy::Public),
@@ -432,6 +435,7 @@ mod server {
                     .priority(EventPriority::High)
                     .context(self.context())
                     .field("function", event.function, FieldPrivacy::Public)
+                    .field("function_path", event.function_path, FieldPrivacy::Public)
                     .field("request_id", event.request_id, FieldPrivacy::Public)
                     .field("error_class", event.error_class, FieldPrivacy::Public)
                     .field("duration_ms", event.duration_ms, FieldPrivacy::Public),

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -3216,6 +3216,7 @@ pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
     let fn_name_str = fn_ident.to_string();
     let route_ident = format_ident!("__{fn_name_str}_route");
     let path_ident = format_ident!("__{fn_name_str}_path");
+    let function_path_ident = format_ident!("__{fn_name_str}_function_path");
     let path_fn = match policy.path.as_ref() {
         Some(path) => quote! {
             #[doc(hidden)]
@@ -3236,6 +3237,12 @@ pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
                 }).as_str()
             }
         },
+    };
+    let function_path_fn = quote! {
+        #[doc(hidden)]
+        pub fn #function_path_ident() -> &'static str {
+            concat!(module_path!(), "::", #fn_name_str)
+        }
     };
 
     // Collect (pat_ident, type) pairs, rejecting self / ref args.
@@ -3367,6 +3374,7 @@ pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
                 ::pocopine_server::tracing::warn!(
                     target: "pocopine.log",
                     function = #fn_name_str,
+                    function_path = #function_path_ident(),
                     route = #path_ident(),
                     duration_ms = __pocopine_duration_ms,
                     error_kind = __pocopine_error_kind,
@@ -3377,6 +3385,7 @@ pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
                     ::pocopine_server::emit(
                         ::pocopine_server::ServerFunctionRejected {
                             function: #fn_name_str,
+                            function_path: #function_path_ident(),
                             request_id: __pocopine_request_id,
                             status: __pocopine_status,
                             reason: __pocopine_error_kind,
@@ -3410,6 +3419,7 @@ pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
                         ::pocopine_server::emit(
                             ::pocopine_server::ServerFunctionStarted {
                                 function: #fn_name_str,
+                                function_path: #function_path_ident(),
                                 request_id: __pocopine_request_id,
                             },
                         );
@@ -3430,6 +3440,7 @@ pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
                             ::pocopine_server::tracing::warn!(
                                 target: "pocopine.log",
                                 function = #fn_name_str,
+                                function_path = #function_path_ident(),
                                 route = #path_ident(),
                                 duration_ms = __pocopine_duration_ms,
                                 error_kind = "bad_request",
@@ -3440,6 +3451,7 @@ pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 ::pocopine_server::emit(
                                     ::pocopine_server::ServerFunctionRejected {
                                         function: #fn_name_str,
+                                        function_path: #function_path_ident(),
                                         request_id: __pocopine_request_id,
                                         status: 400,
                                         reason: "bad_request",
@@ -3463,6 +3475,7 @@ pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 ::pocopine_server::tracing::warn!(
                                     target: "pocopine.log",
                                     function = #fn_name_str,
+                                    function_path = #function_path_ident(),
                                     route = #path_ident(),
                                     duration_ms = __pocopine_duration_ms,
                                     body_bytes = __pocopine_body_bytes,
@@ -3474,6 +3487,7 @@ pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
                                     ::pocopine_server::emit(
                                         ::pocopine_server::ServerFunctionRejected {
                                             function: #fn_name_str,
+                                            function_path: #function_path_ident(),
                                             request_id: __pocopine_request_id,
                                             status: 400,
                                             reason: "bad_request",
@@ -3494,6 +3508,7 @@ pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
                             ::pocopine_server::tracing::info!(
                                 target: "pocopine.trace",
                                 function = #fn_name_str,
+                                function_path = #function_path_ident(),
                                 route = #path_ident(),
                                 duration_ms = __pocopine_duration_ms,
                                 body_bytes = __pocopine_body_bytes,
@@ -3503,6 +3518,7 @@ pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 ::pocopine_server::emit(
                                     ::pocopine_server::ServerFunctionCompleted {
                                         function: #fn_name_str,
+                                        function_path: #function_path_ident(),
                                         request_id: __pocopine_request_id,
                                         duration_ms: __pocopine_duration_ms_f64,
                                     },
@@ -3520,6 +3536,7 @@ pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
                             ::pocopine_server::tracing::warn!(
                                 target: "pocopine.log",
                                 function = #fn_name_str,
+                                function_path = #function_path_ident(),
                                 route = #path_ident(),
                                 duration_ms = __pocopine_duration_ms,
                                 body_bytes = __pocopine_body_bytes,
@@ -3531,6 +3548,7 @@ pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 ::pocopine_server::emit(
                                     ::pocopine_server::ServerFunctionFailed {
                                         function: #fn_name_str,
+                                        function_path: #function_path_ident(),
                                         request_id: __pocopine_request_id,
                                         error_class: __pocopine_error_kind,
                                         duration_ms: __pocopine_duration_ms_f64,
@@ -3545,6 +3563,7 @@ pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
                     target: "pocopine.trace",
                     "pocopine.server_function",
                     function = #fn_name_str,
+                    function_path = #function_path_ident(),
                     route = #path_ident(),
                 ))
                 .await
@@ -3578,6 +3597,7 @@ pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
     let out = quote! {
         #policy_warning
         #path_fn
+        #function_path_fn
         #client
         #server
     };

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -3056,13 +3056,14 @@ pub fn store(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// Expands to two `cfg`-gated definitions:
 ///
 /// * **wasm32** — a client stub that POSTs the arguments as JSON to
-///   `/_pocopine/<name>` and deserializes the JSON response as
+///   a generated endpoint path and deserializes the JSON response as
 ///   `Result<R, ServerError>`. The user-supplied body is discarded on
 ///   this target.
 /// * **non-wasm32** — the original user body, plus a helper
 ///   `__<name>_route(router) -> axum::Router` that registers the POST
-///   route so a server binary can mount it. `#[server(guard = path)]`
-///   runs the guard before the user body.
+///   route and an inventory entry that lets `pocopine_server::Server`
+///   mount the route automatically. `#[server(guard = path)]` runs the
+///   guard before the user body.
 ///
 /// Access policy:
 ///
@@ -3074,6 +3075,9 @@ pub fn store(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///   replay-safe for middleware. Auth middleware may retry these at
 ///   most once after a successful refresh; unmarked calls remain
 ///   fail-closed.
+/// * `#[server(path = "/api/stable-name")]` opts into a public, stable
+///   route path. Without `path`, the macro uses a generated internal
+///   path scoped by module path and function name.
 /// * `#[server]` without either marker still compiles, but emits a
 ///   warning so authors do not accidentally ship unreviewed endpoints.
 ///
@@ -3089,6 +3093,7 @@ struct ServerPolicy {
     public: bool,
     guard: Option<Path>,
     idempotent: bool,
+    path: Option<LitStr>,
 }
 
 impl ServerPolicy {
@@ -3124,6 +3129,12 @@ fn parse_server_policy(attr: TokenStream) -> syn::Result<ServerPolicy> {
                 }
                 policy.guard = Some(parse_server_guard_value(value)?);
             }
+            Meta::NameValue(MetaNameValue { path, value, .. }) if path.is_ident("path") => {
+                if policy.path.is_some() {
+                    return Err(syn::Error::new_spanned(path, "duplicate route path"));
+                }
+                policy.path = Some(parse_server_path_value(value)?);
+            }
             Meta::List(list) if list.path.is_ident("guard") => {
                 if policy.guard.is_some() {
                     return Err(syn::Error::new_spanned(list.path, "duplicate auth guard"));
@@ -3133,7 +3144,7 @@ fn parse_server_policy(attr: TokenStream) -> syn::Result<ServerPolicy> {
             other => {
                 return Err(syn::Error::new_spanned(
                     other,
-                    "unsupported `#[server]` option; expected `public`, `idempotent`, or `guard = path`",
+                    "unsupported `#[server]` option; expected `public`, `idempotent`, `guard = path`, or `path = \"/api/name\"`",
                 ));
             }
         }
@@ -3165,6 +3176,31 @@ fn parse_server_guard_value(value: Expr) -> syn::Result<Path> {
     }
 }
 
+fn parse_server_path_value(value: Expr) -> syn::Result<LitStr> {
+    let Expr::Lit(ExprLit {
+        lit: Lit::Str(lit), ..
+    }) = value
+    else {
+        return Err(syn::Error::new_spanned(
+            value,
+            "`path` must be a string literal, for example `path = \"/api/posts\"`",
+        ));
+    };
+
+    let value = lit.value();
+    if !value.starts_with('/') {
+        return Err(syn::Error::new_spanned(lit, "`path` must start with `/`"));
+    }
+    if value.trim() != value || value.chars().any(char::is_control) {
+        return Err(syn::Error::new_spanned(
+            lit,
+            "`path` must not contain surrounding whitespace or control characters",
+        ));
+    }
+
+    Ok(lit)
+}
+
 #[proc_macro_attribute]
 pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
     let policy = match parse_server_policy(attr) {
@@ -3178,8 +3214,29 @@ pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
 
     let fn_ident = sig.ident.clone();
     let fn_name_str = fn_ident.to_string();
-    let route_path = format!("/_pocopine/{fn_name_str}");
     let route_ident = format_ident!("__{fn_name_str}_route");
+    let path_ident = format_ident!("__{fn_name_str}_path");
+    let path_fn = match policy.path.as_ref() {
+        Some(path) => quote! {
+            #[doc(hidden)]
+            pub fn #path_ident() -> &'static str {
+                #path
+            }
+        },
+        None => quote! {
+            #[doc(hidden)]
+            pub fn #path_ident() -> &'static str {
+                static PATH: ::std::sync::OnceLock<::std::string::String> =
+                    ::std::sync::OnceLock::new();
+                PATH.get_or_init(|| {
+                    ::pocopine::__private::server_function_default_path(
+                        module_path!(),
+                        #fn_name_str,
+                    )
+                }).as_str()
+            }
+        },
+    };
 
     // Collect (pat_ident, type) pairs, rejecting self / ref args.
     let mut arg_idents = Vec::new();
@@ -3263,7 +3320,7 @@ pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
         #[cfg(target_arch = "wasm32")]
         #sig_without_body {
             #client_call(
-                #route_path,
+                #path_ident(),
                 &#args_tuple_value,
             ).await
         }
@@ -3310,7 +3367,7 @@ pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
                 ::pocopine_server::tracing::warn!(
                     target: "pocopine.log",
                     function = #fn_name_str,
-                    route = #route_path,
+                    route = #path_ident(),
                     duration_ms = __pocopine_duration_ms,
                     error_kind = __pocopine_error_kind,
                     error = %__pocopine_error,
@@ -3373,7 +3430,7 @@ pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
                             ::pocopine_server::tracing::warn!(
                                 target: "pocopine.log",
                                 function = #fn_name_str,
-                                route = #route_path,
+                                route = #path_ident(),
                                 duration_ms = __pocopine_duration_ms,
                                 error_kind = "bad_request",
                                 error = %__pocopine_error,
@@ -3406,7 +3463,7 @@ pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 ::pocopine_server::tracing::warn!(
                                     target: "pocopine.log",
                                     function = #fn_name_str,
-                                    route = #route_path,
+                                    route = #path_ident(),
                                     duration_ms = __pocopine_duration_ms,
                                     body_bytes = __pocopine_body_bytes,
                                     error_kind = "bad_request",
@@ -3437,7 +3494,7 @@ pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
                             ::pocopine_server::tracing::info!(
                                 target: "pocopine.trace",
                                 function = #fn_name_str,
-                                route = #route_path,
+                                route = #path_ident(),
                                 duration_ms = __pocopine_duration_ms,
                                 body_bytes = __pocopine_body_bytes,
                                 "server function completed"
@@ -3463,7 +3520,7 @@ pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
                             ::pocopine_server::tracing::warn!(
                                 target: "pocopine.log",
                                 function = #fn_name_str,
-                                route = #route_path,
+                                route = #path_ident(),
                                 duration_ms = __pocopine_duration_ms,
                                 body_bytes = __pocopine_body_bytes,
                                 error_kind = __pocopine_error_kind,
@@ -3488,7 +3545,7 @@ pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
                     target: "pocopine.trace",
                     "pocopine.server_function",
                     function = #fn_name_str,
-                    route = #route_path,
+                    route = #path_ident(),
                 ))
                 .await
             },
@@ -3504,12 +3561,23 @@ pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
         pub fn #route_ident(
             router: ::pocopine_server::axum::Router,
         ) -> ::pocopine_server::axum::Router {
-            router.route(#route_path, #route_handler)
+            router.route(#path_ident(), #route_handler)
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        ::pocopine_server::inventory::submit! {
+            ::pocopine_server::ServerFunctionRoute {
+                module_path: module_path!(),
+                function: #fn_name_str,
+                path: #path_ident,
+                install: #route_ident,
+            }
         }
     };
 
     let out = quote! {
         #policy_warning
+        #path_fn
         #client
         #server
     };

--- a/crates/pocopine-server/Cargo.toml
+++ b/crates/pocopine-server/Cargo.toml
@@ -16,6 +16,7 @@ tower = "0.5"
 tower-http = { version = "0.6", features = ["fs", "trace"] }
 serde_json = "1"
 tracing = { workspace = true }
+inventory = { workspace = true }
 
 [dependencies]
 pocopine-auth = { workspace = true }

--- a/crates/pocopine-server/src/lib.rs
+++ b/crates/pocopine-server/src/lib.rs
@@ -9,18 +9,21 @@
 //! ```no_run
 //! use pocopine_server::{axum::{self, Router}, serve, static_files};
 //!
-//! # mod app { pub fn __get_post_route(r: pocopine_server::axum::Router) -> pocopine_server::axum::Router { r } }
+//! # mod my_app {}
+//! // Link the app crate once so its `#[server]` inventory entries are present.
+//! use my_app as _;
+//!
 //! #[tokio::main]
 //! async fn main() -> std::io::Result<()> {
 //!     let router = Router::new()
 //!         .nest_service("/", static_files("pkg"))
 //!         .merge(Router::new());
-//!     let router = app::__get_post_route(router);
 //!     serve(router, "0.0.0.0:3000").await
 //! }
 //! ```
 
 pub use axum;
+pub use inventory;
 pub use serde_json;
 pub use tokio;
 pub use tower;
@@ -30,6 +33,7 @@ pub use tracing;
 mod observability;
 pub mod plugin;
 mod server;
+mod server_functions;
 
 pub use observability::request_event_layer;
 pub use plugin::{
@@ -44,6 +48,9 @@ pub use plugin::{
     ServerHook, ServerListening, ServerPluginHandle,
 };
 pub use server::{Server, ServerPlugin};
+pub use server_functions::{
+    install_server_functions, ServerFunctionRoute, ServerFunctionRouteConflict,
+};
 
 #[doc(hidden)]
 pub use plugin::__reset_for_test;
@@ -175,13 +182,19 @@ async fn auth_middleware(
     next.run(req).await
 }
 
-/// Extension trait that installs an [`AuthProvider`] on an axum
+/// Extension trait that installs an [`AuthProvider`] on a raw axum
 /// [`Router`] in one line.
 ///
-/// **Install after routes.** `Router::layer` (which this calls
-/// under the hood) only wraps the routes that exist at the call
-/// site — routes added afterwards silently bypass the middleware.
-/// Always call `with_auth` last:
+/// Normal applications should prefer [`Server::with_auth`], because
+/// [`Server::new`] first installs all linked `#[server]` routes and
+/// then the builder method wraps them. This raw-router extension is
+/// still useful for tests and custom routers that manually install
+/// routes.
+///
+/// **Install after routes.** `Router::layer` (which this calls under
+/// the hood) only wraps the routes that exist at the call site —
+/// routes added afterwards silently bypass the middleware. Always call
+/// `with_auth` last:
 ///
 /// ```no_run
 /// # use pocopine_server::{axum::Router, RouterAuthExt};
@@ -192,11 +205,8 @@ async fn auth_middleware(
 /// #         -> AuthFuture<'a, Option<AuthUser>>
 /// #     { Box::pin(async { Ok(None) }) }
 /// # }
-/// # mod app { pub fn __whoami_route(r: pocopine_server::axum::Router)
-/// #     -> pocopine_server::axum::Router { r } }
 /// let router = Router::new();
-/// let router = app::__whoami_route(router);
-/// // ... register all server-function routes first ...
+/// // ... manually register routes first ...
 /// let router = router.with_auth(StubProvider);
 /// ```
 ///
@@ -230,7 +240,9 @@ impl RouterAuthExt for Router {
 ///
 /// Compatibility wrapper around [`Server::new(router).serve(addr)`].
 /// New code should prefer the builder so plugins can install
-/// services, hooks, and tower layers before bind.
+/// services, hooks, and tower layers before bind. Do not pre-install
+/// generated `__*_route` helpers before calling this wrapper; linked
+/// server functions are installed automatically.
 pub async fn serve(router: Router, addr: &str) -> std::io::Result<()> {
     Server::new(router).serve(addr).await
 }

--- a/crates/pocopine-server/src/plugin.rs
+++ b/crates/pocopine-server/src/plugin.rs
@@ -187,14 +187,20 @@ pub struct HttpRequestFailed {
 /// HTTP layer has matched the route and before guard/body work.
 #[derive(Clone, Debug)]
 pub struct ServerFunctionStarted {
+    /// Short Rust function identifier, useful for display.
     pub function: &'static str,
+    /// Fully-qualified Rust path (`module::function`), useful for disambiguation.
+    pub function_path: &'static str,
     pub request_id: u64,
 }
 
 /// Emitted when a `#[server]` handler returns an `Ok` value.
 #[derive(Clone, Debug)]
 pub struct ServerFunctionCompleted {
+    /// Short Rust function identifier, useful for display.
     pub function: &'static str,
+    /// Fully-qualified Rust path (`module::function`), useful for disambiguation.
+    pub function_path: &'static str,
     pub request_id: u64,
     pub duration_ms: f64,
 }
@@ -206,7 +212,10 @@ pub struct ServerFunctionCompleted {
 /// (`"unauthorized"`, `"forbidden"`, `"bad_request"`, …).
 #[derive(Clone, Debug)]
 pub struct ServerFunctionRejected {
+    /// Short Rust function identifier, useful for display.
     pub function: &'static str,
+    /// Fully-qualified Rust path (`module::function`), useful for disambiguation.
+    pub function_path: &'static str,
     pub request_id: u64,
     pub status: u16,
     pub reason: &'static str,
@@ -218,7 +227,10 @@ pub struct ServerFunctionRejected {
 /// `"bad_request"`, `"network"`).
 #[derive(Clone, Debug)]
 pub struct ServerFunctionFailed {
+    /// Short Rust function identifier, useful for display.
     pub function: &'static str,
+    /// Fully-qualified Rust path (`module::function`), useful for disambiguation.
+    pub function_path: &'static str,
     pub request_id: u64,
     pub error_class: &'static str,
     pub duration_ms: f64,

--- a/crates/pocopine-server/src/server.rs
+++ b/crates/pocopine-server/src/server.rs
@@ -9,11 +9,13 @@
 //! ```no_run
 //! use pocopine_server::{axum::Router, static_files, Server};
 //!
-//! # mod app { pub fn __get_post_route(r: pocopine_server::axum::Router) -> pocopine_server::axum::Router { r } }
+//! # mod my_app {}
+//! // Link the app crate once so its `#[server]` inventory entries are present.
+//! use my_app as _;
+//!
 //! #[tokio::main]
 //! async fn main() -> std::io::Result<()> {
 //!     let router = Router::new().fallback_service(static_files("pkg"));
-//!     let router = app::__get_post_route(router);
 //!     Server::new(router).serve("0.0.0.0:3000").await
 //! }
 //! ```
@@ -21,14 +23,19 @@
 //! Plain [`crate::serve`] still works as a one-liner wrapper.
 
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 use axum::Router;
+use pocopine_auth::AuthProvider;
 use tower::Layer;
 use tower::Service;
 
 use crate::plugin::{
     self, PluginRegistry, PluginValidationError, ServerBootFailed, ServerBootStarted, ServerHook,
     ServerListening,
+};
+use crate::{
+    auth_middleware, install_server_functions, ServerFunctionRouteConflict, SharedAuthProvider,
 };
 
 /// App-level extension point on the host side.
@@ -78,17 +85,23 @@ pub struct Server {
     router: Router,
     plugins: PluginRegistry,
     installing_plugin: Option<&'static str>,
+    server_function_conflicts: Vec<ServerFunctionRouteConflict>,
 }
 
 impl Server {
     /// Wrap `router` in a builder. Plugin work composes on top; the
     /// router itself remains the user's source of truth for route
     /// composition, fallback services, and `with_state` calls.
+    ///
+    /// All linked `#[server]` functions are installed before plugin
+    /// work starts, so later [`Self::layer`] calls wrap those routes.
     pub fn new(router: Router) -> Self {
+        let (router, server_function_conflicts) = install_server_functions(router);
         Self {
             router,
             plugins: PluginRegistry::default(),
             installing_plugin: None,
+            server_function_conflicts,
         }
     }
 
@@ -112,6 +125,26 @@ impl Server {
     /// name both providers in the diagnostic.
     pub fn provide_plugin<T: Send + Sync + 'static>(mut self, service: T) -> Self {
         self.plugins.provide(service, self.installing_plugin);
+        self
+    }
+
+    /// Install an [`AuthProvider`] as request middleware.
+    ///
+    /// This is the preferred auth entry point for normal apps because
+    /// [`Self::new`] has already installed all linked `#[server]`
+    /// routes. The middleware therefore wraps server-function routes
+    /// and lets guarded functions read authenticated principals from
+    /// `RequestContext`.
+    pub fn with_auth<P: AuthProvider + 'static>(self, provider: P) -> Self {
+        self.with_auth_arc(Arc::new(provider))
+    }
+
+    /// Install a pre-`Arc`'d auth provider.
+    pub fn with_auth_arc(mut self, provider: SharedAuthProvider) -> Self {
+        self.router = self.router.layer(axum::middleware::from_fn_with_state(
+            provider,
+            auth_middleware,
+        ));
         self
     }
 
@@ -141,7 +174,7 @@ impl Server {
     /// adds routes, install middleware last:
     ///
     /// ```ignore
-    /// Server::new(my_app::__routes(Router::new()))
+    /// Server::new(Router::new())
     ///     .plugin(plugin_that_adds_health_routes())
     ///     .layer(request_event_layer())   // wraps user routes + health routes
     ///     .serve(addr).await
@@ -233,8 +266,19 @@ impl Server {
     #[doc(hidden)]
     pub fn try_finalize(self) -> std::io::Result<Router> {
         let Self {
-            router, plugins, ..
+            router,
+            plugins,
+            server_function_conflicts,
+            ..
         } = self;
+
+        if !server_function_conflicts.is_empty() {
+            log_server_function_route_conflicts(&server_function_conflicts);
+            plugin::activate(PluginRegistry::default());
+            return Err(server_function_route_conflict_error(
+                &server_function_conflicts,
+            ));
+        }
 
         if let Err(errors) = plugins.validate() {
             log_plugin_validation_errors(&errors);
@@ -332,5 +376,34 @@ fn plugin_validation_error(errors: &[PluginValidationError]) -> std::io::Error {
     std::io::Error::new(
         std::io::ErrorKind::InvalidInput,
         format!("pocopine server: plugin configuration invalid: {summary}"),
+    )
+}
+
+fn log_server_function_route_conflicts(errors: &[ServerFunctionRouteConflict]) {
+    tracing::error!(
+        target: "pocopine.log",
+        count = errors.len(),
+        "pocopine server: server-function routes are invalid; refusing to bind"
+    );
+    for err in errors {
+        tracing::error!(
+            target: "pocopine.log",
+            path = err.path,
+            first = %err.first,
+            second = %err.second,
+            "duplicate server-function route path"
+        );
+    }
+}
+
+fn server_function_route_conflict_error(errors: &[ServerFunctionRouteConflict]) -> std::io::Error {
+    let summary = errors
+        .iter()
+        .map(|err| format!("{} used by {} and {}", err.path, err.first, err.second))
+        .collect::<Vec<_>>()
+        .join("; ");
+    std::io::Error::new(
+        std::io::ErrorKind::InvalidInput,
+        format!("pocopine server: server-function route conflict: {summary}"),
     )
 }

--- a/crates/pocopine-server/src/server_functions.rs
+++ b/crates/pocopine-server/src/server_functions.rs
@@ -1,0 +1,83 @@
+use std::collections::BTreeSet;
+
+use axum::Router;
+
+/// A server-function route registered by macro-generated host code.
+///
+/// Values are collected through `inventory`; applications normally never
+/// construct this type directly.
+#[derive(Clone, Copy)]
+pub struct ServerFunctionRoute {
+    pub module_path: &'static str,
+    pub function: &'static str,
+    pub path: fn() -> &'static str,
+    pub install: fn(Router) -> Router,
+}
+
+/// Duplicate server-function route path detected while finalizing a server.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ServerFunctionRouteConflict {
+    pub path: &'static str,
+    pub first: String,
+    pub second: String,
+}
+
+impl ServerFunctionRouteConflict {
+    fn new(path: &'static str, first: ServerFunctionRoute, second: ServerFunctionRoute) -> Self {
+        Self {
+            path,
+            first: route_label(first),
+            second: route_label(second),
+        }
+    }
+}
+
+inventory::collect!(ServerFunctionRoute);
+
+/// Installs all linked `#[server]` functions into `router`.
+///
+/// Duplicate paths are reported instead of installed. The first route wins
+/// only long enough for `Server::try_finalize` to return a structured
+/// validation error; real servers should treat any conflict as a startup
+/// failure.
+pub fn install_server_functions(mut router: Router) -> (Router, Vec<ServerFunctionRouteConflict>) {
+    let mut routes: Vec<_> = inventory::iter::<ServerFunctionRoute>
+        .into_iter()
+        .copied()
+        .collect();
+    routes.sort_by(|left, right| {
+        let left_path = (left.path)();
+        let right_path = (right.path)();
+        (left_path, left.module_path, left.function).cmp(&(
+            right_path,
+            right.module_path,
+            right.function,
+        ))
+    });
+
+    let mut installed_paths = BTreeSet::new();
+    let mut installed_routes = Vec::new();
+    let mut conflicts = Vec::new();
+
+    for route in routes {
+        let path = (route.path)();
+        if installed_paths.insert(path) {
+            router = (route.install)(router);
+            installed_routes.push(route);
+            continue;
+        }
+
+        let first = installed_routes
+            .iter()
+            .copied()
+            .find(|candidate| (candidate.path)() == path)
+            .expect("installed route path should have a route entry");
+        conflicts.push(ServerFunctionRouteConflict::new(path, first, route));
+    }
+
+    (router, conflicts)
+}
+
+fn route_label(route: ServerFunctionRoute) -> String {
+    format!("{}::{}", route.module_path, route.function)
+}

--- a/crates/pocopine/src/lib.rs
+++ b/crates/pocopine/src/lib.rs
@@ -113,6 +113,7 @@ pub mod __private {
     pub use pocopine_core::registry::{
         clear_active_phf_registry_for_test, set_active_phf_registry,
     };
+    pub use pocopine_core::server::server_function_default_path;
     pub use pocopine_core::{
         compile_template, component_computed, computed as runtime_computed, inject_pp_data,
         inject_style, mark_registered, register_component_with_mount, register_row_plans,

--- a/crates/pocopine/tests/auth_middleware.rs
+++ b/crates/pocopine/tests/auth_middleware.rs
@@ -67,7 +67,7 @@ async fn good_token_reaches_guarded_handler() {
         .oneshot(
             Request::builder()
                 .method(Method::POST)
-                .uri("/_pocopine/whoami")
+                .uri(__whoami_path())
                 .header("content-type", "application/json")
                 .header("authorization", "Bearer good-token")
                 .body(Body::from(r#"["world"]"#))
@@ -90,7 +90,7 @@ async fn missing_token_falls_through_as_anonymous_and_guard_rejects() {
         .oneshot(
             Request::builder()
                 .method(Method::POST)
-                .uri("/_pocopine/whoami")
+                .uri(__whoami_path())
                 .header("content-type", "application/json")
                 .body(Body::from(r#"["world"]"#))
                 .unwrap(),
@@ -116,7 +116,7 @@ async fn provider_error_treated_as_anonymous_and_guard_rejects() {
         .oneshot(
             Request::builder()
                 .method(Method::POST)
-                .uri("/_pocopine/whoami")
+                .uri(__whoami_path())
                 .header("content-type", "application/json")
                 .header("authorization", "Bearer bad-token")
                 .body(Body::from(r#"["world"]"#))
@@ -148,7 +148,7 @@ async fn with_auth_arc_shares_a_single_provider_handle() {
         .oneshot(
             Request::builder()
                 .method(Method::POST)
-                .uri("/_pocopine/whoami")
+                .uri(__whoami_path())
                 .header("content-type", "application/json")
                 .header("authorization", "Bearer good-token")
                 .body(Body::from(r#"["world"]"#))

--- a/crates/pocopine/tests/observability_server.rs
+++ b/crates/pocopine/tests/observability_server.rs
@@ -135,12 +135,12 @@ fn server_observability_correlates_http_and_server_function_events_without_paylo
 
     capture.run(|| {
         rt.block_on(async {
-            let router = finalize(__observed_echo_route(Router::new()));
+            let router = finalize(Router::new());
             let response = send(
                 &router,
                 Request::builder()
                     .method(Method::POST)
-                    .uri("/_pocopine/observed_echo")
+                    .uri(__observed_echo_path())
                     .header("content-type", "application/json")
                     .body(Body::from("[\"payload-secret\"]"))
                     .unwrap(),
@@ -185,13 +185,13 @@ fn server_observability_logs_server_function_rejections_and_failures_without_pay
 
     capture.run(|| {
         rt.block_on(async {
-            let router = finalize(__observed_fail_route(__observed_echo_route(Router::new())));
+            let router = finalize(Router::new());
 
             let rejected = send(
                 &router,
                 Request::builder()
                     .method(Method::POST)
-                    .uri("/_pocopine/observed_echo")
+                    .uri(__observed_echo_path())
                     .header("content-type", "application/json")
                     .body(Body::from("\"reject-secret\""))
                     .unwrap(),
@@ -203,7 +203,7 @@ fn server_observability_logs_server_function_rejections_and_failures_without_pay
                 &router,
                 Request::builder()
                     .method(Method::POST)
-                    .uri("/_pocopine/observed_fail")
+                    .uri(__observed_fail_path())
                     .header("content-type", "application/json")
                     .body(Body::from("[\"fail-secret\"]"))
                     .unwrap(),

--- a/crates/pocopine/tests/observability_server.rs
+++ b/crates/pocopine/tests/observability_server.rs
@@ -268,20 +268,56 @@ fn find_observed_event<'a>(
         })
 }
 
-fn fields(event: &CapturedEvent) -> &str {
-    event
-        .field("fields")
-        .expect("observed event should capture fields")
+fn fields(event: &CapturedEvent) -> String {
+    if let Some(fields) = event.field("fields") {
+        return fields.to_owned();
+    }
+
+    let slots = event
+        .field("observed_field_slots")
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(0);
+    let mut rendered = String::new();
+    for index in 0..slots {
+        if event.field(&format!("observed_field_{index}_present")) != Some("true") {
+            continue;
+        }
+        let name = event
+            .field(&format!("observed_field_{index}_name"))
+            .unwrap_or("");
+        let value = observed_field_value(event, index).unwrap_or_default();
+        rendered.push_str(name);
+        rendered.push('=');
+        rendered.push_str(&value);
+        rendered.push(';');
+    }
+    rendered
 }
 
-fn context(event: &CapturedEvent) -> &str {
-    event
-        .field("context")
-        .expect("observed event should capture context")
+fn context(event: &CapturedEvent) -> String {
+    if let Some(context) = event.field("context") {
+        return context.to_owned();
+    }
+
+    [
+        event.field("observed_context_service"),
+        event.field("observed_context_environment"),
+        event.field("observed_context_route"),
+    ]
+    .into_iter()
+    .flatten()
+    .collect::<Vec<_>>()
+    .join(" ")
 }
 
 fn request_id(event: &CapturedEvent) -> u64 {
     let fields = fields(event);
+    if let Some(value) = observed_named_field_value(event, "request_id") {
+        return value
+            .parse()
+            .unwrap_or_else(|_| panic!("request_id is not numeric: {fields}"));
+    }
+
     let needle = "\"request_id\": ObservedField { value: U64(";
     let start = fields
         .find(needle)
@@ -294,6 +330,45 @@ fn request_id(event: &CapturedEvent) -> u64 {
     rest[..end]
         .parse()
         .unwrap_or_else(|_| panic!("request_id is not numeric: {fields}"))
+}
+
+fn observed_named_field_value(event: &CapturedEvent, name: &str) -> Option<String> {
+    let slots = event
+        .field("observed_field_slots")
+        .and_then(|value| value.parse::<usize>().ok())?;
+    for index in 0..slots {
+        if event.field(&format!("observed_field_{index}_name")) == Some(name) {
+            return observed_field_raw_value(event, index);
+        }
+    }
+    None
+}
+
+fn observed_field_value(event: &CapturedEvent, index: usize) -> Option<String> {
+    let kind = event.field(&format!("observed_field_{index}_kind"))?;
+    let raw = observed_field_raw_value(event, index)?;
+    Some(match kind {
+        "u64" => format!("U64({raw})"),
+        "i64" => format!("I64({raw})"),
+        "f64" => format!("F64({raw})"),
+        "bool" => format!("Bool({raw})"),
+        _ => raw,
+    })
+}
+
+fn observed_field_raw_value(event: &CapturedEvent, index: usize) -> Option<String> {
+    let kind = event.field(&format!("observed_field_{index}_kind"))?;
+    let suffix = match kind {
+        "u64" => "u64",
+        "i64" => "i64",
+        "f64" => "f64",
+        "bool" => "bool",
+        "string" => "string",
+        _ => return None,
+    };
+    event
+        .field(&format!("observed_field_{index}_value_{suffix}"))
+        .map(ToOwned::to_owned)
 }
 
 fn assert_no_values_contain(events: &[CapturedEvent], needles: &[&str]) {

--- a/crates/pocopine/tests/observability_server.rs
+++ b/crates/pocopine/tests/observability_server.rs
@@ -168,7 +168,9 @@ fn server_observability_correlates_http_and_server_function_events_without_paylo
     assert_eq!(request_id(function_started), shared_request_id);
     assert_eq!(request_id(function_completed), shared_request_id);
     assert!(fields(function_started).contains("observed_echo"));
+    assert!(fields(function_started).contains(__observed_echo_function_path()));
     assert!(fields(function_completed).contains("observed_echo"));
+    assert!(fields(function_completed).contains(__observed_echo_function_path()));
     assert_no_values_contain(&events, &["payload-secret"]);
 }
 
@@ -218,9 +220,11 @@ fn server_observability_logs_server_function_rejections_and_failures_without_pay
     let failed = find_observed_event(&events, "pocopine.log", "server_function_failed");
 
     assert!(fields(rejected).contains("observed_echo"));
+    assert!(fields(rejected).contains(__observed_echo_function_path()));
     assert!(fields(rejected).contains("bad_request"));
     assert!(fields(rejected).contains("U64(400)"));
     assert!(fields(failed).contains("observed_fail"));
+    assert!(fields(failed).contains(__observed_fail_function_path()));
     assert!(fields(failed).contains("app"));
     assert_no_values_contain(&events, &["reject-secret", "fail-secret"]);
 }

--- a/crates/pocopine/tests/server_auth.rs
+++ b/crates/pocopine/tests/server_auth.rs
@@ -63,7 +63,7 @@ fn request_context_extracts_user_from_extensions() {
 
     let ctx = pocopine::auth::RequestContext::from_parts(
         Method::GET,
-        Uri::from_static("/_pocopine/admin_echo"),
+        Uri::from_static(__admin_echo_path()),
         HeaderMap::new(),
         extensions,
     );
@@ -81,7 +81,7 @@ fn protected_macro_guard_checks_inline_policy() {
 
     let allowed = pocopine::auth::RequestContext::new(
         Method::POST,
-        Uri::from_static("/_pocopine/admin_echo"),
+        Uri::from_static(__admin_echo_path()),
         HeaderMap::new(),
     )
     .with_user(AuthUser::new("admin").with_role(Role::admin()));
@@ -89,7 +89,7 @@ fn protected_macro_guard_checks_inline_policy() {
 
     let denied = pocopine::auth::RequestContext::new(
         Method::POST,
-        Uri::from_static("/_pocopine/admin_echo"),
+        Uri::from_static(__admin_echo_path()),
         HeaderMap::new(),
     )
     .with_user(AuthUser::new("user").with_role(Role::user()));
@@ -119,7 +119,7 @@ fn oversized_body_returns_bad_request() {
                 .oneshot(
                     Request::builder()
                         .method(Method::POST)
-                        .uri("/_pocopine/public_echo")
+                        .uri(__public_echo_path())
                         .header("content-type", "application/json")
                         .body(Body::from(oversized_body))
                         .unwrap(),
@@ -138,7 +138,7 @@ fn oversized_body_returns_bad_request() {
         capture.events_with_message("pocopine.log", "server function request body read failed");
     let event = events
         .iter()
-        .find(|event| event.field("route") == Some("/_pocopine/public_echo"))
+        .find(|event| event.field("route") == Some(__public_echo_path()))
         .expect("body-read failure event should be captured");
 
     assert_eq!(event.field("function"), Some("public_echo"));
@@ -174,7 +174,7 @@ fn malformed_body_returns_bad_request_and_emits_parse_log_without_payload() {
                 .oneshot(
                     Request::builder()
                         .method(Method::POST)
-                        .uri("/_pocopine/public_echo")
+                        .uri(__public_echo_path())
                         .header("content-type", "application/json")
                         .body(Body::from("\"parse-secret\""))
                         .unwrap(),
@@ -193,7 +193,7 @@ fn malformed_body_returns_bad_request_and_emits_parse_log_without_payload() {
         capture.events_with_message("pocopine.log", "server function request body parse failed");
     let event = events
         .iter()
-        .find(|event| event.field("route") == Some("/_pocopine/public_echo"))
+        .find(|event| event.field("route") == Some(__public_echo_path()))
         .expect("body-parse failure event should be captured");
 
     assert_eq!(event.field("function"), Some("public_echo"));
@@ -231,7 +231,7 @@ fn server_function_route_emits_trace_without_payload() {
                 .oneshot(
                     Request::builder()
                         .method(Method::POST)
-                        .uri("/_pocopine/public_echo")
+                        .uri(__public_echo_path())
                         .header("content-type", "application/json")
                         .body(Body::from("[\"hello\"]"))
                         .unwrap(),
@@ -249,7 +249,7 @@ fn server_function_route_emits_trace_without_payload() {
     let events = capture.events_with_message("pocopine.trace", "server function completed");
     let event = events
         .iter()
-        .find(|event| event.field("route") == Some("/_pocopine/public_echo"))
+        .find(|event| event.field("route") == Some(__public_echo_path()))
         .expect("server function completion event should be captured");
 
     assert_eq!(event.field("function"), Some("public_echo"));
@@ -282,7 +282,7 @@ fn server_function_guard_rejection_emits_log_without_payload() {
                 .oneshot(
                     Request::builder()
                         .method(Method::POST)
-                        .uri("/_pocopine/guarded_echo")
+                        .uri(__guarded_echo_path())
                         .header("content-type", "application/json")
                         .body(Body::from("[\"guard-secret\"]"))
                         .unwrap(),
@@ -301,7 +301,7 @@ fn server_function_guard_rejection_emits_log_without_payload() {
         capture.events_with_message("pocopine.log", "server function guard rejected request");
     let event = events
         .iter()
-        .find(|event| event.field("route") == Some("/_pocopine/guarded_echo"))
+        .find(|event| event.field("route") == Some(__guarded_echo_path()))
         .expect("guard rejection event should be captured");
 
     assert_eq!(event.field("function"), Some("guarded_echo"));
@@ -337,7 +337,7 @@ fn server_function_app_failure_emits_log_without_payload() {
                 .oneshot(
                     Request::builder()
                         .method(Method::POST)
-                        .uri("/_pocopine/failing_echo")
+                        .uri(__failing_echo_path())
                         .header("content-type", "application/json")
                         .body(Body::from("[\"fail-input\"]"))
                         .unwrap(),
@@ -355,7 +355,7 @@ fn server_function_app_failure_emits_log_without_payload() {
     let events = capture.events_with_message("pocopine.log", "server function failed");
     let event = events
         .iter()
-        .find(|event| event.field("route") == Some("/_pocopine/failing_echo"))
+        .find(|event| event.field("route") == Some(__failing_echo_path()))
         .expect("server function failure event should be captured");
 
     assert_eq!(event.field("function"), Some("failing_echo"));

--- a/crates/pocopine/tests/server_function_auto_routes.rs
+++ b/crates/pocopine/tests/server_function_auto_routes.rs
@@ -1,0 +1,83 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+use pocopine::ServerResult;
+use pocopine_server::axum::{
+    body::{to_bytes, Body},
+    http::{Method, Request},
+    Router,
+};
+use pocopine_server::tower::ServiceExt;
+use pocopine_server::Server;
+
+#[pocopine::server(public)]
+async fn auto_echo(value: String) -> ServerResult<String> {
+    Ok(format!("root:{value}"))
+}
+
+mod nested {
+    use pocopine::ServerResult;
+
+    #[pocopine::server(public)]
+    pub async fn auto_echo(value: String) -> ServerResult<String> {
+        Ok(format!("nested:{value}"))
+    }
+}
+
+#[pocopine::server(public, path = "/api/custom-echo")]
+async fn custom_echo(value: String) -> ServerResult<String> {
+    Ok(format!("custom:{value}"))
+}
+
+#[test]
+fn default_route_paths_are_module_scoped() {
+    assert_ne!(__auto_echo_path(), nested::__auto_echo_path());
+    assert!(matches!(
+        __auto_echo_path().strip_prefix("/_pocopine/auto_echo_"),
+        Some(suffix) if suffix.len() == 16
+    ));
+    assert!(matches!(
+        nested::__auto_echo_path().strip_prefix("/_pocopine/auto_echo_"),
+        Some(suffix) if suffix.len() == 16
+    ));
+}
+
+#[test]
+fn explicit_route_path_is_stable() {
+    assert_eq!(__custom_echo_path(), "/api/custom-echo");
+}
+
+#[tokio::test]
+async fn server_new_installs_linked_server_functions() {
+    let router = Server::new(Router::new())
+        .try_finalize()
+        .expect("server functions should finalize");
+
+    assert_eq!(post(&router, __auto_echo_path(), "one").await, "root:one");
+    assert_eq!(
+        post(&router, nested::__auto_echo_path(), "two").await,
+        "nested:two"
+    );
+    assert_eq!(
+        post(&router, __custom_echo_path(), "three").await,
+        "custom:three"
+    );
+}
+
+async fn post(router: &Router, path: &str, value: &str) -> String {
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::POST)
+                .uri(path)
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::json!([value]).to_string()))
+                .unwrap(),
+        )
+        .await
+        .expect("server-function route should respond");
+    assert_eq!(response.status(), 200);
+    let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let result: ServerResult<String> = serde_json::from_slice(&bytes).unwrap();
+    result.unwrap()
+}

--- a/crates/pocopine/tests/server_function_auto_routes.rs
+++ b/crates/pocopine/tests/server_function_auto_routes.rs
@@ -31,6 +31,18 @@ async fn custom_echo(value: String) -> ServerResult<String> {
 #[test]
 fn default_route_paths_are_module_scoped() {
     assert_ne!(__auto_echo_path(), nested::__auto_echo_path());
+    assert_ne!(
+        __auto_echo_function_path(),
+        nested::__auto_echo_function_path()
+    );
+    assert!(matches!(
+        __auto_echo_function_path().strip_suffix("::auto_echo"),
+        Some(module) if module.ends_with("server_function_auto_routes")
+    ));
+    assert!(matches!(
+        nested::__auto_echo_function_path().strip_suffix("::auto_echo"),
+        Some(module) if module.ends_with("server_function_auto_routes::nested")
+    ));
     assert!(matches!(
         __auto_echo_path().strip_prefix("/_pocopine/auto_echo_"),
         Some(suffix) if suffix.len() == 16

--- a/crates/pocopine/tests/server_function_events.rs
+++ b/crates/pocopine/tests/server_function_events.rs
@@ -137,19 +137,23 @@ async fn guarded(text: String) -> ServerResult<String> {
 }
 
 fn build_public_router() -> Router {
-    let router = Router::new();
-    let router = __echo_route(router);
-    __fail_with_app_route(router)
+    Router::new()
 }
 
 fn build_guarded_router() -> Router {
-    let router = Router::new();
-    let router = __guarded_route(router);
-    router.with_auth(StubProvider)
+    Router::new()
 }
 
 fn finalize(router: Router, events: EventLog) -> Router {
     Server::new(router)
+        .plugin(server_function_event_plugin(events))
+        .try_finalize()
+        .expect("plugin validation succeeds")
+}
+
+fn finalize_with_auth(router: Router, events: EventLog) -> Router {
+    Server::new(router)
+        .router_mut(|router| router.with_auth(StubProvider))
         .plugin(server_function_event_plugin(events))
         .try_finalize()
         .expect("plugin validation succeeds")
@@ -180,7 +184,7 @@ async fn successful_call_emits_started_then_completed_with_shared_request_id() {
         &router,
         Request::builder()
             .method(Method::POST)
-            .uri("/_pocopine/echo")
+            .uri(__echo_path())
             .header("content-type", "application/json")
             .body(Body::from("[\"hi\"]"))
             .unwrap(),
@@ -223,7 +227,7 @@ async fn app_error_emits_failed_with_error_class() {
         &router,
         Request::builder()
             .method(Method::POST)
-            .uri("/_pocopine/fail_with_app")
+            .uri(__fail_with_app_path())
             .header("content-type", "application/json")
             .body(Body::from("[\"x\"]"))
             .unwrap(),
@@ -259,7 +263,7 @@ async fn body_parse_failure_emits_rejected_with_bad_request() {
         &router,
         Request::builder()
             .method(Method::POST)
-            .uri("/_pocopine/echo")
+            .uri(__echo_path())
             .header("content-type", "application/json")
             .body(Body::from("not json"))
             .unwrap(),
@@ -287,13 +291,13 @@ async fn guard_rejection_emits_rejected_with_unauthorized() {
     pocopine_server::__reset_for_test();
 
     let events = EventLog::default();
-    let router = finalize(build_guarded_router(), events.clone());
+    let router = finalize_with_auth(build_guarded_router(), events.clone());
 
     let response = send(
         &router,
         Request::builder()
             .method(Method::POST)
-            .uri("/_pocopine/guarded")
+            .uri(__guarded_path())
             .header("content-type", "application/json")
             .body(Body::from("[\"hi\"]"))
             .unwrap(),
@@ -324,13 +328,13 @@ async fn guarded_call_with_good_token_emits_started_then_completed() {
     pocopine_server::__reset_for_test();
 
     let events = EventLog::default();
-    let router = finalize(build_guarded_router(), events.clone());
+    let router = finalize_with_auth(build_guarded_router(), events.clone());
 
     let response = send(
         &router,
         Request::builder()
             .method(Method::POST)
-            .uri("/_pocopine/guarded")
+            .uri(__guarded_path())
             .header("content-type", "application/json")
             .header("authorization", "Bearer good")
             .body(Body::from("[\"hi\"]"))
@@ -379,7 +383,7 @@ async fn server_function_events_self_allocate_request_id_without_http_layer() {
         &router,
         Request::builder()
             .method(Method::POST)
-            .uri("/_pocopine/echo")
+            .uri(__echo_path())
             .header("content-type", "application/json")
             .body(Body::from("[\"first\"]"))
             .unwrap(),
@@ -391,7 +395,7 @@ async fn server_function_events_self_allocate_request_id_without_http_layer() {
         &router,
         Request::builder()
             .method(Method::POST)
-            .uri("/_pocopine/echo")
+            .uri(__echo_path())
             .header("content-type", "application/json")
             .body(Body::from("[\"second\"]"))
             .unwrap(),

--- a/crates/pocopine/tests/server_function_events.rs
+++ b/crates/pocopine/tests/server_function_events.rs
@@ -208,6 +208,8 @@ async fn successful_call_emits_started_then_completed_with_shared_request_id() {
 
     assert_eq!(started.function, "echo");
     assert_eq!(completed.function, "echo");
+    assert_eq!(started.function_path, __echo_function_path());
+    assert_eq!(completed.function_path, __echo_function_path());
     assert_eq!(
         started.request_id, completed.request_id,
         "started/completed must share request_id (HTTP layer correlation)"
@@ -242,6 +244,7 @@ async fn app_error_emits_failed_with_error_class() {
     });
     let failed = failed.expect("expected ServerFunctionFailed");
     assert_eq!(failed.function, "fail_with_app");
+    assert_eq!(failed.function_path, __fail_with_app_function_path());
     assert_eq!(failed.error_class, "app");
 
     let completed = log.iter().any(|e| matches!(e, Event::Completed(_)));
@@ -278,6 +281,7 @@ async fn body_parse_failure_emits_rejected_with_bad_request() {
     });
     let rejected = rejected.expect("expected ServerFunctionRejected");
     assert_eq!(rejected.function, "echo");
+    assert_eq!(rejected.function_path, __echo_function_path());
     assert_eq!(rejected.status, 400);
     assert_eq!(rejected.reason, "bad_request");
 
@@ -312,6 +316,7 @@ async fn guard_rejection_emits_rejected_with_unauthorized() {
     });
     let rejected = rejected.expect("expected ServerFunctionRejected for missing bearer");
     assert_eq!(rejected.function, "guarded");
+    assert_eq!(rejected.function_path, __guarded_function_path());
     assert_eq!(rejected.status, 401);
     assert_eq!(rejected.reason, "unauthorized");
 

--- a/crates/pocopine/tests/server_function_route_conflicts.rs
+++ b/crates/pocopine/tests/server_function_route_conflicts.rs
@@ -1,0 +1,32 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+use pocopine::ServerResult;
+use pocopine_server::axum::Router;
+use pocopine_server::Server;
+
+#[pocopine::server(public, path = "/api/conflicting-server-function")]
+async fn first_conflicting_route() -> ServerResult<()> {
+    Ok(())
+}
+
+mod nested {
+    use pocopine::ServerResult;
+
+    #[pocopine::server(public, path = "/api/conflicting-server-function")]
+    pub async fn second_conflicting_route() -> ServerResult<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn duplicate_explicit_server_function_paths_fail_startup() {
+    let err = Server::new(Router::new())
+        .try_finalize()
+        .expect_err("duplicate server-function paths should fail startup");
+    let message = err.to_string();
+
+    assert!(message.contains("server-function route conflict"));
+    assert!(message.contains("/api/conflicting-server-function"));
+    assert!(message.contains("first_conflicting_route"));
+    assert!(message.contains("second_conflicting_route"));
+}

--- a/docs/auth-credentials.md
+++ b/docs/auth-credentials.md
@@ -65,9 +65,9 @@ async fn main() -> std::io::Result<()> {
     let creds = Credentials::new(secret, store, tokens);
 
     let verifier = JwtVerifier::custom(creds.verifier_config()).unwrap();
-    let router = my_app::__routes(Router::new()).with_auth(verifier);
 
-    Server::new(router)
+    Server::new(Router::new())
+        .with_auth(verifier)
         .plugin(creds)
         .serve("0.0.0.0:3000")
         .await
@@ -476,9 +476,8 @@ async fn main() -> std::io::Result<()> {
     // BEFORE installing the credentials plugin, otherwise the
     // signup/login routes added by the plugin would be wrapped in
     // the auth middleware and reject anonymous requests.
-    let router = my_app::__routes(Router::new()).with_auth(verifier);
-
-    Server::new(router)
+    Server::new(Router::new())
+        .with_auth(verifier)
         .plugin(creds)
         .serve("0.0.0.0:3000")
         .await

--- a/docs/auth-phone-otp-tutorial.md
+++ b/docs/auth-phone-otp-tutorial.md
@@ -675,9 +675,8 @@ async fn main() -> std::io::Result<()> {
     // Authorization header → JwtVerifier → Principal in extensions
     // → #[server(guard = ...)] sees a real user regardless of
     // whether they signed in via OTP, password, or OAuth.
-    let router = my_app::__routes(Router::new()).with_auth(verifier);
-
-    Server::new(router)
+    Server::new(Router::new())
+        .with_auth(verifier)
         .plugin(otp)
         .serve("0.0.0.0:3000")
         .await

--- a/docs/components/02-state.md
+++ b/docs/components/02-state.md
@@ -213,7 +213,7 @@ is the real body.
 #[pocopine::server]
 pub async fn get_post(id: u32) -> ServerResult<Post> {
     // Runs on the server; on wasm32 this body is replaced with a
-    // client stub that POSTs to /_pocopine/get_post.
+    // client stub that POSTs to the generated server-function route.
     db::posts::by_id(id).await.map_err(|e| ServerError::App(e.to_string()))
 }
 ```

--- a/docs/live.md
+++ b/docs/live.md
@@ -136,8 +136,7 @@ allow the topics the browser may request. The default policy is deny-all.
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
     use my_app::{
-        __create_post_route, __list_posts_route, __reset_posts_route, live_backend,
-        POSTS_COLLECTION, POSTS_LIST_QUERY_TAG,
+        live_backend, POSTS_COLLECTION, POSTS_LIST_QUERY_TAG,
     };
     use pocopine::live::{collection_topic, query_tag_topic, routes, LiveHub};
     use pocopine_logging::init_default;
@@ -158,9 +157,6 @@ async fn main() -> std::io::Result<()> {
     let router = Router::new()
         .merge(routes(live_hub))
         .fallback_service(static_files(manifest_dir));
-    let router = __list_posts_route(router);
-    let router = __create_post_route(router);
-    let router = __reset_posts_route(router);
 
     serve(router, "127.0.0.1:3000").await
 }

--- a/docs/logging-tracing-observer.md
+++ b/docs/logging-tracing-observer.md
@@ -288,6 +288,10 @@ hooks into `ObservedEvent`s:
 | `ServerFunctionRejected` | `server_function_rejected` log |
 | `ServerFunctionFailed` | `server_function_failed` log |
 
+Server-function events include both `function` (the short Rust function
+identifier for display) and `function_path` (the fully-qualified
+`module::function` path for debugging collisions and same-name handlers).
+
 HTTP events report axum's matched route pattern, such as `/posts/:id`, rather
 than the concrete request path. Headers, cookies, query strings, request
 bodies, response bodies, and raw server-function payloads are never exported by

--- a/docs/logging-tracing-observer.md
+++ b/docs/logging-tracing-observer.md
@@ -259,7 +259,6 @@ async fn main() -> std::io::Result<()> {
         .expect("logging should initialize");
 
     let router = Router::new().nest_service("/", static_files("pkg"));
-    let router = my_app::__routes(router);
 
     Server::new(router)
         .plugin(server_observability_with_config(

--- a/docs/server-plugins.md
+++ b/docs/server-plugins.md
@@ -18,7 +18,6 @@ use pocopine_server::{static_files, Server};
 async fn main() -> std::io::Result<()> {
     let router = Router::new()
         .nest_service("/", static_files("pkg"));
-    let router = my_app::__routes(router);
 
     Server::new(router)
         .plugin(server_observability()) // installs hooks + HTTP request layer
@@ -28,8 +27,9 @@ async fn main() -> std::io::Result<()> {
 ```
 
 Plain `pocopine_server::serve(router, addr)` still works as a one-line
-wrapper — `Server::new(router).serve(addr)` under the hood — so existing
-apps don't need to migrate.
+wrapper — `Server::new(router).serve(addr)` under the hood. Do not also
+call generated `__*_route` helpers before `serve`; linked server
+functions are installed by `Server::new`.
 
 ## Writing a plugin
 
@@ -170,7 +170,7 @@ layer.
 Install layers after routes:
 
 ```rust
-Server::new(my_app::__routes(Router::new()))
+Server::new(Router::new())
     .plugin(adds_health_endpoints())          // adds /healthz
     .layer(request_event_layer())             // wraps user + health routes
     .plugin(observability_plugin(config))

--- a/examples/blog/src/bin/server.rs
+++ b/examples/blog/src/bin/server.rs
@@ -1,14 +1,13 @@
 //! Blog server binary — host-only.
 //!
-//! Wires the static file server (serves `pkg/` + `index.html`) with the
-//! `__get_post_route` helper emitted by the `#[server]` macro. The bin
+//! Wires the static file server (serves `pkg/` + `index.html`). The bin
 //! target still exists on wasm32 for workspace consistency, but its
 //! `main` is a no-op there.
 
 #[cfg(not(target_arch = "wasm32"))]
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
-    use blog::__get_post_route;
+    use blog as _;
     use pocopine_logging::init_default;
     use pocopine_server::{axum::Router, serve, static_files};
 
@@ -19,7 +18,6 @@ async fn main() -> std::io::Result<()> {
     // `pocopine dev` from the workspace root).
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let router = Router::new().fallback_service(static_files(manifest_dir));
-    let router = __get_post_route(router);
 
     let addr = "127.0.0.1:3000";
     tracing::info!(target: "pocopine.log", %addr, "serving blog example");

--- a/examples/blog/src/lib.rs
+++ b/examples/blog/src/lib.rs
@@ -35,10 +35,10 @@ pub async fn refresh_blog_index() -> JobResult<()> {
 }
 
 /// `#[server]` generates:
-/// * on wasm32 — a client stub that POSTs `[post_id]` to
-///   `/_pocopine/get_post` and deserializes the response.
-/// * on the host — this body is the real handler, plus a
-///   `__get_post_route` helper used by `bin/server.rs`.
+/// * on wasm32 — a client stub that POSTs `[post_id]` to the
+///   generated route and deserializes the response.
+/// * on the host — this body is the real handler, and the route is
+///   registered automatically by `pocopine_server::Server`.
 #[pocopine::server(public)]
 pub async fn get_post(post_id: u32) -> ServerResult<Post> {
     #[cfg(not(target_arch = "wasm32"))]

--- a/examples/hn/src/bin/server.rs
+++ b/examples/hn/src/bin/server.rs
@@ -1,11 +1,11 @@
 //! HN server binary — host-only. Serves static files with SPA
-//! history-fallback and registers the two `#[server]` routes from
-//! `src/lib.rs`.
+//! history-fallback; linked `#[server]` routes are installed by
+//! `pocopine_server::Server`.
 
 #[cfg(not(target_arch = "wasm32"))]
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
-    use hn::{__get_item_tree_route, __search_stories_route};
+    use hn as _;
     use pocopine_logging::init_default;
     use pocopine_server::{axum::Router, serve, static_files, tower_http::services::ServeFile};
 
@@ -16,8 +16,6 @@ async fn main() -> std::io::Result<()> {
 
     let static_service = static_files(manifest_dir).fallback(ServeFile::new(index_path));
     let router = Router::new().fallback_service(static_service);
-    let router = __search_stories_route(router);
-    let router = __get_item_tree_route(router);
 
     let addr = "127.0.0.1:3001";
     tracing::info!(target: "pocopine.log", %addr, "serving pocopine HN");

--- a/examples/keep/src/bin/server.rs
+++ b/examples/keep/src/bin/server.rs
@@ -1,10 +1,10 @@
 #[cfg(pocopine_host)]
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
-    use keep_example::{__reset_keep_notes_route, live_backend, sync_server};
+    use keep_example::{live_backend, sync_server};
     use pocopine_live::{routes, LiveHub};
     use pocopine_logging::init_default;
-    use pocopine_server::{axum, axum::Router, serve, static_files, Server};
+    use pocopine_server::{axum, axum::Router, static_files, Server};
     use pocopine_sync::sync_server_plugin;
 
     init_default().map_err(std::io::Error::other)?;
@@ -22,15 +22,12 @@ async fn main() -> std::io::Result<()> {
         .layer(axum::middleware::map_response(
             cross_origin_isolation_headers,
         ));
-    let router = Server::new(router)
-        .plugin(sync_server_plugin(sync))
-        .try_finalize()
-        .map_err(std::io::Error::other)?;
-    let router = __reset_keep_notes_route(router);
-
     let addr = "127.0.0.1:3022";
     tracing::info!(target: "pocopine.log", %addr, "serving keep example");
-    serve(router, addr).await
+    Server::new(router)
+        .plugin(sync_server_plugin(sync))
+        .serve(addr)
+        .await
 }
 
 #[cfg(pocopine_browser)]

--- a/examples/keep/src/lib.rs
+++ b/examples/keep/src/lib.rs
@@ -30,5 +30,5 @@ pub use model::*;
 pub use store::KeepStore;
 pub use sync::reset_keep_notes;
 #[cfg(pocopine_host)]
-pub use sync::{__reset_keep_notes_route, live_backend, sync_server};
+pub use sync::{live_backend, sync_server};
 pub use utils::{focus_after_flush, now_ms, shared_layout_transition};

--- a/examples/live/src/bin/server.rs
+++ b/examples/live/src/bin/server.rs
@@ -1,10 +1,7 @@
 #[cfg(pocopine_host)]
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
-    use live_example::{
-        __create_post_route, __list_posts_route, __reset_posts_route, live_backend,
-        POSTS_COLLECTION, POSTS_LIST_QUERY_TAG,
-    };
+    use live_example::{live_backend, POSTS_COLLECTION, POSTS_LIST_QUERY_TAG};
     use pocopine::live::{collection_topic, query_tag_topic, routes, LiveHub};
     use pocopine_logging::init_default;
     use pocopine_server::{axum::Router, serve, static_files};
@@ -21,9 +18,6 @@ async fn main() -> std::io::Result<()> {
     let router = Router::new()
         .merge(routes(live_hub))
         .fallback_service(static_files(manifest_dir));
-    let router = __list_posts_route(router);
-    let router = __create_post_route(router);
-    let router = __reset_posts_route(router);
 
     let addr = "127.0.0.1:3020";
     tracing::info!(target: "pocopine.log", %addr, "serving live example");

--- a/examples/observability-smoke/src/lib.rs
+++ b/examples/observability-smoke/src/lib.rs
@@ -22,7 +22,7 @@ pub struct EchoResponse {
     pub accepted: bool,
 }
 
-#[pocopine::server(public)]
+#[pocopine::server(public, path = "/_pocopine/observe_echo")]
 pub async fn observe_echo(request: EchoRequest) -> ServerResult<EchoResponse> {
     let message_len = request.message.len();
     let span = tracing::info_span!(
@@ -49,10 +49,9 @@ pub async fn observe_echo(request: EchoRequest) -> ServerResult<EchoResponse> {
 
 #[cfg(not(target_arch = "wasm32"))]
 pub fn router() -> Router {
-    let router = Router::new()
+    Router::new()
         .route("/", get(index))
-        .route("/health", get(health));
-    __observe_echo_route(router)
+        .route("/health", get(health))
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/examples/observability-smoke/tests/otlp_smoke.rs
+++ b/examples/observability-smoke/tests/otlp_smoke.rs
@@ -18,6 +18,7 @@ use pocopine::logging::{init_server_logging, OtlpConfig, ServerLoggingConfig};
 use pocopine_server::axum::body::{to_bytes, Body};
 use pocopine_server::axum::http::{Method, Request};
 use pocopine_server::tower::ServiceExt;
+use pocopine_server::Server;
 use tokio::net::TcpListener;
 use tokio_stream::wrappers::TcpListenerStream;
 use tonic::{Response, Status};
@@ -139,7 +140,10 @@ async fn start_collector() -> TestCollector {
 
 async fn call_observe_echo(message: &str, index: usize) -> String {
     let request_body = serde_json::json!([{ "message": message }]).to_string();
-    let response = router()
+    let app = Server::new(router())
+        .try_finalize()
+        .expect("server-function routes should finalize");
+    let response = app
         .oneshot(
             Request::builder()
                 .method(Method::POST)

--- a/examples/site/src/bin/server.rs
+++ b/examples/site/src/bin/server.rs
@@ -1,16 +1,15 @@
 //! Site server binary — host-only.
 //!
 //! Serves the static site files (index.html + pkg/ + the SPA
-//! history-fallback) alongside the `__submit_contact_route`
-//! helper emitted by the single `#[server]` function in
-//! `src/lib.rs`.
+//! history-fallback). Linked `#[server]` routes are installed by
+//! `pocopine_server::Server`.
 
 #[cfg(not(target_arch = "wasm32"))]
 #[tokio::main]
 async fn main() -> std::io::Result<()> {
     use pocopine_logging::init_default;
     use pocopine_server::{axum::Router, serve, static_files, tower_http::services::ServeFile};
-    use site::__submit_contact_route;
+    use site as _;
 
     init_default().map_err(std::io::Error::other)?;
 
@@ -21,7 +20,6 @@ async fn main() -> std::io::Result<()> {
     // Static + SPA history fallback.
     let static_service = static_files(manifest_dir).fallback(ServeFile::new(index_path));
     let router = Router::new().fallback_service(static_service);
-    let router = __submit_contact_route(router);
 
     let addr = "127.0.0.1:3000";
     tracing::info!(target: "pocopine.log", %addr, "serving site");

--- a/examples/sync/src/bin/server.rs
+++ b/examples/sync/src/bin/server.rs
@@ -3,9 +3,9 @@
 async fn main() -> std::io::Result<()> {
     use pocopine_live::{routes, LiveHub};
     use pocopine_logging::init_default;
-    use pocopine_server::{axum::Router, serve, static_files, Server};
+    use pocopine_server::{axum::Router, static_files, Server};
     use pocopine_sync::sync_server_plugin;
-    use sync_example::{__reset_posts_route, live_backend, sync_server};
+    use sync_example::{live_backend, sync_server};
 
     init_default().map_err(std::io::Error::other)?;
 
@@ -19,15 +19,12 @@ async fn main() -> std::io::Result<()> {
     let router = Router::new()
         .merge(routes(live_hub))
         .fallback_service(static_files(manifest_dir));
-    let router = Server::new(router)
-        .plugin(sync_server_plugin(sync))
-        .try_finalize()
-        .map_err(std::io::Error::other)?;
-    let router = __reset_posts_route(router);
-
     let addr = "127.0.0.1:3021";
     tracing::info!(target: "pocopine.log", %addr, "serving sync example");
-    serve(router, addr).await
+    Server::new(router)
+        .plugin(sync_server_plugin(sync))
+        .serve(addr)
+        .await
 }
 
 #[cfg(pocopine_browser)]


### PR DESCRIPTION
## Summary

- add inventory-backed automatic registration for linked `#[server]` functions
- generate stable module-scoped default paths, support explicit `path = "..."`, and detect duplicate explicit routes during server finalization
- add `Server::with_auth` / `with_auth_arc` so auth middleware wraps auto-installed server function routes
- include full `function_path` telemetry for server-function observability events
- update examples and docs to use automatic route wiring instead of generated `__*_route` helpers

## Local Verification

CI is currently unavailable, so I ran the relevant local checks:

- `cargo fmt --check`
- `cargo test -p pocopine-core default_paths`
- `cargo test -p pocopine-server`
- `cargo test -p pocopine --test server_function_auto_routes --test server_function_route_conflicts --test server_function_events --test server_auth --test auth_middleware`
- `cargo test -p pocopine --features logging --test observability_server`
- `cargo test -p sync-example --test sync_flow`
- `cargo test -p keep-example --test keep_flow`
- `cargo test -p observability-smoke --test otlp_smoke`
- `cargo check -p blog -p hn -p site -p live-example -p sync-example -p keep-example -p observability-smoke`