### PR TITLE
Add local-first sync rebase and typed resource view

### DIFF
--- a/crates/pocopine-sync-crud/src/lib.rs
+++ b/crates/pocopine-sync-crud/src/lib.rs
@@ -11,6 +11,7 @@ mod options;
 mod outcome;
 mod row;
 mod transaction;
+mod view;
 
 #[cfg(not(target_arch = "wasm32"))]
 mod resource;
@@ -36,3 +37,7 @@ pub use source::{CrudConflict, CrudRemoveResult, CrudSource, CrudWriteResult};
 #[cfg(not(target_arch = "wasm32"))]
 pub use resource::RowVersionOf;
 pub use transaction::{Transaction, TransactionBindable, TransactionFuture, TransactionRunner};
+pub use view::{
+    local_resource_view, LocalResourcePendingMutation, LocalResourceRow, LocalResourceRowStatus,
+    LocalResourceView,
+};

--- a/crates/pocopine-sync-crud/src/view.rs
+++ b/crates/pocopine-sync-crud/src/view.rs
@@ -172,6 +172,7 @@ impl<Id, Row> LocalResourceView<Id, Row> {
             .or_else(|| {
                 self.pending_mutations
                     .iter()
+                    .rev()
                     .find(|pending| pending.id.as_ref() == Some(id))
                     .and_then(|pending| pending.base_version.as_ref())
             })
@@ -362,6 +363,91 @@ mod tests {
         assert!(view.has_conflicts());
         assert_eq!(view.conflict_count, 1);
         assert_eq!(view.pending_mutations.len(), 0);
+    }
+
+    #[test]
+    fn resource_view_keeps_conflict_visible_under_later_pending_overlay() {
+        let mut state = initial_state();
+        state.apply_optimistic_mutation(
+            MutationId::new("device_1:first").unwrap(),
+            SyncOp::Upsert,
+            Some(RowKey::new("post_1").unwrap()),
+            Some(
+                SyncRow::new(
+                    "post_1",
+                    Post {
+                        title: "Local first".to_string(),
+                    },
+                )
+                .unwrap(),
+            ),
+        );
+        state.apply_optimistic_mutation(
+            MutationId::new("device_1:second").unwrap(),
+            SyncOp::Upsert,
+            Some(RowKey::new("post_1").unwrap()),
+            Some(
+                SyncRow::new(
+                    "post_1",
+                    Post {
+                        title: "Local second".to_string(),
+                    },
+                )
+                .unwrap(),
+            ),
+        );
+        let mut response = SyncPushResponse::new(SyncStreamName::new("posts").unwrap());
+        response.conflicts.push(SyncConflict {
+            mutation_id: MutationId::new("device_1:first").unwrap(),
+            key: Some(RowKey::new("post_1").unwrap()),
+            server_row: Some(row("post_1", "Server updated", "row_2")),
+            reason: "base version is stale".to_string(),
+        });
+        state.apply_push(response);
+
+        let view = local_resource_view::<String, _>(&state).unwrap();
+
+        assert_eq!(view.rows[0].value.title, "Local second");
+        assert_eq!(view.rows[0].status, LocalResourceRowStatus::Conflict);
+        assert!(view.rows[0].is_conflict());
+        assert!(view.has_pending());
+        assert!(view.has_conflicts());
+        assert_eq!(view.conflict_count, 1);
+    }
+
+    #[test]
+    fn resource_view_base_version_uses_latest_pending_fallback() {
+        let view = LocalResourceView::<String, Post> {
+            rows: Vec::new(),
+            pending_mutations: vec![
+                LocalResourcePendingMutation {
+                    mutation_id: MutationId::new("device_1:first").unwrap(),
+                    id: Some("post_1".to_string()),
+                    op: SyncOp::Delete,
+                    base_version: Some(RowVersion::new("row_1").unwrap()),
+                },
+                LocalResourcePendingMutation {
+                    mutation_id: MutationId::new("device_1:second").unwrap(),
+                    id: Some("post_1".to_string()),
+                    op: SyncOp::Delete,
+                    base_version: Some(RowVersion::new("row_2").unwrap()),
+                },
+            ],
+            loading: false,
+            syncing: false,
+            stale: false,
+            error: String::new(),
+            version: 0,
+            pending_count: 2,
+            conflict_count: 0,
+            rejected_count: 0,
+            last_reason: SyncReason::Push,
+        };
+
+        assert_eq!(
+            view.base_version(&"post_1".to_string()).unwrap(),
+            &RowVersion::new("row_2").unwrap()
+        );
     }
 
     #[test]

--- a/crates/pocopine-sync-crud/src/view.rs
+++ b/crates/pocopine-sync-crud/src/view.rs
@@ -1,0 +1,385 @@
+use pocopine_sync::{
+    CollectionState, MutationId, RowVersion, SyncOp, SyncReason, SyncResult, SyncRow,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::ResourceId;
+
+/// Render status for a typed resource row.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LocalResourceRowStatus {
+    /// The row matches the latest known canonical server state.
+    #[default]
+    Synced,
+    /// The row includes a local optimistic overlay waiting for `/push`.
+    Pending,
+    /// The server reported a conflict for this row.
+    Conflict,
+}
+
+impl LocalResourceRowStatus {
+    pub fn is_pending(self) -> bool {
+        matches!(self, Self::Pending)
+    }
+
+    pub fn is_conflict(self) -> bool {
+        matches!(self, Self::Conflict)
+    }
+}
+
+/// A typed row currently visible to application code.
+///
+/// `row_version` belongs to the rendered row. `base_version` is the latest
+/// canonical server version known for the id and is the value generated CRUD
+/// saves/removes should use for conflict detection.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "Id: Serialize, Row: Serialize",
+    deserialize = "Id: Deserialize<'de>, Row: Deserialize<'de>"
+))]
+pub struct LocalResourceRow<Id, Row> {
+    pub id: Id,
+    pub value: Row,
+    pub row_version: Option<RowVersion>,
+    pub base_version: Option<RowVersion>,
+    pub status: LocalResourceRowStatus,
+}
+
+impl<Id, Row> LocalResourceRow<Id, Row> {
+    pub fn is_pending(&self) -> bool {
+        self.status.is_pending()
+    }
+
+    pub fn is_conflict(&self) -> bool {
+        self.status.is_conflict()
+    }
+}
+
+/// A queued resource mutation, including mutations with no visible row.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(bound(serialize = "Id: Serialize", deserialize = "Id: Deserialize<'de>"))]
+pub struct LocalResourcePendingMutation<Id> {
+    pub mutation_id: MutationId,
+    pub id: Option<Id>,
+    pub op: SyncOp,
+    pub base_version: Option<RowVersion>,
+}
+
+impl<Id> LocalResourcePendingMutation<Id> {
+    pub fn is_delete(&self) -> bool {
+        self.op == SyncOp::Delete
+    }
+}
+
+/// Typed local-first resource state ready for components or generated CRUD APIs.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "Id: Serialize, Row: Serialize",
+    deserialize = "Id: Deserialize<'de>, Row: Deserialize<'de>"
+))]
+pub struct LocalResourceView<Id, Row> {
+    pub rows: Vec<LocalResourceRow<Id, Row>>,
+    pub pending_mutations: Vec<LocalResourcePendingMutation<Id>>,
+    pub loading: bool,
+    pub syncing: bool,
+    pub stale: bool,
+    pub error: String,
+    pub version: u64,
+    pub pending_count: u64,
+    pub conflict_count: u64,
+    pub rejected_count: u64,
+    pub last_reason: SyncReason,
+}
+
+impl<Id, Row> LocalResourceView<Id, Row> {
+    /// Build a typed resource view from the low-level sync collection state.
+    pub fn from_collection_state(state: &CollectionState<Row>) -> SyncResult<Self>
+    where
+        Id: ResourceId,
+        Row: Clone,
+    {
+        let rows = state
+            .rows
+            .iter()
+            .map(|row| row_from_sync::<Id, Row>(state, row))
+            .collect::<SyncResult<Vec<_>>>()?;
+        let pending_mutations = state
+            .pending_mutations
+            .iter()
+            .map(|pending| {
+                let id = pending.key.as_ref().map(Id::from_row_key).transpose()?;
+                let base_version = pending.key.as_ref().and_then(|key| state.base_version(key));
+                Ok(LocalResourcePendingMutation {
+                    mutation_id: pending.id.clone(),
+                    id,
+                    op: pending.op,
+                    base_version,
+                })
+            })
+            .collect::<SyncResult<Vec<_>>>()?;
+
+        Ok(Self {
+            rows,
+            pending_mutations,
+            loading: state.loading,
+            syncing: state.syncing,
+            stale: state.stale,
+            error: state.error.clone(),
+            version: state.version,
+            pending_count: state.pending_count,
+            conflict_count: state.conflict_count,
+            rejected_count: state.rejected_count,
+            last_reason: state.last_reason,
+        })
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.rows.is_empty()
+    }
+
+    pub fn has_pending(&self) -> bool {
+        self.pending_count > 0 || self.rows.iter().any(LocalResourceRow::is_pending)
+    }
+
+    pub fn has_conflicts(&self) -> bool {
+        self.conflict_count > 0 || self.rows.iter().any(LocalResourceRow::is_conflict)
+    }
+
+    pub fn get(&self, id: &Id) -> Option<&LocalResourceRow<Id, Row>>
+    where
+        Id: Eq,
+    {
+        self.rows.iter().find(|row| &row.id == id)
+    }
+
+    pub fn pending_for(&self, id: &Id) -> Vec<&LocalResourcePendingMutation<Id>>
+    where
+        Id: Eq,
+    {
+        self.pending_mutations
+            .iter()
+            .filter(|pending| pending.id.as_ref() == Some(id))
+            .collect()
+    }
+
+    pub fn base_version(&self, id: &Id) -> Option<&RowVersion>
+    where
+        Id: Eq,
+    {
+        self.get(id)
+            .and_then(|row| row.base_version.as_ref())
+            .or_else(|| {
+                self.pending_mutations
+                    .iter()
+                    .find(|pending| pending.id.as_ref() == Some(id))
+                    .and_then(|pending| pending.base_version.as_ref())
+            })
+    }
+}
+
+/// Build a typed resource view from the low-level sync collection state.
+pub fn local_resource_view<Id, Row>(
+    state: &CollectionState<Row>,
+) -> SyncResult<LocalResourceView<Id, Row>>
+where
+    Id: ResourceId,
+    Row: Clone,
+{
+    LocalResourceView::from_collection_state(state)
+}
+
+fn row_from_sync<Id, Row>(
+    state: &CollectionState<Row>,
+    row: &SyncRow<Row>,
+) -> SyncResult<LocalResourceRow<Id, Row>>
+where
+    Id: ResourceId,
+    Row: Clone,
+{
+    let status = if row.conflict {
+        LocalResourceRowStatus::Conflict
+    } else if row.pending {
+        LocalResourceRowStatus::Pending
+    } else {
+        LocalResourceRowStatus::Synced
+    };
+
+    Ok(LocalResourceRow {
+        id: Id::from_row_key(&row.key)?,
+        value: row.value.clone(),
+        row_version: row.version.clone(),
+        base_version: state.base_version(&row.key),
+        status,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use pocopine_sync::{
+        CollectionState, MutationId, RowKey, RowVersion, SyncConflict, SyncCursor,
+        SyncPullResponse, SyncPushResponse, SyncRow, SyncStreamName,
+    };
+
+    use super::*;
+
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    struct Post {
+        title: String,
+    }
+
+    fn row(key: &str, title: &str, version: &str) -> SyncRow<Post> {
+        SyncRow::new(
+            key,
+            Post {
+                title: title.to_string(),
+            },
+        )
+        .unwrap()
+        .version(version)
+        .unwrap()
+    }
+
+    fn initial_state() -> CollectionState<Post> {
+        let mut state = CollectionState::default();
+        let request = state.begin_initial();
+        state.apply_pull(
+            request,
+            SyncPullResponse::snapshot(
+                SyncStreamName::new("posts").unwrap(),
+                pocopine_sync::SyncCollectionName::new("posts").unwrap(),
+                vec![row("post_1", "Server", "row_1")],
+                Some(SyncCursor::new("1").unwrap()),
+            ),
+        );
+        state
+    }
+
+    #[test]
+    fn resource_view_maps_synced_rows_to_typed_ids() {
+        let state = initial_state();
+
+        let view = local_resource_view::<String, _>(&state).unwrap();
+
+        assert_eq!(view.rows.len(), 1);
+        assert_eq!(view.rows[0].id, "post_1");
+        assert_eq!(view.rows[0].value.title, "Server");
+        assert_eq!(view.rows[0].status, LocalResourceRowStatus::Synced);
+        assert_eq!(
+            view.rows[0].base_version.as_ref().unwrap(),
+            &RowVersion::new("row_1").unwrap()
+        );
+        assert!(!view.has_pending());
+        assert!(!view.has_conflicts());
+    }
+
+    #[test]
+    fn resource_view_exposes_rebased_pending_overlay_base_version() {
+        let mut state = initial_state();
+        state.apply_optimistic_mutation(
+            MutationId::new("device_1:save").unwrap(),
+            SyncOp::Upsert,
+            Some(RowKey::new("post_1").unwrap()),
+            Some(
+                SyncRow::new(
+                    "post_1",
+                    Post {
+                        title: "Local".to_string(),
+                    },
+                )
+                .unwrap(),
+            ),
+        );
+
+        let view = local_resource_view::<String, _>(&state).unwrap();
+
+        assert_eq!(view.rows[0].value.title, "Local");
+        assert_eq!(view.rows[0].status, LocalResourceRowStatus::Pending);
+        assert!(view.rows[0].is_pending());
+        assert!(view.rows[0].row_version.is_none());
+        assert_eq!(
+            view.base_version(&"post_1".to_string()).unwrap(),
+            &RowVersion::new("row_1").unwrap()
+        );
+        assert_eq!(view.pending_mutations.len(), 1);
+        assert_eq!(view.pending_mutations[0].id.as_deref(), Some("post_1"));
+        assert_eq!(view.pending_mutations[0].op, SyncOp::Upsert);
+    }
+
+    #[test]
+    fn resource_view_exposes_pending_delete_without_visible_row() {
+        let mut state = initial_state();
+        state.apply_optimistic_mutation(
+            MutationId::new("device_1:delete").unwrap(),
+            SyncOp::Delete,
+            Some(RowKey::new("post_1").unwrap()),
+            None,
+        );
+
+        let view = local_resource_view::<String, _>(&state).unwrap();
+
+        assert!(view.rows.is_empty());
+        assert!(view.has_pending());
+        assert_eq!(view.pending_mutations.len(), 1);
+        assert!(view.pending_mutations[0].is_delete());
+        assert_eq!(
+            view.base_version(&"post_1".to_string()).unwrap(),
+            &RowVersion::new("row_1").unwrap()
+        );
+    }
+
+    #[test]
+    fn resource_view_marks_conflict_rows() {
+        let mut state = initial_state();
+        state.apply_optimistic_mutation(
+            MutationId::new("device_1:save").unwrap(),
+            SyncOp::Upsert,
+            Some(RowKey::new("post_1").unwrap()),
+            Some(
+                SyncRow::new(
+                    "post_1",
+                    Post {
+                        title: "Local".to_string(),
+                    },
+                )
+                .unwrap(),
+            ),
+        );
+        let mut response = SyncPushResponse::new(SyncStreamName::new("posts").unwrap());
+        response.conflicts.push(SyncConflict {
+            mutation_id: MutationId::new("device_1:save").unwrap(),
+            key: Some(RowKey::new("post_1").unwrap()),
+            server_row: Some(row("post_1", "Server updated", "row_2")),
+            reason: "base version is stale".to_string(),
+        });
+        state.apply_push(response);
+
+        let view = local_resource_view::<String, _>(&state).unwrap();
+
+        assert_eq!(view.rows[0].value.title, "Server updated");
+        assert_eq!(view.rows[0].status, LocalResourceRowStatus::Conflict);
+        assert!(view.rows[0].is_conflict());
+        assert!(view.has_conflicts());
+        assert_eq!(view.conflict_count, 1);
+        assert_eq!(view.pending_mutations.len(), 0);
+    }
+
+    #[test]
+    fn resource_view_rejects_rows_that_do_not_match_typed_id() {
+        let mut state = CollectionState::default();
+        let request = state.begin_initial();
+        state.apply_pull(
+            request,
+            SyncPullResponse::snapshot(
+                SyncStreamName::new("posts").unwrap(),
+                pocopine_sync::SyncCollectionName::new("posts").unwrap(),
+                vec![row("not-an-integer", "Bad", "row_1")],
+                None,
+            ),
+        );
+
+        let err = local_resource_view::<i64, _>(&state).unwrap_err();
+
+        assert!(err.to_string().contains("invalid resource id"));
+    }
+}

--- a/crates/pocopine-sync-indexdb/src/wasm.rs
+++ b/crates/pocopine-sync-indexdb/src/wasm.rs
@@ -3,9 +3,10 @@ use std::{collections::BTreeMap, fmt, rc::Rc};
 use futures::lock::Mutex as AsyncMutex;
 use js_sys::{Function, Promise, Reflect};
 use pocopine_sync::{
-    generate_sync_device_id, ClientMutation, LocalChangeBatch, LocalPushResult, LocalSnapshotBatch,
-    LocalStreamSnapshot, MutationId, RowKey, SyncError, SyncLocalFuture, SyncLocalIdentity,
-    SyncLocalStore, SyncOp, SyncResult, SyncRow, SyncStreamName,
+    generate_sync_device_id, ClientMutation, LocalChangeBatch, LocalPendingMutation,
+    LocalPushResult, LocalSnapshotBatch, LocalStreamSnapshot, MutationId, RowKey, SyncError,
+    SyncLocalFuture, SyncLocalIdentity, SyncLocalStore, SyncOp, SyncResult, SyncRow,
+    SyncStreamName,
 };
 use wasm_bindgen::{closure::Closure, JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
@@ -121,9 +122,17 @@ impl SyncLocalStore for IndexedDbLocalStore {
         stream: &SyncStreamName,
         mutation: ClientMutation<serde_json::Value>,
     ) -> SyncLocalFuture<'_, ()> {
+        self.enqueue_pending_mutation(stream, LocalPendingMutation::new(mutation))
+    }
+
+    fn enqueue_pending_mutation(
+        &self,
+        stream: &SyncStreamName,
+        pending: LocalPendingMutation,
+    ) -> SyncLocalFuture<'_, ()> {
         let database_name = self.database_name.clone();
         let stream = stream.clone();
-        self.run(enqueue_mutation(database_name, stream, mutation))
+        self.run(enqueue_mutation(database_name, stream, pending))
     }
 
     fn mark_push_result(&self, result: LocalPushResult) -> SyncLocalFuture<'_, ()> {
@@ -140,7 +149,10 @@ impl SyncLocalStore for IndexedDbLocalStore {
         self.run(async move {
             Ok(hydrate_stream(database_name, stream)
                 .await?
-                .pending_mutations)
+                .pending_mutations
+                .into_iter()
+                .map(|pending| pending.mutation)
+                .collect())
         })
     }
 }
