### PR TITLE
Fix sync CRUD wasm test build

### DIFF
--- a/crates/pocopine-sync-crud/src/transaction.rs
+++ b/crates/pocopine-sync-crud/src/transaction.rs
@@ -77,7 +77,9 @@ impl TransactionOptions {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(not(target_arch = "wasm32"))]
     use pocopine_sync::SyncError;
+    #[cfg(not(target_arch = "wasm32"))]
     use std::sync::{Arc, Mutex};
 
     #[test]
@@ -113,6 +115,7 @@ mod tests {
         assert_eq!(tx.raw().log, vec!["created"]);
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     #[tokio::test]
     async fn transaction_options_run_commits_on_success_and_rolls_back_on_error() {
         #[derive(Clone, Default)]


### PR DESCRIPTION
## Summary
- gate the Tokio-backed transaction unit test to host targets
- gate host-only test imports so wasm test compilation stays warning-free

## Verification
- cargo fmt
- cargo test -p pocopine-sync-crud
- cargo test -p pocopine-sync-crud --target wasm32-unknown-unknown --no-run
- cargo clippy -p pocopine-sync-crud --all-targets -- -D warnings