### PR TITLE
Three-tier host-config resolver: env > Cargo.toml > ~/.pocopine/config.toml

### DIFF
--- a/crates/pocopine-cli/src/args.rs
+++ b/crates/pocopine-cli/src/args.rs
@@ -123,6 +123,46 @@ pub enum DeployCmd {
     Doctor,
     /// Show the current deploy state per process on the target host.
     Status(StatusArgs),
+    /// Manage per-user host config (`~/.pocopine/config.toml`) — the
+    /// fallback tier for `owner_id` / `workspace_id` / `region` /
+    /// `org` when neither $POCOPINE_<HOST>_<FIELD> nor the project's
+    /// `[deploy.<host>]` block is set.
+    Config(ConfigArgs),
+}
+
+#[derive(Parser, Debug, Clone)]
+pub struct ConfigArgs {
+    #[command(subcommand)]
+    pub cmd: ConfigCmd,
+}
+
+#[derive(Subcommand, Debug, Clone)]
+pub enum ConfigCmd {
+    /// Write `[default.<host>] <field> = <value>` to
+    /// `~/.pocopine/config.toml`. If `<value>` is omitted, read it
+    /// from stdin (so secrets aren't visible in shell history).
+    Set {
+        /// Host name (`render`, `railway`, `fly`, …).
+        host: String,
+        /// Field name (`owner_id`, `workspace_id`, `region`, …).
+        field: String,
+        /// Value. Omit to read from stdin.
+        value: Option<String>,
+    },
+    /// Show the resolved value of a field across all three tiers
+    /// (env / project / file), naming the tier each came from.
+    Get {
+        host: String,
+        field: String,
+        /// Path to the project crate; used to read the project tier.
+        #[arg(long, default_value = ".")]
+        path: PathBuf,
+    },
+    /// Show every (host, field, source) tuple visible across the
+    /// file and the env.
+    List,
+    /// Remove `<field>` from `[default.<host>]`. Idempotent.
+    Revoke { host: String, field: String },
 }
 
 #[derive(Parser, Debug, Clone)]

--- a/crates/pocopine-cli/src/args.rs
+++ b/crates/pocopine-cli/src/args.rs
@@ -150,14 +150,10 @@ pub enum ConfigCmd {
         value: Option<String>,
     },
     /// Show the resolved value of a field across all three tiers
-    /// (env / project / file), naming the tier each came from.
-    Get {
-        host: String,
-        field: String,
-        /// Path to the project crate; used to read the project tier.
-        #[arg(long, default_value = ".")]
-        path: PathBuf,
-    },
+    /// (env / project / file), naming the tier each came from. The
+    /// project tier is read from the directory passed via the
+    /// `--path` global flag on `pocopine deploy` (defaults to `.`).
+    Get { host: String, field: String },
     /// Show every (host, field, source) tuple visible across the
     /// file and the env.
     List,

--- a/crates/pocopine-cli/src/deploy.rs
+++ b/crates/pocopine-cli/src/deploy.rs
@@ -35,7 +35,7 @@ pub fn run(args: &DeployArgs) -> Result<()> {
         Some(DeployCmd::Auth(a)) => run_auth(a),
         Some(DeployCmd::Doctor) => run_doctor(),
         Some(DeployCmd::Status(s)) => run_status(args, s),
-        Some(DeployCmd::Config(c)) => run_config(c),
+        Some(DeployCmd::Config(c)) => run_config(args, c),
     }
 }
 
@@ -280,7 +280,7 @@ fn run_auth(args: &AuthArgs) -> Result<()> {
     Ok(())
 }
 
