### PR TITLE
Add transaction-backed CRUD server writes

### DIFF
--- a/crates/pocopine-sync-crud/src/lib.rs
+++ b/crates/pocopine-sync-crud/src/lib.rs
@@ -33,16 +33,20 @@ pub use outcome::{CrudOutcome, Queued, QueuedStatus};
 pub use resource::{
     resource, CrudAcceptedMutation, CrudMutationLog, CrudResource, CrudResourceBuilder,
     MemoryCrudMutationLog, MissingMutationLog, NoRowVersion, RowVersionValue,
-    DEFAULT_CRUD_SNAPSHOT_ROW_LIMIT,
+    TransactionalCrudMutationLog, TransactionalCrudResource, DEFAULT_CRUD_SNAPSHOT_ROW_LIMIT,
 };
 pub use row::optimistic_row;
 #[cfg(not(target_arch = "wasm32"))]
-pub use source::{CrudConflict, CrudRemoveResult, CrudSource, CrudWriteResult};
+pub use source::{
+    CrudConflict, CrudRemoveResult, CrudSource, CrudWriteResult, TransactionalCrudSource,
+};
 pub use subscription::observe_local_resource_view;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use resource::RowVersionOf;
-pub use transaction::{Transaction, TransactionBindable, TransactionFuture, TransactionRunner};
+pub use transaction::{
+    CrudTransactionRunner, Transaction, TransactionBindable, TransactionFuture, TransactionRunner,
+};
 pub use view::{
     local_resource_view, LocalResourcePendingMutation, LocalResourceRow, LocalResourceRowStatus,
     LocalResourceView, LocalResourceViewState,

--- a/crates/pocopine-sync-crud/src/resource.rs
+++ b/crates/pocopine-sync-crud/src/resource.rs
@@ -827,12 +827,14 @@ where
             match self
                 .apply_transactional_payload(
                     &ctx,
-                    mutation_id,
-                    expected_key,
-                    op,
-                    base_version,
-                    payload_value,
-                    payload,
+                    TransactionalCrudMutation {
+                        mutation_id,
+                        key: expected_key,
+                        op,
+                        base_version,
+                        payload_value,
+                        payload,
+                    },
                 )
                 .await?
             {
@@ -855,13 +857,16 @@ where
     async fn apply_transactional_payload(
         &self,
         ctx: &RequestContext,
-        mutation_id: MutationId,
-        key: RowKey,
-        op: SyncOp,
-        base_version: Option<RowVersion>,
-        payload_value: Value,
-        payload: CrudMutationPayload<S::Id, S::Draft>,
+        mutation: TransactionalCrudMutation<S::Id, S::Draft>,
     ) -> SyncResult<CrudApplyOutcome<S::Row>> {
+        let TransactionalCrudMutation {
+            mutation_id,
+            key,
+            op,
+            base_version,
+            payload_value,
+            payload,
+        } = mutation;
         let mut tx = self.transaction_runner.begin().await?;
         let result = async {
             if let Some(accepted) = self
@@ -1025,6 +1030,15 @@ enum CrudApplyOutcome<Row> {
     },
     Rejected(SyncRejectedMutation),
     Conflict(SyncConflict<Row>),
+}
+
+struct TransactionalCrudMutation<Id, Draft> {
+    mutation_id: MutationId,
+    key: RowKey,
+    op: SyncOp,
+    base_version: Option<RowVersion>,
+    payload_value: Value,
+    payload: CrudMutationPayload<Id, Draft>,
 }
 
 fn row_to_value<Row>(row: SyncRow<Row>) -> SyncResult<SyncRow<Value>>

--- a/crates/pocopine-sync-crud/src/resource.rs
+++ b/crates/pocopine-sync-crud/src/resource.rs
@@ -10,7 +10,10 @@ use pocopine_sync::{
 use serde::Serialize;
 use serde_json::Value;
 
-use crate::{CrudMutationPayload, CrudRemoveResult, CrudSource, CrudWriteResult, ResourceId};
+use crate::{
+    CrudMutationPayload, CrudRemoveResult, CrudSource, CrudTransactionRunner, CrudWriteResult,
+    ResourceId, TransactionalCrudSource,
+};
 
 /// Default maximum rows returned by one CRUD snapshot pull.
 pub const DEFAULT_CRUD_SNAPSHOT_ROW_LIMIT: usize = 1_000;
@@ -141,6 +144,48 @@ where
     ) -> CrudResource<S, IdOf, VersionOf, MemoryCrudMutationLog<S::Row>> {
         self.mutation_log(MemoryCrudMutationLog::new())
     }
+
+    /// Attach a transaction runner and mutation log for atomic server writes.
+    ///
+    /// This path runs each accepted CRUD mutation in one app/database
+    /// transaction: check the accepted-mutation log, apply the source write,
+    /// record the accepted mutation id, then commit. Use this for production
+    /// resources where the source write and idempotency insert must not split
+    /// across separate commits.
+    pub fn transactional<Runner, Log>(
+        self,
+        transaction_runner: Runner,
+        mutation_log: Log,
+    ) -> TransactionalCrudResource<S, IdOf, VersionOf, Log, Runner>
+    where
+        Runner: CrudTransactionRunner,
+        S: TransactionalCrudSource<Runner::Tx>,
+        Log: TransactionalCrudMutationLog<Runner::Tx, S::Row>,
+    {
+        TransactionalCrudResource {
+            stream: self.stream,
+            collection: self.collection,
+            source: self.source,
+            max_snapshot_rows: self.max_snapshot_rows,
+            id_of: self.id_of,
+            version_of: self.version_of,
+            mutation_log,
+            transaction_runner,
+        }
+    }
+}
+
+/// CRUD resource adapter that applies writes and idempotency log inserts in one
+/// app/database transaction.
+pub struct TransactionalCrudResource<S, IdOf, VersionOf, Log, Runner> {
+    stream: SyncStreamName,
+    collection: SyncCollectionName,
+    source: S,
+    max_snapshot_rows: usize,
+    id_of: IdOf,
+    version_of: VersionOf,
+    mutation_log: Log,
+    transaction_runner: Runner,
 }
 
 /// Marker used before a resource has an idempotency backend.
@@ -293,6 +338,34 @@ where
 
     async fn record_accepted_mutation(
         &self,
+        ctx: &RequestContext,
+        accepted: CrudAcceptedMutation,
+    ) -> SyncResult<()>;
+}
+
+/// Transaction-aware idempotency log for CRUD mutations.
+///
+/// Production implementations should use the same transaction handle and
+/// authorization scope as the corresponding [`TransactionalCrudSource`].
+/// The accepted-mutation table should also enforce uniqueness for that scope
+/// and mutation id so concurrent retries cannot both observe "missing" and
+/// apply the same write.
+#[async_trait::async_trait]
+pub trait TransactionalCrudMutationLog<Tx, Row>: Send + Sync + 'static
+where
+    Tx: Send,
+    Row: Clone + Send + Sync + 'static,
+{
+    async fn accepted_mutation_in_tx(
+        &self,
+        tx: &mut Tx,
+        ctx: &RequestContext,
+        mutation_id: &MutationId,
+    ) -> SyncResult<Option<CrudAcceptedMutation>>;
+
+    async fn record_accepted_mutation_in_tx(
+        &self,
+        tx: &mut Tx,
         ctx: &RequestContext,
         accepted: CrudAcceptedMutation,
     ) -> SyncResult<()>;
@@ -627,6 +700,324 @@ where
     }
 }
 
