### PR TITLE
`#[derive(Props)]`: bare `#[prop(flatten)]` + exact leaf typing

### DIFF
--- a/crates/pine-charts/src/cartesian_chart/mod.rs
+++ b/crates/pine-charts/src/cartesian_chart/mod.rs
@@ -1004,11 +1004,15 @@ impl PineYAxis {
 /// `#[prop(flatten)]` (RFC-044 §5.10): the container is one Rust
 /// field, but the wire surface stays one attribute per leaf, so
 /// `<pine-line-series key=… label=… color=…>` is unchanged.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Props, Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SeriesCommon {
+    #[prop]
     pub key: String,
+    #[prop]
     pub label: String,
+    #[prop]
     pub color: String,
+    #[prop]
     pub visible: bool,
 }
 
@@ -1026,7 +1030,7 @@ impl Default for SeriesCommon {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[component(template = "PineLineSeries.poco", role = "visual")]
 pub struct PineLineSeries {
-    #[prop(flatten = ["key", "label", "color", "visible"])]
+    #[prop(flatten)]
     pub common: SeriesCommon,
     #[prop]
     pub stroke_width: f64,
@@ -1121,7 +1125,7 @@ impl PineLineSeries {
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[component(template = "PineBarSeries.poco", role = "visual")]
 pub struct PineBarSeries {
-    #[prop(flatten = ["key", "label", "color", "visible"])]
+    #[prop(flatten)]
     pub common: SeriesCommon,
     #[prop]
     pub data: Vec<ChartBar>,
@@ -1169,7 +1173,7 @@ impl PineBarSeries {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[component(template = "PineAreaSeries.poco", role = "visual")]
 pub struct PineAreaSeries {
-    #[prop(flatten = ["key", "label", "color", "visible"])]
+    #[prop(flatten)]
     pub common: SeriesCommon,
     #[prop]
     pub fill: String,
@@ -1245,7 +1249,7 @@ impl PineAreaSeries {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[component(template = "PineScatterSeries.poco", role = "visual")]
 pub struct PineScatterSeries {
-    #[prop(flatten = ["key", "label", "color", "visible"])]
+    #[prop(flatten)]
     pub common: SeriesCommon,
     #[prop]
     pub point_radius: f64,

--- a/crates/pocopine-core/src/lib.rs
+++ b/crates/pocopine-core/src/lib.rs
@@ -36,6 +36,7 @@ pub mod mount;
 pub mod path;
 pub mod plugin;
 pub mod profiler;
+pub mod props;
 pub mod reactive;
 pub mod refs;
 pub mod registry;
@@ -96,6 +97,7 @@ pub use plugin::{
 pub use profiler::mount::{
     enabled as mount_profile_enabled, report as report_mount_profile, reset as reset_mount_profile,
 };
+pub use props::{PropValue, Props};
 pub use reactive::{
     batch, current_effect, effect, effect_scoped, effect_with, flush_sync, on_cleanup, release,
     run_now, set_auto_flush, track, trigger_scope, EffectId, EffectOptions, ScopeId, SignalId,

--- a/crates/pocopine-core/src/props.rs
+++ b/crates/pocopine-core/src/props.rs
@@ -1,0 +1,126 @@
+//! RFC-044 §5.10 — `Props` and `PropValue` traits backing
+//! `#[derive(Props)]`.
+//!
+//! A `Props` struct describes a reusable group of component props.
+//! The `#[derive(Props)]` macro reads fields marked `#[prop]` on the
+//! struct and emits an `impl Props` that exposes the leaf names and a
+//! direct per-leaf `JsValue` conversion. When such a struct is
+//! flattened into a `#[component]` field via a *bare*
+//! `#[prop(flatten)]`, the `#[component]` macro routes leaf
+//! get/set/static_prop_kind through this trait at runtime — avoiding
+//! the whole-struct serde round-trip and providing exact per-leaf
+//! types (no probe-the-default heuristic).
+
+use wasm_bindgen::JsValue;
+
+use crate::scope::StaticPropKind;
+
+/// Conversion contract for an individual flatten-leaf value.
+///
+/// Every `#[prop]` field on a `#[derive(Props)]` struct must have a
+/// type that implements `PropValue` — the derive uses these methods
+/// to convert the field to/from a `JsValue` and to report the leaf's
+/// `StaticPropKind` for HTML-attribute coercion.
+///
+/// v1 ships impls for `String`, `bool`, the common integer + float
+/// types, and `Option<T: PropValue>`. Custom leaf types are future
+/// work (an `#[prop(with = ...)]` escape hatch, RFC-044 future-work).
+pub trait PropValue: Sized {
+    /// Render this value as a `JsValue` for `prop_get`.
+    fn to_prop_js(&self) -> JsValue;
+
+    /// Parse a `JsValue` (typically the result of a parent's static
+    /// attribute coercion or `pp-bind` write) into the leaf type.
+    /// Returns `None` if the value cannot be converted; the
+    /// generated `prop_set` arm drops the write silently in that
+    /// case, matching the explicit-list flatten path's behaviour.
+    fn from_prop_js(value: JsValue) -> Option<Self>;
+
+    /// Static-attribute coercion hint for this leaf type.
+    fn prop_static_kind() -> StaticPropKind;
+}
+
+impl PropValue for String {
+    fn to_prop_js(&self) -> JsValue {
+        JsValue::from_str(self)
+    }
+    fn from_prop_js(value: JsValue) -> Option<Self> {
+        value.as_string()
+    }
+    fn prop_static_kind() -> StaticPropKind {
+        StaticPropKind::String
+    }
+}
+
+impl PropValue for bool {
+    fn to_prop_js(&self) -> JsValue {
+        JsValue::from_bool(*self)
+    }
+    fn from_prop_js(value: JsValue) -> Option<Self> {
+        value.as_bool()
+    }
+    fn prop_static_kind() -> StaticPropKind {
+        StaticPropKind::Bool
+    }
+}
+
+macro_rules! impl_numeric_prop_value {
+    ($($t:ty),* $(,)?) => { $(
+        impl PropValue for $t {
+            fn to_prop_js(&self) -> JsValue {
+                JsValue::from_f64(*self as f64)
+            }
+            fn from_prop_js(value: JsValue) -> Option<Self> {
+                value.as_f64().map(|n| n as $t)
+            }
+            fn prop_static_kind() -> StaticPropKind {
+                StaticPropKind::Number
+            }
+        }
+    )* };
+}
+
+impl_numeric_prop_value!(f32, f64, i8, i16, i32, i64, isize, u8, u16, u32, u64, usize);
+
+/// `Option<T>` impl — `None` round-trips through `JsValue::NULL`, and
+/// an empty-string inbound write coerces to `None` to match the
+/// long-standing empty-attribute → `None` convention the explicit
+/// flatten path also honours.
+impl<T: PropValue> PropValue for Option<T> {
+    fn to_prop_js(&self) -> JsValue {
+        match self {
+            Some(v) => v.to_prop_js(),
+            None => JsValue::NULL,
+        }
+    }
+    fn from_prop_js(value: JsValue) -> Option<Self> {
+        if value.is_null() || value.is_undefined() {
+            return Some(None);
+        }
+        if value.as_string().as_deref() == Some("") {
+            return Some(None);
+        }
+        T::from_prop_js(value).map(Some)
+    }
+    fn prop_static_kind() -> StaticPropKind {
+        T::prop_static_kind()
+    }
+}
+
+/// Implemented by `#[derive(Props)]` structs.
+///
+/// `prop_leaves()` returns the static slice of leaf names — the
+/// `#[component]` macro consumes this to extend a component's
+/// `keys()` and to dispatch `get`/`set`/`is_prop` for a bare
+/// `#[prop(flatten)]` / `#[model(flatten)]` field. `prop_get` /
+/// `prop_set` route directly through each field's `PropValue` impl
+/// (no whole-struct serde round-trip). `prop_static_kind` reports
+/// the exact static-attribute kind for each leaf, removing the
+/// runtime "probe the serialised default" heuristic the explicit-list
+/// flatten path uses.
+pub trait Props {
+    fn prop_leaves() -> &'static [&'static str];
+    fn prop_get(&self, leaf: &str) -> JsValue;
+    fn prop_set(&mut self, leaf: &str, value: JsValue);
+    fn prop_static_kind(leaf: &str) -> StaticPropKind;
+}

--- a/crates/pocopine-core/src/props.rs
+++ b/crates/pocopine-core/src/props.rs
@@ -80,12 +80,25 @@ macro_rules! impl_numeric_prop_value {
     )* };
 }
 
-impl_numeric_prop_value!(f32, f64, i8, i16, i32, i64, isize, u8, u16, u32, u64, usize);
+// JS numbers are IEEE-754 doubles, so `i64` / `u64` over the safe-int
+// range (±2^53) would silently lose precision through `as f64` and
+// the round-trip back. Restrict the v1 impls to widths that round-trip
+// losslessly. `usize` / `isize` are safe — pocopine targets wasm32
+// only, where they are 32-bit. A future revision can add `i64` / `u64`
+// via `BigInt` if a real prop type needs them.
+impl_numeric_prop_value!(f32, f64, i8, i16, i32, isize, u8, u16, u32, usize);
 
 /// `Option<T>` impl — `None` round-trips through `JsValue::NULL`, and
-/// an empty-string inbound write coerces to `None` to match the
+/// an empty-string inbound value coerces to `None` to match the
 /// long-standing empty-attribute → `None` convention the explicit
-/// flatten path also honours.
+/// flatten path also honours (RFC-044 §5.4).
+///
+/// Note this is lossy for `Option<String>` going through `pp-bind`:
+/// a parent's `Some(String::new())` becomes `None` on the child
+/// because the value is indistinguishable from an empty static
+/// attribute `<… leaf=""/>`. Use a sentinel or a separate flag if
+/// you need to round-trip a real empty string; the same caveat
+/// applies to the explicit-list flatten path.
 impl<T: PropValue> PropValue for Option<T> {
     fn to_prop_js(&self) -> JsValue {
         match self {

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -1716,7 +1716,19 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
                 };
                 match parsed {
                     Ok((name, flatten, bare)) => {
-                        if let Some(leaves) = flatten {
+                        // RFC-044 §5.10 — `flatten` is incompatible with
+                        // `name`: there is no single wire name to rename
+                        // when the field is exploded into per-leaf keys.
+                        // Catch the combination instead of silently
+                        // dropping `name` on the floor.
+                        if name.is_some() && (flatten.is_some() || bare) {
+                            observe_err = Some(syn::Error::new_spanned(
+                                a,
+                                "#[model(name = \"...\", flatten…)] is not allowed — \
+                                 `flatten` explodes the field into per-leaf wire keys, \
+                                 so a single rename has no target. Drop one of the two.",
+                            ));
+                        } else if let Some(leaves) = flatten {
                             // Explicit-list flatten — container is
                             // internal, leaves take the prop + model
                             // role (added to `flatten_fields`).
@@ -2056,6 +2068,82 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
         .flat_map(|(_, leaves, _)| leaves.iter())
         .collect();
 
+    // RFC-044 §5.10.4 — collision shield for the bare-flatten
+    // fallthrough. A bare leaf is only known at runtime; without
+    // guarding the `_` arms a key that ALSO names a real struct field
+    // (or an explicit-flatten leaf) would be misclassified as
+    // belonging to a bare container — `is_prop("x")` would flip true
+    // via the bare OR-term even when `x` is unmarked state, and
+    // `flatten_container_of("x")` would point at the wrong container,
+    // dual-triggering a `#[watch(<container>)]` that wasn't actually
+    // mutated. Gate the fallthrough on "key isn't already a static
+    // known key".
+    //
+    // `static_known_field_names_check` matches every real struct
+    // field (used by `flatten_container_of` / `model_name`, whose
+    // static arms cover only explicit-flatten leaves).
+    // `static_known_keys_check` matches every real field PLUS every
+    // explicit-flatten leaf (used by `is_prop` / `is_model`, whose
+    // matches-cover only the *role-marked* subset).
+    let static_known_field_names_check = if field_names.is_empty() {
+        quote! { false }
+    } else {
+        quote! { matches!(key, #(#field_names)|*) }
+    };
+    let static_known_keys_check_idents: Vec<&String> = field_names
+        .iter()
+        .chain(flatten_leaf_names.iter().copied())
+        .collect();
+    let static_known_keys_check = if static_known_keys_check_idents.is_empty() {
+        quote! { false }
+    } else {
+        quote! { matches!(key, #(#static_known_keys_check_idents)|*) }
+    };
+    // Runtime collision audit emitted into `keys()` initialisation —
+    // panics on first call (mount time) if any bare-flatten leaf
+    // collides with a real field, an explicit-flatten leaf, or
+    // another bare leaf. Compile-time const-eval is future work
+    // (needs an inherent `const` on the `Props` impl); this fails
+    // loud at mount, matching RFC §5.10.4's "hard error" promise in
+    // practice without blocking the v1 derive shape.
+    let static_known_keys_audit_arr = static_known_keys_check_idents.iter().map(|n| quote! { #n });
+    let bare_flatten_audit_extends = bare_flatten_fields.iter().map(|(_, ty, _)| {
+        quote! {
+            __bare_leaves.extend_from_slice(
+                <#ty as ::pocopine::__private::Props>::prop_leaves(),
+            );
+        }
+    });
+    let bare_flatten_collision_audit = if bare_flatten_fields.is_empty() {
+        quote! {}
+    } else {
+        quote! {
+            // Gathered once on first `keys()` call; panics on any
+            // leaf-name collision (RFC-044 §5.10.4).
+            let mut __bare_leaves: ::std::vec::Vec<&'static str> = ::std::vec::Vec::new();
+            #(#bare_flatten_audit_extends)*
+            let __static_known: &[&'static str] = &[#(#static_known_keys_audit_arr),*];
+            for __i in 0..__bare_leaves.len() {
+                let __leaf = __bare_leaves[__i];
+                if __static_known.contains(&__leaf) {
+                    panic!(
+                        "RFC-044 §5.10.4 — bare-flatten leaf `{}` collides with \
+                         an existing field or explicit-flatten leaf on this \
+                         component; rename the leaf",
+                        __leaf,
+                    );
+                }
+                if __bare_leaves[..__i].contains(&__leaf) {
+                    panic!(
+                        "RFC-044 §5.10.4 — bare-flatten leaf `{}` is exposed by \
+                         more than one container on this component",
+                        __leaf,
+                    );
+                }
+            }
+        }
+    };
+
     // RFC-044 §5.10 — leaf → container map for `flatten_container_of`.
     // A write to any leaf mutates the whole container field, so the
     // proxy `set` trap triggers the container key too, letting one
@@ -2102,10 +2190,16 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
     ) {
         (true, true) => quote! { let _ = key; false },
         (false, true) => quote! { matches!(key, #(#prop_field_names)|*) },
-        (true, false) => quote! { #(#bare_flatten_is_prop_terms)||* },
+        // Bare-flatten OR-terms are gated by `!static_known_keys_check`
+        // so a real field that shadows a bare leaf doesn't flip
+        // `is_prop` to true via the bare path (RFC-044 §5.10.4).
+        (true, false) => quote! {
+            !(#static_known_keys_check) && (#(#bare_flatten_is_prop_terms)||*)
+        },
         (false, false) => quote! {
             matches!(key, #(#prop_field_names)|*)
-                || #(#bare_flatten_is_prop_terms)||*
+                || (!(#static_known_keys_check)
+                    && (#(#bare_flatten_is_prop_terms)||*))
         },
     };
 
@@ -2178,17 +2272,22 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
         .collect();
     // Same shape as `is_prop_body` (above) — bare model-flatten
     // containers contribute OR terms resolved through
-    // `<Ty as Props>::prop_leaves()` at runtime.
+    // `<Ty as Props>::prop_leaves()` at runtime, gated by
+    // `!static_known_keys_check` so a real field that happens to
+    // share a bare leaf's name doesn't bleed into the model role.
     let is_model_body = match (
         model_field_names.is_empty(),
         bare_flatten_is_model_terms.is_empty(),
     ) {
         (true, true) => quote! { let _ = key; false },
         (false, true) => quote! { matches!(key, #(#model_field_names)|*) },
-        (true, false) => quote! { #(#bare_flatten_is_model_terms)||* },
+        (true, false) => quote! {
+            !(#static_known_keys_check) && (#(#bare_flatten_is_model_terms)||*)
+        },
         (false, false) => quote! {
             matches!(key, #(#model_field_names)|*)
-                || #(#bare_flatten_is_model_terms)||*
+                || (!(#static_known_keys_check)
+                    && (#(#bare_flatten_is_model_terms)||*))
         },
     };
     let model_name_arms = field_names
@@ -2894,6 +2993,10 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
                         <Self as ::pocopine::__private::HandlerDispatch>::computed_keys(),
                     );
                     #(#bare_flatten_keys_extend)*
+                    // RFC-044 §5.10.4 — one-time bare-flatten leaf
+                    // collision audit. No-op when the component has
+                    // no bare flatten fields.
+                    #bare_flatten_collision_audit
                     let __boxed: ::std::boxed::Box<[&'static str]> = __keys.into_boxed_slice();
                     ::std::boxed::Box::leak(__boxed)
                 })
@@ -2911,6 +3014,14 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
                 match key {
                     #(#flatten_container_arms)*
                     _ => {
+                        // RFC-044 §5.10.4 — a real struct field that
+                        // happens to share a bare-flatten leaf's name
+                        // must not falsely report a container (which
+                        // would trigger `#[watch(<container>)]` on a
+                        // write that only touched the field).
+                        if #static_known_field_names_check {
+                            return ::core::option::Option::None;
+                        }
                         #(#bare_flatten_container_lookups)*
                         ::core::option::Option::None
                     }
@@ -2923,6 +3034,13 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
                 match key {
                     #(#model_name_arms)*
                     _ => {
+                        // RFC-044 §5.10.4 — gate the bare-model-flatten
+                        // fallthrough so a real field's name can't
+                        // accidentally be reported as a wire-emitted
+                        // model leaf.
+                        if #static_known_field_names_check {
+                            return ::core::option::Option::None;
+                        }
                         #(#bare_flatten_model_name_lookups)*
                         ::core::option::Option::None
                     }

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -1532,6 +1532,14 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
     // `is_model = false` → `#[prop(flatten)]`: leaves are
     //   parent-writable props only — inbound, no `pp:update:` channel.
     let mut flatten_fields: Vec<(syn::Ident, Vec<String>, bool)> = Vec::new();
+    // Bare-flatten fields — `#[prop(flatten)]` / `#[model(flatten)]`
+    // with no explicit list. The field's type must implement
+    // `::pocopine::__private::Props` (typically via
+    // `#[derive(Props)]`); the runtime fallthrough in get / set /
+    // keys / is_prop / is_model / static_prop_kind /
+    // flatten_container_of / model_name routes through that trait.
+    // Tuple is `(container_ident, container_type, is_model)`.
+    let mut bare_flatten_fields: Vec<(syn::Ident, syn::Type, bool)> = Vec::new();
     for field in input.fields.iter_mut() {
         let Some(ident) = field.ident.clone() else {
             continue;
@@ -1546,14 +1554,15 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
             if a.path().is_ident("prop") {
                 // Shapes accepted:
                 //   #[prop]                                  bare
-                //   #[prop(flatten = ["leaf1", "leaf2"])]    inbound per-leaf shape
-                //   #[prop(flatten)]                         (reserved — auto-discovery)
+                //   #[prop(flatten = ["leaf1", "leaf2"])]    explicit-list flatten
+                //   #[prop(flatten)]                         bare flatten — field type
+                //                                            must impl `Props`
                 match &a.meta {
                     Meta::Path(_) => {
                         is_prop = true;
                     }
                     Meta::List(_) => {
-                        let parsed: syn::Result<Vec<String>> =
+                        let parsed: syn::Result<Option<Vec<String>>> =
                             a.parse_args_with(|input: syn::parse::ParseStream| {
                                 let mut flatten_leaves: Option<Vec<String>> = None;
                                 let mut bare_flatten = false;
@@ -1590,28 +1599,34 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
                                         input.parse::<Token![,]>()?;
                                     }
                                 }
-                                match flatten_leaves {
-                                    Some(leaves) => Ok(leaves),
-                                    None if bare_flatten => Err(syn::Error::new_spanned(
+                                match (flatten_leaves, bare_flatten) {
+                                    // explicit leaf list
+                                    (Some(leaves), _) => Ok(Some(leaves)),
+                                    // bare `#[prop(flatten)]` — field
+                                    // type must impl `Props`; leaves
+                                    // resolve through the trait at
+                                    // runtime.
+                                    (None, true) => Ok(None),
+                                    (None, false) => Err(syn::Error::new_spanned(
                                         a,
-                                        "bare #[prop(flatten)] auto-discovery is not yet \
-                                         implemented — provide an explicit leaf list: \
-                                         #[prop(flatten = [\"field1\", \"field2\"])]",
-                                    )),
-                                    None => Err(syn::Error::new_spanned(
-                                        a,
-                                        "#[prop] list form expects `flatten = [...]`",
+                                        "#[prop] list form expects `flatten` or \
+                                         `flatten = [\"leaf1\", \"leaf2\"]`",
                                     )),
                                 }
                             });
                         match parsed {
-                            Ok(leaves) => {
-                                // Container is internal — not prop,
-                                // not model. Leaves take the prop
-                                // role (added to `flatten_fields`
-                                // with `is_model = false`).
+                            Ok(Some(leaves)) => {
+                                // Explicit-list flatten — container is
+                                // internal, leaves take the prop role.
                                 is_prop = false;
                                 flatten_fields.push((ident.clone(), leaves, false));
+                            }
+                            Ok(None) => {
+                                // Bare flatten — container is
+                                // internal, leaves resolve through
+                                // `<FieldTy as Props>` at runtime.
+                                is_prop = false;
+                                bare_flatten_fields.push((ident.clone(), field_ty.clone(), false));
                             }
                             Err(e) => observe_err = Some(e),
                         }
@@ -1630,8 +1645,9 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
                 // Shapes accepted:
                 //   #[model]                                  bare
                 //   #[model(name = "…")]                      wire-name rename
-                //   #[model(flatten = ["leaf1", "leaf2"])]    per-leaf wire shape
-                //   #[model(flatten)]                         (reserved — see below)
+                //   #[model(flatten = ["leaf1", "leaf2"])]    explicit-list flatten
+                //   #[model(flatten)]                         bare flatten — field type
+                //                                              must impl `Props`
                 let parsed: syn::Result<(Option<String>, Option<Vec<String>>, bool)> = match &a.meta
                 {
                     Meta::Path(_) => Ok((None, None, false)),
@@ -1670,14 +1686,14 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
                                     ));
                                 }
                             } else if key == "flatten" {
-                                // Bare `#[model(flatten)]` —
-                                // auto-discovery form per RFC-044
-                                // §5.10. Reserved for a follow-up
-                                // PR that adds the runtime leaves
-                                // side-table; today's macro emits
-                                // static match arms and can't
-                                // produce those without knowing
-                                // the leaf list.
+                                // Bare `#[model(flatten)]` — the
+                                // field type must implement
+                                // `Props` (typically via
+                                // `#[derive(Props)]`). Leaves
+                                // resolve through that trait at
+                                // runtime; outer match below
+                                // pushes the container into
+                                // `bare_flatten_fields`.
                                 bare_flatten = true;
                             } else {
                                 return Err(syn::Error::new_spanned(
@@ -1700,24 +1716,25 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
                 };
                 match parsed {
                     Ok((name, flatten, bare)) => {
-                        if bare && flatten.is_none() {
-                            observe_err = Some(syn::Error::new_spanned(
-                                a,
-                                "bare #[model(flatten)] auto-discovery is not yet \
-                                 implemented — provide an explicit leaf list: \
-                                 #[model(flatten = [\"field1\", \"field2\"])]",
-                            ));
-                        } else if let Some(leaves) = flatten {
-                            // Container is internal — not prop, not
-                            // model. Leaves take those roles (added
-                            // to `flatten_fields` below, spliced into
-                            // codegen after the per-field loop).
-                            // `is_model = true` — model-flatten leaves
-                            // are both parent-writable and emittable.
+                        if let Some(leaves) = flatten {
+                            // Explicit-list flatten — container is
+                            // internal, leaves take the prop + model
+                            // role (added to `flatten_fields`).
                             is_prop = false;
                             is_model = false;
                             model_name = None;
                             flatten_fields.push((ident.clone(), leaves, true));
+                        } else if bare {
+                            // Bare `#[model(flatten)]` — container is
+                            // internal, leaves resolve through
+                            // `<FieldTy as Props>` at runtime and
+                            // additionally carry the `#[model]` role
+                            // (`is_model = true` -> per-leaf
+                            // `pp:update:<leaf>` channel).
+                            is_prop = false;
+                            is_model = false;
+                            model_name = None;
+                            bare_flatten_fields.push((ident.clone(), field_ty.clone(), true));
                         } else {
                             is_prop = true;
                             is_model = true;
@@ -1817,6 +1834,102 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
             }
         }
     }
+
+    // RFC-044 §5.10 — bare-flatten codegen precompute. For each
+    // `#[prop(flatten)]` / `#[model(flatten)]` field with NO explicit
+    // leaf list, the field's type must implement
+    // `::pocopine::__private::Props` (typically via
+    // `#[derive(Props)]`); the runtime fallthrough below routes leaf
+    // metadata through that trait at runtime. Explicit-list flatten
+    // (still supported, RFC-044 §5.10.2) emits static match arms; the
+    // two paths coexist and the explicit arms run first.
+    let bare_flatten_is_prop_terms: Vec<proc_macro2::TokenStream> = bare_flatten_fields
+        .iter()
+        .map(|(_, ty, _)| {
+            quote! {
+                <#ty as ::pocopine::__private::Props>::prop_leaves().contains(&key)
+            }
+        })
+        .collect();
+    let bare_flatten_is_model_terms: Vec<proc_macro2::TokenStream> = bare_flatten_fields
+        .iter()
+        .filter(|(_, _, is_model)| *is_model)
+        .map(|(_, ty, _)| {
+            quote! {
+                <#ty as ::pocopine::__private::Props>::prop_leaves().contains(&key)
+            }
+        })
+        .collect();
+    let bare_flatten_keys_extend: Vec<proc_macro2::TokenStream> = bare_flatten_fields
+        .iter()
+        .map(|(_, ty, _)| {
+            quote! {
+                __keys.extend_from_slice(
+                    <#ty as ::pocopine::__private::Props>::prop_leaves(),
+                );
+            }
+        })
+        .collect();
+    let bare_flatten_get_lookups: Vec<proc_macro2::TokenStream> = bare_flatten_fields
+        .iter()
+        .map(|(ident, ty, _)| {
+            quote! {
+                if <#ty as ::pocopine::__private::Props>::prop_leaves().contains(&key) {
+                    return ::pocopine::__private::Props::prop_get(&self.#ident, key);
+                }
+            }
+        })
+        .collect();
+    let bare_flatten_set_lookups: Vec<proc_macro2::TokenStream> = bare_flatten_fields
+        .iter()
+        .map(|(ident, ty, _)| {
+            quote! {
+                if <#ty as ::pocopine::__private::Props>::prop_leaves().contains(&key) {
+                    return ::pocopine::__private::Props::prop_set(
+                        &mut self.#ident,
+                        key,
+                        value,
+                    );
+                }
+            }
+        })
+        .collect();
+    let bare_flatten_static_kind_lookups: Vec<proc_macro2::TokenStream> = bare_flatten_fields
+        .iter()
+        .map(|(_, ty, _)| {
+            quote! {
+                if <#ty as ::pocopine::__private::Props>::prop_leaves().contains(&key) {
+                    return <#ty as ::pocopine::__private::Props>::prop_static_kind(key);
+                }
+            }
+        })
+        .collect();
+    let bare_flatten_container_lookups: Vec<proc_macro2::TokenStream> = bare_flatten_fields
+        .iter()
+        .map(|(ident, ty, _)| {
+            let container_name = ident.to_string().trim_start_matches("r#").to_string();
+            quote! {
+                if <#ty as ::pocopine::__private::Props>::prop_leaves().contains(&key) {
+                    return ::core::option::Option::Some(#container_name);
+                }
+            }
+        })
+        .collect();
+    let bare_flatten_model_name_lookups: Vec<proc_macro2::TokenStream> = bare_flatten_fields
+        .iter()
+        .filter(|(_, _, is_model)| *is_model)
+        .map(|(_, ty, _)| {
+            quote! {
+                for __leaf in
+                    <#ty as ::pocopine::__private::Props>::prop_leaves().iter()
+                {
+                    if *__leaf == key {
+                        return ::core::option::Option::Some(*__leaf);
+                    }
+                }
+            }
+        })
+        .collect();
 
     // RFC-044 §5.10 flatten-leaf codegen. For each `flatten = ["a",
     // "b"]` container field, each leaf becomes a synthetic public
@@ -1980,11 +2093,20 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
         .chain(flatten_leaf_names.iter().copied())
         .collect();
     // `matches!(key, a | b | c)` needs at least one pattern —
-    // fall back to a `false` literal when no field is a prop.
-    let is_prop_body = if prop_field_names.is_empty() {
-        quote! { let _ = key; false }
-    } else {
-        quote! { matches!(key, #(#prop_field_names)|*) }
+    // fall back to a `false` literal when no field is a prop. Each
+    // bare-flatten container contributes an extra OR term resolved
+    // through `<Ty as Props>::prop_leaves()` at runtime.
+    let is_prop_body = match (
+        prop_field_names.is_empty(),
+        bare_flatten_is_prop_terms.is_empty(),
+    ) {
+        (true, true) => quote! { let _ = key; false },
+        (false, true) => quote! { matches!(key, #(#prop_field_names)|*) },
+        (true, false) => quote! { #(#bare_flatten_is_prop_terms)||* },
+        (false, false) => quote! {
+            matches!(key, #(#prop_field_names)|*)
+                || #(#bare_flatten_is_prop_terms)||*
+        },
     };
 
     // Flatten leaves have no statically-known Rust type at the
@@ -2039,7 +2161,10 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
     let static_prop_kind_body = quote! {
         match key {
             #(#static_prop_kind_arms)*
-            _ => ::pocopine::__private::StaticPropKind::Auto,
+            _ => {
+                #(#bare_flatten_static_kind_lookups)*
+                ::pocopine::__private::StaticPropKind::Auto
+            }
         }
     };
 
@@ -2051,10 +2176,20 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
         .filter_map(|(n, is_model)| is_model.then_some(n))
         .chain(flatten_model_leaf_names.iter().copied())
         .collect();
-    let is_model_body = if model_field_names.is_empty() {
-        quote! { let _ = key; false }
-    } else {
-        quote! { matches!(key, #(#model_field_names)|*) }
+    // Same shape as `is_prop_body` (above) — bare model-flatten
+    // containers contribute OR terms resolved through
+    // `<Ty as Props>::prop_leaves()` at runtime.
+    let is_model_body = match (
+        model_field_names.is_empty(),
+        bare_flatten_is_model_terms.is_empty(),
+    ) {
+        (true, true) => quote! { let _ = key; false },
+        (false, true) => quote! { matches!(key, #(#model_field_names)|*) },
+        (true, false) => quote! { #(#bare_flatten_is_model_terms)||* },
+        (false, false) => quote! {
+            matches!(key, #(#model_field_names)|*)
+                || #(#bare_flatten_is_model_terms)||*
+        },
     };
     let model_name_arms = field_names
         .iter()
@@ -2734,14 +2869,20 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
             fn get(&self, key: &str) -> ::pocopine::__private::JsValue {
                 match key {
                     #(#get_arms)*
-                    _ => <Self as ::pocopine::__private::HandlerDispatch>::computed_get(self, key)
-                        .unwrap_or(::pocopine::__private::JsValue::UNDEFINED),
+                    _ => {
+                        #(#bare_flatten_get_lookups)*
+                        <Self as ::pocopine::__private::HandlerDispatch>::computed_get(self, key)
+                            .unwrap_or(::pocopine::__private::JsValue::UNDEFINED)
+                    }
                 }
             }
             fn set(&mut self, key: &str, value: ::pocopine::__private::JsValue) {
                 match key {
                     #(#set_arms)*
-                    _ => {}
+                    _ => {
+                        #(#bare_flatten_set_lookups)*
+                        let _ = value;
+                    }
                 }
             }
             fn keys(&self) -> &'static [&'static str] {
@@ -2752,6 +2893,7 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
                     __keys.extend_from_slice(
                         <Self as ::pocopine::__private::HandlerDispatch>::computed_keys(),
                     );
+                    #(#bare_flatten_keys_extend)*
                     let __boxed: ::std::boxed::Box<[&'static str]> = __keys.into_boxed_slice();
                     ::std::boxed::Box::leak(__boxed)
                 })
@@ -2768,7 +2910,10 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
             ) -> ::core::option::Option<&'static str> {
                 match key {
                     #(#flatten_container_arms)*
-                    _ => ::core::option::Option::None,
+                    _ => {
+                        #(#bare_flatten_container_lookups)*
+                        ::core::option::Option::None
+                    }
                 }
             }
             fn is_model(&self, key: &str) -> bool {
@@ -2777,7 +2922,10 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
             fn model_name(&self, key: &str) -> ::core::option::Option<&'static str> {
                 match key {
                     #(#model_name_arms)*
-                    _ => ::core::option::Option::None,
+                    _ => {
+                        #(#bare_flatten_model_name_lookups)*
+                        ::core::option::Option::None
+                    }
                 }
             }
             fn get_model_value(&self, key: &str) -> ::pocopine::__private::JsValue {
@@ -4962,6 +5110,145 @@ pub fn derive_emit(input: TokenStream) -> TokenStream {
                 match name {
                     #(#from_event_arms)*
                     _ => ::core::option::Option::None,
+                }
+            }
+        }
+    };
+    out.into()
+}
+
+// ── RFC-044 §5.10 — `#[derive(Props)]` ────────────────────────────
+
+/// Generates a `Props` impl for a flatten-container struct.
+///
+/// Fields marked `#[prop]` become wire leaves (in declaration order);
+/// unmarked fields are ignored. Leaf field types must implement
+/// `PropValue` (impls ship for `String`, `bool`, the int/float
+/// numerics, and `Option<T: PropValue>`).
+///
+/// ```ignore
+/// #[derive(Props, Default, Clone, PartialEq, Serialize, Deserialize)]
+/// pub struct SeriesCommon {
+///     #[prop] pub key: String,
+///     #[prop] pub label: String,
+///     #[prop] pub color: String,
+///     #[prop] pub visible: bool,
+/// }
+/// ```
+#[proc_macro_derive(Props, attributes(prop))]
+pub fn derive_props(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let struct_ident = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let Data::Struct(data) = &input.data else {
+        return syn::Error::new_spanned(
+            &input.ident,
+            "#[derive(Props)] can only be applied to structs",
+        )
+        .to_compile_error()
+        .into();
+    };
+
+    let Fields::Named(fields) = &data.fields else {
+        return syn::Error::new_spanned(
+            &input.ident,
+            "#[derive(Props)] requires a struct with named fields",
+        )
+        .to_compile_error()
+        .into();
+    };
+
+    // Collect (ident, type) for every field marked `#[prop]`. Order
+    // follows declaration order, which is what `prop_leaves()`
+    // returns. Unmarked fields are internal — same role split as
+    // `#[component]` (RFC-031): `#[prop]` = exposed, default = state.
+    let mut leaves: Vec<(syn::Ident, syn::Type)> = Vec::new();
+    for field in fields.named.iter() {
+        if !field.attrs.iter().any(|a| a.path().is_ident("prop")) {
+            continue;
+        }
+        let Some(ident) = field.ident.clone() else {
+            continue;
+        };
+        leaves.push((ident, field.ty.clone()));
+    }
+
+    if leaves.is_empty() {
+        return syn::Error::new_spanned(
+            &input.ident,
+            "#[derive(Props)] requires at least one field marked `#[prop]`",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    let leaf_names: Vec<String> = leaves
+        .iter()
+        .map(|(i, _)| i.to_string().trim_start_matches("r#").to_string())
+        .collect();
+
+    let get_arms = leaves.iter().zip(leaf_names.iter()).map(|((id, _), name)| {
+        quote! {
+            #name => ::pocopine::__private::PropValue::to_prop_js(&self.#id),
+        }
+    });
+
+    let set_arms = leaves
+        .iter()
+        .zip(leaf_names.iter())
+        .map(|((id, ty), name)| {
+            quote! {
+                #name => {
+                    if let ::core::option::Option::Some(__v) =
+                        <#ty as ::pocopine::__private::PropValue>::from_prop_js(value)
+                    {
+                        self.#id = __v;
+                    }
+                }
+            }
+        });
+
+    let kind_arms = leaves.iter().zip(leaf_names.iter()).map(|((_, ty), name)| {
+        quote! {
+            #name => <#ty as ::pocopine::__private::PropValue>::prop_static_kind(),
+        }
+    });
+
+    let out = quote! {
+        impl #impl_generics ::pocopine::__private::Props for #struct_ident #ty_generics
+            #where_clause
+        {
+            fn prop_leaves() -> &'static [&'static str] {
+                &[#(#leaf_names),*]
+            }
+            fn prop_get(
+                &self,
+                leaf: &str,
+            ) -> ::pocopine::__private::JsValue {
+                match leaf {
+                    #(#get_arms)*
+                    _ => ::pocopine::__private::JsValue::UNDEFINED,
+                }
+            }
+            fn prop_set(
+                &mut self,
+                leaf: &str,
+                value: ::pocopine::__private::JsValue,
+            ) {
+                match leaf {
+                    #(#set_arms)*
+                    _ => {
+                        let _ = value;
+                    }
+                }
+            }
+            fn prop_static_kind(
+                leaf: &str,
+            ) -> ::pocopine::__private::StaticPropKind {
+                match leaf {
+                    #(#kind_arms)*
+                    _ => ::pocopine::__private::StaticPropKind::Auto,
                 }
             }
         }

--- a/crates/pocopine/src/lib.rs
+++ b/crates/pocopine/src/lib.rs
@@ -51,7 +51,7 @@ pub use pocopine_jobs::{JobError, JobResult};
 // Note: `store` exists in both the value namespace (the accessor `fn store<T>()`)
 // and the macro namespace (the attribute `#[store]`). They don't collide.
 pub use pocopine_macros::{
-    app, client_module, component, handlers, job, protected, server, store, Emit,
+    app, client_module, component, handlers, job, protected, server, store, Emit, Props,
 };
 
 pub mod auth {
@@ -98,11 +98,11 @@ pub mod prelude {
         ComponentUnmounted, Computed, ContextKey, ContextMarker, Emit, ForComponent, Handle, Hook,
         Inject, JobError, JobResult, Loader, LoaderContext, LoaderError, LocalStorage,
         NearestParent, Parent, Permission, Plugin, PluginValidationError, Plugins, Principal,
-        ReturnTo, Role, RouteComponent, RouteConfig, RouteContext, RouteErrorSurface, RouteGuard,
-        RouteGuardDecision, RouteLoader, RouteNavigationCompleted, RouteNavigationFailed,
-        RouteNavigationStarted, RouteRejection, RouteRejectionAction, RouteRejectionContext,
-        RouteRejectionHandler, RouteTarget, RouteTargetError, RwSignal, Scope, ScopeId,
-        ServerError, ServerFunctionClientCompleted, ServerFunctionClientFailed,
+        Props, ReturnTo, Role, RouteComponent, RouteConfig, RouteContext, RouteErrorSurface,
+        RouteGuard, RouteGuardDecision, RouteLoader, RouteNavigationCompleted,
+        RouteNavigationFailed, RouteNavigationStarted, RouteRejection, RouteRejectionAction,
+        RouteRejectionContext, RouteRejectionHandler, RouteTarget, RouteTargetError, RwSignal,
+        Scope, ScopeId, ServerError, ServerFunctionClientCompleted, ServerFunctionClientFailed,
         ServerFunctionClientStarted, ServerResult, Setter, Signal, StorageError, Store,
     };
     pub use wasm_bindgen::prelude::*;
@@ -125,8 +125,8 @@ pub mod __private {
         spawn_scoped as runtime_spawn_scoped, store_scope, task::TaskHandle, track,
         with_write_origin, BindingKind, ClientModule, ClientModuleError, Component,
         ComponentMountFn, ComponentState, ComponentVTable, FromHandlerArg, Handle, HandlerDispatch,
-        LifecycleContext, Scope, StaticBinOp, StaticBinding, StaticExpr, StaticListener,
-        StaticLiteral, StaticPropKind, StaticRowPlan, Store, WriteOrigin,
+        LifecycleContext, PropValue, Props, Scope, StaticBinOp, StaticBinding, StaticExpr,
+        StaticListener, StaticLiteral, StaticPropKind, StaticRowPlan, Store, WriteOrigin,
     };
     // RFC 081 — typed ref accessor used by the macro-generated
     // `<ComponentName>Refs` struct.

--- a/crates/pocopine/tests/prop_flatten.rs
+++ b/crates/pocopine/tests/prop_flatten.rs
@@ -349,3 +349,176 @@ async fn bare_flatten_leaves_round_trip_through_static_attrs() {
 
     host.remove();
 }
+
+// ─── bare-flatten + pp-bind + #[watch(<container>)] dual-trigger ───
+
+thread_local! {
+    static BARE_COMMON_FIRES: Cell<u32> = const { Cell::new(0) };
+    static BARE_LABEL_FIRES: Cell<u32> = const { Cell::new(0) };
+    static BARE_LAST_COMMON_LABEL: RefCell<String> = const { RefCell::new(String::new()) };
+}
+
+#[derive(Props, Default, Clone, PartialEq, Serialize, Deserialize)]
+struct BareWatchLeaves {
+    #[prop]
+    label: String,
+    #[prop]
+    color: String,
+}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "bare-flatten-watch-child",
+    template_inline = r#"<div><span class="lbl" pp-text="label"></span></div>"#
+)]
+struct BareFlattenWatchChild {
+    #[prop(flatten)]
+    common: BareWatchLeaves,
+}
+
+#[handlers]
+impl BareFlattenWatchChild {
+    // Confirms RFC-044 §5.10.5 dual-key triggering still fires through
+    // the bare-flatten path, not just the explicit-list path PR #102
+    // tested.
+    #[watch(common)]
+    fn on_common(&mut self, new: BareWatchLeaves, _: Option<BareWatchLeaves>) {
+        BARE_COMMON_FIRES.with(|c| c.set(c.get() + 1));
+        BARE_LAST_COMMON_LABEL.with(|s| *s.borrow_mut() = new.label.clone());
+    }
+
+    #[watch(label)]
+    fn on_label(&mut self, _: String, _: Option<String>) {
+        BARE_LABEL_FIRES.with(|c| c.set(c.get() + 1));
+    }
+}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "bare-flatten-watch-parent",
+    template_inline = r#"<div>
+        <bare-flatten-watch-child pp-bind:label="child_label"></bare-flatten-watch-child>
+        <button class="bump" pp-on:click="bump"></button>
+    </div>"#
+)]
+struct BareFlattenWatchParent {
+    child_label: String,
+}
+
+#[handlers]
+impl BareFlattenWatchParent {
+    fn bump(&mut self) {
+        self.child_label = "fresh".into();
+    }
+}
+
+#[wasm_bindgen_test]
+async fn bare_flatten_pp_bind_fires_both_leaf_and_container_watch() {
+    BareFlattenWatchChild::register();
+    BareFlattenWatchParent::register();
+    let host = mount(
+        "bare-flatten-watch-parent",
+        r#"<bare-flatten-watch-parent></bare-flatten-watch-parent>"#,
+    );
+    settle().await;
+
+    BARE_COMMON_FIRES.with(|c| c.set(0));
+    BARE_LABEL_FIRES.with(|c| c.set(0));
+    BARE_LAST_COMMON_LABEL.with(|s| s.borrow_mut().clear());
+
+    host.query_selector(".bump")
+        .unwrap()
+        .unwrap()
+        .dyn_into::<HtmlElement>()
+        .unwrap()
+        .click();
+    settle().await;
+
+    assert_eq!(
+        BARE_COMMON_FIRES.with(|c| c.get()),
+        1,
+        "#[watch(common)] fires through the bare-flatten path",
+    );
+    assert_eq!(
+        BARE_LABEL_FIRES.with(|c| c.get()),
+        1,
+        "per-leaf #[watch(label)] still fires alongside",
+    );
+    assert_eq!(
+        BARE_LAST_COMMON_LABEL.with(|s| s.borrow().clone()),
+        "fresh",
+        "container watch observes the updated leaf value",
+    );
+    assert_eq!(read(&host, ".lbl"), "fresh");
+
+    host.remove();
+}
+
+// ─── Option<T> empty-string → None (lossy, documented) ───
+
+thread_local! {
+    static OPTION_LEAF_IS_NONE: Cell<Option<bool>> = const { Cell::new(None) };
+}
+
+#[derive(Props, Default, Clone, PartialEq, Serialize, Deserialize)]
+struct OptionLeaves {
+    #[prop]
+    code: Option<String>,
+}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "option-flatten-target",
+    template_inline = r#"<div>
+        <button class="probe" pp-on:click="probe"></button>
+    </div>"#
+)]
+struct OptionFlattenTarget {
+    #[prop(flatten)]
+    common: OptionLeaves,
+}
+
+#[handlers]
+impl OptionFlattenTarget {
+    fn probe(&mut self) {
+        OPTION_LEAF_IS_NONE.with(|c| c.set(Some(self.common.code.is_none())));
+    }
+}
+
+#[wasm_bindgen_test]
+async fn option_leaf_collapses_empty_string_attr_to_none() {
+    // Documented lossy behaviour (`PropValue<Option<T>>::from_prop_js`
+    // in `pocopine-core/src/props.rs`): an empty static attribute is
+    // indistinguishable from "absent" and coerces to `None`. A real
+    // `Some(String::new())` over `pp-bind` would collapse the same
+    // way — same as the explicit-list flatten path (RFC-044 §5.4).
+    OptionFlattenTarget::register();
+    let body = doc().body().unwrap();
+    let host = doc().create_element("div").unwrap();
+    host.set_inner_html(r#"<option-flatten-target code=""></option-flatten-target>"#);
+    body.append_child(&host).unwrap();
+    let el = host
+        .query_selector("option-flatten-target")
+        .unwrap()
+        .unwrap();
+    pocopine_core::mount::mount_child_component(&el, "option-flatten-target");
+    pocopine_core::mount::finalize_compiled_subtree(&el);
+    settle().await;
+
+    OPTION_LEAF_IS_NONE.with(|c| c.set(None));
+    host.query_selector(".probe")
+        .unwrap()
+        .unwrap()
+        .dyn_into::<HtmlElement>()
+        .unwrap()
+        .click();
+    settle().await;
+
+    assert_eq!(
+        OPTION_LEAF_IS_NONE.with(|c| c.get()),
+        Some(true),
+        "Option<String> leaf with empty-string static attr lands as None",
+    );
+
+    host.remove();
+}

--- a/crates/pocopine/tests/prop_flatten.rs
+++ b/crates/pocopine/tests/prop_flatten.rs
@@ -270,3 +270,82 @@ async fn writing_a_leaf_fires_both_the_leaf_and_the_container_watch() {
 
     host.remove();
 }
+
+// ──────────── #[derive(Props)] + bare #[prop(flatten)] ────────────
+
+#[derive(Props, Default, Clone, PartialEq, Serialize, Deserialize)]
+struct BareLeaves {
+    #[prop]
+    heading: String,
+    #[prop]
+    code: String,
+    #[prop]
+    enabled: bool,
+}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "bare-flatten-target",
+    template_inline = r#"<div>
+        <span class="b-heading" pp-text="heading"></span>
+        <span class="b-code" pp-text="code"></span>
+        <span class="b-enabled" pp-text="enabled"></span>
+    </div>"#
+)]
+struct BareFlattenTarget {
+    #[prop(flatten)]
+    leaves: BareLeaves,
+}
+
+#[handlers]
+impl BareFlattenTarget {}
+
+#[wasm_bindgen_test]
+fn bare_flatten_via_derive_props_exposes_leaves_through_the_trait() {
+    // No explicit leaf list on `#[prop(flatten)]` — the macro routes
+    // through `<BareLeaves as Props>::prop_leaves()` at runtime.
+    let c = BareFlattenTarget::default();
+    // leaves are props (parent-writable)
+    assert!(c.is_prop("heading"));
+    assert!(c.is_prop("code"));
+    assert!(c.is_prop("enabled"));
+    // …but NOT models — `#[prop(flatten)]` is inbound-only
+    assert!(!c.is_model("heading"));
+    // leaf → container map resolved at runtime
+    assert_eq!(c.flatten_container_of("heading"), Some("leaves"));
+    assert_eq!(c.flatten_container_of("code"), Some("leaves"));
+    assert_eq!(c.flatten_container_of("enabled"), Some("leaves"));
+    // the container field itself is not a leaf
+    assert_eq!(c.flatten_container_of("leaves"), None);
+    // unknown key
+    assert_eq!(c.flatten_container_of("nope"), None);
+}
+
+#[wasm_bindgen_test]
+async fn bare_flatten_leaves_round_trip_through_static_attrs() {
+    BareFlattenTarget::register();
+    let body = doc().body().unwrap();
+    let host = doc().create_element("div").unwrap();
+    host.set_inner_html(
+        r#"<bare-flatten-target
+            heading="Sales"
+            code="2024"
+            enabled="true"></bare-flatten-target>"#,
+    );
+    body.append_child(&host).unwrap();
+    let el = host.query_selector("bare-flatten-target").unwrap().unwrap();
+    pocopine_core::mount::mount_child_component(&el, "bare-flatten-target");
+    pocopine_core::mount::finalize_compiled_subtree(&el);
+    tick().await;
+
+    // Each leaf reaches `self.leaves.<leaf>` and renders by its bare
+    // wire name. `code="2024"` proves exact-type coercion: the derive
+    // reports `<String as PropValue>::prop_static_kind() == String`
+    // (no runtime probe), so the numeric-looking value stays a string
+    // and is NOT coerced to a number — closing the §5.10.3 gap.
+    assert_eq!(read(&host, ".b-heading"), "Sales");
+    assert_eq!(read(&host, ".b-code"), "2024");
+    assert_eq!(read(&host, ".b-enabled"), "true");
+
+    host.remove();
+}

--- a/rfcs/rfc-044-model-fields.md
+++ b/rfcs/rfc-044-model-fields.md
@@ -532,49 +532,82 @@ authoring surface.
   for model-flatten: a parent sees N independent events, same as a
   pre-struct flat layout would have produced.
 
-#### 5.10.2 Explicit leaf list
+#### 5.10.2 Two surface shapes — bare or explicit
 
-v1 requires an **explicit leaf list**. Each name must be a valid key
-in the container's serialised form (honouring `#[serde(rename)]` on
-the inner struct's fields); names not present are silently dropped,
-matching inbound-mirror behaviour for unknown parent-side keys. The
-explicit list also lets a component expose a deliberate *subset* of
-the struct, or flatten a foreign struct whose wire names don't match
-their Rust identifiers.
+`flatten` accepts two field-attribute forms.
+
+**Bare — `#[prop(flatten)]` / `#[model(flatten)]`.** The container's
+type must implement `Props` — typically via `#[derive(Props)]`:
 
 ```rust
-#[prop(flatten = ["key", "label", "color", "visible"])]
-#[model(flatten = ["start", "end"])]
+#[derive(Props, Default, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SeriesCommon {
+    #[prop] pub key: String,
+    #[prop] pub label: String,
+    #[prop] pub color: String,
+    #[prop] pub visible: bool,
+}
+
+#[component(...)]
+pub struct PineLineSeries {
+    #[prop(flatten)]
+    pub common: SeriesCommon,
+}
 ```
 
-Bare `#[prop(flatten)]` / `#[model(flatten)]` — auto-discovery, where
-the runtime reads the leaf set by serialising the container once at
-mount — is **reserved**. The macro emits a hard error pointing at the
-explicit form. Auto-discovery needs a runtime leaves side-table the
-current static-match codegen cannot produce, and interacts badly with
-`skip_serializing_if` (§5.10.6); it is deferred to a follow-up.
+The struct is **self-describing**: `#[derive(Props)]` reads its
+`#[prop]` fields (declaration order) and emits a `Props` impl
+exposing the leaf list, direct per-leaf get/set, and exact per-leaf
+`static_prop_kind`. The `#[component]` macro routes the bare flatten
+field through `<SeriesCommon as Props>` at runtime — no whole-struct
+serde round-trip per leaf write, and no static leaf list to keep in
+sync with the struct.
+
+**Explicit — `#[prop(flatten = ["a","b"])]` / `#[model(flatten = […])]`.**
+For foreign structs (where you can't add a derive), deliberate
+*subsets* of a struct, or wire-key renaming via `#[serde(rename)]` on
+the inner struct's fields. Each listed name must be a valid key in
+the container's serialised form; unknown names are silently dropped.
+Leaf get/set goes through serde (`to_value`/`Reflect`/`from_value`)
+on the whole container, and per-leaf `static_prop_kind` is resolved
+by the runtime probe (§5.10.3).
+
+The two forms coexist on a single component; explicit-list arms run
+first, then bare-flatten containers' leaves are consulted in
+declaration order. New components should prefer the bare form when
+the container is first-party — it is faster, has exact leaf types,
+and removes leaf-list duplication.
 
 #### 5.10.3 Leaf typing and static-attr coercion
 
-The attribute carries leaf *names*, not types — the macro has no
-statically-known Rust type at the leaf granularity. A leaf's
-`static_prop_kind` (which governs how an authored string attribute is
-coerced) is instead resolved by **probing the serialised container**:
-during `apply_static_props` the runtime serialises the
-default-constructed container and inspects the leaf's JS type —
-boolean → `Bool`, number → `Number`, string → `String`, otherwise
-`Auto`.
+The two surface shapes have *different* per-leaf `static_prop_kind`
+strategies — they resolve the same hazard with different precision.
 
-This is load-bearing. A `String` leaf with a numeric-looking authored
-value (`label="2024"`) *must* be classified `String`, so the value is
-not coerced to a number — a number spliced into the container fails
-the leaf's serde round-trip and the write is silently dropped.
+The hazard: a `String` leaf with a numeric-looking authored value
+(`label="2024"`) *must* be classified `String`, so the value is not
+coerced to a number — a number spliced into the container fails the
+leaf's round-trip and the write is silently dropped.
 
-The probe is accurate for every non-`Option` leaf. An `Option::None`
-leaf serialises to `null`, carries no type witness, and falls back to
-`Auto` — the same limitation the non-flatten `Option<T>` static-attr
-path already has. A fully typed leaf contract (covering `Option`
-leaves and foreign structs) is future work (§11).
+**Bare `#[prop(flatten)]` (via `#[derive(Props)]`).** The derive sees
+each leaf field's Rust type and emits `prop_static_kind` as a direct
+match over `<FieldTy as PropValue>::prop_static_kind()` — `String` →
+`String`, `bool` → `Bool`, the int / float numerics → `Number`,
+`Option<T>` → `T::prop_static_kind()`. **Exact** at compile time —
+no runtime probe, and `Option::None` leaves are typed correctly.
+
+**Explicit `#[prop(flatten = [...])]`.** The attribute carries leaf
+*names*, not types — the macro has no statically-known Rust type at
+the leaf granularity, so a leaf's kind is resolved by **probing the
+serialised container**: during `apply_static_props` the runtime
+serialises the default-constructed container and inspects the leaf's
+JS type — boolean → `Bool`, number → `Number`, string → `String`,
+otherwise `Auto`. Accurate for every non-`Option` leaf; an
+`Option::None` default serialises to `null`, carries no type witness,
+and falls back to `Auto` — the same gap the non-flatten `Option<T>`
+static-attr path has.
+
+The bare form's exact typing is the recommended path; the explicit
+form's probe is the foreign-struct fallback.
 
 #### 5.10.4 Collision rules
 
@@ -619,29 +652,42 @@ Two caveats:
 #### 5.10.6 `skip_serializing_if` on a flattened container
 
 `skip_serializing_if` on an inner field can omit a leaf key from the
-serialised object. Under the **explicit leaf list** this is benign:
-`get(<leaf>)` returns `null` for an omitted leaf and the set arm
-splices the value back regardless. It becomes load-bearing only for
-the reserved auto-discovery form, where an omitted key would vanish
-from the discovered leaf set — a further reason auto-discovery is
-deferred. Components should avoid `skip_serializing_if` on leaves
-they intend to expose.
+serialised object. Under either surface shape it is essentially
+benign: `get(<leaf>)` returns `null` for an omitted leaf and the set
+arm splices the value back regardless. The bare form (`Props`)
+sidesteps the issue entirely — leaves are enumerated by the derive
+from the struct's field list, not from a serialised default, so a
+`skip_serializing_if`-hidden leaf still appears in `prop_leaves()`.
+Components should still avoid `skip_serializing_if` on leaves they
+intend to expose.
 
 #### 5.10.7 Performance — keep hot leaves unflattened
 
-Every inbound write to *any* leaf costs one serialise + one
-deserialise of the **whole** container. Negligible for small scalar
-config (`key` / `label` / `color` / `visible`); wasteful for large or
-frequently-updated payloads. **Do not flatten hot leaves** — a
-`Vec<ChartPoint>` `points` field, a large `data` blob. Leave those as
-direct `#[prop]` fields and flatten only the shared scalar config.
-pine-charts does exactly this: `SeriesCommon` carries the four
-scalars; `points` / `data` stay unflattened `#[prop]` fields.
+The per-leaf cost differs by surface shape.
+
+- **Bare flatten (`#[derive(Props)]`).** Per-leaf get/set is a direct
+  `<FieldTy as PropValue>::to_prop_js` / `from_prop_js` call —
+  scalar-fast, no whole-struct serialise.
+- **Explicit-list flatten.** Per-leaf get/set serialises + deserialises
+  the **whole** container through `serde_wasm_bindgen`. Negligible
+  for small scalar config; wasteful for large or frequently-updated
+  payloads.
+
+**Don't flatten hot leaves** — a `Vec<ChartPoint>` `points` field, a
+large `data` blob. Leave those as direct `#[prop]` fields and flatten
+only the shared scalar config. pine-charts does exactly this:
+`SeriesCommon` carries the four scalars; `points` / `data` stay
+unflattened `#[prop]` fields. The rule is sharper for the explicit
+form but applies to both — flatten is for shared *scalar* config.
 
 Constraints in v1 (both roles):
 
-- `flatten` requires an explicit leaf list; bare auto-discovery is
-  reserved (§5.10.2).
+- Bare `flatten` requires the container's type to implement `Props`
+  (typically via `#[derive(Props)]`); leaf field types must implement
+  `PropValue` (v1 ships impls for `String`, `bool`, the int/float
+  numerics, and `Option<T: PropValue>`). Explicit-list `flatten`
+  stays available for foreign structs and intentional subsets
+  (§5.10.2).
 - `flatten` is incompatible with `#[model(name = "...")]` — there is
   no single wire name to rename when the field is exploded. Per-leaf
   rename is future work.
@@ -987,16 +1033,21 @@ This RFC takes the following positions:
    whatever the field's serde shape is.
 6. **`flatten` is a role-agnostic modifier, opt-in per
    struct-typed field (§5.10).**
-   It explodes a struct field into per-leaf wire keys whose get/set
-   route through the container's serde impl, so a shared or
-   organisational struct field does not regress the flat
+   It explodes a struct field into per-leaf wire keys, so a shared
+   or organisational struct field does not regress the flat
    attribute-per-prop authoring surface. `#[prop(flatten)]` exposes
    the leaves as inbound props only; `#[model(flatten)]` additionally
-   gives each leaf a `pp:update:<leaf>` channel. v1 takes an explicit
-   leaf list — `#[prop(flatten = ["key", "label", …])]`; bare
-   auto-discovery is reserved. Per-leaf `static_prop_kind` is resolved
-   by probing the serialised container so a `String` leaf is not
-   miscoerced. Leaf-name collisions are a hard error.
+   gives each leaf a `pp:update:<leaf>` channel.
+   Two surface shapes coexist: **bare** `#[prop(flatten)]` /
+   `#[model(flatten)]` when the container's type implements `Props`
+   (typically via `#[derive(Props)]`) — leaves are enumerated by the
+   derive, leaf get/set is a direct typed `PropValue` call (no
+   whole-struct serde round-trip), and per-leaf `static_prop_kind` is
+   exact at compile time; or **explicit** `#[prop(flatten = […])]`
+   for foreign structs / intentional subsets, where leaves resolve
+   through serde on the whole container and `static_prop_kind` is
+   probed at runtime. Leaf-name collisions across the static set are
+   a hard error.
 
 Future work, intentionally deferred:
 
@@ -1013,23 +1064,22 @@ Future work, intentionally deferred:
    `flatten_rename` (author-chosen per-leaf wire names) and nested
    flattening (a flattened struct containing another). Both are
    additive and don't block v1.
-3. **Bare `flatten` auto-discovery.**
-   `#[prop(flatten)]` / `#[model(flatten)]` with no explicit list —
-   the runtime reads the leaf set by serialising the container once
-   at mount. Needs a runtime leaves side-table the current
-   static-match codegen cannot produce, and a resolution for
-   `skip_serializing_if` hiding keys (§5.10.6). Reserved; the macro
-   errors today and points at the explicit-list form.
-4. **Coalescing multi-leaf writes for `#[watch(<container>)]`.**
+3. **Coalescing multi-leaf writes for `#[watch(<container>)]`.**
    Dual-key triggering (§5.10.5) is implemented, but a batch that
    writes N leaves fires the container watch N times. A future pass
    could microtask-coalesce a multi-leaf write into one container
    fire — additive, and a no-op for the single-leaf-write case.
-5. **A fully typed leaf contract.**
-   Per-leaf `static_prop_kind` is probed from the serialised default
-   value (§5.10.3), which cannot type an `Option::None` leaf. A
-   derive on the container struct could surface exact per-leaf types
-   (and the leaf list, feeding item 3).
+4. **`PropValue` escape hatch for non-scalar leaves.**
+   v1 `PropValue` impls cover `String`, `bool`, the int / float
+   numerics, and `Option<T: PropValue>`. A `#[prop(with = …)]`
+   escape hatch (and / or a derive for enum leaves) would let custom
+   leaf types implement `PropValue` without manual `to_prop_js` /
+   `from_prop_js`.
+5. **`#[derive(Props)]` emits `Serialize` / `Deserialize`.**
+   v1 keeps a `Props` struct deriving serde alongside `Props` (so
+   `#[component]` structs that derive `Serialize` work without
+   change). A future pass could have the `Props` derive emit the
+   serde impl itself, dropping the per-struct boilerplate.
 
 ## 12. Why this helps others understand the system
 


### PR DESCRIPTION
## Summary

Follow-up to PR #102. `#[derive(Props)]` makes a flatten-container struct **self-describing**: fields marked `#[prop]` are the leaves, and the derive emits a `Props` impl with **direct typed accessors**. Components can then write a **bare** `#[prop(flatten)]` / `#[model(flatten)]` (no list) — the `#[component]` macro routes leaf metadata through `<FieldTy as Props>` at runtime.

The explicit-list form `#[prop(flatten = [...])]` keeps working unchanged for foreign structs / intentional subsets.

## Shape

```rust
#[derive(Props, Default, Clone, PartialEq, Serialize, Deserialize)]
pub struct SeriesCommon {
    #[prop] pub key: String,
    #[prop] pub label: String,
    #[prop] pub color: String,
    #[prop] pub visible: bool,
}

#[component(...)]
pub struct PineLineSeries {
    #[prop(flatten)]                       // bare — no list
    pub common: SeriesCommon,
}
```

## What it buys

1. **No serde round-trip per leaf write.** Direct `<FieldTy as PropValue>::to_prop_js` / `from_prop_js` replaces the whole-struct `to_value` / `Reflect` / `from_value` dance the explicit-list path does. Removes the §5.10.7 hot-leaf caveat for `Props` containers.
2. **Exact per-leaf types — closes the §5.10.3 `Option::None` typing gap.** The derive sees each field's Rust type, so `<String as PropValue>::prop_static_kind` is `String`. `label="2024"` stays a string and is not miscoerced to a number. No runtime probe.
3. **No explicit leaf list to keep in sync** with the struct — add a field, it auto-flattens.
4. **Leaf typos become compile errors** instead of silently-dropped unknown wire keys.

## Implementation

- **`pocopine-core`** — new `Props` and `PropValue` traits in `crates/pocopine-core/src/props.rs`. `PropValue` impls for `String`, `bool`, `f32`/`f64`/all 8–32-bit integer types/`usize`/`isize`, and `Option<T: PropValue>` (the `Option<T>` impl carries the empty-string → `None` coercion convention; documented as lossy and tested).
- **`pocopine-macros`** — `#[proc_macro_derive(Props, attributes(prop))]` mirrors `#[derive(Emit)]`; emits `prop_leaves` / `prop_get` / `prop_set` / `prop_static_kind` from the struct's `#[prop]` fields. `#[component]` accepts bare `#[prop(flatten)]` / `#[model(flatten)]` and adds runtime fallthrough in `get` / `set` / `keys` / `is_prop` / `is_model` / `static_prop_kind` / `flatten_container_of` / `model_name`.
- **Bare-flatten collision shield (RFC-044 §5.10.4).** The fallthroughs are gated on "key isn't a known static field or explicit-flatten leaf" so a real field sharing a bare leaf's name can't be misclassified; plus a one-time runtime audit in `keys()` initialisation that panics with a clear §5.10.4 message on bare↔bare / bare↔real-field / bare↔explicit-leaf collisions.
- **`#[model(name = "...", flatten…)]`** now errors at parse time (`flatten` explodes into per-leaf keys; `name` has no target).
- **`pine-charts`** — `SeriesCommon` now derives `Props` with `#[prop]` on each field; all four series swap from `#[prop(flatten = ["key","label","color","visible"])]` to bare `#[prop(flatten)]`. **No `.poco` file touched.**
- **`tests/prop_flatten.rs`** — bare-flatten test exercising `flatten_container_of`, `is_prop` / `is_model`, static-attr round-trip including the `code="2024"` String-leaf typing case, end-to-end `pp-bind` + `#[watch(common)]` dual-trigger, and an `Option<String>` empty-string → `None` regression with a click-handler probe.
- **RFC-044 §5.10** — §5.10.2 rewritten to document both surface shapes (bare vs explicit), §5.10.3 split into exact-typing (bare) and runtime probe (explicit), §5.10.6 / §5.10.7 reflect both paths, future-work reordered.

## Verification (CI toolchain, `RUSTFLAGS=-D warnings`)

| Gate | Result |
|---|---|
| `cargo fmt --all --check` | ✅ clean |
| `cargo clippy --workspace --exclude pocopine-cli --target wasm32-unknown-unknown --all-targets` | ✅ clean for this PR's code (the gate currently fails on `pocopine-deploy-*` / `pocopine-launcher` from a pre-existing breakage on `main` — see note below — not this PR) |
| `cargo clippy -p pocopine-cli --all-targets` + `cargo build` | ✅ clean |
| `cargo test --workspace --tests --no-fail-fast` | ✅ 115 binaries pass; only the 4 `jobs_redis` Docker tests fail (sandbox has no Docker — CI has) |
| `wasm-pack --firefox` pine-charts / prop_flatten / static_props / template_plan / pine | ✅ 31 / 8 / 2 / 35 / 118 |

### Note on the red `clippy (wasm32)` check

`main` itself currently fails the `clippy (wasm32)` job — the RFC-080 deploy / launcher commits (`pocopine-deploy-*`, `pocopine-launcher`) added host-only code and dev-deps that don't compile for `wasm32-unknown-unknown` under `--all-targets`. That breakage is independent of this PR and will be cleared by a separate workspace-cleanup PR scoped to those crates. Once `main`'s clippy-wasm is green again, rebasing this PR will pick the fix up.

Diff: 7 files, +691 / −143.