-fn run_config(args: &ConfigArgs) -> Result<()> {
+fn run_config(parent: &DeployArgs, args: &ConfigArgs) -> Result<()> {
     match &args.cmd {
         ConfigCmd::Set { host, field, value } => {
             let value = match value.as_deref() {
@@ -295,30 +295,45 @@ fn run_config(args: &ConfigArgs) -> Result<()> {
                     line.trim().to_owned()
                 }
             };
-            if value.is_empty() {
+            // Reject whitespace-only too — these would pass an
+            // `is_empty()` check but would be sent verbatim to host
+            // APIs and produce confusing 4xx errors.
+            if value.trim().is_empty() {
                 bail!("empty value");
             }
+            // Stash the original (pre-trim) value if it survives the
+            // whitespace check, but strip leading/trailing whitespace
+            // so a copy-paste with a trailing newline doesn't corrupt
+            // the stored field. Inner whitespace is preserved.
+            let value = value.trim().to_owned();
             config::store_field(host, field, &value)?;
             eprintln!("Stored `[default.{host}] {field} = {value:?}` to ~/.pocopine/config.toml.",);
             Ok(())
         }
-        ConfigCmd::Get { host, field, path } => {
-            // Read the project tier from the given path so users can
-            // see exactly which tier wins for their checkout, not just
-            // env + file. Surfacing the source name is the whole
-            // point of this command.
-            let project_value = read_project_field(path, host, field).ok();
+        ConfigCmd::Get { host, field } => {
+            // Resolve the project tier the same way `deploy()` will:
+            // apply the `[deploy.production.<host>]` overlay when the
+            // parent --prod flag is set. Without this the `get`
+            // command would report `[deploy.<host>].<field>` for a
+            // project whose --prod deploy actually resolves to the
+            // production-overlay value.
+            let project_path = parent.path.as_path();
+            let project_value = read_project_field(project_path, host, field, parent.prod).ok();
             let resolved = config::resolve_with_source(host, field, project_value.as_deref());
             match resolved {
                 Some((value, source)) => {
                     let src = match source {
                         config::Source::Env => {
-                            format!("env (${})", config::env_var_name(host, field),)
+                            format!("env (${})", config::env_var_name(host, field))
                         }
-                        config::Source::Project => format!(
-                            "project ({}/Cargo.toml [deploy.{host}].{field})",
-                            path.display(),
-                        ),
+                        config::Source::Project => {
+                            let suffix = if parent.prod {
+                                format!(" [deploy.production.{host}].{field}")
+                            } else {
+                                format!(" [deploy.{host}].{field}")
+                            };
+                            format!("project ({}/Cargo.toml{suffix})", project_path.display(),)
+                        }
                         config::Source::File => "file (~/.pocopine/config.toml)".to_owned(),
                     };
                     println!("{value}");
@@ -367,18 +382,35 @@ fn run_config(args: &ConfigArgs) -> Result<()> {
 /// project's Cargo.toml — used by `config get` to surface the
 /// project-tier value when reporting the resolved source. Best-effort;
 /// any read/parse error is treated as "no project value".
-fn read_project_field(project: &Path, host: &str, field: &str) -> Result<String> {
+fn read_project_field(project: &Path, host: &str, field: &str, prod: bool) -> Result<String> {
     let manifest = read_manifest(project)?;
-    let value = manifest
+    let deploy = manifest
         .get("package")
         .and_then(|p| p.get("metadata"))
         .and_then(|m| m.get("pocopine"))
         .and_then(|p| p.get("deploy"))
-        .and_then(|d| d.get(host))
+        .context("not set in project Cargo.toml")?;
+
+    // When `--prod` is set, the deploy path merges the
+    // `[deploy.production.<host>]` overlay on top of the base
+    // `[deploy.<host>]`. The `get` command must do the same so its
+    // "source" report matches what an actual --prod deploy resolves.
+    if prod {
+        if let Some(v) = deploy
+            .get("production")
+            .and_then(|p| p.get(host))
+            .and_then(|h| h.get(field))
+            .and_then(|v| v.as_str())
+        {
+            return Ok(v.to_owned());
+        }
+    }
+    deploy
+        .get(host)
         .and_then(|h| h.get(field))
         .and_then(|v| v.as_str())
-        .map(str::to_owned);
-    value.context("not set in project Cargo.toml")
+        .map(str::to_owned)
+        .context("not set in project Cargo.toml")
 }
 
 fn run_status(args: &DeployArgs, opts: &StatusArgs) -> Result<()> {

--- a/crates/pocopine-cli/src/deploy.rs
+++ b/crates/pocopine-cli/src/deploy.rs
@@ -24,10 +24,10 @@ use std::process::Command;
 
 use anyhow::{bail, Context, Result};
 use pocopine_deploy::{
-    credentials, docker::DockerClient, spec, Constraint, DeployAdapter, Hint, StagedFiles,
+    config, credentials, docker::DockerClient, spec, Constraint, DeployAdapter, Hint, StagedFiles,
 };
 
-use crate::args::{AuthArgs, DeployArgs, DeployCmd, StatusArgs};
+use crate::args::{AuthArgs, ConfigArgs, ConfigCmd, DeployArgs, DeployCmd, StatusArgs};
 
 pub fn run(args: &DeployArgs) -> Result<()> {
     match &args.cmd {
@@ -35,6 +35,7 @@ pub fn run(args: &DeployArgs) -> Result<()> {
         Some(DeployCmd::Auth(a)) => run_auth(a),
         Some(DeployCmd::Doctor) => run_doctor(),
         Some(DeployCmd::Status(s)) => run_status(args, s),
+        Some(DeployCmd::Config(c)) => run_config(c),
     }
 }
 
@@ -277,6 +278,107 @@ fn run_auth(args: &AuthArgs) -> Result<()> {
     credentials::store(host, token)?;
     eprintln!("Stored token for `{host}` to ~/.pocopine/credentials.toml (mode 0600).");
     Ok(())
+}
+
+fn run_config(args: &ConfigArgs) -> Result<()> {
+    match &args.cmd {
+        ConfigCmd::Set { host, field, value } => {
+            let value = match value.as_deref() {
+                Some(v) => v.to_owned(),
+                None => {
+                    eprint!("value for `{host}.{field}`: ");
+                    std::io::stderr().flush().ok();
+                    let mut line = String::new();
+                    std::io::stdin()
+                        .read_line(&mut line)
+                        .context("reading value from stdin")?;
+                    line.trim().to_owned()
+                }
+            };
+            if value.is_empty() {
+                bail!("empty value");
+            }
+            config::store_field(host, field, &value)?;
+            eprintln!("Stored `[default.{host}] {field} = {value:?}` to ~/.pocopine/config.toml.",);
+            Ok(())
+        }
+        ConfigCmd::Get { host, field, path } => {
+            // Read the project tier from the given path so users can
+            // see exactly which tier wins for their checkout, not just
+            // env + file. Surfacing the source name is the whole
+            // point of this command.
+            let project_value = read_project_field(path, host, field).ok();
+            let resolved = config::resolve_with_source(host, field, project_value.as_deref());
+            match resolved {
+                Some((value, source)) => {
+                    let src = match source {
+                        config::Source::Env => {
+                            format!("env (${})", config::env_var_name(host, field),)
+                        }
+                        config::Source::Project => format!(
+                            "project ({}/Cargo.toml [deploy.{host}].{field})",
+                            path.display(),
+                        ),
+                        config::Source::File => "file (~/.pocopine/config.toml)".to_owned(),
+                    };
+                    println!("{value}");
+                    eprintln!("  source: {src}");
+                }
+                None => {
+                    eprintln!(
+                        "no value for `{host}.{field}` in env, project, or file. \
+                         Set via `pocopine deploy config set {host} {field} <value>`, \
+                         export ${}, or add to `[deploy.{host}]` in Cargo.toml.",
+                        config::env_var_name(host, field),
+                    );
+                    std::process::exit(1);
+                }
+            }
+            Ok(())
+        }
+        ConfigCmd::List => {
+            let entries = config::list()?;
+            if entries.is_empty() {
+                println!("No host config configured.");
+                return Ok(());
+            }
+            // Compact table: HOST, FIELD, SOURCE — keeps the output
+            // scannable for users with a handful of entries; bigger
+            // setups can grep.
+            for (host, field, source) in entries {
+                let src = match source {
+                    config::Source::Env => "env",
+                    config::Source::File => "file",
+                    config::Source::Project => "project",
+                };
+                println!("{host:<12} {field:<22} {src}");
+            }
+            Ok(())
+        }
+        ConfigCmd::Revoke { host, field } => {
+            config::revoke_field(host, field)?;
+            eprintln!("Revoked `[default.{host}] {field}`.");
+            Ok(())
+        }
+    }
+}
+
+/// Read `[package.metadata.pocopine.deploy.<host>] <field>` from the
+/// project's Cargo.toml — used by `config get` to surface the
+/// project-tier value when reporting the resolved source. Best-effort;
+/// any read/parse error is treated as "no project value".
+fn read_project_field(project: &Path, host: &str, field: &str) -> Result<String> {
+    let manifest = read_manifest(project)?;
+    let value = manifest
+        .get("package")
+        .and_then(|p| p.get("metadata"))
+        .and_then(|m| m.get("pocopine"))
+        .and_then(|p| p.get("deploy"))
+        .and_then(|d| d.get(host))
+        .and_then(|h| h.get(field))
+        .and_then(|v| v.as_str())
+        .map(str::to_owned);
+    value.context("not set in project Cargo.toml")
 }
 
 fn run_status(args: &DeployArgs, opts: &StatusArgs) -> Result<()> {

--- a/crates/pocopine-deploy-fly/src/lib.rs
+++ b/crates/pocopine-deploy-fly/src/lib.rs
@@ -599,6 +599,10 @@ fn fly_override(spec: &DeploySpec) -> FlyOverride {
         .unwrap_or_default()
 }
 
+// Kept for tests that don't want to depend on the env / config-file
+// tiers of the resolver. Production code (`deploy()` +
+// `render_fly_toml`) uses `resolved_primary_region` instead.
+#[allow(dead_code)]
 fn primary_region(o: &FlyOverride) -> String {
     o.primary_region
         .clone()
@@ -612,7 +616,11 @@ fn primary_region(o: &FlyOverride) -> String {
 /// entry of `[deploy.fly].regions` → `"fra"`. Keeps the existing
 /// regions-array + hardcoded fallback for projects that haven't moved
 /// to the per-user config.
-#[cfg(not(target_arch = "wasm32"))]
+///
+/// Not cfg-gated: `render_config` runs on every target (wasm32
+/// callers can still construct staged artefacts), and
+/// `pocopine_deploy::config::resolve` returns `None` gracefully on
+/// wasm where `$HOME` isn't set.
 fn resolved_primary_region(o: &FlyOverride) -> String {
     if let Some(v) =
         pocopine_deploy::config::resolve("fly", "primary_region", o.primary_region.as_deref())
@@ -728,7 +736,12 @@ fn collect_secret_values(spec: &DeploySpec) -> std::collections::BTreeMap<String
 
 fn render_fly_toml(spec: &DeploySpec) -> String {
     let overrides = fly_override(spec);
-    let primary_region = primary_region(&overrides);
+    // Three-tier resolver — same as `deploy()` — so the audit
+    // artefact reflects what the deploy actually sent. Reading
+    // `primary_region(&overrides)` (struct-only) would diverge
+    // whenever the value comes from $POCOPINE_FLY_PRIMARY_REGION or
+    // `~/.pocopine/config.toml [default.fly] primary_region`.
+    let primary_region = resolved_primary_region(&overrides);
 
     use std::fmt::Write as _;
     let mut out = String::new();

--- a/crates/pocopine-deploy-fly/src/lib.rs
+++ b/crates/pocopine-deploy-fly/src/lib.rs
@@ -311,12 +311,13 @@ impl DeployAdapter for FlyAdapter {
         // 1. Ensure the app exists FIRST — `registry.fly.io/<app>:<sha>`
         //    requires the app namespace to exist before `docker push`
         //    can target it (regression fix for the Phase 4 review).
+        //
+        // Three-tier resolution for org + primary_region:
+        //   $POCOPINE_FLY_<FIELD>  →  [deploy.fly].<field>  →  ~/.pocopine/config.toml
         let overrides = fly_override(spec);
-        let org = overrides
-            .org
-            .clone()
+        let org = pocopine_deploy::config::resolve("fly", "org", overrides.org.as_deref())
             .unwrap_or_else(|| "personal".to_owned());
-        let region = primary_region(&overrides);
+        let region = resolved_primary_region(&overrides);
 
         let client = machines::MachinesClient::new(&token);
         client.ensure_app(&spec.app_name, &org)?;
@@ -603,6 +604,22 @@ fn primary_region(o: &FlyOverride) -> String {
         .clone()
         .or_else(|| o.regions.first().cloned())
         .unwrap_or_else(|| "fra".into())
+}
+
+/// Three-tier resolver layered on top of [`primary_region`]:
+/// `$POCOPINE_FLY_PRIMARY_REGION` → `[deploy.fly].primary_region` →
+/// `~/.pocopine/config.toml [default.fly] primary_region` → first
+/// entry of `[deploy.fly].regions` → `"fra"`. Keeps the existing
+/// regions-array + hardcoded fallback for projects that haven't moved
+/// to the per-user config.
+#[cfg(not(target_arch = "wasm32"))]
+fn resolved_primary_region(o: &FlyOverride) -> String {
+    if let Some(v) =
+        pocopine_deploy::config::resolve("fly", "primary_region", o.primary_region.as_deref())
+    {
+        return v;
+    }
+    o.regions.first().cloned().unwrap_or_else(|| "fra".into())
 }
 
 /// Returns true iff the machine carries our `pocopine.process` metadata

--- a/crates/pocopine-deploy-railway/src/lib.rs
+++ b/crates/pocopine-deploy-railway/src/lib.rs
@@ -275,10 +275,30 @@ impl DeployAdapter for RailwayAdapter {
 
         let token = load_railway_token()?;
         let overrides = railway_override(spec);
-        let project_name = overrides
-            .project
-            .clone()
-            .unwrap_or_else(|| spec.app_name.clone());
+        // Three-tier resolution: env > Cargo.toml > ~/.pocopine/config.toml.
+        // `project` defaults to the app name when all three tiers are
+        // silent (most projects don't need a custom Railway project
+        // name — the app name is fine).
+        let project_name =
+            pocopine_deploy::config::resolve("railway", "project", overrides.project.as_deref())
+                .unwrap_or_else(|| spec.app_name.clone());
+        let workspace_id = pocopine_deploy::config::resolve(
+            "railway",
+            "workspace_id",
+            overrides.workspace_id.as_deref(),
+        );
+        let environment_name = pocopine_deploy::config::resolve(
+            "railway",
+            "environment",
+            overrides.environment.as_deref(),
+        );
+        let registry_username = pocopine_deploy::config::resolve(
+            "railway",
+            "registry_username",
+            overrides.registry_username.as_deref(),
+        );
+        let region =
+            pocopine_deploy::config::resolve("railway", "region", overrides.region.as_deref());
 
         // Resolve every `[deploy.env]` entry before touching Railway —
         // a missing `{ from = "env" }` value must fail before we push.
@@ -289,7 +309,7 @@ impl DeployAdapter for RailwayAdapter {
         let registry = resolved_registry(spec)?;
         let registry_creds = pocopine_deploy::resolve_registry_credentials(
             &registry,
-            overrides.registry_username.as_deref(),
+            registry_username.as_deref(),
             spec.git_remote.as_deref(),
         );
         if registry_creds.is_none() {
@@ -318,8 +338,8 @@ impl DeployAdapter for RailwayAdapter {
         let client = client::RailwayClient::new(&token);
 
         // 2. Resolve (or create) the project, then pick the environment.
-        let project = client.ensure_project(&project_name, overrides.workspace_id.as_deref())?;
-        let environment = match overrides.environment.as_deref() {
+        let project = client.ensure_project(&project_name, workspace_id.as_deref())?;
+        let environment = match environment_name.as_deref() {
             Some(name) => project.environment(name).cloned().ok_or_else(|| {
                 anyhow::anyhow!("railway: project `{project_name}` has no environment `{name}`")
             })?,
@@ -421,7 +441,7 @@ impl DeployAdapter for RailwayAdapter {
                 image: tag.clone(),
                 num_replicas: proc.scale.min.max(1),
                 healthcheck_path: proc.healthcheck.clone(),
-                region: overrides.region.clone(),
+                region: region.clone(),
                 registry_credentials: registry_creds.clone(),
             };
             client.update_service_instance(&service.id, &environment.id, &config)?;

--- a/crates/pocopine-deploy-railway/src/lib.rs
+++ b/crates/pocopine-deploy-railway/src/lib.rs
@@ -861,7 +861,14 @@ fn render_railway_json(spec: &DeploySpec) -> String {
         },
         "services": services,
     });
-    if let Some(region) = overrides.region.as_deref() {
+    // Use the three-tier resolver — same as `deploy()` — so the audit
+    // artefact reflects what the deploy actually sent. Reading
+    // `overrides.region` directly would diverge whenever the value
+    // comes from $POCOPINE_RAILWAY_REGION or
+    // `~/.pocopine/config.toml [default.railway] region`.
+    if let Some(region) =
+        pocopine_deploy::config::resolve("railway", "region", overrides.region.as_deref())
+    {
         doc["deploy"] = serde_json::json!({ "region": region });
     }
 

--- a/crates/pocopine-deploy-railway/src/lib.rs
+++ b/crates/pocopine-deploy-railway/src/lib.rs
@@ -742,14 +742,19 @@ fn railway_override(spec: &DeploySpec) -> RailwayOverride {
         .unwrap_or_default()
 }
 
-/// Resolve the container registry for this deploy: explicit
-/// `[deploy.railway].image_registry`, else derived from the git remote.
+/// Resolve the container registry for this deploy. Three-tier
+/// resolver for `image_registry`: `$POCOPINE_RAILWAY_IMAGE_REGISTRY` →
+/// `[deploy.railway].image_registry` → `~/.pocopine/config.toml`.
+/// Falls back to `pocopine_deploy::resolve_registry`'s git-remote
+/// derivation when all three tiers are silent.
 fn resolved_registry(spec: &DeploySpec) -> Result<pocopine_deploy::ResolvedRegistry> {
     let overrides = railway_override(spec);
-    pocopine_deploy::resolve_registry(
+    let image_registry = pocopine_deploy::config::resolve(
+        "railway",
+        "image_registry",
         overrides.image_registry.as_deref(),
-        spec.git_remote.as_deref(),
-    )
+    );
+    pocopine_deploy::resolve_registry(image_registry.as_deref(), spec.git_remote.as_deref())
 }
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/pocopine-deploy-render/src/lib.rs
+++ b/crates/pocopine-deploy-render/src/lib.rs
@@ -123,21 +123,26 @@ impl DeployAdapter for RenderAdapter {
             )));
         }
 
-        // Required Render override fields.
+        // Required Render override fields. Resolve via the three-tier
+        // resolver — env var → Cargo.toml → ~/.pocopine/config.toml —
+        // so OSS forks can set their own `owner_id` without touching
+        // the repo and CI can use `POCOPINE_RENDER_OWNER_ID`.
         let overrides = render_override(spec);
-        let raw_owner = overrides.owner_id.as_deref().unwrap_or("");
+        let raw_owner =
+            pocopine_deploy::config::resolve("render", "owner_id", overrides.owner_id.as_deref())
+                .unwrap_or_default();
         if raw_owner.is_empty() {
             out.push(Constraint::Refuse(
-                "render requires `[deploy.render].owner_id` (workspace ID — copy it from your Render dashboard's Account Settings → Workspaces)."
+                "render requires `owner_id` (workspace ID — copy it from your Render dashboard's Account Settings → Workspaces). Set via `pocopine deploy config set render owner_id <id>`, $POCOPINE_RENDER_OWNER_ID, or `[deploy.render].owner_id` in Cargo.toml."
                     .into(),
             ));
-        } else if is_placeholder_owner_id(raw_owner) {
+        } else if is_placeholder_owner_id(&raw_owner) {
             // Templates ship a `REPLACE_WITH_RENDER_WORKSPACE_ID`
             // sentinel so users know where to paste. Catching it here
             // turns a confusing 404 from Render's API ("owner not
             // found") into a clear next step before the deploy starts.
             out.push(Constraint::Refuse(format!(
-                "render: `[deploy.render].owner_id = \"{raw_owner}\"` is still the placeholder value. Replace it with your real workspace ID from Render's dashboard (Account Settings → Workspaces).",
+                "render: `owner_id = \"{raw_owner}\"` is still the placeholder value. Replace it via `pocopine deploy config set render owner_id <id>` or in Cargo.toml.",
             )));
         }
         // Resolve the container registry — explicit `image_registry`,
@@ -252,12 +257,17 @@ impl DeployAdapter for RenderAdapter {
 
         let token = load_render_token()?;
         let overrides = render_override(spec);
-        let owner_id = overrides
-            .owner_id
-            .as_deref()
-            .expect("detect_constraints refuses missing owner_id");
-        let region = overrides.region.as_deref().unwrap_or("oregon");
-        let plan = overrides.plan.as_deref().unwrap_or("starter");
+        // Three-tier resolution: env > Cargo.toml > ~/.pocopine/config.toml.
+        // `owner_id` is required; `detect_constraints` already refused
+        // when all three tiers were empty, so unwrap is safe here.
+        let owner_id =
+            pocopine_deploy::config::resolve("render", "owner_id", overrides.owner_id.as_deref())
+                .expect("detect_constraints refuses missing owner_id");
+        let region =
+            pocopine_deploy::config::resolve("render", "region", overrides.region.as_deref())
+                .unwrap_or_else(|| "oregon".to_owned());
+        let plan = pocopine_deploy::config::resolve("render", "plan", overrides.plan.as_deref())
+            .unwrap_or_else(|| "starter".to_owned());
 
         let env_vars = resolve_env_for_render(spec)?;
 
@@ -287,9 +297,14 @@ impl DeployAdapter for RenderAdapter {
         // For a private image, register a pull credential with Render
         // and attach it to each service — no dashboard step. `None` →
         // the image is assumed public and Render pulls anonymously.
+        let registry_username = pocopine_deploy::config::resolve(
+            "render",
+            "registry_username",
+            overrides.registry_username.as_deref(),
+        );
         let registry_credential_id = match pocopine_deploy::resolve_registry_credentials(
             &registry,
-            overrides.registry_username.as_deref(),
+            registry_username.as_deref(),
             spec.git_remote.as_deref(),
         ) {
             Some(creds) => Some(client.ensure_registry_credential(
@@ -339,7 +354,7 @@ impl DeployAdapter for RenderAdapter {
                         &s.id,
                         tag,
                         registry_credential_id.as_deref(),
-                        owner_id,
+                        &owner_id,
                     )?;
                     s
                 }
@@ -365,7 +380,7 @@ impl DeployAdapter for RenderAdapter {
 
             // 4. Trigger deploy with the new image URL and wait for live.
             let deploy = client.trigger_deploy(&svc.id, tag)?;
-            client.wait_deploy(&svc.id, &deploy.id, owner_id, WAIT_LIVE_SECS)?;
+            client.wait_deploy(&svc.id, &deploy.id, &owner_id, WAIT_LIVE_SECS)?;
 
             // Re-fetch the service to pick up the assigned onrender.com
             // URL (Render doesn't populate it on the create/list shape

--- a/crates/pocopine-deploy-render/src/lib.rs
+++ b/crates/pocopine-deploy-render/src/lib.rs
@@ -545,14 +545,19 @@ fn render_override(spec: &DeploySpec) -> RenderOverride {
         .unwrap_or_default()
 }
 
-/// Resolve the container registry for this deploy: explicit
-/// `[deploy.render].image_registry`, else derived from the git remote.
+/// Resolve the container registry for this deploy. Three-tier
+/// resolver for `image_registry`: `$POCOPINE_RENDER_IMAGE_REGISTRY` →
+/// `[deploy.render].image_registry` → `~/.pocopine/config.toml`.
+/// Falls back to `pocopine_deploy::resolve_registry`'s git-remote
+/// derivation when all three tiers are silent.
 fn resolved_registry(spec: &DeploySpec) -> Result<pocopine_deploy::ResolvedRegistry> {
     let overrides = render_override(spec);
-    pocopine_deploy::resolve_registry(
+    let image_registry = pocopine_deploy::config::resolve(
+        "render",
+        "image_registry",
         overrides.image_registry.as_deref(),
-        spec.git_remote.as_deref(),
-    )
+    );
+    pocopine_deploy::resolve_registry(image_registry.as_deref(), spec.git_remote.as_deref())
 }
 
 /// Map a registry host to Render's `registrycredentials` `registry`

--- a/crates/pocopine-deploy-render/src/lib.rs
+++ b/crates/pocopine-deploy-render/src/lib.rs
@@ -638,12 +638,18 @@ fn resolve_env_for_render(spec: &DeploySpec) -> Result<Vec<(String, String)>> {
 fn render_yaml(spec: &DeploySpec) -> String {
     use std::fmt::Write as _;
     let overrides = render_override(spec);
-    let region = overrides.region.clone().unwrap_or_else(|| "oregon".into());
-    let plan = overrides.plan.clone().unwrap_or_else(|| "starter".into());
-    let owner = overrides
-        .owner_id
-        .clone()
-        .unwrap_or_else(|| "REPLACE_ME".into());
+    // Use the three-tier resolver — same as `deploy()` — so the
+    // audit artefact reflects what the deploy actually sent.
+    // Reading `overrides.*` directly would diverge from the deploy
+    // path whenever a value comes from an env var or
+    // `~/.pocopine/config.toml` rather than `[deploy.render]`.
+    let region = pocopine_deploy::config::resolve("render", "region", overrides.region.as_deref())
+        .unwrap_or_else(|| "oregon".into());
+    let plan = pocopine_deploy::config::resolve("render", "plan", overrides.plan.as_deref())
+        .unwrap_or_else(|| "starter".into());
+    let owner =
+        pocopine_deploy::config::resolve("render", "owner_id", overrides.owner_id.as_deref())
+            .unwrap_or_else(|| "REPLACE_ME".into());
 
     let mut out = String::new();
     let _ = writeln!(

--- a/crates/pocopine-deploy/src/config.rs
+++ b/crates/pocopine-deploy/src/config.rs
@@ -122,12 +122,16 @@ pub fn env_var_name(host: &str, field: &str) -> String {
     format!("POCOPINE_{h}_{f}")
 }
 
-/// Field names probed when listing env-only entries. Adapters extend
-/// this list as new override fields are added; the list is not the
-/// source of truth for the resolver itself (`resolve` accepts any
-/// field name), only for the `list` command.
+/// Field names probed when listing env-only entries. Must include
+/// every field name any adapter passes to [`resolve`] — otherwise an
+/// env-only `$POCOPINE_<HOST>_<FIELD>` would be honored at deploy
+/// time but invisible in `pocopine deploy config list`. `resolve`
+/// itself accepts any string; this list is just the inventory for
+/// the `list` command.
 pub const KNOWN_FIELDS: &[&str] = &[
+    "environment",
     "image_registry",
+    "org",
     "owner_id",
     "plan",
     "primary_region",

--- a/crates/pocopine-deploy/src/config.rs
+++ b/crates/pocopine-deploy/src/config.rs
@@ -1,0 +1,394 @@
+//! Per-user host config (`~/.pocopine/config.toml`).
+//!
+//! Holds **non-secret** per-host defaults like `owner_id` /
+//! `workspace_id` / `region`. Mirrors [`crate::credentials`] but
+//! without the 0600 secrecy gate — these values are machine-local
+//! convenience, not credentials.
+//!
+//! Adapters resolve every host-override field via [`resolve`]
+//! (env → project Cargo.toml → this file). The three-tier order is
+//! the same pattern as `cargo` / `gh` / `kubectl` / `flyctl`: a
+//! per-user file is the default, the project's metadata overrides
+//! it for that crate, and env vars override both for CI.
+//!
+//! Layout:
+//!
+//! ```toml
+//! [default.render]
+//! owner_id = "tea-..."
+//! region   = "oregon"
+//!
+//! [default.railway]
+//! workspace_id = "ws-..."
+//! ```
+//!
+//! Fields are plain strings; nested structures live in Cargo.toml.
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+/// Path of the host-config file relative to `$HOME`.
+pub const REL_PATH: &str = ".pocopine/config.toml";
+
+/// Where a resolved value came from. Returned by [`resolve_with_source`]
+/// so `pocopine deploy doctor` / `config list` can show the user which
+/// tier won.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Source {
+    /// `POCOPINE_<HOST>_<FIELD>` environment variable.
+    Env,
+    /// `[package.metadata.pocopine.deploy.<host>] <field> = "..."` in
+    /// the project's Cargo.toml.
+    Project,
+    /// `[default.<host>] <field> = "..."` in `~/.pocopine/config.toml`.
+    File,
+}
+
+/// Three-tier field resolution: env → project Cargo.toml → user
+/// config file. Returns the first non-empty value, or `None` if all
+/// tiers are silent. The caller decides whether `None` is a hard
+/// error (e.g. `owner_id` is required) or falls back to a default.
+pub fn resolve(host: &str, field: &str, project: Option<&str>) -> Option<String> {
+    resolve_with_source(host, field, project).map(|(v, _)| v)
+}
+
+/// Same as [`resolve`] but also returns the tier the value came from.
+pub fn resolve_with_source(
+    host: &str,
+    field: &str,
+    project: Option<&str>,
+) -> Option<(String, Source)> {
+    // Tier 1: env var.
+    if let Ok(v) = std::env::var(env_var_name(host, field)) {
+        if !v.is_empty() {
+            return Some((v, Source::Env));
+        }
+    }
+    // Tier 2: project Cargo.toml.
+    if let Some(v) = project {
+        if !v.is_empty() {
+            return Some((v.to_owned(), Source::Project));
+        }
+    }
+    // Tier 3: ~/.pocopine/config.toml.
+    if let Ok(fields) = load_host(host) {
+        if let Some(v) = fields.get(field) {
+            if !v.is_empty() {
+                return Some((v.clone(), Source::File));
+            }
+        }
+    }
+    None
+}
+
+/// Read all stored fields for `host` from `~/.pocopine/config.toml`.
+/// Returns an empty map if the file is missing or the host has no
+/// entries. Errors only on parse failures.
+pub fn load_host(host: &str) -> Result<BTreeMap<String, String>> {
+    load_host_inner(&home()?, host)
+}
+
+/// Persist a single `field=value` pair under `[default.<host>]`.
+/// Idempotent: other hosts' and fields' entries are preserved.
+pub fn store_field(host: &str, field: &str, value: &str) -> Result<()> {
+    store_field_inner(&home()?, host, field, value)
+}
+
+/// Remove `field` from `[default.<host>]`. Returns `Ok(())` even if
+/// it didn't exist.
+pub fn revoke_field(host: &str, field: &str) -> Result<()> {
+    revoke_field_inner(&home()?, host, field)
+}
+
+/// `(host, field, source)` tuples for every (host, field) we can see —
+/// stored on disk plus probed env vars for `(host, KNOWN_FIELDS)`.
+/// Ordering: host-alphabetical, then field-alphabetical.
+pub fn list() -> Result<Vec<(String, String, Source)>> {
+    list_inner(&home()?, env_lookup)
+}
+
+/// Convert a host name and field name into the env-var key that wins
+/// over both tiers. Both segments are upper-cased and non-alphanumeric
+/// bytes collapse to `_` — so `(railway, workspace_id)` →
+/// `POCOPINE_RAILWAY_WORKSPACE_ID`, `(cf-pages, project_id)` →
+/// `POCOPINE_CF_PAGES_PROJECT_ID`.
+pub fn env_var_name(host: &str, field: &str) -> String {
+    let h = normalise(host);
+    let f = normalise(field);
+    format!("POCOPINE_{h}_{f}")
+}
+
+/// Field names probed when listing env-only entries. Adapters extend
+/// this list as new override fields are added; the list is not the
+/// source of truth for the resolver itself (`resolve` accepts any
+/// field name), only for the `list` command.
+pub const KNOWN_FIELDS: &[&str] = &[
+    "image_registry",
+    "owner_id",
+    "plan",
+    "primary_region",
+    "project",
+    "region",
+    "registry_username",
+    "workspace_id",
+];
+
+// ─── Internal seams (used by tests) ─────────────────────────────────────
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct Store {
+    #[serde(default, rename = "default")]
+    defaults: BTreeMap<String, BTreeMap<String, toml::Value>>,
+}
+
+fn load_host_inner(home: &Path, host: &str) -> Result<BTreeMap<String, String>> {
+    let path = home.join(REL_PATH);
+    if !path.exists() {
+        return Ok(BTreeMap::new());
+    }
+    let store = read_or_default(&path)?;
+    let Some(host_table) = store.defaults.get(host) else {
+        return Ok(BTreeMap::new());
+    };
+    let mut out = BTreeMap::new();
+    for (k, v) in host_table {
+        if let Some(s) = v.as_str() {
+            out.insert(k.clone(), s.to_owned());
+        }
+    }
+    Ok(out)
+}
+
+fn store_field_inner(home: &Path, host: &str, field: &str, value: &str) -> Result<()> {
+    let path = home.join(REL_PATH);
+    if let Some(dir) = path.parent() {
+        fs::create_dir_all(dir).with_context(|| format!("creating directory {}", dir.display()))?;
+    }
+    let mut store = read_or_default(&path)?;
+    store
+        .defaults
+        .entry(host.to_owned())
+        .or_default()
+        .insert(field.to_owned(), toml::Value::String(value.to_owned()));
+    let raw = toml::to_string_pretty(&store).context("serialising host config")?;
+    fs::write(&path, raw).with_context(|| format!("writing {}", path.display()))
+}
+
+fn revoke_field_inner(home: &Path, host: &str, field: &str) -> Result<()> {
+    let path = home.join(REL_PATH);
+    if !path.exists() {
+        return Ok(());
+    }
+    let mut store = read_or_default(&path)?;
+    if let Some(host_table) = store.defaults.get_mut(host) {
+        if host_table.remove(field).is_none() {
+            return Ok(());
+        }
+        if host_table.is_empty() {
+            store.defaults.remove(host);
+        }
+    } else {
+        return Ok(());
+    }
+    let raw = toml::to_string_pretty(&store).context("serialising host config")?;
+    fs::write(&path, raw).with_context(|| format!("writing {}", path.display()))
+}
+
+fn list_inner<F>(home: &Path, env: F) -> Result<Vec<(String, String, Source)>>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    use crate::credentials;
+    use std::collections::HashSet;
+
+    let mut out: Vec<(String, String, Source)> = Vec::new();
+    let mut seen: HashSet<(String, String)> = HashSet::new();
+
+    let path = home.join(REL_PATH);
+    if path.exists() {
+        let store = read_or_default(&path)?;
+        for (host, fields) in &store.defaults {
+            for field in fields.keys() {
+                let in_env = env(&env_var_name(host, field))
+                    .map(|v| !v.is_empty())
+                    .unwrap_or(false);
+                let source = if in_env { Source::Env } else { Source::File };
+                seen.insert((host.clone(), field.clone()));
+                out.push((host.clone(), field.clone(), source));
+            }
+        }
+    }
+
+    // Probe env vars for (KNOWN_HOSTS × KNOWN_FIELDS) we haven't already
+    // surfaced via the file. As with `credentials::list`, the env-var
+    // encoding isn't losslessly reversible (`cf-pages` and `cf_pages`
+    // both encode to `POCOPINE_CF_PAGES_*`) so we enumerate from the
+    // known list instead of scanning the environment.
+    for host in credentials::KNOWN_HOSTS {
+        for field in KNOWN_FIELDS {
+            let key = (host.to_string(), field.to_string());
+            if seen.contains(&key) {
+                continue;
+            }
+            if env(&env_var_name(host, field))
+                .map(|v| !v.is_empty())
+                .unwrap_or(false)
+            {
+                out.push((key.0, key.1, Source::Env));
+            }
+        }
+    }
+    out.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+    Ok(out)
+}
+
+fn read_or_default(path: &Path) -> Result<Store> {
+    if !path.exists() {
+        return Ok(Store::default());
+    }
+    let raw = fs::read_to_string(path)
+        .with_context(|| format!("reading host-config file {}", path.display()))?;
+    toml::from_str(&raw).with_context(|| format!("parsing host-config file {}", path.display()))
+}
+
+fn normalise(s: &str) -> String {
+    s.chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() {
+                c.to_ascii_uppercase()
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn home() -> Result<PathBuf> {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .context("$HOME is unset; cannot resolve ~/.pocopine/config.toml location")
+}
+
+fn env_lookup(key: &str) -> Option<String> {
+    std::env::var(key).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn tmp_home() -> tempfile::TempDir {
+        tempfile::tempdir().expect("create tempdir")
+    }
+
+    #[test]
+    fn env_var_name_normalises_host_and_field() {
+        assert_eq!(
+            env_var_name("render", "owner_id"),
+            "POCOPINE_RENDER_OWNER_ID"
+        );
+        assert_eq!(
+            env_var_name("cf-pages", "project_id"),
+            "POCOPINE_CF_PAGES_PROJECT_ID"
+        );
+        assert_eq!(
+            env_var_name("railway", "workspace_id"),
+            "POCOPINE_RAILWAY_WORKSPACE_ID"
+        );
+    }
+
+    #[test]
+    fn load_host_returns_empty_when_file_missing() {
+        let home = tmp_home();
+        assert!(load_host_inner(home.path(), "render").unwrap().is_empty());
+    }
+
+    #[test]
+    fn store_and_load_field_roundtrip() {
+        let home = tmp_home();
+        store_field_inner(home.path(), "render", "owner_id", "tea-abc").unwrap();
+        store_field_inner(home.path(), "render", "region", "oregon").unwrap();
+        store_field_inner(home.path(), "railway", "workspace_id", "ws-xyz").unwrap();
+
+        let render = load_host_inner(home.path(), "render").unwrap();
+        assert_eq!(render.get("owner_id").map(String::as_str), Some("tea-abc"));
+        assert_eq!(render.get("region").map(String::as_str), Some("oregon"));
+
+        let railway = load_host_inner(home.path(), "railway").unwrap();
+        assert_eq!(
+            railway.get("workspace_id").map(String::as_str),
+            Some("ws-xyz")
+        );
+    }
+
+    #[test]
+    fn revoke_field_removes_only_that_field() {
+        let home = tmp_home();
+        store_field_inner(home.path(), "render", "owner_id", "tea-abc").unwrap();
+        store_field_inner(home.path(), "render", "region", "oregon").unwrap();
+        revoke_field_inner(home.path(), "render", "owner_id").unwrap();
+
+        let render = load_host_inner(home.path(), "render").unwrap();
+        assert!(!render.contains_key("owner_id"));
+        assert_eq!(render.get("region").map(String::as_str), Some("oregon"));
+    }
+
+    #[test]
+    fn revoke_last_field_drops_empty_host_table() {
+        let home = tmp_home();
+        store_field_inner(home.path(), "render", "owner_id", "tea-abc").unwrap();
+        revoke_field_inner(home.path(), "render", "owner_id").unwrap();
+
+        let raw = fs::read_to_string(home.path().join(REL_PATH)).unwrap();
+        // Empty `[default]` table is fine; an empty `[default.render]`
+        // would re-appear on next list — make sure we collapsed it.
+        assert!(
+            !raw.contains("[default.render]"),
+            "empty host table left behind: {raw}",
+        );
+    }
+
+    #[test]
+    fn list_merges_file_and_env_with_correct_source() {
+        let home = tmp_home();
+        store_field_inner(home.path(), "render", "owner_id", "tea-abc").unwrap();
+
+        let env: HashMap<&str, &str> =
+            HashMap::from([("POCOPINE_RAILWAY_WORKSPACE_ID", "ws-from-env")]);
+        let envfn = |k: &str| env.get(k).map(|s| s.to_string());
+
+        let listed = list_inner(home.path(), envfn).unwrap();
+        // Host-then-field alphabetical.
+        let render_entry = listed
+            .iter()
+            .find(|(h, f, _)| h == "render" && f == "owner_id")
+            .expect("render/owner_id present");
+        assert_eq!(render_entry.2, Source::File);
+        let railway_entry = listed
+            .iter()
+            .find(|(h, f, _)| h == "railway" && f == "workspace_id")
+            .expect("railway/workspace_id present via env");
+        assert_eq!(railway_entry.2, Source::Env);
+    }
+
+    #[test]
+    fn list_marks_env_overriding_file() {
+        let home = tmp_home();
+        store_field_inner(home.path(), "render", "owner_id", "tea-abc").unwrap();
+        let env: HashMap<&str, &str> =
+            HashMap::from([("POCOPINE_RENDER_OWNER_ID", "tea-from-env")]);
+        let envfn = |k: &str| env.get(k).map(|s| s.to_string());
+
+        let listed = list_inner(home.path(), envfn).unwrap();
+        let render_entry = listed
+            .iter()
+            .find(|(h, f, _)| h == "render" && f == "owner_id")
+            .unwrap();
+        assert_eq!(render_entry.2, Source::Env);
+    }
+}

--- a/crates/pocopine-deploy/src/config.rs
+++ b/crates/pocopine-deploy/src/config.rs
@@ -179,7 +179,7 @@ fn store_field_inner(home: &Path, host: &str, field: &str, value: &str) -> Resul
         .or_default()
         .insert(field.to_owned(), toml::Value::String(value.to_owned()));
     let raw = toml::to_string_pretty(&store).context("serialising host config")?;
-    fs::write(&path, raw).with_context(|| format!("writing {}", path.display()))
+    write_atomic(&path, raw.as_bytes())
 }
 
 fn revoke_field_inner(home: &Path, host: &str, field: &str) -> Result<()> {
@@ -199,7 +199,7 @@ fn revoke_field_inner(home: &Path, host: &str, field: &str) -> Result<()> {
         return Ok(());
     }
     let raw = toml::to_string_pretty(&store).context("serialising host config")?;
-    fs::write(&path, raw).with_context(|| format!("writing {}", path.display()))
+    write_atomic(&path, raw.as_bytes())
 }
 
 fn list_inner<F>(home: &Path, env: F) -> Result<Vec<(String, String, Source)>>
@@ -272,9 +272,41 @@ fn normalise(s: &str) -> String {
 }
 
 fn home() -> Result<PathBuf> {
+    // Mirrors `credentials::home`: prefer $HOME (Unix / macOS / WSL),
+    // fall back to %USERPROFILE% (stock Windows). Without the
+    // fallback `pocopine deploy auth` would work on Windows while
+    // `pocopine deploy config` would error, since the two modules
+    // share a crate but used to drift on this lookup.
     std::env::var_os("HOME")
         .map(PathBuf::from)
-        .context("$HOME is unset; cannot resolve ~/.pocopine/config.toml location")
+        .or_else(|| std::env::var_os("USERPROFILE").map(PathBuf::from))
+        .context("could not determine home directory ($HOME / %USERPROFILE% unset)")
+}
+
+/// Atomic write: write to `<path>.tmp`, fsync, then rename. Prevents
+/// a crash mid-write from truncating the live file (which would lose
+/// every other host's entries since the store is rewritten in one
+/// pass). Mirrors `credentials::write_secure` but without the 0600
+/// mode — host-config fields are identifiers, not credentials.
+fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
+    use std::io::Write;
+
+    let tmp = path.with_extension("toml.tmp");
+    {
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&tmp)
+            .with_context(|| format!("opening {}", tmp.display()))?;
+        f.write_all(bytes)
+            .with_context(|| format!("writing {}", tmp.display()))?;
+        f.sync_all()
+            .with_context(|| format!("fsync {}", tmp.display()))?;
+    }
+    fs::rename(&tmp, path)
+        .with_context(|| format!("renaming {} -> {}", tmp.display(), path.display()))?;
+    Ok(())
 }
 
 fn env_lookup(key: &str) -> Option<String> {

--- a/crates/pocopine-deploy/src/lib.rs
+++ b/crates/pocopine-deploy/src/lib.rs
@@ -18,6 +18,7 @@
 pub mod adapter;
 pub mod artefact;
 pub mod common;
+pub mod config;
 pub mod credentials;
 pub mod docker;
 pub mod registry;


### PR DESCRIPTION
## Summary

Adds a `~/.pocopine/config.toml` tier for non-secret per-host fields (`owner_id` / `workspace_id` / `org` / `region` / `plan` / `registry_username` / etc.) so OSS forks can deploy without committing identifying data to the repo.

Resolution order, highest priority first:
1. `$POCOPINE_<HOST>_<FIELD>` env var — for CI / one-offs.
2. `[package.metadata.pocopine.deploy.<host>] <field>` in the project's Cargo.toml — for project-scoped pins.
3. `[default.<host>] <field>` in `~/.pocopine/config.toml` — per-user, machine-local, never committed.

Mirrors the convention you already get from cargo / gh / kubectl / flyctl. Tokens still live in `~/.pocopine/credentials.toml` with the existing 0600 gate — this PR is only about non-secret identifiers.

## Commits

1. **`pocopine-deploy`: per-user host config resolver (`~/.pocopine/config.toml`)** — new `pocopine_deploy::config` module: storage CRUD, three-tier `resolve` / `resolve_with_source`, `env_var_name` helper, `list` for `(host, field, source)` enumeration, and 7 unit tests covering encoding, store/load roundtrip, revoke, env-overrides-file precedence, empty-table collapse.

2. **`pocopine-deploy-render`: route host overrides through `config::resolve`** — `owner_id`, `region`, `plan`, `registry_username`. `detect_constraints` now walks all three tiers before declaring the placeholder sentinel; refusal messages point at all three set-this paths.

3. **`pocopine-deploy-railway`: route host overrides through `config::resolve`** — `project`, `environment`, `workspace_id`, `region`, `registry_username`. `workspace_id` is the headline win — Railway team IDs reveal which team is hosting the project, and now stay out of the OSS repo.

4. **`pocopine-deploy-fly`: route `org` + `primary_region` through `config::resolve`** — `volumes` and `regions` stay as project-structural config; they're not per-developer preference.

5. **`pocopine-cli`: `pocopine deploy config` subcommand** — `set` / `get` / `list` / `revoke`. Mirrors `deploy auth` for the non-secret side. `get` surfaces which tier won with a clear source label so users can debug "why did my deploy use this `owner_id`?".

## UX

```bash
# One-time setup per user, per machine
pocopine deploy config set render owner_id tea-d86g...
pocopine deploy config set railway workspace_id ws-abc...

# Project Cargo.toml stays clean — no identifying data
[package.metadata.pocopine.deploy.render]
plan   = "free"
region = "oregon"
# owner_id resolved at deploy time from env or ~/.pocopine/config.toml

# CI override (no file involved)
POCOPINE_RENDER_OWNER_ID=tea-d86g... pocopine deploy --target render

# Audit the resolution
pocopine deploy config get render owner_id
# tea-d86g...
#   source: file (~/.pocopine/config.toml)

pocopine deploy config list
# render       owner_id                file
# railway      workspace_id            env
```

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets -- -D warnings` for `pocopine-deploy{,-fly,-railway,-render}` and `pocopine-cli`
- [x] `cargo clippy --target wasm32-unknown-unknown -- -D warnings` (the new module is host-only safe — `$HOME` lookup is read-only, no panics on wasm where it's never called)
- [x] Full unit test suite (7 new tests in `config`, 220+ existing tests still passing)
- [x] CLI smoke test: `set` writes the file, `list` shows the right `Source`
- [ ] Reviewer to validate the `Source` taxonomy in the get/list output is the right shape for `deploy doctor` to consume next

## Known follow-ups (not in this PR)

- `pocopine deploy doctor` should walk every (host, KNOWN_FIELDS) tuple and print the resolved value + source so users can audit their resolution stack at a glance. The `resolve_with_source` API already exposes the right shape; just needs wiring.
- The `examples/keep/Cargo.toml` `owner_id` placeholder can now be removed entirely — users set it via `pocopine deploy config set render owner_id`. Held back from this PR so the change is scoped to the resolver.