### PR TITLE
Add automatic sync mutation id allocation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,11 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: "-D warnings"
 
+permissions:
+  contents: read
+  packages: read
+  pull-requests: read
+
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3527,6 +3527,7 @@ dependencies = [
  "tokio",
  "tower",
  "tracing",
+ "uuid",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-bindgen-test",

--- a/crates/pocopine-sync-sqlite/src/native.rs
+++ b/crates/pocopine-sync-sqlite/src/native.rs
@@ -6,9 +6,10 @@ use std::{
 };
 
 use pocopine_sync::{
-    ClientMutation, LocalChangeBatch, LocalPushResult, LocalSnapshotBatch, LocalStreamSnapshot,
-    RowKey, RowVersion, SyncCollectionName, SyncCursor, SyncDeviceId, SyncError, SyncLocalFuture,
-    SyncLocalIdentity, SyncLocalStore, SyncOp, SyncResult, SyncRow, SyncStreamName,
+    generate_sync_device_id, ClientMutation, LocalChangeBatch, LocalPushResult, LocalSnapshotBatch,
+    LocalStreamSnapshot, MutationId, RowKey, RowVersion, SyncCollectionName, SyncCursor,
+    SyncDeviceId, SyncError, SyncLocalFuture, SyncLocalIdentity, SyncLocalStore, SyncOp,
+    SyncResult, SyncRow, SyncStreamName,
 };
 use rusqlite::{params, Connection, OptionalExtension, Transaction};
 
@@ -67,6 +68,10 @@ impl SyncLocalStore for SqliteLocalStore {
 
     fn save_identity(&self, identity: SyncLocalIdentity) -> SyncLocalFuture<'_, ()> {
         Self::ready(self.with_conn(|conn| save_identity(conn, identity)))
+    }
+
+    fn reserve_mutation_id(&self) -> SyncLocalFuture<'_, MutationId> {
+        Self::ready(self.with_conn(reserve_mutation_id))
     }
 
     fn hydrate_stream(&self, stream: &SyncStreamName) -> SyncLocalFuture<'_, LocalStreamSnapshot> {
@@ -178,6 +183,41 @@ fn save_identity(conn: &mut Connection, identity: SyncLocalIdentity) -> SyncResu
         &identity.next_mutation_counter.to_string(),
     )?;
     tx.commit().map_err(sqlite_error)
