### PR TITLE
pocopine-deploy: fix wasm clippy error in credentials.rs

### DIFF
--- a/crates/pocopine-deploy/src/credentials.rs
+++ b/crates/pocopine-deploy/src/credentials.rs
@@ -227,21 +227,26 @@ fn home() -> Result<PathBuf> {
 fn write_secure(path: &Path, bytes: &[u8]) -> Result<()> {
     let tmp = path.with_extension("toml.tmp");
 
-    let mut opts = OpenOptions::new();
-    opts.write(true).create(true).truncate(true);
-    #[cfg(unix)]
+    // Scope the file so it is closed (dropped) before the rename below —
+    // an open handle can block a rename on Windows. A block, rather than
+    // an explicit `drop(f)`, because `std::fs::File` is a no-op stub on
+    // wasm where `drop()` of a non-`Drop` type is a clippy error.
     {
-        use std::os::unix::fs::OpenOptionsExt;
-        opts.mode(0o600);
+        let mut opts = OpenOptions::new();
+        opts.write(true).create(true).truncate(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            opts.mode(0o600);
+        }
+        let mut f = opts
+            .open(&tmp)
+            .with_context(|| format!("opening {}", tmp.display()))?;
+        f.write_all(bytes)
+            .with_context(|| format!("writing {}", tmp.display()))?;
+        f.sync_all()
+            .with_context(|| format!("fsync {}", tmp.display()))?;
     }
-    let mut f = opts
-        .open(&tmp)
-        .with_context(|| format!("opening {}", tmp.display()))?;
-    f.write_all(bytes)
-        .with_context(|| format!("writing {}", tmp.display()))?;
-    f.sync_all()
-        .with_context(|| format!("fsync {}", tmp.display()))?;
-    drop(f);
 
     #[cfg(unix)]
     {


### PR DESCRIPTION
## Fix the `clippy (wasm32)` CI failure on `main`

`main`'s `clippy (wasm32)` job is failing on `crates/pocopine-deploy/src/credentials.rs:244`:

```
error: call to `std::mem::drop` with a value that does not implement `Drop`
```

`write_secure` closed the temp file with an explicit `drop(f)` before
`fs::rename`. On `wasm32-unknown-unknown`, `std::fs::File` is a no-op
stub that does **not** implement `Drop`, so `drop(f)` trips
`clippy::drop_non_drop` — an error under `-D warnings`. Host clippy
never sees it, because `File` *is* `Drop` there.

### Fix
Scope the file handle in a `{ … }` block instead of `drop(f)` — it is
closed at the block's end, before the rename. Identical behavior, no
lint on any target.

Single-file change; host + wasm clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)