### PR TITLE
Advance local-first CRUD sync runtime

### DIFF
--- a/crates/pocopine-sync-crud/src/client.rs
+++ b/crates/pocopine-sync-crud/src/client.rs
@@ -1,0 +1,442 @@
+use pocopine_sync::{MutationId, SyncCollection, SyncPushResponse, SyncResult, SyncRow};
+use std::marker::PhantomData;
+
+use crate::{
+    optimistic_row, CreateOptions, CrudMutationPayload, CrudOutcome, LocalResourceView,
+    RemoveOptions, ResourceId, SaveOptions, WritePolicy,
+};
+
+/// Non-macro client runtime for one CRUD resource.
+///
+/// Generated resource modules should target this layer instead of manually
+/// constructing sync protocol envelopes.
+pub struct CrudClientResource<C: 'static, Id, Row> {
+    collection: SyncCollection<C, Row>,
+    view: LocalResourceView<Id, Row>,
+    _marker: PhantomData<fn(C) -> (Id, Row)>,
+}
+
+/// Build a non-macro CRUD client resource from a sync collection and typed
+/// local resource view.
+pub fn client_resource<C: 'static, Id, Row>(
+    collection: SyncCollection<C, Row>,
+    view: LocalResourceView<Id, Row>,
+) -> CrudClientResource<C, Id, Row> {
+    CrudClientResource {
+        collection,
+        view,
+        _marker: PhantomData,
+    }
+}
+
+impl<C, Id, Row> CrudClientResource<C, Id, Row>
+where
+    C: 'static,
+    Id: ResourceId,
+    Row: Clone + serde::de::DeserializeOwned + serde::Serialize + 'static,
+{
+    /// Queue or send a create mutation with default options.
+    pub async fn create<Draft>(self, id: Id, draft: Draft) -> SyncResult<CrudOutcome<Id, Row>>
+    where
+        Draft: serde::Serialize + 'static,
+    {
+        self.create_with_options(id, draft, CreateOptions::default())
+            .await
+    }
+
+    /// Queue or send a create mutation with explicit options.
+    pub async fn create_with_options<Draft>(
+        self,
+        id: Id,
+        draft: Draft,
+        options: CreateOptions<Row>,
+    ) -> SyncResult<CrudOutcome<Id, Row>>
+    where
+        Draft: serde::Serialize + 'static,
+    {
+        let optimistic = options
+            .optimistic
+            .map(|row| optimistic_row(&id, row))
+            .transpose()?;
+        let payload = CrudMutationPayload::create(id.clone(), draft);
+        self.send(id, payload, optimistic, options.write_policy, false)
+            .await
+    }
+
+    /// Queue or send a save mutation with default options.
+    pub async fn save<Draft>(self, id: Id, draft: Draft) -> SyncResult<CrudOutcome<Id, Row>>
+    where
+        Draft: serde::Serialize + 'static,
+    {
+        self.save_with_options(id, draft, SaveOptions::default())
+            .await
+    }
+
+    /// Queue or send a save mutation with explicit options.
+    ///
+    /// When `base_version` is not supplied explicitly, this method reads the
+    /// latest canonical version from `LocalResourceView`. If the same row has
+    /// pending local writes, a later save may still conflict on the server; the
+    /// default is optimistic concurrency against the last confirmed server row,
+    /// not a silent merge across queued edits.
+    pub async fn save_with_options<Draft>(
+        self,
+        id: Id,
+        draft: Draft,
+        options: SaveOptions<Row>,
+    ) -> SyncResult<CrudOutcome<Id, Row>>
+    where
+        Draft: serde::Serialize + 'static,
+    {
+        let base_version = options
+            .base_version
+            .or_else(|| self.view.base_version(&id).cloned());
+        let optimistic = options
+            .optimistic
+            .map(|row| optimistic_row(&id, row))
+            .transpose()?;
+        let payload = CrudMutationPayload::save(id.clone(), draft);
+        let draft = payload.into_sync_draft_with_base_version(base_version)?;
+        self.send_draft(id, draft, optimistic, options.write_policy, false)
+            .await
+    }
+
+    /// Queue or send a remove mutation with default options.
+    pub async fn remove(self, id: Id) -> SyncResult<CrudOutcome<Id, Row>> {
+        self.remove_with_options(id, RemoveOptions::default()).await
+    }
+
+    /// Queue or send a remove mutation with explicit options.
+    ///
+    /// Like save, the default `base_version` comes from the latest canonical
+    /// row in `LocalResourceView`; pending local writes for the same id are not
+    /// collapsed into a synthetic version.
+    pub async fn remove_with_options(
+        self,
+        id: Id,
+        options: RemoveOptions,
+    ) -> SyncResult<CrudOutcome<Id, Row>> {
+        let base_version = options
+            .base_version
+            .or_else(|| self.view.base_version(&id).cloned());
+        let payload: CrudMutationPayload<Id, ()> = CrudMutationPayload::remove(id.clone());
+        let draft = payload.into_sync_draft_with_base_version(base_version)?;
+        self.send_draft(id, draft, None, options.write_policy, true)
+            .await
+    }
+
+    async fn send<Draft>(
+        self,
+        id: Id,
+        payload: CrudMutationPayload<Id, Draft>,
+        optimistic: Option<SyncRow<Row>>,
+        write_policy: WritePolicy,
+        remove: bool,
+    ) -> SyncResult<CrudOutcome<Id, Row>>
+    where
+        Draft: serde::Serialize + 'static,
+    {
+        let draft = payload.into_sync_draft()?;
+        self.send_draft(id, draft, optimistic, write_policy, remove)
+            .await
+    }
+
+    async fn send_draft<Draft>(
+        self,
+        id: Id,
+        draft: pocopine_sync::ClientMutationDraft<CrudMutationPayload<Id, Draft>>,
+        optimistic: Option<SyncRow<Row>>,
+        write_policy: WritePolicy,
+        remove: bool,
+    ) -> SyncResult<CrudOutcome<Id, Row>>
+    where
+        Draft: serde::Serialize + 'static,
+    {
+        match write_policy {
+            WritePolicy::QueueOffline => {
+                let mutation_id = self
+                    .collection
+                    .queue_with_generated_id(draft, optimistic)
+                    .await?;
+                Ok(CrudOutcome::Queued(crate::Queued::new(mutation_id, id)))
+            }
+            WritePolicy::RequireOnline => {
+                let (mutation_id, response) = self
+                    .collection
+                    .push_with_generated_id_online_confirmed(draft, optimistic)
+                    .await?;
+                outcome_from_push_response(id, mutation_id, response, remove)
+            }
+        }
+    }
+}
+
+fn outcome_from_push_response<Id, Row>(
+    id: Id,
+    mutation_id: MutationId,
+    response: SyncPushResponse<Row>,
+    remove: bool,
+) -> SyncResult<CrudOutcome<Id, Row>>
+where
+    Id: ResourceId,
+{
+    if let Some(rejected) = response
+        .rejected
+        .into_iter()
+        .find(|rejected| rejected.mutation_id == mutation_id)
+    {
+        return Ok(CrudOutcome::Rejected {
+            id,
+            reason: rejected.reason,
+        });
+    }
+
+    if let Some(conflict) = response
+        .conflicts
+        .into_iter()
+        .find(|conflict| conflict.mutation_id == mutation_id)
+    {
+        return Ok(CrudOutcome::Conflict {
+            id,
+            server_row: conflict.server_row.map(|row| row.value),
+            reason: conflict.reason,
+        });
+    }
+
+    if response
+        .accepted
+        .iter()
+        .any(|accepted| accepted == &mutation_id)
+    {
+        if remove {
+            return Ok(CrudOutcome::Removed { id });
+        }
+
+        let key = id.to_row_key()?;
+        let row = response
+            .rows
+            .into_iter()
+            .find(|row| row.key == key)
+            .ok_or_else(|| {
+                pocopine_sync::SyncError::client(format!(
+                    "accepted CRUD mutation {mutation_id} did not include row {}",
+                    key.as_str()
+                ))
+            })?;
+        return Ok(CrudOutcome::Accepted { id, row: row.value });
+    }
+
+    Err(pocopine_sync::SyncError::client(format!(
+        "push response did not include outcome for mutation {mutation_id}"
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use pocopine_sync::{
+        MutationId, RowKey, RowVersion, SyncConflict, SyncPushResponse, SyncRejectedMutation,
+        SyncRow,
+    };
+    use serde::{Deserialize, Serialize};
+
+    use super::*;
+
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    struct Post {
+        title: String,
+    }
+
+    #[test]
+    fn online_response_maps_accepted_remove_to_removed_outcome() {
+        let mutation_id = MutationId::new("device_1:1").unwrap();
+        let mut response =
+            SyncPushResponse::new(pocopine_sync::SyncStreamName::new("posts").unwrap());
+        response.accepted.push(mutation_id.clone());
+
+        let outcome = outcome_from_push_response::<String, Post>(
+            "post_1".to_string(),
+            mutation_id,
+            response,
+            true,
+        )
+        .unwrap();
+
+        assert_eq!(
+            outcome,
+            CrudOutcome::Removed {
+                id: "post_1".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn online_response_maps_accepted_row_to_accepted_outcome() {
+        let mutation_id = MutationId::new("device_1:1").unwrap();
+        let mut response =
+            SyncPushResponse::new(pocopine_sync::SyncStreamName::new("posts").unwrap());
+        response.accepted.push(mutation_id.clone());
+        response.rows.push(
+            SyncRow::new(
+                "post_1",
+                Post {
+                    title: "server".to_string(),
+                },
+            )
+            .unwrap(),
+        );
+
+        let outcome = outcome_from_push_response::<String, Post>(
+            "post_1".to_string(),
+            mutation_id,
+            response,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(
+            outcome,
+            CrudOutcome::Accepted {
+                id: "post_1".to_string(),
+                row: Post {
+                    title: "server".to_string()
+                }
+            }
+        );
+    }
+
+    #[test]
+    fn online_response_errors_when_accepted_row_is_absent() {
+        let mutation_id = MutationId::new("device_1:1").unwrap();
+        let mut response =
+            SyncPushResponse::new(pocopine_sync::SyncStreamName::new("posts").unwrap());
+        response.accepted.push(mutation_id.clone());
+
+        let err = outcome_from_push_response::<String, Post>(
+            "post_1".to_string(),
+            mutation_id,
+            response,
+            false,
+        )
+        .unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("accepted CRUD mutation device_1:1 did not include row post_1"));
+    }
+
+    #[test]
+    fn online_response_maps_rejected_mutation() {
+        let mutation_id = MutationId::new("device_1:1").unwrap();
+        let mut response =
+            SyncPushResponse::new(pocopine_sync::SyncStreamName::new("posts").unwrap());
+        response.rejected.push(SyncRejectedMutation {
+            mutation_id: mutation_id.clone(),
+            key: None,
+            reason: "invalid".to_string(),
+        });
+
+        let outcome = outcome_from_push_response::<String, Post>(
+            "post_1".to_string(),
+            mutation_id,
+            response,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(
+            outcome,
+            CrudOutcome::Rejected {
+                id: "post_1".to_string(),
+                reason: "invalid".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn online_response_maps_conflict_mutation() {
+        let mutation_id = MutationId::new("device_1:1").unwrap();
+        let mut response =
+            SyncPushResponse::new(pocopine_sync::SyncStreamName::new("posts").unwrap());
+        response.conflicts.push(SyncConflict {
+            mutation_id: mutation_id.clone(),
+            key: Some(RowKey::new("post_1").unwrap()),
+            server_row: Some(
+                SyncRow::new(
+                    "post_1",
+                    Post {
+                        title: "server".to_string(),
+                    },
+                )
+                .unwrap(),
+            ),
+            reason: "stale".to_string(),
+        });
+
+        let outcome = outcome_from_push_response::<String, Post>(
+            "post_1".to_string(),
+            mutation_id,
+            response,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(
+            outcome,
+            CrudOutcome::Conflict {
+                id: "post_1".to_string(),
+                server_row: Some(Post {
+                    title: "server".to_string()
+                }),
+                reason: "stale".to_string()
+            }
+        );
+    }
+
+    #[test]
+    fn online_response_errors_when_mutation_has_no_outcome() {
+        let mutation_id = MutationId::new("device_1:1").unwrap();
+        let response = SyncPushResponse::new(pocopine_sync::SyncStreamName::new("posts").unwrap());
+
+        let err = outcome_from_push_response::<String, Post>(
+            "post_1".to_string(),
+            mutation_id,
+            response,
+            false,
+        )
+        .unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("push response did not include outcome"));
+    }
+
+    #[test]
+    fn save_options_can_use_view_base_version() {
+        let view = LocalResourceView::<String, Post> {
+            rows: vec![crate::LocalResourceRow {
+                id: "post_1".to_string(),
+                value: Post {
+                    title: "server".to_string(),
+                },
+                row_version: Some(RowVersion::new("rendered").unwrap()),
+                base_version: Some(RowVersion::new("canonical").unwrap()),
+                status: crate::LocalResourceRowStatus::Synced,
+            }],
+            pending_mutations: Vec::new(),
+            loading: false,
+            syncing: false,
+            stale: false,
+            error: String::new(),
+            version: 0,
+            pending_count: 0,
+            conflict_count: 0,
+            rejected_count: 0,
+            last_reason: pocopine_sync::SyncReason::Manual,
+        };
+
+        assert_eq!(
+            view.base_version(&"post_1".to_string()).unwrap().as_str(),
+            "canonical"
+        );
+    }
+}

--- a/crates/pocopine-sync-crud/src/lib.rs
+++ b/crates/pocopine-sync-crud/src/lib.rs
@@ -5,6 +5,7 @@
 //! contracts that a later proc macro will target. It does not generate SQL and
 //! it is not an ORM.
 
+mod client;
 mod id;
 mod mutation;
 mod options;
@@ -20,6 +21,7 @@ mod source;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use async_trait::async_trait;
+pub use client::{client_resource, CrudClientResource};
 pub use id::{new_id, ResourceId};
 pub use mutation::{CreatePayload, CrudMutationPayload, RemovePayload, SavePayload};
 pub use options::{CreateOptions, RemoveOptions, SaveOptions, TransactionOptions, WritePolicy};

--- a/crates/pocopine-sync-crud/src/outcome.rs
+++ b/crates/pocopine-sync-crud/src/outcome.rs
@@ -49,6 +49,9 @@ pub enum CrudOutcome<Id, Row> {
         id: Id,
         row: Row,
     },
+    Removed {
+        id: Id,
+    },
     Rejected {
         id: Id,
         reason: String,
@@ -83,6 +86,10 @@ mod tests {
         assert!(CrudOutcome::<String, String>::Rejected {
             id: "post_1".to_string(),
             reason: "invalid".to_string()
+        }
+        .is_terminal());
+        assert!(CrudOutcome::<String, String>::Removed {
+            id: "post_1".to_string()
         }
         .is_terminal());
     }

--- a/crates/pocopine-sync/src/client.rs
+++ b/crates/pocopine-sync/src/client.rs
@@ -1,20 +1,19 @@
 use std::{marker::PhantomData, rc::Rc};
 
 use pocopine_core::{App, AppPlugin, Handle};
-#[cfg(target_arch = "wasm32")]
 use serde_json::Value;
 
 use crate::{
-    ClientMutation, ClientMutationDraft, CollectionState, MemoryLocalStore, SyncCursor, SyncError,
-    SyncLocalStore, SyncReason, SyncResult, SyncRow, SyncStreamName, SYNC_ENDPOINT_PREFIX,
+    ClientMutation, ClientMutationDraft, CollectionState, LocalPendingMutation, MemoryLocalStore,
+    MutationId, SyncCursor, SyncError, SyncLocalStore, SyncPushResponse, SyncReason, SyncResult,
+    SyncRow, SyncStreamName, SYNC_ENDPOINT_PREFIX,
 };
 
 #[cfg(target_arch = "wasm32")]
 use crate::{
-    sync_stream_tag, LocalChangeBatch, LocalPendingMutation, LocalPushResult, LocalSnapshotBatch,
-    LocalStreamSnapshot, PendingMutation, SyncChange, SyncConflict, SyncOp, SyncOpenRequest,
-    SyncOpenResponse, SyncPullMode, SyncPullRequest, SyncPullResponse, SyncPushRequest,
-    SyncPushResponse,
+    sync_stream_tag, LocalChangeBatch, LocalPushResult, LocalSnapshotBatch, LocalStreamSnapshot,
+    PendingMutation, SyncChange, SyncConflict, SyncOp, SyncOpenRequest, SyncOpenResponse,
+    SyncPullMode, SyncPullRequest, SyncPullResponse, SyncPushRequest,
 };
 
 /// Selector from an app-owned component/store into one sync collection field.
@@ -265,6 +264,53 @@ where
         self.push_with_generated_id_online_impl(mutation, optimistic)
     }
 
+    /// Reserve a durable mutation id, enqueue the mutation locally, apply
+    /// optimistic state, and return the reserved id after the local enqueue
+    /// succeeds.
+    ///
+    /// This is the stronger local-first boundary used by generated CRUD
+    /// resource helpers. The returned id is safe to expose because the local
+    /// store has already persisted the incremented mutation counter and queued
+    /// mutation before this future resolves.
+    ///
+    /// Mutation ids are monotonic, not dense: if id reservation succeeds but
+    /// enqueueing fails, the reserved id is intentionally skipped instead of
+    /// reused. On the browser runtime, a successful local enqueue immediately
+    /// starts a background push; network errors are reflected in collection
+    /// state, not in this returned queued outcome. The host implementation is a
+    /// compile/test stub and only reserves and enqueues locally.
+    pub async fn queue_with_generated_id<M>(
+        self,
+        mutation: ClientMutationDraft<M>,
+        optimistic: Option<SyncRow<T>>,
+    ) -> SyncResult<MutationId>
+    where
+        T: Clone + serde::de::DeserializeOwned + serde::Serialize + 'static,
+        M: serde::Serialize + 'static,
+    {
+        self.queue_with_generated_id_impl(mutation, optimistic)
+            .await
+    }
+
+    /// Reserve a durable mutation id and push one generated-id mutation without
+    /// adding it to the durable offline queue, waiting for the server response.
+    ///
+    /// This is the async primitive for `WritePolicy::RequireOnline`. The host
+    /// implementation returns `SyncError::Unsupported`; confirmed browser
+    /// pushes require the wasm fetch runtime.
+    pub async fn push_with_generated_id_online_confirmed<M>(
+        self,
+        mutation: ClientMutationDraft<M>,
+        optimistic: Option<SyncRow<T>>,
+    ) -> SyncResult<(MutationId, SyncPushResponse<T>)>
+    where
+        T: Clone + serde::de::DeserializeOwned + serde::Serialize + 'static,
+        M: serde::Serialize + 'static,
+    {
+        self.push_with_generated_id_online_confirmed_impl(mutation, optimistic)
+            .await
+    }
+
     fn stream_value(&self) -> SyncResult<SyncStreamName> {
         self.stream
             .clone()
@@ -459,6 +505,78 @@ where
         );
         Ok(())
     }
+
+    async fn queue_with_generated_id_impl<M>(
+        self,
+        mutation: ClientMutationDraft<M>,
+        optimistic: Option<SyncRow<T>>,
+    ) -> SyncResult<MutationId>
+    where
+        T: Clone + serde::de::DeserializeOwned + serde::Serialize + 'static,
+        M: serde::Serialize + 'static,
+    {
+        let stream = self.stream_value()?;
+        let scope_id = self.handle.scope_id();
+        let push_url = endpoint_path(&self.endpoint, "push");
+        let pull_endpoint = self.endpoint.clone();
+        let pull_after_accept = !self.live_wakeup;
+        let mutation_id = self.local_store.reserve_mutation_id().await?;
+        let mutation = mutation.with_id(mutation_id.clone());
+        enqueue_pending_mutation(&self.local_store, &stream, &mutation, optimistic.as_ref())
+            .await?;
+        apply_optimistic_mutation(&self.handle, self.selector, &mutation, optimistic);
+
+        pocopine_core::spawn_for_scope(scope_id, async move {
+            let _ = send_push_and_reconcile(
+                scope_id,
+                self.handle,
+                self.selector,
+                push_url,
+                pull_endpoint,
+                self.local_store,
+                stream,
+                mutation,
+                pull_after_accept,
+                true,
+            )
+            .await;
+        });
+
+        Ok(mutation_id)
+    }
+
+    async fn push_with_generated_id_online_confirmed_impl<M>(
+        self,
+        mutation: ClientMutationDraft<M>,
+        optimistic: Option<SyncRow<T>>,
+    ) -> SyncResult<(MutationId, SyncPushResponse<T>)>
+    where
+        T: Clone + serde::de::DeserializeOwned + serde::Serialize + 'static,
+        M: serde::Serialize + 'static,
+    {
+        let stream = self.stream_value()?;
+        let scope_id = self.handle.scope_id();
+        let push_url = endpoint_path(&self.endpoint, "push");
+        let pull_endpoint = self.endpoint.clone();
+        let pull_after_accept = !self.live_wakeup;
+        let mutation_id = self.local_store.reserve_mutation_id().await?;
+        let mutation = mutation.with_id(mutation_id.clone());
+        apply_optimistic_mutation(&self.handle, self.selector, &mutation, optimistic);
+        let response = send_push_and_reconcile(
+            scope_id,
+            self.handle,
+            self.selector,
+            push_url,
+            pull_endpoint,
+            self.local_store,
+            stream,
+            mutation,
+            pull_after_accept,
+            false,
+        )
+        .await?;
+        Ok((mutation_id, response))
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -537,6 +655,44 @@ where
         let _ = self.stream_value()?;
         let _ = (mutation, optimistic);
         Ok(())
+    }
+
+    async fn queue_with_generated_id_impl<M>(
+        self,
+        mutation: ClientMutationDraft<M>,
+        optimistic: Option<SyncRow<T>>,
+    ) -> SyncResult<MutationId>
+    where
+        T: Clone + serde::de::DeserializeOwned + serde::Serialize + 'static,
+        M: serde::Serialize + 'static,
+    {
+        self.touch_host_fields();
+        let stream = self.stream_value()?;
+        let mutation_id = self.local_store.reserve_mutation_id().await?;
+        let mutation = mutation.with_id(mutation_id.clone());
+        enqueue_pending_mutation(&self.local_store, &stream, &mutation, optimistic.as_ref())
+            .await?;
+        // Host-side collection calls are no-op stubs; the browser path applies
+        // the optimistic row before starting the background push.
+        let _ = optimistic;
+        Ok(mutation_id)
+    }
+
+    async fn push_with_generated_id_online_confirmed_impl<M>(
+        self,
+        mutation: ClientMutationDraft<M>,
+        optimistic: Option<SyncRow<T>>,
+    ) -> SyncResult<(MutationId, SyncPushResponse<T>)>
+    where
+        T: Clone + serde::de::DeserializeOwned + serde::Serialize + 'static,
+        M: serde::Serialize + 'static,
+    {
+        self.touch_host_fields();
+        let _ = self.stream_value()?;
+        let _ = (mutation, optimistic);
+        Err(SyncError::unsupported(
+            "online sync push confirmation is only available in the browser runtime",
+        ))
     }
 }
 
@@ -952,42 +1108,108 @@ async fn run_push<C, T, M>(
     let mutation_key = mutation.key.clone();
 
     if queue_offline {
-        let local_pending = match pending_mutation_to_value(&mutation, optimistic.as_ref()) {
-            Ok(pending) => pending,
-            Err(err) => {
-                handle.update(|state| {
-                    selector(state).set_error(format!("sync mutation encode failed: {err}"));
-                });
-                return;
-            }
-        };
-        if let Err(err) = local_store
-            .enqueue_pending_mutation(&stream, local_pending)
-            .await
+        if let Err(err) =
+            enqueue_pending_mutation(&local_store, &stream, &mutation, optimistic.as_ref()).await
         {
             handle.update(|state| {
-                selector(state).set_error(format!("local sync mutation enqueue failed: {err}"));
+                selector(state).set_error(err.to_string());
             });
             return;
         }
     }
 
-    let optimistic_mutation_id = mutation_id.clone();
     handle.update(|state| {
         selector(state).apply_optimistic_mutation(
-            optimistic_mutation_id,
+            mutation_id,
             mutation_op,
             mutation_key,
             optimistic,
         );
     });
 
+    let _ = send_push_and_reconcile(
+        scope_id,
+        handle,
+        selector,
+        push_url,
+        pull_endpoint,
+        local_store,
+        stream,
+        mutation,
+        pull_after_accept,
+        queue_offline,
+    )
+    .await;
+}
+
+async fn enqueue_pending_mutation<T, M>(
+    local_store: &SyncLocalStoreHandle,
+    stream: &SyncStreamName,
+    mutation: &ClientMutation<M>,
+    optimistic: Option<&SyncRow<T>>,
+) -> SyncResult<()>
+where
+    M: serde::Serialize,
+    T: serde::Serialize,
+{
+    let local_pending = pending_mutation_to_value(mutation, optimistic)
+        .map_err(|err| SyncError::client(format!("sync mutation encode failed: {err}")))?;
+    local_store
+        .enqueue_pending_mutation(stream, local_pending)
+        .await
+        .map_err(|err| SyncError::client(format!("local sync mutation enqueue failed: {err}")))
+}
+
+#[cfg(target_arch = "wasm32")]
+fn apply_optimistic_mutation<C, T, M>(
+    handle: &Handle<C>,
+    selector: CollectionSelector<C, T>,
+    mutation: &ClientMutation<M>,
+    optimistic: Option<SyncRow<T>>,
+) where
+    C: 'static,
+    T: Clone + 'static,
+{
+    let mutation_id = mutation.id.clone();
+    let mutation_op = mutation.op;
+    let mutation_key = mutation.key.clone();
+    handle.update(|state| {
+        selector(state).apply_optimistic_mutation(
+            mutation_id,
+            mutation_op,
+            mutation_key,
+            optimistic,
+        );
+    });
+}
+
+#[cfg(target_arch = "wasm32")]
+#[allow(clippy::too_many_arguments)]
+async fn send_push_and_reconcile<C, T, M>(
+    scope_id: pocopine_core::ScopeId,
+    handle: Handle<C>,
+    selector: CollectionSelector<C, T>,
+    push_url: String,
+    pull_endpoint: String,
+    local_store: SyncLocalStoreHandle,
+    stream: SyncStreamName,
+    mutation: ClientMutation<M>,
+    pull_after_accept: bool,
+    queue_offline: bool,
+) -> SyncResult<SyncPushResponse<T>>
+where
+    C: 'static,
+    T: Clone + serde::de::DeserializeOwned + serde::Serialize + 'static,
+    M: serde::Serialize + 'static,
+{
+    let mutation_id = mutation.id.clone();
+
     let request = SyncPushRequest::new(stream.clone(), [mutation]);
     let result =
         pocopine_core::fetch::call::<SyncPushRequest<M>, SyncPushResponse<T>>(&push_url, &request)
             .await;
     let mut local_error = None;
-    let result = match result {
+    let result: Result<SyncPushResponse<T>, String> = match result {
         Ok(response) => {
             if queue_offline {
                 match local_push_result_from_response(&response) {
@@ -1004,7 +1226,11 @@ async fn run_push<C, T, M>(
             }
             Ok(response)
         }
-        Err(err) => Err(err),
+        Err(err) => Err(err.to_string()),
+    };
+    let return_result = match &result {
+        Ok(response) => Ok(response.clone()),
+        Err(err) => Err(SyncError::client(err.clone())),
     };
     let should_pull = handle.update(|state| {
         let collection = selector(state);
@@ -1040,6 +1266,8 @@ async fn run_push<C, T, M>(
             false,
         );
     }
+
+    return_result
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -1203,7 +1431,6 @@ where
     })
 }
 
-#[cfg(target_arch = "wasm32")]
 fn mutation_to_value<M>(mutation: &ClientMutation<M>) -> SyncResult<ClientMutation<Value>>
 where
     M: serde::Serialize,
@@ -1217,7 +1444,6 @@ where
     })
 }
 
-#[cfg(target_arch = "wasm32")]
 fn pending_mutation_to_value<M, T>(
     mutation: &ClientMutation<M>,
     optimistic: Option<&SyncRow<T>>,
@@ -1230,7 +1456,6 @@ where
         .with_optimistic_row(optimistic.map(row_to_value).transpose()?))
 }
 
-#[cfg(target_arch = "wasm32")]
 fn row_to_value<T>(row: &SyncRow<T>) -> SyncResult<SyncRow<Value>>
 where
     T: serde::Serialize,
@@ -1284,6 +1509,81 @@ where
         server_row: conflict.server_row.as_ref().map(row_to_value).transpose()?,
         reason: conflict.reason.clone(),
     })
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use std::{cell::RefCell, marker::PhantomData, rc::Rc};
+
+    use pocopine_core::{Handle, ScopeId};
+    use serde::{Deserialize, Serialize};
+
+    use super::*;
+    use crate::{
+        ClientMutationDraft, CollectionState, MemoryLocalStore, SyncDeviceId, SyncLocalIdentity,
+        SyncOp, SyncRow,
+    };
+
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    struct Post {
+        title: String,
+    }
+
+    #[derive(Default)]
+    struct TestState {
+        posts: CollectionState<Post>,
+    }
+
+    fn posts(state: &mut TestState) -> &mut CollectionState<Post> {
+        &mut state.posts
+    }
+
+    #[tokio::test]
+    async fn queue_with_generated_id_reserves_and_enqueues_before_returning() {
+        let store: SyncLocalStoreHandle = Rc::new(MemoryLocalStore::new());
+        store
+            .save_identity(SyncLocalIdentity::new(
+                SyncDeviceId::new("device_local").unwrap(),
+            ))
+            .await
+            .unwrap();
+        let state = Rc::new(RefCell::new(TestState::default()));
+        let handle = Handle::new(state.clone(), ScopeId(1));
+        let stream = SyncStreamName::new("posts").unwrap();
+        let collection = SyncCollection {
+            handle,
+            selector: posts,
+            endpoint: SYNC_ENDPOINT_PREFIX.to_string(),
+            live_endpoint: None,
+            live_wakeup: false,
+            with_credentials: false,
+            local_store: store.clone(),
+            stream: Some(stream.clone()),
+            cursor: None,
+            _marker: PhantomData,
+        };
+        let row = SyncRow::new(
+            "post_1",
+            Post {
+                title: "queued".to_string(),
+            },
+        )
+        .unwrap();
+        let draft =
+            ClientMutationDraft::new(SyncOp::Upsert, row.value.clone()).row_key(row.key.clone());
+
+        let mutation_id = collection
+            .queue_with_generated_id(draft, Some(row.clone()))
+            .await
+            .unwrap();
+
+        assert_eq!(mutation_id.as_str(), "device_local:1");
+        let pending = store.pending_mutations(&stream).await.unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].id, mutation_id);
+        assert_eq!(pending[0].key.as_ref().unwrap().as_str(), "post_1");
+        assert!(state.borrow().posts.rows.is_empty());
+    }
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/pocopine-sync/src/client.rs
+++ b/crates/pocopine-sync/src/client.rs
@@ -1520,8 +1520,8 @@ mod tests {
 
     use super::*;
     use crate::{
-        ClientMutationDraft, CollectionState, MemoryLocalStore, SyncDeviceId, SyncLocalIdentity,
-        SyncOp, SyncRow,
+        ClientMutationDraft, CollectionState, MemoryLocalStore, RowKey, SyncDeviceId,
+        SyncLocalIdentity, SyncOp, SyncRow,
     };
 
     #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -1538,6 +1538,27 @@ mod tests {
         &mut state.posts
     }
 
+    fn test_collection(
+        store: SyncLocalStoreHandle,
+        stream: SyncStreamName,
+    ) -> (Rc<RefCell<TestState>>, SyncCollection<TestState, Post>) {
+        let state = Rc::new(RefCell::new(TestState::default()));
+        let handle = Handle::new(state.clone(), ScopeId(1));
+        let collection = SyncCollection {
+            handle,
+            selector: posts,
+            endpoint: SYNC_ENDPOINT_PREFIX.to_string(),
+            live_endpoint: None,
+            live_wakeup: false,
+            with_credentials: false,
+            local_store: store,
+            stream: Some(stream),
+            cursor: None,
+            _marker: PhantomData,
+        };
+        (state, collection)
+    }
+
     #[tokio::test]
     async fn queue_with_generated_id_reserves_and_enqueues_before_returning() {
         let store: SyncLocalStoreHandle = Rc::new(MemoryLocalStore::new());
@@ -1547,21 +1568,8 @@ mod tests {
             ))
             .await
             .unwrap();
-        let state = Rc::new(RefCell::new(TestState::default()));
-        let handle = Handle::new(state.clone(), ScopeId(1));
         let stream = SyncStreamName::new("posts").unwrap();
-        let collection = SyncCollection {
-            handle,
-            selector: posts,
-            endpoint: SYNC_ENDPOINT_PREFIX.to_string(),
-            live_endpoint: None,
-            live_wakeup: false,
-            with_credentials: false,
-            local_store: store.clone(),
-            stream: Some(stream.clone()),
-            cursor: None,
-            _marker: PhantomData,
-        };
+        let (state, collection) = test_collection(store.clone(), stream.clone());
         let row = SyncRow::new(
             "post_1",
             Post {
@@ -1583,6 +1591,28 @@ mod tests {
         assert_eq!(pending[0].id, mutation_id);
         assert_eq!(pending[0].key.as_ref().unwrap().as_str(), "post_1");
         assert!(state.borrow().posts.rows.is_empty());
+    }
+
+    #[tokio::test]
+    async fn generated_id_online_confirmed_is_unsupported_on_host() {
+        let store: SyncLocalStoreHandle = Rc::new(MemoryLocalStore::new());
+        let stream = SyncStreamName::new("posts").unwrap();
+        let (_state, collection) = test_collection(store.clone(), stream.clone());
+        let draft = ClientMutationDraft::new(
+            SyncOp::Upsert,
+            Post {
+                title: "online".to_string(),
+            },
+        )
+        .row_key(RowKey::new("post_1").unwrap());
+
+        let err = collection
+            .push_with_generated_id_online_confirmed(draft, None)
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, SyncError::Unsupported(_)));
+        assert!(store.pending_mutations(&stream).await.unwrap().is_empty());
     }
 }
 

--- a/crates/pocopine-sync/src/client.rs
+++ b/crates/pocopine-sync/src/client.rs
@@ -297,7 +297,11 @@ where
     ///
     /// This is the async primitive for `WritePolicy::RequireOnline`. The host
     /// implementation returns `SyncError::Unsupported`; confirmed browser
-    /// pushes require the wasm fetch runtime.
+    /// pushes require the wasm fetch runtime. Mutation ids are still
+    /// monotonic, not dense: a failed confirmed push may skip an id after the
+    /// counter has been durably reserved. On request errors, collection state
+    /// reflects the push error for the optimistic mutation before this future
+    /// returns `Err`.
     pub async fn push_with_generated_id_online_confirmed<M>(
         self,
         mutation: ClientMutationDraft<M>,
@@ -1195,7 +1199,7 @@ async fn send_push_and_reconcile<C, T, M>(
     stream: SyncStreamName,
     mutation: ClientMutation<M>,
     pull_after_accept: bool,
-    queue_offline: bool,
+    reconcile_queued_mutation: bool,
 ) -> SyncResult<SyncPushResponse<T>>
 where
     C: 'static,
@@ -1204,6 +1208,10 @@ where
 {
     let mutation_id = mutation.id.clone();
 
+    // `reconcile_queued_mutation` means the mutation is already in the
+    // durable local queue. A server response should therefore be persisted as
+    // the local push result so the queue can clear accepted/rejected/conflict
+    // outcomes. Online-only pushes skip this local queue reconciliation.
     let request = SyncPushRequest::new(stream.clone(), [mutation]);
     let result =
         pocopine_core::fetch::call::<SyncPushRequest<M>, SyncPushResponse<T>>(&push_url, &request)
@@ -1211,7 +1219,7 @@ where
     let mut local_error = None;
     let result: Result<SyncPushResponse<T>, String> = match result {
         Ok(response) => {
-            if queue_offline {
+            if reconcile_queued_mutation {
                 match local_push_result_from_response(&response) {
                     Ok(result) => {
                         if let Err(err) = local_store.mark_push_result(result).await {
@@ -1243,7 +1251,7 @@ where
                 should_pull
             }
             Err(err) => {
-                if queue_offline {
+                if reconcile_queued_mutation {
                     collection.set_error(err.to_string());
                 } else {
                     collection.apply_push_error(&mutation_id, err.to_string());

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,9 @@ looks the way it does — the code itself tells you *what*.
   current roadmap for turning the shipped sync protocol, local store, and
   SQLite backend into a database-agnostic local-first sync engine without
   becoming a sync database.
+- [`sync-local-first-architecture-review.md`](./sync-local-first-architecture-review.md) —
+  architecture review against established local-first systems, with the
+  phase plan for the next resource-runtime slice.
 - [`sync-conflict-architecture.md`](./sync-conflict-architecture.md) —
   deep dive on the sync layers, canonical-vs-rendered local state,
   pending overlays, push outcomes, conflict resolution direction, and the

--- a/docs/sync-crud.md
+++ b/docs/sync-crud.md
@@ -85,30 +85,53 @@ The first crate slice provides the reusable contracts:
   registering a non-macro `CrudSource` as a `pocopine-sync` stream,
 - `CrudMutationLog` and `MemoryCrudMutationLog` so accepted mutation ids
   are explicit and replayed writes do not silently run twice,
+- `client_resource(collection, view)` and `CrudClientResource` for the
+  non-macro client runtime that generated modules should call,
 - low-level `pocopine-sync` online-only push helpers that give
   `WritePolicy::RequireOnline` a runtime target without changing the
   queue-offline default.
 
 The crate deliberately does not yet generate typed client modules. The
-non-macro adapter is the runtime contract the later proc macro should
+non-macro client runtime is the contract the later proc macro should
 target.
 
-The current manual client shape is intentionally low level:
+The current non-macro client shape is explicit about the two moving
+parts a generated module will hide: the low-level sync collection and the
+typed local resource view.
 
 ```rust
-use pocopine_sync_crud::{new_id, CrudMutationPayload};
+use pocopine_sync_crud::{
+    client_resource, local_resource_view, CreateOptions, CrudOutcome,
+};
 
-let id = new_id::<uuid::Uuid>()?;
-let payload = CrudMutationPayload::create(id.clone(), CustomerDraft { name, email });
-let optimistic = pocopine_sync_crud::optimistic_row(&id, customer)?;
+let view = local_resource_view::<uuid::Uuid, Customer>(&self.customers)?;
+let customers = client_resource(customers_collection, view);
 
-customers_collection.push_with_generated_id(
-    payload.into_sync_draft()?,
-    Some(optimistic),
-)?;
+let outcome = customers
+    .create_with_options(
+        customer_id,
+        CustomerDraft { name, email },
+        CreateOptions {
+            optimistic: Some(optimistic_customer),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+match outcome {
+    CrudOutcome::Queued(queued) => {
+        tracing::debug!(mutation_id = %queued.mutation_id, "customer queued");
+    }
+    CrudOutcome::Accepted { .. }
+    | CrudOutcome::Removed { .. }
+    | CrudOutcome::Rejected { .. }
+    | CrudOutcome::Conflict { .. } => {}
+}
 ```
 
-That is the code the macro should hide later.
+Ordinary CRUD callers should not build `ClientMutationDraft` directly.
+That remains the protocol escape hatch for custom sync flows that do not
+fit generated create/save/remove methods.
 
 ## Proc Macro Shape
 
@@ -304,7 +327,9 @@ generation:
 
 ```rust
 let customer_id = customers::new_id()?;
-customers.create(customer_id, CustomerDraft { name, email })?;
+customers
+    .create(customer_id, CustomerDraft { name, email })
+    .await?;
 ```
 
 Apps can still pass ids explicitly. That remains the clearest path when
@@ -519,9 +544,150 @@ from the mutation log; the next pull is the source of canonical row data.
 This avoids leaking a row accepted under one principal into another
 principal's retry path.
 
+## Client Runtime Walkthrough
+
+The non-macro runtime is the author-visible shape until the proc macro
+generates resource modules. It keeps the app's component state in
+`pocopine-sync`, then layers typed CRUD methods over that state.
+
+```rust
+pub struct CustomersPage {
+    customers: pocopine_sync::CollectionState<Customer>,
+}
+
+fn customers_state(
+    page: &mut CustomersPage,
+) -> &mut pocopine_sync::CollectionState<Customer> {
+    &mut page.customers
+}
+```
+
+Open/pull still belongs to the sync collection:
+
+```rust
+let collection = sync
+    .collection(pocopine::this::<CustomersPage>(), customers_state)
+    .stream("customers")?;
+
+collection.open()?;
+```
+
+Create/save/remove use `CrudClientResource`. The handle is cheap to
+rebuild for each event handler because it only binds the current sync
+collection and the current typed view.
+
+```rust
+use pocopine_sync_crud::{
+    client_resource, local_resource_view, CreateOptions, CrudOutcome,
+};
+
+let collection = sync
+    .collection(pocopine::this::<CustomersPage>(), customers_state)
+    .stream("customers")?;
+let view = local_resource_view::<uuid::Uuid, Customer>(&self.customers)?;
+let customers = client_resource(collection, view);
+
+let outcome = customers
+    .create_with_options(
+        customer_id,
+        CustomerDraft { name, email },
+        CreateOptions {
+            optimistic: Some(optimistic_customer),
+            ..Default::default()
+        },
+    )
+    .await?;
+
+match outcome {
+    CrudOutcome::Queued(queued) => {
+        self.last_mutation = Some(queued.mutation_id);
+    }
+    CrudOutcome::Accepted { row, .. } => {
+        self.form_name = row.name;
+    }
+    CrudOutcome::Rejected { reason, .. } => {
+        self.error = reason;
+    }
+    CrudOutcome::Conflict {
+        server_row, reason, ..
+    } => {
+        self.conflict_reason = Some(reason);
+        self.server_customer = server_row;
+    }
+    CrudOutcome::Removed { .. } => {
+        // Not expected for create; included for exhaustive matching.
+    }
+}
+```
+
+The default write policy is `QueueOffline`. A queued outcome means the
+mutation id has been durably reserved and the pending mutation has been
+stored locally. In the browser runtime Pocopine then starts a background
+push; the queued outcome is not server acceptance.
+
+`RequireOnline` changes the contract:
+
+```rust
+use pocopine_sync_crud::{SaveOptions, WritePolicy};
+
+let outcome = customers
+    .save_with_options(
+        customer.id,
+        CustomerDraft {
+            name: edited_name,
+            email: edited_email,
+        },
+        SaveOptions {
+            optimistic: Some(edited_customer),
+            write_policy: WritePolicy::RequireOnline,
+            ..Default::default()
+        },
+    )
+    .await?;
+```
+
+`RequireOnline` waits for a server push response and returns
+`Accepted`, `Removed`, `Rejected`, or `Conflict`. If the browser cannot
+complete the request, the operation fails and no pending mutation is
+queued. The host implementation returns `SyncError::Unsupported` because
+confirmed pushes require the browser fetch runtime.
+
+`LocalResourceView` is the read side generated components should render:
+
+```rust
+let view = local_resource_view::<uuid::Uuid, Customer>(&self.customers)?;
+
+if view.has_pending() {
+    self.badge = "syncing".to_string();
+}
+
+if view.has_conflicts() {
+    self.badge = "conflict".to_string();
+}
+
+for row in &view.rows {
+    match row.status {
+        pocopine_sync_crud::LocalResourceRowStatus::Synced => {}
+        pocopine_sync_crud::LocalResourceRowStatus::Pending => {
+            // render local draft styling
+        }
+        pocopine_sync_crud::LocalResourceRowStatus::Conflict => {
+            // render conflict affordance
+        }
+    }
+}
+```
+
+`LocalResourceRow::base_version` is the latest canonical server version
+known for that id, even when the visible row includes a local optimistic
+overlay. `save` and `remove` use that value by default. Pending writes
+for the same id are not silently merged into a synthetic version; stale
+server responses still return explicit conflicts.
+
 ## Generated Client API
 
-The client gets a typed resource handle:
+The macro layer should wrap the runtime above. The generated client gets
+a typed resource handle:
 
 ```rust
 let customers = customers::use_resource();
@@ -532,14 +698,18 @@ customers.open();
 The default methods should be the normal path:
 
 ```rust
-customers.create(customer_id, CustomerDraft { name, email })?;
+customers
+    .create(customer_id, CustomerDraft { name, email })
+    .await?;
 
-customers.save(customer.id, CustomerDraft {
-    name: edited_name,
-    email: edited_email,
-})?;
+customers
+    .save(customer.id, CustomerDraft {
+        name: edited_name,
+        email: edited_email,
+    })
+    .await?;
 
-customers.remove(customer.id)?;
+customers.remove(customer.id).await?;
 ```
 
 The generated methods choose good sync defaults:
@@ -562,7 +732,8 @@ customers.create_with_options(
         optimistic: Some(customer),
         ..Default::default()
     },
-)?;
+)
+.await?;
 
 customers.save_with_options(
     customer.id,
@@ -575,7 +746,8 @@ customers.save_with_options(
         optimistic: Some(edited_customer),
         ..Default::default()
     },
-)?;
+)
+.await?;
 
 customers.remove_with_options(
     customer.id,
@@ -583,7 +755,8 @@ customers.remove_with_options(
         base_version: Some(customer_version),
         ..Default::default()
     },
-)?;
+)
+.await?;
 ```
 
 The macro can also generate `OpenOptions`-style fluent options methods
@@ -593,7 +766,8 @@ for advanced call sites that read better as chained configuration:
 customers
     .create_options()
     .optimistic(customer)
-    .send(customer_id, CustomerDraft { name, email })?;
+    .send(customer_id, CustomerDraft { name, email })
+    .await?;
 
 customers
     .save_options()
@@ -602,12 +776,14 @@ customers
     .send(customer.id, CustomerDraft {
         name: edited_name,
         email: edited_email,
-    })?;
+    })
+    .await?;
 
 customers
     .remove_options()
     .base_version(customer_version)
-    .send(customer.id)?;
+    .send(customer.id)
+    .await?;
 ```
 
 The public authoring shape is the method chain, not a generic upsert
@@ -649,7 +825,8 @@ pub struct Queued {
 
 ## Generated Mutation Lifecycle
 
-Each generated client CRUD method owns the sync lifecycle:
+The non-macro runtime already owns the sync lifecycle that generated
+client CRUD methods should call:
 
 1. load or create the durable `SyncDeviceId`,
 2. reserve the next durable mutation counter,
@@ -673,8 +850,7 @@ pub struct Queued {
 }
 ```
 
-Generated remove methods have different optimistic behavior from
-create/save:
+Remove methods have different optimistic behavior from create/save:
 
 1. allocates a durable mutation id,
 2. enqueues a delete mutation,
@@ -820,9 +996,9 @@ side-effecting domains.
 Generated simple methods should keep `QueueOffline` as the default:
 
 ```rust
-customers.create(id, draft)?;
-customers.save(id, draft)?;
-customers.remove(id)?;
+customers.create(id, draft).await?;
+customers.save(id, draft).await?;
+customers.remove(id).await?;
 ```
 
 Advanced call sites can opt into server-required behavior:
@@ -832,7 +1008,8 @@ customers
     .save_options()
     .require_online()
     .base_version(row_version)
-    .send(customer.id, draft)?;
+    .send(customer.id, draft)
+    .await?;
 ```
 
 The transaction options API should use the same policy vocabulary:
@@ -896,12 +1073,10 @@ is.
 
 ## Implementation Slices
 
-The first `pocopine-sync-crud` PR avoids proc-macro complexity and ships
-the testable contract:
+The current `pocopine-sync-crud` foundation avoids proc-macro complexity
+and ships the testable contract:
 
-- crate scaffold,
-- `CrudSource` trait,
-- `ResourceId` trait with built-in UUID/string/integer implementations,
+- `CrudSource` and `ResourceId`,
 - CRUD payload types for create/save/remove,
 - queued/outcome/status types,
 - `WritePolicy` and transaction options,
@@ -909,17 +1084,8 @@ the testable contract:
   internally,
 - transaction lifecycle API using `TransactionRunner` and
   `TransactionOptions::run(...)`,
-- mapping into `SyncCollection::push_with_generated_id` through
-  `ClientMutationDraft`,
 - helper APIs for optimistic rows,
 - typed local resource views over `CollectionState<Row>`,
-- unit tests for ids, payload mapping, write policies, queued outcomes,
-  local views, and transaction binding,
-- low-level sync helpers for online-only push behavior,
-- docs for the next non-macro and macro slices.
-
-The second `pocopine-sync-crud` PR adds the non-macro runtime adapter:
-
 - resource registration against `SyncServer` through the existing
   `pocopine-sync` server plugin,
 - snapshot pull through bounded `list(limit)` and row id extraction,
@@ -930,23 +1096,14 @@ The second `pocopine-sync-crud` PR adds the non-macro runtime adapter:
   mutation ids do not duplicate writes,
 - exact replay validation so a reused mutation id with different
   operation, row id, or payload is rejected,
-- tests for accepted, rejected, conflict, snapshot-limit, empty-version,
-  and duplicate-replay flows,
-- route-level integration coverage proving a CRUD resource registered with
-  `SyncServer` serves `/pull` and `/push` through the normal sync plugin,
-- customer-style SQLx documentation showing explicit app-owned `list`,
-  `get`, `create`, `save`, and `remove` queries.
+- non-macro `CrudClientResource` methods for create/save/remove,
+- durable generated-id queueing for `QueueOffline`,
+- online-confirmed generated-id push for `RequireOnline`,
+- route-level integration coverage proving a CRUD resource registered
+  with `SyncServer` serves `/pull` and `/push` through the normal sync
+  plugin.
 
-Still left before the macro layer:
-
-- generated CRUD methods and source adapters that use `TransactionRunner`
-  or an app-owned SQL transaction to pair a source write and durable
-  mutation-log record in one database transaction,
-- generated CRUD methods that map `WritePolicy::RequireOnline` to the
-  low-level online-only sync push helpers.
-
-The third PR should add the macro layer once the runtime contract is
-stable:
+The macro layer should come after this runtime contract is stable:
 
 - `#[resource(name = "...")]` proc macro,
 - generated typed client resource module,

--- a/docs/sync-crud.md
+++ b/docs/sync-crud.md
@@ -652,6 +652,11 @@ complete the request, the operation fails and no pending mutation is
 queued. The host implementation returns `SyncError::Unsupported` because
 confirmed pushes require the browser fetch runtime.
 
+`RequireOnline` still reserves a durable mutation id before the request,
+so failed attempts can leave gaps in mutation ids. If the request errors
+after an optimistic row was applied, collection state reflects the push
+error/rollback for that mutation before the method returns `Err`.
+
 `LocalResourceView` is the read side generated components should render:
 
 ```rust
@@ -1066,6 +1071,12 @@ view instead of exposing raw protocol structs to application code.
 need a single-row refresh. When a save/remove conflicts, the CRUD layer
 can call `get(ctx, key)` to fetch the current server-visible row and mark
 it conflicted locally.
+
+`CrudOutcome::Conflict` returns `server_row: Option<Row>` for rendering
+and comparison, not `Option<SyncRow<Row>>`. The row version stays in the
+canonical sync state. A retry should read the refreshed
+`LocalResourceView::base_version(&id)` after reconciliation or after a
+pull, rather than deriving a retry version from the typed conflict row.
 
 If `get` returns `None`, the client should treat the row as gone or not
 visible. It should not assume the caller is allowed to know which case it

--- a/docs/sync-local-first-architecture-review.md
+++ b/docs/sync-local-first-architecture-review.md
@@ -1,0 +1,311 @@
+# Local-First Sync Architecture Review
+
+This document records the architecture check behind the next Pocopine
+local-first sync phases. It is written for framework authors reviewing
+whether the current direction is sound and what the next implementation
+slices should prove.
+
+Pocopine should remain a database-agnostic local-first sync engine, not a
+sync database product. The framework owns protocol shape, local
+durability, optimistic state, rebase, conflict metadata, live wake-up
+integration, and resource ergonomics. Apps and adapter crates own
+database queries, schemas, authorization filters, domain validation, and
+backend-specific change tracking.
+
+## Reference Architectures
+
+These systems validate the current Pocopine direction, but none should be
+copied wholesale.
+
+### Replicache
+
+Replicache is the closest match for the low-level Pocopine model. Its
+client applies mutations optimistically, persists pending work, pulls
+canonical server state, and rebases local mutations over the latest
+server state. Its server "poke" is a wake-up signal that tells clients to
+pull; it is not the row transport itself.
+
+Pocopine should keep:
+
+- canonical server state separate from rendered optimistic state,
+- deterministic replay of pending mutations,
+- mutation ids as idempotency keys,
+- live wake-up as "pull this stream", not "here are rows".
+
+Pocopine should avoid:
+
+- coupling the app model to one hosted sync service,
+- hiding backend authorization or database writes inside the sync layer.
+
+Reference: <https://doc.replicache.dev/concepts/how-it-works>
+
+### Zero
+
+Zero uses local mutators, server-side mutators, optimistic state, and
+server reconciliation. Its useful lesson is that custom business logic,
+authorization, and partial sync have to be first-class design concerns.
+
+Pocopine should keep:
+
+- generated resource ergonomics on top of explicit sync contracts,
+- server-side transaction boundaries for writes,
+- app-owned business logic instead of generated SQL.
+
+Pocopine should avoid:
+
+- making the sync crate own the app's data model,
+- treating a queued local write as server success.
+
+References: <https://zero.rocicorp.dev/docs/sync>,
+<https://zero.rocicorp.dev/docs/mutators>
+
+### PowerSync
+
+PowerSync validates the durable local queue side of the architecture. The
+client writes locally, records local changes into an upload queue, keeps
+working offline, and later routes uploads through the app backend.
+
+Pocopine should keep:
+
+- durable enqueue before reporting a local-first write as queued,
+- replay after reconnect,
+- app backend ownership of validation and side effects,
+- explicit handling for validation failures and conflicts.
+
+Pocopine should avoid:
+
+- making browser SQLite the public application database API,
+- turning the framework into a managed sync database.
+
+References: <https://docs.powersync.com/architecture/client-architecture>,
+<https://docs.powersync.com/architecture/consistency>
+
+### Electric
+
+Electric's current Postgres sync product is primarily a read-sync and
+shape system. The older ElectricSQL generation also emphasized routing
+writes through the application's backend/API. The lesson Pocopine should
+carry forward is the shape/read boundary, not any one Electric write
+model.
+
+Pocopine should keep:
+
+- opaque cursors,
+- backend-specific adapters outside the core,
+- room for partial resource subscriptions later.
+
+Pocopine should avoid:
+
+- making Postgres or shape streams a core assumption,
+- requiring database-specific changefeeds before the resource runtime is
+  ergonomic.
+
+References: <https://electric-sql.com/product/sync>,
+<https://electric.ax/products/postgres-sync>
+
+### CouchDB
+
+CouchDB's replication model shows the cost of multi-master document
+sync: conflicts are normal data and applications must resolve them.
+
+Pocopine should keep:
+
+- conflicts visible and explicit,
+- rejected writes separate from stale-version conflicts,
+- deterministic rollback/rebase behavior.
+
+Pocopine should avoid:
+
+- silent last-write-wins for normal CRUD rows,
+- automatic merging without a resource-specific policy.
+
+Reference: <https://docs.couchdb.org/en/stable/replication/conflicts.html>
+
+### Firestore
+
+Firestore validates the value of transparent local cache and latency
+compensation, but it resolves multiple writes to the same document by
+last write wins.
+
+Pocopine should keep:
+
+- local reads before network freshness,
+- UI updates from cached data,
+- simple installation for common apps.
+
+Pocopine should avoid:
+
+- last-write-wins as the default conflict policy,
+- hiding offline/server status from author-facing APIs.
+
+Reference: <https://firebase.google.com/docs/firestore/manage-data/enable-offline>
+
+### Yjs And Automerge
+
+Yjs and Automerge validate CRDT-backed collaborative documents. Their
+updates are designed to merge concurrent edits automatically.
+
+Pocopine should keep:
+
+- CRDT fields as a separate collaboration layer,
+- explicit boundaries between row sync and document collaboration.
+
+Pocopine should avoid:
+
+- treating ordinary business rows as CRDT documents by default,
+- using automatic merge semantics for payments, inventory, or tenant
+  scoped CRUD without an app-approved policy.
+
+References: <https://docs.yjs.dev/api/document-updates>,
+<https://automerge.org/>
+
+## Architecture Decision
+
+The current Pocopine architecture is sound if we keep these invariants:
+
+1. Canonical rows remain separate from rendered optimistic rows.
+2. Rendered rows are canonical rows plus pending local overlay.
+3. Pending mutations replay deterministically in queue order.
+4. Mutation ids are durable idempotency keys.
+5. A local-first write reports success only after it is durably queued.
+6. Local-first CRUD creates use app-visible client-generated ids as final
+   resource ids. The server must echo that id in the canonical row. Apps
+   that require server-generated ids should use an online-only/custom
+   create flow instead of the offline-capable generated create path.
+7. Rejected writes remove the pending overlay and rebase from canonical
+   rows. Conflicted writes keep user-visible data available and marked
+   conflicted.
+8. Server writes remain app-owned and authorization-aware.
+9. Conflicts stay visible; ordinary CRUD does not silently merge.
+10. Live wake-up invalidates streams and triggers pulls; it does not move
+   row data.
+11. SQLite/IndexedDB/OPFS stores are sync caches, not the app's database
+   abstraction.
+12. CRDT collaboration remains separate from default CRUD row sync.
+
+The main gap after the current foundation is not protocol shape. It is
+the resource runtime that turns these invariants into the API authors use
+every day.
+
+## Reviewable Implementation Phases
+
+Each phase below should be one logical commit. Each commit should receive
+a Claude Code CLI review before the next phase begins. Findings should be
+fixed in the same phase commit until the review has no blockers. After
+all phases pass, run a final full-branch Claude review before opening the
+PR.
+
+### Phase 1: Architecture And Phase Doc
+
+Goal: make the design and review path explicit.
+
+Deliverables:
+
+- this architecture review document,
+- explicit reference-system comparison,
+- phase list tied to commit boundaries,
+- criteria for what must stay out of the core.
+
+Acceptance:
+
+- the doc explains why the next slice is a resource runtime, not a
+  database adapter,
+- the doc states the durable enqueue boundary,
+- the doc separates CRUD conflict handling from CRDT collaboration.
+
+### Phase 2: Non-Macro CRUD Client Runtime
+
+Goal: add the runtime contract that future generated resource modules can
+target without proc-macro complexity.
+
+Deliverables:
+
+- a typed `CrudClientResource` or equivalent handle in
+  `pocopine-sync-crud`,
+- `create`, `save`, and `remove` methods,
+- `_with_options` or fluent options methods that use the existing
+  `CreateOptions`, `SaveOptions`, and `RemoveOptions`,
+- a lower-level async sync hook that reserves the mutation id, enqueues
+  the pending mutation, applies optimistic state, and returns the
+  reserved id only after the durable enqueue succeeds,
+- `QueueOffline` mapped to durable generated-id queueing,
+- `RequireOnline` mapped to the online-only sync push helper,
+- `save` and `remove` default `base_version` sourced from
+  `LocalResourceView::base_version`.
+
+Acceptance:
+
+- normal CRUD callers do not build `ClientMutationDraft` directly,
+- save/remove use canonical base versions when available,
+- create/save can attach optimistic rows,
+- remove can hide the row through a delete overlay,
+- rejected create/save/remove outcomes remove the overlay and rebase from
+  canonical rows,
+- tests cover queue-offline and require-online mapping,
+- `cargo test -p pocopine-sync-crud` passes,
+- `cargo test -p pocopine-sync-crud --target wasm32-unknown-unknown --no-run`
+  passes.
+
+Phase 2 should choose the stronger API shape: generated and non-macro
+resource methods return `Queued<Id>` only after the store has durably
+reserved and enqueued the mutation id. That requires an async runtime
+entry point instead of the existing fire-and-forget helper. Existing
+low-level `ClientMutationDraft` callers remain supported as protocol
+escape hatches; this phase removes direct draft construction from normal
+CRUD examples and docs, not from the public sync API.
+
+### Phase 3: Example And Author-Facing Docs
+
+Goal: make the API reviewable in a small app without hiding important
+state.
+
+Deliverables:
+
+- add a focused author-facing CRUD runtime walkthrough in
+  `docs/sync-crud.md`,
+- add tests in `pocopine-sync-crud` that exercise the same public runtime
+  path shown in the walkthrough,
+- document the author-facing create/save/remove path,
+- document when to use `QueueOffline` versus `RequireOnline`,
+- document how `LocalResourceView` exposes pending/conflict/base-version
+  state.
+
+Acceptance:
+
+- the documented code path no longer hand-builds CRUD sync envelopes for
+  ordinary create/save/remove,
+- docs show the common path first and protocol escape hatches second,
+- no doc implies Pocopine owns SQL or application schema.
+
+### Phase 4: Final Verification And PR
+
+Goal: prove the branch is reviewable and CI-shaped before PR creation.
+
+Deliverables:
+
+- `cargo fmt`,
+- targeted `pocopine-sync-crud` tests,
+- wasm no-run check for target-gated code where relevant,
+- final full-branch Claude Code CLI review,
+- PR with phase summary and verification commands.
+
+Acceptance:
+
+- Claude final review has no blockers,
+- local verification passes or any skipped check is explicitly justified,
+- PR description lists each phase commit and the review status.
+
+## Deferred Work
+
+These are intentionally outside this PR:
+
+- SQLx helper adapters,
+- backend-specific changefeeds,
+- conflict resolution UI helpers such as `retry_local` or
+  `merge_with`,
+- auth cache partitioning helpers,
+- proc-macro code generation,
+- CRDT field integration.
+
+Those layers become safer once the non-macro resource runtime has a
+tested contract.


### PR DESCRIPTION
## Summary

- Documents the local-first sync architecture review and phase plan, including reference architecture takeaways and core invariants.
- Adds the non-macro CRUD client runtime for `pocopine-sync-crud`, with `client_resource`, create/save/remove methods, `QueueOffline` durable enqueue handling, `RequireOnline` confirmed push handling, and explicit removed/accepted/rejected/conflict outcomes.
- Updates the author-facing CRUD sync docs to show the runtime path, `LocalResourceView` behavior, conflict retry/version semantics, and `QueueOffline` vs `RequireOnline` behavior.
- Adds final review cleanups for queued reconciliation naming and RequireOnline/conflict documentation.

## Phase commits

- `793089a4` Document local-first sync architecture phases
- `359bd4c5` Add non-macro CRUD client runtime
- `97e144d0` Document CRUD sync client runtime
- `6094a6af` Address final sync review notes

## Claude Code CLI review

- Phase 1 per-commit review: no blockers after amendments.
- Phase 2 per-commit review: no blockers after amendments.
- Phase 3 per-commit review: no blockers after amendments.
- Final full-branch review: no blockers. Remaining notes are non-blocking test/ergonomic followups for future wasm integration coverage.

## Verification

- `cargo fmt`
- `git diff --check`
- `cargo test -p pocopine-sync -p pocopine-sync-crud`
- `cargo test -p pocopine-sync -p pocopine-sync-crud --target wasm32-unknown-unknown --no-run`
- `cargo clippy -p pocopine-sync -p pocopine-sync-crud --all-targets -- -D warnings`
- `cargo clippy -p pocopine-sync -p pocopine-sync-crud --target wasm32-unknown-unknown --all-targets -- -D warnings`