### PR TITLE
Add sync resource view subscriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4665,6 +4665,7 @@ dependencies = [
 name = "pocopine-sync-crud-macros"
 version = "0.1.0"
 dependencies = [
+ "js-sys",
  "pocopine-auth",
  "pocopine-core",
  "pocopine-sync",
@@ -4675,6 +4676,7 @@ dependencies = [
  "syn 2.0.117",
  "tokio",
  "trybuild",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4647,6 +4647,7 @@ dependencies = [
  "async-trait",
  "http 1.4.0",
  "http-body-util",
+ "js-sys",
  "pocopine-auth",
  "pocopine-core",
  "pocopine-server",
@@ -4657,6 +4658,7 @@ dependencies = [
  "tokio",
  "tower",
  "uuid",
+ "wasm-bindgen",
 ]
 
 [[package]]

--- a/crates/pocopine-sync-crud-macros/Cargo.toml
+++ b/crates/pocopine-sync-crud-macros/Cargo.toml
@@ -15,6 +15,7 @@ quote = { workspace = true }
 syn = { workspace = true }
 
 [dev-dependencies]
+js-sys = { workspace = true }
 pocopine-auth = { workspace = true }
 pocopine-core = { workspace = true }
 pocopine-sync = { workspace = true }
@@ -22,3 +23,4 @@ pocopine-sync-crud = { workspace = true }
 serde = { workspace = true }
 tokio = { version = "1", features = ["macros", "rt"] }
 trybuild = "1"
+wasm-bindgen = { workspace = true }

--- a/crates/pocopine-sync-crud-macros/src/lib.rs
+++ b/crates/pocopine-sync-crud-macros/src/lib.rs
@@ -131,6 +131,8 @@ fn expand_resource(args: ResourceArgs, item: ItemImpl) -> syn::Result<TokenStrea
             pub type CreateOptions = ::pocopine_sync_crud::CreateOptions<Row>;
             pub type SaveOptions = ::pocopine_sync_crud::SaveOptions<Row>;
             pub type RemoveOptions = ::pocopine_sync_crud::RemoveOptions;
+            pub type View = ::pocopine_sync_crud::LocalResourceView<Id, Row>;
+            pub type ViewState = ::pocopine_sync_crud::LocalResourceViewState<Id, Row>;
             pub type Outcome = ::pocopine_sync_crud::CrudOutcome<Id, Row>;
             pub type Queued = ::pocopine_sync_crud::Queued<Id>;
             pub type Client<C> = ::pocopine_sync_crud::CrudClientResource<C, Id, Row>;
@@ -189,7 +191,7 @@ fn expand_resource(args: ResourceArgs, item: ItemImpl) -> syn::Result<TokenStrea
 
                 pub fn view(
                     &self,
-                ) -> ::pocopine_sync::SyncResult<::pocopine_sync_crud::LocalResourceView<Id, Row>>
+                ) -> ::pocopine_sync::SyncResult<View>
                 where
                     Id: ::pocopine_sync_crud::ResourceId,
                     Row: Clone,
@@ -200,6 +202,19 @@ fn expand_resource(args: ResourceArgs, item: ItemImpl) -> syn::Result<TokenStrea
                         )
                     })?;
                     view((self.selector)(&mut state))
+                }
+
+                pub fn observe_view<F>(&self, callback: F) -> ::pocopine_sync::SyncResult<()>
+                where
+                    Id: ::pocopine_sync_crud::ResourceId,
+                    Row: Clone,
+                    F: Fn(&ViewState, Option<&ViewState>) + 'static,
+                {
+                    ::pocopine_sync_crud::observe_local_resource_view::<C, Id, Row, F>(
+                        self.handle.clone(),
+                        self.selector,
+                        callback,
+                    )
                 }
 
                 pub fn client(&self) -> ::pocopine_sync::SyncResult<Client<C>>
@@ -372,7 +387,7 @@ fn expand_resource(args: ResourceArgs, item: ItemImpl) -> syn::Result<TokenStrea
 
             pub fn view(
                 state: &::pocopine_sync::CollectionState<Row>,
-            ) -> ::pocopine_sync::SyncResult<::pocopine_sync_crud::LocalResourceView<Id, Row>> {
+            ) -> ::pocopine_sync::SyncResult<View> {
                 ::pocopine_sync_crud::local_resource_view(state)
             }
 

--- a/crates/pocopine-sync-crud-macros/tests/resource.rs
+++ b/crates/pocopine-sync-crud-macros/tests/resource.rs
@@ -14,7 +14,7 @@ use pocopine_sync_crud::{
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::JsValue;
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Customer {
     pub id: String,
 }

--- a/crates/pocopine-sync-crud-macros/tests/resource.rs
+++ b/crates/pocopine-sync-crud-macros/tests/resource.rs
@@ -2,18 +2,19 @@
 
 use std::{cell::RefCell, rc::Rc};
 
-use pocopine_core::ScopeId;
+use pocopine_core::{ComponentState, Scope, ScopeId};
 use pocopine_sync::{
     sync_plugin, CollectionSelector, CollectionState, Handle, MemoryLocalStore, RowVersion,
-    SyncClient, SyncCollection, SyncDeviceId, SyncLocalIdentity, SyncLocalStoreHandle, SyncResult,
-    SyncStreamName,
+    SyncClient, SyncCollection, SyncCollectionName, SyncCursor, SyncDeviceId, SyncLocalIdentity,
+    SyncLocalStoreHandle, SyncPullResponse, SyncResult, SyncRow, SyncStreamName,
 };
 use pocopine_sync_crud::{
     CrudClientResource, CrudOutcome, CrudRemoveResult, CrudSource, CrudWriteResult, Queued,
 };
 use serde::{Deserialize, Serialize};
+use wasm_bindgen::JsValue;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct Customer {
     pub id: String,
 }
@@ -30,8 +31,56 @@ struct TestPage {
     customers: CollectionState<Customer>,
 }
 
+#[derive(Default)]
+struct Consumer;
+
 fn customers_state(page: &mut TestPage) -> &mut CollectionState<Customer> {
     &mut page.customers
+}
+
+fn host_safe_js_value() -> JsValue {
+    // `JsValue::UNDEFINED` touches imported JS statics and panics in native
+    // tests. The generated observer test never inspects this dummy value.
+    JsValue::from_str("")
+}
+
+impl ComponentState for TestPage {
+    fn get(&self, _key: &str) -> JsValue {
+        host_safe_js_value()
+    }
+
+    fn set(&mut self, _key: &str, _value: JsValue) {}
+
+    fn invoke(&mut self, _name: &str, _args: &js_sys::Array) -> JsValue {
+        host_safe_js_value()
+    }
+
+    fn keys(&self) -> &'static [&'static str] {
+        &[]
+    }
+}
+
+impl ComponentState for Consumer {
+    fn get(&self, _key: &str) -> JsValue {
+        host_safe_js_value()
+    }
+
+    fn set(&mut self, _key: &str, _value: JsValue) {}
+
+    fn invoke(&mut self, _name: &str, _args: &js_sys::Array) -> JsValue {
+        host_safe_js_value()
+    }
+
+    fn keys(&self) -> &'static [&'static str] {
+        &[]
+    }
+}
+
+fn customer_row(id: &str, version: &str) -> SyncRow<Customer> {
+    SyncRow::new(id, Customer { id: id.to_string() })
+        .unwrap()
+        .version(version)
+        .unwrap()
 }
 
 #[pocopine_sync_crud::resource(name = "customers")]
