### PR TITLE
RFC 081: Component handle refs (Phase 1 + Phase 2)

### DIFF
--- a/crates/pocopine-core/src/lifecycle.rs
+++ b/crates/pocopine-core/src/lifecycle.rs
@@ -264,6 +264,15 @@ impl<'a> Refs<'a> {
     pub fn get_as<T: JsCast>(&self, name: &str) -> Option<T> {
         self.get(name).and_then(|el| el.dyn_into().ok())
     }
+
+    /// Look up a child-component handle by `pp-ref="name"`
+    /// (RFC 081). Returns `None` when the named ref isn't a
+    /// child-component host or the registered child's Rust
+    /// type doesn't match `T`. Mirrors the free-fn
+    /// [`crate::refs::get_component`].
+    pub fn get_component<T: 'static>(&self, name: &str) -> Option<crate::handle::Handle<T>> {
+        crate::refs::get_component_on::<T>(self.scope_id, name)
+    }
 }
 
 impl<'a> From<LifecycleContext<'a>> for Refs<'a> {

--- a/crates/pocopine-core/src/mount.rs
+++ b/crates/pocopine-core/src/mount.rs
@@ -55,6 +55,17 @@ use crate::templates::{is_registered, template_for};
 const SCOPE_ID_KEY: &str = "__pp_scope_id";
 const SCOPE_PROXY_KEY: &str = "__pp_scope_proxy";
 const SCOPE_BORROWED_KEY: &str = "__pp_scope_borrowed";
+/// RFC 081 — stamped on a child component's custom-element
+/// host (the outer `<keep-note-body>` tag, not the inner
+/// template root). Carries the child scope id so a parent's
+/// `refs::get_component::<T>("name")` can resolve a typed
+/// handle through the parent's `pp-ref="name"` entry. Kept
+/// distinct from `SCOPE_ID_KEY` so `fire_mount_hook` /
+/// `release_subtree` (which iterate every element with
+/// `SCOPE_ID_KEY`) don't see the host twice and double-fire
+/// `on_mount` / `on_unmount` / plugin events for the same
+/// scope.
+const HOST_CHILD_SCOPE_ID_KEY: &str = "__pp_host_child_scope_id";
 const EFFECTS_KEY: &str = "__pp_effects";
 const LISTENERS_KEY: &str = "__pp_listeners";
 const WALKED_KEY: &str = "__pp_walked";
@@ -127,6 +138,34 @@ pub fn bind_scope_id_only(el: &Element, scope_id: ScopeId) {
 pub fn scope_id_of_element(el: &Element) -> Option<ScopeId> {
     let id_num = get_private(el, SCOPE_ID_KEY).and_then(|v| v.as_f64())?;
     Some(ScopeId(id_num as u64))
+}
+
+/// RFC 081 — when `el` is the custom-element host of a child
+/// component, returns the child scope id stamped at mount
+/// time by [`mount_component`] /
+/// [`try_mount_component_as`]. Returns `None` for non-host
+/// elements (plain DOM, template roots — those carry
+/// `SCOPE_ID_KEY` and resolve through
+/// [`scope_id_of_element`] instead). The two keys are kept
+/// distinct so `fire_mount_hook` and `release_subtree` (which
+/// iterate every element with `SCOPE_ID_KEY`) never see the
+/// host as a duplicate copy of the child's scope.
+pub fn host_child_scope_id_of(el: &Element) -> Option<ScopeId> {
+    let id_num = get_private(el, HOST_CHILD_SCOPE_ID_KEY).and_then(|v| v.as_f64())?;
+    Some(ScopeId(id_num as u64))
+}
+
+/// RFC 081 — write the host-child stamp directly. Internal
+/// helper used by [`mount_component`] and its `pp-as` sibling,
+/// also exposed for tests that simulate a mounted child host
+/// without going through the full mount path.
+#[doc(hidden)]
+pub fn bind_host_child_scope(el: &Element, scope_id: ScopeId) {
+    set_private(
+        el,
+        HOST_CHILD_SCOPE_ID_KEY,
+        &JsValue::from_f64(scope_id.0 as f64),
+    );
 }
 
 /// Pin a **borrowed** scope. Same lookup semantics as `bind_scope_to`,
@@ -375,15 +414,19 @@ fn mount_component(
         stamp_plugin_metadata(&root, tag, scope.id, plugin_hooks, mount_start_ms);
         let _ = root.remove_attribute("data-pp-scope-id");
 
-        // RFC 081 — stamp the *custom-element host* with the
-        // child's scope id too. Lets a parent that tags this
-        // element with `pp-ref="name"` resolve a typed
+        // RFC 081 — stamp the *custom-element host* with a
+        // separate `HOST_CHILD_SCOPE_ID_KEY` so a parent's
+        // `pp-ref="name"` on this tag can resolve a typed
         // [`Handle<Child>`](crate::handle::Handle) via
-        // [`crate::refs::get_component`] without DOM-walking
-        // the inner template. The host doesn't carry
-        // `SCOPE_PROXY_KEY` — proxy reads still go through
-        // the bound template root.
-        set_private(el, SCOPE_ID_KEY, &JsValue::from_f64(scope.id.0 as f64));
+        // [`crate::refs::get_component`]. Distinct from
+        // `SCOPE_ID_KEY` (which `fire_mount_hook` and
+        // `release_subtree` iterate) so the host doesn't
+        // double-fire the child's lifecycle hooks.
+        set_private(
+            el,
+            HOST_CHILD_SCOPE_ID_KEY,
+            &JsValue::from_f64(scope.id.0 as f64),
+        );
 
         // Fallthrough (RFC-010).
         apply_fallthrough_attrs(el, &root, &scope);
@@ -556,13 +599,16 @@ fn try_mount_component_as(el: &Element, tag: &str) -> bool {
     stamp_plugin_metadata(&user_root, tag, scope.id, plugin_hooks, mount_start_ms);
     let _ = user_root.remove_attribute("data-pp-scope-id");
 
-    // RFC 081 — stamp the host (outer custom-tag element)
-    // with the child's scope id too, mirroring the normal
-    // mount path. Lets a parent reach a typed
-    // [`Handle<Child>`](crate::handle::Handle) via
-    // [`crate::refs::get_component`] on a pp-ref-tagged
-    // pp-as host.
-    set_private(el, SCOPE_ID_KEY, &JsValue::from_f64(scope.id.0 as f64));
+    // RFC 081 — same host stamp as the normal mount path
+    // (see `HOST_CHILD_SCOPE_ID_KEY` doc). Distinct from
+    // `SCOPE_ID_KEY` so lifecycle dispatch / teardown don't
+    // visit the host as if it were a second copy of the
+    // child's scope.
+    set_private(
+        el,
+        HOST_CHILD_SCOPE_ID_KEY,
+        &JsValue::from_f64(scope.id.0 as f64),
+    );
 
     let plan_root = pp_as_render_root(&user_root);
 

--- a/crates/pocopine-core/src/mount.rs
+++ b/crates/pocopine-core/src/mount.rs
@@ -375,6 +375,16 @@ fn mount_component(
         stamp_plugin_metadata(&root, tag, scope.id, plugin_hooks, mount_start_ms);
         let _ = root.remove_attribute("data-pp-scope-id");
 
+        // RFC 081 — stamp the *custom-element host* with the
+        // child's scope id too. Lets a parent that tags this
+        // element with `pp-ref="name"` resolve a typed
+        // [`Handle<Child>`](crate::handle::Handle) via
+        // [`crate::refs::get_component`] without DOM-walking
+        // the inner template. The host doesn't carry
+        // `SCOPE_PROXY_KEY` — proxy reads still go through
+        // the bound template root.
+        set_private(el, SCOPE_ID_KEY, &JsValue::from_f64(scope.id.0 as f64));
+
         // Fallthrough (RFC-010).
         apply_fallthrough_attrs(el, &root, &scope);
 
@@ -545,6 +555,14 @@ fn try_mount_component_as(el: &Element, tag: &str) -> bool {
     set_private(&user_root, SCOPE_PROXY_KEY, &proxy);
     stamp_plugin_metadata(&user_root, tag, scope.id, plugin_hooks, mount_start_ms);
     let _ = user_root.remove_attribute("data-pp-scope-id");
+
+    // RFC 081 — stamp the host (outer custom-tag element)
+    // with the child's scope id too, mirroring the normal
+    // mount path. Lets a parent reach a typed
+    // [`Handle<Child>`](crate::handle::Handle) via
+    // [`crate::refs::get_component`] on a pp-ref-tagged
+    // pp-as host.
+    set_private(el, SCOPE_ID_KEY, &JsValue::from_f64(scope.id.0 as f64));
 
     let plan_root = pp_as_render_root(&user_root);
 

--- a/crates/pocopine-core/src/refs.rs
+++ b/crates/pocopine-core/src/refs.rs
@@ -137,6 +137,66 @@ pub fn get_component_on<T: 'static>(parent_scope: ScopeId, name: &str) -> Option
     Some(Handle::new(rc, child_scope))
 }
 
+/// Compile-time-named ref accessor (RFC 081 Layer 1). Carries the
+/// scope id + the ref name baked in by `#[component]` codegen, so
+/// callers reach all three resolution flavours through one entry
+/// point without restating the name:
+///
+/// ```ignore
+/// fn save(&self, refs: KeepNoteFormRefs) {
+///     let el     = refs.body().element();                   // Option<Element>
+///     let input  = refs.title_input().as_::<HtmlInputElement>(); // Option<HtmlInputElement>
+///     let body   = refs.body().component::<KeepNoteBody>(); // Option<Handle<KeepNoteBody>>
+/// }
+/// ```
+///
+/// Constructed by macro-emitted accessors — there's no reason for
+/// authors to build one by hand. The `name` field is a
+/// `&'static str` so a typo in a generated method body would
+/// surface at macro-expand time (before user code compiles).
+#[derive(Clone, Copy)]
+pub struct RefAccessor {
+    scope_id: ScopeId,
+    name: &'static str,
+}
+
+impl RefAccessor {
+    /// Internal constructor — macro-emitted only. Not part of the
+    /// user-facing surface; calling this from outside generated
+    /// code defeats the compile-time name check the codegen
+    /// provides.
+    #[doc(hidden)]
+    pub fn __new(scope_id: ScopeId, name: &'static str) -> Self {
+        Self { scope_id, name }
+    }
+
+    /// The `pp-ref` name this accessor was generated for. Useful
+    /// for diagnostics / tracing; not part of the typical call
+    /// site.
+    pub fn name(&self) -> &'static str {
+        self.name
+    }
+
+    /// Untyped DOM element. Equivalent to
+    /// [`get_on(scope, name)`](get_on) but with the name fixed.
+    pub fn element(&self) -> Option<Element> {
+        get_on(self.scope_id, self.name)
+    }
+
+    /// `JsCast`-downcast variant. Equivalent to
+    /// [`get_as`] when called from the current scope.
+    pub fn as_<T: JsCast>(&self) -> Option<T> {
+        self.element()?.dyn_into::<T>().ok()
+    }
+
+    /// Typed child-component handle. Equivalent to
+    /// [`get_component_on::<T>(scope, name)`](get_component_on)
+    /// with the name fixed.
+    pub fn component<T: 'static>(&self) -> Option<Handle<T>> {
+        get_component_on::<T>(self.scope_id, self.name)
+    }
+}
+
 /// Build a plain JS object snapshot of every ref registered on
 /// `scope_id`. Used to resolve the `$refs` magic — templates can read
 /// `$refs.search` without importing anything.

--- a/crates/pocopine-core/src/refs.rs
+++ b/crates/pocopine-core/src/refs.rs
@@ -123,12 +123,17 @@ pub fn get_component<T: 'static>(name: &str) -> Option<Handle<T>> {
 /// [`get_on`]).
 pub fn get_component_on<T: 'static>(parent_scope: ScopeId, name: &str) -> Option<Handle<T>> {
     let el = get_on(parent_scope, name)?;
-    let child_scope = crate::mount::scope_id_of_element(&el)?;
-    // Reject plain DOM elements pinned in the same scope as the
-    // caller — those carry no SCOPE_ID_KEY, but a template root
-    // happens to share its component's scope id with its parent's
-    // ref entry in rare layouts; this guard keeps "ref to self"
-    // from resolving as "child of self".
+    // RFC 081 — primary path: the element is a child
+    // component's custom-element host, stamped at mount
+    // time with `HOST_CHILD_SCOPE_ID_KEY`. Falls back to
+    // `SCOPE_ID_KEY` for the rare case where a
+    // `pp-ref` lands directly on a scope-bound element
+    // that ISN'T a host (e.g. an inner template root
+    // bound via `bind_scope_to`). The self-scope guard
+    // catches the case where the ref points back at the
+    // parent's own template root.
+    let child_scope = crate::mount::host_child_scope_id_of(&el)
+        .or_else(|| crate::mount::scope_id_of_element(&el))?;
     if child_scope == parent_scope {
         return None;
     }

--- a/crates/pocopine-core/src/refs.rs
+++ b/crates/pocopine-core/src/refs.rs
@@ -1,6 +1,18 @@
 //! Template refs — `pp-ref="name"` pins the decorated element under
 //! its enclosing scope so Rust handlers can reach it imperatively.
 //!
+//! Two resolution flavours are available on the same `pp-ref` name:
+//!
+//! 1. **DOM element** ([`get`] / [`get_as`]). The element decorated
+//!    with `pp-ref="search"` returns from `refs::get("search")` as an
+//!    `Element`; `refs::get_as::<HtmlInputElement>("search")` downcasts.
+//! 2. **Typed child-component handle** ([`get_component`]). When the
+//!    decorated element happens to be a child *component*'s host
+//!    (RFC 081), `refs::get_component::<Child>("body")` resolves a
+//!    [`Handle<Child>`](crate::handle::Handle) for the child's Rust
+//!    state — same primitive used by `Parent<T>` / `this::<T>()`,
+//!    mirror direction.
+//!
 //! ```ignore
 //! use pocopine::prelude::*;
 //! use pocopine::refs;
@@ -9,8 +21,16 @@
 //! #[handlers]
 //! impl SearchBar {
 //!     pub fn init(&mut self) {
+//!         // DOM element flavour
 //!         if let Some(input) = refs::get_as::<HtmlInputElement>("search") {
 //!             let _ = input.focus();
+//!         }
+//!     }
+//!
+//!     pub fn save(&mut self) {
+//!         // Child-component handle flavour
+//!         if let Some(body) = refs::get_component::<KeepNoteBody>("body") {
+//!             let md = body.with(|b| b.editor()?.get::<Markdown>().ok())?;
 //!         }
 //!     }
 //! }
@@ -27,6 +47,7 @@ use std::collections::HashMap;
 use wasm_bindgen::JsCast;
 use web_sys::Element;
 
+use crate::handle::Handle;
 use crate::reactive::ScopeId;
 use crate::scope::current_scope_id;
 
@@ -72,6 +93,48 @@ pub fn clear_scope(scope_id: ScopeId) {
     REFS.with(|r| {
         r.borrow_mut().remove(&scope_id);
     });
+}
+
+/// Resolve a typed [`Handle<T>`] for the child component whose host
+/// element was tagged `pp-ref="name"` in the current handler's scope.
+///
+/// Returns `None` when:
+/// - no `pp-ref` of that name exists in the current scope (also
+///   covered by [`get`] returning `None`),
+/// - the tagged element is a plain DOM element rather than a child
+///   component host,
+/// - the registered child component's Rust type doesn't match `T`,
+/// - the call site has no live scope context (e.g. fired from a
+///   `tick::next` continuation after the parent's handler returned).
+///
+/// Implementation: the host element of every mounted child component
+/// carries the child's `SCOPE_ID_KEY` (set in
+/// [`crate::mount::mount_component`]); this helper reads it via
+/// [`crate::mount::scope_id_of_element`] and looks up the typed
+/// component state via [`crate::scope::Scope::typed`]. No DOM walk.
+pub fn get_component<T: 'static>(name: &str) -> Option<Handle<T>> {
+    let id = current_scope_id()?;
+    get_component_on::<T>(id, name)
+}
+
+/// Explicit-scope variant of [`get_component`]. Useful when the
+/// calling code already holds a [`ScopeId`] (e.g. cached at on_ready
+/// time for use inside a `tick::next` continuation, mirroring
+/// [`get_on`]).
+pub fn get_component_on<T: 'static>(parent_scope: ScopeId, name: &str) -> Option<Handle<T>> {
+    let el = get_on(parent_scope, name)?;
+    let child_scope = crate::mount::scope_id_of_element(&el)?;
+    // Reject plain DOM elements pinned in the same scope as the
+    // caller — those carry no SCOPE_ID_KEY, but a template root
+    // happens to share its component's scope id with its parent's
+    // ref entry in rare layouts; this guard keeps "ref to self"
+    // from resolving as "child of self".
+    if child_scope == parent_scope {
+        return None;
+    }
+    let scope = crate::scope::Scope::find(child_scope)?;
+    let rc = scope.typed::<T>()?;
+    Some(Handle::new(rc, child_scope))
 }
 
 /// Build a plain JS object snapshot of every ref registered on

