### PR TITLE
Polish Pine overlay and dropdown animations

### DIFF
--- a/crates/pine/README.md
+++ b/crates/pine/README.md
@@ -29,3 +29,29 @@ fn main() {
 ```
 
 See `examples/pine-demo` for each component in use.
+
+## Overlay Event Contract
+
+Popover and DropdownMenu triggers isolate `pointerdown` and `click`
+events by default, so embedding them in clickable cards, rows, or
+tiles does not trigger the parent surface. Their content surfaces also
+stop internal pointer/click bubbling; normal page-level bubbling still
+occurs for true outside clicks.
+
+Outside interactions are preventable before the primitive closes:
+
+```html
+<pine-popover-content @pp:pointer-down-outside.prevent="keep_open">
+  ...
+</pine-popover-content>
+```
+
+- `pp:pointer-down-outside` fires before outside pointerdown dismissal.
+- `pp:interact-outside` fires before outside click/interact dismissal.
+- Calling `preventDefault()` on either event keeps the overlay open.
+- Clicking the trigger while open is exempt from outside-dismiss, so it
+  toggles closed exactly once.
+
+Application code may still need capture-phase or gesture-specific
+guards for custom drag/select surfaces, but ordinary overlay
+trigger/content click-through is owned by the Pine primitive.

--- a/crates/pine/src/dropdown_menu/PineDropdownMenuCheckboxItem.poco
+++ b/crates/pine/src/dropdown_menu/PineDropdownMenuCheckboxItem.poco
@@ -5,6 +5,8 @@
       :data-state="state"
       :aria-disabled="disabled"
       :data-disabled="disabled"
-      @click="on_select">
+      @click="on_select"
+      @keydown.enter.prevent="on_select"
+      @keydown.space.prevent="on_select">
   <slot></slot>
 </root>

--- a/crates/pine/src/dropdown_menu/PineDropdownMenuContent.poco
+++ b/crates/pine/src/dropdown_menu/PineDropdownMenuContent.poco
@@ -3,8 +3,10 @@
       pp-ref="menu"
       data-state="open"
       pp-roving
-      @pointerdown.outside="close"
-      @click.outside="close"
+      @pointerdown.stop="isolate_interaction"
+      @click.stop="isolate_interaction"
+      @pointerdown.outside="on_pointer_down_outside"
+      @click.outside="on_interact_outside"
       @keydown.escape.prevent="close">
   <slot></slot>
 </root>

--- a/crates/pine/src/dropdown_menu/PineDropdownMenuItem.poco
+++ b/crates/pine/src/dropdown_menu/PineDropdownMenuItem.poco
@@ -3,6 +3,8 @@
       tabindex="-1"
       :aria-disabled="disabled"
       :data-disabled="disabled"
-      @click="on_select">
+      @click="on_select"
+      @keydown.enter.prevent="on_select"
+      @keydown.space.prevent="on_select">
   <slot></slot>
 </root>

--- a/crates/pine/src/dropdown_menu/PineDropdownMenuRadioItem.poco
+++ b/crates/pine/src/dropdown_menu/PineDropdownMenuRadioItem.poco
@@ -5,6 +5,8 @@
       :data-state="checked ? 'checked' : 'unchecked'"
       :aria-disabled="disabled"
       :data-disabled="disabled"
-      @click="on_select">
+      @click="on_select"
+      @keydown.enter.prevent="on_select"
+      @keydown.space.prevent="on_select">
   <slot></slot>
 </root>

--- a/crates/pine/src/dropdown_menu/PineDropdownMenuSubContent.poco
+++ b/crates/pine/src/dropdown_menu/PineDropdownMenuSubContent.poco
@@ -6,17 +6,19 @@
        and the menu's `position: fixed` would anchor to the
        portal instead of the viewport — dragging the sub-menu
        down to wherever the teleported portal landed in body
-       flow. The menu itself already owns its own `transform`
-       via `pp-anchor`, so translating it via the preset stacks
-       cleanly with the anchor positioning. -->
+       flow. The menu is anchored programmatically after pp-if
+       mounts, so the transition belongs on this inner surface. -->
   <div class="pine-dm-sub-portal">
     <root role="menu"
           class="pine-dm-sub-content"
           pp-ref="menu"
           data-state="open"
+          :data-pine-dm-sub-content="sub_id"
+          :data-pine-dm-sub-content-root="root_id"
           pp-transition="slide-down"
-          pp-anchor:right-start.offset.2.flip="anchor"
           pp-roving
+          @pointerdown.stop="isolate_interaction"
+          @click.stop="isolate_interaction"
           @keydown.escape.prevent="close"
           @keydown.arrow-left.prevent="close">
       <slot></slot>

--- a/crates/pine/src/dropdown_menu/PineDropdownMenuSubTrigger.poco
+++ b/crates/pine/src/dropdown_menu/PineDropdownMenuSubTrigger.poco
@@ -7,6 +7,9 @@
       :data-state="open ? 'open' : 'closed'"
       :aria-disabled="disabled"
       :data-disabled="disabled"
-      @click="on_select">
+      @click="on_select"
+      @keydown.enter.prevent="on_select"
+      @keydown.space.prevent="on_select"
+      @keydown.arrow-right.prevent="open">
   <slot></slot>
 </root>

--- a/crates/pine/src/dropdown_menu/mod.rs
+++ b/crates/pine/src/dropdown_menu/mod.rs
@@ -25,15 +25,31 @@
 //! Content auto-anchors to its Trigger via RFC-027 inject + the
 //! `on_setup` lifecycle — no selector required.
 
-use crate::compound;
+use crate::{compound, overlay};
 use pocopine::prelude::*;
-use pocopine::{create_context, current_scope_id, focus, refs, watch_scope_field_scoped};
+use pocopine::{create_context, current_scope_id, focus, refs, watch_scope_field_scoped, ScopeId};
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::JsCast;
 use web_sys::Element;
 
 const SLUG: &str = "dm";
 const SUB_SLUG: &str = "dm-sub";
+const SUB_CONTENT_ATTR: &str = "data-pine-dm-sub-content";
+const SUB_CONTENT_ROOT_ATTR: &str = "data-pine-dm-sub-content-root";
+const MENU_ITEM_SELECTOR: &str =
+    "[role=\"menuitem\"], [role=\"menuitemradio\"], [role=\"menuitemcheckbox\"]";
+
+fn sub_content_selector(root_scope: ScopeId) -> String {
+    format!("[{SUB_CONTENT_ROOT_ATTR}=\"{}\"]", root_scope.0)
+}
+
+fn outside_exempt_selector(root_scope: ScopeId) -> String {
+    format!(
+        "{}, {}",
+        compound::trigger_selector(root_scope, SLUG),
+        sub_content_selector(root_scope)
+    )
+}
 
 // Provide/inject key for the Root handle.
 create_context!(ROOT: Handle<PineDropdownMenuRoot>);
@@ -53,8 +69,10 @@ create_context!(ROOT: Handle<PineDropdownMenuRoot>);
 pub struct PineDropdownMenuRoot {
     /// Open state. Two-way bindable via `pp-model:open="current"`
     /// on the tag.
-    #[prop]
+    #[model]
     pub open: bool,
+    pub closing: bool,
+    pub open_submenus: u32,
 }
 
 #[handlers]
@@ -74,14 +92,43 @@ impl PineDropdownMenuRoot {
 
     pub fn open_menu(&mut self) {
         self.open = true;
+        self.closing = false;
+        self.open_submenus = 0;
     }
 
     pub fn close(&mut self) {
+        if !self.open {
+            self.closing = false;
+            self.open_submenus = 0;
+            return;
+        }
+
+        if self.open_submenus > 0 && !self.closing {
+            self.closing = true;
+            let root = this::<Self>();
+            pocopine::tick::next_frame(move || {
+                root.update(|r: &mut PineDropdownMenuRoot| {
+                    if r.closing {
+                        r.open = false;
+                        r.closing = false;
+                        r.open_submenus = 0;
+                    }
+                });
+            });
+            return;
+        }
+
         self.open = false;
+        self.closing = false;
+        self.open_submenus = 0;
     }
 
     pub fn toggle(&mut self) {
-        self.open = !self.open;
+        if self.open {
+            self.close();
+        } else {
+            self.open_menu();
+        }
     }
 }
 
@@ -228,7 +275,7 @@ impl PineDropdownMenuContent {
         if let Some(root) = ROOT.inject() {
             let _ = menu.set_attribute(
                 "data-pp-outside-exempt",
-                &compound::trigger_selector(root.scope_id(), SLUG),
+                &outside_exempt_selector(root.scope_id()),
             );
         }
 
@@ -256,6 +303,22 @@ impl PineDropdownMenuContent {
             root.update(|r: &mut PineDropdownMenuRoot| r.close());
         }
     }
+
+    pub fn on_pointer_down_outside(&mut self) {
+        if overlay::dispatch_pointer_down_outside() {
+            return;
+        }
+        self.close();
+    }
+
+    pub fn on_interact_outside(&mut self) {
+        if overlay::dispatch_interact_outside() {
+            return;
+        }
+        self.close();
+    }
+
+    pub fn isolate_interaction(&mut self) {}
 }
 
 // ── Item ──────────────────────────────────────────────────────────
@@ -312,7 +375,7 @@ fn dispatch_pp_select() -> bool {
 ///
 /// v0 is click-to-open (no hover-intent timers). Escape in
 /// SubContent closes just the sub, not the outer menu.
-#[derive(Default, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 #[component(
     template = "PineDropdownMenuSub.poco",
     role = "scope",
@@ -324,6 +387,20 @@ fn dispatch_pp_select() -> bool {
 #[slot(default, only = [PineDropdownMenuSubTrigger, PineDropdownMenuSubContent])]
 pub struct PineDropdownMenuSub {
     pub open: bool,
+    pub content_side: String,
+    pub content_align: String,
+    pub content_side_offset: f64,
+}
+
+impl Default for PineDropdownMenuSub {
+    fn default() -> Self {
+        Self {
+            open: false,
+            content_side: "right".into(),
+            content_align: "start".into(),
+            content_side_offset: 2.0,
+        }
+    }
 }
 
 create_context!(SUB: Handle<PineDropdownMenuSub>);
@@ -334,11 +411,37 @@ impl PineDropdownMenuSub {
         SUB.provide(this::<Self>());
     }
 
-    pub fn close(&mut self) {
-        self.open = false;
+    fn on_ready(&self, handle: pocopine::Handle<Self>) {
+        let Some(root) = ROOT.inject() else { return };
+        watch_scope_field_scoped::<bool, _>(root.scope_id(), "closing", move |&closing, _| {
+            if closing {
+                handle.update(|s: &mut PineDropdownMenuSub| s.set_open(false));
+            }
+        });
     }
+
+    fn set_open(&mut self, next: bool) {
+        if self.open == next {
+            return;
+        }
+        self.open = next;
+        if let Some(root) = ROOT.inject() {
+            root.update(|r: &mut PineDropdownMenuRoot| {
+                if next {
+                    r.open_submenus = r.open_submenus.saturating_add(1);
+                } else {
+                    r.open_submenus = r.open_submenus.saturating_sub(1);
+                }
+            });
+        }
+    }
+
+    pub fn close(&mut self) {
+        self.set_open(false);
+    }
+
     pub fn toggle(&mut self) {
-        self.open = !self.open;
+        self.set_open(!self.open);
     }
 }
 
@@ -372,7 +475,23 @@ impl PineDropdownMenuSubTrigger {
         // Item-select dismissal. Item.on_select still fires first
         // via native bubble if the author stacked handlers.
         if let Some(sub) = SUB.inject() {
-            sub.update(|s: &mut PineDropdownMenuSub| s.toggle());
+            let is_open = sub.update(|s: &mut PineDropdownMenuSub| {
+                s.set_open(!s.open);
+                s.open
+            });
+            if is_open {
+                prepare_open_sub_content_from_sub(&sub);
+            }
+        }
+    }
+
+    pub fn open(&mut self) {
+        if self.disabled {
+            return;
+        }
+        if let Some(sub) = SUB.inject() {
+            sub.update(|s: &mut PineDropdownMenuSub| s.set_open(true));
+            prepare_open_sub_content_from_sub(&sub);
         }
     }
 }
@@ -398,6 +517,8 @@ impl PineDropdownMenuSubTrigger {
 pub struct PineDropdownMenuSubContent {
     pub open: bool,
     pub anchor: String,
+    pub sub_id: String,
+    pub root_id: String,
     #[prop]
     pub side: String,
     #[prop]
@@ -411,6 +532,8 @@ impl Default for PineDropdownMenuSubContent {
         Self {
             open: false,
             anchor: String::new(),
+            sub_id: String::new(),
+            root_id: String::new(),
             // Submenus conventionally pop out to the right.
             side: "right".into(),
             align: "start".into(),
@@ -423,24 +546,60 @@ impl Default for PineDropdownMenuSubContent {
 impl PineDropdownMenuSubContent {
     fn on_setup(&mut self) {
         if let Some(sub) = SUB.inject() {
-            self.anchor = compound::trigger_selector(sub.scope_id(), SUB_SLUG);
+            let sub_scope = sub.scope_id();
+            self.anchor = compound::trigger_selector(sub_scope, SUB_SLUG);
+            self.sub_id = sub_scope.0.to_string();
             self.open = sub.with(|s| s.open);
+            let side = self.side.clone();
+            let align = self.align.clone();
+            let side_offset = self.side_offset;
+            sub.update(|s: &mut PineDropdownMenuSub| {
+                s.content_side = side;
+                s.content_align = align;
+                s.content_side_offset = side_offset;
+            });
         }
+        if let Some(root) = ROOT.inject() {
+            self.root_id = root.scope_id().0.to_string();
+        }
+        CONTENT_SIDE.provide(self.side.clone());
     }
 
     fn on_ready(&self, handle: pocopine::Handle<Self>) {
         let Some(sub) = SUB.inject() else { return };
         let sub_scope = sub.scope_id();
+        let content_scope = handle.scope_id();
+        let root_scope = ROOT.inject().map(|root| root.scope_id());
+        let side = self.side.clone();
+        let align = self.align.clone();
+        let side_offset = self.side_offset;
         // Watch for the sub's open transitions so roving-focus +
-        // auto-focus can run when the menu mounts. pp-anchor is
-        // handled declaratively in the template; we only need to
-        // forward `open` into self.
+        // auto-focus + programmatic anchoring can run after the
+        // pp-if subtree mounts.
         watch_scope_field_scoped::<bool, _>(sub_scope, "open", move |&is_open, _| {
             handle.update(|s| s.open = is_open);
             if is_open {
-                focus_first_sub_item();
+                prepare_open_sub_content(
+                    content_scope,
+                    root_scope,
+                    sub_scope,
+                    side.clone(),
+                    align.clone(),
+                    side_offset,
+                );
             }
         });
+
+        if sub.with(|s| s.open) {
+            prepare_open_sub_content(
+                content_scope,
+                root_scope,
+                sub_scope,
+                self.side.clone(),
+                self.align.clone(),
+                self.side_offset,
+            );
+        }
     }
 
     pub fn close(&mut self) {
@@ -448,23 +607,110 @@ impl PineDropdownMenuSubContent {
             sub.update(|s: &mut PineDropdownMenuSub| s.close());
         }
     }
+
+    pub fn isolate_interaction(&mut self) {}
 }
 
-/// Give keyboard focus to the first enabled item in the sub
-/// menu once it mounts. Runs via `tick::next` so pp-if has
-/// actually cloned + walked the teleported subtree before we
-/// query for the menu ref.
-fn focus_first_sub_item() {
-    pocopine::tick::next(|| {
-        let Some(scope) = current_scope_id() else {
+/// Finish submenu setup once its pp-if subtree has cloned and
+/// walked: stamp it into the parent dismiss boundary, anchor it
+/// to the sub-trigger, and move focus into the first enabled item.
+fn prepare_open_sub_content_from_sub(sub: &Handle<PineDropdownMenuSub>) {
+    let sub_scope = sub.scope_id();
+    let root_scope = ROOT.inject().map(|root| root.scope_id());
+    let (side, align, side_offset) = sub.with(|s| {
+        (
+            s.content_side.clone(),
+            s.content_align.clone(),
+            s.content_side_offset,
+        )
+    });
+    prepare_open_sub_content(sub_scope, root_scope, sub_scope, side, align, side_offset);
+}
+
+fn prepare_open_sub_content(
+    content_scope: ScopeId,
+    root_scope: Option<ScopeId>,
+    sub_scope: ScopeId,
+    side: String,
+    align: String,
+    side_offset: f64,
+) {
+    prepare_open_sub_content_attempt(
+        content_scope,
+        root_scope,
+        sub_scope,
+        side,
+        align,
+        side_offset,
+        0,
+    );
+}
+
+fn prepare_open_sub_content_attempt(
+    content_scope: ScopeId,
+    root_scope: Option<ScopeId>,
+    sub_scope: ScopeId,
+    side: String,
+    align: String,
+    side_offset: f64,
+    attempt: u8,
+) {
+    pocopine::tick::next(move || {
+        let ready_menu = resolve_open_sub_content_menu(content_scope, sub_scope).and_then(|menu| {
+            let has_items = menu
+                .query_selector(MENU_ITEM_SELECTOR)
+                .ok()
+                .flatten()
+                .is_some();
+            if has_items || attempt >= 5 {
+                Some(menu)
+            } else {
+                None
+            }
+        });
+
+        let Some(menu) = ready_menu else {
+            if attempt < 5 {
+                prepare_open_sub_content_attempt(
+                    content_scope,
+                    root_scope,
+                    sub_scope,
+                    side,
+                    align,
+                    side_offset,
+                    attempt + 1,
+                );
+            }
             return;
         };
-        let Some(menu) = refs::get_on(scope, "menu") else {
-            return;
-        };
+
+        if let Some(root_scope) = root_scope {
+            let _ = menu.set_attribute(SUB_CONTENT_ROOT_ATTR, &root_scope.0.to_string());
+        }
+
         init_roving_tabindex(&menu);
         focus::auto_focus_first(&menu);
+
+        if let Ok(floater) = menu.clone().dyn_into::<web_sys::HtmlElement>() {
+            compound::install_anchor_to_trigger(
+                &floater,
+                sub_scope,
+                SUB_SLUG,
+                &side,
+                &align,
+                side_offset,
+                true,
+            );
+        }
     });
+}
+
+fn resolve_open_sub_content_menu(content_scope: ScopeId, sub_scope: ScopeId) -> Option<Element> {
+    let selector = format!("[{SUB_CONTENT_ATTR}=\"{}\"]", sub_scope.0);
+    web_sys::window()
+        .and_then(|w| w.document())
+        .and_then(|d| d.query_selector(&selector).ok().flatten())
+        .or_else(|| refs::get_on(content_scope, "menu"))
 }
 
 // ── Arrow ─────────────────────────────────────────────────────────
@@ -826,9 +1072,7 @@ impl PineDropdownMenuLabel {
 /// `pp-roving`. Runs after the slot materialises so the items
 /// are in the DOM.
 fn init_roving_tabindex(menu: &Element) {
-    let Ok(items) = menu.query_selector_all(
-        "[role=\"menuitem\"], [role=\"menuitemradio\"], [role=\"menuitemcheckbox\"]",
-    ) else {
+    let Ok(items) = menu.query_selector_all(MENU_ITEM_SELECTOR) else {
         return;
     };
     let mut first_enabled: Option<Element> = None;

--- a/crates/pine/src/overlay/mod.rs
+++ b/crates/pine/src/overlay/mod.rs
@@ -13,12 +13,32 @@
 //! true and [`deactivate`] on close / unmount. Pass `modal=true`
 //! to acquire scroll-lock + focus trap (Dialog); `modal=false`
 //! for non-modal overlays (Popover).
+//!
+//! Popover and DropdownMenu also share the cancelable outside
+//! interaction event contract here. Their template-level
+//! `@*.outside` listeners call the dispatch helpers before
+//! closing so authors can use `@pp:pointer-down-outside.prevent`
+//! or `@pp:interact-outside.prevent` on the Content primitive.
 
 use std::cell::RefCell;
 use std::collections::HashMap;
 
-use pocopine::{focus, scroll_lock, ScopeId};
+use pocopine::{emit_cancelable, focus, scroll_lock, ScopeId};
 use web_sys::Element;
+
+/// Fired before an outside pointerdown dismisses an overlay.
+///
+/// The event is cancelable; `preventDefault()` keeps the overlay
+/// open and suppresses that primitive's default outside-dismiss
+/// action.
+pub const POINTER_DOWN_OUTSIDE_EVENT: &str = "pp:pointer-down-outside";
+
+/// Fired before a click/interact outside dismisses an overlay.
+///
+/// This covers the post-pointer activation step, matching Radix's
+/// "interact outside" terminology while still travelling through
+/// normal browser `CustomEvent.detail` plumbing.
+pub const INTERACT_OUTSIDE_EVENT: &str = "pp:interact-outside";
 
 thread_local! {
     static RUNTIMES: RefCell<HashMap<ScopeId, OverlayRuntime>> =
@@ -30,6 +50,20 @@ struct OverlayRuntime {
     trap: Option<focus::TrapHandle>,
     saved: Option<focus::Saved>,
     scroll_locked: bool,
+}
+
+/// Dispatch [`POINTER_DOWN_OUTSIDE_EVENT`] from the current
+/// Content element. Returns `true` when an author prevented the
+/// default dismiss action.
+pub fn dispatch_pointer_down_outside() -> bool {
+    emit_cancelable(POINTER_DOWN_OUTSIDE_EVENT, ())
+}
+
+/// Dispatch [`INTERACT_OUTSIDE_EVENT`] from the current Content
+/// element. Returns `true` when an author prevented the default
+/// dismiss action.
+pub fn dispatch_interact_outside() -> bool {
+    emit_cancelable(INTERACT_OUTSIDE_EVENT, ())
 }
 
 /// Install focus management + optional scroll-lock for an

--- a/crates/pine/src/popover/PinePopoverContent.poco
+++ b/crates/pine/src/popover/PinePopoverContent.poco
@@ -2,8 +2,10 @@
       class="pine-popover-content"
       pp-ref="content"
       data-state="open"
-      @pointerdown.outside="on_outside"
-      @click.outside="on_outside"
+      @pointerdown.stop="isolate_interaction"
+      @click.stop="isolate_interaction"
+      @pointerdown.outside="on_pointer_down_outside"
+      @click.outside="on_interact_outside"
       @keydown.escape.prevent="on_escape">
   <slot></slot>
 </root>

--- a/crates/pine/src/popover/mod.rs
+++ b/crates/pine/src/popover/mod.rs
@@ -234,14 +234,21 @@ impl PinePopoverContent {
         }
     }
 
-    pub fn on_outside(&mut self) {
-        if let Some(root) = ROOT.inject() {
-            let dismiss = root.with(|r| r.dismiss_on_outside);
-            if dismiss {
-                root.update(|r: &mut PinePopoverRoot| r.close());
-            }
+    pub fn on_pointer_down_outside(&mut self) {
+        if overlay::dispatch_pointer_down_outside() {
+            return;
         }
+        close_popover_on_outside();
     }
+
+    pub fn on_interact_outside(&mut self) {
+        if overlay::dispatch_interact_outside() {
+            return;
+        }
+        close_popover_on_outside();
+    }
+
+    pub fn isolate_interaction(&mut self) {}
 
     pub fn on_escape(&mut self) {
         if let Some(root) = ROOT.inject() {
@@ -249,6 +256,15 @@ impl PinePopoverContent {
             if dismiss {
                 root.update(|r: &mut PinePopoverRoot| r.close());
             }
+        }
+    }
+}
+
+fn close_popover_on_outside() {
+    if let Some(root) = ROOT.inject() {
+        let dismiss = root.with(|r| r.dismiss_on_outside);
+        if dismiss {
+            root.update(|r: &mut PinePopoverRoot| r.close());
         }
     }
 }

--- a/crates/pine/tests/pine.rs
+++ b/crates/pine/tests/pine.rs
@@ -4,6 +4,9 @@
 #![cfg(target_arch = "wasm32")]
 
 use pocopine::prelude::*;
+use std::cell::Cell;
+use std::rc::Rc;
+use wasm_bindgen::closure::Closure;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 use web_sys::{window, Element, HtmlElement, HtmlInputElement};
@@ -117,6 +120,80 @@ async fn sleep_ms(ms: i32) {
             w.set_timeout_with_callback_and_timeout_and_arguments_0(resolve.unchecked_ref(), ms);
     });
     let _ = wasm_bindgen_futures::JsFuture::from(p).await;
+}
+
+fn text_for(root: &Element, selector: &str) -> String {
+    root.query_selector(selector)
+        .unwrap()
+        .unwrap()
+        .dyn_into::<HtmlElement>()
+        .unwrap()
+        .inner_text()
+        .trim()
+        .to_string()
+}
+
+fn install_body_click_counter() -> Rc<Cell<u32>> {
+    let count = Rc::new(Cell::new(0));
+    let seen = count.clone();
+    let cb: Closure<dyn FnMut(web_sys::Event)> =
+        Closure::wrap(Box::new(move |_| seen.set(seen.get() + 1)));
+    let body = doc().body().unwrap();
+    let target: &web_sys::EventTarget = body.as_ref();
+    target
+        .add_event_listener_with_callback("click", cb.as_ref().unchecked_ref())
+        .unwrap();
+    cb.forget();
+    count
+}
+
+fn prevent_event_counter(target: &Element, event: &str) -> Rc<Cell<u32>> {
+    let count = Rc::new(Cell::new(0));
+    let seen = count.clone();
+    let cb: Closure<dyn FnMut(web_sys::Event)> =
+        Closure::wrap(Box::new(move |ev: web_sys::Event| {
+            seen.set(seen.get() + 1);
+            ev.prevent_default();
+        }));
+    let target: &web_sys::EventTarget = target.as_ref();
+    target
+        .add_event_listener_with_callback(event, cb.as_ref().unchecked_ref())
+        .unwrap();
+    cb.forget();
+    count
+}
+
+fn dispatch_body_pointerdown() {
+    let init = web_sys::PointerEventInit::new();
+    init.set_bubbles(true);
+    init.set_cancelable(true);
+    let ev = web_sys::PointerEvent::new_with_event_init_dict("pointerdown", &init).unwrap();
+    doc().body().unwrap().dispatch_event(&ev).unwrap();
+}
+
+fn dispatch_body_click() {
+    let init = web_sys::MouseEventInit::new();
+    init.set_bubbles(true);
+    init.set_cancelable(true);
+    let ev = web_sys::MouseEvent::new_with_mouse_event_init_dict("click", &init).unwrap();
+    doc().body().unwrap().dispatch_event(&ev).unwrap();
+}
+
+fn dispatch_pointer_click(target: &Element) {
+    for event in ["pointerdown", "pointerup"] {
+        let init = web_sys::PointerEventInit::new();
+        init.set_bubbles(true);
+        init.set_cancelable(true);
+        let ev = web_sys::PointerEvent::new_with_event_init_dict(event, &init).unwrap();
+        target.dispatch_event(&ev).unwrap();
+    }
+    for event in ["mousedown", "mouseup", "click"] {
+        let init = web_sys::MouseEventInit::new();
+        init.set_bubbles(true);
+        init.set_cancelable(true);
+        let ev = web_sys::MouseEvent::new_with_mouse_event_init_dict(event, &init).unwrap();
+        target.dispatch_event(&ev).unwrap();
+    }
 }
 
 // ─── PineButton ───────────────────────────────────────────────────
@@ -678,6 +755,243 @@ async fn compound_menu_injects_through_slot_owner_when_nested() {
 #[derive(Default, serde::Serialize, serde::Deserialize)]
 #[component(template_inline = r#"
 <div>
+  <div class="dm-card" @click="card_click">
+    <span class="dm-card-clicks" pp-text="card_clicks"></span>
+    <pine-dropdown-menu-root>
+      <pine-dropdown-menu-trigger class="dm-trigger">Actions</pine-dropdown-menu-trigger>
+      <pine-dropdown-menu-portal>
+        <pine-dropdown-menu-content>
+          <pine-dropdown-menu-label>Menu</pine-dropdown-menu-label>
+          <pine-dropdown-menu-item class="dm-item">Item</pine-dropdown-menu-item>
+        </pine-dropdown-menu-content>
+      </pine-dropdown-menu-portal>
+    </pine-dropdown-menu-root>
+  </div>
+</div>
+"#)]
+struct DropdownClickableParentHost {
+    card_clicks: u32,
+}
+
+#[handlers]
+impl DropdownClickableParentHost {
+    pub fn card_click(&mut self) {
+        self.card_clicks += 1;
+    }
+}
+
+#[wasm_bindgen_test]
+async fn dropdown_menu_isolates_trigger_and_content_inside_clickable_parent() {
+    let host = mount_fixture::<DropdownClickableParentHost>();
+    tick().await;
+
+    let body_clicks = install_body_click_counter();
+    let trigger = host
+        .query_selector(".dm-trigger")
+        .unwrap()
+        .expect("trigger rendered");
+
+    trigger.clone().dyn_into::<HtmlElement>().unwrap().click();
+    tick().await;
+    tick().await;
+    assert!(
+        doc()
+            .query_selector("ul[role=\"menu\"].pine-dm-content")
+            .unwrap()
+            .is_some(),
+        "trigger click opens the menu"
+    );
+    assert_eq!(text_for(&host, ".dm-card-clicks"), "0");
+    assert_eq!(body_clicks.get(), 0, "trigger click does not leak");
+
+    trigger.clone().dyn_into::<HtmlElement>().unwrap().click();
+    tick().await;
+    tick().await;
+    assert!(
+        doc()
+            .query_selector("ul[role=\"menu\"].pine-dm-content")
+            .unwrap()
+            .is_none(),
+        "re-clicking the trigger closes instead of re-opening via outside-dismiss race"
+    );
+    assert_eq!(text_for(&host, ".dm-card-clicks"), "0");
+    assert_eq!(body_clicks.get(), 0, "trigger re-click stays isolated");
+
+    trigger.dyn_into::<HtmlElement>().unwrap().click();
+    tick().await;
+    tick().await;
+    let menu = doc()
+        .query_selector("ul[role=\"menu\"].pine-dm-content")
+        .unwrap()
+        .expect("menu reopened");
+    menu.clone().dyn_into::<HtmlElement>().unwrap().click();
+    tick().await;
+    assert!(
+        doc()
+            .query_selector("ul[role=\"menu\"].pine-dm-content")
+            .unwrap()
+            .is_some(),
+        "clicking inside content does not outside-dismiss"
+    );
+    assert_eq!(text_for(&host, ".dm-card-clicks"), "0");
+    assert_eq!(
+        body_clicks.get(),
+        0,
+        "content click does not bubble to the page"
+    );
+
+    doc()
+        .body()
+        .unwrap()
+        .dyn_into::<HtmlElement>()
+        .unwrap()
+        .click();
+    tick().await;
+    tick().await;
+    assert!(
+        doc()
+            .query_selector("ul[role=\"menu\"].pine-dm-content")
+            .unwrap()
+            .is_none(),
+        "body click outside closes the menu"
+    );
+    assert_eq!(body_clicks.get(), 1, "outside click still reaches the page");
+
+    host.remove();
+}
+
+#[wasm_bindgen_test]
+async fn dropdown_menu_outside_events_are_preventable() {
+    let host = mount_fixture::<DropdownClickableParentHost>();
+    tick().await;
+
+    let trigger = host.query_selector(".dm-trigger").unwrap().unwrap();
+    trigger.dyn_into::<HtmlElement>().unwrap().click();
+    tick().await;
+    tick().await;
+
+    let menu = doc()
+        .query_selector("ul[role=\"menu\"].pine-dm-content")
+        .unwrap()
+        .expect("menu opened");
+    let pointer_count = prevent_event_counter(&menu, "pp:pointer-down-outside");
+    dispatch_body_pointerdown();
+    tick().await;
+    tick().await;
+    assert_eq!(pointer_count.get(), 1);
+    assert!(
+        doc()
+            .query_selector("ul[role=\"menu\"].pine-dm-content")
+            .unwrap()
+            .is_some(),
+        "preventing pp:pointer-down-outside keeps the menu open"
+    );
+
+    let interact_count = prevent_event_counter(&menu, "pp:interact-outside");
+    dispatch_body_click();
+    tick().await;
+    tick().await;
+    assert_eq!(interact_count.get(), 1);
+    assert!(
+        doc()
+            .query_selector("ul[role=\"menu\"].pine-dm-content")
+            .unwrap()
+            .is_some(),
+        "preventing pp:interact-outside keeps the menu open"
+    );
+
+    let init = web_sys::KeyboardEventInit::new();
+    init.set_key("Escape");
+    init.set_bubbles(true);
+    let ev = web_sys::KeyboardEvent::new_with_keyboard_event_init_dict("keydown", &init).unwrap();
+    menu.dispatch_event(&ev).unwrap();
+    tick().await;
+    tick().await;
+    assert!(
+        doc()
+            .query_selector("ul[role=\"menu\"].pine-dm-content")
+            .unwrap()
+            .is_none(),
+        "Escape still closes after prevented outside events"
+    );
+
+    host.remove();
+}
+
+#[derive(Default, serde::Serialize, serde::Deserialize)]
+#[component(template_inline = r#"
+<div>
+  <button class="dm-model-open" @click="open_it">open</button>
+  <span class="dm-model-state" pp-text="menu_open ? 'open' : 'closed'"></span>
+  <pine-dropdown-menu-root pp-model:open="menu_open">
+    <pine-dropdown-menu-trigger class="dm-model-trigger">menu</pine-dropdown-menu-trigger>
+    <pine-dropdown-menu-portal>
+      <pine-dropdown-menu-content>
+        <pine-dropdown-menu-item class="dm-model-item">Item</pine-dropdown-menu-item>
+      </pine-dropdown-menu-content>
+    </pine-dropdown-menu-portal>
+  </pine-dropdown-menu-root>
+</div>
+"#)]
+struct DropdownModelHost {
+    menu_open: bool,
+}
+
+#[handlers]
+impl DropdownModelHost {
+    pub fn open_it(&mut self) {
+        self.menu_open = true;
+    }
+}
+
+#[wasm_bindgen_test]
+async fn dropdown_menu_pp_model_open_round_trips_through_parent() {
+    let host = mount_fixture::<DropdownModelHost>();
+    tick().await;
+
+    assert_eq!(text_for(&host, ".dm-model-state"), "closed");
+    host.query_selector(".dm-model-open")
+        .unwrap()
+        .unwrap()
+        .dyn_into::<HtmlElement>()
+        .unwrap()
+        .click();
+    tick().await;
+    tick().await;
+
+    let menu = doc()
+        .query_selector("ul[role=\"menu\"].pine-dm-content")
+        .unwrap()
+        .expect("menu opened from parent pp-model field");
+    assert_eq!(text_for(&host, ".dm-model-state"), "open");
+
+    let init = web_sys::KeyboardEventInit::new();
+    init.set_key("Escape");
+    init.set_bubbles(true);
+    let ev = web_sys::KeyboardEvent::new_with_keyboard_event_init_dict("keydown", &init).unwrap();
+    menu.dispatch_event(&ev).unwrap();
+    tick().await;
+    tick().await;
+
+    assert_eq!(
+        text_for(&host, ".dm-model-state"),
+        "closed",
+        "Root.close emitted through pp-model:open"
+    );
+    assert!(
+        doc()
+            .query_selector("ul[role=\"menu\"].pine-dm-content")
+            .unwrap()
+            .is_none(),
+        "menu unmounted after model-backed close"
+    );
+
+    host.remove();
+}
+
+#[derive(Default, serde::Serialize, serde::Deserialize)]
+#[component(template_inline = r#"
+<div>
   <pine-dropdown-menu-root>
     <pine-dropdown-menu-trigger class="pv-trig">open</pine-dropdown-menu-trigger>
     <pine-dropdown-menu-portal>
@@ -748,6 +1062,44 @@ async fn dropdown_menu_item_pp_select_preventable_keeps_menu_open() {
             .unwrap()
             .is_none(),
         "menu dismisses when nothing prevents pp:select"
+    );
+
+    host.remove();
+}
+
+#[wasm_bindgen_test]
+async fn dropdown_menu_items_activate_from_keyboard() {
+    let host = mount_fixture::<CompoundMenuHost>();
+    tick().await;
+
+    host.query_selector("pine-dropdown-menu-trigger button")
+        .unwrap()
+        .unwrap()
+        .dyn_into::<HtmlElement>()
+        .unwrap()
+        .click();
+    tick().await;
+    tick().await;
+
+    let item = doc()
+        .query_selector(".m-a")
+        .unwrap()
+        .expect("item rendered");
+    let item_li = item.query_selector("li").unwrap().unwrap_or(item);
+    let init = web_sys::KeyboardEventInit::new();
+    init.set_key("Enter");
+    init.set_bubbles(true);
+    let ev = web_sys::KeyboardEvent::new_with_keyboard_event_init_dict("keydown", &init).unwrap();
+    item_li.dispatch_event(&ev).unwrap();
+    tick().await;
+    tick().await;
+
+    assert!(
+        doc()
+            .query_selector("ul[role=\"menu\"].pine-dm-content")
+            .unwrap()
+            .is_none(),
+        "Enter on a focused menuitem activates Item.on_select and closes the menu"
     );
 
     host.remove();
@@ -1138,6 +1490,404 @@ async fn dropdown_menu_sub_opens_anchored_to_sub_trigger() {
     host.remove();
 }
 
+#[wasm_bindgen_test]
+async fn dropdown_menu_sub_opens_from_arrow_right_and_focuses_first_item() {
+    let host = mount_fixture::<SubMenuHost>();
+    tick().await;
+
+    host.query_selector(".sub-root-t")
+        .unwrap()
+        .unwrap()
+        .dyn_into::<HtmlElement>()
+        .unwrap()
+        .click();
+    tick().await;
+    tick().await;
+
+    let sub_trig = doc()
+        .query_selector(".s-sub-t")
+        .unwrap()
+        .expect("sub trigger rendered");
+    let init = web_sys::KeyboardEventInit::new();
+    init.set_key("ArrowRight");
+    init.set_bubbles(true);
+    let ev = web_sys::KeyboardEvent::new_with_keyboard_event_init_dict("keydown", &init).unwrap();
+    sub_trig.dispatch_event(&ev).unwrap();
+    for _ in 0..5 {
+        tick().await;
+    }
+
+    let sub_menu = doc()
+        .query_selector("ul.pine-dm-sub-content")
+        .unwrap()
+        .expect("sub-content opened from ArrowRight");
+    let active = doc().active_element().unwrap();
+    assert!(
+        sub_menu.contains(Some(active.as_ref())),
+        "submenu open moves focus inside the submenu"
+    );
+    assert_eq!(
+        active.get_attribute("tabindex").as_deref(),
+        Some("0"),
+        "focused submenu item is the roving tab stop"
+    );
+    assert_eq!(
+        sub_menu
+            .dyn_into::<HtmlElement>()
+            .unwrap()
+            .style()
+            .get_property_value("position")
+            .unwrap_or_default(),
+        "fixed",
+        "submenu content is anchored programmatically after opening"
+    );
+
+    host.remove();
+}
+
+#[wasm_bindgen_test]
+async fn dropdown_menu_sub_click_toggle_reopens_after_close() {
+    let host = mount_fixture::<SubMenuHost>();
+    tick().await;
+
+    host.query_selector(".sub-root-t")
+        .unwrap()
+        .unwrap()
+        .dyn_into::<HtmlElement>()
+        .unwrap()
+        .click();
+    tick().await;
+    tick().await;
+
+    let sub_trig = doc()
+        .query_selector(".s-sub-t")
+        .unwrap()
+        .expect("sub trigger rendered");
+    sub_trig.clone().dyn_into::<HtmlElement>().unwrap().click();
+    for _ in 0..5 {
+        tick().await;
+    }
+    assert!(
+        doc()
+            .query_selector("ul.pine-dm-sub-content")
+            .unwrap()
+            .is_some(),
+        "first submenu trigger click opens the submenu"
+    );
+
+    sub_trig.clone().dyn_into::<HtmlElement>().unwrap().click();
+    tick().await;
+    tick().await;
+    assert!(
+        doc()
+            .query_selector("ul.pine-dm-sub-content")
+            .unwrap()
+            .is_none(),
+        "second submenu trigger click closes the submenu"
+    );
+
+    sub_trig.dyn_into::<HtmlElement>().unwrap().click();
+    for _ in 0..5 {
+        tick().await;
+    }
+    assert!(
+        doc()
+            .query_selector("ul.pine-dm-sub-content")
+            .unwrap()
+            .is_some(),
+        "third submenu trigger click reopens the submenu after close"
+    );
+
+    host.remove();
+}
+
+#[derive(Default, serde::Serialize, serde::Deserialize)]
+#[component(template_inline = r#"
+<div>
+  <pine-dropdown-menu-root>
+    <pine-dropdown-menu-trigger class="file-root-t">File</pine-dropdown-menu-trigger>
+    <pine-dropdown-menu-portal>
+      <pine-dropdown-menu-content side="top" align="start" side_offset="8">
+        <pine-dropdown-menu-arrow></pine-dropdown-menu-arrow>
+        <pine-dropdown-menu-item @click="action_bump">New file</pine-dropdown-menu-item>
+        <pine-dropdown-menu-item @click="action_bump">Open...</pine-dropdown-menu-item>
+        <pine-dropdown-menu-separator></pine-dropdown-menu-separator>
+        <pine-dropdown-menu-sub>
+          <pine-dropdown-menu-sub-trigger class="file-sub-t">Share to</pine-dropdown-menu-sub-trigger>
+          <pine-dropdown-menu-sub-content>
+            <pine-dropdown-menu-item @click="action_bump">Email...</pine-dropdown-menu-item>
+            <pine-dropdown-menu-item @click="action_bump">Slack...</pine-dropdown-menu-item>
+            <pine-dropdown-menu-item @click="action_bump">Copy link</pine-dropdown-menu-item>
+          </pine-dropdown-menu-sub-content>
+        </pine-dropdown-menu-sub>
+        <pine-dropdown-menu-separator></pine-dropdown-menu-separator>
+        <pine-dropdown-menu-item class="file-quit" @click="action_bump">Quit</pine-dropdown-menu-item>
+      </pine-dropdown-menu-content>
+    </pine-dropdown-menu-portal>
+  </pine-dropdown-menu-root>
+</div>
+"#)]
+struct FileDropdownSubMenuHost {
+    bumps: u32,
+}
+
+#[handlers]
+impl FileDropdownSubMenuHost {
+    pub fn action_bump(&mut self) {
+        self.bumps += 1;
+    }
+}
+
+#[wasm_bindgen_test]
+async fn dropdown_menu_file_sub_click_toggle_reopens_after_close() {
+    let host = mount_fixture::<FileDropdownSubMenuHost>();
+    tick().await;
+
+    let file_trigger = host.query_selector(".file-root-t").unwrap().unwrap();
+    dispatch_pointer_click(&file_trigger);
+    tick().await;
+    tick().await;
+
+    let sub_trig = doc()
+        .query_selector(".file-sub-t")
+        .unwrap()
+        .expect("file submenu trigger rendered");
+    dispatch_pointer_click(&sub_trig);
+    for _ in 0..5 {
+        tick().await;
+    }
+    let first_sub_menu = doc()
+        .query_selector("ul.pine-dm-sub-content")
+        .unwrap()
+        .expect("File submenu opens on first click");
+    assert_eq!(
+        first_sub_menu
+            .dyn_into::<HtmlElement>()
+            .unwrap()
+            .style()
+            .get_property_value("position")
+            .unwrap_or_default(),
+        "fixed",
+        "File submenu is anchored on first open"
+    );
+
+    dispatch_pointer_click(&sub_trig);
+    tick().await;
+    tick().await;
+    assert!(
+        doc()
+            .query_selector("ul.pine-dm-sub-content")
+            .unwrap()
+            .is_none(),
+        "File submenu closes on second click"
+    );
+
+    dispatch_pointer_click(&sub_trig);
+    for _ in 0..5 {
+        tick().await;
+    }
+    let reopened_sub_menu = doc()
+        .query_selector("ul.pine-dm-sub-content")
+        .unwrap()
+        .expect("File submenu reopens on third click");
+    assert_eq!(
+        reopened_sub_menu
+            .dyn_into::<HtmlElement>()
+            .unwrap()
+            .style()
+            .get_property_value("position")
+            .unwrap_or_default(),
+        "fixed",
+        "File submenu is re-anchored after a full close/reopen"
+    );
+
+    host.remove();
+}
+
+#[wasm_bindgen_test]
+async fn dropdown_menu_closes_submenu_before_parent_content() {
+    let host = mount_fixture::<FileDropdownSubMenuHost>();
+    tick().await;
+
+    let file_trigger = host.query_selector(".file-root-t").unwrap().unwrap();
+    dispatch_pointer_click(&file_trigger);
+    tick().await;
+    tick().await;
+
+    let sub_trig = doc()
+        .query_selector(".file-sub-t")
+        .unwrap()
+        .expect("file submenu trigger rendered");
+    dispatch_pointer_click(&sub_trig);
+    for _ in 0..5 {
+        tick().await;
+    }
+    assert_eq!(
+        sub_trig.get_attribute("data-state").as_deref(),
+        Some("open"),
+        "submenu starts open"
+    );
+
+    let quit = doc()
+        .query_selector(".file-quit")
+        .unwrap()
+        .expect("outer menu item rendered");
+    dispatch_pointer_click(&quit);
+    tick().await;
+    tick().await;
+
+    assert_eq!(
+        sub_trig.get_attribute("data-state").as_deref(),
+        Some("closed"),
+        "root close asks the submenu to close first"
+    );
+    assert!(
+        doc()
+            .query_selector("ul[role=\"menu\"].pine-dm-content")
+            .unwrap()
+            .is_some(),
+        "parent content remains mounted until the next animation frame"
+    );
+
+    sleep_ms(40).await;
+    tick().await;
+    assert!(
+        doc()
+            .query_selector("ul[role=\"menu\"].pine-dm-content")
+            .unwrap()
+            .is_none(),
+        "parent content closes after the submenu was told to leave"
+    );
+
+    host.remove();
+}
+
+#[derive(Default, serde::Serialize, serde::Deserialize)]
+#[component(template_inline = r#"
+<div>
+  <pine-dropdown-menu-root>
+    <pine-dropdown-menu-trigger class="svp-root-t">open</pine-dropdown-menu-trigger>
+    <pine-dropdown-menu-portal>
+      <pine-dropdown-menu-content>
+        <pine-dropdown-menu-sub>
+          <pine-dropdown-menu-sub-trigger class="svp-sub-t">More...</pine-dropdown-menu-sub-trigger>
+          <pine-dropdown-menu-sub-content>
+            <pine-dropdown-menu-item class="svp-keep">Keep open</pine-dropdown-menu-item>
+            <pine-dropdown-menu-item class="svp-close">Close</pine-dropdown-menu-item>
+          </pine-dropdown-menu-sub-content>
+        </pine-dropdown-menu-sub>
+      </pine-dropdown-menu-content>
+    </pine-dropdown-menu-portal>
+  </pine-dropdown-menu-root>
+</div>
+"#)]
+struct SubPreventableSelectHost {}
+#[handlers]
+impl SubPreventableSelectHost {}
+
+#[wasm_bindgen_test]
+async fn dropdown_menu_sub_select_prevent_keeps_parent_and_sub_open() {
+    let host = mount_fixture::<SubPreventableSelectHost>();
+    tick().await;
+
+    host.query_selector(".svp-root-t")
+        .unwrap()
+        .unwrap()
+        .dyn_into::<HtmlElement>()
+        .unwrap()
+        .click();
+    tick().await;
+    tick().await;
+    doc()
+        .query_selector(".svp-sub-t")
+        .unwrap()
+        .unwrap()
+        .dyn_into::<HtmlElement>()
+        .unwrap()
+        .click();
+    for _ in 0..5 {
+        tick().await;
+    }
+
+    let sub_menu = doc()
+        .query_selector("ul.pine-dm-sub-content")
+        .unwrap()
+        .expect("submenu opened");
+    let keep = sub_menu
+        .query_selector(".svp-keep")
+        .unwrap()
+        .expect("prevented submenu item rendered");
+    let select_count = prevent_event_counter(&keep, "pp:select");
+    let body_clicks = install_body_click_counter();
+    keep.clone().dyn_into::<HtmlElement>().unwrap().click();
+    tick().await;
+    tick().await;
+
+    assert_eq!(select_count.get(), 1);
+    assert_eq!(
+        body_clicks.get(),
+        0,
+        "submenu content click is isolated from page-level bubbling"
+    );
+    assert!(
+        doc()
+            .query_selector("ul[role=\"menu\"].pine-dm-content")
+            .unwrap()
+            .is_some(),
+        "preventing submenu item select keeps the parent menu open"
+    );
+    assert!(
+        doc()
+            .query_selector("ul.pine-dm-sub-content")
+            .unwrap()
+            .is_some(),
+        "preventing submenu item select keeps the submenu open"
+    );
+
+    let sub_menu = doc()
+        .query_selector("ul.pine-dm-sub-content")
+        .unwrap()
+        .expect("submenu still open");
+    sub_menu
+        .query_selector(".svp-close")
+        .unwrap()
+        .unwrap()
+        .dyn_into::<HtmlElement>()
+        .unwrap()
+        .click();
+    tick().await;
+    tick().await;
+    assert_eq!(
+        doc()
+            .query_selector(".svp-sub-t")
+            .unwrap()
+            .expect("submenu trigger still rendered during close handoff")
+            .get_attribute("data-state")
+            .as_deref(),
+        Some("closed"),
+        "unprevented submenu item select asks the submenu to close first"
+    );
+    assert!(
+        doc()
+            .query_selector("ul[role=\"menu\"].pine-dm-content")
+            .unwrap()
+            .is_some(),
+        "parent menu remains mounted for the submenu close handoff"
+    );
+
+    sleep_ms(40).await;
+    tick().await;
+    assert!(
+        doc()
+            .query_selector("ul[role=\"menu\"].pine-dm-content")
+            .unwrap()
+            .is_none(),
+        "unprevented submenu item select still closes the parent menu"
+    );
+
+    host.remove();
+}
+
 // Closing the outer menu while a sub is open must NOT leak its
 // teleported portal in `<body>`. Prior bug: Sub's DOM was
 // inside the outer portal, so outer close destroyed Sub's
@@ -1172,10 +1922,8 @@ async fn dropdown_menu_sub_cleanup_on_outer_close() {
 
     // Open outer, open sub, close outer. Repeat — without the
     // cleanup, each cycle adds an orphan `.pine-dm-sub-portal`
-    // to body. Close via a body click (outer Content's
-    // `@click.outside` fires) rather than re-clicking the
-    // trigger — a trigger-click-while-open races with its own
-    // `@click.outside` closer and nets to no state change.
+    // to body. Close via a body click so this stays focused on
+    // the outside-dismiss teardown path.
     let body = doc().body().unwrap();
     for _ in 0..3 {
         let outer_trig = host.query_selector(".sc-root-t").unwrap().unwrap();
@@ -1191,6 +1939,10 @@ async fn dropdown_menu_sub_cleanup_on_outer_close() {
         tick().await;
         body.clone().dyn_into::<HtmlElement>().unwrap().click();
         tick().await;
+        tick().await;
+        // Root close deliberately gives any open submenu one frame
+        // to start its leave before the parent content leaves.
+        sleep_ms(220).await;
         tick().await;
     }
 
@@ -1251,6 +2003,69 @@ async fn dropdown_menu_arrow_mirrors_content_side() {
         arrow.get_attribute("aria-hidden").as_deref(),
         Some("true"),
         "arrow is decorative"
+    );
+
+    host.remove();
+}
+
+#[derive(Default, serde::Serialize, serde::Deserialize)]
+#[component(template_inline = r#"
+<div>
+  <pine-dropdown-menu-root>
+    <pine-dropdown-menu-trigger class="sar-root-t">open</pine-dropdown-menu-trigger>
+    <pine-dropdown-menu-portal>
+      <pine-dropdown-menu-content side="bottom">
+        <pine-dropdown-menu-sub>
+          <pine-dropdown-menu-sub-trigger class="sar-sub-t">More...</pine-dropdown-menu-sub-trigger>
+          <pine-dropdown-menu-sub-content side="left" align="end" side_offset="10">
+            <pine-dropdown-menu-arrow class="sar-arrow"></pine-dropdown-menu-arrow>
+            <pine-dropdown-menu-item>Nested</pine-dropdown-menu-item>
+          </pine-dropdown-menu-sub-content>
+        </pine-dropdown-menu-sub>
+      </pine-dropdown-menu-content>
+    </pine-dropdown-menu-portal>
+  </pine-dropdown-menu-root>
+</div>
+"#)]
+struct SubArrowMenuHost {}
+#[handlers]
+impl SubArrowMenuHost {}
+
+#[wasm_bindgen_test]
+async fn dropdown_menu_sub_arrow_mirrors_subcontent_side() {
+    let host = mount_fixture::<SubArrowMenuHost>();
+    tick().await;
+    host.query_selector(".sar-root-t")
+        .unwrap()
+        .unwrap()
+        .dyn_into::<HtmlElement>()
+        .unwrap()
+        .click();
+    tick().await;
+    tick().await;
+    doc()
+        .query_selector(".sar-sub-t")
+        .unwrap()
+        .unwrap()
+        .dyn_into::<HtmlElement>()
+        .unwrap()
+        .click();
+    for _ in 0..5 {
+        tick().await;
+    }
+
+    let sub_menu = doc()
+        .query_selector("ul.pine-dm-sub-content")
+        .unwrap()
+        .expect("submenu opened");
+    let arrow = sub_menu
+        .query_selector(".sar-arrow")
+        .unwrap()
+        .expect("submenu arrow rendered");
+    assert_eq!(
+        arrow.get_attribute("data-side").as_deref(),
+        Some("left"),
+        "submenu arrow mirrors SubContent's side, not the outer menu's side"
     );
 
     host.remove();
@@ -1720,6 +2535,171 @@ async fn popover_opens_anchors_and_closes_on_escape() {
     host.remove();
 }
 
+#[derive(Default, serde::Serialize, serde::Deserialize)]
+#[component(template_inline = r#"
+<div>
+  <div class="pc-card" @click="card_click">
+    <span class="pc-card-clicks" pp-text="card_clicks"></span>
+    <pine-popover-root>
+      <pine-popover-trigger class="pc-trigger">Open</pine-popover-trigger>
+      <pine-popover-portal>
+        <pine-popover-content>
+          <button class="pc-inside">Inside</button>
+        </pine-popover-content>
+      </pine-popover-portal>
+    </pine-popover-root>
+  </div>
+</div>
+"#)]
+struct PopoverClickableParentHost {
+    card_clicks: u32,
+}
+
+#[handlers]
+impl PopoverClickableParentHost {
+    pub fn card_click(&mut self) {
+        self.card_clicks += 1;
+    }
+}
+
+#[wasm_bindgen_test]
+async fn popover_isolates_trigger_and_content_inside_clickable_parent() {
+    let host = mount_fixture::<PopoverClickableParentHost>();
+    tick().await;
+
+    let body_clicks = install_body_click_counter();
+    let trigger = host
+        .query_selector(".pc-trigger")
+        .unwrap()
+        .expect("trigger rendered");
+
+    trigger.clone().dyn_into::<HtmlElement>().unwrap().click();
+    tick().await;
+    tick().await;
+    assert!(
+        doc()
+            .query_selector("[role=\"dialog\"].pine-popover-content")
+            .unwrap()
+            .is_some(),
+        "trigger click opens the popover"
+    );
+    assert_eq!(text_for(&host, ".pc-card-clicks"), "0");
+    assert_eq!(body_clicks.get(), 0, "trigger click does not leak");
+
+    trigger.clone().dyn_into::<HtmlElement>().unwrap().click();
+    tick().await;
+    tick().await;
+    assert!(
+        doc()
+            .query_selector("[role=\"dialog\"].pine-popover-content")
+            .unwrap()
+            .is_none(),
+        "re-clicking the trigger closes instead of re-opening via outside-dismiss race"
+    );
+    assert_eq!(text_for(&host, ".pc-card-clicks"), "0");
+    assert_eq!(body_clicks.get(), 0, "trigger re-click stays isolated");
+
+    trigger.dyn_into::<HtmlElement>().unwrap().click();
+    tick().await;
+    tick().await;
+    let inside = doc()
+        .query_selector(".pc-inside")
+        .unwrap()
+        .expect("inside button rendered");
+    inside.dyn_into::<HtmlElement>().unwrap().click();
+    tick().await;
+    assert!(
+        doc()
+            .query_selector("[role=\"dialog\"].pine-popover-content")
+            .unwrap()
+            .is_some(),
+        "clicking inside content does not outside-dismiss"
+    );
+    assert_eq!(text_for(&host, ".pc-card-clicks"), "0");
+    assert_eq!(
+        body_clicks.get(),
+        0,
+        "content click does not bubble to the page"
+    );
+
+    doc()
+        .body()
+        .unwrap()
+        .dyn_into::<HtmlElement>()
+        .unwrap()
+        .click();
+    tick().await;
+    tick().await;
+    assert!(
+        doc()
+            .query_selector("[role=\"dialog\"].pine-popover-content")
+            .unwrap()
+            .is_none(),
+        "body click outside closes the popover"
+    );
+    assert_eq!(body_clicks.get(), 1, "outside click still reaches the page");
+
+    host.remove();
+}
+
+#[wasm_bindgen_test]
+async fn popover_outside_events_are_preventable() {
+    let host = mount_fixture::<PopoverClickableParentHost>();
+    tick().await;
+
+    let trigger = host.query_selector(".pc-trigger").unwrap().unwrap();
+    trigger.dyn_into::<HtmlElement>().unwrap().click();
+    tick().await;
+    tick().await;
+
+    let popover = doc()
+        .query_selector("[role=\"dialog\"].pine-popover-content")
+        .unwrap()
+        .expect("popover opened");
+    let pointer_count = prevent_event_counter(&popover, "pp:pointer-down-outside");
+    dispatch_body_pointerdown();
+    tick().await;
+    tick().await;
+    assert_eq!(pointer_count.get(), 1);
+    assert!(
+        doc()
+            .query_selector("[role=\"dialog\"].pine-popover-content")
+            .unwrap()
+            .is_some(),
+        "preventing pp:pointer-down-outside keeps the popover open"
+    );
+
+    let interact_count = prevent_event_counter(&popover, "pp:interact-outside");
+    dispatch_body_click();
+    tick().await;
+    tick().await;
+    assert_eq!(interact_count.get(), 1);
+    assert!(
+        doc()
+            .query_selector("[role=\"dialog\"].pine-popover-content")
+            .unwrap()
+            .is_some(),
+        "preventing pp:interact-outside keeps the popover open"
+    );
+
+    let init = web_sys::KeyboardEventInit::new();
+    init.set_key("Escape");
+    init.set_bubbles(true);
+    let ev = web_sys::KeyboardEvent::new_with_keyboard_event_init_dict("keydown", &init).unwrap();
+    popover.dispatch_event(&ev).unwrap();
+    tick().await;
+    tick().await;
+    assert!(
+        doc()
+            .query_selector("[role=\"dialog\"].pine-popover-content")
+            .unwrap()
+            .is_none(),
+        "Escape still closes after prevented outside events"
+    );
+
+    host.remove();
+}
+
 // ─── PineDialog (pp-model:open round-trip) ────────────────────────
 
 #[derive(Default, serde::Serialize, serde::Deserialize)]
@@ -1996,6 +2976,20 @@ async fn dialog_teleports_traps_focus_and_locks_scroll() {
         .query_selector("[role=\"dialog\"].pine-dialog-content")
         .unwrap()
         .expect("dialog role element rendered");
+    assert_eq!(
+        dialog.get_attribute("pp-transition:enter").as_deref(),
+        Some("pp-tx-fade-scale-base"),
+        "dialog content keeps the built-in card fade-scale transition"
+    );
+    let overlay = doc()
+        .query_selector(".pine-dialog-overlay")
+        .unwrap()
+        .expect("dialog overlay rendered");
+    assert_eq!(
+        overlay.get_attribute("pp-transition:enter").as_deref(),
+        Some("pp-tx-fade-base"),
+        "dialog overlay keeps the built-in background fade transition"
+    );
 
     // ARIA wiring: aria-labelledby + aria-describedby point at
     // rendered Title / Description.

--- a/crates/pocopine-core/src/animate/atoms.css
+++ b/crates/pocopine-core/src/animate/atoms.css
@@ -39,13 +39,11 @@
    * Feels snappier than `cubic-bezier(0, 0, 0.2, 1)` at the same
    * duration. */
   --pp-tx-easing: cubic-bezier(0.16, 1, 0.3, 1);
-  /* `fade` is the overlay/backdrop preset — keep it noticeably
-   * faster than scale/slide so the backdrop snaps in while the
-   * focal Content takes its full duration. The two start
-   * together; fade finishes early and Content's tail overlaps
-   * the settled overlay. Mirrors Material/Apple HIG behaviour. */
-  --pp-tx-fade-duration: 100ms;
-  --pp-tx-fade-easing: cubic-bezier(0.4, 0, 0.2, 1);
+  /* `fade` is the overlay/backdrop preset. Keep it aligned with
+   * the content duration so dimmed backgrounds do not snap in or
+   * disappear before the foreground panel settles. */
+  --pp-tx-fade-duration: 180ms;
+  --pp-tx-fade-easing: cubic-bezier(0.16, 1, 0.3, 1);
   --pp-tx-collapse-duration: 180ms;
   --pp-tx-collapse-easing: cubic-bezier(0.4, 0, 0.2, 1);
   --pp-tx-flip-duration: 320ms;
@@ -56,6 +54,7 @@
 .pp-tx-fade-base {
   transition: opacity var(--pp-tx-fade-duration, var(--pp-tx-duration))
               var(--pp-tx-fade-easing, var(--pp-tx-easing));
+  will-change: opacity;
 }
 .pp-tx-fade-from { opacity: 0; }
 .pp-tx-fade-to   { opacity: 1; }
@@ -76,6 +75,8 @@
               var(--pp-tx-fade-scale-easing, var(--pp-tx-easing)),
               transform var(--pp-tx-fade-scale-duration, var(--pp-tx-duration))
               var(--pp-tx-fade-scale-easing, var(--pp-tx-easing));
+  transform-origin: center;
+  will-change: opacity, transform;
 }
 .pp-tx-fade-scale-from { opacity: 0; transform: scale(0.94); }
 .pp-tx-fade-scale-to   { opacity: 1; transform: scale(1); }

--- a/examples/keep/DEVELOPMENT.md
+++ b/examples/keep/DEVELOPMENT.md
@@ -382,7 +382,9 @@ becomes the default.
 
 Cards open on click, but toolbar buttons inside cards should not open the
 card. Use `@pointerdown.stop` and `@click.stop` on card toolbars and action
-buttons that should consume the event.
+buttons that should consume the event. Pine overlay primitives already isolate
+their own triggers and content, so only the surrounding toolbar or non-overlay
+actions need app-level stops.
 
 The pattern is:
 
@@ -394,8 +396,7 @@ The pattern is:
 
 Use this for:
 
-- color picker buttons,
-- label picker buttons,
+- toolbar groups that mix overlay and non-overlay actions,
 - archive/delete actions,
 - multi-select controls.
 

--- a/examples/keep/src/components/note_card/KeepNoteCard.poco
+++ b/examples/keep/src/components/note_card/KeepNoteCard.poco
@@ -53,7 +53,7 @@
 
   <div class="note-actions" @pointerdown.stop @click.stop>
     <pine-popover-root pp-model:open="label_picker_open">
-      <pine-popover-trigger class="ic-btn" aria-label="Labels" @pointerdown.stop>
+      <pine-popover-trigger class="ic-btn" aria-label="Labels">
         <pine-icon name="tag" size="18"></pine-icon>
       </pine-popover-trigger>
       <pine-popover-portal>
@@ -114,7 +114,7 @@
       <pine-icon name="archive" size="18"></pine-icon>
     </button>
     <pine-dropdown-menu-root>
-      <pine-dropdown-menu-trigger aria-label="More" @pointerdown.stop>
+      <pine-dropdown-menu-trigger aria-label="More">
         <pine-icon name="dots-vertical" size="18"></pine-icon>
       </pine-dropdown-menu-trigger>
       <pine-dropdown-menu-portal>

--- a/examples/website/src/components/showcase/alert_dialog/AlertDialogDemo.poco
+++ b/examples/website/src/components/showcase/alert_dialog/AlertDialogDemo.poco
@@ -7,7 +7,7 @@
       </pine-alert-dialog-trigger>
       <pine-alert-dialog-portal>
         <pine-alert-dialog-overlay></pine-alert-dialog-overlay>
-        <pine-alert-dialog-content pp-transition="none">
+        <pine-alert-dialog-content>
           <pine-alert-dialog-title>Destroy project?</pine-alert-dialog-title>
           <pine-alert-dialog-description>
             All files will be permanently removed. This cannot be undone.

--- a/examples/website/src/components/showcase/alert_dialog/alert_dialog.css
+++ b/examples/website/src/components/showcase/alert_dialog/alert_dialog.css
@@ -17,13 +17,6 @@ pine-alert-dialog-content {
   justify-content: center;
   z-index: 51;
   pointer-events: none;
-  opacity: 1;
-  transition: opacity 160ms ease-out;
-}
-@starting-style {
-  pine-alert-dialog-content {
-    opacity: 0;
-  }
 }
 .pine-alert-dialog-content {
   pointer-events: auto;
@@ -35,7 +28,7 @@ pine-alert-dialog-content {
   border-radius: var(--radius);
   padding: 1.5rem;
   box-shadow: var(--shadow);
+  transform-origin: center;
 }
 .pine-alert-dialog-title       { font-size: 1.25rem; font-weight: 600; margin: 0 0 0.25rem; }
 .pine-alert-dialog-description { color: var(--fg-muted); margin: 0 0 1rem; }
-

--- a/examples/website/src/components/showcase/dialog/DialogDemo.poco
+++ b/examples/website/src/components/showcase/dialog/DialogDemo.poco
@@ -7,10 +7,7 @@
       </pine-dialog-trigger>
       <pine-dialog-portal>
         <pine-dialog-overlay></pine-dialog-overlay>
-        <!-- `pp-transition="none"` disables the preset's class-swap
-             machinery so the demo CSS can drive the enter animation
-             via native `@starting-style`. See styles.css. -->
-        <pine-dialog-content pp-transition="none">
+        <pine-dialog-content>
           <pine-dialog-title>Delete file?</pine-dialog-title>
           <pine-dialog-description>This action cannot be undone.</pine-dialog-description>
           <div class="row" style="margin-top:1rem;justify-content:flex-end">

--- a/examples/website/src/components/showcase/dialog/dialog.css
+++ b/examples/website/src/components/showcase/dialog/dialog.css
@@ -10,16 +10,10 @@
   background: rgba(0, 0, 0, 0.5);
   z-index: 50;
 }
-/* GPU-friendly opacity-only fade. `opacity` is one of the two
- * properties browsers composite on their own layer (the other is
- * `transform`) — see Chromium's GPU-accelerated compositing
- * architecture. Dropping `scale` here keeps the motion on the
- * compositor's fast path and feels snappier than the
- * scale + opacity combo, even at a slightly longer duration.
- *
- * `pp-transition="none"` on the tag disables the preset
- * machinery so the class-swap doesn't fight `@starting-style`.
- */
+/* The custom element is only the viewport centering wrapper. The
+ * rendered `.pine-dialog-content` card keeps Pine's default
+ * fade-scale transition, so transform animation stays on the panel
+ * instead of moving the full-screen wrapper. */
 pine-dialog-content {
   position: fixed;
   inset: 0;
@@ -28,13 +22,6 @@ pine-dialog-content {
   justify-content: center;
   z-index: 51;
   pointer-events: none;
-  opacity: 1;
-  transition: opacity 160ms ease-out;
-}
-@starting-style {
-  pine-dialog-content {
-    opacity: 0;
-  }
 }
 .pine-dialog-content {
   pointer-events: auto;
@@ -45,7 +32,7 @@ pine-dialog-content {
   border-radius: var(--radius);
   padding: 1.5rem;
   box-shadow: var(--shadow);
+  transform-origin: center;
 }
 .pine-dialog-title       { font-size: 1.25rem; font-weight: 600; margin: 0 0 0.25rem; }
 .pine-dialog-description { color: var(--fg-muted); margin: 0 0 1rem; }
-


### PR DESCRIPTION
## Summary
- Add shared preventable outside-interaction hooks for Popover and DropdownMenu, with trigger/content isolation so overlays behave correctly inside clickable parents.
- Tighten DropdownMenu submenu behavior: submenu content re-anchors on reopen, submenu clicks are isolated, and root close now gives open submenus a frame to start their exit before the parent content unmounts.
- Smooth overlay/dialog motion by aligning fade timing, keeping card fade-scale animation on dialog content, and updating Keep/demo docs and markup for the hardened primitive contract.

## Self-review
- Reviewed the submenu close sequencing specifically for regressions in normal root close behavior; the delayed parent close only activates when `open_submenus > 0`, so plain dropdown dismissal remains immediate.
- Checked the submenu portal cleanup path after adding the close handoff; the browser regression repeats open/sub-open/outside-close cycles and verifies no orphan `.pine-dm-sub-portal` nodes remain.
- Checked preventable select/outside event behavior so custom `preventDefault()` hooks still keep menus/popovers open, while unprevented submenu item selection still closes the parent after the handoff frame.

## Verification
- `cargo fmt --check`
- `cargo check -p pine`
- `cargo clippy -p pine --all-targets`
- `wasm-pack test --firefox --headless crates/pine` (`118 passed`)
- `cargo check -p keep-example --target wasm32-unknown-unknown`
- `cargo test -p keep-example`
- `git diff --check origin/main...HEAD`

Refs #78