+}
+
+fn reserve_mutation_id(conn: &mut Connection) -> SyncResult<MutationId> {
+    let tx = conn.transaction().map_err(sqlite_error)?;
+    let identity = match load_identity_from_tx(&tx)? {
+        Some(identity) => identity,
+        None => SyncLocalIdentity::new(generate_sync_device_id()?),
+    };
+    let (id, advanced) = identity.reserve_mutation_id()?;
+    upsert_meta(&tx, META_DEVICE_ID, advanced.device_id.as_str())?;
+    upsert_meta(
+        &tx,
+        META_NEXT_MUTATION_COUNTER,
+        &advanced.next_mutation_counter.to_string(),
+    )?;
+    tx.commit().map_err(sqlite_error)?;
+    Ok(id)
+}
+
+fn load_identity_from_tx(tx: &Transaction<'_>) -> SyncResult<Option<SyncLocalIdentity>> {
+    let Some(device_id) = select_meta_tx(tx, META_DEVICE_ID)? else {
+        return Ok(None);
+    };
+    let next_counter = select_meta_tx(tx, META_NEXT_MUTATION_COUNTER)?
+        .map(|value| {
+            value.parse::<u64>().map_err(|_| {
+                SyncError::backend(format!(
+                    "invalid sync next mutation counter in sqlite store: {value}"
+                ))
+            })
+        })
+        .transpose()?
+        .unwrap_or(1);
+
+    SyncLocalIdentity::with_next_counter(SyncDeviceId::new(device_id)?, next_counter).map(Some)
 }
 
 fn hydrate_stream(
@@ -478,6 +518,16 @@ fn select_meta(conn: &Connection, key: &str) -> SyncResult<Option<String>> {
     .map_err(sqlite_error)
 }
 
+fn select_meta_tx(tx: &Transaction<'_>, key: &str) -> SyncResult<Option<String>> {
+    tx.query_row(
+        "select value from __pocopine_meta where key = ?1",
+        params![key],
+        |row| row.get(0),
+    )
+    .optional()
+    .map_err(sqlite_error)
+}
+
 fn delete_mutation(tx: &Transaction<'_>, mutation_id: &str) -> SyncResult<()> {
     tx.execute(DELETE_MUTATION_SQL, params![mutation_id])
         .map_err(sqlite_error)?;
@@ -559,6 +609,40 @@ mod tests {
         block(store.save_identity(identity.clone())).unwrap();
 
         assert_eq!(block(store.load_identity()).unwrap(), Some(identity));
+    }
+
+    #[test]
+    fn sqlite_store_reserves_mutation_ids_and_persists_counter() {
+        let store = SqliteLocalStore::open_in_memory().unwrap();
+        let identity =
+            SyncLocalIdentity::with_next_counter(SyncDeviceId::new("device_abc").unwrap(), 9)
+                .unwrap();
+        block(store.save_identity(identity)).unwrap();
+
+        let first = block(store.reserve_mutation_id()).unwrap();
+        let second = block(store.reserve_mutation_id()).unwrap();
+
+        assert_eq!(first.as_str(), "device_abc:9");
+        assert_eq!(second.as_str(), "device_abc:10");
+        assert_eq!(
+            block(store.load_identity())
+                .unwrap()
+                .unwrap()
+                .next_mutation_counter,
+            11
+        );
+    }
+
+    #[test]
+    fn sqlite_store_reserve_creates_identity_when_missing() {
+        let store = SqliteLocalStore::open_in_memory().unwrap();
+
+        let id = block(store.reserve_mutation_id()).unwrap();
+        let identity = block(store.load_identity()).unwrap().unwrap();
+
+        assert!(id.as_str().starts_with(identity.device_id.as_str()));
+        assert!(id.as_str().ends_with(":1"));
+        assert_eq!(identity.next_mutation_counter, 2);
     }
 
     #[test]

--- a/crates/pocopine-sync-sqlite/src/wasm.rs
+++ b/crates/pocopine-sync-sqlite/src/wasm.rs
@@ -3,9 +3,10 @@ use std::{cell::RefCell, collections::BTreeSet, fmt, rc::Rc};
 use futures::lock::Mutex as AsyncMutex;
 use js_sys::{Array, Reflect};
 use pocopine_sync::{
-    ClientMutation, LocalChangeBatch, LocalPushResult, LocalSnapshotBatch, LocalStreamSnapshot,
-    RowKey, RowVersion, SyncCollectionName, SyncCursor, SyncDeviceId, SyncError, SyncLocalFuture,
-    SyncLocalIdentity, SyncLocalStore, SyncOp, SyncResult, SyncRow, SyncStreamName,
+    generate_sync_device_id, ClientMutation, LocalChangeBatch, LocalPushResult, LocalSnapshotBatch,
+    LocalStreamSnapshot, MutationId, RowKey, RowVersion, SyncCollectionName, SyncCursor,
+    SyncDeviceId, SyncError, SyncLocalFuture, SyncLocalIdentity, SyncLocalStore, SyncOp,
+    SyncResult, SyncRow, SyncStreamName,
 };
 use serde_json::Value;
 use wasm_bindgen::{JsCast, JsValue};
@@ -95,6 +96,10 @@ impl SyncLocalStore for SqliteLocalStore {
 
     fn save_identity(&self, identity: SyncLocalIdentity) -> SyncLocalFuture<'_, ()> {
         self.run(save_identity(identity))
+    }
+
+    fn reserve_mutation_id(&self) -> SyncLocalFuture<'_, MutationId> {
+        self.run(reserve_mutation_id())
     }
 
     fn hydrate_stream(&self, stream: &SyncStreamName) -> SyncLocalFuture<'_, LocalStreamSnapshot> {
@@ -224,6 +229,26 @@ async fn save_identity(identity: SyncLocalIdentity) -> SyncResult<()> {
     }
     .await;
     finish_transaction(result).await
+}
+
+async fn reserve_mutation_id() -> SyncResult<MutationId> {
+    exec("BEGIN IMMEDIATE TRANSACTION", Vec::new()).await?;
+    let result = async {
+        let identity = match load_identity().await? {
+            Some(identity) => identity,
+            None => SyncLocalIdentity::new(generate_sync_device_id()?),
+        };
+        let (id, advanced) = identity.reserve_mutation_id()?;
+        upsert_meta(META_DEVICE_ID, advanced.device_id.as_str()).await?;
+        upsert_meta(
+            META_NEXT_MUTATION_COUNTER,
+            &advanced.next_mutation_counter.to_string(),
+        )
+        .await?;
+        Ok(id)
+    }
+    .await;
+    finish_transaction_value(result).await
 }
 
 async fn hydrate_stream(stream: SyncStreamName) -> SyncResult<LocalStreamSnapshot> {
@@ -534,6 +559,19 @@ async fn delete_mutation(mutation_id: &str) -> SyncResult<()> {
 async fn finish_transaction(result: SyncResult<()>) -> SyncResult<()> {
     match result {
         Ok(()) => exec("COMMIT", Vec::new()).await,
+        Err(err) => {
+            let _ = exec("ROLLBACK", Vec::new()).await;
+            Err(err)
+        }
+    }
+}
+
+async fn finish_transaction_value<T>(result: SyncResult<T>) -> SyncResult<T> {
+    match result {
+        Ok(value) => {
+            exec("COMMIT", Vec::new()).await?;
+            Ok(value)
+        }
         Err(err) => {
             let _ = exec("ROLLBACK", Vec::new()).await;
             Err(err)

--- a/crates/pocopine-sync-sqlite/tests/wasm_sqlite_store.rs
+++ b/crates/pocopine-sync-sqlite/tests/wasm_sqlite_store.rs
@@ -24,6 +24,19 @@ async fn sqlite_wasm_store_round_trips_cached_rows_and_pending_mutations() {
 
     store.save_identity(identity.clone()).await.unwrap();
     assert_eq!(store.load_identity().await.unwrap(), Some(identity));
+    assert_eq!(
+        store.reserve_mutation_id().await.unwrap().as_str(),
+        "device_browser:3"
+    );
+    assert_eq!(
+        store
+            .load_identity()
+            .await
+            .unwrap()
+            .unwrap()
+            .next_mutation_counter,
+        4
+    );
 
     store
         .save_snapshot(LocalSnapshotBatch::new(
@@ -41,7 +54,7 @@ async fn sqlite_wasm_store_round_trips_cached_rows_and_pending_mutations() {
     assert_eq!(snapshot.rows, vec![row]);
 
     let mutation = ClientMutation {
-        id: MutationId::new("device_browser:3").unwrap(),
+        id: MutationId::new("device_browser:4").unwrap(),
         key: Some(RowKey::new("post_1").unwrap()),
         op: SyncOp::Upsert,
         base_version: Some(pocopine_sync::RowVersion::new("row_1").unwrap()),
@@ -60,7 +73,7 @@ async fn sqlite_wasm_store_round_trips_cached_rows_and_pending_mutations() {
         .mark_push_result(LocalPushResult {
             stream: stream.clone(),
             collection: Some(SyncCollectionName::new("posts").unwrap()),
-            accepted: vec![MutationId::new("device_browser:3").unwrap()],
+            accepted: vec![MutationId::new("device_browser:4").unwrap()],
             rejected: Vec::new(),
             rows: vec![
                 SyncRow::new("post_1", serde_json::json!({"title": "Updated"}))
@@ -84,7 +97,7 @@ async fn sqlite_wasm_store_round_trips_cached_rows_and_pending_mutations() {
         .mark_push_result(LocalPushResult {
             stream: push_first_stream.clone(),
             collection: Some(SyncCollectionName::new("posts").unwrap()),
-            accepted: vec![MutationId::new("device_browser:4").unwrap()],
+            accepted: vec![MutationId::new("device_browser:5").unwrap()],
             rejected: Vec::new(),
             rows: vec![
                 SyncRow::new("post_2", serde_json::json!({"title": "Push first"}))

--- a/crates/pocopine-sync/Cargo.toml
+++ b/crates/pocopine-sync/Cargo.toml
@@ -12,6 +12,7 @@ pocopine-live = { workspace = true }
 serde = { workspace = true }
 serde_json = "1"
 tracing = { workspace = true }
+uuid = { version = "1", features = ["v4", "js"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 pocopine-events = { workspace = true }

--- a/crates/pocopine-sync/src/client.rs
+++ b/crates/pocopine-sync/src/client.rs
@@ -5,8 +5,8 @@ use pocopine_core::{App, AppPlugin, Handle};
 use serde_json::Value;
 
 use crate::{
-    ClientMutation, CollectionState, MemoryLocalStore, SyncCursor, SyncError, SyncLocalStore,
-    SyncReason, SyncResult, SyncRow, SyncStreamName, SYNC_ENDPOINT_PREFIX,
+    ClientMutation, ClientMutationDraft, CollectionState, MemoryLocalStore, SyncCursor, SyncError,
+    SyncLocalStore, SyncReason, SyncResult, SyncRow, SyncStreamName, SYNC_ENDPOINT_PREFIX,
 };
 
 #[cfg(target_arch = "wasm32")]
@@ -212,6 +212,21 @@ where
         self.push_impl(mutation, optimistic)
     }
 
+    /// Reserve a durable mutation id, push one draft mutation, and apply an
+    /// optional optimistic row while the server confirms, rejects, or
+    /// conflicts the write.
+    pub fn push_with_generated_id<M>(
+        self,
+        mutation: ClientMutationDraft<M>,
+        optimistic: Option<SyncRow<T>>,
+    ) -> SyncResult<()>
+    where
+        T: Clone + serde::de::DeserializeOwned + serde::Serialize,
+        M: serde::Serialize + 'static,
+    {
+        self.push_with_generated_id_impl(mutation, optimistic)
+    }
+
     fn stream_value(&self) -> SyncResult<SyncStreamName> {
         self.stream
             .clone()
@@ -315,6 +330,35 @@ where
         );
         Ok(())
     }
+
+    fn push_with_generated_id_impl<M>(
+        self,
+        mutation: ClientMutationDraft<M>,
+        optimistic: Option<SyncRow<T>>,
+    ) -> SyncResult<()>
+    where
+        T: Clone + serde::de::DeserializeOwned + serde::Serialize + 'static,
+        M: serde::Serialize + 'static,
+    {
+        let stream = self.stream_value()?;
+        let scope_id = pocopine_core::current_scope_id().ok_or_else(|| {
+            SyncError::client(
+                "SyncCollection::push_with_generated_id used outside a component handler/lifecycle hook",
+            )
+        })?;
+        start_push_with_generated_id(
+            scope_id,
+            self.handle,
+            self.selector,
+            self.endpoint,
+            self.local_store,
+            stream,
+            mutation,
+            optimistic,
+            !self.live_wakeup,
+        );
+        Ok(())
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -338,6 +382,21 @@ where
     fn push_impl<M>(
         self,
         mutation: ClientMutation<M>,
+        optimistic: Option<SyncRow<T>>,
+    ) -> SyncResult<()>
+    where
+        T: Clone + serde::de::DeserializeOwned + serde::Serialize + 'static,
+        M: serde::Serialize + 'static,
+    {
+        self.touch_host_fields();
+        let _ = self.stream_value()?;
+        let _ = (mutation, optimistic);
+        Ok(())
+    }
+
+    fn push_with_generated_id_impl<M>(
+        self,
+        mutation: ClientMutationDraft<M>,
         optimistic: Option<SyncRow<T>>,
     ) -> SyncResult<()>
     where
@@ -659,90 +718,168 @@ fn start_push<C, T, M>(
 {
     let push_url = endpoint_path(&endpoint, "push");
     let pull_endpoint = endpoint.clone();
-    let mutation_id = mutation.id.clone();
-    let mutation_op = mutation.op;
-    let mutation_key = mutation.key.clone();
 
     pocopine_core::spawn_for_scope(scope_id, async move {
-        let local_mutation = match mutation_to_value(&mutation) {
-            Ok(mutation) => mutation,
+        run_push(
+            scope_id,
+            handle,
+            selector,
+            push_url,
+            pull_endpoint,
+            local_store,
+            stream,
+            mutation,
+            optimistic,
+            pull_after_accept,
+        )
+        .await;
+    });
+}
+
+#[cfg(target_arch = "wasm32")]
+#[allow(clippy::too_many_arguments)]
+fn start_push_with_generated_id<C, T, M>(
+    scope_id: pocopine_core::ScopeId,
+    handle: Handle<C>,
+    selector: CollectionSelector<C, T>,
+    endpoint: String,
+    local_store: SyncLocalStoreHandle,
+    stream: SyncStreamName,
+    mutation: ClientMutationDraft<M>,
+    optimistic: Option<SyncRow<T>>,
+    pull_after_accept: bool,
+) where
+    C: 'static,
+    T: Clone + serde::de::DeserializeOwned + serde::Serialize + 'static,
+    M: serde::Serialize + 'static,
+{
+    let push_url = endpoint_path(&endpoint, "push");
+    let pull_endpoint = endpoint.clone();
+
+    pocopine_core::spawn_for_scope(scope_id, async move {
+        let mutation_id = match local_store.reserve_mutation_id().await {
+            Ok(id) => id,
             Err(err) => {
                 handle.update(|state| {
-                    selector(state).set_error(format!("sync mutation encode failed: {err}"));
+                    selector(state).set_error(format!("sync mutation id allocation failed: {err}"));
                 });
                 return;
             }
         };
-        if let Err(err) = local_store.enqueue_mutation(&stream, local_mutation).await {
+        run_push(
+            scope_id,
+            handle,
+            selector,
+            push_url,
+            pull_endpoint,
+            local_store,
+            stream,
+            mutation.with_id(mutation_id),
+            optimistic,
+            pull_after_accept,
+        )
+        .await;
+    });
+}
+
+#[cfg(target_arch = "wasm32")]
+#[allow(clippy::too_many_arguments)]
+async fn run_push<C, T, M>(
+    scope_id: pocopine_core::ScopeId,
+    handle: Handle<C>,
+    selector: CollectionSelector<C, T>,
+    push_url: String,
+    pull_endpoint: String,
+    local_store: SyncLocalStoreHandle,
+    stream: SyncStreamName,
+    mutation: ClientMutation<M>,
+    optimistic: Option<SyncRow<T>>,
+    pull_after_accept: bool,
+) where
+    C: 'static,
+    T: Clone + serde::de::DeserializeOwned + serde::Serialize + 'static,
+    M: serde::Serialize + 'static,
+{
+    let mutation_id = mutation.id.clone();
+    let mutation_op = mutation.op;
+    let mutation_key = mutation.key.clone();
+
+    let local_mutation = match mutation_to_value(&mutation) {
+        Ok(mutation) => mutation,
+        Err(err) => {
             handle.update(|state| {
-                selector(state).set_error(format!("local sync mutation enqueue failed: {err}"));
+                selector(state).set_error(format!("sync mutation encode failed: {err}"));
             });
             return;
         }
-
+    };
+    if let Err(err) = local_store.enqueue_mutation(&stream, local_mutation).await {
         handle.update(|state| {
-            selector(state).apply_optimistic_mutation(
-                mutation_id,
-                mutation_op,
-                mutation_key,
-                optimistic,
-            );
+            selector(state).set_error(format!("local sync mutation enqueue failed: {err}"));
         });
+        return;
+    }
 
-        let request = SyncPushRequest::new(stream.clone(), [mutation]);
-        let result = pocopine_core::fetch::call::<SyncPushRequest<M>, SyncPushResponse<T>>(
-            &push_url, &request,
-        )
-        .await;
-        let mut local_error = None;
-        let result = match result {
-            Ok(response) => {
-                match local_push_result_from_response(&response) {
-                    Ok(result) => {
-                        if let Err(err) = local_store.mark_push_result(result).await {
-                            local_error =
-                                Some(format!("local sync push result persist failed: {err}"));
-                        }
+    handle.update(|state| {
+        selector(state).apply_optimistic_mutation(
+            mutation_id,
+            mutation_op,
+            mutation_key,
+            optimistic,
+        );
+    });
+
+    let request = SyncPushRequest::new(stream.clone(), [mutation]);
+    let result =
+        pocopine_core::fetch::call::<SyncPushRequest<M>, SyncPushResponse<T>>(&push_url, &request)
+            .await;
+    let mut local_error = None;
+    let result = match result {
+        Ok(response) => {
+            match local_push_result_from_response(&response) {
+                Ok(result) => {
+                    if let Err(err) = local_store.mark_push_result(result).await {
+                        local_error = Some(format!("local sync push result persist failed: {err}"));
                     }
-                    Err(err) => {
-                        local_error = Some(format!("local sync push result encode failed: {err}"));
-                    }
-                }
-                Ok(response)
-            }
-            Err(err) => Err(err),
-        };
-        let should_pull = handle.update(|state| {
-            let collection = selector(state);
-            match result {
-                Ok(response) => {
-                    let should_pull = collection.apply_push(response);
-                    if let Some(error) = local_error {
-                        collection.set_error(error);
-                    }
-                    should_pull
                 }
                 Err(err) => {
-                    collection.set_error(err.to_string());
-                    false
+                    local_error = Some(format!("local sync push result encode failed: {err}"));
                 }
             }
-        });
-
-        if should_pull && pull_after_accept {
-            start_pull(
-                scope_id,
-                handle,
-                selector,
-                pull_endpoint,
-                local_store,
-                stream,
-                None,
-                SyncReason::Push,
-                false,
-            );
+            Ok(response)
+        }
+        Err(err) => Err(err),
+    };
+    let should_pull = handle.update(|state| {
+        let collection = selector(state);
+        match result {
+            Ok(response) => {
+                let should_pull = collection.apply_push(response);
+                if let Some(error) = local_error {
+                    collection.set_error(error);
+                }
+                should_pull
+            }
+            Err(err) => {
+                collection.set_error(err.to_string());
+                false
+            }
         }
     });
+
+    if should_pull && pull_after_accept {
+        start_pull(
+            scope_id,
+            handle,
+            selector,
+            pull_endpoint,
+            local_store,
+            stream,
+            None,
+            SyncReason::Push,
+            false,
+        );
+    }
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/pocopine-sync/src/lib.rs
+++ b/crates/pocopine-sync/src/lib.rs
@@ -20,16 +20,16 @@ mod server;
 pub use error::{SyncError, SyncResult};
 pub use local_memory::MemoryLocalStore;
 pub use local_store::{
-    LocalChangeBatch, LocalPushResult, LocalSnapshotBatch, LocalStreamSnapshot,
-    MutationIdGenerator, SyncLocalFuture, SyncLocalIdentity, SyncLocalStore,
+    generate_sync_device_id, LocalChangeBatch, LocalPushResult, LocalSnapshotBatch,
+    LocalStreamSnapshot, MutationIdGenerator, SyncLocalFuture, SyncLocalIdentity, SyncLocalStore,
 };
 pub use protocol::{
-    sync_stream_tag, ClientMutation, MutationId, RowKey, RowVersion, SyncChange,
-    SyncCollectionName, SyncConflict, SyncCursor, SyncDeviceId, SyncOp, SyncOpenRequest,
-    SyncOpenResponse, SyncOpenStream, SyncPullMode, SyncPullRequest, SyncPullResponse,
-    SyncPushRequest, SyncPushResponse, SyncRejectedMutation, SyncRow, SyncSessionId,
-    SyncStreamName, MAX_SYNC_TOKEN_LEN, SYNC_ENDPOINT_PREFIX, SYNC_OPEN_PATH, SYNC_PROTOCOL_V1,
-    SYNC_PULL_PATH, SYNC_PUSH_PATH,
+    sync_stream_tag, ClientMutation, ClientMutationDraft, MutationId, RowKey, RowVersion,
+    SyncChange, SyncCollectionName, SyncConflict, SyncCursor, SyncDeviceId, SyncOp,
+    SyncOpenRequest, SyncOpenResponse, SyncOpenStream, SyncPullMode, SyncPullRequest,
+    SyncPullResponse, SyncPushRequest, SyncPushResponse, SyncRejectedMutation, SyncRow,
+    SyncSessionId, SyncStreamName, MAX_SYNC_TOKEN_LEN, SYNC_ENDPOINT_PREFIX, SYNC_OPEN_PATH,
+    SYNC_PROTOCOL_V1, SYNC_PULL_PATH, SYNC_PUSH_PATH,
 };
 pub use state::{CollectionState, PendingMutation, SyncReason, SyncRequest};
 

--- a/crates/pocopine-sync/src/local_memory.rs
+++ b/crates/pocopine-sync/src/local_memory.rs
@@ -5,9 +5,9 @@ use std::{
 };
 
 use crate::{
-    ClientMutation, LocalChangeBatch, LocalPushResult, LocalSnapshotBatch, LocalStreamSnapshot,
-    RowKey, SyncCollectionName, SyncError, SyncLocalFuture, SyncLocalIdentity, SyncLocalStore,
-    SyncOp, SyncResult, SyncRow, SyncStreamName,
+    generate_sync_device_id, ClientMutation, LocalChangeBatch, LocalPushResult, LocalSnapshotBatch,
+    LocalStreamSnapshot, MutationId, RowKey, SyncCollectionName, SyncError, SyncLocalFuture,
+    SyncLocalIdentity, SyncLocalStore, SyncOp, SyncResult, SyncRow, SyncStreamName,
 };
 
 /// In-memory [`SyncLocalStore`] implementation for tests and demos.
@@ -64,6 +64,18 @@ impl SyncLocalStore for MemoryLocalStore {
         Self::ready(self.with_inner(|inner| {
             inner.identity = Some(identity);
             Ok(())
+        }))
+    }
+
+    fn reserve_mutation_id(&self) -> SyncLocalFuture<'_, MutationId> {
+        Self::ready(self.with_inner(|inner| {
+            let identity = match inner.identity.clone() {
+                Some(identity) => identity,
+                None => SyncLocalIdentity::new(generate_sync_device_id()?),
+            };
+            let (id, advanced) = identity.reserve_mutation_id()?;
+            inner.identity = Some(advanced);
+            Ok(id)
         }))
     }
 
@@ -252,6 +264,58 @@ mod tests {
         assert!(store.load_identity().await.unwrap().is_none());
         store.save_identity(identity.clone()).await.unwrap();
 
+        assert_eq!(store.load_identity().await.unwrap(), Some(identity));
+    }
+
+    #[tokio::test]
+    async fn memory_store_reserves_mutation_ids_and_persists_counter() {
+        let store = MemoryLocalStore::new();
+        let identity =
+            SyncLocalIdentity::with_next_counter(SyncDeviceId::new("device_abc").unwrap(), 7)
+                .unwrap();
+        store.save_identity(identity).await.unwrap();
+
+        let first = store.reserve_mutation_id().await.unwrap();
+        let second = store.reserve_mutation_id().await.unwrap();
+
+        assert_eq!(first.as_str(), "device_abc:7");
+        assert_eq!(second.as_str(), "device_abc:8");
+        assert_eq!(
+            store
+                .load_identity()
+                .await
+                .unwrap()
+                .unwrap()
+                .next_mutation_counter,
+            9
+        );
+    }
+
+    #[tokio::test]
+    async fn memory_store_reserve_creates_identity_when_missing() {
+        let store = MemoryLocalStore::new();
+
+        let id = store.reserve_mutation_id().await.unwrap();
+        let identity = store.load_identity().await.unwrap().unwrap();
+
+        assert!(id.as_str().starts_with(identity.device_id.as_str()));
+        assert!(id.as_str().ends_with(":1"));
+        assert_eq!(identity.next_mutation_counter, 2);
+    }
+
+    #[tokio::test]
+    async fn memory_store_reserve_overflow_does_not_advance_counter() {
+        let store = MemoryLocalStore::new();
+        let identity = SyncLocalIdentity::with_next_counter(
+            SyncDeviceId::new("device_abc").unwrap(),
+            u64::MAX,
+        )
+        .unwrap();
+        store.save_identity(identity.clone()).await.unwrap();
+
+        let err = store.reserve_mutation_id().await.unwrap_err();
+
+        assert!(err.to_string().contains("next mutation counter"));
         assert_eq!(store.load_identity().await.unwrap(), Some(identity));
     }
 

--- a/crates/pocopine-sync/src/local_store.rs
+++ b/crates/pocopine-sync/src/local_store.rs
@@ -49,6 +49,30 @@ impl SyncLocalIdentity {
     pub fn mutation_id_generator(&self) -> SyncResult<MutationIdGenerator> {
         MutationIdGenerator::with_next_counter(self.device_id.clone(), self.next_mutation_counter)
     }
+
+    /// Reserve the current mutation id and return the advanced identity.
+    ///
+    /// Stores use this to persist the incremented counter before exposing the
+    /// id to client code. If the counter cannot advance, no id is returned.
+    pub fn reserve_mutation_id(&self) -> SyncResult<(MutationId, Self)> {
+        let next_mutation_counter = self
+            .next_mutation_counter
+            .checked_add(1)
+            .ok_or_else(|| SyncError::invalid_value("next mutation counter", "overflow"))?;
+        let id = MutationId::new(format!("{}:{}", self.device_id, self.next_mutation_counter))?;
+        Ok((
+            id,
+            Self {
+                device_id: self.device_id.clone(),
+                next_mutation_counter,
+            },
+        ))
+    }
+}
+
+/// Generate a fresh sync device identity.
+pub fn generate_sync_device_id() -> SyncResult<SyncDeviceId> {
+    SyncDeviceId::new(format!("device_{}", uuid::Uuid::new_v4().simple()))
 }
 
 /// Deterministic mutation id generator for one persisted device id.
@@ -212,16 +236,18 @@ impl LocalPushResult {
 /// result operations atomically. The local store improves durability and
 /// startup latency; it is not an authorization boundary.
 ///
-/// `load_identity` and `save_identity` expose the durable identity slot used
-/// by apps or future Pocopine client helpers to allocate stable mutation ids.
-/// The current `SyncCollection::push` API remains id-explicit: callers still
-/// provide `ClientMutation::id` themselves.
+/// `reserve_mutation_id` is the safe allocation boundary for stable mutation
+/// ids. Implementations must persist the incremented counter before returning
+/// the id, so a reload or failed network request cannot reuse it.
 pub trait SyncLocalStore {
     /// Load the persisted client identity, if this store has one.
     fn load_identity(&self) -> SyncLocalFuture<'_, Option<SyncLocalIdentity>>;
 
     /// Persist the client identity and next mutation counter.
     fn save_identity(&self, identity: SyncLocalIdentity) -> SyncLocalFuture<'_, ()>;
+
+    /// Reserve a durable mutation id for the local device.
+    fn reserve_mutation_id(&self) -> SyncLocalFuture<'_, MutationId>;
 
     /// Hydrate locally cached rows and pending mutations for a stream.
     fn hydrate_stream(&self, stream: &SyncStreamName) -> SyncLocalFuture<'_, LocalStreamSnapshot>;
@@ -273,6 +299,39 @@ mod tests {
             .unwrap_err();
 
         assert!(err.to_string().contains("next mutation counter"));
+    }
+
+    #[test]
+    fn local_identity_reserves_mutation_id_and_advances_counter() {
+        let identity =
+            SyncLocalIdentity::with_next_counter(SyncDeviceId::new("device_abc").unwrap(), 7)
+                .unwrap();
+
+        let (id, advanced) = identity.reserve_mutation_id().unwrap();
+
+        assert_eq!(id.as_str(), "device_abc:7");
+        assert_eq!(advanced.device_id.as_str(), "device_abc");
+        assert_eq!(advanced.next_mutation_counter, 8);
+    }
+
+    #[test]
+    fn local_identity_rejects_counter_overflow_without_id() {
+        let identity = SyncLocalIdentity::with_next_counter(
+            SyncDeviceId::new("device_abc").unwrap(),
+            u64::MAX,
+        )
+        .unwrap();
+
+        let err = identity.reserve_mutation_id().unwrap_err();
+
+        assert!(err.to_string().contains("next mutation counter"));
+    }
+
+    #[test]
+    fn generate_sync_device_id_returns_valid_device_token() {
+        let id = generate_sync_device_id().unwrap();
+
+        assert!(id.as_str().starts_with("device_"));
     }
 
     #[test]

--- a/crates/pocopine-sync/src/protocol.rs
+++ b/crates/pocopine-sync/src/protocol.rs
@@ -337,6 +337,78 @@ pub struct ClientMutation<M> {
     pub payload: M,
 }
 
+/// Client mutation before the local store reserves a durable mutation id.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(bound(serialize = "M: Serialize", deserialize = "M: Deserialize<'de>"))]
+pub struct ClientMutationDraft<M> {
+    pub key: Option<RowKey>,
+    pub op: SyncOp,
+    pub base_version: Option<RowVersion>,
+    pub payload: M,
+}
+
+impl<M> ClientMutationDraft<M> {
+    /// Build a draft mutation for the given operation.
+    pub fn new(op: SyncOp, payload: M) -> Self {
+        Self {
+            key: None,
+            op,
+            base_version: None,
+            payload,
+        }
+    }
+
+    /// Build an upsert draft.
+    pub fn upsert(payload: M) -> Self {
+        Self::new(SyncOp::Upsert, payload)
+    }
+
+    /// Build a delete draft.
+    pub fn delete(payload: M) -> Self {
+        Self::new(SyncOp::Delete, payload)
+    }
+
+    /// Build a reset draft.
+    pub fn reset(payload: M) -> Self {
+        Self::new(SyncOp::Reset, payload)
+    }
+
+    /// Attach a row key.
+    pub fn key(mut self, key: impl Into<String>) -> SyncResult<Self> {
+        self.key = Some(RowKey::new(key)?);
+        Ok(self)
+    }
+
+    /// Attach an already validated row key.
+    pub fn row_key(mut self, key: RowKey) -> Self {
+        self.key = Some(key);
+        self
+    }
+
+    /// Attach a base row version for conflict detection.
+    pub fn base_version(mut self, version: impl Into<String>) -> SyncResult<Self> {
+        self.base_version = Some(RowVersion::new(version)?);
+        Ok(self)
+    }
+
+    /// Attach an already validated base row version.
+    pub fn row_version(mut self, version: RowVersion) -> Self {
+        self.base_version = Some(version);
+        self
+    }
+
+    /// Convert this draft into a wire mutation after an id is reserved.
+    pub fn with_id(self, id: MutationId) -> ClientMutation<M> {
+        ClientMutation {
+            id,
+            key: self.key,
+            op: self.op,
+            base_version: self.base_version,
+            payload: self.payload,
+        }
+    }
+}
+
 /// Push request for one stream.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(bound(serialize = "M: Serialize", deserialize = "M: Deserialize<'de>"))]

--- a/crates/pocopine-sync/tests/client_browser.rs
+++ b/crates/pocopine-sync/tests/client_browser.rs
@@ -96,12 +96,12 @@ impl SyncBrowserPushBoard {
         };
         let result = ClientMutationDraft::upsert(post.clone())
             .key(post.id.clone())
-            .and_then(|mutation| {
-                Ok((
+            .map(|mutation| {
+                (
                     mutation,
                     SyncRow::new(post.id.clone(), post)
                         .expect("test optimistic row should be valid"),
-                ))
+                )
             })
             .and_then(|(mutation, optimistic)| {
                 self.plugin::<pocopine_sync::SyncClient>()

--- a/crates/pocopine-sync/tests/client_browser.rs
+++ b/crates/pocopine-sync/tests/client_browser.rs
@@ -11,10 +11,11 @@ use std::rc::Rc;
 use js_sys::Promise;
 use pocopine::prelude::*;
 use pocopine_sync::{
-    sync_plugin, ClientMutation, CollectionState, LocalSnapshotBatch, MemoryLocalStore, MutationId,
-    RowKey, SyncChange, SyncCollectionName, SyncCursor, SyncLocalStore, SyncOp, SyncOpenRequest,
-    SyncOpenResponse, SyncOpenStream, SyncPullRequest, SyncPullResponse, SyncPushRequest,
-    SyncPushResponse, SyncRow, SyncStreamName, SYNC_OPEN_PATH, SYNC_PULL_PATH, SYNC_PUSH_PATH,
+    sync_plugin, ClientMutation, ClientMutationDraft, CollectionState, LocalSnapshotBatch,
+    MemoryLocalStore, MutationId, RowKey, SyncChange, SyncCollectionName, SyncCursor, SyncDeviceId,
+    SyncLocalIdentity, SyncLocalStore, SyncOp, SyncOpenRequest, SyncOpenResponse, SyncOpenStream,
+    SyncPullRequest, SyncPullResponse, SyncPushRequest, SyncPushResponse, SyncRow, SyncStreamName,
+    SYNC_OPEN_PATH, SYNC_PULL_PATH, SYNC_PUSH_PATH,
 };
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::JsValue;
@@ -63,6 +64,57 @@ impl SyncBrowserBoard {
             .stream(STREAM)
             .and_then(|collection| collection.open())
         {
+            self.posts.set_error(err.to_string());
+        }
+    }
+}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "sync-browser-push-board",
+    template_inline = r#"
+    <section class="sync-browser-push-board">
+      <p class="error" pp-text="posts.error"></p>
+      <ol class="posts">
+        <template pp-for="row in posts.rows" pp-key="row.key">
+          <li class="post" pp-text="row.value.title"></li>
+        </template>
+      </ol>
+    </section>
+    "#
+)]
+struct SyncBrowserPushBoard {
+    posts: CollectionState<BrowserPost>,
+}
+
+#[handlers]
+impl SyncBrowserPushBoard {
+    pub fn on_mount(&mut self) {
+        let post = BrowserPost {
+            id: "post_generated".to_string(),
+            title: "Generated id push".to_string(),
+        };
+        let result = ClientMutationDraft::upsert(post.clone())
+            .key(post.id.clone())
+            .and_then(|mutation| {
+                Ok((
+                    mutation,
+                    SyncRow::new(post.id.clone(), post)
+                        .expect("test optimistic row should be valid"),
+                ))
+            })
+            .and_then(|(mutation, optimistic)| {
+                self.plugin::<pocopine_sync::SyncClient>()
+                    .collection(pocopine::this::<Self>(), |state: &mut Self| {
+                        &mut state.posts
+                    })
+                    .stream(STREAM)
+                    .and_then(|collection| {
+                        collection.push_with_generated_id(mutation, Some(optimistic))
+                    })
+            });
+
+        if let Err(err) = result {
             self.posts.set_error(err.to_string());
         }
     }
@@ -417,6 +469,109 @@ async fn open_replays_pending_mutations_before_pull() {
         2,
         "local store should hold cached + replay-confirmed rows"
     );
+
+    host.remove();
+    pocopine::fetch::__reset_middleware_chain_for_test();
+}
+
+#[wasm_bindgen_test(async)]
+async fn push_with_generated_id_reserves_identity_before_enqueue() {
+    pocopine::fetch::__reset_middleware_chain_for_test();
+
+    let store = MemoryLocalStore::new();
+    store
+        .save_identity(
+            SyncLocalIdentity::with_next_counter(SyncDeviceId::new("device_browser").unwrap(), 42)
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    let pushed_id = Rc::new(RefCell::new(None::<String>));
+    let pushed_id_for_mw = pushed_id.clone();
+    pocopine::fetch::install_middleware(
+        move |req: pocopine::fetch::FetchRequest, _next: pocopine::fetch::FetchNext| {
+            let pushed_id = pushed_id_for_mw.clone();
+            async move {
+                match req.url.as_str() {
+                    SYNC_PUSH_PATH => {
+                        let request: SyncPushRequest<BrowserPost> =
+                            serde_json::from_str(&req.body).unwrap();
+                        assert_eq!(request.mutations.len(), 1);
+                        let mutation = &request.mutations[0];
+                        *pushed_id.borrow_mut() = Some(mutation.id.to_string());
+                        assert_eq!(mutation.id.as_str(), "device_browser:42");
+                        assert_eq!(mutation.key.as_ref().unwrap().as_str(), "post_generated");
+
+                        let mut response = SyncPushResponse::<BrowserPost>::new(
+                            SyncStreamName::new(STREAM).unwrap(),
+                        );
+                        response.collection = Some(SyncCollectionName::new(COLLECTION).unwrap());
+                        response
+                            .accepted
+                            .push(MutationId::new("device_browser:42").unwrap());
+                        response.rows.push(
+                            SyncRow::new(
+                                "post_generated",
+                                BrowserPost {
+                                    id: "post_generated".to_string(),
+                                    title: "Confirmed generated id".to_string(),
+                                },
+                            )
+                            .unwrap(),
+                        );
+                        response.cursor = Some(SyncCursor::new("after_push").unwrap());
+                        Ok(json_response(response))
+                    }
+                    SYNC_PULL_PATH => {
+                        Ok(json_response(SyncPullResponse::<BrowserPost>::incremental(
+                            SyncStreamName::new(STREAM).unwrap(),
+                            SyncCollectionName::new(COLLECTION).unwrap(),
+                            Vec::new(),
+                            Some(SyncCursor::new("after_pull").unwrap()),
+                        )))
+                    }
+                    other => Err(pocopine::ServerError::Network(format!(
+                        "unexpected sync browser test request: {other}"
+                    ))),
+                }
+            }
+        },
+    );
+
+    let document = window().unwrap().document().unwrap();
+    let host = document.create_element("div").unwrap();
+    host.set_attribute("pp-app", "").unwrap();
+    host.set_inner_html("<sync-browser-push-board></sync-browser-push-board>");
+    document.body().unwrap().append_child(&host).unwrap();
+
+    App::new()
+        .plugin(
+            sync_plugin()
+                .with_live_wakeup(false)
+                .local_store(store.clone()),
+        )
+        .register::<SyncBrowserPushBoard>()
+        .run();
+
+    settle().await;
+
+    assert_eq!(pushed_id.borrow().as_deref(), Some("device_browser:42"));
+    assert_eq!(
+        store
+            .load_identity()
+            .await
+            .unwrap()
+            .unwrap()
+            .next_mutation_counter,
+        43
+    );
+    let persisted = store
+        .hydrate_stream(&SyncStreamName::new(STREAM).unwrap())
+        .await
+        .unwrap();
+    assert!(persisted.pending_mutations.is_empty());
+    assert_eq!(persisted.rows[0].value["title"], "Confirmed generated id");
 
     host.remove();
     pocopine::fetch::__reset_middleware_chain_for_test();

--- a/docs/sync-local-store-plan.md
+++ b/docs/sync-local-store-plan.md
@@ -88,7 +88,7 @@ mutations before the hydrated row reflects every pending edit.
 
 ## Identity And Mutation Ids
 
-The next phase should add stable client identity:
+The local store now owns stable client identity:
 
 ```text
 SyncDeviceId
@@ -118,6 +118,8 @@ should cover these operations:
 pub trait SyncLocalStore {
     fn load_identity(&self) -> SyncLocalFuture<'_, Option<SyncLocalIdentity>>;
     fn save_identity(&self, identity: SyncLocalIdentity) -> SyncLocalFuture<'_, ()>;
+
+    fn reserve_mutation_id(&self) -> SyncLocalFuture<'_, MutationId>;
 
     fn hydrate_stream(
         &self,

--- a/docs/sync-local-store-plan.md
+++ b/docs/sync-local-store-plan.md
@@ -104,9 +104,10 @@ durably before exposing a mutation id that can be sent to the server.
 This keeps mutation ids stable across reloads and avoids the current
 example-only `post_local_{n}` pattern becoming a production habit.
 
-The first client API remains explicit: apps pass `ClientMutation::id` to
-`SyncCollection::push`. Automatic id allocation from `SyncLocalIdentity`
-is a future helper layered on this storage slot.
+Apps can still pass an explicit `ClientMutation::id` to
+`SyncCollection::push` when they need full control. The normal local-first
+path should use `SyncCollection::push_with_generated_id`, which reserves
+the next durable id from `SyncLocalStore` before enqueueing the mutation.
 
 ## Store Contract Sketch
 

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -359,10 +359,10 @@ passes and before the authoritative pull. With `MemoryLocalStore` this is
 useful inside one page lifetime. With `pocopine-sync-sqlite`, it also
 survives reloads in browsers that support OPFS.
 
-`SyncLocalIdentity` and `MutationIdGenerator` are available for apps that
-want stable device-scoped mutation ids today. The current
-`SyncCollection::push` method still expects the app to provide
-`ClientMutation::id`; automatic id allocation is a follow-up API.
+`SyncCollection::push_with_generated_id` reserves a durable
+device-scoped mutation id before enqueueing a mutation. Apps that need
+full control can still build a `ClientMutation` and call
+`SyncCollection::push` directly.
 
 Templates read `CollectionState<T>` directly:
 
@@ -385,8 +385,9 @@ Templates read `CollectionState<T>` directly:
 
 ## 6. Push Optimistic Mutations
 
-`SyncCollection::push` first enqueues the mutation in the local store,
-then applies an optimistic row locally, sends a stable mutation id to
+`SyncCollection::push_with_generated_id` reserves and persists the next
+mutation id, enqueues the mutation in the local store, applies an
+optimistic row locally, sends the stable mutation id to
 `/__pocopine/sync/v1/push`, and applies the server's accepted, rejected,
 or conflict response. Accepted pushes also wake live listeners through
 the sync server's event backend, so other tabs pull the committed stream
@@ -404,7 +405,9 @@ pub fn create(&mut self) {
             self.plugin::<pocopine_sync::SyncClient>()
                 .collection(pocopine::this::<Self>(), |s: &mut Self| &mut s.posts)
                 .stream(POSTS_STREAM)
-                .and_then(|collection| collection.push(mutation, Some(optimistic)))
+                .and_then(|collection| {
+                    collection.push_with_generated_id(mutation, Some(optimistic))
+                })
         });
 
     if let Err(err) = result {

--- a/examples/sync/src/lib.rs
+++ b/examples/sync/src/lib.rs
@@ -141,7 +141,9 @@ impl SyncBoard {
             self.plugin::<pocopine_sync::SyncClient>()
                 .collection(pocopine::this::<Self>(), |s: &mut Self| &mut s.posts)
                 .stream(POSTS_STREAM)
-                .and_then(|collection| collection.push(mutation, Some(optimistic)))
+                .and_then(|collection| {
+                    collection.push_with_generated_id(mutation, Some(optimistic))
+                })
         });
 
         match result {
@@ -193,17 +195,10 @@ impl SyncBoard {
 fn build_create_mutation(
     post: Post,
 ) -> pocopine_sync::SyncResult<(
-    pocopine_sync::ClientMutation<Post>,
+    pocopine_sync::ClientMutationDraft<Post>,
     pocopine_sync::SyncRow<Post>,
 )> {
-    let key = pocopine_sync::RowKey::new(post.id.clone())?;
-    let mutation = pocopine_sync::ClientMutation {
-        id: pocopine_sync::MutationId::new(format!("create_post:{}", post.id))?,
-        key: Some(key),
-        op: pocopine_sync::SyncOp::Upsert,
-        base_version: None,
-        payload: post.clone(),
-    };
+    let mutation = pocopine_sync::ClientMutationDraft::upsert(post.clone()).key(post.id.clone())?;
     let optimistic = pocopine_sync::SyncRow::new(post.id.clone(), post)?;
     Ok((mutation, optimistic))
 }


### PR DESCRIPTION
## Summary
- add a durable SyncLocalStore::reserve_mutation_id boundary backed by memory and SQLite stores
- add ClientMutationDraft and SyncCollection::push_with_generated_id for local-first writes
- update the sync example/docs to use generated mutation ids

## Testing
- cargo test -p pocopine-sync -p pocopine-sync-sqlite
- cargo check -p sync-example
- cargo check -p sync-example --target wasm32-unknown-unknown
- cargo clippy -p pocopine-sync -p pocopine-sync-sqlite -p sync-example --all-targets -- -D warnings
- wasm-pack test --firefox --headless crates/pocopine-sync --test client_browser