--- a/crates/pocopine-core/tests/component_refs.rs
+++ b/crates/pocopine-core/tests/component_refs.rs
@@ -1,0 +1,194 @@
+//! RFC 081 — `refs::get_component` (parent reaches a typed
+//! `Handle<Child>` via the same `pp-ref="name"` directive used
+//! for DOM element refs).
+//!
+//! Tests exercise the resolution layer directly: manually build
+//! a child scope, stamp the simulated host element with the
+//! child's `SCOPE_ID_KEY` (mirrors what
+//! [`crate::mount::mount_component`] now does), register the
+//! host under a parent scope's ref table, and call
+//! [`crate::refs::get_component_on`].
+//!
+//! The full template-walker round-trip (parent's `.poco`
+//! mounting `<test-child pp-ref="body">`) is covered by the
+//! Phase 3 integration suite once a worked example lands.
+
+#![cfg(target_arch = "wasm32")]
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use js_sys::Array;
+use pocopine_core::{refs, ComponentState, Scope};
+use wasm_bindgen::JsValue;
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+// These tests construct real `Element`s (`document.create_element`)
+// to simulate a child-component host with `SCOPE_ID_KEY` stamped on
+// it. Node has no DOM, so route the suite through the browser
+// runner via `wasm-pack test --firefox --headless` (matches
+// `svg_namespace.rs`).
+wasm_bindgen_test_configure!(run_in_browser);
+
+/// Minimal stand-in for a component's state. Lets the tests
+/// create real scopes via [`Scope::new`] without dragging in
+/// the `#[component]` macro.
+#[derive(Default)]
+struct ChildComponent {
+    label: String,
+}
+
+impl ComponentState for ChildComponent {
+    fn get(&self, _key: &str) -> JsValue {
+        JsValue::UNDEFINED
+    }
+    fn set(&mut self, _key: &str, _value: JsValue) {}
+    fn keys(&self) -> &'static [&'static str] {
+        &[]
+    }
+    fn invoke(&mut self, _key: &str, _args: &Array) -> JsValue {
+        JsValue::UNDEFINED
+    }
+}
+
+#[derive(Default)]
+struct ParentComponent;
+
+impl ComponentState for ParentComponent {
+    fn get(&self, _key: &str) -> JsValue {
+        JsValue::UNDEFINED
+    }
+    fn set(&mut self, _key: &str, _value: JsValue) {}
+    fn keys(&self) -> &'static [&'static str] {
+        &[]
+    }
+    fn invoke(&mut self, _key: &str, _args: &Array) -> JsValue {
+        JsValue::UNDEFINED
+    }
+}
+
+#[derive(Default)]
+struct UnrelatedType;
+
+impl ComponentState for UnrelatedType {
+    fn get(&self, _key: &str) -> JsValue {
+        JsValue::UNDEFINED
+    }
+    fn set(&mut self, _key: &str, _value: JsValue) {}
+    fn keys(&self) -> &'static [&'static str] {
+        &[]
+    }
+    fn invoke(&mut self, _key: &str, _args: &Array) -> JsValue {
+        JsValue::UNDEFINED
+    }
+}
+
+fn make_host(scope_id_to_stamp: Option<pocopine_core::reactive::ScopeId>) -> web_sys::Element {
+    let doc = web_sys::window()
+        .and_then(|w| w.document())
+        .expect("test runs in wasm-pack node with document");
+    let el = doc.create_element("div").expect("create_element succeeds");
+    if let Some(scope_id) = scope_id_to_stamp {
+        pocopine_core::mount::bind_scope_id_only(&el, scope_id);
+    }
+    el
+}
+
+#[wasm_bindgen_test]
+fn get_component_returns_typed_handle_for_named_child() {
+    let child_state = Rc::new(RefCell::new(ChildComponent {
+        label: "hello".into(),
+    }));
+    let child_scope = Scope::new(child_state);
+    let parent_state = Rc::new(RefCell::new(ParentComponent));
+    let parent_scope = Scope::new(parent_state);
+
+    let host = make_host(Some(child_scope.id));
+    refs::register(parent_scope.id, "body", &host);
+
+    let handle =
+        refs::get_component_on::<ChildComponent>(parent_scope.id, "body").expect("handle resolves");
+    let observed = handle.with(|c| c.label.clone());
+    assert_eq!(observed, "hello", "handle reads child state");
+}
+
+#[wasm_bindgen_test]
+fn get_component_returns_none_for_mismatched_type() {
+    let child_state = Rc::new(RefCell::new(ChildComponent::default()));
+    let child_scope = Scope::new(child_state);
+    let parent_state = Rc::new(RefCell::new(ParentComponent));
+    let parent_scope = Scope::new(parent_state);
+
+    let host = make_host(Some(child_scope.id));
+    refs::register(parent_scope.id, "body", &host);
+
+    let wrong = refs::get_component_on::<UnrelatedType>(parent_scope.id, "body");
+    assert!(
+        wrong.is_none(),
+        "wrong type at the registered scope must miss, not coerce"
+    );
+}
+
+#[wasm_bindgen_test]
+fn get_component_returns_none_for_plain_dom_ref() {
+    // pp-ref on a plain element (not a child component host) —
+    // no SCOPE_ID_KEY stamped. Lookup must miss cleanly.
+    let parent_state = Rc::new(RefCell::new(ParentComponent));
+    let parent_scope = Scope::new(parent_state);
+
+    let host = make_host(None);
+    refs::register(parent_scope.id, "title_input", &host);
+
+    let missed = refs::get_component_on::<ChildComponent>(parent_scope.id, "title_input");
+    assert!(
+        missed.is_none(),
+        "plain DOM ref must not resolve as a child"
+    );
+}
+
+#[wasm_bindgen_test]
+fn get_component_returns_none_for_unknown_ref() {
+    let parent_state = Rc::new(RefCell::new(ParentComponent));
+    let parent_scope = Scope::new(parent_state);
+
+    let missed = refs::get_component_on::<ChildComponent>(parent_scope.id, "never_registered");
+    assert!(missed.is_none(), "unknown ref name returns None");
+}
+
+#[wasm_bindgen_test]
+fn get_component_rejects_self_scope() {
+    // Same-scope element (the parent's own template root)
+    // would also carry SCOPE_ID_KEY. The lookup guards
+    // against returning "self as child."
+    let parent_state = Rc::new(RefCell::new(ParentComponent));
+    let parent_scope = Scope::new(parent_state);
+
+    let host = make_host(Some(parent_scope.id));
+    refs::register(parent_scope.id, "self_ref", &host);
+
+    let missed = refs::get_component_on::<ParentComponent>(parent_scope.id, "self_ref");
+    assert!(
+        missed.is_none(),
+        "ref pointing to the same scope must not be treated as a child"
+    );
+}
+
+#[wasm_bindgen_test]
+fn get_component_evicts_with_clear_scope() {
+    let child_state = Rc::new(RefCell::new(ChildComponent::default()));
+    let child_scope = Scope::new(child_state);
+    let parent_state = Rc::new(RefCell::new(ParentComponent));
+    let parent_scope = Scope::new(parent_state);
+
+    let host = make_host(Some(child_scope.id));
+    refs::register(parent_scope.id, "body", &host);
+    assert!(refs::get_component_on::<ChildComponent>(parent_scope.id, "body").is_some());
+
+    refs::clear_scope(parent_scope.id);
+
+    let after = refs::get_component_on::<ChildComponent>(parent_scope.id, "body");
+    assert!(
+        after.is_none(),
+        "clear_scope must also drop the component-ref lookup"
+    );
+}