@@ -108,6 +157,9 @@ fn resource_attribute_generates_module_contract() {
     let _builder = customers::resource(Customers).unwrap();
     let _resource: Option<customers::Resource<()>> = None;
     let _resource_new = customers::Resource::<()>::new;
+    let _observe_view = customers::Resource::<()>::observe_view::<
+        fn(&customers::ViewState, Option<&customers::ViewState>),
+    >;
     let _use_resource = customers::use_resource::<()>;
     let _collection = customers::collection::<()>;
     let _use_server = customers::Resource::<()>::use_server;
@@ -123,6 +175,8 @@ fn resource_attribute_generates_module_contract() {
         let _runtime_outcome: Option<CrudOutcome<customers::Id, customers::Row>> = None;
         let _runtime_queued: Option<Queued<customers::Id>> = None;
         let _runtime_client: Option<CrudClientResource<C, customers::Id, customers::Row>> = None;
+        let _view: Option<customers::View> = None;
+        let _view_state: Option<customers::ViewState> = None;
 
         customers::client(collection, state)
     }
@@ -183,6 +237,57 @@ async fn generated_resource_create_queues_to_local_store() {
         .await
         .unwrap();
     assert_eq!(pending.len(), 1);
+}
+
+#[test]
+fn generated_resource_observe_view_tracks_state() {
+    pocopine_core::set_auto_flush(false);
+
+    let sync = sync_plugin().into_client();
+    let page = Rc::new(RefCell::new(TestPage::default()));
+    let page_scope = Scope::new(page.clone());
+    let handle = Handle::new(page, page_scope.id);
+    let resource = customers::use_resource(&sync, handle.clone(), customers_state);
+    let consumer_scope = Scope::new(Rc::new(RefCell::new(Consumer)));
+    let observed: Rc<RefCell<Vec<customers::ViewState>>> = Rc::new(RefCell::new(Vec::new()));
+    let observed_for_callback = observed.clone();
+
+    pocopine_core::scope::with_current_scope_id(consumer_scope.id, || {
+        resource
+            .observe_view(move |state, _previous| {
+                observed_for_callback.borrow_mut().push(state.clone());
+            })
+            .unwrap();
+    });
+
+    assert_eq!(observed.borrow().len(), 1);
+    assert_eq!(observed.borrow()[0].view().unwrap().rows.len(), 0);
+
+    {
+        let mut page = handle.borrow_mut();
+        let request = page.customers.begin_initial();
+        page.customers.apply_pull(
+            request,
+            SyncPullResponse::snapshot(
+                SyncStreamName::new(customers::NAME).unwrap(),
+                SyncCollectionName::new(customers::NAME).unwrap(),
+                vec![customer_row("customer_1", "row_1")],
+                Some(SyncCursor::new("cursor_1").unwrap()),
+            ),
+        );
+    }
+    pocopine_core::trigger_scope(page_scope.id);
+    pocopine_core::flush_sync();
+
+    assert_eq!(observed.borrow().len(), 2);
+    assert_eq!(
+        observed.borrow()[1].view().unwrap().rows[0].id,
+        "customer_1"
+    );
+
+    Scope::remove(consumer_scope.id);
+    Scope::remove(page_scope.id);
+    pocopine_core::set_auto_flush(true);
 }
 
 #[test]

--- a/crates/pocopine-sync-crud/Cargo.toml
+++ b/crates/pocopine-sync-crud/Cargo.toml
@@ -8,9 +8,14 @@ description = "Typed local-first CRUD contracts for Pocopine sync."
 
 [dependencies]
 pocopine-sync-crud-macros = { workspace = true }
+pocopine-core = { workspace = true }
 pocopine-sync = { workspace = true }
 serde = { workspace = true }
 uuid = { version = "1", features = ["v4", "js", "serde"] }
+
+[dev-dependencies]
+js-sys = { workspace = true }
+wasm-bindgen = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 async-trait = "0.1"
@@ -20,7 +25,6 @@ serde_json = { workspace = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 http-body-util = "0.1"
 http = { workspace = true }
-pocopine-core = { workspace = true }
 pocopine-server = { workspace = true }
 tokio = { version = "1", features = ["macros", "rt"] }
 tower = { version = "0.5", features = ["util"] }

--- a/crates/pocopine-sync-crud/src/lib.rs
+++ b/crates/pocopine-sync-crud/src/lib.rs
@@ -13,6 +13,7 @@ mod mutation;
 mod options;
 mod outcome;
 mod row;
+mod subscription;
 mod transaction;
 mod view;
 
@@ -37,11 +38,12 @@ pub use resource::{
 pub use row::optimistic_row;
 #[cfg(not(target_arch = "wasm32"))]
 pub use source::{CrudConflict, CrudRemoveResult, CrudSource, CrudWriteResult};
+pub use subscription::observe_local_resource_view;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use resource::RowVersionOf;
 pub use transaction::{Transaction, TransactionBindable, TransactionFuture, TransactionRunner};
 pub use view::{
     local_resource_view, LocalResourcePendingMutation, LocalResourceRow, LocalResourceRowStatus,
-    LocalResourceView,
+    LocalResourceView, LocalResourceViewState,
 };

--- a/crates/pocopine-sync-crud/src/subscription.rs
+++ b/crates/pocopine-sync-crud/src/subscription.rs
@@ -1,6 +1,15 @@
-use pocopine_sync::{CollectionSelector, Handle, SyncError, SyncResult};
+use std::cell::RefCell;
+use std::rc::Rc;
 
-use crate::{LocalResourceViewState, ResourceId};
+use pocopine_core::EffectId;
+use pocopine_sync::{
+    CollectionSelector, Handle, MutationId, RowVersion, SyncError, SyncOp, SyncResult,
+};
+
+use crate::{
+    LocalResourcePendingMutation, LocalResourceRow, LocalResourceRowStatus, LocalResourceViewState,
+    ResourceId,
+};
 
 const RESOURCE_VIEW_OBSERVE_KEY: &str = "__pp_sync_crud_resource_view";
 
@@ -21,7 +30,7 @@ pub fn observe_local_resource_view<C, Id, Row, F>(
 where
     C: 'static,
     Id: ResourceId + 'static,
-    Row: Clone + PartialEq + 'static,
+    Row: Clone + 'static,
     F: Fn(&LocalResourceViewState<Id, Row>, Option<&LocalResourceViewState<Id, Row>>) + 'static,
 {
     let consumer_scope = pocopine_core::current_scope_id().ok_or_else(|| {
@@ -29,27 +38,64 @@ where
             "sync CRUD resource observer used outside a component handler/lifecycle hook",
         )
     })?;
-    let owner_scope = handle.scope_id();
-    let source = move || {
-        pocopine_core::track(owner_scope, RESOURCE_VIEW_OBSERVE_KEY);
-        read_resource_view_state(&handle, selector)
-    };
-
     #[cfg(target_arch = "wasm32")]
     {
-        let _ = consumer_scope;
-        pocopine_core::watch_scoped(source, callback);
+        let pending: Rc<std::cell::Cell<Option<EffectId>>> = Rc::new(std::cell::Cell::new(None));
+        let pending_for_install = pending.clone();
+        pocopine_core::tick::next(move || {
+            let effect = install_resource_view_observer(handle, selector, callback);
+            pending_for_install.set(Some(effect));
+        });
+        pocopine_core::on_scope_unmount_for(consumer_scope, move || {
+            if let Some(effect) = pending.take() {
+                pocopine_core::release(effect);
+            }
+        });
     }
 
     #[cfg(not(target_arch = "wasm32"))]
     {
-        let effect = pocopine_core::watch(source, callback);
+        let effect = install_resource_view_observer(handle, selector, callback);
         pocopine_core::on_scope_unmount_for(consumer_scope, move || {
             pocopine_core::release(effect);
         });
     }
 
     Ok(())
+}
+
+fn install_resource_view_observer<C, Id, Row, F>(
+    handle: Handle<C>,
+    selector: CollectionSelector<C, Row>,
+    callback: F,
+) -> EffectId
+where
+    C: 'static,
+    Id: ResourceId + 'static,
+    Row: Clone + 'static,
+    F: Fn(&LocalResourceViewState<Id, Row>, Option<&LocalResourceViewState<Id, Row>>) + 'static,
+{
+    let owner_scope = handle.scope_id();
+    let previous: Rc<RefCell<Option<LocalResourceViewState<Id, Row>>>> =
+        Rc::new(RefCell::new(None));
+    let previous_fingerprint: Rc<RefCell<Option<ResourceViewFingerprint<Id>>>> =
+        Rc::new(RefCell::new(None));
+
+    pocopine_core::effect(move || {
+        pocopine_core::track(owner_scope, RESOURCE_VIEW_OBSERVE_KEY);
+
+        let next = read_resource_view_state(&handle, selector);
+        let next_fingerprint = ResourceViewFingerprint::from_state(&next);
+        let last_fingerprint = previous_fingerprint.borrow().clone();
+        if last_fingerprint.as_ref() == Some(&next_fingerprint) {
+            return;
+        }
+
+        let last = previous.borrow().clone();
+        callback(&next, last.as_ref());
+        *previous.borrow_mut() = Some(next);
+        *previous_fingerprint.borrow_mut() = Some(next_fingerprint);
+    })
 }
 
 fn read_resource_view_state<C, Id, Row>(
@@ -65,6 +111,109 @@ where
         Ok(mut state) => LocalResourceViewState::from_collection_state(selector(&mut state)),
         Err(_) => {
             LocalResourceViewState::from_error("sync CRUD resource state is already borrowed")
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ResourceViewFingerprint<Id> {
+    rows: Vec<ResourceRowFingerprint<Id>>,
+    pending_mutations: Vec<ResourcePendingFingerprint<Id>>,
+    loading: bool,
+    syncing: bool,
+    stale: bool,
+    error: String,
+    version: u64,
+    pending_count: u64,
+    conflict_count: u64,
+    rejected_count: u64,
+    state_error: Option<String>,
+}
+
+impl<Id> ResourceViewFingerprint<Id>
+where
+    Id: Clone,
+{
+    fn from_state<Row>(state: &LocalResourceViewState<Id, Row>) -> Self {
+        match state {
+            LocalResourceViewState::Ready(view) => Self {
+                rows: view
+                    .rows
+                    .iter()
+                    .map(ResourceRowFingerprint::from_row)
+                    .collect(),
+                pending_mutations: view
+                    .pending_mutations
+                    .iter()
+                    .map(ResourcePendingFingerprint::from_pending)
+                    .collect(),
+                loading: view.loading,
+                syncing: view.syncing,
+                stale: view.stale,
+                error: view.error.clone(),
+                version: view.version,
+                pending_count: view.pending_count,
+                conflict_count: view.conflict_count,
+                rejected_count: view.rejected_count,
+                state_error: None,
+            },
+            LocalResourceViewState::Error(error) => Self {
+                rows: Vec::new(),
+                pending_mutations: Vec::new(),
+                loading: false,
+                syncing: false,
+                stale: false,
+                error: String::new(),
+                version: 0,
+                pending_count: 0,
+                conflict_count: 0,
+                rejected_count: 0,
+                state_error: Some(error.clone()),
+            },
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ResourceRowFingerprint<Id> {
+    id: Id,
+    row_version: Option<RowVersion>,
+    base_version: Option<RowVersion>,
+    status: LocalResourceRowStatus,
+}
+
+impl<Id> ResourceRowFingerprint<Id>
+where
+    Id: Clone,
+{
+    fn from_row<Row>(row: &LocalResourceRow<Id, Row>) -> Self {
+        Self {
+            id: row.id.clone(),
+            row_version: row.row_version.clone(),
+            base_version: row.base_version.clone(),
+            status: row.status,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct ResourcePendingFingerprint<Id> {
+    mutation_id: MutationId,
+    id: Option<Id>,
+    op: SyncOp,
+    base_version: Option<RowVersion>,
+}
+
+impl<Id> ResourcePendingFingerprint<Id>
+where
+    Id: Clone,
+{
+    fn from_pending(pending: &LocalResourcePendingMutation<Id>) -> Self {
+        Self {
+            mutation_id: pending.mutation_id.clone(),
+            id: pending.id.clone(),
+            op: pending.op,
+            base_version: pending.base_version.clone(),
         }
     }
 }

--- a/crates/pocopine-sync-crud/src/subscription.rs
+++ b/crates/pocopine-sync-crud/src/subscription.rs
@@ -1,0 +1,277 @@
+use pocopine_sync::{CollectionSelector, Handle, SyncError, SyncResult};
+
+use crate::{LocalResourceViewState, ResourceId};
+
+const RESOURCE_VIEW_OBSERVE_KEY: &str = "__pp_sync_crud_resource_view";
+
+/// Observe a typed local resource view from the current Pocopine scope.
+///
+/// The observer tracks the scope that owns the sync collection and is
+/// released when the current consumer scope unmounts. Generated resources
+/// should call this helper instead of exposing raw `CollectionState`.
+///
+/// Browser installs use Pocopine's scoped watcher and defer the first callback
+/// to the next tick to avoid lifecycle re-entrant borrows. Native test/runtime
+/// installs run synchronously and bind cleanup to the current scope explicitly.
+pub fn observe_local_resource_view<C, Id, Row, F>(
+    handle: Handle<C>,
+    selector: CollectionSelector<C, Row>,
+    callback: F,
+) -> SyncResult<()>
+where
+    C: 'static,
+    Id: ResourceId + 'static,
+    Row: Clone + PartialEq + 'static,
+    F: Fn(&LocalResourceViewState<Id, Row>, Option<&LocalResourceViewState<Id, Row>>) + 'static,
+{
+    let consumer_scope = pocopine_core::current_scope_id().ok_or_else(|| {
+        SyncError::client(
+            "sync CRUD resource observer used outside a component handler/lifecycle hook",
+        )
+    })?;
+    let owner_scope = handle.scope_id();
+    let source = move || {
+        pocopine_core::track(owner_scope, RESOURCE_VIEW_OBSERVE_KEY);
+        read_resource_view_state(&handle, selector)
+    };
+
+    #[cfg(target_arch = "wasm32")]
+    {
+        let _ = consumer_scope;
+        pocopine_core::watch_scoped(source, callback);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        let effect = pocopine_core::watch(source, callback);
+        pocopine_core::on_scope_unmount_for(consumer_scope, move || {
+            pocopine_core::release(effect);
+        });
+    }
+
+    Ok(())
+}
+
+fn read_resource_view_state<C, Id, Row>(
+    handle: &Handle<C>,
+    selector: CollectionSelector<C, Row>,
+) -> LocalResourceViewState<Id, Row>
+where
+    C: 'static,
+    Id: ResourceId,
+    Row: Clone,
+{
+    match handle.try_borrow_mut() {
+        Ok(mut state) => LocalResourceViewState::from_collection_state(selector(&mut state)),
+        Err(_) => {
+            LocalResourceViewState::from_error("sync CRUD resource state is already borrowed")
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    use pocopine_core::{ComponentState, Scope};
+    use pocopine_sync::{
+        CollectionState, SyncCollectionName, SyncCursor, SyncPullResponse, SyncRow, SyncStreamName,
+    };
+    use serde::{Deserialize, Serialize};
+    use wasm_bindgen::JsValue;
+
+    use super::*;
+
+    fn host_safe_js_value() -> JsValue {
+        // `JsValue::UNDEFINED` touches imported JS statics and panics in
+        // native tests. The observer tests never inspect this dummy value.
+        JsValue::from_str("")
+    }
+
+    #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+    struct Post {
+        title: String,
+    }
+
+    #[derive(Default)]
+    struct Owner {
+        posts: CollectionState<Post>,
+    }
+
+    #[derive(Default)]
+    struct Consumer;
+
+    impl ComponentState for Owner {
+        fn get(&self, _key: &str) -> JsValue {
+            host_safe_js_value()
+        }
+
+        fn set(&mut self, _key: &str, _value: JsValue) {}
+
+        fn invoke(&mut self, _name: &str, _args: &js_sys::Array) -> JsValue {
+            host_safe_js_value()
+        }
+
+        fn keys(&self) -> &'static [&'static str] {
+            &[]
+        }
+    }
+
+    impl ComponentState for Consumer {
+        fn get(&self, _key: &str) -> JsValue {
+            host_safe_js_value()
+        }
+
+        fn set(&mut self, _key: &str, _value: JsValue) {}
+
+        fn invoke(&mut self, _name: &str, _args: &js_sys::Array) -> JsValue {
+            host_safe_js_value()
+        }
+
+        fn keys(&self) -> &'static [&'static str] {
+            &[]
+        }
+    }
+
+    fn posts(owner: &mut Owner) -> &mut CollectionState<Post> {
+        &mut owner.posts
+    }
+
+    fn post(key: &str, title: &str, version: &str) -> SyncRow<Post> {
+        SyncRow::new(
+            key,
+            Post {
+                title: title.to_string(),
+            },
+        )
+        .unwrap()
+        .version(version)
+        .unwrap()
+    }
+
+    #[test]
+    fn resource_view_observer_tracks_owner_scope_updates() {
+        pocopine_core::set_auto_flush(false);
+
+        let owner_state = Rc::new(RefCell::new(Owner::default()));
+        let owner_scope = Scope::new(owner_state.clone());
+        let owner = Handle::new(owner_state, owner_scope.id);
+        let consumer_scope = Scope::new(Rc::new(RefCell::new(Consumer)));
+        let observed: Rc<RefCell<Vec<LocalResourceViewState<String, Post>>>> =
+            Rc::new(RefCell::new(Vec::new()));
+        let observed_for_callback = observed.clone();
+
+        pocopine_core::scope::with_current_scope_id(consumer_scope.id, || {
+            observe_local_resource_view(owner.clone(), posts, move |state, _previous| {
+                observed_for_callback.borrow_mut().push(state.clone());
+            })
+            .unwrap();
+        });
+
+        assert_eq!(observed.borrow().len(), 1);
+        assert_eq!(observed.borrow()[0].view().unwrap().rows.len(), 0);
+
+        {
+            let mut owner = owner.borrow_mut();
+            let request = owner.posts.begin_initial();
+            owner.posts.apply_pull(
+                request,
+                SyncPullResponse::snapshot(
+                    SyncStreamName::new("posts").unwrap(),
+                    SyncCollectionName::new("posts").unwrap(),
+                    vec![post("post_1", "one", "v1")],
+                    Some(SyncCursor::new("c1").unwrap()),
+                ),
+            );
+        }
+        pocopine_core::trigger_scope(owner_scope.id);
+        pocopine_core::flush_sync();
+
+        assert_eq!(observed.borrow().len(), 2);
+        assert_eq!(observed.borrow()[1].view().unwrap().rows[0].id, "post_1");
+
+        pocopine_core::trigger_scope(owner_scope.id);
+        pocopine_core::flush_sync();
+        assert_eq!(
+            observed.borrow().len(),
+            2,
+            "unchanged views should not fire the callback again"
+        );
+
+        {
+            let mut owner = owner.borrow_mut();
+            owner.posts.set_error("network offline");
+        }
+        pocopine_core::trigger_scope(owner_scope.id);
+        pocopine_core::flush_sync();
+
+        assert_eq!(observed.borrow().len(), 3);
+        assert_eq!(
+            observed.borrow()[2].view().unwrap().error,
+            "network offline"
+        );
+
+        Scope::remove(consumer_scope.id);
+        {
+            let mut owner = owner.borrow_mut();
+            owner.posts.clear_error();
+        }
+        pocopine_core::trigger_scope(owner_scope.id);
+        pocopine_core::flush_sync();
+
+        assert_eq!(
+            observed.borrow().len(),
+            3,
+            "consumer unmount should release the observer"
+        );
+
+        Scope::remove(owner_scope.id);
+        pocopine_core::set_auto_flush(true);
+    }
+
+    #[test]
+    fn resource_view_observer_requires_current_scope() {
+        let owner_state = Rc::new(RefCell::new(Owner::default()));
+        let owner_scope = Scope::new(owner_state.clone());
+        let owner = Handle::new(owner_state, owner_scope.id);
+
+        let err =
+            observe_local_resource_view::<_, String, Post, _>(owner, posts, |_state, _previous| {})
+                .unwrap_err();
+
+        assert!(err.to_string().contains("outside a component"));
+
+        Scope::remove(owner_scope.id);
+    }
+
+    #[test]
+    fn resource_view_observer_reports_borrow_errors_as_state() {
+        pocopine_core::set_auto_flush(false);
+
+        let owner_state = Rc::new(RefCell::new(Owner::default()));
+        let owner_scope = Scope::new(owner_state.clone());
+        let owner = Handle::new(owner_state, owner_scope.id);
+        let consumer_scope = Scope::new(Rc::new(RefCell::new(Consumer)));
+        let observed: Rc<RefCell<Vec<LocalResourceViewState<String, Post>>>> =
+            Rc::new(RefCell::new(Vec::new()));
+        let observed_for_callback = observed.clone();
+        let _borrow = owner.borrow_mut();
+
+        pocopine_core::scope::with_current_scope_id(consumer_scope.id, || {
+            observe_local_resource_view(owner.clone(), posts, move |state, _previous| {
+                observed_for_callback.borrow_mut().push(state.clone());
+            })
+            .unwrap();
+        });
+
+        assert_eq!(observed.borrow().len(), 1);
+        assert!(observed.borrow()[0]
+            .error()
+            .is_some_and(|error| error.contains("already borrowed")));
+
+        Scope::remove(consumer_scope.id);
+        Scope::remove(owner_scope.id);
+        pocopine_core::set_auto_flush(true);
+    }
+}

--- a/crates/pocopine-sync-crud/src/view.rs
+++ b/crates/pocopine-sync-crud/src/view.rs
@@ -92,6 +92,68 @@ pub struct LocalResourceView<Id, Row> {
     pub last_reason: SyncReason,
 }
 
+/// Comparable state emitted by resource-view subscriptions.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "Id: Serialize, Row: Serialize",
+    deserialize = "Id: Deserialize<'de>, Row: Deserialize<'de>"
+))]
+pub enum LocalResourceViewState<Id, Row> {
+    Ready(LocalResourceView<Id, Row>),
+    Error(String),
+}
+
+impl<Id, Row> LocalResourceViewState<Id, Row> {
+    pub fn ready(view: LocalResourceView<Id, Row>) -> Self {
+        Self::Ready(view)
+    }
+
+    pub fn from_error(error: impl ToString) -> Self {
+        Self::Error(error.to_string())
+    }
+
+    pub fn from_result(result: SyncResult<LocalResourceView<Id, Row>>) -> Self {
+        match result {
+            Ok(view) => Self::Ready(view),
+            Err(err) => Self::Error(err.to_string()),
+        }
+    }
+
+    pub fn from_collection_state(state: &CollectionState<Row>) -> Self
+    where
+        Id: ResourceId,
+        Row: Clone,
+    {
+        Self::from_result(LocalResourceView::from_collection_state(state))
+    }
+
+    pub fn view(&self) -> Option<&LocalResourceView<Id, Row>> {
+        match self {
+            Self::Ready(view) => Some(view),
+            Self::Error(_) => None,
+        }
+    }
+
+    pub fn error_message(&self) -> Option<&str> {
+        match self {
+            Self::Ready(_) => None,
+            Self::Error(error) => Some(error.as_str()),
+        }
+    }
+
+    pub fn error(&self) -> Option<&str> {
+        self.error_message()
+    }
+
+    pub fn has_pending(&self) -> bool {
+        self.view().is_some_and(LocalResourceView::has_pending)
+    }
+
+    pub fn has_conflicts(&self) -> bool {
+        self.view().is_some_and(LocalResourceView::has_conflicts)
+    }
+}
+
 impl<Id, Row> LocalResourceView<Id, Row> {
     /// Build a typed resource view from the low-level sync collection state.
     pub fn from_collection_state(state: &CollectionState<Row>) -> SyncResult<Self>
@@ -487,5 +549,23 @@ mod tests {
         let err = local_resource_view::<i64, _>(&state).unwrap_err();
 
         assert!(err.to_string().contains("invalid resource id"));
+    }
+
+    #[test]
+    fn view_state_wraps_ready_views_and_errors() {
+        let state = initial_state();
+        let view_state = LocalResourceViewState::<String, Post>::from_collection_state(&state);
+
+        let view = view_state.view().expect("view state should be ready");
+        assert_eq!(view.rows.len(), 1);
+        assert!(!view_state.has_pending());
+        assert!(!view_state.has_conflicts());
+        assert_eq!(view_state.error(), None);
+
+        let error_state = LocalResourceViewState::<String, Post>::from_error("already borrowed");
+        assert!(error_state.view().is_none());
+        assert_eq!(error_state.error(), Some("already borrowed"));
+        assert!(!error_state.has_pending());
+        assert!(!error_state.has_conflicts());
     }
 }

--- a/docs/sync-conflict-architecture.md
+++ b/docs/sync-conflict-architecture.md
@@ -227,12 +227,12 @@ Generated CRUD methods use this view instead of directly poking at
 `SyncRow` flags. That keeps protocol structs as an implementation detail
 and gives future query/resource layers one place to improve.
 
-The generated subscription layer should observe that same typed view.
-Once `observe_view(...)` lands, components should subscribe to
-`LocalResourceViewState<Id, Row>` through the generated resource instead
-of watching `CollectionState<Row>` directly. Conflict banners, pending
-badges, and row-level conflict UIs will then all read the same canonical
-`base_version` and row status data that generated saves/removes use.
+The generated subscription layer observes that same typed view. Components
+should subscribe to `LocalResourceViewState<Id, Row>` through the
+generated resource instead of watching `CollectionState<Row>` directly.
+Conflict banners, pending badges, and row-level conflict UIs then all read
+the same canonical `base_version` and row status data that generated
+saves/removes use.
 
 ## Conflict Resolution Shape
 

--- a/docs/sync-conflict-architecture.md
+++ b/docs/sync-conflict-architecture.md
@@ -227,6 +227,13 @@ Generated CRUD methods use this view instead of directly poking at
 `SyncRow` flags. That keeps protocol structs as an implementation detail
 and gives future query/resource layers one place to improve.
 
+The generated subscription layer should observe that same typed view.
+Once `observe_view(...)` lands, components should subscribe to
+`LocalResourceViewState<Id, Row>` through the generated resource instead
+of watching `CollectionState<Row>` directly. Conflict banners, pending
+badges, and row-level conflict UIs will then all read the same canonical
+`base_version` and row status data that generated saves/removes use.
+
 ## Conflict Resolution Shape
 
 The first conflict contract is conservative: mark the conflict, keep data

--- a/docs/sync-crud-macro-contract.md
+++ b/docs/sync-crud-macro-contract.md
@@ -254,6 +254,8 @@ pub mod customers {
     pub type CreateOptions = pocopine_sync_crud::CreateOptions<Row>;
     pub type SaveOptions = pocopine_sync_crud::SaveOptions<Row>;
     pub type RemoveOptions = pocopine_sync_crud::RemoveOptions;
+    pub type View = pocopine_sync_crud::LocalResourceView<Id, Row>;
+    pub type ViewState = pocopine_sync_crud::LocalResourceViewState<Id, Row>;
     pub type Outcome = pocopine_sync_crud::CrudOutcome<Id, Row>;
     pub type Queued = pocopine_sync_crud::Queued<Id>;
     pub type Client<C> = pocopine_sync_crud::CrudClientResource<C, Id, Row>;
@@ -301,6 +303,11 @@ pub mod customers {
             options: RemoveOptions,
         ) -> pocopine_sync::SyncResult<Outcome>;
         pub async fn use_server(&self, id: Id) -> pocopine_sync::SyncResult<bool>;
+        pub fn observe_view<F>(&self, callback: F) -> pocopine_sync::SyncResult<()>
+        where
+            Id: pocopine_sync_crud::ResourceId,
+            Row: Clone,
+            F: Fn(&ViewState, Option<&ViewState>) + 'static;
         pub async fn retry_local(
             &self,
             id: Id,

--- a/docs/sync-crud.md
+++ b/docs/sync-crud.md
@@ -516,7 +516,11 @@ The generated `observe_view(...)` method avoids repeated callbacks by
 comparing sync metadata such as row ids, versions, row status, pending
 mutation ids, counters, and errors. It does not require row payload
 equality, so create/save/remove and observe paths can share the same row
-types.
+types. Payload changes that come from normal sync operations still update
+observable metadata such as row versions or pending mutation ids. The
+fingerprint intentionally does not treat `last_reason` by itself as a
+render trigger; it is diagnostic context attached to the state that
+already changed.
 
 This is still a component subscription, not a database query planner. It
 does not read arbitrary SQLite tables, push filters into SQL, or replace

--- a/docs/sync-crud.md
+++ b/docs/sync-crud.md
@@ -487,10 +487,11 @@ The observer is framework-native:
 - it never exposes raw `CollectionState`, `SyncRow`, or protocol mutation
   structs to component code.
 
-The first callback invocation will be deferred to the next tick so
-callers can install the observer from lifecycle code and still call
-`Handle::update` inside the callback without re-entering the lifecycle
-borrow.
+In browser components, the first callback invocation will be deferred to
+the next tick so callers can install the observer from lifecycle code and
+still call `Handle::update` inside the callback without re-entering the
+lifecycle borrow. Native host tests install synchronously so they can
+assert observer state without a browser microtask queue.
 
 `LocalResourceViewState` will be a small comparable wrapper around either
 a ready view or a local view-construction error such as an

--- a/docs/sync-crud.md
+++ b/docs/sync-crud.md
@@ -101,6 +101,7 @@ pieces:
 
 The remaining higher-level layer is deliberately smaller now:
 
+- scoped generated `observe_view(...)` hooks for framework-native resource subscriptions,
 - fluent options builders such as `customers.create_options().optimistic(row).send(...)`,
 - transaction convenience helpers such as `customers.transaction_options().require_online().run(...)`,
 - macro tests that exercise more complete generated browser-style call sites,
@@ -442,6 +443,84 @@ contract has a durable row-scoped pending-mutation purge operation.
 using the latest canonical `base_version` from the view. The conflict
 marker remains visible until the server accepts the retry and returns a
 new canonical row.
+
+## Local Resource Subscriptions
+
+`view()` is an owned snapshot. It is still useful inside event handlers,
+server-rendered tests, and one-shot calculations. Component UIs usually
+need a subscription instead: run once with the current typed view, then
+run again whenever the collection's owning scope is updated by open,
+pull, push, conflict clearing, or any other `Handle::update` path.
+
+Generated resources will expose that path as a scoped observer:
+
+```rust
+let page = pocopine::this::<CustomersPage>();
+
+customers.observe_view(move |state, previous| {
+    page.update(|page| {
+        match state {
+            pocopine_sync_crud::LocalResourceViewState::Ready(view) => {
+                page.pending_count = view.pending_count;
+                page.conflict_count = view.conflict_count;
+                page.rows = view.rows.iter().map(|row| row.value.clone()).collect();
+            }
+            pocopine_sync_crud::LocalResourceViewState::Error(err) => {
+                page.error = err.clone();
+            }
+        }
+
+        if previous.map(|prev| prev.has_conflicts()) != Some(state.has_conflicts()) {
+            page.show_conflict_banner = state.has_conflicts();
+        }
+    });
+});
+```
+
+The observer is framework-native:
+
+- it is installed against the current Pocopine scope,
+- it is released automatically when that scope unmounts,
+- it tracks the resource owner's scope and re-runs when that scope is
+  triggered,
+- it passes the same typed `LocalResourceView` shape that CRUD writes use,
+- it never exposes raw `CollectionState`, `SyncRow`, or protocol mutation
+  structs to component code.
+
+The first callback invocation will be deferred to the next tick so
+callers can install the observer from lifecycle code and still call
+`Handle::update` inside the callback without re-entering the lifecycle
+borrow.
+
+`LocalResourceViewState` will be a small comparable wrapper around either
+a ready view or a local view-construction error such as an
+already-borrowed component/store handle:
+
+```rust
+pub enum LocalResourceViewState<Id, Row> {
+    Ready(LocalResourceView<Id, Row>),
+    Error(String),
+}
+
+impl<Id, Row> LocalResourceViewState<Id, Row> {
+    pub fn view(&self) -> Option<&LocalResourceView<Id, Row>>;
+    pub fn error(&self) -> Option<&str>;
+    pub fn has_pending(&self) -> bool;
+    pub fn has_conflicts(&self) -> bool;
+}
+```
+
+The error variant stores a displayable string instead of `SyncError`, so
+the observer state can be compared. The generated `observe_view(...)`
+method will require `Id: PartialEq` and `Row: PartialEq` because it
+compares the typed view to avoid invoking the callback for repeated
+framework updates that do not change the resource view. Those bounds are
+local to the observer path; create/save/remove do not need row equality.
+
+This is still a component subscription, not a database query planner. It
+does not read arbitrary SQLite tables, push filters into SQL, or replace
+the server-side source query. Database-specific query adapters remain a
+later layer.
 
 ## Generated Client API
 

--- a/docs/sync-crud.md
+++ b/docs/sync-crud.md
@@ -86,6 +86,7 @@ pieces:
 - `CrudMutationLog` and `MemoryCrudMutationLog` so accepted mutation ids are explicit and replayed writes do not silently run twice,
 - exact replay validation so a reused mutation id with a different operation, row id, or payload is rejected,
 - `local_resource_view(...)` and `LocalResourceView<Id, Row>` for typed read-side state over `CollectionState<Row>`,
+- `LocalResourceViewState<Id, Row>` and `observe_local_resource_view(...)` for comparable resource-view subscriptions,
 - `LocalResourceView::conflicts()` and `LocalResourceView::conflict_for(...)` for conflict UI lookup without raw sync rows,
 - `client_resource(collection, view)` and `CrudClientResource` for non-macro client CRUD methods,
 - `CrudClientResource::use_server`, `retry_local`, and `merge_with` as the first conservative conflict-resolution helpers,
@@ -93,15 +94,14 @@ pieces:
 - online-confirmed generated-id push for `WritePolicy::RequireOnline`,
 - low-level `pocopine-sync` online-only push helpers,
 - `#[pocopine_sync_crud::resource(name = "...")]` for generating a typed resource module from a `CrudSource` impl,
-- generated resource aliases: `Id`, `Row`, `Draft`, `CreateOptions`, `SaveOptions`, `RemoveOptions`, `Queued`, `Outcome`, and `Client<C>`,
+- generated resource aliases: `Id`, `Row`, `Draft`, `CreateOptions`, `SaveOptions`, `RemoveOptions`, `View`, `ViewState`, `Queued`, `Outcome`, and `Client<C>`,
 - generated server registration: `customers::resource(source)`,
 - generated client helpers: `customers::new_id()`, `view(...)`, `collection(...)`, `client(...)`, and `use_resource(...)`,
-- generated `Resource<C>` methods: `open`, `pull`, `view`, `client`, `create`, `create_with_options`, `save`, `save_with_options`, `remove`, `remove_with_options`, `use_server`, `retry_local`, `retry_local_with_options`, `merge_with`, and `merge_with_options`,
+- generated `Resource<C>` methods: `open`, `pull`, `view`, `observe_view`, `client`, `create`, `create_with_options`, `save`, `save_with_options`, `remove`, `remove_with_options`, `use_server`, `retry_local`, `retry_local_with_options`, `merge_with`, and `merge_with_options`,
 - route-level integration coverage proving a CRUD resource registered with `SyncServer` serves `/pull` and `/push` through the normal sync plugin.
 
 The remaining higher-level layer is deliberately smaller now:
 
-- scoped generated `observe_view(...)` hooks for framework-native resource subscriptions,
 - fluent options builders such as `customers.create_options().optimistic(row).send(...)`,
 - transaction convenience helpers such as `customers.transaction_options().require_online().run(...)`,
 - macro tests that exercise more complete generated browser-style call sites,
@@ -452,7 +452,7 @@ need a subscription instead: run once with the current typed view, then
 run again whenever the collection's owning scope is updated by open,
 pull, push, conflict clearing, or any other `Handle::update` path.
 
-Generated resources will expose that path as a scoped observer:
+Generated resources expose that path as a scoped observer:
 
 ```rust
 let page = pocopine::this::<CustomersPage>();
@@ -493,8 +493,8 @@ still call `Handle::update` inside the callback without re-entering the
 lifecycle borrow. Native host tests install synchronously so they can
 assert observer state without a browser microtask queue.
 
-`LocalResourceViewState` will be a small comparable wrapper around either
-a ready view or a local view-construction error such as an
+`LocalResourceViewState` is a small comparable wrapper around either a
+ready view or a local view-construction error such as an
 already-borrowed component/store handle:
 
 ```rust
@@ -511,12 +511,12 @@ impl<Id, Row> LocalResourceViewState<Id, Row> {
 }
 ```
 
-The error variant stores a displayable string instead of `SyncError`, so
-the observer state can be compared. The generated `observe_view(...)`
-method will require `Id: PartialEq` and `Row: PartialEq` because it
-compares the typed view to avoid invoking the callback for repeated
-framework updates that do not change the resource view. Those bounds are
-local to the observer path; create/save/remove do not need row equality.
+The error variant stores a displayable string instead of `SyncError`.
+The generated `observe_view(...)` method avoids repeated callbacks by
+comparing sync metadata such as row ids, versions, row status, pending
+mutation ids, counters, and errors. It does not require row payload
+equality, so create/save/remove and observe paths can share the same row
+types.
 
 This is still a component subscription, not a database query planner. It
 does not read arbitrary SQLite tables, push filters into SQL, or replace
@@ -537,6 +537,16 @@ let customers = customers::use_resource(
 customers.open()?;
 customers.pull()?;
 let view = customers.view()?;
+
+let page = pocopine::this::<CustomersPage>();
+customers.observe_view(move |state, _previous| {
+    page.update(|page| {
+        if let Some(view) = state.view() {
+            page.syncing = view.syncing;
+            page.conflict_count = view.conflict_count;
+        }
+    });
+})?;
 
 customers
     .create(customer_id, CustomerDraft { name, email })

--- a/docs/sync-local-first-roadmap.md
+++ b/docs/sync-local-first-roadmap.md
@@ -215,9 +215,9 @@ The framework needs a typed client-side view layer that can:
 This can borrow ideas from TanStack DB, but Pocopine should keep the API
 resource-oriented and framework-native.
 
-The first implementation step is a scoped generated resource observer,
-not a database query engine. `Resource::observe_view(...)` will watch the
-Pocopine scope that owns the resource collection and emit a typed
+The first implementation step adds a scoped generated resource observer,
+not a database query engine. `Resource::observe_view(...)` watches the
+Pocopine scope that owns the resource collection and emits a typed
 `LocalResourceViewState<Id, Row>` whenever the view changes. It gives
 component authors a reactive read path while preserving the existing
 `CollectionState` boundary as an implementation detail.

--- a/docs/sync-local-first-roadmap.md
+++ b/docs/sync-local-first-roadmap.md
@@ -215,6 +215,13 @@ The framework needs a typed client-side view layer that can:
 This can borrow ideas from TanStack DB, but Pocopine should keep the API
 resource-oriented and framework-native.
 
+The first implementation step is a scoped generated resource observer,
+not a database query engine. `Resource::observe_view(...)` will watch the
+Pocopine scope that owns the resource collection and emit a typed
+`LocalResourceViewState<Id, Row>` whenever the view changes. It gives
+component authors a reactive read path while preserving the existing
+`CollectionState` boundary as an implementation detail.
+
 ### 7. Auth And Multi-Tenant Boundaries
 
 Sync does not make local data trusted.


### PR DESCRIPTION
## Summary

- Add `LocalResourceViewState` and a framework-native `observe_local_resource_view` runtime helper for typed local resource subscriptions.
- Generate `View` / `ViewState` aliases and `Resource::observe_view(...)` from `#[pocopine_sync_crud::resource]`.
- Document the observer contract, native/wasm timing behavior, fingerprint comparison boundary, and generated API shape.
- Add runtime and macro tests, including a generated resource observer test whose row type intentionally does not derive `PartialEq`.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `cargo test -p pocopine-sync-crud`
- `cargo test -p pocopine-sync-crud-macros --tests`
- `cargo test -p pocopine-sync-crud --target wasm32-unknown-unknown --no-run`
- `cargo test -p pocopine-sync-crud-macros --target wasm32-unknown-unknown --no-run`
- `cargo clippy -p pocopine-sync-crud -p pocopine-sync-crud-macros --all-targets -- -D warnings`

## Review

Claude Opus reviewed each phase commit and the final full branch diff. All reviews ended with GREEN LIGHT.