@@ -255,7 +267,7 @@ async fn apply_changes(database_name: String, changes: LocalChangeBatch) -> Sync
 async fn enqueue_mutation(
     database_name: String,
     stream: SyncStreamName,
-    mutation: ClientMutation<serde_json::Value>,
+    pending: LocalPendingMutation,
 ) -> SyncResult<()> {
     let database = open_database(&database_name).await?;
     let transaction = transaction(&database, STREAMS_STORE, IdbTransactionMode::Readwrite)?;
@@ -265,11 +277,11 @@ async fn enqueue_mutation(
     if let Some(existing) = state
         .pending_mutations
         .iter_mut()
-        .find(|existing| existing.id == mutation.id)
+        .find(|existing| existing.mutation.id == pending.mutation.id)
     {
-        *existing = mutation;
+        *existing = pending;
     } else {
-        state.pending_mutations.push(mutation);
+        state.pending_mutations.push(pending);
     }
     put_stream_state(&store, &state).await?;
     await_transaction(done).await?;
@@ -291,20 +303,22 @@ async fn mark_push_result(database_name: String, result: LocalPushResult) -> Syn
     }
 
     for id in result.accepted {
-        state.pending_mutations.retain(|mutation| mutation.id != id);
+        state
+            .pending_mutations
+            .retain(|pending| pending.mutation.id != id);
     }
 
     for rejected in result.rejected {
         state
             .pending_mutations
-            .retain(|mutation| mutation.id != rejected.mutation_id);
+            .retain(|pending| pending.mutation.id != rejected.mutation_id);
     }
 
     let mut rows = rows_by_key(state.rows);
     for conflict in result.conflicts {
         state
             .pending_mutations
-            .retain(|mutation| mutation.id != conflict.mutation_id);
+            .retain(|pending| pending.mutation.id != conflict.mutation_id);
         if let Some(mut row) = conflict.server_row {
             row.pending = false;
             row.conflict = true;

--- a/crates/pocopine-sync-indexdb/tests/indexdb_store.rs
+++ b/crates/pocopine-sync-indexdb/tests/indexdb_store.rs
@@ -6,7 +6,10 @@ use pocopine_sync::{
     SyncLocalIdentity, SyncLocalStore, SyncOp, SyncPushResponse, SyncRow, SyncStreamName,
 };
 use pocopine_sync_indexdb::IndexedDbLocalStore;
+use wasm_bindgen::{closure::Closure, JsCast, JsValue};
+use wasm_bindgen_futures::JsFuture;
 use wasm_bindgen_test::*;
+use web_sys::{Event, IdbDatabase, IdbOpenDbRequest, IdbRequest, IdbTransactionMode};
 
 wasm_bindgen_test_configure!(run_in_browser);
 
@@ -76,6 +79,44 @@ async fn indexeddb_store_persists_identity_snapshot_and_pending_mutations() {
 }
 
 #[wasm_bindgen_test(async)]
+async fn indexeddb_store_reads_legacy_pending_mutation_shape() {
+    let database_name = database_name("legacy_pending");
+    let stream = SyncStreamName::new("posts").unwrap();
+    let legacy = serde_json::json!({
+        "stream": "posts",
+        "collection": "posts",
+        "cursor": "cursor_1",
+        "rows": [],
+        "pending_mutations": [{
+            "id": "device_abc:1",
+            "key": "post_1",
+            "op": "upsert",
+            "base_version": "row_1",
+            "payload": {"title": "Legacy pending"}
+        }]
+    });
+    seed_legacy_stream_state(&database_name, stream.as_str(), &legacy.to_string()).await;
+
+    let store = IndexedDbLocalStore::with_database_name(database_name).unwrap();
+    let snapshot = store.hydrate_stream(&stream).await.unwrap();
+
+    assert_eq!(snapshot.pending_mutations.len(), 1);
+    assert_eq!(
+        snapshot.pending_mutations[0].mutation.id.as_str(),
+        "device_abc:1"
+    );
+    assert_eq!(
+        snapshot.pending_mutations[0].mutation.key.as_ref().unwrap(),
+        &RowKey::new("post_1").unwrap()
+    );
+    assert!(snapshot.pending_mutations[0].optimistic_row.is_none());
+    assert_eq!(
+        store.pending_mutations(&stream).await.unwrap(),
+        vec![snapshot.pending_mutations[0].mutation.clone()]
+    );
+}
+
+#[wasm_bindgen_test(async)]
 async fn indexeddb_store_applies_changes_and_push_results() {
     let store = IndexedDbLocalStore::with_database_name(database_name("changes")).unwrap();
     let stream = SyncStreamName::new("posts").unwrap();
@@ -135,4 +176,93 @@ async fn indexeddb_store_applies_changes_and_push_results() {
     let snapshot = store.hydrate_stream(&stream).await.unwrap();
     assert_eq!(snapshot.cursor.unwrap().as_str(), "cursor_3");
     assert_eq!(snapshot.rows, vec![updated]);
+}
+
+async fn seed_legacy_stream_state(database_name: &str, stream: &str, json: &str) {
+    let database = open_test_database(database_name).await;
+    let transaction = database
+        .transaction_with_str_and_mode("streams", IdbTransactionMode::Readwrite)
+        .unwrap();
+    let done = transaction_done(&transaction);
+    let store = transaction.object_store("streams").unwrap();
+    let request = store
+        .put_with_key(&JsValue::from_str(json), &JsValue::from_str(stream))
+        .unwrap();
+    request_value(request).await.unwrap();
+    done.await.unwrap();
+    database.close();
+}
+
+async fn open_test_database(database_name: &str) -> IdbDatabase {
+    let indexed_db = web_sys::window().unwrap().indexed_db().unwrap().unwrap();
+    let request = indexed_db.open_with_u32(database_name, 1).unwrap();
+    install_upgrade_handler(&request);
+    request_value(request.unchecked_into())
+        .await
+        .unwrap()
+        .dyn_into()
+        .unwrap()
+}
+
+fn install_upgrade_handler(request: &IdbOpenDbRequest) {
+    let handler_request = request.clone();
+    let on_upgrade = Closure::<dyn FnMut(Event)>::new(move |_event| {
+        if let Ok(database) = handler_request
+            .result()
+            .and_then(|value| value.dyn_into::<IdbDatabase>())
+        {
+            let _ = database.create_object_store("meta");
+            let _ = database.create_object_store("streams");
+        }
+    });
+    request.set_onupgradeneeded(Some(on_upgrade.as_ref().unchecked_ref()));
+    on_upgrade.forget();
+}
+
+fn request_value(request: IdbRequest) -> JsFuture {
+    let promise = js_sys::Promise::new(&mut |resolve: js_sys::Function, reject| {
+        let success_request = request.clone();
+        let reject_from_success = reject.clone();
+        let on_success =
+            Closure::<dyn FnMut(Event)>::new(move |_event| match success_request.result() {
+                Ok(value) => {
+                    let _ = resolve.call1(&JsValue::UNDEFINED, &value);
+                }
+                Err(err) => {
+                    let _ = reject_from_success.call1(&JsValue::UNDEFINED, &err);
+                }
+            });
+        request.set_onsuccess(Some(on_success.as_ref().unchecked_ref()));
+        on_success.forget();
+
+        let error_request = request.clone();
+        let on_error = Closure::<dyn FnMut(Event)>::new(move |_event| {
+            let _ = reject.call1(&JsValue::UNDEFINED, &error_request.error().unwrap().into());
+        });
+        request.set_onerror(Some(on_error.as_ref().unchecked_ref()));
+        on_error.forget();
+    });
+    JsFuture::from(promise)
+}
+
+fn transaction_done(transaction: &web_sys::IdbTransaction) -> JsFuture {
+    let transaction = transaction.clone();
+    let promise = js_sys::Promise::new(&mut |resolve: js_sys::Function, reject| {
+        let on_complete = Closure::<dyn FnMut(Event)>::new(move |_event| {
+            let _ = resolve.call0(&JsValue::UNDEFINED);
+        });
+        transaction.set_oncomplete(Some(on_complete.as_ref().unchecked_ref()));
+        on_complete.forget();
+
+        let error_transaction = transaction.clone();
+        let on_error = Closure::<dyn FnMut(Event)>::new(move |_event| {
+            let _ = reject.call1(
+                &JsValue::UNDEFINED,
+                &error_transaction.error().unwrap().into(),
+            );
+        });
+        transaction.set_onerror(Some(on_error.as_ref().unchecked_ref()));
+        on_error.forget();
+    });
+    JsFuture::from(promise)
 }

--- a/crates/pocopine-sync-indexdb/tests/indexdb_store.rs
+++ b/crates/pocopine-sync-indexdb/tests/indexdb_store.rs
@@ -1,9 +1,9 @@
 #![cfg(target_arch = "wasm32")]
 
 use pocopine_sync::{
-    ClientMutation, LocalChangeBatch, LocalPushResult, LocalSnapshotBatch, MutationId, RowKey,
-    RowVersion, SyncChange, SyncCollectionName, SyncCursor, SyncDeviceId, SyncLocalIdentity,
-    SyncLocalStore, SyncOp, SyncPushResponse, SyncRow, SyncStreamName,
+    ClientMutation, LocalChangeBatch, LocalPendingMutation, LocalPushResult, LocalSnapshotBatch,
+    MutationId, RowKey, RowVersion, SyncChange, SyncCollectionName, SyncCursor, SyncDeviceId,
+    SyncLocalIdentity, SyncLocalStore, SyncOp, SyncPushResponse, SyncRow, SyncStreamName,
 };
 use pocopine_sync_indexdb::IndexedDbLocalStore;
 use wasm_bindgen_test::*;
@@ -31,8 +31,12 @@ async fn indexeddb_store_persists_identity_snapshot_and_pending_mutations() {
         key: Some(RowKey::new("post_2").unwrap()),
         op: SyncOp::Upsert,
         base_version: Some(RowVersion::new("row_1").unwrap()),
-        payload: serde_json::json!({"title": "Pending"}),
+        payload: serde_json::json!({
+            "op": "create",
+            "payload": {"id": "post_2", "draft": {"title": "Pending"}}
+        }),
     };
+    let optimistic = SyncRow::new("post_2", serde_json::json!({"title": "Pending"})).unwrap();
 
     store.save_identity(identity.clone()).await.unwrap();
     store
@@ -45,7 +49,11 @@ async fn indexeddb_store_persists_identity_snapshot_and_pending_mutations() {
         .await
         .unwrap();
     store
-        .enqueue_mutation(&stream, mutation.clone())
+        .enqueue_pending_mutation(
+            &stream,
+            LocalPendingMutation::new(mutation.clone())
+                .with_optimistic_row(Some(optimistic.clone())),
+        )
         .await
         .unwrap();
 
@@ -56,7 +64,15 @@ async fn indexeddb_store_persists_identity_snapshot_and_pending_mutations() {
     assert_eq!(snapshot.collection, Some(collection));
     assert_eq!(snapshot.cursor.unwrap().as_str(), "cursor_1");
     assert_eq!(snapshot.rows, vec![row]);
-    assert_eq!(snapshot.pending_mutations, vec![mutation]);
+    assert_eq!(snapshot.pending_mutations[0].mutation, mutation);
+    assert_eq!(
+        snapshot.pending_mutations[0].optimistic_row.as_ref(),
+        Some(&optimistic)
+    );
+    assert_eq!(
+        reopened.pending_mutations(&stream).await.unwrap(),
+        vec![snapshot.pending_mutations[0].mutation.clone()]
+    );
 }
 
 #[wasm_bindgen_test(async)]

--- a/crates/pocopine-sync-sqlite/src/native.rs
+++ b/crates/pocopine-sync-sqlite/src/native.rs
@@ -6,10 +6,10 @@ use std::{
 };
 
 use pocopine_sync::{
-    generate_sync_device_id, ClientMutation, LocalChangeBatch, LocalPushResult, LocalSnapshotBatch,
-    LocalStreamSnapshot, MutationId, RowKey, RowVersion, SyncCollectionName, SyncCursor,
-    SyncDeviceId, SyncError, SyncLocalFuture, SyncLocalIdentity, SyncLocalStore, SyncOp,
-    SyncResult, SyncRow, SyncStreamName,
+    generate_sync_device_id, ClientMutation, LocalChangeBatch, LocalPendingMutation,
+    LocalPushResult, LocalSnapshotBatch, LocalStreamSnapshot, MutationId, RowKey, RowVersion,
+    SyncCollectionName, SyncCursor, SyncDeviceId, SyncError, SyncLocalFuture, SyncLocalIdentity,
+    SyncLocalStore, SyncOp, SyncResult, SyncRow, SyncStreamName,
 };
 use rusqlite::{params, Connection, OptionalExtension, Transaction};
 
@@ -92,8 +92,16 @@ impl SyncLocalStore for SqliteLocalStore {
         stream: &SyncStreamName,
         mutation: ClientMutation<serde_json::Value>,
     ) -> SyncLocalFuture<'_, ()> {
+        self.enqueue_pending_mutation(stream, LocalPendingMutation::new(mutation))
+    }
+
+    fn enqueue_pending_mutation(
+        &self,
+        stream: &SyncStreamName,
+        pending: LocalPendingMutation,
+    ) -> SyncLocalFuture<'_, ()> {
         let stream = stream.clone();
-        Self::ready(self.with_conn(|conn| enqueue_mutation(conn, stream, mutation)))
+        Self::ready(self.with_conn(|conn| enqueue_mutation(conn, stream, pending)))
     }
 
     fn mark_push_result(&self, result: LocalPushResult) -> SyncLocalFuture<'_, ()> {
@@ -114,6 +122,7 @@ fn bootstrap_schema(conn: &mut Connection) -> SyncResult<()> {
     for sql in BOOTSTRAP_SQL {
         tx.execute_batch(sql).map_err(sqlite_error)?;
     }
+    migrate_schema(&tx)?;
     validate_schema_version(&tx)?;
     upsert_meta(&tx, META_SCHEMA_VERSION, &SCHEMA_VERSION.to_string())?;
     tx.commit().map_err(sqlite_error)
@@ -154,6 +163,44 @@ fn validate_schema_version(tx: &Transaction<'_>) -> SyncResult<()> {
     }
 
     Ok(())
+}
+
+fn migrate_schema(tx: &Transaction<'_>) -> SyncResult<()> {
+    let existing = select_meta_tx(tx, META_SCHEMA_VERSION)?;
+    let Some(existing) = existing else {
+        return Ok(());
+    };
+    let version = existing.parse::<u32>().map_err(|_| {
+        SyncError::backend(format!(
+            "invalid sync sqlite schema version in local store: {existing}"
+        ))
+    })?;
+    if version == 2 && !column_exists(tx, "__pocopine_mutations", "optimistic_row")? {
+        tx.execute(
+            "alter table __pocopine_mutations add column optimistic_row text",
+            [],
+        )
+        .map_err(sqlite_error)?;
+    }
+    if version == 2 {
+        upsert_meta(tx, META_SCHEMA_VERSION, &SCHEMA_VERSION.to_string())?;
+    }
+    Ok(())
+}
+
+fn column_exists(tx: &Transaction<'_>, table: &str, column: &str) -> SyncResult<bool> {
+    let mut stmt = tx
+        .prepare(&format!("pragma table_info({table})"))
+        .map_err(sqlite_error)?;
+    let rows = stmt
+        .query_map([], |row| row.get::<_, String>(1))
+        .map_err(sqlite_error)?;
+    for row in rows {
+        if row.map_err(sqlite_error)? == column {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 fn load_identity(conn: &mut Connection) -> SyncResult<Option<SyncLocalIdentity>> {
@@ -232,7 +279,7 @@ fn hydrate_stream(
         .map_err(sqlite_error)?;
 
     let rows = load_rows(conn, &stream)?;
-    let pending_mutations = pending_mutations(conn, &stream)?;
+    let pending_mutations = pending_mutation_records(conn, &stream)?;
     let Some((collection, cursor)) = stream_meta else {
         if rows.is_empty() && pending_mutations.is_empty() {
             return Ok(LocalStreamSnapshot::empty(stream));
@@ -317,10 +364,16 @@ fn apply_changes(conn: &mut Connection, changes: LocalChangeBatch) -> SyncResult
 fn enqueue_mutation(
     conn: &mut Connection,
     stream: SyncStreamName,
-    mutation: ClientMutation<serde_json::Value>,
+    pending: LocalPendingMutation,
 ) -> SyncResult<()> {
     let now = epoch_ms();
+    let mutation = pending.mutation;
     let payload = serde_json::to_string(&mutation.payload)?;
+    let optimistic_row = pending
+        .optimistic_row
+        .as_ref()
+        .map(serde_json::to_string)
+        .transpose()?;
     conn.execute(
         UPSERT_MUTATION_SQL,
         params![
@@ -330,6 +383,7 @@ fn enqueue_mutation(
             mutation.base_version.as_ref().map(RowVersion::as_str),
             op_to_str(mutation.op),
             payload,
+            optimistic_row,
             now,
         ],
     )
@@ -394,6 +448,16 @@ fn pending_mutations(
     conn: &mut Connection,
     stream: &SyncStreamName,
 ) -> SyncResult<Vec<ClientMutation<serde_json::Value>>> {
+    Ok(pending_mutation_records(conn, stream)?
+        .into_iter()
+        .map(|pending| pending.mutation)
+        .collect())
+}
+
+fn pending_mutation_records(
+    conn: &mut Connection,
+    stream: &SyncStreamName,
+) -> SyncResult<Vec<LocalPendingMutation>> {
     let mut stmt = conn
         .prepare(SELECT_PENDING_MUTATIONS_SQL)
         .map_err(sqlite_error)?;
@@ -404,22 +468,36 @@ fn pending_mutations(
             let base_version: Option<String> = row.get(2)?;
             let op: String = row.get(3)?;
             let payload: Option<String> = row.get(4)?;
-            Ok((mutation_id, row_key, base_version, op, payload))
+            let optimistic_row: Option<String> = row.get(5)?;
+            Ok((
+                mutation_id,
+                row_key,
+                base_version,
+                op,
+                payload,
+                optimistic_row,
+            ))
         })
         .map_err(sqlite_error)?;
 
     let mut mutations = Vec::new();
     for row in rows {
-        let (mutation_id, row_key, base_version, op, payload) = row.map_err(sqlite_error)?;
-        mutations.push(ClientMutation {
-            id: pocopine_sync::MutationId::new(mutation_id)?,
-            key: row_key.map(RowKey::new).transpose()?,
-            base_version: base_version.map(RowVersion::new).transpose()?,
-            op: op_from_str(&op)?,
-            payload: payload
-                .map(|payload| serde_json::from_str(&payload))
-                .transpose()?
-                .unwrap_or(serde_json::Value::Null),
+        let (mutation_id, row_key, base_version, op, payload, optimistic_row) =
+            row.map_err(sqlite_error)?;
+        mutations.push(LocalPendingMutation {
+            mutation: ClientMutation {
+                id: pocopine_sync::MutationId::new(mutation_id)?,
+                key: row_key.map(RowKey::new).transpose()?,
+                base_version: base_version.map(RowVersion::new).transpose()?,
+                op: op_from_str(&op)?,
+                payload: payload
+                    .map(|payload| serde_json::from_str(&payload))
+                    .transpose()?
+                    .unwrap_or(serde_json::Value::Null),
+            },
+            optimistic_row: optimistic_row
+                .map(|row| serde_json::from_str(&row))
+                .transpose()?,
         });
     }
     Ok(mutations)
@@ -754,6 +832,47 @@ mod tests {
     }
 
     #[test]
+    fn sqlite_store_round_trips_pending_optimistic_rows() {
+        let store = SqliteLocalStore::open_in_memory().unwrap();
+        let stream = SyncStreamName::new("posts").unwrap();
+        let mutation = ClientMutation {
+            id: MutationId::new("device_abc:1").unwrap(),
+            key: Some(RowKey::new("post_1").unwrap()),
+            op: SyncOp::Upsert,
+            base_version: None,
+            payload: serde_json::json!({
+                "op": "create",
+                "payload": {"id": "post_1", "draft": {"title": "Envelope only"}}
+            }),
+        };
+        let optimistic = SyncRow::new(
+            "post_1",
+            serde_json::json!({"id": "post_1", "title": "Visible"}),
+        )
+        .unwrap();
+
+        block(
+            store.enqueue_pending_mutation(
+                &stream,
+                LocalPendingMutation::new(mutation.clone())
+                    .with_optimistic_row(Some(optimistic.clone())),
+            ),
+        )
+        .unwrap();
+
+        let snapshot = block(store.hydrate_stream(&stream)).unwrap();
+        assert_eq!(snapshot.pending_mutations[0].mutation, mutation);
+        assert_eq!(
+            snapshot.pending_mutations[0].optimistic_row.as_ref(),
+            Some(&optimistic)
+        );
+        assert_eq!(
+            block(store.pending_mutations(&stream)).unwrap(),
+            vec![snapshot.pending_mutations[0].mutation.clone()]
+        );
+    }
+
+    #[test]
     fn sqlite_store_persists_push_cursor_before_snapshot_when_collection_is_present() {
         let store = SqliteLocalStore::open_in_memory().unwrap();
         let stream = SyncStreamName::new("posts").unwrap();
@@ -853,6 +972,81 @@ mod tests {
         assert!(err
             .to_string()
             .contains("incompatible sync sqlite schema version"));
+    }
+
+    #[test]
+    fn sqlite_store_migrates_v2_pending_mutations_to_optimistic_rows() {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "create table __pocopine_meta (
+                key text primary key,
+                value text not null
+            );
+            create table __pocopine_streams (
+                stream text primary key,
+                collection text not null,
+                cursor text,
+                schema_version integer not null,
+                updated_at_ms integer not null
+            );
+            create table __pocopine_rows (
+                stream text not null,
+                row_key text not null,
+                version text,
+                payload text not null,
+                pending integer not null default 0,
+                conflict integer not null default 0,
+                updated_at_ms integer not null,
+                primary key (stream, row_key)
+            );
+            create table __pocopine_mutations (
+                enqueue_seq integer primary key autoincrement,
+                stream text not null,
+                mutation_id text not null unique,
+                row_key text,
+                base_version text,
+                op text not null,
+                payload text,
+                status text not null,
+                error text,
+                created_at_ms integer not null,
+                updated_at_ms integer not null
+            );
+            insert into __pocopine_meta (key, value) values ('schema_version', '2');",
+        )
+        .unwrap();
+
+        let store = SqliteLocalStore::from_connection(conn).unwrap();
+        let stream = SyncStreamName::new("posts").unwrap();
+        let mutation = ClientMutation {
+            id: MutationId::new("device_abc:1").unwrap(),
+            key: Some(RowKey::new("post_1").unwrap()),
+            op: SyncOp::Upsert,
+            base_version: None,
+            payload: serde_json::json!({"op": "create"}),
+        };
+        let optimistic = SyncRow::new("post_1", serde_json::json!({"title": "Visible"})).unwrap();
+
+        block(store.enqueue_pending_mutation(
+            &stream,
+            LocalPendingMutation::new(mutation).with_optimistic_row(Some(optimistic.clone())),
+        ))
+        .unwrap();
+
+        let snapshot = block(store.hydrate_stream(&stream)).unwrap();
+        assert_eq!(
+            snapshot.pending_mutations[0].optimistic_row.as_ref(),
+            Some(&optimistic)
+        );
+        store
+            .with_conn(|conn| {
+                assert_eq!(
+                    select_meta(conn, META_SCHEMA_VERSION)?,
+                    Some(SCHEMA_VERSION.to_string())
+                );
+                Ok(())
+            })
+            .unwrap();
     }
 
     #[test]

--- a/crates/pocopine-sync-sqlite/src/schema.rs
+++ b/crates/pocopine-sync-sqlite/src/schema.rs
@@ -1,5 +1,5 @@
 /// Current Pocopine sync SQLite schema version.
-pub const SCHEMA_VERSION: u32 = 2;
+pub const SCHEMA_VERSION: u32 = 3;
 
 /// Metadata table for device identity and internal settings.
 pub const META_TABLE: &str = "__pocopine_meta";
@@ -48,6 +48,7 @@ pub const BOOTSTRAP_SQL: &[&str] = &[
         base_version text,
         op text not null,
         payload text,
+        optimistic_row text,
         status text not null,
         error text,
         created_at_ms integer not null,
@@ -93,14 +94,15 @@ pub const UPDATE_ROW_CONFLICT_SQL: &str =
 
 /// SQL upsert used for durable pending mutations.
 pub const UPSERT_MUTATION_SQL: &str = "insert into __pocopine_mutations
-    (stream, mutation_id, row_key, base_version, op, payload, status, error, created_at_ms, updated_at_ms)
-    values (?1, ?2, ?3, ?4, ?5, ?6, 'pending', null, ?7, ?7)
+    (stream, mutation_id, row_key, base_version, op, payload, optimistic_row, status, error, created_at_ms, updated_at_ms)
+    values (?1, ?2, ?3, ?4, ?5, ?6, ?7, 'pending', null, ?8, ?8)
     on conflict(mutation_id) do update set
         stream = excluded.stream,
         row_key = excluded.row_key,
         base_version = excluded.base_version,
         op = excluded.op,
         payload = excluded.payload,
+        optimistic_row = excluded.optimistic_row,
         status = 'pending',
         error = null,
         updated_at_ms = excluded.updated_at_ms";
@@ -110,7 +112,7 @@ pub const DELETE_MUTATION_SQL: &str = "delete from __pocopine_mutations where mu
 
 /// SQL query used to load pending mutations for a stream in enqueue order.
 pub const SELECT_PENDING_MUTATIONS_SQL: &str =
-    "select mutation_id, row_key, base_version, op, payload
+    "select mutation_id, row_key, base_version, op, payload, optimistic_row
     from __pocopine_mutations
     where stream = ?1 and status = 'pending'
     order by enqueue_seq asc";

--- a/crates/pocopine-sync-sqlite/src/wasm.rs
+++ b/crates/pocopine-sync-sqlite/src/wasm.rs
@@ -3,10 +3,10 @@ use std::{cell::RefCell, collections::BTreeSet, fmt, rc::Rc};
 use futures::lock::Mutex as AsyncMutex;
 use js_sys::{Array, Reflect};
 use pocopine_sync::{
-    generate_sync_device_id, ClientMutation, LocalChangeBatch, LocalPushResult, LocalSnapshotBatch,
-    LocalStreamSnapshot, MutationId, RowKey, RowVersion, SyncCollectionName, SyncCursor,
-    SyncDeviceId, SyncError, SyncLocalFuture, SyncLocalIdentity, SyncLocalStore, SyncOp,
-    SyncResult, SyncRow, SyncStreamName,
+    generate_sync_device_id, ClientMutation, LocalChangeBatch, LocalPendingMutation,
+    LocalPushResult, LocalSnapshotBatch, LocalStreamSnapshot, MutationId, RowKey, RowVersion,
+    SyncCollectionName, SyncCursor, SyncDeviceId, SyncError, SyncLocalFuture, SyncLocalIdentity,
+    SyncLocalStore, SyncOp, SyncResult, SyncRow, SyncStreamName,
 };
 use serde_json::Value;
 use wasm_bindgen::{JsCast, JsValue};
@@ -119,7 +119,15 @@ impl SyncLocalStore for SqliteLocalStore {
         stream: &SyncStreamName,
         mutation: ClientMutation<serde_json::Value>,
     ) -> SyncLocalFuture<'_, ()> {
-        self.run(enqueue_mutation(stream.clone(), mutation))
+        self.enqueue_pending_mutation(stream, LocalPendingMutation::new(mutation))
+    }
+
+    fn enqueue_pending_mutation(
+        &self,
+        stream: &SyncStreamName,
+        pending: LocalPendingMutation,
+    ) -> SyncLocalFuture<'_, ()> {
+        self.run(enqueue_mutation(stream.clone(), pending))
     }
 
     fn mark_push_result(&self, result: LocalPushResult) -> SyncLocalFuture<'_, ()> {
@@ -177,6 +185,7 @@ async fn bootstrap_schema() -> SyncResult<()> {
     for sql in BOOTSTRAP_SQL {
         exec(sql, Vec::new()).await?;
     }
+    migrate_schema().await?;
     validate_schema_version().await?;
     upsert_meta(META_SCHEMA_VERSION, &SCHEMA_VERSION.to_string()).await
 }
@@ -215,6 +224,38 @@ async fn validate_schema_version() -> SyncResult<()> {
         )));
     }
     Ok(())
+}
+
+async fn migrate_schema() -> SyncResult<()> {
+    let Some(existing) = select_meta(META_SCHEMA_VERSION).await? else {
+        return Ok(());
+    };
+    let version = existing.parse::<u32>().map_err(|_| {
+        SyncError::backend(format!(
+            "invalid sync sqlite schema version in local store: {existing}"
+        ))
+    })?;
+    if version == 2 && !column_exists("__pocopine_mutations", "optimistic_row").await? {
+        exec(
+            "alter table __pocopine_mutations add column optimistic_row text",
+            Vec::new(),
+        )
+        .await?;
+    }
+    if version == 2 {
+        upsert_meta(META_SCHEMA_VERSION, &SCHEMA_VERSION.to_string()).await?;
+    }
+    Ok(())
+}
+
+async fn column_exists(table: &str, column: &str) -> SyncResult<bool> {
+    let rows = query_rows(&format!("pragma table_info({table})"), Vec::new()).await?;
+    for row in rows {
+        if optional_string(&row, "name")?.as_deref() == Some(column) {
+            return Ok(true);
+        }
+    }
+    Ok(false)
 }
 
 async fn save_identity(identity: SyncLocalIdentity) -> SyncResult<()> {
@@ -256,7 +297,7 @@ async fn hydrate_stream(stream: SyncStreamName) -> SyncResult<LocalStreamSnapsho
         query_rows(SELECT_STREAM_SQL, vec![JsValue::from_str(stream.as_str())]).await?;
     let stream_meta = stream_rows.first();
     let rows = load_rows(&stream).await?;
-    let pending_mutations = pending_mutations(stream.clone()).await?;
+    let pending_mutations = pending_mutation_records(stream.clone()).await?;
 
     let Some(meta) = stream_meta else {
         if rows.is_empty() && pending_mutations.is_empty() {
@@ -358,10 +399,13 @@ async fn apply_changes(changes: LocalChangeBatch) -> SyncResult<()> {
     finish_transaction(result).await
 }
 
-async fn enqueue_mutation(
-    stream: SyncStreamName,
-    mutation: ClientMutation<serde_json::Value>,
-) -> SyncResult<()> {
+async fn enqueue_mutation(stream: SyncStreamName, pending: LocalPendingMutation) -> SyncResult<()> {
+    let mutation = pending.mutation;
+    let optimistic_row = pending
+        .optimistic_row
+        .as_ref()
+        .map(serde_json::to_string)
+        .transpose()?;
     exec(
         UPSERT_MUTATION_SQL,
         vec![
@@ -371,6 +415,7 @@ async fn enqueue_mutation(
             optional_param(mutation.base_version.as_ref().map(RowVersion::as_str)),
             JsValue::from_str(op_to_str(mutation.op)),
             JsValue::from_str(&serde_json::to_string(&mutation.payload)?),
+            optional_param(optimistic_row.as_deref()),
             JsValue::from_f64(epoch_ms() as f64),
         ],
     )
@@ -444,6 +489,14 @@ async fn mark_push_result(result: LocalPushResult) -> SyncResult<()> {
 async fn pending_mutations(
     stream: SyncStreamName,
 ) -> SyncResult<Vec<ClientMutation<serde_json::Value>>> {
+    Ok(pending_mutation_records(stream)
+        .await?
+        .into_iter()
+        .map(|pending| pending.mutation)
+        .collect())
+}
+
+async fn pending_mutation_records(stream: SyncStreamName) -> SyncResult<Vec<LocalPendingMutation>> {
     let rows = query_rows(
         SELECT_PENDING_MUTATIONS_SQL,
         vec![JsValue::from_str(stream.as_str())],
@@ -456,16 +509,22 @@ async fn pending_mutations(
             .map(|payload| serde_json::from_str(&payload))
             .transpose()?
             .unwrap_or(Value::Null);
-        mutations.push(ClientMutation {
-            id: pocopine_sync::MutationId::new(required_string(&row, "mutation_id")?)?,
-            key: optional_string(&row, "row_key")?
-                .map(RowKey::new)
-                .transpose()?,
-            base_version: optional_string(&row, "base_version")?
-                .map(RowVersion::new)
-                .transpose()?,
-            op: op_from_str(&required_string(&row, "op")?)?,
-            payload,
+        let optimistic_row = optional_string(&row, "optimistic_row")?
+            .map(|row| serde_json::from_str(&row))
+            .transpose()?;
+        mutations.push(LocalPendingMutation {
+            mutation: ClientMutation {
+                id: pocopine_sync::MutationId::new(required_string(&row, "mutation_id")?)?,
+                key: optional_string(&row, "row_key")?
+                    .map(RowKey::new)
+                    .transpose()?,
+                base_version: optional_string(&row, "base_version")?
+                    .map(RowVersion::new)
+                    .transpose()?,
+                op: op_from_str(&required_string(&row, "op")?)?,
+                payload,
+            },
+            optimistic_row,
         });
     }
     Ok(mutations)

--- a/crates/pocopine-sync-sqlite/tests/wasm_sqlite_store.rs
+++ b/crates/pocopine-sync-sqlite/tests/wasm_sqlite_store.rs
@@ -1,8 +1,9 @@
 #![cfg(target_arch = "wasm32")]
 
 use pocopine_sync::{
-    ClientMutation, LocalPushResult, LocalSnapshotBatch, MutationId, RowKey, SyncCollectionName,
-    SyncCursor, SyncDeviceId, SyncLocalIdentity, SyncLocalStore, SyncOp, SyncRow, SyncStreamName,
+    ClientMutation, LocalPendingMutation, LocalPushResult, LocalSnapshotBatch, MutationId, RowKey,
+    SyncCollectionName, SyncCursor, SyncDeviceId, SyncLocalIdentity, SyncLocalStore, SyncOp,
+    SyncRow, SyncStreamName,
 };
 use pocopine_sync_sqlite::SqliteLocalStore;
 use wasm_bindgen_test::*;
@@ -58,15 +59,30 @@ async fn sqlite_wasm_store_round_trips_cached_rows_and_pending_mutations() {
         key: Some(RowKey::new("post_1").unwrap()),
         op: SyncOp::Upsert,
         base_version: Some(pocopine_sync::RowVersion::new("row_1").unwrap()),
-        payload: serde_json::json!({"title": "Updated"}),
+        payload: serde_json::json!({
+            "op": "save",
+            "payload": {"id": "post_1", "draft": {"title": "Updated"}}
+        }),
     };
+    let optimistic = SyncRow::new("post_1", serde_json::json!({"title": "Updated"})).unwrap();
     store
-        .enqueue_mutation(&stream, mutation.clone())
+        .enqueue_pending_mutation(
+            &stream,
+            LocalPendingMutation::new(mutation.clone())
+                .with_optimistic_row(Some(optimistic.clone())),
+        )
         .await
         .unwrap();
     assert_eq!(
         store.pending_mutations(&stream).await.unwrap(),
         vec![mutation]
+    );
+    let pending_snapshot = store.hydrate_stream(&stream).await.unwrap();
+    assert_eq!(
+        pending_snapshot.pending_mutations[0]
+            .optimistic_row
+            .as_ref(),
+        Some(&optimistic)
     );
 
     store

--- a/crates/pocopine-sync/src/client.rs
+++ b/crates/pocopine-sync/src/client.rs
@@ -580,12 +580,12 @@ fn start_open_then_pull<C, T>(
                     .map(|pending| pending.mutation.clone())
                     .collect();
                 match decode_local_snapshot(snapshot) {
-                    Ok((rows, cursor, pending_for_state)) => {
+                    Ok(decoded) => {
                         handle.update(|state| {
                             selector(state).apply_local_snapshot_with_pending(
-                                rows,
-                                cursor,
-                                pending_for_state,
+                                decoded.rows,
+                                decoded.cursor,
+                                decoded.pending_mutations,
                             );
                         });
                     }
@@ -1043,9 +1043,14 @@ async fn run_push<C, T, M>(
 }
 
 #[cfg(target_arch = "wasm32")]
-fn decode_local_snapshot<T>(
-    snapshot: LocalStreamSnapshot,
-) -> SyncResult<(Vec<SyncRow<T>>, Option<SyncCursor>, Vec<PendingMutation<T>>)>
+struct DecodedLocalSnapshot<T> {
+    rows: Vec<SyncRow<T>>,
+    cursor: Option<SyncCursor>,
+    pending_mutations: Vec<PendingMutation<T>>,
+}
+
+#[cfg(target_arch = "wasm32")]
+fn decode_local_snapshot<T>(snapshot: LocalStreamSnapshot) -> SyncResult<DecodedLocalSnapshot<T>>
 where
     T: serde::de::DeserializeOwned,
 {
@@ -1059,7 +1064,11 @@ where
         .into_iter()
         .map(row_from_value)
         .collect::<SyncResult<Vec<_>>>()?;
-    Ok((rows, snapshot.cursor, pending_mutations))
+    Ok(DecodedLocalSnapshot {
+        rows,
+        cursor: snapshot.cursor,
+        pending_mutations,
+    })
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/pocopine-sync/src/client.rs
+++ b/crates/pocopine-sync/src/client.rs
@@ -11,9 +11,10 @@ use crate::{
 
 #[cfg(target_arch = "wasm32")]
 use crate::{
-    sync_stream_tag, LocalChangeBatch, LocalPushResult, LocalSnapshotBatch, LocalStreamSnapshot,
-    SyncChange, SyncConflict, SyncOpenRequest, SyncOpenResponse, SyncPullMode, SyncPullRequest,
-    SyncPullResponse, SyncPushRequest, SyncPushResponse,
+    sync_stream_tag, LocalChangeBatch, LocalPendingMutation, LocalPushResult, LocalSnapshotBatch,
+    LocalStreamSnapshot, PendingMutation, SyncChange, SyncConflict, SyncOp, SyncOpenRequest,
+    SyncOpenResponse, SyncPullMode, SyncPullRequest, SyncPullResponse, SyncPushRequest,
+    SyncPushResponse,
 };
 
 /// Selector from an app-owned component/store into one sync collection field.
@@ -185,7 +186,7 @@ where
     /// Pull initial data and, when configured, open a live wake-up stream.
     pub fn open(self) -> SyncResult<()>
     where
-        T: serde::de::DeserializeOwned + serde::Serialize,
+        T: Clone + serde::de::DeserializeOwned + serde::Serialize,
     {
         self.open_impl()
     }
@@ -193,7 +194,7 @@ where
     /// Trigger a manual pull.
     pub fn pull(self) -> SyncResult<()>
     where
-        T: serde::de::DeserializeOwned + serde::Serialize,
+        T: Clone + serde::de::DeserializeOwned + serde::Serialize,
     {
         self.pull_impl(SyncReason::Manual, false)
     }
@@ -288,7 +289,7 @@ where
 impl<C, T> SyncCollection<C, T>
 where
     C: 'static,
-    T: serde::de::DeserializeOwned + serde::Serialize + 'static,
+    T: Clone + serde::de::DeserializeOwned + serde::Serialize + 'static,
 {
     fn open_impl(self) -> SyncResult<()> {
         let stream = self.stream_value()?;
@@ -559,7 +560,7 @@ fn start_open_then_pull<C, T>(
     live_wakeup: Option<LiveWakeupOptions>,
 ) where
     C: 'static,
-    T: serde::de::DeserializeOwned + serde::Serialize + 'static,
+    T: Clone + serde::de::DeserializeOwned + serde::Serialize + 'static,
 {
     let open_url = endpoint_path(&endpoint, "open");
     let pull_url = endpoint_path(&endpoint, "pull");
@@ -573,11 +574,19 @@ fn start_open_then_pull<C, T>(
         match local_store.hydrate_stream(&stream).await {
             Ok(snapshot) => {
                 local_cursor = snapshot.cursor.clone();
-                pending_mutations = snapshot.pending_mutations.clone();
+                pending_mutations = snapshot
+                    .pending_mutations
+                    .iter()
+                    .map(|pending| pending.mutation.clone())
+                    .collect();
                 match decode_local_snapshot(snapshot) {
-                    Ok((rows, cursor, pending_count)) => {
+                    Ok((rows, cursor, pending_for_state)) => {
                         handle.update(|state| {
-                            selector(state).apply_local_snapshot(rows, cursor, pending_count);
+                            selector(state).apply_local_snapshot_with_pending(
+                                rows,
+                                cursor,
+                                pending_for_state,
+                            );
                         });
                     }
                     Err(err) => {
@@ -639,7 +648,11 @@ fn start_open_then_pull<C, T>(
             )
             .await
             {
-                Ok(()) => {}
+                Ok(response) => {
+                    handle.update(|state| {
+                        selector(state).apply_push(response);
+                    });
+                }
                 Err(err) => {
                     local_error = Some(format!("pending sync mutation replay failed: {err}"));
                 }
@@ -687,7 +700,7 @@ fn open_live_wakeup<C, T>(
     options: LiveWakeupOptions,
 ) where
     C: 'static,
-    T: serde::de::DeserializeOwned + serde::Serialize + 'static,
+    T: Clone + serde::de::DeserializeOwned + serde::Serialize + 'static,
 {
     let live_tag = sync_stream_tag(stream.as_str());
     let mut refresh = pocopine_live::LiveRefresh::scoped()
@@ -779,7 +792,7 @@ fn start_pull<C, T>(
     live_event: bool,
 ) where
     C: 'static,
-    T: serde::de::DeserializeOwned + serde::Serialize + 'static,
+    T: Clone + serde::de::DeserializeOwned + serde::Serialize + 'static,
 {
     let pull_url = endpoint_path(&endpoint, "pull");
 
@@ -939,8 +952,8 @@ async fn run_push<C, T, M>(
     let mutation_key = mutation.key.clone();
 
     if queue_offline {
-        let local_mutation = match mutation_to_value(&mutation) {
-            Ok(mutation) => mutation,
+        let local_pending = match pending_mutation_to_value(&mutation, optimistic.as_ref()) {
+            Ok(pending) => pending,
             Err(err) => {
                 handle.update(|state| {
                     selector(state).set_error(format!("sync mutation encode failed: {err}"));
@@ -948,7 +961,10 @@ async fn run_push<C, T, M>(
                 return;
             }
         };
-        if let Err(err) = local_store.enqueue_mutation(&stream, local_mutation).await {
+        if let Err(err) = local_store
+            .enqueue_pending_mutation(&stream, local_pending)
+            .await
+        {
             handle.update(|state| {
                 selector(state).set_error(format!("local sync mutation enqueue failed: {err}"));
             });
@@ -1029,17 +1045,21 @@ async fn run_push<C, T, M>(
 #[cfg(target_arch = "wasm32")]
 fn decode_local_snapshot<T>(
     snapshot: LocalStreamSnapshot,
-) -> SyncResult<(Vec<SyncRow<T>>, Option<SyncCursor>, u64)>
+) -> SyncResult<(Vec<SyncRow<T>>, Option<SyncCursor>, Vec<PendingMutation<T>>)>
 where
     T: serde::de::DeserializeOwned,
 {
-    let pending_count = snapshot.pending_mutations.len() as u64;
+    let pending_mutations = snapshot
+        .pending_mutations
+        .into_iter()
+        .map(pending_mutation_from_local)
+        .collect::<SyncResult<Vec<_>>>()?;
     let rows = snapshot
         .rows
         .into_iter()
         .map(row_from_value)
         .collect::<SyncResult<Vec<_>>>()?;
-    Ok((rows, snapshot.cursor, pending_count))
+    Ok((rows, snapshot.cursor, pending_mutations))
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -1048,7 +1068,7 @@ async fn replay_pending_mutations<T>(
     push_url: &str,
     stream: SyncStreamName,
     pending_mutations: Vec<ClientMutation<Value>>,
-) -> SyncResult<()>
+) -> SyncResult<SyncPushResponse<T>>
 where
     T: serde::de::DeserializeOwned + serde::Serialize + 'static,
 {
@@ -1059,7 +1079,53 @@ where
     .await
     .map_err(|err| SyncError::client(err.to_string()))?;
     let result = local_push_result_from_response(&response)?;
-    local_store.mark_push_result(result).await
+    local_store.mark_push_result(result).await?;
+    Ok(response)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn pending_mutation_from_local<T>(pending: LocalPendingMutation) -> SyncResult<PendingMutation<T>>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let LocalPendingMutation {
+        mutation,
+        optimistic_row,
+    } = pending;
+    let optimistic = match optimistic_row {
+        Some(row) => Some(row_from_value(row)?),
+        None => pending_optimistic_from_payload(&mutation),
+    };
+
+    Ok(PendingMutation {
+        id: mutation.id,
+        op: mutation.op,
+        key: mutation.key,
+        before: None,
+        before_rows: Vec::new(),
+        optimistic,
+    })
+}
+
+#[cfg(target_arch = "wasm32")]
+fn pending_optimistic_from_payload<T>(mutation: &ClientMutation<Value>) -> Option<SyncRow<T>>
+where
+    T: serde::de::DeserializeOwned,
+{
+    match mutation.op {
+        SyncOp::Upsert => mutation.key.clone().and_then(|key| {
+            serde_json::from_value(mutation.payload.clone())
+                .ok()
+                .map(|value| SyncRow {
+                    key,
+                    version: mutation.base_version.clone(),
+                    value,
+                    pending: true,
+                    conflict: false,
+                })
+        }),
+        SyncOp::Delete | SyncOp::Reset => None,
+    }
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -1140,6 +1206,19 @@ where
         base_version: mutation.base_version.clone(),
         payload: serde_json::to_value(&mutation.payload)?,
     })
+}
+
+#[cfg(target_arch = "wasm32")]
+fn pending_mutation_to_value<M, T>(
+    mutation: &ClientMutation<M>,
+    optimistic: Option<&SyncRow<T>>,
+) -> SyncResult<LocalPendingMutation>
+where
+    M: serde::Serialize,
+    T: serde::Serialize,
+{
+    Ok(LocalPendingMutation::new(mutation_to_value(mutation)?)
+        .with_optimistic_row(optimistic.map(row_to_value).transpose()?))
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/pocopine-sync/src/lib.rs
+++ b/crates/pocopine-sync/src/lib.rs
@@ -20,8 +20,9 @@ mod server;
 pub use error::{SyncError, SyncResult};
 pub use local_memory::MemoryLocalStore;
 pub use local_store::{
-    generate_sync_device_id, LocalChangeBatch, LocalPushResult, LocalSnapshotBatch,
-    LocalStreamSnapshot, MutationIdGenerator, SyncLocalFuture, SyncLocalIdentity, SyncLocalStore,
+    generate_sync_device_id, LocalChangeBatch, LocalPendingMutation, LocalPushResult,
+    LocalSnapshotBatch, LocalStreamSnapshot, MutationIdGenerator, SyncLocalFuture,
+    SyncLocalIdentity, SyncLocalStore,
 };
 pub use protocol::{
     sync_stream_tag, ClientMutation, ClientMutationDraft, MutationId, RowKey, RowVersion,

--- a/crates/pocopine-sync/src/local_memory.rs
+++ b/crates/pocopine-sync/src/local_memory.rs
@@ -5,9 +5,10 @@ use std::{
 };
 
 use crate::{
-    generate_sync_device_id, ClientMutation, LocalChangeBatch, LocalPushResult, LocalSnapshotBatch,
-    LocalStreamSnapshot, MutationId, RowKey, SyncCollectionName, SyncError, SyncLocalFuture,
-    SyncLocalIdentity, SyncLocalStore, SyncOp, SyncResult, SyncRow, SyncStreamName,
+    generate_sync_device_id, ClientMutation, LocalChangeBatch, LocalPendingMutation,
+    LocalPushResult, LocalSnapshotBatch, LocalStreamSnapshot, MutationId, RowKey,
+    SyncCollectionName, SyncError, SyncLocalFuture, SyncLocalIdentity, SyncLocalStore, SyncOp,
+    SyncResult, SyncRow, SyncStreamName,
 };
 
 /// In-memory [`SyncLocalStore`] implementation for tests and demos.
@@ -30,7 +31,7 @@ struct MemoryStreamState {
     collection: Option<SyncCollectionName>,
     cursor: Option<crate::SyncCursor>,
     rows: BTreeMap<RowKey, SyncRow<serde_json::Value>>,
-    pending: Vec<ClientMutation<serde_json::Value>>,
+    pending: Vec<LocalPendingMutation>,
 }
 
 impl MemoryLocalStore {
@@ -147,17 +148,25 @@ impl SyncLocalStore for MemoryLocalStore {
         stream: &SyncStreamName,
         mutation: ClientMutation<serde_json::Value>,
     ) -> SyncLocalFuture<'_, ()> {
+        self.enqueue_pending_mutation(stream, LocalPendingMutation::new(mutation))
+    }
+
+    fn enqueue_pending_mutation(
+        &self,
+        stream: &SyncStreamName,
+        pending: LocalPendingMutation,
+    ) -> SyncLocalFuture<'_, ()> {
         let stream = stream.clone();
         Self::ready(self.with_inner(|inner| {
             let state = inner.streams.entry(stream).or_default();
             if let Some(existing) = state
                 .pending
                 .iter_mut()
-                .find(|existing| existing.id == mutation.id)
+                .find(|existing| existing.mutation.id == pending.mutation.id)
             {
-                *existing = mutation;
+                *existing = pending;
             } else {
-                state.pending.push(mutation);
+                state.pending.push(pending);
             }
             Ok(())
         }))
@@ -174,19 +183,19 @@ impl SyncLocalStore for MemoryLocalStore {
             }
 
             for id in result.accepted {
-                state.pending.retain(|mutation| mutation.id != id);
+                state.pending.retain(|pending| pending.mutation.id != id);
             }
 
             for rejected in result.rejected {
                 state
                     .pending
-                    .retain(|mutation| mutation.id != rejected.mutation_id);
+                    .retain(|pending| pending.mutation.id != rejected.mutation_id);
             }
 
             for conflict in result.conflicts {
                 state
                     .pending
-                    .retain(|mutation| mutation.id != conflict.mutation_id);
+                    .retain(|pending| pending.mutation.id != conflict.mutation_id);
                 if let Some(mut row) = conflict.server_row {
                     row.pending = false;
                     row.conflict = true;
@@ -218,7 +227,13 @@ impl SyncLocalStore for MemoryLocalStore {
             Ok(inner
                 .streams
                 .get(&stream)
-                .map(|state| state.pending.clone())
+                .map(|state| {
+                    state
+                        .pending
+                        .iter()
+                        .map(|pending| pending.mutation.clone())
+                        .collect()
+                })
                 .unwrap_or_default())
         }))
     }
@@ -614,8 +629,52 @@ mod tests {
             .unwrap();
 
         let snapshot = store.hydrate_stream(&stream).await.unwrap();
-        assert_eq!(snapshot.pending_mutations, vec![mutation]);
+        assert_eq!(
+            snapshot.pending_mutations,
+            vec![LocalPendingMutation::new(mutation)]
+        );
         assert_eq!(snapshot.rows.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn memory_store_preserves_pending_optimistic_rows() {
+        let store = MemoryLocalStore::new();
+        let stream = SyncStreamName::new("posts").unwrap();
+        let mutation = ClientMutation {
+            id: MutationId::new("device_abc:1").unwrap(),
+            key: Some(RowKey::new("post_1").unwrap()),
+            op: SyncOp::Upsert,
+            base_version: None,
+            payload: serde_json::json!({
+                "op": "create",
+                "payload": {"id": "post_1", "draft": {"title": "Envelope only"}}
+            }),
+        };
+        let optimistic = SyncRow::new(
+            "post_1",
+            serde_json::json!({"id": "post_1", "title": "Visible"}),
+        )
+        .unwrap();
+
+        store
+            .enqueue_pending_mutation(
+                &stream,
+                LocalPendingMutation::new(mutation.clone())
+                    .with_optimistic_row(Some(optimistic.clone())),
+            )
+            .await
+            .unwrap();
+
+        let snapshot = store.hydrate_stream(&stream).await.unwrap();
+        assert_eq!(snapshot.pending_mutations[0].mutation, mutation);
+        assert_eq!(
+            snapshot.pending_mutations[0].optimistic_row.as_ref(),
+            Some(&optimistic)
+        );
+        assert_eq!(
+            store.pending_mutations(&stream).await.unwrap(),
+            vec![snapshot.pending_mutations[0].mutation.clone()]
+        );
     }
 
     #[tokio::test]

--- a/crates/pocopine-sync/src/local_store.rs
+++ b/crates/pocopine-sync/src/local_store.rs
@@ -1,6 +1,7 @@
 use std::{future::Future, pin::Pin};
 
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 use crate::{
     ClientMutation, MutationId, SyncChange, SyncCollectionName, SyncConflict, SyncCursor,
@@ -123,6 +124,61 @@ impl MutationIdGenerator {
     }
 }
 
+/// Local-only queued mutation metadata.
+///
+/// `mutation` is the wire payload sent to `/push`. `optimistic_row` is never
+/// sent to the server; it lets the client reconstruct the rendered pending
+/// overlay after reload when the wire payload is not itself a row.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct LocalPendingMutation {
+    pub mutation: ClientMutation<Value>,
+    #[serde(default)]
+    pub optimistic_row: Option<SyncRow<Value>>,
+}
+
+impl LocalPendingMutation {
+    pub fn new(mutation: ClientMutation<Value>) -> Self {
+        Self {
+            mutation,
+            optimistic_row: None,
+        }
+    }
+
+    pub fn with_optimistic_row(mut self, optimistic_row: Option<SyncRow<Value>>) -> Self {
+        self.optimistic_row = optimistic_row;
+        self
+    }
+}
+
+impl<'de> Deserialize<'de> for LocalPendingMutation {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum PendingMutationRepr {
+            Record {
+                mutation: ClientMutation<Value>,
+                #[serde(default)]
+                optimistic_row: Option<SyncRow<Value>>,
+            },
+            Legacy(ClientMutation<Value>),
+        }
+
+        match PendingMutationRepr::deserialize(deserializer)? {
+            PendingMutationRepr::Record {
+                mutation,
+                optimistic_row,
+            } => Ok(Self {
+                mutation,
+                optimistic_row,
+            }),
+            PendingMutationRepr::Legacy(mutation) => Ok(Self::new(mutation)),
+        }
+    }
+}
+
 /// Locally cached rows and cursor for one stream.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct LocalStreamSnapshot {
@@ -132,7 +188,7 @@ pub struct LocalStreamSnapshot {
     #[serde(default)]
     pub rows: Vec<SyncRow<serde_json::Value>>,
     #[serde(default)]
-    pub pending_mutations: Vec<ClientMutation<serde_json::Value>>,
+    pub pending_mutations: Vec<LocalPendingMutation>,
 }
 
 impl LocalStreamSnapshot {
@@ -265,6 +321,16 @@ pub trait SyncLocalStore {
         mutation: ClientMutation<serde_json::Value>,
     ) -> SyncLocalFuture<'_, ()>;
 
+    /// Persist a local pending mutation and its optional optimistic row before
+    /// the mutation is sent to the server.
+    fn enqueue_pending_mutation(
+        &self,
+        stream: &SyncStreamName,
+        pending: LocalPendingMutation,
+    ) -> SyncLocalFuture<'_, ()> {
+        self.enqueue_mutation(stream, pending.mutation)
+    }
+
     /// Persist accepted, rejected, or conflicted mutation outcomes.
     ///
     /// Row `pending` flags persisted here describe the latest server outcome.
@@ -383,6 +449,43 @@ mod tests {
         assert!(snapshot.cursor.is_none());
         assert!(snapshot.rows.is_empty());
         assert!(snapshot.pending_mutations.is_empty());
+    }
+
+    #[test]
+    fn local_pending_mutation_reads_legacy_wire_shape() {
+        let legacy = serde_json::json!({
+            "id": "device_abc:1",
+            "key": "post_1",
+            "op": "upsert",
+            "base_version": "row_1",
+            "payload": {"title": "Legacy"}
+        });
+
+        let pending: LocalPendingMutation = serde_json::from_value(legacy).unwrap();
+
+        assert_eq!(pending.mutation.id.as_str(), "device_abc:1");
+        assert_eq!(pending.mutation.key.as_ref().unwrap().as_str(), "post_1");
+        assert!(pending.optimistic_row.is_none());
+    }
+
+    #[test]
+    fn local_pending_mutation_records_optimistic_row() {
+        let mutation = ClientMutation {
+            id: MutationId::new("device_abc:1").unwrap(),
+            key: Some(RowKey::new("post_1").unwrap()),
+            op: SyncOp::Upsert,
+            base_version: None,
+            payload: serde_json::json!({"op": "create"}),
+        };
+        let optimistic = SyncRow::new("post_1", serde_json::json!({"title": "Visible"})).unwrap();
+
+        let pending = LocalPendingMutation::new(mutation.clone())
+            .with_optimistic_row(Some(optimistic.clone()));
+        let round_trip: LocalPendingMutation =
+            serde_json::from_str(&serde_json::to_string(&pending).unwrap()).unwrap();
+
+        assert_eq!(round_trip.mutation, mutation);
+        assert_eq!(round_trip.optimistic_row, Some(optimistic));
     }
 
     #[test]

--- a/crates/pocopine-sync/src/state.rs
+++ b/crates/pocopine-sync/src/state.rs
@@ -364,7 +364,7 @@ where
             SyncOp::Upsert => {
                 if let Some(mut row) = pending.optimistic.clone() {
                     row.pending = true;
-                    row.conflict = false;
+                    row.conflict = self.canonical_conflict(&row.key);
                     self.upsert_row(row);
                 } else if let Some(key) = &pending.key {
                     if let Some(row) = self.row_mut(key) {
@@ -374,18 +374,65 @@ where
             }
             SyncOp::Delete => {
                 if let Some(key) = &pending.key {
-                    self.remove_row(key);
+                    if self.canonical_conflict(key) {
+                        if let Some(row) = self.row_mut(key) {
+                            row.pending = true;
+                            row.conflict = true;
+                        }
+                    } else {
+                        self.remove_row(key);
+                    }
                 }
             }
             SyncOp::Reset => {
                 self.rows.clear();
                 if let Some(mut row) = pending.optimistic.clone() {
                     row.pending = true;
-                    row.conflict = false;
+                    row.conflict = self.canonical_conflict(&row.key);
                     self.rows.push(row);
                 }
             }
         }
+    }
+
+    fn canonical_conflict(&self, key: &RowKey) -> bool {
+        self.canonical_row(key)
+            .map(|row| row.conflict)
+            .unwrap_or(false)
+    }
+
+    fn bootstrap_canonical_rows_from_legacy_rows(&mut self) {
+        if !self.canonical_rows.is_empty() || self.rows.is_empty() {
+            return;
+        }
+
+        let mut rows = self.rows.clone();
+        for pending in self.pending_mutations.iter().rev() {
+            match pending.op {
+                SyncOp::Upsert => {
+                    if let Some(before) = pending.before.clone() {
+                        upsert_row_in(&mut rows, before);
+                    } else if let Some(key) = &pending.key {
+                        remove_row_from(&mut rows, key);
+                    }
+                }
+                SyncOp::Delete => {
+                    if let Some(before) = pending.before.clone() {
+                        upsert_row_in(&mut rows, before);
+                    }
+                }
+                SyncOp::Reset => {
+                    if !pending.before_rows.is_empty() {
+                        rows = pending.before_rows.clone();
+                    }
+                }
+            }
+        }
+
+        for row in &mut rows {
+            row.pending = false;
+        }
+        self.canonical_rows = rows;
     }
 
     pub fn apply_optimistic_mutation(
@@ -395,12 +442,7 @@ where
         key: Option<RowKey>,
         optimistic: Option<SyncRow<T>>,
     ) {
-        if self.canonical_rows.is_empty()
-            && !self.rows.is_empty()
-            && self.pending_mutations.is_empty()
-        {
-            self.canonical_rows = self.rows.clone();
-        }
+        self.bootstrap_canonical_rows_from_legacy_rows();
         self.pending_mutations.retain(|pending| pending.id != id);
         self.rebase_rows_from_canonical();
 
@@ -523,21 +565,25 @@ where
     }
 
     fn upsert_row(&mut self, row: SyncRow<T>) {
-        if let Some(existing) = self
-            .rows
-            .iter_mut()
-            .find(|existing| existing.key == row.key)
-        {
-            *existing = row;
-        } else {
-            self.rows.push(row);
-        }
+        upsert_row_in(&mut self.rows, row);
     }
 
     fn remove_row(&mut self, key: &RowKey) {
-        if let Some(index) = self.rows.iter().position(|row| &row.key == key) {
-            self.rows.remove(index);
-        }
+        remove_row_from(&mut self.rows, key);
+    }
+}
+
+fn upsert_row_in<T>(rows: &mut Vec<SyncRow<T>>, row: SyncRow<T>) {
+    if let Some(existing) = rows.iter_mut().find(|existing| existing.key == row.key) {
+        *existing = row;
+    } else {
+        rows.push(row);
+    }
+}
+
+fn remove_row_from<T>(rows: &mut Vec<SyncRow<T>>, key: &RowKey) {
+    if let Some(index) = rows.iter().position(|row| &row.key == key) {
+        rows.remove(index);
     }
 }
 
@@ -1197,6 +1243,99 @@ mod tests {
         assert_eq!(
             state.rows[0].version.as_ref().unwrap(),
             &RowVersion::new("row_2").unwrap()
+        );
+    }
+
+    #[test]
+    fn conflicted_stacked_mutation_keeps_later_overlay_marked_conflicted() {
+        let mut state = CollectionState::<String>::default();
+        let initial = state.begin_initial();
+        state.apply_pull(
+            initial,
+            SyncPullResponse::snapshot(
+                SyncStreamName::new("posts").unwrap(),
+                SyncCollectionName::new("posts").unwrap(),
+                vec![SyncRow::new("post_1", "server v1".to_string())
+                    .unwrap()
+                    .version("row_1")
+                    .unwrap()],
+                Some(SyncCursor::new("1").unwrap()),
+            ),
+        );
+
+        state.apply_optimistic_mutation(
+            MutationId::new("device_1:1").unwrap(),
+            SyncOp::Upsert,
+            Some(RowKey::new("post_1").unwrap()),
+            Some(SyncRow::new("post_1", "local first".to_string()).unwrap()),
+        );
+        state.apply_optimistic_mutation(
+            MutationId::new("device_1:2").unwrap(),
+            SyncOp::Upsert,
+            Some(RowKey::new("post_1").unwrap()),
+            Some(SyncRow::new("post_1", "local second".to_string()).unwrap()),
+        );
+
+        let mut conflicted = SyncPushResponse::new(SyncStreamName::new("posts").unwrap());
+        conflicted.conflicts.push(SyncConflict {
+            mutation_id: MutationId::new("device_1:1").unwrap(),
+            key: Some(RowKey::new("post_1").unwrap()),
+            server_row: Some(
+                SyncRow::new("post_1", "server v2".to_string())
+                    .unwrap()
+                    .version("row_2")
+                    .unwrap(),
+            ),
+            reason: "base version is stale".to_string(),
+        });
+        state.apply_push(conflicted);
+
+        assert_eq!(state.rows[0].value, "local second");
+        assert!(state.rows[0].pending);
+        assert!(state.rows[0].conflict);
+        assert_eq!(state.pending_count, 1);
+        assert_eq!(state.conflict_count, 1);
+        assert_eq!(
+            state.base_version(&RowKey::new("post_1").unwrap()).unwrap(),
+            RowVersion::new("row_2").unwrap()
+        );
+    }
+
+    #[test]
+    fn legacy_rendered_rows_with_pending_without_optimistic_do_not_get_wiped() {
+        let mut state = CollectionState::<String>::default();
+        let key = RowKey::new("post_1").unwrap();
+        let canonical = SyncRow::new("post_1", "server".to_string())
+            .unwrap()
+            .version("row_1")
+            .unwrap();
+        state.rows = vec![canonical.clone()];
+        state.pending_mutations.push(PendingMutation {
+            id: MutationId::new("device_1:existing").unwrap(),
+            op: SyncOp::Upsert,
+            key: Some(key.clone()),
+            before: Some(canonical),
+            before_rows: Vec::new(),
+            optimistic: None,
+        });
+
+        state.apply_optimistic_mutation(
+            MutationId::new("device_1:new").unwrap(),
+            SyncOp::Upsert,
+            Some(RowKey::new("post_2").unwrap()),
+            Some(SyncRow::new("post_2", "new local".to_string()).unwrap()),
+        );
+
+        assert_eq!(state.rows.len(), 2);
+        assert_eq!(state.row(&key).unwrap().value, "server");
+        assert!(state.row(&key).unwrap().pending);
+        assert_eq!(
+            state.base_version(&key).unwrap(),
+            RowVersion::new("row_1").unwrap()
+        );
+        assert_eq!(
+            state.row(&RowKey::new("post_2").unwrap()).unwrap().value,
+            "new local"
         );
     }
 

--- a/crates/pocopine-sync/src/state.rs
+++ b/crates/pocopine-sync/src/state.rs
@@ -49,6 +49,8 @@ pub struct PendingMutation<T> {
 #[serde(default)]
 #[serde(bound(serialize = "T: Serialize", deserialize = "T: Deserialize<'de>"))]
 pub struct CollectionState<T> {
+    #[serde(default)]
+    canonical_rows: Vec<SyncRow<T>>,
     pub rows: Vec<SyncRow<T>>,
     pub loading: bool,
     pub syncing: bool,
@@ -74,6 +76,7 @@ impl<T> Default for CollectionState<T> {
     // Manual impl avoids the `T: Default` bound that `derive(Default)` would add.
     fn default() -> Self {
         Self {
+            canonical_rows: Vec::new(),
             rows: Vec::new(),
             loading: false,
             syncing: false,
@@ -121,18 +124,21 @@ impl<T> CollectionState<T> {
         }
     }
 
-    pub fn apply_pull(&mut self, request: SyncRequest, response: SyncPullResponse<T>) -> bool {
+    pub fn apply_pull(&mut self, request: SyncRequest, response: SyncPullResponse<T>) -> bool
+    where
+        T: Clone,
+    {
         if !self.is_current(request) {
             return false;
         }
 
-        let rows_changed = match response.mode {
+        match response.mode {
             SyncPullMode::Snapshot => {
-                self.rows = response.rows;
-                true
+                self.canonical_rows = response.rows;
             }
-            SyncPullMode::Incremental => self.apply_changes(response.changes),
-        };
+            SyncPullMode::Incremental => self.apply_canonical_changes(response.changes),
+        }
+        self.rebase_rows_from_canonical();
 
         self.cursor = response.cursor;
         self.loading = false;
@@ -140,9 +146,6 @@ impl<T> CollectionState<T> {
         self.stale = false;
         self.error.clear();
         self.version = self.version.saturating_add(1);
-        if rows_changed {
-            self.recount_row_flags();
-        }
         true
     }
 
@@ -151,12 +154,43 @@ impl<T> CollectionState<T> {
         rows: Vec<SyncRow<T>>,
         cursor: Option<SyncCursor>,
         pending_count: u64,
-    ) -> bool {
+    ) -> bool
+    where
+        T: Clone,
+    {
+        self.apply_local_snapshot_inner(rows, cursor, Vec::new(), pending_count)
+    }
+
+    pub fn apply_local_snapshot_with_pending(
+        &mut self,
+        rows: Vec<SyncRow<T>>,
+        cursor: Option<SyncCursor>,
+        pending_mutations: Vec<PendingMutation<T>>,
+    ) -> bool
+    where
+        T: Clone,
+    {
+        let pending_count = pending_mutations.len() as u64;
+        self.apply_local_snapshot_inner(rows, cursor, pending_mutations, pending_count)
+    }
+
+    fn apply_local_snapshot_inner(
+        &mut self,
+        rows: Vec<SyncRow<T>>,
+        cursor: Option<SyncCursor>,
+        pending_mutations: Vec<PendingMutation<T>>,
+        pending_count: u64,
+    ) -> bool
+    where
+        T: Clone,
+    {
         if rows.is_empty() && cursor.is_none() && pending_count == 0 {
             return false;
         }
 
-        self.rows = rows;
+        self.canonical_rows = rows;
+        self.pending_mutations = pending_mutations;
+        self.rebase_rows_from_canonical();
         self.cursor = cursor;
         self.loading = false;
         self.syncing = false;
@@ -164,7 +198,6 @@ impl<T> CollectionState<T> {
         self.error.clear();
         self.version = self.version.saturating_add(1);
         self.last_reason = SyncReason::Initial;
-        self.recount_row_flags();
         if pending_count > self.pending_count {
             self.pending_count = pending_count;
         }
@@ -216,7 +249,9 @@ impl<T> CollectionState<T> {
 
     /// Return the current server-issued row version, if one is known.
     pub fn row_version(&self, key: &RowKey) -> Option<&RowVersion> {
-        self.row(key).and_then(|row| row.version.as_ref())
+        self.canonical_row(key)
+            .or_else(|| self.row(key))
+            .and_then(|row| row.version.as_ref())
     }
 
     /// Clone the current row version for use as a mutation base version.
@@ -248,51 +283,58 @@ impl<T> CollectionState<T> {
         }
     }
 
-    fn apply_changes(&mut self, changes: Vec<SyncChange<T>>) -> bool {
+    fn apply_canonical_changes(&mut self, changes: Vec<SyncChange<T>>) {
         // Linear scans are deliberate for this first small-collection state
         // container; larger local stores should move to an indexed backend.
-        let mut rows_changed = false;
         for change in changes {
             match change.op {
                 SyncOp::Upsert => {
                     let Some(row) = change.row else {
                         continue;
                     };
-                    if let Some(existing) = self
-                        .rows
-                        .iter_mut()
-                        .find(|existing| existing.key == row.key)
-                    {
-                        *existing = row;
-                    } else {
-                        self.rows.push(row);
-                    }
-                    rows_changed = true;
+                    self.upsert_canonical_row(row);
                 }
                 SyncOp::Delete => {
                     let Some(key) = change.key else {
                         continue;
                     };
-                    if let Some(index) = self.rows.iter().position(|row| row.key == key) {
-                        self.rows.remove(index);
-                        rows_changed = true;
-                    }
+                    self.remove_canonical_row(&key);
                 }
                 SyncOp::Reset => match change.row {
                     Some(row) => {
-                        self.rows.clear();
-                        self.rows.push(row);
-                        rows_changed = true;
+                        self.canonical_rows.clear();
+                        self.canonical_rows.push(row);
                     }
-                    None if !self.rows.is_empty() => {
-                        self.rows.clear();
-                        rows_changed = true;
-                    }
-                    None => {}
+                    None => self.canonical_rows.clear(),
                 },
             }
         }
-        rows_changed
+    }
+
+    fn canonical_row(&self, key: &RowKey) -> Option<&SyncRow<T>> {
+        self.canonical_rows.iter().find(|row| &row.key == key)
+    }
+
+    fn canonical_row_mut(&mut self, key: &RowKey) -> Option<&mut SyncRow<T>> {
+        self.canonical_rows.iter_mut().find(|row| &row.key == key)
+    }
+
+    fn upsert_canonical_row(&mut self, row: SyncRow<T>) {
+        if let Some(existing) = self
+            .canonical_rows
+            .iter_mut()
+            .find(|existing| existing.key == row.key)
+        {
+            *existing = row;
+        } else {
+            self.canonical_rows.push(row);
+        }
+    }
+
+    fn remove_canonical_row(&mut self, key: &RowKey) {
+        if let Some(index) = self.canonical_rows.iter().position(|row| &row.key == key) {
+            self.canonical_rows.remove(index);
+        }
     }
 
     fn recount_row_flags(&mut self) {
@@ -309,6 +351,43 @@ impl<T> CollectionState<T>
 where
     T: Clone,
 {
+    fn rebase_rows_from_canonical(&mut self) {
+        self.rows = self.canonical_rows.clone();
+        for pending in self.pending_mutations.clone() {
+            self.apply_pending_overlay(&pending);
+        }
+        self.recount_row_flags();
+    }
+
+    fn apply_pending_overlay(&mut self, pending: &PendingMutation<T>) {
+        match pending.op {
+            SyncOp::Upsert => {
+                if let Some(mut row) = pending.optimistic.clone() {
+                    row.pending = true;
+                    row.conflict = false;
+                    self.upsert_row(row);
+                } else if let Some(key) = &pending.key {
+                    if let Some(row) = self.row_mut(key) {
+                        row.pending = true;
+                    }
+                }
+            }
+            SyncOp::Delete => {
+                if let Some(key) = &pending.key {
+                    self.remove_row(key);
+                }
+            }
+            SyncOp::Reset => {
+                self.rows.clear();
+                if let Some(mut row) = pending.optimistic.clone() {
+                    row.pending = true;
+                    row.conflict = false;
+                    self.rows.push(row);
+                }
+            }
+        }
+    }
+
     pub fn apply_optimistic_mutation(
         &mut self,
         id: MutationId,
@@ -316,36 +395,21 @@ where
         key: Option<RowKey>,
         optimistic: Option<SyncRow<T>>,
     ) {
+        if self.canonical_rows.is_empty()
+            && !self.rows.is_empty()
+            && self.pending_mutations.is_empty()
+        {
+            self.canonical_rows = self.rows.clone();
+        }
+        self.pending_mutations.retain(|pending| pending.id != id);
+        self.rebase_rows_from_canonical();
+
         let before = key.as_ref().and_then(|key| self.row(key).cloned());
         let before_rows = if op == SyncOp::Reset {
             self.rows.clone()
         } else {
             Vec::new()
         };
-        self.pending_mutations.retain(|pending| pending.id != id);
-
-        match op {
-            SyncOp::Upsert => {
-                if let Some(mut row) = optimistic.clone() {
-                    row.pending = true;
-                    row.conflict = false;
-                    self.upsert_row(row);
-                }
-            }
-            SyncOp::Delete => {
-                if let Some(key) = &key {
-                    self.remove_row(key);
-                }
-            }
-            SyncOp::Reset => {
-                self.rows.clear();
-                if let Some(mut row) = optimistic.clone() {
-                    row.pending = true;
-                    row.conflict = false;
-                    self.rows.push(row);
-                }
-            }
-        }
 
         self.pending_mutations.push(PendingMutation {
             id,
@@ -357,7 +421,7 @@ where
         });
         self.error.clear();
         self.last_reason = SyncReason::Push;
-        self.recount_row_flags();
+        self.rebase_rows_from_canonical();
     }
 
     pub fn apply_push(&mut self, response: SyncPushResponse<T>) -> bool {
@@ -370,7 +434,7 @@ where
             if first_failure.is_none() {
                 first_failure = Some(rejected.reason.clone());
             }
-            self.rollback_mutation(&rejected.mutation_id);
+            self.remove_pending_mutation(&rejected.mutation_id);
             self.rejected_count = self.rejected_count.saturating_add(1);
         }
 
@@ -378,13 +442,20 @@ where
             if first_failure.is_none() {
                 first_failure = Some(conflict.reason.clone());
             }
-            self.complete_mutation(&conflict.mutation_id);
+            let pending = self.remove_pending_mutation(&conflict.mutation_id);
             if let Some(mut row) = conflict.server_row {
                 row.pending = false;
                 row.conflict = true;
-                self.upsert_row(row);
+                self.upsert_canonical_row(row);
             } else if let Some(key) = conflict.key {
-                if let Some(row) = self.row_mut(&key) {
+                let fallback = pending
+                    .and_then(|pending| pending.optimistic)
+                    .or_else(|| self.row(&key).cloned());
+                if let Some(mut row) = fallback {
+                    row.pending = false;
+                    row.conflict = true;
+                    self.upsert_canonical_row(row);
+                } else if let Some(row) = self.canonical_row_mut(&key) {
                     row.pending = false;
                     row.conflict = true;
                 }
@@ -392,13 +463,13 @@ where
         }
 
         for id in response.accepted {
-            self.complete_mutation(&id);
+            self.accept_mutation(&id);
         }
 
         for mut row in response.rows {
             row.pending = false;
             row.conflict = false;
-            self.upsert_row(row);
+            self.upsert_canonical_row(row);
         }
 
         if let Some(cursor) = response.cursor {
@@ -413,62 +484,42 @@ where
         self.loading = false;
         self.syncing = false;
         self.stale = has_accepted;
-        self.recount_row_flags();
+        self.rebase_rows_from_canonical();
         has_accepted
     }
 
     pub fn apply_push_error(&mut self, id: &MutationId, error: impl ToString) -> bool {
-        self.rollback_mutation(id);
+        self.remove_pending_mutation(id);
+        self.rebase_rows_from_canonical();
         self.loading = false;
         self.syncing = false;
         self.stale = self.version > 0 || self.stale;
         self.error = error.to_string();
         self.last_reason = SyncReason::Error;
-        self.recount_row_flags();
         true
     }
 
-    fn rollback_mutation(&mut self, id: &MutationId) {
-        let Some(index) = self
-            .pending_mutations
-            .iter()
-            .position(|pending| &pending.id == id)
-        else {
+    fn accept_mutation(&mut self, id: &MutationId) {
+        let Some(pending) = self.remove_pending_mutation(id) else {
             return;
         };
-        let pending = self.pending_mutations.remove(index);
         match pending.op {
-            SyncOp::Upsert => {
-                if let Some(before) = pending.before {
-                    self.upsert_row(before);
-                } else if let Some(key) = pending.key {
-                    self.remove_row(&key);
+            SyncOp::Delete => {
+                if let Some(key) = pending.key {
+                    self.remove_canonical_row(&key);
                 }
             }
-            SyncOp::Delete | SyncOp::Reset => {
-                if pending.op == SyncOp::Reset {
-                    self.rows = pending.before_rows;
-                } else if let Some(before) = pending.before {
-                    self.upsert_row(before);
-                }
-            }
+            SyncOp::Reset => self.canonical_rows.clear(),
+            SyncOp::Upsert => {}
         }
     }
 
-    fn complete_mutation(&mut self, id: &MutationId) {
-        let Some(index) = self
+    fn remove_pending_mutation(&mut self, id: &MutationId) -> Option<PendingMutation<T>> {
+        let index = self
             .pending_mutations
             .iter()
-            .position(|pending| &pending.id == id)
-        else {
-            return;
-        };
-        let pending = self.pending_mutations.remove(index);
-        if let Some(key) = pending.key {
-            if let Some(row) = self.row_mut(&key) {
-                row.pending = false;
-            }
-        }
+            .position(|pending| &pending.id == id)?;
+        Some(self.pending_mutations.remove(index))
     }
 
     fn upsert_row(&mut self, row: SyncRow<T>) {
@@ -542,6 +593,79 @@ mod tests {
         assert_eq!(state.version, 1);
         assert_eq!(state.pending_count, 2);
         assert_eq!(state.last_reason, SyncReason::Initial);
+    }
+
+    #[test]
+    fn local_snapshot_replays_hydrated_pending_overlay() {
+        let mut state = CollectionState::<String>::default();
+        let canonical = SyncRow::new("post_1", "cached".to_string())
+            .unwrap()
+            .version("row_1")
+            .unwrap();
+        let pending = PendingMutation {
+            id: MutationId::new("device_1:1").unwrap(),
+            op: SyncOp::Upsert,
+            key: Some(RowKey::new("post_1").unwrap()),
+            before: None,
+            before_rows: Vec::new(),
+            optimistic: Some(SyncRow::new("post_1", "queued local".to_string()).unwrap()),
+        };
+
+        assert!(state.apply_local_snapshot_with_pending(
+            vec![canonical],
+            Some(SyncCursor::new("cursor_1").unwrap()),
+            vec![pending],
+        ));
+
+        assert_eq!(state.rows[0].value, "queued local");
+        assert!(state.rows[0].pending);
+        assert_eq!(state.pending_count, 1);
+        assert_eq!(
+            state.base_version(&RowKey::new("post_1").unwrap()).unwrap(),
+            RowVersion::new("row_1").unwrap()
+        );
+    }
+
+    #[test]
+    fn local_snapshot_replays_hydrated_pending_delete() {
+        let mut state = CollectionState::<String>::default();
+        let canonical = SyncRow::new("post_1", "cached".to_string())
+            .unwrap()
+            .version("row_1")
+            .unwrap();
+        let pending = PendingMutation {
+            id: MutationId::new("device_1:delete").unwrap(),
+            op: SyncOp::Delete,
+            key: Some(RowKey::new("post_1").unwrap()),
+            before: None,
+            before_rows: Vec::new(),
+            optimistic: None,
+        };
+
+        assert!(state.apply_local_snapshot_with_pending(
+            vec![canonical],
+            Some(SyncCursor::new("cursor_1").unwrap()),
+            vec![pending],
+        ));
+
+        assert!(state.rows.is_empty());
+        assert_eq!(state.pending_count, 1);
+        assert_eq!(
+            state.base_version(&RowKey::new("post_1").unwrap()).unwrap(),
+            RowVersion::new("row_1").unwrap()
+        );
+
+        let mut rejected = SyncPushResponse::new(SyncStreamName::new("posts").unwrap());
+        rejected.rejected.push(SyncRejectedMutation {
+            mutation_id: MutationId::new("device_1:delete").unwrap(),
+            key: Some(RowKey::new("post_1").unwrap()),
+            reason: "cannot delete".to_string(),
+        });
+        state.apply_push(rejected);
+
+        assert_eq!(state.rows[0].value, "cached");
+        assert!(!state.rows[0].pending);
+        assert_eq!(state.pending_count, 0);
     }
 
     #[test]
@@ -723,6 +847,388 @@ mod tests {
         assert!(state.rows[0].pending);
         assert_eq!(state.pending_count, 1);
         assert_eq!(state.last_reason, SyncReason::Push);
+    }
+
+    #[test]
+    fn duplicate_pending_mutation_id_replaces_previous_overlay() {
+        let mut state = CollectionState::<String>::default();
+        let initial = state.begin_initial();
+        state.apply_pull(
+            initial,
+            SyncPullResponse::snapshot(
+                SyncStreamName::new("posts").unwrap(),
+                SyncCollectionName::new("posts").unwrap(),
+                vec![SyncRow::new("post_1", "server".to_string()).unwrap()],
+                Some(SyncCursor::new("1").unwrap()),
+            ),
+        );
+
+        state.apply_optimistic_mutation(
+            MutationId::new("device_1:dup").unwrap(),
+            SyncOp::Upsert,
+            Some(RowKey::new("post_1").unwrap()),
+            Some(SyncRow::new("post_1", "first draft".to_string()).unwrap()),
+        );
+        state.apply_optimistic_mutation(
+            MutationId::new("device_1:dup").unwrap(),
+            SyncOp::Upsert,
+            Some(RowKey::new("post_1").unwrap()),
+            Some(SyncRow::new("post_1", "second draft".to_string()).unwrap()),
+        );
+
+        assert_eq!(state.pending_mutations.len(), 1);
+        assert_eq!(state.pending_count, 1);
+        assert_eq!(state.rows[0].value, "second draft");
+        assert!(state.rows[0].pending);
+
+        let mut rejected = SyncPushResponse::new(SyncStreamName::new("posts").unwrap());
+        rejected.rejected.push(SyncRejectedMutation {
+            mutation_id: MutationId::new("device_1:dup").unwrap(),
+            key: Some(RowKey::new("post_1").unwrap()),
+            reason: "draft rejected".to_string(),
+        });
+        state.apply_push(rejected);
+
+        assert_eq!(state.rows[0].value, "server");
+        assert!(!state.rows[0].pending);
+        assert_eq!(state.pending_count, 0);
+    }
+
+    #[test]
+    fn pull_rebases_pending_upsert_over_new_canonical_row() {
+        let mut state = CollectionState::<String>::default();
+        let initial = state.begin_initial();
+        state.apply_pull(
+            initial,
+            SyncPullResponse::snapshot(
+                SyncStreamName::new("posts").unwrap(),
+                SyncCollectionName::new("posts").unwrap(),
+                vec![SyncRow::new("post_1", "server v1".to_string())
+                    .unwrap()
+                    .version("row_1")
+                    .unwrap()],
+                Some(SyncCursor::new("1").unwrap()),
+            ),
+        );
+
+        state.apply_optimistic_mutation(
+            MutationId::new("device_1:1").unwrap(),
+            SyncOp::Upsert,
+            Some(RowKey::new("post_1").unwrap()),
+            Some(SyncRow::new("post_1", "local draft".to_string()).unwrap()),
+        );
+
+        let request = state.begin_live_pull(SyncReason::Live);
+        state.apply_pull(
+            request,
+            SyncPullResponse::incremental(
+                SyncStreamName::new("posts").unwrap(),
+                SyncCollectionName::new("posts").unwrap(),
+                vec![SyncChange {
+                    stream: SyncStreamName::new("posts").unwrap(),
+                    collection: SyncCollectionName::new("posts").unwrap(),
+                    key: Some(RowKey::new("post_1").unwrap()),
+                    op: SyncOp::Upsert,
+                    row: Some(
+                        SyncRow::new("post_1", "server v2".to_string())
+                            .unwrap()
+                            .version("row_2")
+                            .unwrap(),
+                    ),
+                    cursor: SyncCursor::new("2").unwrap(),
+                }],
+                Some(SyncCursor::new("2").unwrap()),
+            ),
+        );
+
+        assert_eq!(state.rows[0].value, "local draft");
+        assert!(state.rows[0].pending);
+        assert_eq!(
+            state.base_version(&RowKey::new("post_1").unwrap()).unwrap(),
+            RowVersion::new("row_2").unwrap()
+        );
+
+        let mut rejected = SyncPushResponse::new(SyncStreamName::new("posts").unwrap());
+        rejected.rejected.push(SyncRejectedMutation {
+            mutation_id: MutationId::new("device_1:1").unwrap(),
+            key: Some(RowKey::new("post_1").unwrap()),
+            reason: "stale draft".to_string(),
+        });
+        state.apply_push(rejected);
+
+        assert_eq!(state.rows[0].value, "server v2");
+        assert!(!state.rows[0].pending);
+        assert_eq!(
+            state.rows[0].version.as_ref().unwrap(),
+            &RowVersion::new("row_2").unwrap()
+        );
+    }
+
+    #[test]
+    fn pull_delete_keeps_pending_upsert_visible_until_rejected() {
+        let mut state = CollectionState::<String>::default();
+        let initial = state.begin_initial();
+        state.apply_pull(
+            initial,
+            SyncPullResponse::snapshot(
+                SyncStreamName::new("posts").unwrap(),
+                SyncCollectionName::new("posts").unwrap(),
+                vec![SyncRow::new("post_1", "server v1".to_string())
+                    .unwrap()
+                    .version("row_1")
+                    .unwrap()],
+                Some(SyncCursor::new("1").unwrap()),
+            ),
+        );
+
+        state.apply_optimistic_mutation(
+            MutationId::new("device_1:edit").unwrap(),
+            SyncOp::Upsert,
+            Some(RowKey::new("post_1").unwrap()),
+            Some(SyncRow::new("post_1", "local edit".to_string()).unwrap()),
+        );
+
+        let request = state.begin_live_pull(SyncReason::Live);
+        state.apply_pull(
+            request,
+            SyncPullResponse::incremental(
+                SyncStreamName::new("posts").unwrap(),
+                SyncCollectionName::new("posts").unwrap(),
+                vec![SyncChange {
+                    stream: SyncStreamName::new("posts").unwrap(),
+                    collection: SyncCollectionName::new("posts").unwrap(),
+                    key: Some(RowKey::new("post_1").unwrap()),
+                    op: SyncOp::Delete,
+                    row: None,
+                    cursor: SyncCursor::new("2").unwrap(),
+                }],
+                Some(SyncCursor::new("2").unwrap()),
+            ),
+        );
+
+        assert_eq!(state.rows[0].value, "local edit");
+        assert!(state.rows[0].pending);
+        assert!(state
+            .base_version(&RowKey::new("post_1").unwrap())
+            .is_none());
+
+        let mut rejected = SyncPushResponse::new(SyncStreamName::new("posts").unwrap());
+        rejected.rejected.push(SyncRejectedMutation {
+            mutation_id: MutationId::new("device_1:edit").unwrap(),
+            key: Some(RowKey::new("post_1").unwrap()),
+            reason: "row was deleted".to_string(),
+        });
+        state.apply_push(rejected);
+
+        assert!(state.rows.is_empty());
+        assert_eq!(state.pending_count, 0);
+    }
+
+    #[test]
+    fn pull_snapshot_rebases_pending_delete_over_updated_canonical_row() {
+        let mut state = CollectionState::<String>::default();
+        let initial = state.begin_initial();
+        state.apply_pull(
+            initial,
+            SyncPullResponse::snapshot(
+                SyncStreamName::new("posts").unwrap(),
+                SyncCollectionName::new("posts").unwrap(),
+                vec![SyncRow::new("post_1", "server v1".to_string())
+                    .unwrap()
+                    .version("row_1")
+                    .unwrap()],
+                Some(SyncCursor::new("1").unwrap()),
+            ),
+        );
+
+        state.apply_optimistic_mutation(
+            MutationId::new("device_1:delete").unwrap(),
+            SyncOp::Delete,
+            Some(RowKey::new("post_1").unwrap()),
+            None,
+        );
+
+        let request = state.begin_pull(SyncReason::Manual);
+        state.apply_pull(
+            request,
+            SyncPullResponse::snapshot(
+                SyncStreamName::new("posts").unwrap(),
+                SyncCollectionName::new("posts").unwrap(),
+                vec![SyncRow::new("post_1", "server v2".to_string())
+                    .unwrap()
+                    .version("row_2")
+                    .unwrap()],
+                Some(SyncCursor::new("2").unwrap()),
+            ),
+        );
+
+        assert!(state.rows.is_empty());
+        assert_eq!(state.pending_count, 1);
+        assert_eq!(
+            state.base_version(&RowKey::new("post_1").unwrap()).unwrap(),
+            RowVersion::new("row_2").unwrap()
+        );
+
+        let mut rejected = SyncPushResponse::new(SyncStreamName::new("posts").unwrap());
+        rejected.rejected.push(SyncRejectedMutation {
+            mutation_id: MutationId::new("device_1:delete").unwrap(),
+            key: Some(RowKey::new("post_1").unwrap()),
+            reason: "cannot delete".to_string(),
+        });
+        state.apply_push(rejected);
+
+        assert_eq!(state.rows[0].value, "server v2");
+        assert_eq!(
+            state.rows[0].version.as_ref().unwrap(),
+            &RowVersion::new("row_2").unwrap()
+        );
+        assert_eq!(state.pending_count, 0);
+    }
+
+    #[test]
+    fn pull_reset_keeps_pending_upsert_visible_until_rejected() {
+        let mut state = CollectionState::<String>::default();
+        let initial = state.begin_initial();
+        state.apply_pull(
+            initial,
+            SyncPullResponse::snapshot(
+                SyncStreamName::new("posts").unwrap(),
+                SyncCollectionName::new("posts").unwrap(),
+                vec![SyncRow::new("post_1", "server".to_string()).unwrap()],
+                Some(SyncCursor::new("1").unwrap()),
+            ),
+        );
+
+        state.apply_optimistic_mutation(
+            MutationId::new("device_1:new").unwrap(),
+            SyncOp::Upsert,
+            Some(RowKey::new("post_2").unwrap()),
+            Some(SyncRow::new("post_2", "local new".to_string()).unwrap()),
+        );
+
+        let request = state.begin_live_pull(SyncReason::Live);
+        state.apply_pull(
+            request,
+            SyncPullResponse::incremental(
+                SyncStreamName::new("posts").unwrap(),
+                SyncCollectionName::new("posts").unwrap(),
+                vec![SyncChange {
+                    stream: SyncStreamName::new("posts").unwrap(),
+                    collection: SyncCollectionName::new("posts").unwrap(),
+                    key: None,
+                    op: SyncOp::Reset,
+                    row: None,
+                    cursor: SyncCursor::new("2").unwrap(),
+                }],
+                Some(SyncCursor::new("2").unwrap()),
+            ),
+        );
+
+        assert_eq!(state.rows.len(), 1);
+        assert_eq!(state.rows[0].key.as_str(), "post_2");
+        assert_eq!(state.rows[0].value, "local new");
+        assert!(state.rows[0].pending);
+
+        let mut rejected = SyncPushResponse::new(SyncStreamName::new("posts").unwrap());
+        rejected.rejected.push(SyncRejectedMutation {
+            mutation_id: MutationId::new("device_1:new").unwrap(),
+            key: Some(RowKey::new("post_2").unwrap()),
+            reason: "server reset won".to_string(),
+        });
+        state.apply_push(rejected);
+
+        assert!(state.rows.is_empty());
+        assert_eq!(state.pending_count, 0);
+    }
+
+    #[test]
+    fn accepting_one_stacked_mutation_keeps_later_overlay_rebased() {
+        let mut state = CollectionState::<String>::default();
+        let initial = state.begin_initial();
+        state.apply_pull(
+            initial,
+            SyncPullResponse::snapshot(
+                SyncStreamName::new("posts").unwrap(),
+                SyncCollectionName::new("posts").unwrap(),
+                vec![SyncRow::new("post_1", "server v1".to_string()).unwrap()],
+                Some(SyncCursor::new("1").unwrap()),
+            ),
+        );
+
+        state.apply_optimistic_mutation(
+            MutationId::new("device_1:1").unwrap(),
+            SyncOp::Upsert,
+            Some(RowKey::new("post_1").unwrap()),
+            Some(SyncRow::new("post_1", "local first".to_string()).unwrap()),
+        );
+        state.apply_optimistic_mutation(
+            MutationId::new("device_1:2").unwrap(),
+            SyncOp::Upsert,
+            Some(RowKey::new("post_1").unwrap()),
+            Some(SyncRow::new("post_1", "local second".to_string()).unwrap()),
+        );
+
+        let mut accepted = SyncPushResponse::new(SyncStreamName::new("posts").unwrap());
+        accepted
+            .accepted
+            .push(MutationId::new("device_1:1").unwrap());
+        accepted.rows.push(
+            SyncRow::new("post_1", "server accepted first".to_string())
+                .unwrap()
+                .version("row_2")
+                .unwrap(),
+        );
+        state.apply_push(accepted);
+
+        assert_eq!(state.rows[0].value, "local second");
+        assert!(state.rows[0].pending);
+        assert_eq!(state.pending_count, 1);
+
+        let mut rejected = SyncPushResponse::new(SyncStreamName::new("posts").unwrap());
+        rejected.rejected.push(SyncRejectedMutation {
+            mutation_id: MutationId::new("device_1:2").unwrap(),
+            key: Some(RowKey::new("post_1").unwrap()),
+            reason: "second rejected".to_string(),
+        });
+        state.apply_push(rejected);
+
+        assert_eq!(state.rows[0].value, "server accepted first");
+        assert!(!state.rows[0].pending);
+        assert_eq!(
+            state.rows[0].version.as_ref().unwrap(),
+            &RowVersion::new("row_2").unwrap()
+        );
+    }
+
+    #[test]
+    fn accepted_delete_removes_canonical_row_after_overlay() {
+        let mut state = CollectionState::<String>::default();
+        let initial = state.begin_initial();
+        state.apply_pull(
+            initial,
+            SyncPullResponse::snapshot(
+                SyncStreamName::new("posts").unwrap(),
+                SyncCollectionName::new("posts").unwrap(),
+                vec![SyncRow::new("post_1", "server".to_string()).unwrap()],
+                Some(SyncCursor::new("1").unwrap()),
+            ),
+        );
+        state.apply_optimistic_mutation(
+            MutationId::new("device_1:delete").unwrap(),
+            SyncOp::Delete,
+            Some(RowKey::new("post_1").unwrap()),
+            None,
+        );
+
+        let mut accepted = SyncPushResponse::new(SyncStreamName::new("posts").unwrap());
+        accepted
+            .accepted
+            .push(MutationId::new("device_1:delete").unwrap());
+        state.apply_push(accepted);
+
+        assert!(state.rows.is_empty());
+        assert!(state.row(&RowKey::new("post_1").unwrap()).is_none());
+        assert_eq!(state.pending_count, 0);
     }
 
     #[test]

--- a/crates/pocopine-sync/tests/client_browser.rs
+++ b/crates/pocopine-sync/tests/client_browser.rs
@@ -11,11 +11,11 @@ use std::rc::Rc;
 use js_sys::Promise;
 use pocopine::prelude::*;
 use pocopine_sync::{
-    sync_plugin, ClientMutation, ClientMutationDraft, CollectionState, LocalSnapshotBatch,
-    MemoryLocalStore, MutationId, RowKey, SyncChange, SyncCollectionName, SyncCursor, SyncDeviceId,
-    SyncLocalIdentity, SyncLocalStore, SyncOp, SyncOpenRequest, SyncOpenResponse, SyncOpenStream,
-    SyncPullRequest, SyncPullResponse, SyncPushRequest, SyncPushResponse, SyncRow, SyncStreamName,
-    SYNC_OPEN_PATH, SYNC_PULL_PATH, SYNC_PUSH_PATH,
+    sync_plugin, ClientMutation, ClientMutationDraft, CollectionState, LocalPendingMutation,
+    LocalSnapshotBatch, MemoryLocalStore, MutationId, RowKey, SyncChange, SyncCollectionName,
+    SyncCursor, SyncDeviceId, SyncLocalIdentity, SyncLocalStore, SyncOp, SyncOpenRequest,
+    SyncOpenResponse, SyncOpenStream, SyncPullRequest, SyncPullResponse, SyncPushRequest,
+    SyncPushResponse, SyncRow, SyncStreamName, SYNC_OPEN_PATH, SYNC_PULL_PATH, SYNC_PUSH_PATH,
 };
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::JsValue;
@@ -520,6 +520,148 @@ async fn open_replays_pending_mutations_before_pull() {
         2,
         "local store should hold cached + replay-confirmed rows"
     );
+
+    host.remove();
+    pocopine::fetch::__reset_middleware_chain_for_test();
+}
+
+#[wasm_bindgen_test(async)]
+async fn open_keeps_hydrated_pending_overlay_when_replay_fails() {
+    pocopine::fetch::__reset_middleware_chain_for_test();
+
+    let store = MemoryLocalStore::new();
+    let stream = SyncStreamName::new(STREAM).unwrap();
+    let collection = SyncCollectionName::new(COLLECTION).unwrap();
+
+    store
+        .save_snapshot(LocalSnapshotBatch::new(
+            stream.clone(),
+            collection,
+            vec![SyncRow::new(
+                "post_1",
+                serde_json::json!({"id": "post_1", "title": "Cached"}),
+            )
+            .unwrap()],
+            Some(SyncCursor::new("cached_cursor").unwrap()),
+        ))
+        .await
+        .unwrap();
+
+    store
+        .enqueue_pending_mutation(
+            &stream,
+            LocalPendingMutation::new(ClientMutation {
+                id: MutationId::new("device_browser:pending").unwrap(),
+                key: Some(RowKey::new("post_2").unwrap()),
+                op: SyncOp::Upsert,
+                base_version: None,
+                payload: serde_json::json!({
+                    "op": "create",
+                    "payload": {"id": "post_2", "draft": {"title": "Envelope only"}}
+                }),
+            })
+            .with_optimistic_row(Some(
+                SyncRow::new(
+                    "post_2",
+                    serde_json::json!({"id": "post_2", "title": "Pending local"}),
+                )
+                .unwrap(),
+            )),
+        )
+        .await
+        .unwrap();
+
+    let push_seen = Rc::new(RefCell::new(0u32));
+    let pull_seen = Rc::new(RefCell::new(0u32));
+    let push_seen_for_mw = push_seen.clone();
+    let pull_seen_for_mw = pull_seen.clone();
+
+    pocopine::fetch::install_middleware(
+        move |req: pocopine::fetch::FetchRequest, _next: pocopine::fetch::FetchNext| {
+            let push_seen = push_seen_for_mw.clone();
+            let pull_seen = pull_seen_for_mw.clone();
+            async move {
+                match req.url.as_str() {
+                    SYNC_OPEN_PATH => {
+                        Ok(json_response(SyncOpenResponse::new(vec![SyncOpenStream {
+                            stream: SyncStreamName::new(STREAM).unwrap(),
+                            collection: SyncCollectionName::new(COLLECTION).unwrap(),
+                            cursor: None,
+                        }])))
+                    }
+                    SYNC_PUSH_PATH => {
+                        *push_seen.borrow_mut() += 1;
+                        let request: SyncPushRequest<serde_json::Value> =
+                            serde_json::from_str(&req.body).unwrap();
+                        assert_eq!(request.mutations.len(), 1);
+                        assert_eq!(request.mutations[0].id.as_str(), "device_browser:pending");
+                        Err(pocopine::ServerError::Network("offline replay".to_string()))
+                    }
+                    SYNC_PULL_PATH => {
+                        *pull_seen.borrow_mut() += 1;
+                        let request: SyncPullRequest = serde_json::from_str(&req.body).unwrap();
+                        assert_eq!(request.cursor.as_ref().unwrap().as_str(), "cached_cursor");
+                        Ok(json_response(SyncPullResponse::<BrowserPost>::incremental(
+                            SyncStreamName::new(STREAM).unwrap(),
+                            SyncCollectionName::new(COLLECTION).unwrap(),
+                            Vec::new(),
+                            Some(SyncCursor::new("after_pull").unwrap()),
+                        )))
+                    }
+                    other => Err(pocopine::ServerError::Network(format!(
+                        "unexpected sync browser test request: {other}"
+                    ))),
+                }
+            }
+        },
+    );
+
+    let document = window().unwrap().document().unwrap();
+    let host = document.create_element("div").unwrap();
+    host.set_attribute("pp-app", "").unwrap();
+    host.set_inner_html("<sync-browser-board></sync-browser-board>");
+    document.body().unwrap().append_child(&host).unwrap();
+
+    App::new()
+        .plugin(
+            sync_plugin()
+                .with_live_wakeup(false)
+                .local_store(store.clone()),
+        )
+        .register::<SyncBrowserBoard>()
+        .run();
+
+    settle().await;
+
+    assert_eq!(*push_seen.borrow(), 1);
+    assert_eq!(*pull_seen.borrow(), 1);
+
+    let posts = host.query_selector_all(".post").unwrap();
+    assert_eq!(posts.length(), 2);
+    assert_eq!(
+        posts.item(0).unwrap().text_content().unwrap_or_default(),
+        "Cached"
+    );
+    assert_eq!(
+        posts.item(1).unwrap().text_content().unwrap_or_default(),
+        "Pending local"
+    );
+    let error = host
+        .query_selector(".error")
+        .unwrap()
+        .unwrap()
+        .text_content()
+        .unwrap_or_default();
+    assert!(error.contains("pending sync mutation replay failed"));
+    assert!(error.contains("offline replay"));
+
+    let persisted = store.hydrate_stream(&stream).await.unwrap();
+    assert_eq!(persisted.pending_mutations.len(), 1);
+    assert_eq!(
+        persisted.pending_mutations[0].mutation.id.as_str(),
+        "device_browser:pending"
+    );
+    assert!(persisted.pending_mutations[0].optimistic_row.is_some());
 
     host.remove();
     pocopine::fetch::__reset_middleware_chain_for_test();

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,10 @@ looks the way it does — the code itself tells you *what*.
   current roadmap for turning the shipped sync protocol, local store, and
   SQLite backend into a database-agnostic local-first sync engine without
   becoming a sync database.
+- [`sync-conflict-architecture.md`](./sync-conflict-architecture.md) —
+  deep dive on the sync layers, canonical-vs-rendered local state,
+  pending overlays, push outcomes, conflict resolution direction, and the
+  invariants future sync/resource authors must preserve.
 - [`sync-crud.md`](./sync-crud.md) — `pocopine-sync-crud` helper layer:
   `CrudSource`, `ResourceId`, CRUD mutation payloads, write policies,
   transaction binding, the non-macro runtime adapter, planned proc-macro

--- a/docs/sync-conflict-architecture.md
+++ b/docs/sync-conflict-architecture.md
@@ -1,0 +1,323 @@
+# Sync And Conflict Resolution Architecture
+
+This document is a deep dive for future Pocopine sync authors. It explains
+how the current sync layers fit together, which parts own conflict
+semantics, and what invariants new CRUD/resource helpers must preserve.
+
+Pocopine sync is a database-agnostic local-first sync engine. It is not a
+sync database. Framework code owns protocol shape, local durability,
+optimistic overlay, rebase, conflict metadata, live wake-up integration,
+and typed resource ergonomics. Apps and adapter crates own database
+schema, source queries, authorization filters, and backend-specific change
+tracking.
+
+## Layers
+
+The stack is intentionally split:
+
+```text
+application resource methods
+  -> pocopine-sync-crud typed resource contract
+  -> pocopine-sync protocol/client/server state machine
+  -> SyncLocalStore implementation
+  -> app database and optional backend adapters
+```
+
+`pocopine-sync` owns the protocol:
+
+- `/open` validates and discovers streams,
+- `/pull` returns snapshot or incremental canonical rows,
+- `/push` submits client mutations and returns accepted, rejected, and
+  conflict outcomes,
+- `CollectionState<T>` owns the client-side state machine,
+- `SyncLocalStore` owns local durability for identities, cached rows,
+  cursors, pending mutations, and push outcomes.
+
+`pocopine-sync-crud` owns resource typing:
+
+- `ResourceId` maps app ids to sync row keys,
+- `CrudMutationPayload` describes create/save/remove payloads,
+- `CrudSource` adapts an app-owned data source to sync routes,
+- `CrudMutationLog` records accepted mutation ids for replay dedupe,
+- `LocalResourceView` exposes typed local rows and pending mutations to
+  generated clients and UI code.
+
+`pocopine-live` remains a wake-up channel. It should tell clients "pull
+this stream again"; it should not carry row data or bypass sync conflict
+rules.
+
+## Protocol Objects
+
+Rows are canonical transport units:
+
+```text
+SyncRow<T> {
+  key,
+  version,
+  value,
+  pending,
+  conflict,
+}
+```
+
+Mutations are client-authored write intents:
+
+```text
+ClientMutation<T> {
+  id,
+  key,
+  op,
+  base_version,
+  payload,
+}
+```
+
+Important meanings:
+
+- `id` is the replay/idempotency key.
+- `key` scopes the mutation to one row when possible.
+- `op` is `upsert`, `delete`, or `reset`.
+- `base_version` is the last canonical server row version the client
+  believes it edited.
+- `payload` is the author-facing write data. For CRUD this is not
+  necessarily the same shape as the rendered row.
+
+The local store persists `LocalPendingMutation`, not only
+`ClientMutation<Value>`. The extra `optimistic_row` is local-only and is
+never sent to `/push`. It exists so a browser reload can reconstruct the
+rendered optimistic row even when the mutation payload is an envelope such
+as `{ op: "save", payload: { id, draft } }`.
+
+## Canonical Rows Versus Rendered Rows
+
+The key local-first invariant is:
+
+```text
+rendered rows = canonical rows + pending local overlay
+```
+
+`CollectionState<T>` keeps canonical server rows separate from `rows`,
+the rendered view. Server pulls update canonical rows. Pending mutations
+then replay over that canonical set in deterministic queue order.
+
+That separation matters because a live pull may arrive while local writes
+are pending:
+
+```text
+server v1
+  -> user edits locally
+  -> UI shows local draft
+  -> pull receives server v2
+  -> UI still shows local draft
+  -> base_version now points at server v2
+```
+
+The user does not see a flicker back to server data, but the next push or
+retry uses the newest known canonical version. If the local mutation is
+rejected, the UI rolls back to server v2 instead of the stale server v1.
+
+This is why `row_version` and `base_version` are different in the typed
+view:
+
+- `row_version` belongs to the rendered row. A purely optimistic row may
+  not have one.
+- `base_version` belongs to the current canonical row and should be used
+  for generated save/remove conflict detection.
+
+## Open And Hydration Flow
+
+Opening a stream should follow this order:
+
+```text
+load local identity
+  -> hydrate cached canonical rows and cursor
+  -> hydrate pending mutations and optimistic rows
+  -> render rebased local view
+  -> replay pending mutations when possible
+  -> pull from server
+  -> persist canonical rows and push outcomes
+  -> rebase local view again
+```
+
+Hydration is allowed to be stale. The contract is immediate local
+availability followed by reconciliation. `stale = true` means the UI is
+rendering from local storage before a successful network pull has
+confirmed freshness.
+
+If pending replay fails because the app is offline, the pending overlay
+must remain visible and durable. A replay failure is not permission to
+drop local edits.
+
+## Push Outcomes
+
+The server returns three categories:
+
+```text
+accepted  - the mutation was applied or deduped as an exact replay
+rejected  - the mutation cannot succeed as sent
+conflict  - the mutation was valid, but its base version lost a race
+```
+
+Rejected and conflicted are deliberately separate.
+
+Use `rejected` for invalid payloads, unauthorized writes, mismatched row
+keys, reused mutation ids with different contents, or domain validation
+failures where retrying the same mutation cannot help.
+
+Use `conflict` when the write was well-formed but the server row changed
+since the client's `base_version`. The UI can then offer conflict
+resolution choices instead of treating the write as a malformed request.
+
+On accepted outcomes:
+
+- remove matching pending mutations,
+- apply returned canonical rows,
+- clear pending/conflict flags for returned rows,
+- remove canonical rows for accepted deletes,
+- persist the push result in the local store.
+
+On rejected outcomes:
+
+- remove matching pending mutations,
+- rebase rendered rows from canonical rows,
+- increment rejection metadata,
+- keep the first reason visible as `state.error`.
+
+On conflict outcomes:
+
+- remove the matching pending mutation,
+- mark the server row conflicted when provided,
+- if no server row is provided, mark the visible fallback row conflicted
+  when possible,
+- keep user-visible data available rather than clearing the screen.
+
+## Typed Local Resource View
+
+`LocalResourceView<Id, Row>` is the bridge from low-level sync state to a
+resource-oriented author surface.
+
+It converts `CollectionState<Row>` into:
+
+- typed `LocalResourceRow<Id, Row>` entries,
+- per-row `LocalResourceRowStatus`,
+- rendered row version,
+- canonical `base_version`,
+- queued `LocalResourcePendingMutation<Id>` entries,
+- loading/syncing/stale/error counters.
+
+This lets generated CRUD APIs and components ask resource questions:
+
+```rust
+let view = local_resource_view::<String, Customer>(&customers_state)?;
+
+if let Some(row) = view.get(&customer_id) {
+    if row.is_conflict() {
+        // show conflict UI for this resource row
+    }
+}
+
+let base_version = view.base_version(&customer_id).cloned();
+```
+
+The view also exposes pending deletes that have no visible row. That
+matters for UI affordances such as "undo delete", disabled save buttons,
+or a compact pending-mutations tray.
+
+Generated CRUD methods should use this view instead of directly poking at
+`SyncRow` flags. That keeps protocol structs as an implementation detail
+and gives future query/resource layers one place to improve.
+
+## Conflict Resolution Shape
+
+The first conflict contract is conservative: mark the conflict, keep data
+visible, and make the state machine deterministic. Rich resolution APIs
+can build on top of that.
+
+The intended future author surface is:
+
+```rust
+conflict.use_server();
+conflict.retry_local();
+conflict.merge_with(draft);
+conflict.discard_local();
+```
+
+Those helpers should map to normal sync operations:
+
+- `use_server` clears the local pending/conflict marker and keeps the
+  canonical server row.
+- `discard_local` is equivalent for simple row edits, but can include
+  app-specific audit or UI behavior.
+- `retry_local` creates a new mutation with the latest canonical
+  `base_version`.
+- `merge_with` creates a new mutation whose payload is the user-approved
+  merge result, also based on the latest canonical `base_version`.
+
+Do not hide conflicts by silently overwriting local or server state. For
+ordinary CRUD, explicit conflict UI is safer than automatic last-write
+wins. CRDT-backed document fields belong in `pocopine-collab`, not in the
+default CRUD conflict policy.
+
+## Server Atomicity And Idempotency
+
+Server-side CRUD writes must be atomic at the app database boundary:
+
+```text
+begin transaction
+  -> authorize and validate
+  -> check base_version
+  -> write row
+  -> record accepted mutation id
+commit
+publish live wake-up after commit
+```
+
+`CrudMutationLog` exists so a replayed mutation id does not duplicate a
+write. Production logs must be scoped to the same authorization domain as
+the source rows, for example `(tenant_id, mutation_id)`, not only
+`mutation_id`.
+
+A mutation id dedupes sync replay. It is not a universal business
+idempotency key. Payments, external side effects, uniqueness-sensitive
+workflows, and inventory reservations still need app-level idempotency
+keys and domain-specific transaction rules.
+
+## Authorization And Cache Boundaries
+
+Every `/open`, `/pull`, and `/push` request must run stream guards and
+source filters. `/open` is discovery and validation, not a session grant.
+Skipping `/open` must not bypass access control.
+
+The local store may retain data that was once visible to a user. Apps that
+switch users, tenants, roles, or auth scopes need either:
+
+- a partitioned local-store identity/database per auth scope, or
+- an explicit sync cache reset on sign-out or tenant switch.
+
+Do not rely on client-side filtering to protect cached data from a
+previous authorization scope.
+
+## Testing Invariants
+
+Core sync tests should prove these invariants without requiring every
+database backend:
+
+- stale pull responses are ignored by generation token,
+- local hydration renders before network pull,
+- pending mutations replay in queue order,
+- duplicate pending ids replace the earlier local pending record,
+- pull while pending rebase keeps optimistic rows visible,
+- rejected mutations roll back to the latest canonical row,
+- conflicts keep a visible conflicted row when possible,
+- accepted deletes remove canonical rows,
+- local stores preserve optimistic rows and legacy pending-mutation wire
+  shapes,
+- CRUD sources reject mismatched row key, operation, or duplicate mutation
+  content,
+- auth guards run independently for open, pull, and push.
+
+Backend-specific adapters should add integration tests for their own
+database, transaction, migration, and changefeed behavior. The core
+contract should stay green with protocol/state tests, memory-store tests,
+native SQLite tests, and targeted browser/wasm checks.
+

--- a/docs/sync-crud.md
+++ b/docs/sync-crud.md
@@ -877,6 +877,12 @@ rejected
 conflict
 ```
 
+`LocalResourceView<Id, Row>` is the typed read side for this state. It
+converts the low-level `CollectionState<Row>` into visible resource rows,
+canonical `base_version` values, pending mutations, pending/conflict
+flags, and collection metadata. Generated CRUD clients should consume this
+view instead of exposing raw protocol structs to application code.
+
 ## Conflict And `get`
 
 `get` is required in the trait because conflict recovery and detail pages
@@ -906,8 +912,9 @@ the testable contract:
 - mapping into `SyncCollection::push_with_generated_id` through
   `ClientMutationDraft`,
 - helper APIs for optimistic rows,
+- typed local resource views over `CollectionState<Row>`,
 - unit tests for ids, payload mapping, write policies, queued outcomes,
-  and transaction binding,
+  local views, and transaction binding,
 - low-level sync helpers for online-only push behavior,
 - docs for the next non-macro and macro slices.
 

--- a/docs/sync-local-first-roadmap.md
+++ b/docs/sync-local-first-roadmap.md
@@ -16,6 +16,12 @@ Pocopine already has the pieces needed to build on:
 - `pocopine-sync` owns `/open`, `/pull`, `/push`, stream registration,
   cursor types, `CollectionState<T>`, mutation ids, pending replay, and
   the `SyncLocalStore` trait.
+- `CollectionState<T>` keeps canonical server rows separate from the
+  rendered merged view, then rebases pending local mutations over
+  canonical rows after hydration, pulls, push outcomes, and replay.
+- Pending local mutations can persist an optional local-only optimistic row
+  alongside the wire mutation, so non-row CRUD payloads can still rebuild
+  their rendered overlay after reload.
 - `pocopine-live` wakes clients after server-side changes. It remains a
   wake-up channel, not a row transport.
 - `pocopine-sync-sqlite` exists. It provides a durable local store with a
@@ -44,12 +50,17 @@ hydrate canonical rows from local store
   -> render the rebased view
 ```
 
-Today the store can persist rows and pending mutations, and the client can
-replay pending mutations during `open()`. The missing piece is a first
-class rebase layer that treats pending local mutations as an overlay over
-canonical server rows. Without that, a pull can temporarily replace
-optimistic state, cause flicker, or leave row flags too coarse for a
-serious offline UI.
+The core `CollectionState<T>` rebase slice is now in place: server pulls
+update canonical rows, pending overlays replay in deterministic queue
+order, rejected writes roll back to the latest canonical rows, and
+row-shaped pending upserts can be reconstructed from local-store
+hydration before replay.
+
+The remaining work is generated resource ergonomics and typed resource
+views. Generated CRUD methods need to produce the durable optimistic rows
+automatically, and typed query/resource views still need to expose the
+rebased state without forcing app code to inspect protocol structs
+directly.
 
 Deliverables:
 
@@ -240,7 +251,8 @@ simple and hard to misuse.
 
 ## Recommended Implementation Order
 
-1. Finish rebase of pending mutations over canonical rows.
+1. Harden resource-level rebase on top of the core canonical/overlay
+   state model.
 2. Add typed local resource/query views over `SyncLocalStore`.
 3. Generate CRUD client methods and options APIs.
 4. Add transaction-backed server helper paths for source write + mutation

--- a/docs/sync-local-first-roadmap.md
+++ b/docs/sync-local-first-roadmap.md
@@ -29,8 +29,8 @@ Pocopine already has the pieces needed to build on:
   OPFS implementation through the same `SyncLocalStore` API.
 - `pocopine-sync-crud` defines the first resource contract:
   `ResourceId`, CRUD mutation payloads, write policies, transaction
-  binding, `CrudSource`, bounded snapshot pulls, and exact mutation
-  replay dedupe.
+  binding, `CrudSource`, bounded snapshot pulls, exact mutation replay
+  dedupe, and a typed `LocalResourceView` over rebased sync state.
 
 That means we are past "can the browser persist sync state?" The next
 work is making persisted sync state behave like a complete local-first
@@ -56,11 +56,12 @@ order, rejected writes roll back to the latest canonical rows, and
 row-shaped pending upserts can be reconstructed from local-store
 hydration before replay.
 
-The remaining work is generated resource ergonomics and typed resource
-views. Generated CRUD methods need to produce the durable optimistic rows
-automatically, and typed query/resource views still need to expose the
-rebased state without forcing app code to inspect protocol structs
-directly.
+The first typed view slice is now in place: `LocalResourceView<Id, Row>`
+turns `CollectionState<Row>` into typed visible rows, canonical
+`base_version` values, hidden pending deletes, pending/conflict flags, and
+collection metadata. Generated CRUD methods still need to produce durable
+optimistic rows automatically and build on that view instead of exposing
+protocol structs directly.
 
 Deliverables:
 
@@ -251,10 +252,11 @@ simple and hard to misuse.
 
 ## Recommended Implementation Order
 
-1. Harden resource-level rebase on top of the core canonical/overlay
-   state model.
-2. Add typed local resource/query views over `SyncLocalStore`.
-3. Generate CRUD client methods and options APIs.
+1. Harden generated resource methods on top of the core canonical/overlay
+   state model and typed `LocalResourceView`.
+2. Extend typed local resource/query views beyond owned snapshots into
+   framework-native subscriptions.
+3. Generate CRUD client methods and options APIs that use the typed view.
 4. Add transaction-backed server helper paths for source write + mutation
    log insert.
 5. Add SQLx helper adapters for server CRUD sources, without becoming an

--- a/docs/sync-local-store-plan.md
+++ b/docs/sync-local-store-plan.md
@@ -32,7 +32,10 @@ place. The client runtime hydrates cached rows before network pull,
 persists pull/push outcomes into the store, and replays stored pending
 mutations during `open()`. `pocopine-sync-sqlite` now contains the shared
 schema, a native SQLite implementation, and a browser SQLite WASM + OPFS
-worker implementation behind the same store trait.
+worker implementation behind the same store trait. Queued mutations can
+also carry an optional local-only optimistic row, which lets the client
+restore non-row CRUD overlays after reload without changing the `/push`
+wire payload.
 
 ## Crate Boundaries
 
@@ -139,6 +142,12 @@ pub trait SyncLocalStore {
         mutation: ClientMutation<serde_json::Value>,
     ) -> SyncLocalFuture<'_, ()>;
 
+    fn enqueue_pending_mutation(
+        &self,
+        stream: &SyncStreamName,
+        pending: LocalPendingMutation,
+    ) -> SyncLocalFuture<'_, ()>;
+
     fn mark_push_result(&self, result: LocalPushResult) -> SyncLocalFuture<'_, ()>;
 
     fn pending_mutations(
@@ -225,6 +234,7 @@ create table __pocopine_mutations (
   base_version text,
   op text not null,
   payload text,
+  optimistic_row text,
   status text not null,
   error text,
   created_at_ms integer not null,

--- a/rfcs/rfc-072-offline-sync-protocol.md
+++ b/rfcs/rfc-072-offline-sync-protocol.md
@@ -29,6 +29,9 @@ Initial implementation has started in `pocopine-sync`:
   `MemoryLocalStore` as the first local-store contract slice,
 - `SyncCollection::open()` hydrates cached local rows, replays pending
   stored mutations, and persists pull responses through `SyncLocalStore`,
+- `CollectionState<T>` keeps canonical rows separate from the rendered
+  merged view and rebases pending local mutations after hydration, pulls,
+  push outcomes, and pending replay,
 - `SyncCollection::push()` enqueues mutations before the network request
   and persists accepted/rejected/conflict outcomes,
 - `pocopine-sync-sqlite` owns the SQLite local-store schema, native
@@ -44,12 +47,13 @@ Current model: `/open` is discovery/validation, not a session grant.
 Every `/open`, `/pull`, and `/push` request runs the stream guard
 independently, so skipping `/open` does not bypass access control.
 
-Still future work: conflict resolution UI, SQLx/database adapters, CDC
-sources, query-driven stream parameters, production guidance for
-storage-denied browser environments, and the planned
-`pocopine-sync-crud` helper layer. Automatic mutation-id allocation in
-the low-level client is also future API work; this slice exposes the
-durable identity slot but keeps `SyncCollection::push` id-explicit.
+Still future work: conflict resolution UI, generated CRUD resource
+methods, SQLx/database adapters, CDC sources, query-driven stream
+parameters, production guidance for storage-denied browser environments,
+and resource-level rebase hardening for non-row CRUD mutation payloads.
+The low-level `SyncCollection::push` API remains id-explicit for callers
+that need full protocol control; the generated-id helpers reserve durable
+mutation ids through `SyncLocalStore`.
 The local-store implementation plan is documented in
 [`docs/sync-local-store-plan.md`](../docs/sync-local-store-plan.md):
 SQLite-first local storage, with SQLx kept as a later host/server


### PR DESCRIPTION
## Summary

- split `CollectionState<T>` into canonical rows plus a rebased rendered view so pending local mutations survive hydration, pulls, push outcomes, and replay
- persist optional local-only optimistic rows with queued mutations across memory, SQLite, SQLite wasm, and IndexedDB local stores
- add `LocalResourceView<Id, Row>` to `pocopine-sync-crud` so generated/resource clients can consume typed rows, pending deletes, conflicts, and canonical `base_version` values without exposing raw protocol structs
- document the sync/conflict architecture and update the local-first roadmap/status docs

## Notes

- Reverted the uncommitted cfg alias cleanup from this branch before publishing.
- The target cfg alias decision is tracked separately in #97.

## Verification

- `cargo test -p pocopine-sync -p pocopine-sync-sqlite -p pocopine-sync-crud`
- `cargo check -p pocopine-sync --target wasm32-unknown-unknown`
- `cargo test -p pocopine-sync-crud --target wasm32-unknown-unknown --no-run`
- `cargo check -p pocopine-sync-sqlite --target wasm32-unknown-unknown`
- `cargo check -p pocopine-sync-indexdb --target wasm32-unknown-unknown`