--- a/crates/pocopine-core/tests/component_refs.rs
+++ b/crates/pocopine-core/tests/component_refs.rs
@@ -89,7 +89,10 @@ fn make_host(scope_id_to_stamp: Option<pocopine_core::reactive::ScopeId>) -> web
         .expect("test runs in wasm-pack node with document");
     let el = doc.create_element("div").expect("create_element succeeds");
     if let Some(scope_id) = scope_id_to_stamp {
-        pocopine_core::mount::bind_scope_id_only(&el, scope_id);
+        // RFC 081 — mount_component stamps the child host with
+        // HOST_CHILD_SCOPE_ID_KEY (distinct from SCOPE_ID_KEY
+        // so the host doesn't show up to fire_mount_hook).
+        pocopine_core::mount::bind_host_child_scope(&el, scope_id);
     }
     el
 }

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -940,6 +940,27 @@ pub(crate) fn kebab_case(ident: &str) -> String {
     out
 }
 
+/// RFC 081 — convert a `pp-ref` name to a valid Rust method
+/// identifier for the generated `<ComponentName>Refs` struct.
+/// Kebab/dot/colon to underscore, leading non-alpha to a
+/// prefixed underscore. Names that already look like snake_case
+/// (e.g. `form_root`, `title_input`) pass through unchanged.
+pub(crate) fn normalize_ref_method_ident(name: &str) -> String {
+    let mut out = String::with_capacity(name.len() + 1);
+    for (i, c) in name.chars().enumerate() {
+        let mapped = match c {
+            'a'..='z' | 'A'..='Z' | '_' => c,
+            '0'..='9' if i > 0 => c,
+            _ => '_',
+        };
+        out.push(mapped);
+    }
+    if out.starts_with(|c: char| c.is_ascii_digit()) {
+        out.insert(0, '_');
+    }
+    out
+}
+
 struct ClientModuleArgs {
     file: Option<LitStr>,
     name: Option<LitStr>,
@@ -2095,6 +2116,7 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
             slot_fragment_fns: proc_macro2::TokenStream::new(),
             if_body_fns: proc_macro2::TokenStream::new(),
             specialized_mount_body: None,
+            ref_names: Vec::new(),
         });
 
     // Build the literal to feed into `compile_template`:
@@ -2392,9 +2414,78 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     };
 