+impl<S, IdOf, VersionOf, Log, Runner> SyncStreamSource
+    for TransactionalCrudResource<S, IdOf, VersionOf, Log, Runner>
+where
+    S: TransactionalCrudSource<Runner::Tx>,
+    IdOf: Fn(&S::Row) -> S::Id + Send + Sync + 'static,
+    VersionOf: RowVersionOf<S::Row>,
+    Log: TransactionalCrudMutationLog<Runner::Tx, S::Row>,
+    Runner: CrudTransactionRunner,
+{
+    fn stream(&self) -> &SyncStreamName {
+        &self.stream
+    }
+
+    fn collection(&self) -> &SyncCollectionName {
+        &self.collection
+    }
+
+    fn pull<'a>(
+        &'a self,
+        ctx: RequestContext,
+        request: SyncPullRequest,
+    ) -> SyncBoxFuture<'a, SyncPullResponse<Value>> {
+        Box::pin(async move { self.pull_snapshot(ctx, request).await })
+    }
+
+    fn push<'a>(
+        &'a self,
+        ctx: RequestContext,
+        request: SyncPushRequest<Value>,
+    ) -> SyncBoxFuture<'a, SyncPushResponse<Value>> {
+        Box::pin(async move { self.push_mutations(ctx, request).await })
+    }
+}
+
+impl<S, IdOf, VersionOf, Log, Runner> TransactionalCrudResource<S, IdOf, VersionOf, Log, Runner>
+where
+    S: TransactionalCrudSource<Runner::Tx>,
+    IdOf: Fn(&S::Row) -> S::Id + Send + Sync + 'static,
+    VersionOf: RowVersionOf<S::Row>,
+    Log: TransactionalCrudMutationLog<Runner::Tx, S::Row>,
+    Runner: CrudTransactionRunner,
+{
+    async fn pull_snapshot(
+        &self,
+        ctx: RequestContext,
+        request: SyncPullRequest,
+    ) -> SyncResult<SyncPullResponse<Value>> {
+        if request.stream != self.stream {
+            return Err(SyncError::UnknownStream(request.stream.to_string()));
+        }
+
+        let rows = self.source.list(ctx, self.max_snapshot_rows).await?;
+        if rows.len() > self.max_snapshot_rows {
+            return Err(SyncError::backend(format!(
+                "CRUD source returned {} rows, exceeding max snapshot row limit {}",
+                rows.len(),
+                self.max_snapshot_rows
+            )));
+        }
+        let rows = rows
+            .into_iter()
+            .map(|row| self.row_to_value(row))
+            .collect::<SyncResult<Vec<_>>>()?;
+
+        Ok(SyncPullResponse::snapshot(
+            self.stream.clone(),
+            self.collection.clone(),
+            rows,
+            None,
+        ))
+    }
+
+    async fn push_mutations(
+        &self,
+        ctx: RequestContext,
+        request: SyncPushRequest<Value>,
+    ) -> SyncResult<SyncPushResponse<Value>> {
+        if request.stream != self.stream {
+            return Err(SyncError::UnknownStream(request.stream.to_string()));
+        }
+
+        let mut response = SyncPushResponse::new(self.stream.clone());
+        response.collection = Some(self.collection.clone());
+
+        for mutation in request.mutations {
+            let mutation_id = mutation.id.clone();
+            let key = mutation.key.clone();
+            let op = mutation.op;
+            let base_version = mutation.base_version;
+            let payload_value = mutation.payload;
+
+            let payload = match serde_json::from_value::<CrudMutationPayload<S::Id, S::Draft>>(
+                payload_value.clone(),
+            ) {
+                Ok(payload) => payload,
+                Err(err) => {
+                    response.rejected.push(SyncRejectedMutation {
+                        mutation_id,
+                        key,
+                        reason: format!("invalid CRUD mutation payload: {err}"),
+                    });
+                    continue;
+                }
+            };
+
+            if payload.sync_op() != op {
+                response.rejected.push(SyncRejectedMutation {
+                    mutation_id,
+                    key,
+                    reason: "CRUD payload does not match sync operation".to_string(),
+                });
+                continue;
+            }
+
+            let expected_key = payload.id().to_row_key()?;
+            if key.as_ref() != Some(&expected_key) {
+                response.rejected.push(SyncRejectedMutation {
+                    mutation_id,
+                    key,
+                    reason: "CRUD mutation row key does not match payload id".to_string(),
+                });
+                continue;
+            }
+
+            match self
+                .apply_transactional_payload(
+                    &ctx,
+                    mutation_id,
+                    expected_key,
+                    op,
+                    base_version,
+                    payload_value,
+                    payload,
+                )
+                .await?
+            {
+                CrudApplyOutcome::Accepted { mutation_id, row } => {
+                    response.accepted.push(mutation_id);
+                    if let Some(row) = row {
+                        response.rows.push(row_to_value(row)?);
+                    }
+                }
+                CrudApplyOutcome::Rejected(rejected) => response.rejected.push(rejected),
+                CrudApplyOutcome::Conflict(conflict) => {
+                    response.conflicts.push(conflict_to_value(conflict)?);
+                }
+            }
+        }
+
+        Ok(response)
+    }
+
+    async fn apply_transactional_payload(
+        &self,
+        ctx: &RequestContext,
+        mutation_id: MutationId,
+        key: RowKey,
+        op: SyncOp,
+        base_version: Option<RowVersion>,
+        payload_value: Value,
+        payload: CrudMutationPayload<S::Id, S::Draft>,
+    ) -> SyncResult<CrudApplyOutcome<S::Row>> {
+        let mut tx = self.transaction_runner.begin().await?;
+        let result = async {
+            if let Some(accepted) = self
+                .mutation_log
+                .accepted_mutation_in_tx(&mut tx, ctx, &mutation_id)
+                .await?
+            {
+                if accepted.matches(op, Some(&key), &payload_value) {
+                    return Ok(CrudApplyOutcome::Accepted {
+                        mutation_id,
+                        row: None,
+                    });
+                }
+
+                return Ok(CrudApplyOutcome::Rejected(SyncRejectedMutation {
+                    mutation_id,
+                    key: Some(key),
+                    reason: "mutation id was already accepted with different contents".to_string(),
+                }));
+            }
+
+            let accepted = CrudAcceptedMutation::new(
+                mutation_id.clone(),
+                op,
+                Some(key.clone()),
+                payload_value,
+            );
+            let outcome = self
+                .apply_payload_in_tx(&mut tx, ctx, mutation_id, key, base_version, payload)
+                .await?;
+
+            if matches!(outcome, CrudApplyOutcome::Accepted { .. }) {
+                self.mutation_log
+                    .record_accepted_mutation_in_tx(&mut tx, ctx, accepted)
+                    .await?;
+            }
+
+            Ok(outcome)
+        }
+        .await;
+
+        match result {
+            Ok(outcome) => {
+                self.transaction_runner.commit(tx).await?;
+                Ok(outcome)
+            }
+            Err(err) => {
+                if let Err(rollback_err) = self.transaction_runner.rollback(tx).await {
+                    return Err(SyncError::backend(format!(
+                        "CRUD transaction rollback failed after {err}: {rollback_err}"
+                    )));
+                }
+                Err(err)
+            }
+        }
+    }
+
+    async fn apply_payload_in_tx(
+        &self,
+        tx: &mut Runner::Tx,
+        ctx: &RequestContext,
+        mutation_id: MutationId,
+        key: RowKey,
+        base_version: Option<RowVersion>,
+        payload: CrudMutationPayload<S::Id, S::Draft>,
+    ) -> SyncResult<CrudApplyOutcome<S::Row>> {
+        match payload {
+            CrudMutationPayload::Create(payload) => {
+                if base_version.is_some() {
+                    return Ok(CrudApplyOutcome::Rejected(SyncRejectedMutation {
+                        mutation_id,
+                        key: Some(key),
+                        reason: "create does not accept a base row version".to_string(),
+                    }));
+                }
+
+                let row = self
+                    .source
+                    .create_in_tx(tx, ctx, payload.id, payload.draft)
+                    .await?;
+                let row = self.row_to_sync(row)?;
+                Ok(CrudApplyOutcome::Accepted {
+                    mutation_id,
+                    row: Some(row),
+                })
+            }
+            CrudMutationPayload::Save(payload) => {
+                let outcome = self
+                    .source
+                    .save_in_tx(tx, ctx, payload.id, payload.draft, base_version)
+                    .await?;
+                match outcome {
+                    CrudWriteResult::Applied(row) => {
+                        let row = self.row_to_sync(row)?;
+                        Ok(CrudApplyOutcome::Accepted {
+                            mutation_id,
+                            row: Some(row),
+                        })
+                    }
+                    CrudWriteResult::Conflict(conflict) => Ok(CrudApplyOutcome::Conflict(
+                        self.source_conflict(mutation_id, Some(key), conflict)?,
+                    )),
+                }
+            }
+            CrudMutationPayload::Remove(payload) => {
+                let outcome = self
+                    .source
+                    .remove_in_tx(tx, ctx, payload.id, base_version)
+                    .await?;
+                match outcome {
+                    CrudRemoveResult::Applied => Ok(CrudApplyOutcome::Accepted {
+                        mutation_id,
+                        row: None,
+                    }),
+                    CrudRemoveResult::Conflict(conflict) => Ok(CrudApplyOutcome::Conflict(
+                        self.source_conflict(mutation_id, Some(key), conflict)?,
+                    )),
+                }
+            }
+        }
+    }
+
+    fn source_conflict(
+        &self,
+        mutation_id: MutationId,
+        key: Option<RowKey>,
+        conflict: crate::CrudConflict<S::Row>,
+    ) -> SyncResult<SyncConflict<S::Row>> {
+        Ok(SyncConflict {
+            mutation_id,
+            key,
+            server_row: conflict
+                .server_row
+                .map(|row| self.row_to_sync(row))
+                .transpose()?,
+            reason: conflict.reason,
+        })
+    }
+
+    fn row_to_sync(&self, row: S::Row) -> SyncResult<SyncRow<S::Row>> {
+        let key = (self.id_of)(&row).to_row_key()?;
+        let version = self.version_of.row_version(&row)?;
+        Ok(SyncRow {
+            key,
+            version,
+            value: row,
+            pending: false,
+            conflict: false,
+        })
+    }
+
+    fn row_to_value(&self, row: S::Row) -> SyncResult<SyncRow<Value>> {
+        row_to_value(self.row_to_sync(row)?)
+    }
+}
+
 enum CrudApplyOutcome<Row> {
     Accepted {
         mutation_id: MutationId,
@@ -668,6 +1059,8 @@ mod tests {
     use http::{HeaderMap, Method, Uri};
     use pocopine_sync::{ClientMutation, SyncPullMode};
     use serde::{Deserialize, Serialize};
+
+    use crate::TransactionFuture;
 
     use super::*;
 
@@ -813,6 +1206,286 @@ mod tests {
             .memory_mutation_log()
     }
 
+    #[derive(Clone, Debug, Default)]
+    struct TxState {
+        rows: BTreeMap<String, Post>,
+        accepted: BTreeMap<String, CrudAcceptedMutation>,
+    }
+
+    #[derive(Clone, Debug, Default)]
+    struct TxFailures {
+        source_write: bool,
+        log_record: bool,
+        rollback: bool,
+    }
+
+    #[derive(Clone, Debug, Default)]
+    struct TxHarness {
+        state: Arc<Mutex<TxState>>,
+        events: Arc<Mutex<Vec<String>>>,
+        failures: Arc<Mutex<TxFailures>>,
+    }
+
+    #[derive(Debug)]
+    struct FakeTx {
+        state: TxState,
+    }
+
+    impl TxHarness {
+        fn insert(&self, post: Post) {
+            self.state
+                .lock()
+                .unwrap()
+                .rows
+                .insert(post.id.clone(), post);
+        }
+
+        fn state(&self) -> TxState {
+            self.state.lock().unwrap().clone()
+        }
+
+        fn events(&self) -> Vec<String> {
+            self.events.lock().unwrap().clone()
+        }
+
+        fn clear_events(&self) {
+            self.events.lock().unwrap().clear();
+        }
+
+        fn fail_source_write(&self) {
+            self.failures.lock().unwrap().source_write = true;
+        }
+
+        fn fail_log_record(&self) {
+            self.failures.lock().unwrap().log_record = true;
+        }
+
+        fn fail_rollback(&self) {
+            self.failures.lock().unwrap().rollback = true;
+        }
+
+        fn record(&self, event: impl Into<String>) {
+            self.events.lock().unwrap().push(event.into());
+        }
+    }
+
+    impl CrudTransactionRunner for TxHarness {
+        type Tx = FakeTx;
+
+        fn begin<'runner>(&'runner self) -> TransactionFuture<'runner, Self::Tx> {
+            Box::pin(async move {
+                self.record("begin");
+                Ok(FakeTx {
+                    state: self.state(),
+                })
+            })
+        }
+
+        fn commit<'runner>(&'runner self, tx: Self::Tx) -> TransactionFuture<'runner, ()> {
+            Box::pin(async move {
+                self.record("commit");
+                *self.state.lock().unwrap() = tx.state;
+                Ok(())
+            })
+        }
+
+        fn rollback<'runner>(&'runner self, tx: Self::Tx) -> TransactionFuture<'runner, ()> {
+            Box::pin(async move {
+                let _ = tx;
+                self.record("rollback");
+                if self.failures.lock().unwrap().rollback {
+                    return Err(SyncError::backend("rollback failed"));
+                }
+                Ok(())
+            })
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl CrudSource for TxHarness {
+        type Id = String;
+        type Row = Post;
+        type Draft = PostDraft;
+
+        async fn list(&self, ctx: RequestContext, limit: usize) -> SyncResult<Vec<Self::Row>> {
+            let _ = ctx;
+            Ok(self
+                .state
+                .lock()
+                .unwrap()
+                .rows
+                .values()
+                .take(limit)
+                .cloned()
+                .collect())
+        }
+
+        async fn get(&self, ctx: RequestContext, id: Self::Id) -> SyncResult<Option<Self::Row>> {
+            let _ = ctx;
+            Ok(self.state.lock().unwrap().rows.get(&id).cloned())
+        }
+
+        async fn create(
+            &self,
+            ctx: RequestContext,
+            id: Self::Id,
+            draft: Self::Draft,
+        ) -> SyncResult<Self::Row> {
+            let _ = (ctx, id, draft);
+            Err(SyncError::backend(
+                "transactional resource called non-transactional create",
+            ))
+        }
+
+        async fn save(
+            &self,
+            ctx: RequestContext,
+            id: Self::Id,
+            draft: Self::Draft,
+            base_version: Option<RowVersion>,
+        ) -> SyncResult<CrudWriteResult<Self::Row>> {
+            let _ = (ctx, id, draft, base_version);
+            Err(SyncError::backend(
+                "transactional resource called non-transactional save",
+            ))
+        }
+
+        async fn remove(
+            &self,
+            ctx: RequestContext,
+            id: Self::Id,
+            base_version: Option<RowVersion>,
+        ) -> SyncResult<CrudRemoveResult<Self::Row>> {
+            let _ = (ctx, id, base_version);
+            Err(SyncError::backend(
+                "transactional resource called non-transactional remove",
+            ))
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl TransactionalCrudSource<FakeTx> for TxHarness {
+        async fn create_in_tx(
+            &self,
+            tx: &mut FakeTx,
+            ctx: &RequestContext,
+            id: Self::Id,
+            draft: Self::Draft,
+        ) -> SyncResult<Self::Row> {
+            let _ = ctx;
+            self.record(format!("source:create:{id}"));
+            let post = Post {
+                id: id.clone(),
+                title: draft.title,
+                version: 1,
+            };
+            tx.state.rows.insert(id, post.clone());
+            if self.failures.lock().unwrap().source_write {
+                return Err(SyncError::backend("source write failed"));
+            }
+            Ok(post)
+        }
+
+        async fn save_in_tx(
+            &self,
+            tx: &mut FakeTx,
+            ctx: &RequestContext,
+            id: Self::Id,
+            draft: Self::Draft,
+            base_version: Option<RowVersion>,
+        ) -> SyncResult<CrudWriteResult<Self::Row>> {
+            let _ = ctx;
+            self.record(format!("source:save:{id}"));
+            let row = tx
+                .state
+                .rows
+                .get_mut(&id)
+                .ok_or_else(|| SyncError::backend("missing post"))?;
+            if let Some(base_version) = &base_version {
+                if base_version.as_str() != row.version.to_string() {
+                    return Ok(CrudWriteResult::stale(Some(row.clone())));
+                }
+            }
+            row.title = draft.title;
+            row.version += 1;
+            if self.failures.lock().unwrap().source_write {
+                return Err(SyncError::backend("source write failed"));
+            }
+            Ok(CrudWriteResult::applied(row.clone()))
+        }
+
+        async fn remove_in_tx(
+            &self,
+            tx: &mut FakeTx,
+            ctx: &RequestContext,
+            id: Self::Id,
+            base_version: Option<RowVersion>,
+        ) -> SyncResult<CrudRemoveResult<Self::Row>> {
+            let _ = ctx;
+            self.record(format!("source:remove:{id}"));
+            if let Some(base_version) = base_version {
+                let Some(row) = tx.state.rows.get(&id) else {
+                    return Ok(CrudRemoveResult::stale(None));
+                };
+                if base_version.as_str() != row.version.to_string() {
+                    return Ok(CrudRemoveResult::stale(Some(row.clone())));
+                }
+            }
+            tx.state.rows.remove(&id);
+            if self.failures.lock().unwrap().source_write {
+                return Err(SyncError::backend("source write failed"));
+            }
+            Ok(CrudRemoveResult::applied())
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl TransactionalCrudMutationLog<FakeTx, Post> for TxHarness {
+        async fn accepted_mutation_in_tx(
+            &self,
+            tx: &mut FakeTx,
+            ctx: &RequestContext,
+            mutation_id: &MutationId,
+        ) -> SyncResult<Option<CrudAcceptedMutation>> {
+            let _ = ctx;
+            self.record(format!("log:lookup:{mutation_id}"));
+            Ok(tx.state.accepted.get(mutation_id.as_str()).cloned())
+        }
+
+        async fn record_accepted_mutation_in_tx(
+            &self,
+            tx: &mut FakeTx,
+            ctx: &RequestContext,
+            accepted: CrudAcceptedMutation,
+        ) -> SyncResult<()> {
+            let _ = ctx;
+            self.record(format!("log:record:{}", accepted.mutation_id));
+            tx.state
+                .accepted
+                .insert(accepted.mutation_id.as_str().to_string(), accepted);
+            if self.failures.lock().unwrap().log_record {
+                return Err(SyncError::backend("mutation log failed"));
+            }
+            Ok(())
+        }
+    }
+
+    fn transactional_posts_resource(
+        harness: TxHarness,
+    ) -> TransactionalCrudResource<
+        TxHarness,
+        impl Fn(&Post) -> String + Send + Sync + 'static,
+        impl Fn(&Post) -> u64 + Send + Sync + 'static,
+        TxHarness,
+        TxHarness,
+    > {
+        resource("posts", harness.clone())
+            .unwrap()
+            .id(|post: &Post| post.id.clone())
+            .version(|post: &Post| post.version)
+            .transactional(harness.clone(), harness)
+    }
+
     fn value_mutation(
         mutation: pocopine_sync::ClientMutation<CrudMutationPayload<String, PostDraft>>,
     ) -> pocopine_sync::ClientMutation<Value> {
@@ -940,6 +1613,231 @@ mod tests {
         assert_eq!(
             posts.calls(),
             vec!["create:post_2", "save:post_1", "remove:post_2"]
+        );
+    }
+
+    #[tokio::test]
+    async fn transactional_push_commits_source_write_and_mutation_log() {
+        let harness = TxHarness::default();
+        let resource = transactional_posts_resource(harness.clone());
+        let payload = CrudMutationPayload::create(
+            "post_1".to_string(),
+            PostDraft {
+                title: "created".to_string(),
+            },
+        );
+        let mutation = payload
+            .into_sync_draft()
+            .unwrap()
+            .with_id(MutationId::new("device_1:1").unwrap());
+
+        let response = resource
+            .push(ctx(), push_request([mutation]))
+            .await
+            .unwrap();
+        let state = harness.state();
+
+        assert_eq!(response.accepted.len(), 1);
+        assert_eq!(response.rows.len(), 1);
+        assert_eq!(state.rows["post_1"].title, "created");
+        assert!(state.accepted.contains_key("device_1:1"));
+        assert_eq!(
+            harness.events(),
+            vec![
+                "begin",
+                "log:lookup:device_1:1",
+                "source:create:post_1",
+                "log:record:device_1:1",
+                "commit"
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn transactional_duplicate_replay_dedupes_inside_transaction() {
+        let harness = TxHarness::default();
+        let resource = transactional_posts_resource(harness.clone());
+        let payload = CrudMutationPayload::create(
+            "post_1".to_string(),
+            PostDraft {
+                title: "created".to_string(),
+            },
+        );
+        let mutation = payload
+            .into_sync_draft()
+            .unwrap()
+            .with_id(MutationId::new("device_1:1").unwrap());
+        resource
+            .push(ctx(), push_request([mutation.clone()]))
+            .await
+            .unwrap();
+        harness.clear_events();
+
+        let response = resource
+            .push(ctx(), push_request([mutation]))
+            .await
+            .unwrap();
+
+        assert_eq!(response.accepted.len(), 1);
+        assert!(
+            response.rows.is_empty(),
+            "dedupe hits acknowledge exact replay without returning cached rows"
+        );
+        assert_eq!(
+            harness.events(),
+            vec!["begin", "log:lookup:device_1:1", "commit"]
+        );
+    }
+
+    #[tokio::test]
+    async fn transactional_conflict_commits_without_recording_mutation_log() {
+        let harness = TxHarness::default();
+        harness.insert(Post {
+            id: "post_1".to_string(),
+            title: "server".to_string(),
+            version: 2,
+        });
+        let resource = transactional_posts_resource(harness.clone());
+        let payload = CrudMutationPayload::save(
+            "post_1".to_string(),
+            PostDraft {
+                title: "client".to_string(),
+            },
+        );
+        let mutation = payload
+            .into_sync_draft_with_base_version(Some(RowVersion::new("1").unwrap()))
+            .unwrap()
+            .with_id(MutationId::new("device_1:stale").unwrap());
+
+        let response = resource
+            .push(ctx(), push_request([mutation]))
+            .await
+            .unwrap();
+        let state = harness.state();
+
+        assert!(response.accepted.is_empty());
+        assert_eq!(response.conflicts.len(), 1);
+        assert_eq!(state.rows["post_1"].title, "server");
+        assert!(state.accepted.is_empty());
+        assert_eq!(
+            harness.events(),
+            vec![
+                "begin",
+                "log:lookup:device_1:stale",
+                "source:save:post_1",
+                "commit"
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn transactional_source_error_rolls_back_without_recording_mutation_log() {
+        let harness = TxHarness::default();
+        harness.fail_source_write();
+        let resource = transactional_posts_resource(harness.clone());
+        let payload = CrudMutationPayload::create(
+            "post_1".to_string(),
+            PostDraft {
+                title: "created".to_string(),
+            },
+        );
+        let mutation = payload
+            .into_sync_draft()
+            .unwrap()
+            .with_id(MutationId::new("device_1:1").unwrap());
+
+        let err = resource
+            .push(ctx(), push_request([mutation]))
+            .await
+            .unwrap_err();
+        let state = harness.state();
+
+        assert!(err.to_string().contains("source write failed"));
+        assert!(state.rows.is_empty());
+        assert!(state.accepted.is_empty());
+        assert_eq!(
+            harness.events(),
+            vec![
+                "begin",
+                "log:lookup:device_1:1",
+                "source:create:post_1",
+                "rollback"
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn transactional_log_record_error_rolls_back_source_write() {
+        let harness = TxHarness::default();
+        harness.fail_log_record();
+        let resource = transactional_posts_resource(harness.clone());
+        let payload = CrudMutationPayload::create(
+            "post_1".to_string(),
+            PostDraft {
+                title: "created".to_string(),
+            },
+        );
+        let mutation = payload
+            .into_sync_draft()
+            .unwrap()
+            .with_id(MutationId::new("device_1:1").unwrap());
+
+        let err = resource
+            .push(ctx(), push_request([mutation]))
+            .await
+            .unwrap_err();
+        let state = harness.state();
+
+        assert!(err.to_string().contains("mutation log failed"));
+        assert!(state.rows.is_empty());
+        assert!(state.accepted.is_empty());
+        assert_eq!(
+            harness.events(),
+            vec![
+                "begin",
+                "log:lookup:device_1:1",
+                "source:create:post_1",
+                "log:record:device_1:1",
+                "rollback"
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn transactional_rollback_error_preserves_original_failure_context() {
+        let harness = TxHarness::default();
+        harness.fail_source_write();
+        harness.fail_rollback();
+        let resource = transactional_posts_resource(harness.clone());
+        let payload = CrudMutationPayload::create(
+            "post_1".to_string(),
+            PostDraft {
+                title: "created".to_string(),
+            },
+        );
+        let mutation = payload
+            .into_sync_draft()
+            .unwrap()
+            .with_id(MutationId::new("device_1:1").unwrap());
+
+        let err = resource
+            .push(ctx(), push_request([mutation]))
+            .await
+            .unwrap_err();
+
+        assert!(err
+            .to_string()
+            .contains("CRUD transaction rollback failed after"));
+        assert!(err.to_string().contains("source write failed"));
+        assert!(err.to_string().contains("rollback failed"));
+        assert_eq!(
+            harness.events(),
+            vec![
+                "begin",
+                "log:lookup:device_1:1",
+                "source:create:post_1",
+                "rollback"
+            ]
         );
     }
 

--- a/crates/pocopine-sync-crud/src/resource.rs
+++ b/crates/pocopine-sync-crud/src/resource.rs
@@ -1731,6 +1731,86 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn transactional_push_uses_one_transaction_per_mutation() {
+        let harness = TxHarness::default();
+        let resource = transactional_posts_resource(harness.clone());
+        let first = CrudMutationPayload::create(
+            "post_1".to_string(),
+            PostDraft {
+                title: "one".to_string(),
+            },
+        )
+        .into_sync_draft()
+        .unwrap()
+        .with_id(MutationId::new("device_1:1").unwrap());
+        let second = CrudMutationPayload::create(
+            "post_2".to_string(),
+            PostDraft {
+                title: "two".to_string(),
+            },
+        )
+        .into_sync_draft()
+        .unwrap()
+        .with_id(MutationId::new("device_1:2").unwrap());
+
+        let response = resource
+            .push(ctx(), push_request([first, second]))
+            .await
+            .unwrap();
+        let state = harness.state();
+
+        assert_eq!(response.accepted.len(), 2);
+        assert_eq!(state.rows["post_1"].title, "one");
+        assert_eq!(state.rows["post_2"].title, "two");
+        assert!(state.accepted.contains_key("device_1:1"));
+        assert!(state.accepted.contains_key("device_1:2"));
+        assert_eq!(
+            harness.events(),
+            vec![
+                "begin",
+                "log:lookup:device_1:1",
+                "source:create:post_1",
+                "log:record:device_1:1",
+                "commit",
+                "begin",
+                "log:lookup:device_1:2",
+                "source:create:post_2",
+                "log:record:device_1:2",
+                "commit",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn transactional_pull_uses_source_snapshot_without_write_transaction() {
+        let harness = TxHarness::default();
+        harness.insert(Post {
+            id: "post_1".to_string(),
+            title: "cached".to_string(),
+            version: 9,
+        });
+        let resource = transactional_posts_resource(harness.clone());
+
+        let response = resource
+            .pull(
+                ctx(),
+                SyncPullRequest::new(SyncStreamName::new("posts").unwrap()),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.mode, SyncPullMode::Snapshot);
+        assert_eq!(response.rows.len(), 1);
+        assert_eq!(response.rows[0].key.as_str(), "post_1");
+        assert_eq!(response.rows[0].version.as_ref().unwrap().as_str(), "9");
+        assert_eq!(
+            harness.events(),
+            Vec::<String>::new(),
+            "snapshot reads should not begin a write transaction"
+        );
+    }
+
+    #[tokio::test]
     async fn transactional_source_error_rolls_back_without_recording_mutation_log() {
         let harness = TxHarness::default();
         harness.fail_source_write();

--- a/crates/pocopine-sync-crud/src/source.rs
+++ b/crates/pocopine-sync-crud/src/source.rs
@@ -1,3 +1,4 @@
+use pocopine_auth::RequestContext;
 use pocopine_sync::{RowVersion, SyncResult};
 use serde::{de::DeserializeOwned, Serialize};
 
@@ -116,7 +117,44 @@ pub trait CrudSource: Send + Sync + 'static {
 
     async fn remove(
         &self,
-        ctx: pocopine_auth::RequestContext,
+        ctx: RequestContext,
+        id: Self::Id,
+        base_version: Option<RowVersion>,
+    ) -> SyncResult<CrudRemoveResult<Self::Row>>;
+}
+
+/// Server-side CRUD source contract for transaction-backed writes.
+///
+/// Implement this in addition to [`CrudSource`] when the source write and
+/// accepted-mutation log insert can share one app/database transaction. Reads
+/// still use [`CrudSource::list`] and [`CrudSource::get`]; only mutating writes
+/// receive the active transaction handle.
+#[async_trait::async_trait]
+pub trait TransactionalCrudSource<Tx>: CrudSource
+where
+    Tx: Send,
+{
+    async fn create_in_tx(
+        &self,
+        tx: &mut Tx,
+        ctx: &RequestContext,
+        id: Self::Id,
+        draft: Self::Draft,
+    ) -> SyncResult<Self::Row>;
+
+    async fn save_in_tx(
+        &self,
+        tx: &mut Tx,
+        ctx: &RequestContext,
+        id: Self::Id,
+        draft: Self::Draft,
+        base_version: Option<RowVersion>,
+    ) -> SyncResult<CrudWriteResult<Self::Row>>;
+
+    async fn remove_in_tx(
+        &self,
+        tx: &mut Tx,
+        ctx: &RequestContext,
         id: Self::Id,
         base_version: Option<RowVersion>,
     ) -> SyncResult<CrudRemoveResult<Self::Row>>;

--- a/crates/pocopine-sync-crud/src/transaction.rs
+++ b/crates/pocopine-sync-crud/src/transaction.rs
@@ -56,6 +56,22 @@ pub trait TransactionRunner: Send + Sync + 'static {
             + 'runner;
 }
 
+/// App/database owned transaction lifecycle for server-side CRUD sync writes.
+///
+/// This runner returns an owned transaction handle so the sync adapter can
+/// apply one mutation, record the accepted mutation id, and commit or roll back
+/// as one unit. It is separate from [`TransactionRunner`], whose callback shape
+/// is intended for author-facing `tx.with(resource)` helpers.
+pub trait CrudTransactionRunner: Send + Sync + 'static {
+    type Tx: Send + 'static;
+
+    fn begin<'runner>(&'runner self) -> TransactionFuture<'runner, Self::Tx>;
+
+    fn commit<'runner>(&'runner self, tx: Self::Tx) -> TransactionFuture<'runner, ()>;
+
+    fn rollback<'runner>(&'runner self, tx: Self::Tx) -> TransactionFuture<'runner, ()>;
+}
+
 impl TransactionOptions {
     /// Run work inside an app-provided transaction lifecycle.
     ///

--- a/docs/sync-conflict-architecture.md
+++ b/docs/sync-conflict-architecture.md
@@ -296,6 +296,15 @@ write. Production logs must be scoped to the same authorization domain as
 the source rows, for example `(tenant_id, mutation_id)`, not only
 `mutation_id`.
 
+Production CRUD resources should use the transaction-backed path:
+`.transactional(runner, log)`. The runner owns begin/commit/rollback, the
+transactional source applies the row write and base-version check with
+the active transaction handle, and the transactional mutation log records
+the accepted mutation id before commit. The accepted-log table still
+needs a unique key over the same authorization scope and mutation id; a
+lookup without a database-level uniqueness rule is not enough for
+concurrent retries.
+
 A mutation id dedupes sync replay. It is not a universal business
 idempotency key. Payments, external side effects, uniqueness-sensitive
 workflows, and inventory reservations still need app-level idempotency

--- a/docs/sync-crud-macro-contract.md
+++ b/docs/sync-crud-macro-contract.md
@@ -399,7 +399,10 @@ pub async fn build_server(pool: sqlx::PgPool) -> anyhow::Result<pocopine_server:
     let customers = customers::resource(Customers { pool: pool.clone() })?
         .id(|row: &Customer| row.id)
         .version(|row: &Customer| row.version)
-        .mutation_log(CustomerMutationLog { pool: pool.clone() });
+        .transactional(
+            SqlxCrudTransactions { pool: pool.clone() },
+            CustomerMutationLog,
+        );
 
     let sync = pocopine_sync::SyncServer::builder()
         .guarded_stream(customers, pocopine_auth::require_auth())
@@ -417,7 +420,8 @@ What the server sees:
 - `customers::resource(source)` registers stream name `"customers"`.
 - `.id(...)` maps each returned row to the resource id and sync row key.
 - `.version(...)` maps each returned row to the canonical row version.
-- `.mutation_log(...)` provides idempotency for accepted mutation ids.
+- `.transactional(...)` binds source writes and accepted mutation ids to
+  one database transaction.
 - `SyncServer::builder().guarded_stream(...)` owns the auth boundary.
 
 What the server handles at runtime:
@@ -425,15 +429,20 @@ What the server handles at runtime:
 1. `/open` discovers the guarded stream and checks the guard.
 2. `/pull` calls `CrudSource::list` and returns canonical rows.
 3. `/push` deserializes the CRUD payload envelope.
-4. Replayed mutation ids are deduped by the mutation log.
+4. Replayed mutation ids are deduped by the mutation log in the same
+   transaction boundary used for writes.
 5. `save` and `remove` compare the client `base_version` to the latest canonical version before calling app write code.
-6. Accepted writes record the mutation id and publish live invalidation after commit.
+6. Accepted writes record the mutation id before commit, and live invalidation is published after commit.
 7. Stale writes return `Conflict` with the server row when available.
 8. Invalid payloads, auth failures, and domain validation failures return `Rejected`.
 
-The server resource helper intentionally does not hide `.mutation_log`.
-Production idempotency must stay tied to the same database and tenant
-scope as the source query.
+The server resource helper intentionally does not generate transactions
+or SQL. Production code should use `.transactional(...)` and implement
+`CrudTransactionRunner`, `TransactionalCrudSource`, and
+`TransactionalCrudMutationLog` against the same database and tenant scope
+as the source query. The accepted-mutation table needs a unique key over
+that scope and `mutation_id`; the lookup alone is not a concurrency
+boundary.
 
 ## Client API
 

--- a/docs/sync-crud-macro-contract.md
+++ b/docs/sync-crud-macro-contract.md
@@ -429,10 +429,12 @@ What the server handles at runtime:
 1. `/open` discovers the guarded stream and checks the guard.
 2. `/pull` calls `CrudSource::list` and returns canonical rows.
 3. `/push` deserializes the CRUD payload envelope.
-4. Replayed mutation ids are deduped by the mutation log in the same
-   transaction boundary used for writes.
-5. `save` and `remove` compare the client `base_version` to the latest canonical version before calling app write code.
-6. Accepted writes record the mutation id before commit, and live invalidation is published after commit.
+4. On the transactional path, replayed mutation ids are deduped by the
+   mutation log in the same transaction boundary used for writes.
+5. `save` and `remove` pass the client `base_version` into the source so
+   the source can compare and write atomically inside the same transaction.
+6. Accepted writes record the mutation id before commit, and live
+   invalidation is published after commit.
 7. Stale writes return `Conflict` with the server row when available.
 8. Invalid payloads, auth failures, and domain validation failures return `Rejected`.
 

--- a/docs/sync-crud.md
+++ b/docs/sync-crud.md
@@ -82,6 +82,7 @@ pieces:
 - `CrudMutationPayload::{create, save, remove}` and `into_sync_draft(...)` for mapping CRUD writes into `pocopine-sync` push drafts,
 - `CreateOptions`, `SaveOptions`, `RemoveOptions`, `WritePolicy`, and `QueuedStatus` for the client lifecycle,
 - `Transaction`, `TransactionBindable`, `TransactionRunner`, and `TransactionOptions::run(...)` so the public transaction API can stay `tx.with(resource)` while the app owns begin/commit/rollback,
+- `CrudTransactionRunner`, `TransactionalCrudSource`, `TransactionalCrudMutationLog`, and `.transactional(...)` for production server resources that need the source write and accepted-mutation log insert in one transaction,
 - `resource(name, source)?.id(...).version(...).mutation_log(...)` for registering a non-macro `CrudSource` as a `pocopine-sync` stream,
 - `CrudMutationLog` and `MemoryCrudMutationLog` so accepted mutation ids are explicit and replayed writes do not silently run twice,
 - exact replay validation so a reused mutation id with a different operation, row id, or payload is rejected,
@@ -240,7 +241,10 @@ let customers = customers::resource(Customers {
 })?
 .id(|row: &Customer| row.id)
 .version(|row: &Customer| row.version)
-.mutation_log(CustomerMutationLog { pool: pool.clone() });
+.transactional(
+    SqlxCrudTransactions { pool: pool.clone() },
+    CustomerMutationLog,
+);
 
 let sync = pocopine_sync::SyncServer::builder()
     .guarded_stream(customers, pocopine_auth::require_auth())
@@ -256,10 +260,13 @@ There is no separate stream setting in the first version. If a later
 version needs stream overrides, add them only after a real use case proves
 the need.
 
-The adapter requires a mutation log before it implements
+The adapter requires an idempotency path before it implements
 `SyncStreamSource`. This is deliberate: a replayed `MutationId` must not
-run `create`, `save`, or `remove` twice. `MemoryCrudMutationLog` is
-available for tests and single-process demos:
+run `create`, `save`, or `remove` twice. The recommended production path
+is `.transactional(...)`, shown above.
+
+`MemoryCrudMutationLog` is available for tests and single-process demos
+with the older non-transactional `.mutation_log(...)` terminator:
 
 ```rust
 let customers = customers::resource(Customers::new())?
@@ -268,11 +275,9 @@ let customers = customers::resource(Customers::new())?
     .memory_mutation_log();
 ```
 
-Production apps should implement `CrudMutationLog` against the same
-database as the `CrudSource`, and record accepted mutation ids in the
-same transaction as the row write. The idempotency lookup must be scoped
-to the same authorization domain as the source query, for example
-`(tenant_id, mutation_id)`, not only `mutation_id`.
+The non-transactional `.mutation_log(...)` terminator remains available
+for simple adapters and compatibility, but it cannot force the source
+write and log insert to share one database transaction.
 
 On replay, the adapter only acknowledges an accepted mutation id when the
 operation, row id, and serialized payload are an exact match for the
@@ -280,6 +285,44 @@ previously accepted mutation. It intentionally does not return cached rows
 from the mutation log; the next pull is the source of canonical row data.
 This avoids leaking a row accepted under one principal into another
 principal's retry path.
+
+The transaction-backed path requires three app-owned pieces:
+
+- `CrudTransactionRunner` begins, commits, and rolls back the database
+  transaction handle.
+- `TransactionalCrudSource<Tx>` applies `create_in_tx`, `save_in_tx`, and
+  `remove_in_tx` using that handle.
+- `TransactionalCrudMutationLog<Tx, Row>` checks and records accepted
+  mutation ids using the same handle and tenant/auth scope.
+
+The sync adapter opens one transaction per mutation in a push request:
+
+```text
+begin transaction
+  -> check accepted mutation id for this tenant/auth scope
+  -> apply source write and base_version check
+  -> record accepted mutation id
+commit
+```
+
+Conflicts and rejected outcomes do not record an accepted mutation id. The
+adapter still commits a conflict transaction because the source may have
+performed safe validation reads, but source implementations that return
+`Conflict` or `Rejected` must not leave business side effects in the
+transaction.
+
+The accepted-mutation table should enforce a unique key over the same
+authorization scope used by the source query, for example
+`(tenant_id, mutation_id)`. The lookup alone is not enough under
+concurrent retry; a unique constraint or equivalent isolation rule must
+prevent two transactions from both observing "missing" and applying the
+same write.
+
+`MutationId` only dedupes sync replay. It is not a complete business
+idempotency key. External side effects such as payments, inventory
+reservations, email sends, uniqueness-sensitive workflows, or third-party
+API calls still need app-level idempotency keys and domain-specific
+transaction rules.
 
 ## Client Runtime
 
@@ -698,12 +741,16 @@ is.
 ## Transactions And Online Policy
 
 CRUD needs a transaction boundary for server-side writes and custom
-domain operations. Pocopine should provide the transaction lifecycle, but
-the app still owns the database code:
+domain operations. Pocopine provides two related contracts, but the app
+still owns the database code.
+
+Server-side sync replay should use the transaction-backed resource path:
 
 ```text
 begin transaction
-  -> run user CRUD/repository/domain code
+  -> check accepted mutation id
+  -> run one CRUD source write and base_version check
+  -> record accepted mutation id when the write is accepted
   -> commit on success
   -> rollback on error
   -> after commit, publish sync/live invalidations
@@ -728,10 +775,11 @@ two should remain committed. Apps that require all-or-nothing behavior
 should model that as one explicit domain operation, then run it through
 the transaction API.
 
-Generated transaction convenience methods are not shipped yet. They
-should build on the existing `TransactionRunner` and
-`TransactionOptions::run(...)` contract instead of creating a second
-transaction model.
+Author-facing transaction convenience methods are separate from sync
+replay. They are represented by `TransactionRunner`,
+`TransactionOptions::run(...)`, and `tx.with(resource)`, and are not
+generated yet. When generated later, they should stay centered on the
+same public operation body rather than exposing raw sync envelopes.
 
 ## Pre-CRUD Sync Helpers
 

--- a/docs/sync-local-first-roadmap.md
+++ b/docs/sync-local-first-roadmap.md
@@ -129,17 +129,25 @@ commit
 publish live wake-up after commit
 ```
 
-The current non-macro adapter exposes the needed pieces but cannot force
-the source write and mutation-log insert to share one transaction. That is
-acceptable for the contract slice, but not enough as the recommended
-production path.
+The first transaction-backed server slice is now in place. Resources can
+opt into `.transactional(runner, log)`, where `CrudTransactionRunner`
+owns begin/commit/rollback, `TransactionalCrudSource<Tx>` applies the
+CRUD write with the active transaction handle, and
+`TransactionalCrudMutationLog<Tx, Row>` checks and records accepted
+mutation ids with the same handle.
 
-Deliverables:
+The older `.mutation_log(...)` terminator remains available for simple
+adapters and tests, but it cannot force the source write and
+accepted-mutation insert to share one transaction. Production resources
+should use the transaction-backed path and enforce a unique accepted-log
+key over the same authorization scope as the source query.
 
-- transaction-backed CRUD adapter helpers,
-- durable mutation log examples,
-- tests for crash/retry boundaries where possible,
-- docs that make app-level idempotency keys explicit for payments,
+What is still left is backend-specific packaging, not the core contract:
+
+- SQLx or other database-specific convenience adapters,
+- complete durable mutation log examples against real databases,
+- integration tests for backend-specific crash/retry boundaries where possible,
+- more docs for app-level idempotency keys in payments,
   inventory, uniqueness-sensitive, or other side-effecting domains.
 
 ### 4. Backend-Agnostic Change Sources


### PR DESCRIPTION
## Summary

- Add a transaction-backed CRUD server resource path with `CrudTransactionRunner`, `TransactionalCrudSource<Tx>`, `TransactionalCrudMutationLog<Tx, Row>`, and `.transactional(runner, log)`.
- Keep the existing `.mutation_log(...)` path available, while giving production resources a way to check idempotency, apply the source write, and record the accepted mutation id in one transaction.
- Add transactional tests for commit ordering, exact replay dedupe, conflict without log record, one transaction per mutation, pull without write transaction, source-error rollback, log-record rollback, and rollback-error context.
- Update sync CRUD, macro contract, conflict architecture, and roadmap docs to describe the shipped contract and remaining backend-specific work.

## Verification

- `cargo fmt --all -- --check`
- `git diff --check origin/main...HEAD`
- `cargo test -p pocopine-sync-crud`
- `cargo test -p pocopine-sync-crud-macros --tests`
- `cargo test -p pocopine-sync-crud --target wasm32-unknown-unknown --no-run`
- `cargo test -p pocopine-sync-crud-macros --target wasm32-unknown-unknown --no-run`
- `cargo clippy -p pocopine-sync-crud -p pocopine-sync-crud-macros --all-targets -- -D warnings`

## Review

Claude Opus reviewed each phase commit and the final full branch diff. All reviews ended with GREEN LIGHT.