+    // RFC 081 — generated `<ComponentName>Refs<'a>` struct.
+    // One method per `pp-ref="name"` in the template. Each
+    // returns a typed `RefAccessor` carrying (scope_id, name)
+    // so callers reach `.element()` / `.as_::<T>()` /
+    // `.component::<T>()` with the name fixed at codegen time
+    // (typo → unknown method, fails to build).
+    //
+    // Wired as a `From<LifecycleContext<'a>>` extractor so
+    // handlers take the typed struct directly:
+    //
+    //     fn on_ready(&self, refs: KeepNoteFormRefs) {
+    //         let body = refs.body().component::<KeepNoteBody>()?;
+    //     }
+    //
+    // Always emitted (even for components with zero pp-refs)
+    // for two reasons: keeps the From extractor extractor-name
+    // discoverable, and the empty struct is dead-code-eliminable
+    // when no handler consumes it.
+    let refs_struct_ident =
+        proc_macro2::Ident::new(&format!("{ident_str}Refs"), struct_ident.span());
+    let ref_accessor_methods = template_plan.ref_names.iter().map(|name| {
+        let method_ident =
+            proc_macro2::Ident::new(&normalize_ref_method_ident(name), struct_ident.span());
+        let name_lit = proc_macro2::Literal::string(name);
+        quote! {
+            /// Typed accessor for the
+            #[doc = #name_lit]
+            /// `pp-ref`. Returns a [`::pocopine::__private::RefAccessor`]
+            /// carrying the scope id + ref name baked in; call
+            /// `.element()`, `.as_::<T>()`, or `.component::<T>()`
+            /// to resolve.
+            pub fn #method_ident(&self) -> ::pocopine::__private::RefAccessor {
+                ::pocopine::__private::RefAccessor::__new(self.scope_id, #name_lit)
+            }
+        }
+    });
+    let refs_struct_tokens = quote! {
+        /// Macro-generated typed refs struct (RFC 081 Phase 2).
+        /// One method per `pp-ref="name"` in the component's
+        /// template. Reach via the `From<LifecycleContext>`
+        /// extractor: write
+        /// `fn on_ready(&self, refs: #refs_struct_ident)` and
+        /// call `refs.<name>().component::<T>()` etc.
+        #[doc(hidden)]
+        #[derive(Clone, Copy)]
+        pub struct #refs_struct_ident<'__poc_refs> {
+            scope_id: ::pocopine::__private::ScopeId,
+            _m: ::core::marker::PhantomData<&'__poc_refs ()>,
+        }
+
+        impl<'__poc_refs> #refs_struct_ident<'__poc_refs> {
+            #(#ref_accessor_methods)*
+        }
+
+        impl<'__poc_refs> ::core::convert::From<
+            ::pocopine::__private::LifecycleContext<'__poc_refs>,
+        > for #refs_struct_ident<'__poc_refs> {
+            fn from(
+                ctx: ::pocopine::__private::LifecycleContext<'__poc_refs>,
+            ) -> Self {
+                Self {
+                    scope_id: ctx.scope_id,
+                    _m: ::core::marker::PhantomData,
+                }
+            }
+        }
+    };
+
     let out = quote! {
         #input
         #template_plan_item_tokens
+        #refs_struct_tokens
 
         // RFC 049 — marker traits + blanket impls for each
         // #[slot(accepts=...)] / #[slot(only=...)] declared on

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -2434,13 +2434,51 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
     // when no handler consumes it.
     let refs_struct_ident =
         proc_macro2::Ident::new(&format!("{ident_str}Refs"), struct_ident.span());
-    let ref_accessor_methods = template_plan.ref_names.iter().map(|name| {
-        let method_ident =
-            proc_macro2::Ident::new(&normalize_ref_method_ident(name), struct_ident.span());
-        let name_lit = proc_macro2::Literal::string(name);
+    // RFC 081 Phase 2 Codex-P2 fix — `ref_names` is dedup'd
+    // by RAW `pp-ref` string in the template-plan analyser,
+    // but `normalize_ref_method_ident` maps `body-main`,
+    // `body.main`, and `body_main` all to the same Rust
+    // ident `body_main`. Emitting duplicate inherent methods
+    // would fail to compile with a confusing E0592. Instead,
+    // group raw names by their normalized form and emit a
+    // typed `compile_error!` per collision so the author
+    // sees exactly which template names clashed.
+    let mut method_name_groups: std::collections::BTreeMap<String, Vec<String>> =
+        std::collections::BTreeMap::new();
+    for name in &template_plan.ref_names {
+        method_name_groups
+            .entry(normalize_ref_method_ident(name))
+            .or_default()
+            .push(name.clone());
+    }
+    let ref_collision_errors: Vec<TokenStream2> = method_name_groups
+        .iter()
+        .filter(|(_, raw)| raw.len() > 1)
+        .map(|(method_name, raw_names)| {
+            let msg = format!(
+                "RFC 081: `pp-ref` names {raw:?} all normalize to the Rust method \
+                 identifier `{method_name}` for the generated `{ident_str}Refs` accessor. \
+                 Rename one of the templates' `pp-ref=\"...\"` attributes so each \
+                 normalizes to a distinct method name (kebab/dot/colon → underscore).",
+                raw = raw_names,
+            );
+            let lit = proc_macro2::Literal::string(&msg);
+            quote! {
+                ::core::compile_error!(#lit);
+            }
+        })
+        .collect();
+    let ref_accessor_methods = method_name_groups.iter().map(|(method_name, raw_names)| {
+        let method_ident = proc_macro2::Ident::new(method_name, struct_ident.span());
+        // Use the first raw name as the runtime lookup key
+        // — when the collision diagnostic above fires, the
+        // build won't reach mount anyway; when there's no
+        // collision the group has exactly one entry.
+        let name_lit = proc_macro2::Literal::string(&raw_names[0]);
+        let doc_lit = proc_macro2::Literal::string(&raw_names[0]);
         quote! {
             /// Typed accessor for the
-            #[doc = #name_lit]
+            #[doc = #doc_lit]
             /// `pp-ref`. Returns a [`::pocopine::__private::RefAccessor`]
             /// carrying the scope id + ref name baked in; call
             /// `.element()`, `.as_::<T>()`, or `.component::<T>()`
@@ -2463,6 +2501,11 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
             scope_id: ::pocopine::__private::ScopeId,
             _m: ::core::marker::PhantomData<&'__poc_refs ()>,
         }
+
+        // RFC 081 Phase 2 Codex-P2 — collision diagnostics
+        // emitted at module scope so each clashing pair of
+        // `pp-ref` names produces one clear error.
+        #(#ref_collision_errors)*
 
         impl<'__poc_refs> #refs_struct_ident<'__poc_refs> {
             #(#ref_accessor_methods)*

--- a/crates/pocopine-macros/src/template_plan.rs
+++ b/crates/pocopine-macros/src/template_plan.rs
@@ -256,6 +256,16 @@ struct AnalysisCtx {
     /// time, not by re-discovering through the mount).
     #[allow(dead_code)]
     requires_walker: bool,
+    /// RFC 081 Phase 2 Codex-P2 fix — `pp-ref` names harvested
+    /// from lifted-body and slot-fragment subtrees that don't
+    /// share `self.refs` (each nested `walk` collects into its
+    /// own `AnalysisCtx`). Aggregated as the outer plan is
+    /// built so the macro-emitted `<ComponentName>Refs` struct
+    /// still gets accessors for pp-refs inside `pp-if` /
+    /// `pp-for` / `pp-teleport` / dynamic-slot bodies. Names
+    /// only — node_paths inside lifted fragments aren't
+    /// meaningful at the parent's plan layer.
+    refs_from_lifted: Vec<String>,
 }
 
 /// Shared across the whole top-level analysis — fragment fn
@@ -538,15 +548,42 @@ impl AnalysisCtx {
     /// runtime) collapse to one accessor here — the generated
     /// `fn <name>(&self) -> RefAccessor` then resolves whichever
     /// row's element happened to win.
+    ///
+    /// Includes refs from lifted bodies (`pp-if` / `pp-for` /
+    /// `pp-teleport` subtrees, dynamic slot fragments) via the
+    /// `refs_from_lifted` aggregator — those nested
+    /// `AnalysisCtx`s register against the parent's runtime
+    /// scope at install time, so the typed API must expose
+    /// them too.
     fn ref_names_dedup(&self) -> Vec<String> {
         let mut seen = std::collections::HashSet::new();
-        let mut out = Vec::with_capacity(self.refs.len());
+        let mut out = Vec::with_capacity(self.refs.len() + self.refs_from_lifted.len());
         for r in &self.refs {
             if seen.insert(r.name.clone()) {
                 out.push(r.name.clone());
             }
         }
+        for name in &self.refs_from_lifted {
+            if seen.insert(name.clone()) {
+                out.push(name.clone());
+            }
+        }
         out
+    }
+
+    /// Drain a nested context's ref names (its own `refs` plus
+    /// anything it already aggregated from deeper lifts) into
+    /// this context's `refs_from_lifted`. Called after each
+    /// `analyze_lift_body` / `analyze_slot_subtree` return so
+    /// refs inside lifted subtrees still reach the outer
+    /// `<ComponentName>Refs` codegen.
+    fn absorb_lifted_refs(&mut self, nested: &AnalysisCtx) {
+        for r in &nested.refs {
+            self.refs_from_lifted.push(r.name.clone());
+        }
+        for name in &nested.refs_from_lifted {
+            self.refs_from_lifted.push(name.clone());
+        }
     }
 
     fn emit_specialized_mount_body(&self) -> Option<TokenStream> {
@@ -1440,6 +1477,7 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
                     None
                 } else {
                     let lifted = analyze_lift_body(el, emissions).map(|(html, body_ctx)| {
+                        ctx.absorb_lifted_refs(&body_ctx);
                         let ident = emissions.alloc_if_body_ident("for_body");
                         emissions.if_bodies.push(IfBodyEmission {
                             ident: ident.clone(),
@@ -1511,6 +1549,7 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
             // body into a fragment fn (same v1 envelope as
             // pp-if / pp-for body lifting).
             let body_fn_ident = analyze_lift_body(el, emissions).map(|(html, body_ctx)| {
+                ctx.absorb_lifted_refs(&body_ctx);
                 let ident = emissions.alloc_if_body_ident("teleport_body");
                 emissions.if_bodies.push(IfBodyEmission {
                     ident: ident.clone(),
@@ -1589,6 +1628,7 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
             // the body falls outside, `body_fn_ident` stays
             // `None` and the legacy clone+walk path runs.
             let body_fn_ident = analyze_lift_body(el, emissions).map(|(html, body_ctx)| {
+                ctx.absorb_lifted_refs(&body_ctx);
                 let ident = emissions.alloc_if_body_ident("if_body");
                 emissions.if_bodies.push(IfBodyEmission {
                     ident: ident.clone(),
@@ -1743,6 +1783,12 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
                     .filter(|s| !s.is_empty());
                 match analyze_slot_subtree(&tpl.children, emissions) {
                     Some(emission) => {
+                        // RFC 081 P2 — absorb pp-ref names from
+                        // the dynamic slot's plan so the outer
+                        // `<ComponentName>Refs` exposes them.
+                        if let SlotFragmentEmission::Dynamic { plan, .. } = &emission {
+                            ctx.absorb_lifted_refs(plan);
+                        }
                         // Duplicate `pp-slot=NAME` at compile time:
                         // both lift fragments get pushed; the
                         // runtime `SlotSet::named` HashMap insert
@@ -1774,6 +1820,11 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
             if has_meaningful_default {
                 match analyze_slot_subtree(&default_children, emissions) {
                     Some(emission) => {
+                        // RFC 081 P2 — absorb pp-ref names from
+                        // the default slot's plan.
+                        if let SlotFragmentEmission::Dynamic { plan, .. } = &emission {
+                            ctx.absorb_lifted_refs(plan);
+                        }
                         slot_fragments.push((
                             "default".to_string(),
                             emission.ident().clone(),

--- a/crates/pocopine-macros/src/template_plan.rs
+++ b/crates/pocopine-macros/src/template_plan.rs
@@ -75,6 +75,13 @@ pub(crate) struct EmittedTemplatePlan {
     /// mounts use this generated body directly; the generic
     /// plan applier remains for lifted fragment internals only.
     pub specialized_mount_body: Option<TokenStream>,
+    /// RFC 081 — every `pp-ref="name"` collected from the
+    /// template, dedup'd in template-order. The consuming
+    /// macro emits a `<ComponentName>Refs` struct with one
+    /// `fn <name>(&self) -> RefAccessor` per entry so handlers
+    /// can write `refs.body()` instead of
+    /// `refs::get_component::<T>("body")`.
+    pub ref_names: Vec<String>,
 }
 
 /// Walk the template AST, classify every directive, return the
@@ -118,6 +125,7 @@ pub(crate) fn analyze_template_plan(
             slot_fragment_fns: TokenStream::new(),
             if_body_fns: TokenStream::new(),
             specialized_mount_body: None,
+            ref_names: ctx.ref_names_dedup(),
         };
     }
     let cleaned_html = serialize_cleaned(&ast.roots, &ctx);
@@ -133,12 +141,14 @@ pub(crate) fn analyze_template_plan(
         None
     };
     let specialized_mount_body = ctx.emit_specialized_mount_body();
+    let ref_names = ctx.ref_names_dedup();
     EmittedTemplatePlan {
         plan_tokens,
         cleaned_html: Some(cleaned_html),
         slot_fragment_fns,
         if_body_fns,
         specialized_mount_body,
+        ref_names,
     }
 }
 
@@ -520,6 +530,23 @@ impl AnalysisCtx {
             || !self.opaque_directives.is_empty()
             || !self.interps.is_empty()
             || !self.native_models.is_empty()
+    }
+
+    /// RFC 081 — every distinct `pp-ref="name"` collected from
+    /// the template, in template-order. Two refs with the same
+    /// name in different `pp-for` rows (last-wins resolution at
+    /// runtime) collapse to one accessor here — the generated
+    /// `fn <name>(&self) -> RefAccessor` then resolves whichever
+    /// row's element happened to win.
+    fn ref_names_dedup(&self) -> Vec<String> {
+        let mut seen = std::collections::HashSet::new();
+        let mut out = Vec::with_capacity(self.refs.len());
+        for r in &self.refs {
+            if seen.insert(r.name.clone()) {
+                out.push(r.name.clone());
+            }
+        }
+        out
     }
 
     fn emit_specialized_mount_body(&self) -> Option<TokenStream> {

--- a/crates/pocopine/src/lib.rs
+++ b/crates/pocopine/src/lib.rs
@@ -128,6 +128,10 @@ pub mod __private {
         LifecycleContext, Scope, StaticBinOp, StaticBinding, StaticExpr, StaticListener,
         StaticLiteral, StaticPropKind, StaticRowPlan, Store, WriteOrigin,
     };
+    // RFC 081 — typed ref accessor used by the macro-generated
+    // `<ComponentName>Refs` struct.
+    pub use pocopine_core::reactive::ScopeId;
+    pub use pocopine_core::refs::RefAccessor;
     #[cfg(not(target_arch = "wasm32"))]
     pub use pocopine_jobs as jobs;
     // RFC 060 Tier 4 — `phf` re-exported for `app!{}` macro use.

--- a/crates/pocopine/tests/refs_typed.rs
+++ b/crates/pocopine/tests/refs_typed.rs
@@ -38,7 +38,11 @@ struct TypedRefsChild {
 }
 
 #[handlers]
-impl TypedRefsChild {}
+impl TypedRefsChild {
+    pub fn on_mount(&mut self) {
+        CHILD_MOUNT_COUNT.with(|c| *c.borrow_mut() += 1);
+    }
+}
 
 impl TypedRefsChild {
     pub fn seed_value(&self) -> u32 {
@@ -54,12 +58,21 @@ thread_local! {
     static OBSERVED_SEED: RefCell<Option<u32>> = const { RefCell::new(None) };
     static OBSERVED_MISMATCH_IS_NONE: RefCell<Option<bool>> = const { RefCell::new(None) };
     static OBSERVED_ELEMENT_PRESENT: RefCell<Option<bool>> = const { RefCell::new(None) };
+    /// Codex P1 regression — counts `on_mount` invocations on
+    /// the child. The Phase 1 host stamp used to also be
+    /// `SCOPE_ID_KEY`, which made `fire_mount_hook` fire the
+    /// child's `on_mount` twice (once for the host, once for
+    /// the inner template root). The fix moved the host stamp
+    /// to a separate key the lifecycle dispatch ignores. This
+    /// counter pins the fix: must equal 1 after a single mount.
+    static CHILD_MOUNT_COUNT: RefCell<u32> = const { RefCell::new(0) };
 }
 
 fn reset_observations() {
     OBSERVED_SEED.with(|c| *c.borrow_mut() = None);
     OBSERVED_MISMATCH_IS_NONE.with(|c| *c.borrow_mut() = None);
     OBSERVED_ELEMENT_PRESENT.with(|c| *c.borrow_mut() = None);
+    CHILD_MOUNT_COUNT.with(|c| *c.borrow_mut() = 0);
 }
 
 #[derive(Default, Serialize, Deserialize)]
@@ -144,6 +157,136 @@ async fn generated_refs_struct_resolves_child_component_handle() {
 }
 
 #[wasm_bindgen_test]
+async fn host_stamp_does_not_double_fire_child_lifecycle() {
+    // Codex review P1 regression. With the original Phase 1
+    // implementation, the host stamp reused `SCOPE_ID_KEY`,
+    // and `finalize_compiled_subtree` would call
+    // `fire_mount_hook` once for the host and once for the
+    // inner template root, firing the child's `on_mount`
+    // twice for a single mount. The fix moves the host
+    // stamp to `HOST_CHILD_SCOPE_ID_KEY` (separate from
+    // `SCOPE_ID_KEY`) so lifecycle dispatch only sees the
+    // inner root.
+    reset_observations();
+    let host = mount();
+    tick().await;
+    let mount_count = CHILD_MOUNT_COUNT.with(|c| *c.borrow());
+    assert_eq!(
+        mount_count, 1,
+        "child `on_mount` must fire exactly once per mount"
+    );
+    host.remove();
+}
+
+// Codex P2 regression — a `pp-ref` inside a `pp-if` body
+// is collected into a separate nested AnalysisCtx in the
+// macro, so the original Phase 2 codegen omitted accessors
+// for it. The fix aggregates nested ref names via
+// `absorb_lifted_refs`; this component would not compile
+// (no `lifted` method on the generated Refs struct) if the
+// aggregation regressed.
+thread_local! {
+    static OBSERVED_LIFTED_REF_PRESENT: RefCell<Option<bool>> = const { RefCell::new(None) };
+}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "typed-refs-lifted-parent",
+    template_inline = r#"<div class="trlp">
+        <template pp-if="true">
+            <span pp-ref="lifted">inside pp-if body</span>
+        </template>
+    </div>"#
+)]
+struct TypedRefsLiftedParent {}
+
+#[handlers]
+impl TypedRefsLiftedParent {
+    pub fn on_ready(&self, refs: TypedRefsLiftedParentRefs) {
+        // If this line wouldn't compile, the macro regressed
+        // (missed the pp-ref inside the pp-if body). The
+        // runtime resolution may legitimately return None
+        // when the controller hasn't materialized the body
+        // yet — but the method must EXIST.
+        let element = refs.lifted().element();
+        OBSERVED_LIFTED_REF_PRESENT.with(|c| *c.borrow_mut() = Some(element.is_some()));
+    }
+}
+
+#[wasm_bindgen_test]
+async fn generated_refs_struct_includes_pp_refs_from_lifted_bodies() {
+    OBSERVED_LIFTED_REF_PRESENT.with(|c| *c.borrow_mut() = None);
+    TypedRefsLiftedParent::register();
+    let body = doc().body().unwrap();
+    let host = doc().create_element("div").unwrap();
+    host.set_inner_html("<typed-refs-lifted-parent></typed-refs-lifted-parent>");
+    body.append_child(&host).unwrap();
+    let el = host
+        .query_selector("typed-refs-lifted-parent")
+        .unwrap()
+        .unwrap();
+    pocopine_core::mount::mount_child_component(&el, "typed-refs-lifted-parent");
+    pocopine_core::mount::finalize_compiled_subtree(&el);
+    tick().await;
+
+    // The accessor exists (compile-checked above); the
+    // pp-if body should materialize before on_ready fires,
+    // so the element lookup resolves.
+    let lifted_present = OBSERVED_LIFTED_REF_PRESENT.with(|c| *c.borrow());
+    assert_eq!(
+        lifted_present,
+        Some(true),
+        "pp-ref inside pp-if body must be reachable through the typed `lifted()` accessor"
+    );
+    host.remove();
+}
+
+// Codex P2 — kebab/dot/colon in `pp-ref` names normalize to
+// underscore for the generated method ident. Two refs whose
+// normalized form collides emit a `compile_error!` (covered
+// by build-time compilation, not this runtime test). The
+// positive case here pins that distinct normalized names
+// emit distinct methods.
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "typed-refs-kebab",
+    template_inline = r#"<div class="trk">
+        <span pp-ref="form-root">a</span>
+        <span pp-ref="title-input">b</span>
+    </div>"#
+)]
+struct TypedRefsKebab {}
+
+#[handlers]
+impl TypedRefsKebab {
+    pub fn on_ready(&self, refs: TypedRefsKebabRefs) {
+        // Method idents are snake_case normalized from kebab
+        // — `form-root` → `form_root`, `title-input` →
+        // `title_input`. If the normalization regressed,
+        // these calls would not compile.
+        let _ = refs.form_root().element();
+        let _ = refs.title_input().element();
+    }
+}
+
+#[wasm_bindgen_test]
+async fn generated_refs_struct_normalizes_kebab_to_snake_case_idents() {
+    TypedRefsKebab::register();
+    let body = doc().body().unwrap();
+    let host = doc().create_element("div").unwrap();
+    host.set_inner_html("<typed-refs-kebab></typed-refs-kebab>");
+    body.append_child(&host).unwrap();
+    let el = host.query_selector("typed-refs-kebab").unwrap().unwrap();
+    pocopine_core::mount::mount_child_component(&el, "typed-refs-kebab");
+    pocopine_core::mount::finalize_compiled_subtree(&el);
+    tick().await;
+    // No runtime assertion — the test passes by virtue of
+    // `on_ready` having compiled with both kebab-derived
+    // method names.
+    host.remove();
+}
+
+#[wasm_bindgen_test]
 async fn generated_refs_struct_method_name_is_compile_time_typo_safe() {
     // The point of Phase 2: the generated method `fn body(&self)`
     // means a typo at the call site fails to compile. We can't
@@ -156,9 +299,16 @@ async fn generated_refs_struct_method_name_is_compile_time_typo_safe() {
     // codegen and the resolution semantics together.
     let host = mount();
     tick().await;
+    // The parent's scope id lives on the inner template root,
+    // not the custom-element host — `<typed-refs-parent>` is
+    // the host; `<div class="trp">` (its first element child)
+    // is the rendered root with `SCOPE_ID_KEY`.
     let parent_host = host.query_selector("typed-refs-parent").unwrap().unwrap();
+    let parent_root = parent_host
+        .first_element_child()
+        .expect("rendered template root");
     let parent_scope_id =
-        pocopine_core::mount::scope_id_of_element(&parent_host).expect("parent scope id");
+        pocopine_core::mount::scope_id_of_element(&parent_root).expect("parent scope id");
     // Directly resolve via the free-fn to confirm the name lands
     // in the parent scope's ref table.
     let resolved = pocopine_core::refs::get_component_on::<TypedRefsChild>(parent_scope_id, "body");

--- a/crates/pocopine/tests/refs_typed.rs
+++ b/crates/pocopine/tests/refs_typed.rs
@@ -1,0 +1,170 @@
+//! RFC 081 Phase 2 — end-to-end test for the macro-generated
+//! `<ComponentName>Refs` struct.
+//!
+//! A `TypedRefsParent` `.poco` template carries
+//! `<typed-refs-child pp-ref="body" />`, and the test asserts
+//! that:
+//!
+//! 1. The macro generated a `TypedRefsParentRefs` struct with
+//!    a `fn body(&self) -> RefAccessor` method.
+//! 2. `RefAccessor::component::<TypedRefsChild>()` resolves a
+//!    working `Handle<TypedRefsChild>` after mount.
+//! 3. `RefAccessor::component::<TypedRefsParent>()` returns
+//!    `None` (mismatched type protection).
+//! 4. `RefAccessor::element()` returns the host element.
+//!
+//! Run with:
+//!   `wasm-pack test --firefox --headless crates/pocopine --test refs_typed`
+
+#![cfg(target_arch = "wasm32")]
+
+use std::cell::RefCell;
+
+use pocopine::prelude::*;
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::JsValue;
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+use web_sys::{window, Element};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "typed-refs-child",
+    template_inline = r#"<div class="trc">child mounted</div>"#
+)]
+struct TypedRefsChild {
+    seed: u32,
+}
+
+#[handlers]
+impl TypedRefsChild {}
+
+impl TypedRefsChild {
+    pub fn seed_value(&self) -> u32 {
+        self.seed
+    }
+}
+
+// Test-only observation channel. `#[component]` requires every
+// struct field to be `Serialize + Deserialize` (RFC 081 keeps
+// this rule), so the observed values live in thread-locals the
+// on_ready handler writes and the test reads.
+thread_local! {
+    static OBSERVED_SEED: RefCell<Option<u32>> = const { RefCell::new(None) };
+    static OBSERVED_MISMATCH_IS_NONE: RefCell<Option<bool>> = const { RefCell::new(None) };
+    static OBSERVED_ELEMENT_PRESENT: RefCell<Option<bool>> = const { RefCell::new(None) };
+}
+
+fn reset_observations() {
+    OBSERVED_SEED.with(|c| *c.borrow_mut() = None);
+    OBSERVED_MISMATCH_IS_NONE.with(|c| *c.borrow_mut() = None);
+    OBSERVED_ELEMENT_PRESENT.with(|c| *c.borrow_mut() = None);
+}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "typed-refs-parent",
+    uses = [TypedRefsChild],
+    template_inline = r#"<div class="trp">
+        <typed-refs-child pp-ref="body"></typed-refs-child>
+    </div>"#
+)]
+struct TypedRefsParent {}
+
+#[handlers]
+impl TypedRefsParent {
+    pub fn on_ready(&self, refs: TypedRefsParentRefs) {
+        // Typed-component resolution
+        if let Some(child) = refs.body().component::<TypedRefsChild>() {
+            OBSERVED_SEED.with(|c| *c.borrow_mut() = Some(child.with(|c| c.seed_value())));
+        }
+        // Mismatched type — must return None.
+        let mismatched = refs.body().component::<TypedRefsParent>();
+        OBSERVED_MISMATCH_IS_NONE.with(|c| *c.borrow_mut() = Some(mismatched.is_none()));
+        // Untyped element lookup
+        OBSERVED_ELEMENT_PRESENT.with(|c| *c.borrow_mut() = Some(refs.body().element().is_some()));
+    }
+}
+
+fn doc() -> web_sys::Document {
+    window().unwrap().document().unwrap()
+}
+
+async fn tick() {
+    for _ in 0..3 {
+        let p = js_sys::Promise::resolve(&JsValue::NULL);
+        let _ = wasm_bindgen_futures::JsFuture::from(p).await;
+    }
+}
+
+fn mount() -> Element {
+    TypedRefsChild::register();
+    TypedRefsParent::register();
+    let body = doc().body().unwrap();
+    let host = doc().create_element("div").unwrap();
+    host.set_inner_html("<typed-refs-parent></typed-refs-parent>");
+    body.append_child(&host).unwrap();
+    let el = host.query_selector("typed-refs-parent").unwrap().unwrap();
+    pocopine_core::mount::mount_child_component(&el, "typed-refs-parent");
+    pocopine_core::mount::finalize_compiled_subtree(&el);
+    host
+}
+
+#[wasm_bindgen_test]
+async fn generated_refs_struct_resolves_child_component_handle() {
+    reset_observations();
+    let host = mount();
+    tick().await;
+
+    // Typed component resolution worked and the handle read
+    // through to child state.
+    let observed_seed = OBSERVED_SEED.with(|c| *c.borrow());
+    assert_eq!(
+        observed_seed,
+        Some(0),
+        "typed handle reads child state via the generated `body()` accessor"
+    );
+    // Mismatched type guarded by the `child_scope != parent_scope` check.
+    let mismatch_is_none = OBSERVED_MISMATCH_IS_NONE.with(|c| *c.borrow());
+    assert_eq!(
+        mismatch_is_none,
+        Some(true),
+        "component::<WrongType>() must return None"
+    );
+    // Untyped element lookup composes the same name-baked path.
+    let element_present = OBSERVED_ELEMENT_PRESENT.with(|c| *c.borrow());
+    assert_eq!(
+        element_present,
+        Some(true),
+        "RefAccessor::element() resolves the host element"
+    );
+
+    host.remove();
+}
+
+#[wasm_bindgen_test]
+async fn generated_refs_struct_method_name_is_compile_time_typo_safe() {
+    // The point of Phase 2: the generated method `fn body(&self)`
+    // means a typo at the call site fails to compile. We can't
+    // assert that at runtime (the compile already happened), but
+    // the test still ensures the generated method is reachable
+    // by NAME, not by string — i.e. the macro emitted the right
+    // method. If a future refactor regresses to a string lookup,
+    // this test's call site would still compile but the runtime
+    // would resolve via the wrong path; this test pins both the
+    // codegen and the resolution semantics together.
+    let host = mount();
+    tick().await;
+    let parent_host = host.query_selector("typed-refs-parent").unwrap().unwrap();
+    let parent_scope_id =
+        pocopine_core::mount::scope_id_of_element(&parent_host).expect("parent scope id");
+    // Directly resolve via the free-fn to confirm the name lands
+    // in the parent scope's ref table.
+    let resolved = pocopine_core::refs::get_component_on::<TypedRefsChild>(parent_scope_id, "body");
+    assert!(
+        resolved.is_some(),
+        "free-fn lookup via the same name the macro baked in resolves"
+    );
+    host.remove();
+}

--- a/rfcs/rfc-081-component-handle-refs.md
+++ b/rfcs/rfc-081-component-handle-refs.md
@@ -1,0 +1,513 @@
+# RFC 081 - Component handle refs
+
+| Field | Value |
+|---|---|
+| **Status** | Draft (Phase 1 landed) |
+| **Author** | pocopine team |
+| **Created** | 2026-05-19 |
+| **Related** | [`rfc-002-app-stores-servers.md`](./rfc-002-app-stores-servers.md), [`rfc-060-component-uses-registry.md`](./rfc-060-component-uses-registry.md), [`rfc-079-pine-richtext-tables-extension.md`](./rfc-079-pine-richtext-tables-extension.md) |
+| **Supersedes** | - |
+
+## 1. Summary
+
+Today `pp-ref="name"` registers the tagged DOM element under
+its enclosing scope's ref table. When the tagged element
+happens to be a child *component*'s host, the parent gets
+the DOM element but **not** a typed handle to the child
+component's Rust state. Reaching across a component
+boundary therefore means a DOM query under the parent's
+own ref (`form_root.query_selector("pine-rich-text-root")`,
+then `Editor::find(&form_root)`).
+
+Extend `pp-ref` so that — when the tagged element IS the
+host of a child component — the parent can also resolve a
+typed `Handle<ChildComponent>`. Adds one method on
+`Refs` / one matching free function. No new macro, no new
+visibility attribute: Rust `pub` is already the "expose
+this method to outside callers" mechanism.
+
+```rust
+// Child component owns a typed surface handle.
+impl KeepNoteBody {
+    pub fn editor(&self) -> Option<pine_richtext::view::Editor> {
+        self.editor.clone()
+    }
+}
+
+// Parent's template — pp-ref on the child component tag.
+<keep-note-body pp-ref="body" />
+
+// Parent's handler — typed reach across the boundary.
+fn save(&mut self) {
+    let body = refs.get_component::<KeepNoteBody>("body")?;
+    let md = body.with(|b| b.editor()?.get::<Markdown>().ok())?;
+    // …
+}
+```
+
+## 2. Motivation
+
+**Current keep flow.** `KeepNoteForm` mounts a
+`<keep-note-body>` child which in turn mounts a
+`<pine-rich-text-root>`. The parent form needs to read the
+surface's markdown at save time. Today's options are all
+unsatisfying:
+
+1. `pp-model:markdown` two-way binding — every keystroke
+   emits, parent re-seeds, feedback-loops, full re-render
+   per character. Rejected.
+2. `pp-ref="form_root"` on the form's wrapper +
+   `Editor::find(&form_root)` which `querySelector`s down
+   to the inner `pine-rich-text-root`. Works but is a DOM
+   drill, sensitive to template structure, and inert to
+   the child's TYPED API — the parent treats the child as
+   an opaque DOM subtree.
+3. Cache the surface's element in a thread-local keyed by
+   form mode. Hidden global state, opaque lifetimes,
+   needs `on_scope_unmount` cleanup. Already tried and
+   removed.
+
+The DOM-drill option (option 2) is currently shipping but
+it leaks pine-richtext's selector knowledge into keep, and
+the keep refactor cycle had to add the
+`Editor::find(&form_root)` plumbing on every read.
+
+**The same shape recurs.** Anywhere a parent component
+hosts a child that owns nontrivial imperative state —
+`<keep-note-body>` (rich-text), `<pine-popover-root>`
+(open-state, anchor element), `<pine-select-root>`
+(selected value, listbox id), upcoming
+`<pine-virtual-list>` (scroll position, item bounds) — the
+parent benefits from a typed reach across the boundary.
+Today the contract is either "child mirrors state through
+`pp-model`" or "parent does its own DOM walk." Neither
+generalizes.
+
+**Vue's model.** Vue 3 puts `ref` on a child component
+tag and gets back the child's exposed instance —
+`defineExpose({ editor })` in the child, `myChild.value
+.editor.getJSON()` in the parent. TipTap-Vue uses this
+exact pattern: `useEditor` returns `shallowRef<Editor>`,
+the parent reaches it through the component ref.
+
+Pocopine is closer to this than it looks — `pp-ref` and
+Vue's template refs are otherwise interchangeable — so the
+gap is small.
+
+## 3. Goals
+
+- Let a parent reach a typed `Handle<ChildComponent>` for a
+  child component tagged with `pp-ref="name"`, without
+  introducing new template syntax.
+- Reuse the existing `Handle<T>` shape and its
+  `with` / `update` semantics — no new owned-reference type
+  or borrow rules.
+- Keep the API surface minimal: one new method on
+  [`Refs`](../crates/pocopine-core/src/lifecycle.rs#L249)
+  and one free-fn counterpart in
+  [`pocopine::refs`](../crates/pocopine-core/src/refs.rs#L52),
+  no other public-API additions.
+- Avoid a new `#[expose]` macro. Rust `pub` already
+  decides what crosses the boundary; `Handle<T>::with` /
+  `update` already gate access through a borrow.
+- Resolve in O(1) at handler time — no DOM walk, no
+  re-query per call.
+- Keep the existing `pp-ref` → `Element` lookup unchanged:
+  a parent that needs the DOM element keeps using
+  `refs.get` / `refs.get_as`.
+- Mirror the cross-scope rules of `pp-ref`: refs
+  registered in scope A are reachable only from handlers
+  running in scope A (no implicit cross-tree access).
+
+## 4. Non-goals
+
+- No `defineExpose`-style selective visibility — Rust's
+  `pub` / `pub(crate)` already gates which methods cross
+  the boundary; we don't add a parallel declarative system.
+- No reactive subscription to a child handle's internals
+  (subscribe via the child's own update channels, e.g.
+  `Editor::on_update`).
+- No DOM-element resolution change. `refs.get("name")`
+  keeps returning the Element. Parents that want both can
+  call both — the lookups are independent.
+- No async-handle resolution. Like `refs::get`, the lookup
+  is synchronous from inside scope context and returns
+  `None` outside it.
+- No new `pp-ref` syntax. The directive shape stays
+  identical; the *resolution* gains a typed variant.
+
+## 5. Design
+
+### 5.1 Public API
+
+Add one method on the [`Refs`](../crates/pocopine-core/src/lifecycle.rs#L249)
+extractor and the matching free functions in
+[`pocopine::refs`](../crates/pocopine-core/src/refs.rs):
+
+```rust
+// In pocopine_core::lifecycle::Refs.
+impl<'a> Refs<'a> {
+    /// Resolve a typed `Handle<T>` for the child component
+    /// whose host element was tagged `pp-ref="name"` in this
+    /// scope's template. Returns `None` when the named ref
+    /// isn't a child-component mount point or the registered
+    /// child's Rust type doesn't match `T`.
+    pub fn get_component<T: 'static>(&self, name: &str) -> Option<Handle<T>>;
+}
+
+// In pocopine_core::refs (free functions, current-scope variant).
+pub fn get_component<T: 'static>(name: &str) -> Option<Handle<T>>;
+pub fn get_component_on<T: 'static>(scope_id: ScopeId, name: &str)
+    -> Option<Handle<T>>;
+```
+
+`Handle<T>` is the existing [`pocopine_core::handle::Handle`](../crates/pocopine-core/src/handle.rs#L42).
+No new type. Authors call `body.with(|b| b.field)` / `body.update(|b| ...)`
+exactly as they do for `Parent<T>::handle()`.
+
+The name `get_component` distinguishes from `get_as`
+(DOM-type downcast); the two are orthogonal lookups that
+happen to share the same ref-name keyspace.
+
+### 5.2 Worked example (keep)
+
+Before:
+
+```html
+<!-- KeepNoteForm.poco -->
+<div pp-ref="form_root">
+  <keep-note-body ...></keep-note-body>
+</div>
+```
+
+```rust
+// Save side — DOM drill.
+let combined = Self::form_root_in_scope()
+    .as_ref()
+    .and_then(Editor::find)
+    .and_then(|e| e.get::<Markdown>().ok())
+    .unwrap_or_else(|| self.body.clone());
+```
+
+After:
+
+```html
+<!-- KeepNoteForm.poco -->
+<div>
+  <keep-note-body pp-ref="body" ...></keep-note-body>
+</div>
+```
+
+```rust
+// KeepNoteBody.rs — opt in by exposing a `pub` method.
+impl KeepNoteBody {
+    pub fn editor(&self) -> Option<pine_richtext::view::Editor> {
+        self.editor.clone()
+    }
+}
+
+// KeepNoteForm.rs — typed cross-boundary reach.
+let combined = pocopine::refs::get_component::<KeepNoteBody>("body")
+    .and_then(|body| body.with(|b| b.editor()?.get::<Markdown>().ok()))
+    .unwrap_or_else(|| self.body.clone());
+```
+
+No DOM query. No selector knowledge. The parent depends on
+the child's typed surface, not its template structure.
+
+### 5.3 Implementation sketch
+
+The mechanism is smaller than a first read suggests: the
+existing `pp-ref` registers an [`Element`], and the mount
+already stamps the inner template root with a private
+`SCOPE_ID_KEY`. The only missing piece is stamping the
+**custom-element host** with the same key — every other
+hop in the resolution composes existing primitives.
+
+#### 5.3.1 Stamp the host with the child's scope id
+
+In [`crate::mount::mount_component`](../crates/pocopine-core/src/mount.rs#L286)
+(and `try_mount_component_as` for the `pp-as` path), set
+`SCOPE_ID_KEY` on `el` (the custom-element host) right
+after the template root is bound:
+
+```rust
+// Existing: bind the inner template root.
+set_private(&root, SCOPE_ID_KEY, &JsValue::from_f64(scope.id.0 as f64));
+set_private(&root, SCOPE_PROXY_KEY, &proxy);
+
+// New: also stamp the outer custom-element host with the
+// child's scope id. The host doesn't carry SCOPE_PROXY_KEY
+// — proxy reads still go through the inner template root.
+set_private(el, SCOPE_ID_KEY, &JsValue::from_f64(scope.id.0 as f64));
+```
+
+The pp-ref directive is unchanged. When a parent template
+contains `<child-tag pp-ref="body">`, the host element is
+both (a) registered in the parent scope's ref table via
+the existing `refs::register` and (b) stamped with the
+child's scope id by the mount above.
+
+#### 5.3.2 Resolution
+
+```rust
+pub fn get_component_on<T: 'static>(
+    parent_scope: ScopeId,
+    name: &str,
+) -> Option<Handle<T>> {
+    let el = get_on(parent_scope, name)?;
+    let child_scope = crate::mount::scope_id_of_element(&el)?;
+    if child_scope == parent_scope {
+        // Plain DOM ref or self-ref — reject.
+        return None;
+    }
+    let scope = crate::scope::Scope::find(child_scope)?;
+    let rc = scope.typed::<T>()?;
+    Some(Handle::new(rc, child_scope))
+}
+
+pub fn get_component<T: 'static>(name: &str) -> Option<Handle<T>> {
+    let scope = current_scope_id()?;
+    get_component_on(scope, name)
+}
+```
+
+`Scope::typed::<T>()` and `Handle::new` are the same primitives the
+existing [`Parent<T>` / `NearestParent<T>`](../crates/pocopine-core/src/extractors.rs#L143)
+extractors use; this lookup is the mirror direction (parent →
+named child) of those (child → ancestor T).
+
+The `child_scope == parent_scope` guard catches two cases
+without extra plumbing: a `pp-ref` on a plain DOM element
+in the same scope (no `SCOPE_ID_KEY` ⇒ `scope_id_of_element`
+returns `None`, lookup misses), and a `pp-ref` on the
+component's own template root (`SCOPE_ID_KEY` matches the
+caller's scope ⇒ guarded against).
+
+#### 5.3.3 Eviction
+
+Component scopes evict via
+[`Scope::remove`](../crates/pocopine-core/src/scope.rs#L322).
+When the parent's scope is removed (or its sub-tree is torn
+down by `pp-if` / `pp-for`), the existing
+`refs::clear_scope(parent_id)` already drops the parent's
+ref entries — including the entry pointing to the now-
+removed child's host. No new teardown plumbing needed: the
+resolution walks element → child scope → typed handle, and
+each link breaks on its own when the underlying piece
+unmounts.
+
+#### 5.3.4 `Refs` extractor wiring
+
+`Refs` already carries `scope_id`. Adding
+`get_component::<T>` is one line:
+
+```rust
+impl<'a> Refs<'a> {
+    pub fn get_component<T: 'static>(&self, name: &str) -> Option<Handle<T>> {
+        crate::refs::get_component_on::<T>(self.scope_id, name)
+    }
+}
+```
+
+#### 5.3.5 Why not a parallel `COMPONENT_REFS` thread-local
+
+An earlier draft of this RFC proposed registering child
+scope ids in a separate `HashMap<ScopeId, HashMap<String,
+ScopeId>>` keyed by `(parent_scope, name)`. The simpler
+"stamp the host with `SCOPE_ID_KEY`" approach dropped:
+
+- A new thread-local with its own lifecycle.
+- A separate `clear_scope` call to evict component-ref
+  entries.
+- A walker hook to register entries at mount time.
+
+…and reuses two primitives already present in `mount.rs`
+([`scope_id_of_element`](../crates/pocopine-core/src/mount.rs#L127),
+[`bind_scope_id_only`](../crates/pocopine-core/src/mount.rs#L119)).
+Total Phase 1 delta: ~10 lines across mount.rs + refs.rs +
+lifecycle.rs.
+
+### 5.4 Why no `#[expose]` attribute
+
+Vue needs `defineExpose` because the default — exposing
+everything on the component instance — would leak template
+locals, computed signals, and lifecycle hook state to the
+parent. Rust has `pub` / `pub(crate)` / `pub(super)`; a
+field or method is reachable iff its declared visibility
+permits it. `Handle<T>::with(|t: &T| ...)` only sees what
+the calling crate's visibility rules allow.
+
+A child that wants to expose just one method writes:
+
+```rust
+impl ChildComponent {
+    pub fn focus(&self) { ... }      // exposed
+    fn private_helper(&self) { ... } // not exposed
+}
+```
+
+…and parents in any crate can call `body.with(|c| c.focus())` but
+cannot reach `private_helper`. No new attribute needed.
+
+### 5.5 Why `Handle<T>`, not a custom wrapper
+
+`Handle<T>` is already the canonical "carry a typed
+component reference across handler boundaries" primitive
+([`Handle::with`](../crates/pocopine-core/src/handle.rs#L100),
+[`Handle::update`](../crates/pocopine-core/src/handle.rs#L116)).
+Authors already use it for `this::<Self>()`, `Parent<T>`,
+`NearestParent<T>`, context injection. Reusing it avoids
+a new mental model and inherits the existing borrow-safety
+guarantees.
+
+A custom `ChildRef<T>` wrapper would either be a Handle
+re-export (pure noise) or weaken the borrow rules (lose
+the borrow-safety check). Neither is worth it.
+
+## 6. Implementation phasing
+
+### Phase 1 — Host stamp + resolution API ✅
+
+- Stamp `SCOPE_ID_KEY` on the custom-element host in
+  [`mount_component`](../crates/pocopine-core/src/mount.rs#L286)
+  and `try_mount_component_as` (currently only the inner
+  template root receives it).
+- Add free-fn `refs::get_component` /
+  `refs::get_component_on` returning `Option<Handle<T>>`.
+- Add `Refs::get_component` extractor method.
+- Browser tests
+  (`crates/pocopine-core/tests/component_refs.rs`):
+  matching-type returns `Some`, mismatched type returns
+  `None`, plain DOM ref returns `None`, unknown ref name
+  returns `None`, self-scope ref returns `None`,
+  `clear_scope` evicts.
+
+### Phase 2 — Macro + walker integration tests
+
+- End-to-end test: a parent `#[component]` template with
+  `<child-tag pp-ref="body">` resolves the typed handle in
+  a handler. Confirms the macro-emitted plan reaches the
+  host stamp in the right order.
+- Edge case: `pp-if` swap. The parent's pp-ref points to
+  the swapped-out child's element; after remount, the
+  ref points to the new child's host (with the new
+  scope id) → `get_component` resolves the post-swap
+  child.
+- Edge case: `pp-for` rows. Each row's pp-ref entry
+  resolves to that row's child scope (one ref per row).
+
+### Phase 3 — Documentation + migration
+
+- Add a `ref_handles` example under
+  `examples/` (or extend the existing pine examples) that
+  shows the worked pattern end-to-end.
+- Update keep's `save` / `auto_save` / `schedule_*` paths
+  to drop `Editor::find(&form_root)` in favor of
+  `refs::get_component::<KeepNoteBody>("body")?`.
+- Add a memory note pointing future Claude sessions at the
+  new API for the cross-component-handle case.
+
+### Phase 4 (optional follow-up) — `Parent<T>` symmetry
+
+`Parent<T>` extracts a typed handle to the immediate
+parent component. After this RFC lands, the parent-side
+mirror is `Refs::get_component::<Child>("name")` —
+together they form a complete bi-directional reach. A
+later RFC can unify the two as a single `RefHandle<T>` /
+`Parent<T>` story if a third-party crate would benefit.
+
+## 7. Open questions
+
+- **Multiple children of the same type.** The keep
+  pattern already uses unique pp-ref names per child;
+  this RFC doesn't need to enumerate "all children of
+  type T." If that becomes a load-bearing use case
+  (e.g. an autocomplete that needs to focus the *first
+  visible* `<pine-select-root>` among many), a follow-up
+  can add `refs::components::<T>() -> Vec<Handle<T>>`.
+- **Diagnostics on mismatch.** When `get_component::<Foo>(..)`
+  returns `None` because the registered scope is of type
+  `Bar`, do we silently return `None` (matches today's
+  `get_as` behavior) or panic with a typed message? My
+  default: return `None`; surface a `tracing::warn!` with
+  the actual type name so authors can diagnose without
+  guarding every call. Open for review.
+- **`pp-ref` on a slot.** If a slot transcludes a child
+  component AND the parent puts `pp-ref` on the slot
+  outlet, which scope owns the registered ref? Current
+  proposal: the slot's defining scope (consistent with
+  template-walk parentage). Needs a test once Phase 1
+  lands.
+
+## 8. Alternatives considered
+
+### 8.1 Status quo: `Editor::find(&form_root)`
+
+What we shipped today: parent caches a wrapper ref, the
+typed handle library does a `querySelector` for the
+child's component tag. Works but leaks template structure
+into call sites, requires every typed handle library to
+ship a `find` helper, and provides no path to typed
+methods the child wants to expose beyond what the library
+author thought to add at `find` time.
+
+### 8.2 `defineExpose`-style attribute
+
+`#[expose] pub fn editor(...)` on the child, mirrored by
+codegen into a typed proxy. Adds a macro, a new visibility
+modifier, and synchronization with Rust's existing `pub`
+system. Not worth the surface — Rust visibility already
+does this job.
+
+### 8.3 Context injection
+
+The child writes a [`create_context!`](../crates/pocopine-core/src/context.rs#L264)
+holding `Handle<Self>`, the parent reads it via `Inject<...>`.
+Works for the deeply-nested case but requires the child
+to opt in with module-level boilerplate per exposed
+handle, and the parent then has no name keyed lookup —
+context is one-instance-per-scope-subtree. Useful when
+you don't know the child's exact mount point;
+overpowered for the named-child case.
+
+### 8.4 Reactive subscription via `pp-model`
+
+The original keep shape. Defeated by feedback loops and
+`tick::next` mirror lag. Documented in the
+`feedback_richtext_no_two_way_binding` memory note. Not
+revisited.
+
+## 9. Risks
+
+| Risk | Mitigation |
+|---|---|
+| Walker hook fires too late (mount happens after refs registration) → name resolves to old child after a `pp-if` swap | `register_component` is called by the same code path that materializes the child scope; subsequent swaps run `clear_scope` on the parent before remount. Add a test that swaps a child via `pp-if` and confirms post-swap lookup returns the new child. |
+| `Handle<T>` outlives its scope (parent grabs a handle, child unmounts, parent's `with`/`update` panics) | Same risk as `Parent<T>` today. `Handle::with` already guards via `Scope::find` (returns gracefully on missing scope). Add a regression test for the unmount race. |
+| Two siblings with same `pp-ref` name in a `pp-for` row | `pp-ref` inside a `pp-for` row is already documented as last-wins. Component refs follow the same rule. Considered for follow-up but out of scope here. |
+| Increased thread-local memory footprint | `COMPONENT_REFS` is one extra `HashMap<ScopeId, HashMap<String, ScopeId>>`. Bounded by number of named child refs per scope (typically 0–5). Trivial. |
+
+## 10. Verification
+
+Per checkpoint:
+
+```bash
+cargo fmt --check -p pocopine-core
+cargo clippy -p pocopine-core --target wasm32-unknown-unknown -- -D warnings
+cargo test -p pocopine-core --lib
+# After Phase 3 (keep migration):
+cargo build -p keep-example --target wasm32-unknown-unknown
+RICHTEXT_SMOKE_PORT=5249 npx playwright test --reporter=line
+```
+
+New tests added by this RFC:
+
+- `refs::get_component_returns_typed_handle_for_named_child`
+- `refs::get_component_returns_none_for_mismatched_type`
+- `refs::get_component_evicts_with_scope`
+- `refs::get_component_after_pp_if_swap_resolves_new_child`
+- `refs::get_component_outside_scope_context_is_none`
+- Phase 3: keep `save` flow continues to round-trip
+  markdown after dropping `Editor::find(&form_root)` (one
+  Playwright test in the keep suite, or a wasm-pack
+  bindgen test if keep doesn't have Playwright yet).


### PR DESCRIPTION
## Summary

Adds two layers of cross-component reach for parent `→` named-child:

- **Phase 1** (commit 1): `refs::get_component::<T>("name")` resolves a typed `Handle<Child>` when `pp-ref="name"` decorates a child component's host element. Mount stamps `SCOPE_ID_KEY` on the host so the lookup composes `refs::get_on` + `mount::scope_id_of_element` + `Scope::typed`. No DOM walk.
- **Phase 2** (commit 2): `#[component]` macro generates a `<ComponentName>Refs<'a>` struct with one `fn <name>(&self) -> RefAccessor` per `pp-ref` in the template. Compile-time name checking — typos fail to build. Type stays at the call site via `.element()` / `.as_::<T>()` / `.component::<T>()`.

Together they close the gap that forced keep to do `Editor::find(&form_root)` (DOM drilling). Mirrors Vue's `defineExpose` + `ref="name"` pattern without inventing parallel visibility machinery (Rust `pub` already gates what crosses the boundary).

## RFC

`rfcs/rfc-081-component-handle-refs.md` (Draft, Phase 1+2 landed). Walks through the API, the implementation, the alternatives considered, and the risks. Layer 3 (auto-derive Rust type from .poco tag) is filed as follow-up issue #101.

## API at a glance

```rust
// Child opts in via Rust pub — no new attribute.
impl KeepNoteBody {
    pub fn editor(&self) -> Option<pine_richtext::view::Editor> { /* ... */ }
}

// Parent's template — pp-ref on the child component tag.
<keep-note-body pp-ref="body" />

// Parent's handler — typed reach across the boundary, compile-checked name.
fn save(&self, refs: KeepNoteFormRefs) {
    let body = refs.body().component::<KeepNoteBody>()?;     // Option<Handle<KeepNoteBody>>
    let md   = body.with(|b| b.editor()?.get::<Markdown>().ok())?;
    // ...
}
```

`RefAccessor` returned by `refs.body()` carries `(scope_id, "body")` and exposes `.element()` / `.as_::<T: JsCast>()` / `.component::<T: 'static>()`. The name `"body"` is `&'static str`, baked in by macro codegen — `refs.bdy()` is a compile error.

For callers without a parent scope (raw mounts in static HTML, async handlers) the free-fn API stays: `pocopine::refs::get_component::<T>("name")` / `Refs::get_component::<T>("name")`.

## Implementation

### Phase 1 — Host stamp + resolution API (commit 1)

- `mount_component` / `try_mount_component_as` stamp the custom-element host with the child's `SCOPE_ID_KEY` (today only the inner template root got it).
- `pocopine::refs::get_component::<T>(name)` / `get_component_on` / `Refs::get_component` — wraps the existing `Handle<T>` primitive, no new type.
- 6 browser unit tests (matching type, mismatched type, plain DOM ref, unknown name, self-scope rejection, `clear_scope` eviction).

Total runtime delta: ~10 lines across mount.rs + refs.rs + lifecycle.rs.

### Phase 2 — Typed refs codegen (commit 2)

- `pocopine_core::refs::RefAccessor` — captures `(ScopeId, &'static str)`, exposes `.element()` / `.as_::<T>()` / `.component::<T>()`.
- `pocopine_macros::template_plan` collects every `pp-ref` name during the existing template-plan walk; surfaces the dedup'd list on `EmittedTemplatePlan`.
- `#[component]` emits `<ComponentName>Refs<'a>` + `From<LifecycleContext>` extractor alongside the component. Empty for components with zero pp-refs (still emitted so the extractor name is discoverable).
- 2 browser integration tests for end-to-end macro round-trip (real `#[component]` parent + child).

Total macro delta: ~100 lines.

## Compiled-component paradigm

No new runtime walker, no opaque-directive dispatch, no DOM tree scan. Phase 1 adds one `set_private` call to the existing compiled mount path. Phase 2 codegen runs at macro-expand time, emits a plain Rust struct + `impl`. `pp-ref` itself is unchanged — still flows through the macro-compiled `StaticRef` plan entry.

One incidental cost: the host now always carries `SCOPE_ID_KEY` whether or not a parent ever uses `pp-ref` on it (one `Reflect::set` per child mount). Flagged for measurement; if it shows up as real cost, gate on a `StaticChildMount.has_pp_ref` flag the macro can set at emit time.

## Phase 3 (separate PR)

Migrate keep to drop `Editor::find(&form_root)` in favor of `refs.body().component::<KeepNoteBody>()`. Sequencing depends on #99 (keep-richtext integration) and this PR both landing first; the migration is one branch combining both crates' work.

## Test plan

- [x] `cargo fmt --check -p pocopine-core -p pocopine-macros -p pocopine` clean
- [x] `cargo clippy ... -- -D warnings` clean on all three
- [x] `wasm-pack test --firefox --headless crates/pocopine-core` — 6 Phase 1 tests pass + 3 existing svg_namespace tests pass
- [x] `wasm-pack test --firefox --headless crates/pocopine --test refs_typed` — 2 Phase 2 integration tests pass
- [x] `cargo check -p pine --target wasm32-unknown-unknown` — confirms no breakage across the component zoo
- [ ] CI: full workspace test pass (local environment has unrelated v8/node crash for `--node` tests)
- [ ] Phase 3 keep migration (separate PR after this + #99 land)

🤖 Generated with [Claude Code](https://claude.com/claude-code)