### PR TITLE
Add SQLx sync CRUD transaction helpers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,6 +247,12 @@ jobs:
         run: cargo test -p pocopine-sync-crud-macros --tests
         env:
           CARGO_TARGET_DIR: target/sync-crud-macros-host
+      - name: SQLx sync helper tests
+        run: cargo test -p pocopine-sync-sqlx --features sqlite --tests
+      - name: SQLx sync backend feature checks
+        run: |
+          cargo check -p pocopine-sync-sqlx --features postgres
+          cargo check -p pocopine-sync-sqlx --features mysql
       - name: workspace host tests
         run: cargo test --workspace --exclude pine --exclude observability-smoke --exclude pocopine-sync-crud-macros --tests
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4817,8 +4817,11 @@ dependencies = [
 name = "pocopine-sync-sqlx"
 version = "0.1.0"
 dependencies = [
+ "http 1.4.0",
+ "pocopine-auth",
  "pocopine-sync",
  "pocopine-sync-crud",
+ "serde_json",
  "sqlx",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,6 +288,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -488,6 +497,9 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "bitvec"
@@ -1047,6 +1059,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1106,6 +1133,15 @@ name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1356,6 +1392,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dprint-core"
 version = "0.67.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1437,6 +1479,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "either_of"
@@ -1554,6 +1599,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1649,6 +1705,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -2272,6 +2339,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2298,6 +2374,24 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "hn"
@@ -3322,6 +3416,16 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
 
 [[package]]
 name = "memchr"
@@ -4710,6 +4814,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pocopine-sync-sqlx"
+version = "0.1.0"
+dependencies = [
+ "pocopine-sync",
+ "pocopine-sync-crud",
+ "sqlx",
+ "tokio",
+]
+
+[[package]]
 name = "pocopine-ts-rs"
 version = "0.1.0"
 dependencies = [
@@ -5386,7 +5500,7 @@ dependencies = [
  "bitflags 2.11.1",
  "fallible-iterator",
  "fallible-streaming-iterator",
- "hashlink",
+ "hashlink 0.9.1",
  "libsqlite3-sys",
  "smallvec",
 ]
@@ -5819,6 +5933,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5933,6 +6058,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smartstring"
@@ -5995,6 +6123,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"
@@ -6028,6 +6159,196 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink 0.10.0",
+ "indexmap 2.14.0",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 2.0.117",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags 2.11.1",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.6",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags 2.11.1",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -6089,6 +6410,17 @@ dependencies = [
  "quote",
  "swc_macros_common",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
 ]
 
 [[package]]
@@ -7052,6 +7384,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-id-start"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7068,6 +7406,21 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -7218,6 +7571,12 @@ checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
 ]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -7436,6 +7795,16 @@ dependencies = [
  "tracing",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ members = [
     "crates/pocopine-sync-crud",
     "crates/pocopine-sync-crud-macros",
     "crates/pocopine-sync-indexdb",
+    "crates/pocopine-sync-sqlx",
     "crates/pocopine-sync-sqlite",
     "crates/pocopine-ts-rs",
     "crates/pocopine-ts-rs-macros",
@@ -97,6 +98,7 @@ pocopine-sync = { path = "crates/pocopine-sync", version = "0.1.0" }
 pocopine-sync-crud = { path = "crates/pocopine-sync-crud", version = "0.1.0" }
 pocopine-sync-crud-macros = { path = "crates/pocopine-sync-crud-macros", version = "0.1.0" }
 pocopine-sync-indexdb = { path = "crates/pocopine-sync-indexdb", version = "0.1.0" }
+pocopine-sync-sqlx = { path = "crates/pocopine-sync-sqlx", version = "0.1.0" }
 pocopine-sync-sqlite = { path = "crates/pocopine-sync-sqlite", version = "0.1.0" }
 pocopine-ts-rs = { path = "crates/pocopine-ts-rs", version = "0.1.0" }
 pine-richtext = { path = "crates/pine-richtext", version = "0.1.0" }

--- a/crates/pocopine-sync-crud/src/lib.rs
+++ b/crates/pocopine-sync-crud/src/lib.rs
@@ -31,8 +31,8 @@ pub use options::{CreateOptions, RemoveOptions, SaveOptions, TransactionOptions,
 pub use outcome::{CrudOutcome, Queued, QueuedStatus};
 #[cfg(not(target_arch = "wasm32"))]
 pub use resource::{
-    resource, CrudAcceptedMutation, CrudMutationLog, CrudResource, CrudResourceBuilder,
-    MemoryCrudMutationLog, MissingMutationLog, NoRowVersion, RowVersionValue,
+    resource, CrudAcceptedMutation, CrudMutationLog, CrudMutationReservation, CrudResource,
+    CrudResourceBuilder, MemoryCrudMutationLog, MissingMutationLog, NoRowVersion, RowVersionValue,
     TransactionalCrudMutationLog, TransactionalCrudResource, DEFAULT_CRUD_SNAPSHOT_ROW_LIMIT,
 };
 pub use row::optimistic_row;

--- a/crates/pocopine-sync-crud/src/resource.rs
+++ b/crates/pocopine-sync-crud/src/resource.rs
@@ -148,10 +148,10 @@ where
     /// Attach a transaction runner and mutation log for atomic server writes.
     ///
     /// This path runs each accepted CRUD mutation in one app/database
-    /// transaction: check the accepted-mutation log, apply the source write,
-    /// record the accepted mutation id, then commit. Use this for production
-    /// resources where the source write and idempotency insert must not split
-    /// across separate commits.
+    /// transaction: reserve the accepted-mutation id, apply the source write,
+    /// then commit both together. Use this for production resources where the
+    /// source write and idempotency reservation must not split across separate
+    /// commits.
     pub fn transactional<Runner, Log>(
         self,
         transaction_runner: Runner,
@@ -319,6 +319,16 @@ impl CrudAcceptedMutation {
     }
 }
 
+/// Result of reserving an accepted mutation id inside a transaction.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum CrudMutationReservation {
+    /// The caller reserved this mutation id and should continue applying the
+    /// source write in the same transaction.
+    Reserved,
+    /// The mutation id already exists in the accepted log.
+    AlreadyAccepted(CrudAcceptedMutation),
+}
+
 /// Idempotency log for CRUD mutations.
 ///
 /// Production implementations must scope lookups to the same authorization
@@ -347,9 +357,11 @@ where
 ///
 /// Production implementations should use the same transaction handle and
 /// authorization scope as the corresponding [`TransactionalCrudSource`].
-/// The accepted-mutation table should also enforce uniqueness for that scope
-/// and mutation id so concurrent retries cannot both observe "missing" and
-/// apply the same write.
+/// The reservation method must be the concurrency boundary: production
+/// implementations should insert first under a unique key for the same scope
+/// and mutation id, then return the existing accepted mutation on duplicate.
+/// This prevents concurrent retries from both observing "missing" before the
+/// source write.
 #[async_trait::async_trait]
 pub trait TransactionalCrudMutationLog<Tx, Row>: Send + Sync + 'static
 where
@@ -369,6 +381,13 @@ where
         ctx: &RequestContext,
         accepted: CrudAcceptedMutation,
     ) -> SyncResult<()>;
+
+    async fn reserve_accepted_mutation_in_tx(
+        &self,
+        tx: &mut Tx,
+        ctx: &RequestContext,
+        accepted: CrudAcceptedMutation,
+    ) -> SyncResult<CrudMutationReservation>;
 }
 
 /// Process-local mutation log for tests and single-process demos.
@@ -869,48 +888,59 @@ where
         } = mutation;
         let mut tx = self.transaction_runner.begin().await?;
         let result = async {
-            if let Some(accepted) = self
-                .mutation_log
-                .accepted_mutation_in_tx(&mut tx, ctx, &mutation_id)
-                .await?
-            {
-                if accepted.matches(op, Some(&key), &payload_value) {
-                    return Ok(CrudApplyOutcome::Accepted {
-                        mutation_id,
-                        row: None,
-                    });
-                }
-
-                return Ok(CrudApplyOutcome::Rejected(SyncRejectedMutation {
-                    mutation_id,
-                    key: Some(key),
-                    reason: "mutation id was already accepted with different contents".to_string(),
-                }));
-            }
-
             let accepted = CrudAcceptedMutation::new(
                 mutation_id.clone(),
                 op,
                 Some(key.clone()),
-                payload_value,
+                payload_value.clone(),
             );
+
+            match self
+                .mutation_log
+                .reserve_accepted_mutation_in_tx(&mut tx, ctx, accepted)
+                .await?
+            {
+                CrudMutationReservation::AlreadyAccepted(accepted) => {
+                    if accepted.matches(op, Some(&key), &payload_value) {
+                        return Ok(CrudTransactionDecision::Commit(
+                            CrudApplyOutcome::Accepted {
+                                mutation_id,
+                                row: None,
+                            },
+                        ));
+                    }
+
+                    return Ok(CrudTransactionDecision::Commit(CrudApplyOutcome::Rejected(
+                        SyncRejectedMutation {
+                            mutation_id,
+                            key: Some(key),
+                            reason: "mutation id was already accepted with different contents"
+                                .to_string(),
+                        },
+                    )));
+                }
+                CrudMutationReservation::Reserved => {}
+            }
+
             let outcome = self
                 .apply_payload_in_tx(&mut tx, ctx, mutation_id, key, base_version, payload)
                 .await?;
 
             if matches!(outcome, CrudApplyOutcome::Accepted { .. }) {
-                self.mutation_log
-                    .record_accepted_mutation_in_tx(&mut tx, ctx, accepted)
-                    .await?;
+                Ok(CrudTransactionDecision::Commit(outcome))
+            } else {
+                Ok(CrudTransactionDecision::Rollback(outcome))
             }
-
-            Ok(outcome)
         }
         .await;
 
         match result {
-            Ok(outcome) => {
+            Ok(CrudTransactionDecision::Commit(outcome)) => {
                 self.transaction_runner.commit(tx).await?;
+                Ok(outcome)
+            }
+            Ok(CrudTransactionDecision::Rollback(outcome)) => {
+                self.transaction_runner.rollback(tx).await?;
                 Ok(outcome)
             }
             Err(err) => {
@@ -1030,6 +1060,11 @@ enum CrudApplyOutcome<Row> {
     },
     Rejected(SyncRejectedMutation),
     Conflict(SyncConflict<Row>),
+}
+
+enum CrudTransactionDecision<Row> {
+    Commit(CrudApplyOutcome<Row>),
+    Rollback(CrudApplyOutcome<Row>),
 }
 
 struct TransactionalCrudMutation<Id, Draft> {
@@ -1482,6 +1517,24 @@ mod tests {
             }
             Ok(())
         }
+
+        async fn reserve_accepted_mutation_in_tx(
+            &self,
+            tx: &mut FakeTx,
+            ctx: &RequestContext,
+            accepted: CrudAcceptedMutation,
+        ) -> SyncResult<CrudMutationReservation> {
+            if let Some(existing) = self
+                .accepted_mutation_in_tx(tx, ctx, &accepted.mutation_id)
+                .await?
+            {
+                return Ok(CrudMutationReservation::AlreadyAccepted(existing));
+            }
+
+            self.record_accepted_mutation_in_tx(tx, ctx, accepted)
+                .await?;
+            Ok(CrudMutationReservation::Reserved)
+        }
     }
 
     fn transactional_posts_resource(
@@ -1660,8 +1713,8 @@ mod tests {
             vec![
                 "begin",
                 "log:lookup:device_1:1",
-                "source:create:post_1",
                 "log:record:device_1:1",
+                "source:create:post_1",
                 "commit"
             ]
         );
@@ -1704,7 +1757,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn transactional_conflict_commits_without_recording_mutation_log() {
+    async fn transactional_conflict_rolls_back_reserved_mutation_log() {
         let harness = TxHarness::default();
         harness.insert(Post {
             id: "post_1".to_string(),
@@ -1738,8 +1791,9 @@ mod tests {
             vec![
                 "begin",
                 "log:lookup:device_1:stale",
+                "log:record:device_1:stale",
                 "source:save:post_1",
-                "commit"
+                "rollback"
             ]
         );
     }
@@ -1783,13 +1837,13 @@ mod tests {
             vec![
                 "begin",
                 "log:lookup:device_1:1",
-                "source:create:post_1",
                 "log:record:device_1:1",
+                "source:create:post_1",
                 "commit",
                 "begin",
                 "log:lookup:device_1:2",
-                "source:create:post_2",
                 "log:record:device_1:2",
+                "source:create:post_2",
                 "commit",
             ]
         );
@@ -1825,7 +1879,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn transactional_source_error_rolls_back_without_recording_mutation_log() {
+    async fn transactional_source_error_rolls_back_reserved_mutation_log() {
         let harness = TxHarness::default();
         harness.fail_source_write();
         let resource = transactional_posts_resource(harness.clone());
@@ -1854,6 +1908,7 @@ mod tests {
             vec![
                 "begin",
                 "log:lookup:device_1:1",
+                "log:record:device_1:1",
                 "source:create:post_1",
                 "rollback"
             ]
@@ -1861,7 +1916,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn transactional_log_record_error_rolls_back_source_write() {
+    async fn transactional_log_record_error_rolls_back_reserved_mutation() {
         let harness = TxHarness::default();
         harness.fail_log_record();
         let resource = transactional_posts_resource(harness.clone());
@@ -1890,7 +1945,6 @@ mod tests {
             vec![
                 "begin",
                 "log:lookup:device_1:1",
-                "source:create:post_1",
                 "log:record:device_1:1",
                 "rollback"
             ]
@@ -1929,6 +1983,7 @@ mod tests {
             vec![
                 "begin",
                 "log:lookup:device_1:1",
+                "log:record:device_1:1",
                 "source:create:post_1",
                 "rollback"
             ]

--- a/crates/pocopine-sync-crud/src/resource.rs
+++ b/crates/pocopine-sync-crud/src/resource.rs
@@ -368,20 +368,6 @@ where
     Tx: Send,
     Row: Clone + Send + Sync + 'static,
 {
-    async fn accepted_mutation_in_tx(
-        &self,
-        tx: &mut Tx,
-        ctx: &RequestContext,
-        mutation_id: &MutationId,
-    ) -> SyncResult<Option<CrudAcceptedMutation>>;
-
-    async fn record_accepted_mutation_in_tx(
-        &self,
-        tx: &mut Tx,
-        ctx: &RequestContext,
-        accepted: CrudAcceptedMutation,
-    ) -> SyncResult<()>;
-
     async fn reserve_accepted_mutation_in_tx(
         &self,
         tx: &mut Tx,
@@ -1490,24 +1476,23 @@ mod tests {
 
     #[async_trait::async_trait]
     impl TransactionalCrudMutationLog<FakeTx, Post> for TxHarness {
-        async fn accepted_mutation_in_tx(
-            &self,
-            tx: &mut FakeTx,
-            ctx: &RequestContext,
-            mutation_id: &MutationId,
-        ) -> SyncResult<Option<CrudAcceptedMutation>> {
-            let _ = ctx;
-            self.record(format!("log:lookup:{mutation_id}"));
-            Ok(tx.state.accepted.get(mutation_id.as_str()).cloned())
-        }
-
-        async fn record_accepted_mutation_in_tx(
+        async fn reserve_accepted_mutation_in_tx(
             &self,
             tx: &mut FakeTx,
             ctx: &RequestContext,
             accepted: CrudAcceptedMutation,
-        ) -> SyncResult<()> {
+        ) -> SyncResult<CrudMutationReservation> {
             let _ = ctx;
+            self.record(format!("log:lookup:{}", accepted.mutation_id));
+            if let Some(existing) = tx
+                .state
+                .accepted
+                .get(accepted.mutation_id.as_str())
+                .cloned()
+            {
+                return Ok(CrudMutationReservation::AlreadyAccepted(existing));
+            }
+
             self.record(format!("log:record:{}", accepted.mutation_id));
             tx.state
                 .accepted
@@ -1515,24 +1500,6 @@ mod tests {
             if self.failures.lock().unwrap().log_record {
                 return Err(SyncError::backend("mutation log failed"));
             }
-            Ok(())
-        }
-
-        async fn reserve_accepted_mutation_in_tx(
-            &self,
-            tx: &mut FakeTx,
-            ctx: &RequestContext,
-            accepted: CrudAcceptedMutation,
-        ) -> SyncResult<CrudMutationReservation> {
-            if let Some(existing) = self
-                .accepted_mutation_in_tx(tx, ctx, &accepted.mutation_id)
-                .await?
-            {
-                return Ok(CrudMutationReservation::AlreadyAccepted(existing));
-            }
-
-            self.record_accepted_mutation_in_tx(tx, ctx, accepted)
-                .await?;
             Ok(CrudMutationReservation::Reserved)
         }
     }

--- a/crates/pocopine-sync-sqlx/Cargo.toml
+++ b/crates/pocopine-sync-sqlx/Cargo.toml
@@ -21,6 +21,6 @@ pocopine-sync-crud = { workspace = true }
 serde_json = { workspace = true }
 sqlx = { version = "0.8", default-features = false }
 
-[dev-dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 http = { workspace = true }
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/pocopine-sync-sqlx/Cargo.toml
+++ b/crates/pocopine-sync-sqlx/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "pocopine-sync-sqlx"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "SQLx helpers for Pocopine sync CRUD transactions."
+
+[features]
+default = []
+postgres = ["sqlx/postgres"]
+mysql = ["sqlx/mysql"]
+sqlite = ["sqlx/sqlite"]
+runtime-tokio = ["sqlx/runtime-tokio"]
+tls-rustls = ["sqlx/tls-rustls-ring-webpki"]
+
+[dependencies]
+pocopine-sync = { workspace = true }
+pocopine-sync-crud = { workspace = true }
+sqlx = { version = "0.8", default-features = false }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/pocopine-sync-sqlx/Cargo.toml
+++ b/crates/pocopine-sync-sqlx/Cargo.toml
@@ -15,9 +15,12 @@ runtime-tokio = ["sqlx/runtime-tokio"]
 tls-rustls = ["sqlx/tls-rustls-ring-webpki"]
 
 [dependencies]
+pocopine-auth = { workspace = true }
 pocopine-sync = { workspace = true }
 pocopine-sync-crud = { workspace = true }
+serde_json = { workspace = true }
 sqlx = { version = "0.8", default-features = false }
 
 [dev-dependencies]
+http = { workspace = true }
 tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/pocopine-sync-sqlx/Cargo.toml
+++ b/crates/pocopine-sync-sqlx/Cargo.toml
@@ -8,13 +8,13 @@ description = "SQLx helpers for Pocopine sync CRUD transactions."
 
 [features]
 default = []
-postgres = ["sqlx/postgres"]
-mysql = ["sqlx/mysql"]
-sqlite = ["sqlx/sqlite"]
+postgres = ["sqlx/postgres", "runtime-tokio"]
+mysql = ["sqlx/mysql", "runtime-tokio"]
+sqlite = ["sqlx/sqlite", "runtime-tokio"]
 runtime-tokio = ["sqlx/runtime-tokio"]
 tls-rustls = ["sqlx/tls-rustls-ring-webpki"]
 
-[dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 pocopine-auth = { workspace = true }
 pocopine-sync = { workspace = true }
 pocopine-sync-crud = { workspace = true }

--- a/crates/pocopine-sync-sqlx/src/lib.rs
+++ b/crates/pocopine-sync-sqlx/src/lib.rs
@@ -11,6 +11,13 @@ use pocopine_sync::SyncError;
 use pocopine_sync_crud::{CrudTransactionRunner, TransactionFuture};
 use sqlx::{Database, Pool, Transaction};
 
+mod mutation_log;
+
+pub use mutation_log::{
+    SqlxCrudMutationLog, DEFAULT_CRUD_MUTATION_LOG_TABLE, MYSQL_CRUD_MUTATION_LOG_SCHEMA,
+    POSTGRES_CRUD_MUTATION_LOG_SCHEMA, SQLITE_CRUD_MUTATION_LOG_SCHEMA,
+};
+
 /// SQLx transaction type used by [`SqlxCrudTransactionRunner`].
 pub type SqlxCrudTransaction<DB> = Transaction<'static, DB>;
 

--- a/crates/pocopine-sync-sqlx/src/lib.rs
+++ b/crates/pocopine-sync-sqlx/src/lib.rs
@@ -24,8 +24,8 @@ pub use mutation_log::{
 pub type SqlxCrudTransaction<DB> = Transaction<'static, DB>;
 
 /// Map a SQLx error into Pocopine's sync error type.
-pub fn sync_sqlx_error(error: sqlx::Error) -> SyncError {
-    SyncError::backend(format!("SQLx error: {error}"))
+pub fn sync_sqlx_error(_error: sqlx::Error) -> SyncError {
+    SyncError::backend("SQLx backend operation failed")
 }
 
 /// Transaction runner backed by a SQLx pool.
@@ -87,12 +87,10 @@ where
     }
 
     fn commit<'runner>(&'runner self, tx: Self::Tx) -> TransactionFuture<'runner, ()> {
-        let _ = self;
         Box::pin(async move { tx.commit().await.map_err(sync_sqlx_error) })
     }
 
     fn rollback<'runner>(&'runner self, tx: Self::Tx) -> TransactionFuture<'runner, ()> {
-        let _ = self;
         Box::pin(async move { tx.rollback().await.map_err(sync_sqlx_error) })
     }
 }

--- a/crates/pocopine-sync-sqlx/src/lib.rs
+++ b/crates/pocopine-sync-sqlx/src/lib.rs
@@ -7,8 +7,6 @@
 
 #![cfg(not(target_arch = "wasm32"))]
 
-use std::marker::PhantomData;
-
 use pocopine_sync::SyncError;
 use pocopine_sync_crud::{CrudTransactionRunner, TransactionFuture};
 use sqlx::{Database, Pool, Transaction};
@@ -38,7 +36,6 @@ where
     DB: Database,
 {
     pool: Pool<DB>,
-    _marker: PhantomData<fn() -> DB>,
 }
 
 impl<DB> Clone for SqlxCrudTransactionRunner<DB>
@@ -48,7 +45,6 @@ where
     fn clone(&self) -> Self {
         Self {
             pool: self.pool.clone(),
-            _marker: PhantomData,
         }
     }
 }
@@ -59,10 +55,7 @@ where
 {
     /// Build a transaction runner from an existing SQLx pool.
     pub fn new(pool: Pool<DB>) -> Self {
-        Self {
-            pool,
-            _marker: PhantomData,
-        }
+        Self { pool }
     }
 
     /// Borrow the underlying SQLx pool.

--- a/crates/pocopine-sync-sqlx/src/lib.rs
+++ b/crates/pocopine-sync-sqlx/src/lib.rs
@@ -24,8 +24,8 @@ pub use mutation_log::{
 pub type SqlxCrudTransaction<DB> = Transaction<'static, DB>;
 
 /// Map a SQLx error into Pocopine's sync error type.
-pub fn sync_sqlx_error(_error: sqlx::Error) -> SyncError {
-    SyncError::backend("SQLx backend operation failed")
+pub fn sync_sqlx_error(error: sqlx::Error) -> SyncError {
+    SyncError::backend(format!("SQLx backend operation failed: {error}"))
 }
 
 /// Transaction runner backed by a SQLx pool.
@@ -127,6 +127,7 @@ pub fn sqlite(pool: sqlx::SqlitePool) -> SqliteCrudTransactionRunner {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "sqlite")]
     use super::*;
 
     #[cfg(feature = "sqlite")]

--- a/crates/pocopine-sync-sqlx/src/lib.rs
+++ b/crates/pocopine-sync-sqlx/src/lib.rs
@@ -1,0 +1,161 @@
+//! SQLx helpers for Pocopine sync CRUD resources.
+//!
+//! This crate is deliberately small. It wires SQLx transactions into
+//! `pocopine-sync-crud`; it does not generate SQL, own application schema, or
+//! act as an ORM. Apps still implement `CrudSource` /
+//! `TransactionalCrudSource` with normal SQLx queries.
+
+use std::marker::PhantomData;
+
+use pocopine_sync::SyncError;
+use pocopine_sync_crud::{CrudTransactionRunner, TransactionFuture};
+use sqlx::{Database, Pool, Transaction};
+
+/// SQLx transaction type used by [`SqlxCrudTransactionRunner`].
+pub type SqlxCrudTransaction<DB> = Transaction<'static, DB>;
+
+/// Map a SQLx error into Pocopine's sync error type.
+pub fn sync_sqlx_error(error: sqlx::Error) -> SyncError {
+    SyncError::backend(format!("SQLx error: {error}"))
+}
+
+/// Transaction runner backed by a SQLx pool.
+///
+/// `Pool::begin` returns an owned transaction handle, so the CRUD sync adapter
+/// can apply the row write and accepted-mutation log insert before committing.
+#[derive(Debug)]
+pub struct SqlxCrudTransactionRunner<DB>
+where
+    DB: Database,
+{
+    pool: Pool<DB>,
+    _marker: PhantomData<fn() -> DB>,
+}
+
+impl<DB> Clone for SqlxCrudTransactionRunner<DB>
+where
+    DB: Database,
+{
+    fn clone(&self) -> Self {
+        Self {
+            pool: self.pool.clone(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<DB> SqlxCrudTransactionRunner<DB>
+where
+    DB: Database,
+{
+    /// Build a transaction runner from an existing SQLx pool.
+    pub fn new(pool: Pool<DB>) -> Self {
+        Self {
+            pool,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Borrow the underlying SQLx pool.
+    pub fn pool(&self) -> &Pool<DB> {
+        &self.pool
+    }
+
+    /// Return the underlying SQLx pool.
+    pub fn into_pool(self) -> Pool<DB> {
+        self.pool
+    }
+}
+
+impl<DB> CrudTransactionRunner for SqlxCrudTransactionRunner<DB>
+where
+    DB: Database,
+{
+    type Tx = SqlxCrudTransaction<DB>;
+
+    fn begin<'runner>(&'runner self) -> TransactionFuture<'runner, Self::Tx> {
+        Box::pin(async move { self.pool.begin().await.map_err(sync_sqlx_error) })
+    }
+
+    fn commit<'runner>(&'runner self, tx: Self::Tx) -> TransactionFuture<'runner, ()> {
+        let _ = self;
+        Box::pin(async move { tx.commit().await.map_err(sync_sqlx_error) })
+    }
+
+    fn rollback<'runner>(&'runner self, tx: Self::Tx) -> TransactionFuture<'runner, ()> {
+        let _ = self;
+        Box::pin(async move { tx.rollback().await.map_err(sync_sqlx_error) })
+    }
+}
+
+/// Postgres transaction runner alias.
+#[cfg(feature = "postgres")]
+pub type PgCrudTransactionRunner = SqlxCrudTransactionRunner<sqlx::Postgres>;
+
+/// MySQL transaction runner alias.
+#[cfg(feature = "mysql")]
+pub type MySqlCrudTransactionRunner = SqlxCrudTransactionRunner<sqlx::MySql>;
+
+/// SQLite transaction runner alias.
+#[cfg(feature = "sqlite")]
+pub type SqliteCrudTransactionRunner = SqlxCrudTransactionRunner<sqlx::Sqlite>;
+
+/// Build a Postgres CRUD transaction runner.
+#[cfg(feature = "postgres")]
+pub fn postgres(pool: sqlx::PgPool) -> PgCrudTransactionRunner {
+    SqlxCrudTransactionRunner::new(pool)
+}
+
+/// Build a MySQL CRUD transaction runner.
+#[cfg(feature = "mysql")]
+pub fn mysql(pool: sqlx::MySqlPool) -> MySqlCrudTransactionRunner {
+    SqlxCrudTransactionRunner::new(pool)
+}
+
+/// Build a SQLite CRUD transaction runner.
+#[cfg(feature = "sqlite")]
+pub fn sqlite(pool: sqlx::SqlitePool) -> SqliteCrudTransactionRunner {
+    SqlxCrudTransactionRunner::new(pool)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn sqlite_runner_commits_and_rolls_back() {
+        let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
+        sqlx::query("create table events (name text not null)")
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let runner = sqlite(pool.clone());
+        let mut tx = runner.begin().await.unwrap();
+        sqlx::query("insert into events (name) values ('committed')")
+            .execute(&mut *tx)
+            .await
+            .unwrap();
+        runner.commit(tx).await.unwrap();
+
+        let committed: i64 = sqlx::query_scalar("select count(*) from events")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(committed, 1);
+
+        let mut tx = runner.begin().await.unwrap();
+        sqlx::query("insert into events (name) values ('rolled back')")
+            .execute(&mut *tx)
+            .await
+            .unwrap();
+        runner.rollback(tx).await.unwrap();
+
+        let committed: i64 = sqlx::query_scalar("select count(*) from events")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(committed, 1);
+    }
+}

--- a/crates/pocopine-sync-sqlx/src/lib.rs
+++ b/crates/pocopine-sync-sqlx/src/lib.rs
@@ -5,6 +5,8 @@
 //! act as an ORM. Apps still implement `CrudSource` /
 //! `TransactionalCrudSource` with normal SQLx queries.
 
+#![cfg(not(target_arch = "wasm32"))]
+
 use std::marker::PhantomData;
 
 use pocopine_sync::SyncError;

--- a/crates/pocopine-sync-sqlx/src/mutation_log.rs
+++ b/crates/pocopine-sync-sqlx/src/mutation_log.rs
@@ -1,0 +1,426 @@
+use std::{fmt, marker::PhantomData, sync::Arc};
+
+use pocopine_auth::RequestContext;
+use pocopine_sync::{MutationId, RowKey, SyncError, SyncOp, SyncResult};
+use pocopine_sync_crud::{CrudAcceptedMutation, TransactionalCrudMutationLog};
+use serde_json::Value;
+use sqlx::{ColumnIndex, Database, Decode, Row, Transaction, Type};
+
+use crate::sync_sqlx_error;
+
+/// Default table used by [`SqlxCrudMutationLog`].
+pub const DEFAULT_CRUD_MUTATION_LOG_TABLE: &str = "__pocopine_crud_mutations";
+
+/// SQLite schema for the default CRUD mutation log table.
+pub const SQLITE_CRUD_MUTATION_LOG_SCHEMA: &str = r#"create table if not exists __pocopine_crud_mutations (
+  scope text not null,
+  mutation_id text not null,
+  op text not null,
+  row_key text,
+  payload text not null,
+  primary key (scope, mutation_id)
+)"#;
+
+/// Postgres schema for the default CRUD mutation log table.
+pub const POSTGRES_CRUD_MUTATION_LOG_SCHEMA: &str = r#"create table if not exists __pocopine_crud_mutations (
+  scope text not null,
+  mutation_id text not null,
+  op text not null,
+  row_key text,
+  payload text not null,
+  primary key (scope, mutation_id)
+)"#;
+
+/// MySQL schema for the default CRUD mutation log table.
+///
+/// The default uses bounded indexed columns because MySQL cannot index
+/// unbounded `text` columns in a primary key. Apps with longer mutation ids or
+/// scope values should use their own table and point [`SqlxCrudMutationLog`] at
+/// it with [`SqlxCrudMutationLog::with_table`].
+pub const MYSQL_CRUD_MUTATION_LOG_SCHEMA: &str = r#"create table if not exists __pocopine_crud_mutations (
+  scope varchar(191) not null,
+  mutation_id varchar(191) not null,
+  op varchar(16) not null,
+  row_key varchar(191),
+  payload text not null,
+  primary key (scope, mutation_id)
+)"#;
+
+type ScopeFn = dyn Fn(&RequestContext) -> SyncResult<String> + Send + Sync;
+
+/// SQLx-backed idempotency log for transactional CRUD sync writes.
+///
+/// The log stores accepted mutation contents by `(scope, mutation_id)`. Scope
+/// must match the authorization domain of the resource, usually a tenant,
+/// organization, or authenticated user id. The helper intentionally stores a
+/// JSON string and sync metadata only; application rows still live in the
+/// app-owned tables.
+#[derive(Clone)]
+pub struct SqlxCrudMutationLog<DB>
+where
+    DB: Database,
+{
+    table: String,
+    scope: Arc<ScopeFn>,
+    _marker: PhantomData<fn() -> DB>,
+}
+
+impl<DB> fmt::Debug for SqlxCrudMutationLog<DB>
+where
+    DB: Database,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SqlxCrudMutationLog")
+            .field("table", &self.table)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<DB> SqlxCrudMutationLog<DB>
+where
+    DB: Database,
+{
+    /// Build a mutation log with an app-owned authorization scope function.
+    pub fn new(
+        scope: impl Fn(&RequestContext) -> SyncResult<String> + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            table: DEFAULT_CRUD_MUTATION_LOG_TABLE.to_string(),
+            scope: Arc::new(scope),
+            _marker: PhantomData,
+        }
+    }
+
+    /// Build a mutation log using one fixed scope.
+    ///
+    /// This is useful for single-tenant tests and demos. Multi-tenant
+    /// production apps should prefer [`Self::new`] and derive scope from the
+    /// authenticated request context.
+    pub fn constant_scope(scope: impl Into<String>) -> Self {
+        let scope = scope.into();
+        Self::new(move |_| Ok(scope.clone()))
+    }
+
+    /// Build a mutation log using the fixed `"global"` scope.
+    ///
+    /// This is intended for tests and single-tenant resources.
+    pub fn global() -> Self {
+        Self::constant_scope("global")
+    }
+
+    /// Use an app-owned table name.
+    ///
+    /// The identifier may be either `table` or `schema.table`; each identifier
+    /// segment must be ASCII alphanumeric or `_`, and must not start with a
+    /// digit. This deliberately avoids raw SQL injection through table names.
+    pub fn with_table(mut self, table: impl Into<String>) -> SyncResult<Self> {
+        self.table = validate_table_name(table.into())?;
+        Ok(self)
+    }
+
+    /// Return the configured table name.
+    pub fn table(&self) -> &str {
+        &self.table
+    }
+
+    fn scope(&self, ctx: &RequestContext) -> SyncResult<String> {
+        let scope = (self.scope)(ctx)?;
+        if scope.trim().is_empty() {
+            return Err(SyncError::client(
+                "SQLx CRUD mutation log scope must not be empty",
+            ));
+        }
+        Ok(scope)
+    }
+}
+
+macro_rules! impl_sqlx_crud_mutation_log {
+    ($feature:literal, $db:path, $p1:literal, $p2:literal, $p3:literal, $p4:literal, $p5:literal) => {
+        #[cfg(feature = $feature)]
+        #[pocopine_sync_crud::async_trait]
+        impl<RowValue> TransactionalCrudMutationLog<Transaction<'static, $db>, RowValue>
+            for SqlxCrudMutationLog<$db>
+        where
+            RowValue: Clone + Send + Sync + 'static,
+        {
+            async fn accepted_mutation_in_tx(
+                &self,
+                tx: &mut Transaction<'static, $db>,
+                ctx: &RequestContext,
+                mutation_id: &MutationId,
+            ) -> SyncResult<Option<CrudAcceptedMutation>> {
+                let scope = self.scope(ctx)?;
+                let sql = format!(
+                    "select op, row_key, payload from {} where scope = {} and mutation_id = {}",
+                    self.table, $p1, $p2
+                );
+                let row = sqlx::query(&sql)
+                    .bind(scope)
+                    .bind(mutation_id.as_str().to_string())
+                    .fetch_optional(&mut **tx)
+                    .await
+                    .map_err(sync_sqlx_error)?;
+
+                let Some(row) = row else {
+                    return Ok(None);
+                };
+
+                accepted_from_row(mutation_id, row)
+            }
+
+            async fn record_accepted_mutation_in_tx(
+                &self,
+                tx: &mut Transaction<'static, $db>,
+                ctx: &RequestContext,
+                accepted: CrudAcceptedMutation,
+            ) -> SyncResult<()> {
+                let scope = self.scope(ctx)?;
+                let payload = serde_json::to_string(&accepted.payload)?;
+                let row_key = accepted.key.as_ref().map(|key| key.as_str().to_string());
+                let sql = format!(
+                    "insert into {} (scope, mutation_id, op, row_key, payload) values ({}, {}, {}, {}, {})",
+                    self.table, $p1, $p2, $p3, $p4, $p5
+                );
+
+                sqlx::query(&sql)
+                    .bind(scope)
+                    .bind(accepted.mutation_id.as_str().to_string())
+                    .bind(op_to_db(accepted.op).to_string())
+                    .bind(row_key)
+                    .bind(payload)
+                    .execute(&mut **tx)
+                    .await
+                    .map_err(sync_sqlx_error)?;
+
+                Ok(())
+            }
+        }
+    };
+}
+
+impl_sqlx_crud_mutation_log!("sqlite", sqlx::Sqlite, "?", "?", "?", "?", "?");
+impl_sqlx_crud_mutation_log!("mysql", sqlx::MySql, "?", "?", "?", "?", "?");
+impl_sqlx_crud_mutation_log!("postgres", sqlx::Postgres, "$1", "$2", "$3", "$4", "$5");
+
+fn accepted_from_row<R>(
+    mutation_id: &MutationId,
+    row: R,
+) -> SyncResult<Option<CrudAcceptedMutation>>
+where
+    R: Row,
+    for<'row> String: Decode<'row, R::Database> + Type<R::Database>,
+    for<'row> Option<String>: Decode<'row, R::Database> + Type<R::Database>,
+    usize: ColumnIndex<R>,
+{
+    let op = op_from_db(row.try_get::<String, _>(0).map_err(sync_sqlx_error)?)?;
+    let key = row
+        .try_get::<Option<String>, _>(1)
+        .map_err(sync_sqlx_error)?
+        .map(RowKey::new)
+        .transpose()?;
+    let payload =
+        serde_json::from_str::<Value>(&row.try_get::<String, _>(2).map_err(sync_sqlx_error)?)?;
+
+    Ok(Some(CrudAcceptedMutation::new(
+        mutation_id.clone(),
+        op,
+        key,
+        payload,
+    )))
+}
+
+fn op_to_db(op: SyncOp) -> &'static str {
+    match op {
+        SyncOp::Upsert => "upsert",
+        SyncOp::Delete => "delete",
+        SyncOp::Reset => "reset",
+    }
+}
+
+fn op_from_db(value: String) -> SyncResult<SyncOp> {
+    match value.as_str() {
+        "upsert" => Ok(SyncOp::Upsert),
+        "delete" => Ok(SyncOp::Delete),
+        "reset" => Ok(SyncOp::Reset),
+        _ => Err(SyncError::backend(format!(
+            "unknown SQLx CRUD mutation op: {value}"
+        ))),
+    }
+}
+
+fn validate_table_name(table: String) -> SyncResult<String> {
+    if table.split('.').all(validate_identifier) {
+        Ok(table)
+    } else {
+        Err(SyncError::client(format!(
+            "invalid SQLx CRUD mutation log table name: {table}"
+        )))
+    }
+}
+
+fn validate_identifier(identifier: &str) -> bool {
+    let mut chars = identifier.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first == '_' || first.is_ascii_alphabetic())
+        && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
+}
+
+#[cfg(test)]
+mod tests {
+    use http::{HeaderMap, Method, Uri};
+    use pocopine_sync_crud::{
+        CrudAcceptedMutation, CrudTransactionRunner, TransactionalCrudMutationLog,
+    };
+
+    use crate::{sqlite, SqlxCrudTransactionRunner};
+
+    use super::*;
+
+    fn ctx_with_tenant(tenant: &'static str) -> RequestContext {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-tenant-id", tenant.parse().unwrap());
+        RequestContext::new(Method::POST, Uri::from_static("/sync"), headers)
+    }
+
+    fn tenant_log() -> SqlxCrudMutationLog<sqlx::Sqlite> {
+        SqlxCrudMutationLog::new(|ctx| {
+            ctx.header("x-tenant-id")
+                .map(str::to_string)
+                .ok_or_else(|| SyncError::client("missing tenant"))
+        })
+    }
+
+    async fn accepted_in_tx(
+        log: &SqlxCrudMutationLog<sqlx::Sqlite>,
+        tx: &mut Transaction<'static, sqlx::Sqlite>,
+        ctx: &RequestContext,
+        mutation_id: &MutationId,
+    ) -> SyncResult<Option<CrudAcceptedMutation>> {
+        <SqlxCrudMutationLog<sqlx::Sqlite> as TransactionalCrudMutationLog<
+            Transaction<'static, sqlx::Sqlite>,
+            (),
+        >>::accepted_mutation_in_tx(log, tx, ctx, mutation_id)
+        .await
+    }
+
+    async fn record_in_tx(
+        log: &SqlxCrudMutationLog<sqlx::Sqlite>,
+        tx: &mut Transaction<'static, sqlx::Sqlite>,
+        ctx: &RequestContext,
+        accepted: CrudAcceptedMutation,
+    ) -> SyncResult<()> {
+        <SqlxCrudMutationLog<sqlx::Sqlite> as TransactionalCrudMutationLog<
+            Transaction<'static, sqlx::Sqlite>,
+            (),
+        >>::record_accepted_mutation_in_tx(log, tx, ctx, accepted)
+        .await
+    }
+
+    #[test]
+    fn table_name_validation_rejects_raw_sql() {
+        let log = SqlxCrudMutationLog::<sqlx::Sqlite>::global()
+            .with_table("public.__pocopine_crud_mutations")
+            .unwrap();
+        assert_eq!(log.table(), "public.__pocopine_crud_mutations");
+
+        let err = SqlxCrudMutationLog::<sqlx::Sqlite>::global()
+            .with_table("__pocopine_crud_mutations; drop table posts")
+            .unwrap_err();
+        assert!(err.to_string().contains("invalid SQLx CRUD mutation"));
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn sqlite_mutation_log_round_trips_by_scope() {
+        let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
+        sqlx::query(SQLITE_CRUD_MUTATION_LOG_SCHEMA)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let runner: SqlxCrudTransactionRunner<sqlx::Sqlite> = sqlite(pool.clone());
+        let log = tenant_log();
+        let mutation_id = MutationId::new("device_a:1").unwrap();
+        let key = RowKey::new("post_1").unwrap();
+        let accepted = CrudAcceptedMutation::new(
+            mutation_id.clone(),
+            SyncOp::Upsert,
+            Some(key),
+            serde_json::json!({"id": "post_1", "title": "Draft"}),
+        );
+
+        let mut tx = runner.begin().await.unwrap();
+        assert_eq!(
+            accepted_in_tx(&log, &mut tx, &ctx_with_tenant("tenant_a"), &mutation_id)
+                .await
+                .unwrap(),
+            None
+        );
+        record_in_tx(
+            &log,
+            &mut tx,
+            &ctx_with_tenant("tenant_a"),
+            accepted.clone(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            accepted_in_tx(&log, &mut tx, &ctx_with_tenant("tenant_a"), &mutation_id)
+                .await
+                .unwrap(),
+            Some(accepted.clone())
+        );
+        assert_eq!(
+            accepted_in_tx(&log, &mut tx, &ctx_with_tenant("tenant_b"), &mutation_id)
+                .await
+                .unwrap(),
+            None
+        );
+        runner.commit(tx).await.unwrap();
+
+        let mut tx = runner.begin().await.unwrap();
+        assert_eq!(
+            accepted_in_tx(&log, &mut tx, &ctx_with_tenant("tenant_a"), &mutation_id)
+                .await
+                .unwrap(),
+            Some(accepted)
+        );
+        runner.rollback(tx).await.unwrap();
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn sqlite_mutation_log_rolls_back_with_transaction() {
+        let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
+        sqlx::query(SQLITE_CRUD_MUTATION_LOG_SCHEMA)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let runner: SqlxCrudTransactionRunner<sqlx::Sqlite> = sqlite(pool.clone());
+        let log = SqlxCrudMutationLog::<sqlx::Sqlite>::global();
+        let ctx = RequestContext::new(Method::POST, Uri::from_static("/sync"), HeaderMap::new());
+        let mutation_id = MutationId::new("device_a:2").unwrap();
+        let accepted = CrudAcceptedMutation::new(
+            mutation_id.clone(),
+            SyncOp::Delete,
+            Some(RowKey::new("post_2").unwrap()),
+            serde_json::json!({"id": "post_2"}),
+        );
+
+        let mut tx = runner.begin().await.unwrap();
+        record_in_tx(&log, &mut tx, &ctx, accepted).await.unwrap();
+        runner.rollback(tx).await.unwrap();
+
+        let mut tx = runner.begin().await.unwrap();
+        assert_eq!(
+            accepted_in_tx(&log, &mut tx, &ctx, &mutation_id)
+                .await
+                .unwrap(),
+            None
+        );
+        runner.rollback(tx).await.unwrap();
+    }
+}

--- a/crates/pocopine-sync-sqlx/src/mutation_log.rs
+++ b/crates/pocopine-sync-sqlx/src/mutation_log.rs
@@ -20,8 +20,7 @@ use crate::sync_sqlx_error;
 /// Default table used by [`SqlxCrudMutationLog`].
 pub const DEFAULT_CRUD_MUTATION_LOG_TABLE: &str = "__pocopine_crud_mutations";
 
-/// SQLite schema for the default CRUD mutation log table.
-pub const SQLITE_CRUD_MUTATION_LOG_SCHEMA: &str = r#"create table if not exists __pocopine_crud_mutations (
+const SQLITE_POSTGRES_CRUD_MUTATION_LOG_SCHEMA: &str = r#"create table if not exists __pocopine_crud_mutations (
   scope text not null,
   mutation_id text not null,
   op text not null,
@@ -30,15 +29,11 @@ pub const SQLITE_CRUD_MUTATION_LOG_SCHEMA: &str = r#"create table if not exists 
   primary key (scope, mutation_id)
 )"#;
 
+/// SQLite schema for the default CRUD mutation log table.
+pub const SQLITE_CRUD_MUTATION_LOG_SCHEMA: &str = SQLITE_POSTGRES_CRUD_MUTATION_LOG_SCHEMA;
+
 /// Postgres schema for the default CRUD mutation log table.
-pub const POSTGRES_CRUD_MUTATION_LOG_SCHEMA: &str = r#"create table if not exists __pocopine_crud_mutations (
-  scope text not null,
-  mutation_id text not null,
-  op text not null,
-  row_key text,
-  payload text not null,
-  primary key (scope, mutation_id)
-)"#;
+pub const POSTGRES_CRUD_MUTATION_LOG_SCHEMA: &str = SQLITE_POSTGRES_CRUD_MUTATION_LOG_SCHEMA;
 
 /// MySQL schema for the default CRUD mutation log table.
 ///
@@ -167,7 +162,9 @@ macro_rules! impl_sqlx_crud_mutation_log_conflict_clause {
                 accepted: CrudAcceptedMutation,
             ) -> SyncResult<CrudMutationReservation> {
                 let scope = self.scope(ctx)?;
+                let scope_for_lookup = scope.clone();
                 let mutation_id = accepted.mutation_id.clone();
+                let mutation_id_for_bind = mutation_id.as_str();
                 let payload = serde_json::to_string(&accepted.payload)?;
                 let row_key = accepted.key.as_ref().map(|key| key.as_str().to_string());
                 let sql = format!(
@@ -177,8 +174,8 @@ macro_rules! impl_sqlx_crud_mutation_log_conflict_clause {
 
                 let result = sqlx::query(&sql)
                     .bind(scope)
-                    .bind(mutation_id.as_str().to_string())
-                    .bind(op_to_db(accepted.op).to_string())
+                    .bind(mutation_id_for_bind)
+                    .bind(op_to_db(accepted.op))
                     .bind(row_key)
                     .bind(payload)
                     .execute(&mut **tx)
@@ -189,14 +186,13 @@ macro_rules! impl_sqlx_crud_mutation_log_conflict_clause {
                     return Ok(CrudMutationReservation::Reserved);
                 }
 
-                let scope = self.scope(ctx)?;
                 let sql = format!(
-                    "select mutation_id, op, row_key, payload from {} where scope = {} and mutation_id = {}",
+                    "select op, row_key, payload from {} where scope = {} and mutation_id = {}",
                     self.table, $p1, $p2
                 );
                 let row = sqlx::query(&sql)
-                    .bind(scope)
-                    .bind(mutation_id.as_str().to_string())
+                    .bind(scope_for_lookup)
+                    .bind(mutation_id_for_bind)
                     .fetch_optional(&mut **tx)
                     .await
                     .map_err(sync_sqlx_error)?
@@ -206,8 +202,7 @@ macro_rules! impl_sqlx_crud_mutation_log_conflict_clause {
                         )
                     })?;
 
-                let existing = accepted_from_row(&mutation_id, row)?
-                    .ok_or_else(|| SyncError::backend("SQLx CRUD mutation reservation was empty"))?;
+                let existing = accepted_from_row(&mutation_id, row)?;
                 Ok(CrudMutationReservation::AlreadyAccepted(existing))
             }
         }
@@ -231,7 +226,9 @@ macro_rules! impl_mysql_sqlx_crud_mutation_log {
                 accepted: CrudAcceptedMutation,
             ) -> SyncResult<CrudMutationReservation> {
                 let scope = self.scope(ctx)?;
+                let scope_for_lookup = scope.clone();
                 let mutation_id = accepted.mutation_id.clone();
+                let mutation_id_for_bind = mutation_id.as_str();
                 let payload = serde_json::to_string(&accepted.payload)?;
                 let row_key = accepted.key.as_ref().map(|key| key.as_str().to_string());
                 let sql = format!(
@@ -241,8 +238,8 @@ macro_rules! impl_mysql_sqlx_crud_mutation_log {
 
                 match sqlx::query(&sql)
                     .bind(scope)
-                    .bind(mutation_id.as_str().to_string())
-                    .bind(op_to_db(accepted.op).to_string())
+                    .bind(mutation_id_for_bind)
+                    .bind(op_to_db(accepted.op))
                     .bind(row_key)
                     .bind(payload)
                     .execute(&mut **tx)
@@ -250,14 +247,13 @@ macro_rules! impl_mysql_sqlx_crud_mutation_log {
                 {
                     Ok(_) => Ok(CrudMutationReservation::Reserved),
                     Err(sqlx::Error::Database(db_error)) if db_error.is_unique_violation() => {
-                        let scope = self.scope(ctx)?;
                         let sql = format!(
-                            "select mutation_id, op, row_key, payload from {} where scope = ? and mutation_id = ?",
+                            "select op, row_key, payload from {} where scope = ? and mutation_id = ?",
                             self.table
                         );
                         let row = sqlx::query(&sql)
-                            .bind(scope)
-                            .bind(mutation_id.as_str().to_string())
+                            .bind(scope_for_lookup)
+                            .bind(mutation_id_for_bind)
                             .fetch_optional(&mut **tx)
                             .await
                             .map_err(sync_sqlx_error)?
@@ -267,9 +263,7 @@ macro_rules! impl_mysql_sqlx_crud_mutation_log {
                                 )
                             })?;
 
-                        let existing = accepted_from_row(&mutation_id, row)?.ok_or_else(|| {
-                            SyncError::backend("SQLx CRUD mutation reservation was empty")
-                        })?;
+                        let existing = accepted_from_row(&mutation_id, row)?;
                         Ok(CrudMutationReservation::AlreadyAccepted(existing))
                     }
                     Err(err) => Err(sync_sqlx_error(err)),
@@ -305,39 +299,28 @@ impl_sqlx_crud_mutation_log_conflict_clause!(
 );
 
 #[cfg(any(feature = "postgres", feature = "mysql", feature = "sqlite"))]
-fn accepted_from_row<R>(
-    mutation_id: &MutationId,
-    row: R,
-) -> SyncResult<Option<CrudAcceptedMutation>>
+fn accepted_from_row<R>(mutation_id: &MutationId, row: R) -> SyncResult<CrudAcceptedMutation>
 where
     R: Row,
     for<'row> String: Decode<'row, R::Database> + Type<R::Database>,
     for<'row> Option<String>: Decode<'row, R::Database> + Type<R::Database>,
     usize: ColumnIndex<R>,
 {
-    let stored_mutation_id =
-        MutationId::new(row.try_get::<String, _>(0).map_err(sync_sqlx_error)?)?;
-    if &stored_mutation_id != mutation_id {
-        return Err(SyncError::backend(
-            "SQLx CRUD mutation lookup returned mismatched mutation id",
-        ));
-    }
-
-    let op = op_from_db(row.try_get::<String, _>(1).map_err(sync_sqlx_error)?)?;
+    let op = op_from_db(row.try_get::<String, _>(0).map_err(sync_sqlx_error)?)?;
     let key = row
-        .try_get::<Option<String>, _>(2)
+        .try_get::<Option<String>, _>(1)
         .map_err(sync_sqlx_error)?
         .map(RowKey::new)
         .transpose()?;
     let payload =
-        serde_json::from_str::<Value>(&row.try_get::<String, _>(3).map_err(sync_sqlx_error)?)?;
+        serde_json::from_str::<Value>(&row.try_get::<String, _>(2).map_err(sync_sqlx_error)?)?;
 
-    Ok(Some(CrudAcceptedMutation::new(
-        stored_mutation_id,
+    Ok(CrudAcceptedMutation::new(
+        mutation_id.clone(),
         op,
         key,
         payload,
-    )))
+    ))
 }
 
 #[cfg(any(feature = "postgres", feature = "mysql", feature = "sqlite"))]

--- a/crates/pocopine-sync-sqlx/src/mutation_log.rs
+++ b/crates/pocopine-sync-sqlx/src/mutation_log.rs
@@ -45,7 +45,8 @@ pub const POSTGRES_CRUD_MUTATION_LOG_SCHEMA: &str = r#"create table if not exist
 /// The default uses bounded indexed columns because MySQL cannot index
 /// unbounded `text` columns in a primary key. Apps with longer mutation ids or
 /// scope values should use their own table and point [`SqlxCrudMutationLog`] at
-/// it with [`SqlxCrudMutationLog::with_table`].
+/// it with [`SqlxCrudMutationLog::with_table`]. The helper validates sync token
+/// shape, but it does not know the configured MySQL column widths.
 pub const MYSQL_CRUD_MUTATION_LOG_SCHEMA: &str = r#"create table if not exists __pocopine_crud_mutations (
   scope varchar(191) not null,
   mutation_id varchar(191) not null,
@@ -149,9 +150,9 @@ where
     }
 }
 
-#[cfg(any(feature = "postgres", feature = "mysql", feature = "sqlite"))]
-macro_rules! impl_sqlx_crud_mutation_log {
-    ($feature:literal, $db:path, $p1:literal, $p2:literal, $p3:literal, $p4:literal, $p5:literal) => {
+#[cfg(any(feature = "postgres", feature = "sqlite"))]
+macro_rules! impl_sqlx_crud_mutation_log_conflict_clause {
+    ($feature:literal, $db:path, $conflict:literal, $p1:literal, $p2:literal, $p3:literal, $p4:literal, $p5:literal) => {
         #[cfg(feature = $feature)]
         #[pocopine_sync_crud::async_trait]
         impl<RowValue> TransactionalCrudMutationLog<Transaction<'static, $db>, RowValue>
@@ -159,58 +160,6 @@ macro_rules! impl_sqlx_crud_mutation_log {
         where
             RowValue: Clone + Send + Sync + 'static,
         {
-            async fn accepted_mutation_in_tx(
-                &self,
-                tx: &mut Transaction<'static, $db>,
-                ctx: &RequestContext,
-                mutation_id: &MutationId,
-            ) -> SyncResult<Option<CrudAcceptedMutation>> {
-                let scope = self.scope(ctx)?;
-                let sql = format!(
-                    "select mutation_id, op, row_key, payload from {} where scope = {} and mutation_id = {}",
-                    self.table, $p1, $p2
-                );
-                let row = sqlx::query(&sql)
-                    .bind(scope)
-                    .bind(mutation_id.as_str().to_string())
-                    .fetch_optional(&mut **tx)
-                    .await
-                    .map_err(sync_sqlx_error)?;
-
-                let Some(row) = row else {
-                    return Ok(None);
-                };
-
-                accepted_from_row(mutation_id, row)
-            }
-
-            async fn record_accepted_mutation_in_tx(
-                &self,
-                tx: &mut Transaction<'static, $db>,
-                ctx: &RequestContext,
-                accepted: CrudAcceptedMutation,
-            ) -> SyncResult<()> {
-                let scope = self.scope(ctx)?;
-                let payload = serde_json::to_string(&accepted.payload)?;
-                let row_key = accepted.key.as_ref().map(|key| key.as_str().to_string());
-                let sql = format!(
-                    "insert into {} (scope, mutation_id, op, row_key, payload) values ({}, {}, {}, {}, {})",
-                    self.table, $p1, $p2, $p3, $p4, $p5
-                );
-
-                sqlx::query(&sql)
-                    .bind(scope)
-                    .bind(accepted.mutation_id.as_str().to_string())
-                    .bind(op_to_db(accepted.op).to_string())
-                    .bind(row_key)
-                    .bind(payload)
-                    .execute(&mut **tx)
-                    .await
-                    .map_err(sync_sqlx_error)?;
-
-                Ok(())
-            }
-
             async fn reserve_accepted_mutation_in_tx(
                 &self,
                 tx: &mut Transaction<'static, $db>,
@@ -222,8 +171,72 @@ macro_rules! impl_sqlx_crud_mutation_log {
                 let payload = serde_json::to_string(&accepted.payload)?;
                 let row_key = accepted.key.as_ref().map(|key| key.as_str().to_string());
                 let sql = format!(
-                    "insert into {} (scope, mutation_id, op, row_key, payload) values ({}, {}, {}, {}, {})",
-                    self.table, $p1, $p2, $p3, $p4, $p5
+                    "insert into {} (scope, mutation_id, op, row_key, payload) values ({}, {}, {}, {}, {}){}",
+                    self.table, $p1, $p2, $p3, $p4, $p5, $conflict
+                );
+
+                let result = sqlx::query(&sql)
+                    .bind(scope)
+                    .bind(mutation_id.as_str().to_string())
+                    .bind(op_to_db(accepted.op).to_string())
+                    .bind(row_key)
+                    .bind(payload)
+                    .execute(&mut **tx)
+                    .await
+                    .map_err(sync_sqlx_error)?;
+
+                if result.rows_affected() == 1 {
+                    return Ok(CrudMutationReservation::Reserved);
+                }
+
+                let scope = self.scope(ctx)?;
+                let sql = format!(
+                    "select mutation_id, op, row_key, payload from {} where scope = {} and mutation_id = {}",
+                    self.table, $p1, $p2
+                );
+                let row = sqlx::query(&sql)
+                    .bind(scope)
+                    .bind(mutation_id.as_str().to_string())
+                    .fetch_optional(&mut **tx)
+                    .await
+                    .map_err(sync_sqlx_error)?
+                    .ok_or_else(|| {
+                        SyncError::backend(
+                            "SQLx CRUD mutation reservation conflict was not readable",
+                        )
+                    })?;
+
+                let existing = accepted_from_row(&mutation_id, row)?
+                    .ok_or_else(|| SyncError::backend("SQLx CRUD mutation reservation was empty"))?;
+                Ok(CrudMutationReservation::AlreadyAccepted(existing))
+            }
+        }
+    };
+}
+
+#[cfg(feature = "mysql")]
+macro_rules! impl_mysql_sqlx_crud_mutation_log {
+    () => {
+        #[pocopine_sync_crud::async_trait]
+        impl<RowValue>
+            TransactionalCrudMutationLog<Transaction<'static, sqlx::MySql>, RowValue>
+            for SqlxCrudMutationLog<sqlx::MySql>
+        where
+            RowValue: Clone + Send + Sync + 'static,
+        {
+            async fn reserve_accepted_mutation_in_tx(
+                &self,
+                tx: &mut Transaction<'static, sqlx::MySql>,
+                ctx: &RequestContext,
+                accepted: CrudAcceptedMutation,
+            ) -> SyncResult<CrudMutationReservation> {
+                let scope = self.scope(ctx)?;
+                let mutation_id = accepted.mutation_id.clone();
+                let payload = serde_json::to_string(&accepted.payload)?;
+                let row_key = accepted.key.as_ref().map(|key| key.as_str().to_string());
+                let sql = format!(
+                    "insert into {} (scope, mutation_id, op, row_key, payload) values (?, ?, ?, ?, ?)",
+                    self.table
                 );
 
                 match sqlx::query(&sql)
@@ -237,16 +250,26 @@ macro_rules! impl_sqlx_crud_mutation_log {
                 {
                     Ok(_) => Ok(CrudMutationReservation::Reserved),
                     Err(sqlx::Error::Database(db_error)) if db_error.is_unique_violation() => {
-                        let existing = <Self as TransactionalCrudMutationLog<
-                            Transaction<'static, $db>,
-                            RowValue,
-                        >>::accepted_mutation_in_tx(self, tx, ctx, &mutation_id)
-                        .await?;
-                        let Some(existing) = existing else {
-                            return Err(SyncError::backend(
-                                "SQLx CRUD mutation reservation conflict was not readable",
-                            ));
-                        };
+                        let scope = self.scope(ctx)?;
+                        let sql = format!(
+                            "select mutation_id, op, row_key, payload from {} where scope = ? and mutation_id = ?",
+                            self.table
+                        );
+                        let row = sqlx::query(&sql)
+                            .bind(scope)
+                            .bind(mutation_id.as_str().to_string())
+                            .fetch_optional(&mut **tx)
+                            .await
+                            .map_err(sync_sqlx_error)?
+                            .ok_or_else(|| {
+                                SyncError::backend(
+                                    "SQLx CRUD mutation reservation conflict was not readable",
+                                )
+                            })?;
+
+                        let existing = accepted_from_row(&mutation_id, row)?.ok_or_else(|| {
+                            SyncError::backend("SQLx CRUD mutation reservation was empty")
+                        })?;
                         Ok(CrudMutationReservation::AlreadyAccepted(existing))
                     }
                     Err(err) => Err(sync_sqlx_error(err)),
@@ -257,11 +280,29 @@ macro_rules! impl_sqlx_crud_mutation_log {
 }
 
 #[cfg(feature = "sqlite")]
-impl_sqlx_crud_mutation_log!("sqlite", sqlx::Sqlite, "?", "?", "?", "?", "?");
+impl_sqlx_crud_mutation_log_conflict_clause!(
+    "sqlite",
+    sqlx::Sqlite,
+    " on conflict(scope, mutation_id) do nothing",
+    "?",
+    "?",
+    "?",
+    "?",
+    "?"
+);
 #[cfg(feature = "mysql")]
-impl_sqlx_crud_mutation_log!("mysql", sqlx::MySql, "?", "?", "?", "?", "?");
+impl_mysql_sqlx_crud_mutation_log!();
 #[cfg(feature = "postgres")]
-impl_sqlx_crud_mutation_log!("postgres", sqlx::Postgres, "$1", "$2", "$3", "$4", "$5");
+impl_sqlx_crud_mutation_log_conflict_clause!(
+    "postgres",
+    sqlx::Postgres,
+    " on conflict(scope, mutation_id) do nothing",
+    "$1",
+    "$2",
+    "$3",
+    "$4",
+    "$5"
+);
 
 #[cfg(any(feature = "postgres", feature = "mysql", feature = "sqlite"))]
 fn accepted_from_row<R>(
@@ -321,7 +362,18 @@ fn op_from_db(value: String) -> SyncResult<SyncOp> {
 }
 
 fn validate_table_name(table: String) -> SyncResult<String> {
-    if table.split('.').all(validate_identifier) {
+    let mut parts = table.split('.');
+    let Some(first) = parts.next() else {
+        return Err(SyncError::client(format!(
+            "invalid SQLx CRUD mutation log table name: {table}"
+        )));
+    };
+    let second = parts.next();
+
+    if parts.next().is_none()
+        && validate_identifier(first)
+        && second.is_none_or(validate_identifier)
+    {
         Ok(table)
     } else {
         Err(SyncError::client(format!(
@@ -365,32 +417,6 @@ mod tests {
         })
     }
 
-    async fn accepted_in_tx(
-        log: &SqlxCrudMutationLog<sqlx::Sqlite>,
-        tx: &mut Transaction<'static, sqlx::Sqlite>,
-        ctx: &RequestContext,
-        mutation_id: &MutationId,
-    ) -> SyncResult<Option<CrudAcceptedMutation>> {
-        <SqlxCrudMutationLog<sqlx::Sqlite> as TransactionalCrudMutationLog<
-            Transaction<'static, sqlx::Sqlite>,
-            (),
-        >>::accepted_mutation_in_tx(log, tx, ctx, mutation_id)
-        .await
-    }
-
-    async fn record_in_tx(
-        log: &SqlxCrudMutationLog<sqlx::Sqlite>,
-        tx: &mut Transaction<'static, sqlx::Sqlite>,
-        ctx: &RequestContext,
-        accepted: CrudAcceptedMutation,
-    ) -> SyncResult<()> {
-        <SqlxCrudMutationLog<sqlx::Sqlite> as TransactionalCrudMutationLog<
-            Transaction<'static, sqlx::Sqlite>,
-            (),
-        >>::record_accepted_mutation_in_tx(log, tx, ctx, accepted)
-        .await
-    }
-
     async fn reserve_in_tx(
         log: &SqlxCrudMutationLog<sqlx::Sqlite>,
         tx: &mut Transaction<'static, sqlx::Sqlite>,
@@ -413,6 +439,11 @@ mod tests {
 
         let err = SqlxCrudMutationLog::<sqlx::Sqlite>::global()
             .with_table("__pocopine_crud_mutations; drop table posts")
+            .unwrap_err();
+        assert!(err.to_string().contains("invalid SQLx CRUD mutation"));
+
+        let err = SqlxCrudMutationLog::<sqlx::Sqlite>::global()
+            .with_table("too.many.segments")
             .unwrap_err();
         assert!(err.to_string().contains("invalid SQLx CRUD mutation"));
     }
@@ -439,39 +470,40 @@ mod tests {
 
         let mut tx = runner.begin().await.unwrap();
         assert_eq!(
-            accepted_in_tx(&log, &mut tx, &ctx_with_tenant("tenant_a"), &mutation_id)
-                .await
-                .unwrap(),
-            None
-        );
-        record_in_tx(
-            &log,
-            &mut tx,
-            &ctx_with_tenant("tenant_a"),
-            accepted.clone(),
-        )
-        .await
-        .unwrap();
-        assert_eq!(
-            accepted_in_tx(&log, &mut tx, &ctx_with_tenant("tenant_a"), &mutation_id)
-                .await
-                .unwrap(),
-            Some(accepted.clone())
-        );
-        assert_eq!(
-            accepted_in_tx(&log, &mut tx, &ctx_with_tenant("tenant_b"), &mutation_id)
-                .await
-                .unwrap(),
-            None
+            reserve_in_tx(
+                &log,
+                &mut tx,
+                &ctx_with_tenant("tenant_a"),
+                accepted.clone(),
+            )
+            .await
+            .unwrap(),
+            CrudMutationReservation::Reserved
         );
         runner.commit(tx).await.unwrap();
 
         let mut tx = runner.begin().await.unwrap();
         assert_eq!(
-            accepted_in_tx(&log, &mut tx, &ctx_with_tenant("tenant_a"), &mutation_id)
-                .await
-                .unwrap(),
-            Some(accepted)
+            reserve_in_tx(
+                &log,
+                &mut tx,
+                &ctx_with_tenant("tenant_a"),
+                accepted.clone(),
+            )
+            .await
+            .unwrap(),
+            CrudMutationReservation::AlreadyAccepted(accepted.clone())
+        );
+        assert_eq!(
+            reserve_in_tx(
+                &log,
+                &mut tx,
+                &ctx_with_tenant("tenant_b"),
+                accepted.clone(),
+            )
+            .await
+            .unwrap(),
+            CrudMutationReservation::Reserved
         );
         runner.rollback(tx).await.unwrap();
     }
@@ -547,15 +579,18 @@ mod tests {
         );
 
         let mut tx = runner.begin().await.unwrap();
-        record_in_tx(&log, &mut tx, &ctx, accepted).await.unwrap();
+        assert_eq!(
+            reserve_in_tx(&log, &mut tx, &ctx, accepted.clone())
+                .await
+                .unwrap(),
+            CrudMutationReservation::Reserved
+        );
         runner.rollback(tx).await.unwrap();
 
         let mut tx = runner.begin().await.unwrap();
         assert_eq!(
-            accepted_in_tx(&log, &mut tx, &ctx, &mutation_id)
-                .await
-                .unwrap(),
-            None
+            reserve_in_tx(&log, &mut tx, &ctx, accepted).await.unwrap(),
+            CrudMutationReservation::Reserved
         );
         runner.rollback(tx).await.unwrap();
     }
@@ -572,15 +607,16 @@ mod tests {
         let runner: SqlxCrudTransactionRunner<sqlx::Sqlite> = sqlite(pool.clone());
         let log = SqlxCrudMutationLog::<sqlx::Sqlite>::constant_scope(" tenant ");
         let ctx = RequestContext::new(Method::POST, Uri::from_static("/sync"), HeaderMap::new());
+        let accepted = CrudAcceptedMutation::new(
+            MutationId::new("device_a:scope").unwrap(),
+            SyncOp::Delete,
+            Some(RowKey::new("post_2").unwrap()),
+            serde_json::json!({"id": "post_2"}),
+        );
         let mut tx = runner.begin().await.unwrap();
-        let err = accepted_in_tx(
-            &log,
-            &mut tx,
-            &ctx,
-            &MutationId::new("device_a:scope").unwrap(),
-        )
-        .await
-        .unwrap_err();
+        let err = reserve_in_tx(&log, &mut tx, &ctx, accepted)
+            .await
+            .unwrap_err();
         assert!(err.to_string().contains("non-empty and trimmed"));
         runner.rollback(tx).await.unwrap();
     }
@@ -609,15 +645,16 @@ mod tests {
         let runner: SqlxCrudTransactionRunner<sqlx::Sqlite> = sqlite(pool.clone());
         let log = SqlxCrudMutationLog::<sqlx::Sqlite>::global();
         let ctx = RequestContext::new(Method::POST, Uri::from_static("/sync"), HeaderMap::new());
+        let accepted = CrudAcceptedMutation::new(
+            MutationId::new("device_a:bad_op").unwrap(),
+            SyncOp::Delete,
+            Some(RowKey::new("post_1").unwrap()),
+            serde_json::json!({"id": "post_1"}),
+        );
         let mut tx = runner.begin().await.unwrap();
-        let err = accepted_in_tx(
-            &log,
-            &mut tx,
-            &ctx,
-            &MutationId::new("device_a:bad_op").unwrap(),
-        )
-        .await
-        .unwrap_err();
+        let err = reserve_in_tx(&log, &mut tx, &ctx, accepted)
+            .await
+            .unwrap_err();
         assert!(err.to_string().contains("unknown SQLx CRUD mutation op"));
         runner.rollback(tx).await.unwrap();
     }

--- a/crates/pocopine-sync-sqlx/src/mutation_log.rs
+++ b/crates/pocopine-sync-sqlx/src/mutation_log.rs
@@ -1,11 +1,18 @@
 use std::{fmt, marker::PhantomData, sync::Arc};
 
 use pocopine_auth::RequestContext;
-use pocopine_sync::{MutationId, RowKey, SyncError, SyncOp, SyncResult};
+#[cfg(any(feature = "postgres", feature = "mysql", feature = "sqlite"))]
+use pocopine_sync::{MutationId, RowKey, SyncOp};
+use pocopine_sync::{SyncError, SyncResult};
+#[cfg(any(feature = "postgres", feature = "mysql", feature = "sqlite"))]
 use pocopine_sync_crud::{CrudAcceptedMutation, TransactionalCrudMutationLog};
+#[cfg(any(feature = "postgres", feature = "mysql", feature = "sqlite"))]
 use serde_json::Value;
-use sqlx::{ColumnIndex, Database, Decode, Row, Transaction, Type};
+use sqlx::Database;
+#[cfg(any(feature = "postgres", feature = "mysql", feature = "sqlite"))]
+use sqlx::{ColumnIndex, Decode, Row, Transaction, Type};
 
+#[cfg(any(feature = "postgres", feature = "mysql", feature = "sqlite"))]
 use crate::sync_sqlx_error;
 
 /// Default table used by [`SqlxCrudMutationLog`].
@@ -61,6 +68,10 @@ where
     DB: Database,
 {
     table: String,
+    #[cfg_attr(
+        not(any(feature = "postgres", feature = "mysql", feature = "sqlite")),
+        allow(dead_code)
+    )]
     scope: Arc<ScopeFn>,
     _marker: PhantomData<fn() -> DB>,
 }
@@ -123,6 +134,7 @@ where
         &self.table
     }
 
+    #[cfg(any(feature = "postgres", feature = "mysql", feature = "sqlite"))]
     fn scope(&self, ctx: &RequestContext) -> SyncResult<String> {
         let scope = (self.scope)(ctx)?;
         if scope.trim().is_empty() {
@@ -134,6 +146,7 @@ where
     }
 }
 
+#[cfg(any(feature = "postgres", feature = "mysql", feature = "sqlite"))]
 macro_rules! impl_sqlx_crud_mutation_log {
     ($feature:literal, $db:path, $p1:literal, $p2:literal, $p3:literal, $p4:literal, $p5:literal) => {
         #[cfg(feature = $feature)]
@@ -198,10 +211,14 @@ macro_rules! impl_sqlx_crud_mutation_log {
     };
 }
 
+#[cfg(feature = "sqlite")]
 impl_sqlx_crud_mutation_log!("sqlite", sqlx::Sqlite, "?", "?", "?", "?", "?");
+#[cfg(feature = "mysql")]
 impl_sqlx_crud_mutation_log!("mysql", sqlx::MySql, "?", "?", "?", "?", "?");
+#[cfg(feature = "postgres")]
 impl_sqlx_crud_mutation_log!("postgres", sqlx::Postgres, "$1", "$2", "$3", "$4", "$5");
 
+#[cfg(any(feature = "postgres", feature = "mysql", feature = "sqlite"))]
 fn accepted_from_row<R>(
     mutation_id: &MutationId,
     row: R,
@@ -229,6 +246,7 @@ where
     )))
 }
 
+#[cfg(any(feature = "postgres", feature = "mysql", feature = "sqlite"))]
 fn op_to_db(op: SyncOp) -> &'static str {
     match op {
         SyncOp::Upsert => "upsert",
@@ -237,6 +255,7 @@ fn op_to_db(op: SyncOp) -> &'static str {
     }
 }
 
+#[cfg(any(feature = "postgres", feature = "mysql", feature = "sqlite"))]
 fn op_from_db(value: String) -> SyncResult<SyncOp> {
     match value.as_str() {
         "upsert" => Ok(SyncOp::Upsert),
@@ -267,7 +286,7 @@ fn validate_identifier(identifier: &str) -> bool {
         && chars.all(|ch| ch == '_' || ch.is_ascii_alphanumeric())
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "sqlite"))]
 mod tests {
     use http::{HeaderMap, Method, Uri};
     use pocopine_sync_crud::{

--- a/crates/pocopine-sync-sqlx/src/mutation_log.rs
+++ b/crates/pocopine-sync-sqlx/src/mutation_log.rs
@@ -5,7 +5,9 @@ use pocopine_auth::RequestContext;
 use pocopine_sync::{MutationId, RowKey, SyncOp};
 use pocopine_sync::{SyncError, SyncResult};
 #[cfg(any(feature = "postgres", feature = "mysql", feature = "sqlite"))]
-use pocopine_sync_crud::{CrudAcceptedMutation, TransactionalCrudMutationLog};
+use pocopine_sync_crud::{
+    CrudAcceptedMutation, CrudMutationReservation, TransactionalCrudMutationLog,
+};
 #[cfg(any(feature = "postgres", feature = "mysql", feature = "sqlite"))]
 use serde_json::Value;
 use sqlx::Database;
@@ -137,9 +139,10 @@ where
     #[cfg(any(feature = "postgres", feature = "mysql", feature = "sqlite"))]
     fn scope(&self, ctx: &RequestContext) -> SyncResult<String> {
         let scope = (self.scope)(ctx)?;
-        if scope.trim().is_empty() {
+        let trimmed = scope.trim();
+        if trimmed.is_empty() || trimmed != scope {
             return Err(SyncError::client(
-                "SQLx CRUD mutation log scope must not be empty",
+                "SQLx CRUD mutation log scope must be non-empty and trimmed",
             ));
         }
         Ok(scope)
@@ -164,7 +167,7 @@ macro_rules! impl_sqlx_crud_mutation_log {
             ) -> SyncResult<Option<CrudAcceptedMutation>> {
                 let scope = self.scope(ctx)?;
                 let sql = format!(
-                    "select op, row_key, payload from {} where scope = {} and mutation_id = {}",
+                    "select mutation_id, op, row_key, payload from {} where scope = {} and mutation_id = {}",
                     self.table, $p1, $p2
                 );
                 let row = sqlx::query(&sql)
@@ -207,6 +210,48 @@ macro_rules! impl_sqlx_crud_mutation_log {
 
                 Ok(())
             }
+
+            async fn reserve_accepted_mutation_in_tx(
+                &self,
+                tx: &mut Transaction<'static, $db>,
+                ctx: &RequestContext,
+                accepted: CrudAcceptedMutation,
+            ) -> SyncResult<CrudMutationReservation> {
+                let scope = self.scope(ctx)?;
+                let mutation_id = accepted.mutation_id.clone();
+                let payload = serde_json::to_string(&accepted.payload)?;
+                let row_key = accepted.key.as_ref().map(|key| key.as_str().to_string());
+                let sql = format!(
+                    "insert into {} (scope, mutation_id, op, row_key, payload) values ({}, {}, {}, {}, {})",
+                    self.table, $p1, $p2, $p3, $p4, $p5
+                );
+
+                match sqlx::query(&sql)
+                    .bind(scope)
+                    .bind(mutation_id.as_str().to_string())
+                    .bind(op_to_db(accepted.op).to_string())
+                    .bind(row_key)
+                    .bind(payload)
+                    .execute(&mut **tx)
+                    .await
+                {
+                    Ok(_) => Ok(CrudMutationReservation::Reserved),
+                    Err(sqlx::Error::Database(db_error)) if db_error.is_unique_violation() => {
+                        let existing = <Self as TransactionalCrudMutationLog<
+                            Transaction<'static, $db>,
+                            RowValue,
+                        >>::accepted_mutation_in_tx(self, tx, ctx, &mutation_id)
+                        .await?;
+                        let Some(existing) = existing else {
+                            return Err(SyncError::backend(
+                                "SQLx CRUD mutation reservation conflict was not readable",
+                            ));
+                        };
+                        Ok(CrudMutationReservation::AlreadyAccepted(existing))
+                    }
+                    Err(err) => Err(sync_sqlx_error(err)),
+                }
+            }
         }
     };
 }
@@ -229,17 +274,25 @@ where
     for<'row> Option<String>: Decode<'row, R::Database> + Type<R::Database>,
     usize: ColumnIndex<R>,
 {
-    let op = op_from_db(row.try_get::<String, _>(0).map_err(sync_sqlx_error)?)?;
+    let stored_mutation_id =
+        MutationId::new(row.try_get::<String, _>(0).map_err(sync_sqlx_error)?)?;
+    if &stored_mutation_id != mutation_id {
+        return Err(SyncError::backend(
+            "SQLx CRUD mutation lookup returned mismatched mutation id",
+        ));
+    }
+
+    let op = op_from_db(row.try_get::<String, _>(1).map_err(sync_sqlx_error)?)?;
     let key = row
-        .try_get::<Option<String>, _>(1)
+        .try_get::<Option<String>, _>(2)
         .map_err(sync_sqlx_error)?
         .map(RowKey::new)
         .transpose()?;
     let payload =
-        serde_json::from_str::<Value>(&row.try_get::<String, _>(2).map_err(sync_sqlx_error)?)?;
+        serde_json::from_str::<Value>(&row.try_get::<String, _>(3).map_err(sync_sqlx_error)?)?;
 
     Ok(Some(CrudAcceptedMutation::new(
-        mutation_id.clone(),
+        stored_mutation_id,
         op,
         key,
         payload,
@@ -290,7 +343,8 @@ fn validate_identifier(identifier: &str) -> bool {
 mod tests {
     use http::{HeaderMap, Method, Uri};
     use pocopine_sync_crud::{
-        CrudAcceptedMutation, CrudTransactionRunner, TransactionalCrudMutationLog,
+        CrudAcceptedMutation, CrudMutationReservation, CrudTransactionRunner,
+        TransactionalCrudMutationLog,
     };
 
     use crate::{sqlite, SqlxCrudTransactionRunner};
@@ -334,6 +388,19 @@ mod tests {
             Transaction<'static, sqlx::Sqlite>,
             (),
         >>::record_accepted_mutation_in_tx(log, tx, ctx, accepted)
+        .await
+    }
+
+    async fn reserve_in_tx(
+        log: &SqlxCrudMutationLog<sqlx::Sqlite>,
+        tx: &mut Transaction<'static, sqlx::Sqlite>,
+        ctx: &RequestContext,
+        accepted: CrudAcceptedMutation,
+    ) -> SyncResult<CrudMutationReservation> {
+        <SqlxCrudMutationLog<sqlx::Sqlite> as TransactionalCrudMutationLog<
+            Transaction<'static, sqlx::Sqlite>,
+            (),
+        >>::reserve_accepted_mutation_in_tx(log, tx, ctx, accepted)
         .await
     }
 
@@ -411,6 +478,56 @@ mod tests {
 
     #[cfg(feature = "sqlite")]
     #[tokio::test]
+    async fn sqlite_mutation_log_reserves_before_duplicate_replay() {
+        let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
+        sqlx::query(SQLITE_CRUD_MUTATION_LOG_SCHEMA)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let runner: SqlxCrudTransactionRunner<sqlx::Sqlite> = sqlite(pool.clone());
+        let log = SqlxCrudMutationLog::<sqlx::Sqlite>::global();
+        let ctx = RequestContext::new(Method::POST, Uri::from_static("/sync"), HeaderMap::new());
+        let mutation_id = MutationId::new("device_a:reserved").unwrap();
+        let accepted = CrudAcceptedMutation::new(
+            mutation_id.clone(),
+            SyncOp::Upsert,
+            Some(RowKey::new("post_1").unwrap()),
+            serde_json::json!({"id": "post_1", "title": "Draft"}),
+        );
+
+        let mut tx = runner.begin().await.unwrap();
+        assert_eq!(
+            reserve_in_tx(&log, &mut tx, &ctx, accepted.clone())
+                .await
+                .unwrap(),
+            CrudMutationReservation::Reserved
+        );
+        runner.commit(tx).await.unwrap();
+
+        let mut tx = runner.begin().await.unwrap();
+        assert_eq!(
+            reserve_in_tx(&log, &mut tx, &ctx, accepted.clone())
+                .await
+                .unwrap(),
+            CrudMutationReservation::AlreadyAccepted(accepted.clone())
+        );
+
+        let changed = CrudAcceptedMutation::new(
+            mutation_id,
+            SyncOp::Delete,
+            Some(RowKey::new("post_1").unwrap()),
+            serde_json::json!({"id": "post_1"}),
+        );
+        assert_eq!(
+            reserve_in_tx(&log, &mut tx, &ctx, changed).await.unwrap(),
+            CrudMutationReservation::AlreadyAccepted(accepted)
+        );
+        runner.rollback(tx).await.unwrap();
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
     async fn sqlite_mutation_log_rolls_back_with_transaction() {
         let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
         sqlx::query(SQLITE_CRUD_MUTATION_LOG_SCHEMA)
@@ -440,6 +557,68 @@ mod tests {
                 .unwrap(),
             None
         );
+        runner.rollback(tx).await.unwrap();
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn sqlite_mutation_log_rejects_untrimmed_scope() {
+        let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
+        sqlx::query(SQLITE_CRUD_MUTATION_LOG_SCHEMA)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let runner: SqlxCrudTransactionRunner<sqlx::Sqlite> = sqlite(pool.clone());
+        let log = SqlxCrudMutationLog::<sqlx::Sqlite>::constant_scope(" tenant ");
+        let ctx = RequestContext::new(Method::POST, Uri::from_static("/sync"), HeaderMap::new());
+        let mut tx = runner.begin().await.unwrap();
+        let err = accepted_in_tx(
+            &log,
+            &mut tx,
+            &ctx,
+            &MutationId::new("device_a:scope").unwrap(),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("non-empty and trimmed"));
+        runner.rollback(tx).await.unwrap();
+    }
+
+    #[cfg(feature = "sqlite")]
+    #[tokio::test]
+    async fn sqlite_mutation_log_rejects_unknown_stored_op() {
+        let pool = sqlx::SqlitePool::connect(":memory:").await.unwrap();
+        sqlx::query(SQLITE_CRUD_MUTATION_LOG_SCHEMA)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        sqlx::query(
+            "insert into __pocopine_crud_mutations (scope, mutation_id, op, row_key, payload) values (?, ?, ?, ?, ?)",
+        )
+        .bind("global")
+        .bind("device_a:bad_op")
+        .bind("merge")
+        .bind("post_1")
+        .bind(r#"{"id":"post_1"}"#)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let runner: SqlxCrudTransactionRunner<sqlx::Sqlite> = sqlite(pool.clone());
+        let log = SqlxCrudMutationLog::<sqlx::Sqlite>::global();
+        let ctx = RequestContext::new(Method::POST, Uri::from_static("/sync"), HeaderMap::new());
+        let mut tx = runner.begin().await.unwrap();
+        let err = accepted_in_tx(
+            &log,
+            &mut tx,
+            &ctx,
+            &MutationId::new("device_a:bad_op").unwrap(),
+        )
+        .await
+        .unwrap_err();
+        assert!(err.to_string().contains("unknown SQLx CRUD mutation op"));
         runner.rollback(tx).await.unwrap();
     }
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -73,6 +73,9 @@ looks the way it does — the code itself tells you *what*.
   concrete generated CRUD macro API contract, including the server
   resource module shape, client binding helpers, queued/online handling,
   and conflict outcome semantics.
+- [`sync-sqlx.md`](./sync-sqlx.md) — host/server SQLx helpers for
+  transactional CRUD sync resources, including backend feature flags,
+  accepted-mutation schema, and the app-owned SQL boundary.
 - [`logging-tracing-observer.md`](./logging-tracing-observer.md) —
   browser console logging, backend logging, structured observed
   events, analytics sinks, privacy labels, and target filtering.

--- a/docs/sync-conflict-architecture.md
+++ b/docs/sync-conflict-architecture.md
@@ -284,17 +284,20 @@ Server-side CRUD writes must be atomic at the app database boundary:
 ```text
 begin transaction
   -> authorize and validate
+  -> reserve accepted mutation id
   -> check base_version
   -> write row
-  -> record accepted mutation id
-commit
+  -> commit accepted writes
+  -> rollback conflicts, rejections, and errors
 publish live wake-up after commit
 ```
 
 `CrudMutationLog` exists so a replayed mutation id does not duplicate a
 write. Production logs must be scoped to the same authorization domain as
 the source rows, for example `(tenant_id, mutation_id)`, not only
-`mutation_id`.
+`mutation_id`. The accepted-mutation reservation must happen before the
+source write under a unique key so concurrent retries cannot both apply
+the same mutation.
 
 Production CRUD resources should use the transaction-backed path:
 `.transactional(runner, log)`. The runner owns begin/commit/rollback, the

--- a/docs/sync-crud-macro-contract.md
+++ b/docs/sync-crud-macro-contract.md
@@ -429,12 +429,12 @@ What the server handles at runtime:
 1. `/open` discovers the guarded stream and checks the guard.
 2. `/pull` calls `CrudSource::list` and returns canonical rows.
 3. `/push` deserializes the CRUD payload envelope.
-4. On the transactional path, replayed mutation ids are deduped by the
-   mutation log in the same transaction boundary used for writes.
+4. On the transactional path, mutation ids are reserved by the mutation
+   log in the same transaction boundary used for writes.
 5. `save` and `remove` pass the client `base_version` into the source so
    the source can compare and write atomically inside the same transaction.
-6. Accepted writes record the mutation id before commit, and live
-   invalidation is published after commit.
+6. Accepted writes commit the reserved mutation id with the row write, and
+   live invalidation is published after commit.
 7. Stale writes return `Conflict` with the server row when available.
 8. Invalid payloads, auth failures, and domain validation failures return `Rejected`.
 
@@ -443,7 +443,7 @@ or SQL. Production code should use `.transactional(...)` and implement
 `CrudTransactionRunner`, `TransactionalCrudSource`, and
 `TransactionalCrudMutationLog` against the same database and tenant scope
 as the source query. The accepted-mutation table needs a unique key over
-that scope and `mutation_id`; the lookup alone is not a concurrency
+that scope and `mutation_id`; the reservation insert is the concurrency
 boundary.
 
 For SQLx-backed resources, `pocopine-sync-sqlx` supplies the transaction

--- a/docs/sync-crud-macro-contract.md
+++ b/docs/sync-crud-macro-contract.md
@@ -400,8 +400,8 @@ pub async fn build_server(pool: sqlx::PgPool) -> anyhow::Result<pocopine_server:
         .id(|row: &Customer| row.id)
         .version(|row: &Customer| row.version)
         .transactional(
-            SqlxCrudTransactions { pool: pool.clone() },
-            CustomerMutationLog,
+            pocopine_sync_sqlx::postgres(pool.clone()),
+            pocopine_sync_sqlx::SqlxCrudMutationLog::<sqlx::Postgres>::new(tenant_scope),
         );
 
     let sync = pocopine_sync::SyncServer::builder()
@@ -445,6 +445,11 @@ or SQL. Production code should use `.transactional(...)` and implement
 as the source query. The accepted-mutation table needs a unique key over
 that scope and `mutation_id`; the lookup alone is not a concurrency
 boundary.
+
+For SQLx-backed resources, `pocopine-sync-sqlx` supplies the transaction
+runner and durable accepted-mutation log helper. Apps still implement
+`CrudSource` and `TransactionalCrudSource` with normal backend-specific
+SQLx queries. See [`sync-sqlx.md`](./sync-sqlx.md).
 
 ## Client API
 

--- a/docs/sync-crud.md
+++ b/docs/sync-crud.md
@@ -292,8 +292,8 @@ The transaction-backed path requires three app-owned pieces:
   transaction handle.
 - `TransactionalCrudSource<Tx>` applies `create_in_tx`, `save_in_tx`, and
   `remove_in_tx` using that handle.
-- `TransactionalCrudMutationLog<Tx, Row>` checks and records accepted
-  mutation ids using the same handle and tenant/auth scope.
+- `TransactionalCrudMutationLog<Tx, Row>` reserves, checks, and records
+  accepted mutation ids using the same handle and tenant/auth scope.
 
 `pocopine-sync-sqlx` now supplies the common SQLx transaction runner and
 accepted-mutation log helper for Postgres, MySQL, and SQLite feature
@@ -305,24 +305,23 @@ The sync adapter opens one transaction per mutation in a push request:
 
 ```text
 begin transaction
-  -> check accepted mutation id for this tenant/auth scope
+  -> reserve accepted mutation id for this tenant/auth scope
+  -> if already accepted, acknowledge exact replay or reject changed contents
   -> apply source write and base_version check
-  -> record accepted mutation id
-commit
+  -> commit accepted writes
+  -> roll back conflicts, rejections, and backend errors
 ```
 
-Conflicts and rejected outcomes do not record an accepted mutation id. The
-adapter still commits a conflict transaction because the source may have
-performed safe validation reads, but source implementations that return
-`Conflict` or `Rejected` must not leave business side effects in the
-transaction.
+The mutation id is reserved before the source write so concurrent retries
+cannot both pass the idempotency check. Conflicts and rejected outcomes
+roll back the transaction, which removes the reservation and leaves the
+client free to correct and retry the mutation.
 
 The accepted-mutation table should enforce a unique key over the same
 authorization scope used by the source query, for example
-`(tenant_id, mutation_id)`. The lookup alone is not enough under
-concurrent retry; a unique constraint or equivalent isolation rule must
-prevent two transactions from both observing "missing" and applying the
-same write.
+`(tenant_id, mutation_id)`. The reservation insert, not a prior lookup,
+is the concurrency boundary that prevents two transactions from both
+applying the same write.
 
 `MutationId` only dedupes sync replay. It is not a complete business
 idempotency key. External side effects such as payments, inventory
@@ -754,11 +753,11 @@ Server-side sync replay should use the transaction-backed resource path:
 
 ```text
 begin transaction
-  -> check accepted mutation id
+  -> reserve accepted mutation id
+  -> if already accepted, acknowledge exact replay or reject changed contents
   -> run one CRUD source write and base_version check
-  -> record accepted mutation id when the write is accepted
-  -> commit on success
-  -> rollback on error
+  -> commit accepted writes
+  -> rollback conflicts, rejections, and errors
   -> after commit, publish sync/live invalidations
 ```
 

--- a/docs/sync-crud.md
+++ b/docs/sync-crud.md
@@ -242,8 +242,8 @@ let customers = customers::resource(Customers {
 .id(|row: &Customer| row.id)
 .version(|row: &Customer| row.version)
 .transactional(
-    SqlxCrudTransactions { pool: pool.clone() },
-    CustomerMutationLog,
+    pocopine_sync_sqlx::postgres(pool.clone()),
+    pocopine_sync_sqlx::SqlxCrudMutationLog::<sqlx::Postgres>::new(tenant_scope),
 );
 
 let sync = pocopine_sync::SyncServer::builder()
@@ -294,6 +294,12 @@ The transaction-backed path requires three app-owned pieces:
   `remove_in_tx` using that handle.
 - `TransactionalCrudMutationLog<Tx, Row>` checks and records accepted
   mutation ids using the same handle and tenant/auth scope.
+
+`pocopine-sync-sqlx` now supplies the common SQLx transaction runner and
+accepted-mutation log helper for Postgres, MySQL, and SQLite feature
+flags. Apps still implement `CrudSource` and `TransactionalCrudSource`
+with normal SQLx queries. See [`sync-sqlx.md`](./sync-sqlx.md) for the
+schema and backend-specific notes.
 
 The sync adapter opens one transaction per mutation in a push request:
 

--- a/docs/sync-local-first-roadmap.md
+++ b/docs/sync-local-first-roadmap.md
@@ -123,9 +123,10 @@ Production server writes must be atomic:
 ```text
 begin transaction
   -> authorize and validate
+  -> reserve accepted mutation id
   -> check base_version and write row
-  -> record accepted mutation id
-commit
+  -> commit accepted writes
+  -> rollback conflicts, rejections, and errors
 publish live wake-up after commit
 ```
 
@@ -133,14 +134,16 @@ The first transaction-backed server slice is now in place. Resources can
 opt into `.transactional(runner, log)`, where `CrudTransactionRunner`
 owns begin/commit/rollback, `TransactionalCrudSource<Tx>` applies the
 CRUD write with the active transaction handle, and
-`TransactionalCrudMutationLog<Tx, Row>` checks and records accepted
+`TransactionalCrudMutationLog<Tx, Row>` reserves and reads accepted
 mutation ids with the same handle.
 
 The older `.mutation_log(...)` terminator remains available for simple
 adapters and tests, but it cannot force the source write and
 accepted-mutation insert to share one transaction. Production resources
 should use the transaction-backed path and enforce a unique accepted-log
-key over the same authorization scope as the source query.
+key over the same authorization scope as the source query. The reservation
+insert is the retry/concurrency boundary; conflicts and rejections roll
+back that reservation.
 
 What is still left is backend-specific packaging, not the core contract:
 

--- a/docs/sync-local-first-roadmap.md
+++ b/docs/sync-local-first-roadmap.md
@@ -144,11 +144,15 @@ key over the same authorization scope as the source query.
 
 What is still left is backend-specific packaging, not the core contract:
 
-- SQLx or other database-specific convenience adapters,
-- complete durable mutation log examples against real databases,
+- richer SQLx source examples for full CRUD resources,
 - integration tests for backend-specific crash/retry boundaries where possible,
 - more docs for app-level idempotency keys in payments,
   inventory, uniqueness-sensitive, or other side-effecting domains.
+
+The first SQLx packaging slice now exists in `pocopine-sync-sqlx`. It
+ships a generic SQLx transaction runner, backend-feature constructors for
+Postgres/MySQL/SQLite, and a durable accepted-mutation log helper with
+SQLite-backed tests. Source SQL remains app-owned and backend-specific.
 
 ### 4. Backend-Agnostic Change Sources
 
@@ -294,7 +298,8 @@ simple and hard to misuse.
 2. Add transaction-backed server helper paths for source write + mutation
    log insert.
 3. Add SQLx helper adapters for server CRUD sources, without becoming an
-   ORM.
+   ORM. The first transaction-runner and accepted-mutation-log helper is
+   in place; richer source examples remain.
 4. Add a durable row-scoped pending-mutation purge operation if the
    author-facing API needs true "discard local edits" semantics.
 5. Document auth/cache partitioning and sign-out reset behavior.

--- a/docs/sync-sqlx.md
+++ b/docs/sync-sqlx.md
@@ -1,0 +1,258 @@
+# SQLx Sync Helpers
+
+`pocopine-sync-sqlx` is the host/server SQLx adapter for
+`pocopine-sync-crud`. It gives production CRUD resources a SQLx-backed
+transaction runner and a durable accepted-mutation log helper.
+
+The crate is not an ORM and does not generate application SQL. Apps still
+own schema, migrations, indexes, authorization predicates, conflict
+checks, and SQLx queries.
+
+## What Ships
+
+The first SQLx slice contains:
+
+- `SqlxCrudTransactionRunner<DB>` for SQLx `Pool<DB>` transactions,
+- backend aliases and constructors behind SQLx features:
+  `postgres(...)`, `mysql(...)`, and `sqlite(...)`,
+- `SqlxCrudMutationLog<DB>` for durable mutation replay idempotency,
+- default mutation-log schema constants for SQLite, Postgres, and MySQL,
+- SQLite integration tests for commit, rollback, scoped lookup, and
+  durable replay.
+
+The transaction runner is generic over `DB: sqlx::Database` because SQLx
+has a generic `sqlx::Transaction<'c, DB>` type. The mutation log has
+backend-specific impls behind `postgres`, `mysql`, and `sqlite` features
+because SQL placeholders and production DDL details are backend-specific.
+
+Application CRUD sources are still backend-specific. Postgres, MySQL, and
+SQLite differ on `RETURNING`, placeholder syntax, JSON/native text
+storage, upsert behavior, and lock/isolation behavior. Pocopine should
+not hide those differences behind a fake portable SQL layer.
+
+## Dependencies
+
+Postgres example:
+
+```toml
+[dependencies]
+pocopine-sync = "..."
+pocopine-sync-crud = "..."
+pocopine-sync-sqlx = { version = "...", features = [
+  "postgres",
+  "runtime-tokio",
+  "tls-rustls",
+] }
+sqlx = { version = "0.8", features = [
+  "postgres",
+  "runtime-tokio",
+  "tls-rustls-ring-webpki",
+  "macros",
+] }
+```
+
+SQLite test/native example:
+
+```toml
+pocopine-sync-sqlx = { version = "...", features = [
+  "sqlite",
+  "runtime-tokio",
+] }
+sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio"] }
+```
+
+MySQL example:
+
+```toml
+pocopine-sync-sqlx = { version = "...", features = [
+  "mysql",
+  "runtime-tokio",
+  "tls-rustls",
+] }
+sqlx = { version = "0.8", features = [
+  "mysql",
+  "runtime-tokio",
+  "tls-rustls-ring-webpki",
+  "macros",
+] }
+```
+
+## Mutation Log Schema
+
+The accepted-mutation log stores the sync replay key. It does not store
+application rows and it is not the source of truth for reads.
+
+Default SQLite/Postgres shape:
+
+```sql
+create table if not exists __pocopine_crud_mutations (
+  scope text not null,
+  mutation_id text not null,
+  op text not null,
+  row_key text,
+  payload text not null,
+  primary key (scope, mutation_id)
+);
+```
+
+Default MySQL shape:
+
+```sql
+create table if not exists __pocopine_crud_mutations (
+  scope varchar(191) not null,
+  mutation_id varchar(191) not null,
+  op varchar(16) not null,
+  row_key varchar(191),
+  payload text not null,
+  primary key (scope, mutation_id)
+);
+```
+
+The MySQL default uses bounded indexed columns because MySQL cannot use
+unbounded `text` columns as a primary key. Apps with longer mutation ids
+or scope values should create an app-specific table and point
+`SqlxCrudMutationLog::with_table(...)` at it.
+
+The `scope` value must match the authorization domain of the resource:
+tenant id, organization id, account id, or another app-owned partition.
+Do not use one global scope for multi-tenant data.
+
+## Server Wiring
+
+```rust
+use pocopine_auth::RequestContext;
+use pocopine_sync::{SyncError, SyncResult};
+use pocopine_sync_crud::TransactionalCrudSource;
+use pocopine_sync_sqlx::{postgres, SqlxCrudMutationLog};
+
+#[derive(Clone)]
+pub struct Customers {
+    pub pool: sqlx::PgPool,
+}
+
+fn tenant_scope(ctx: &RequestContext) -> SyncResult<String> {
+    ctx.require_user()
+        .map(|user| user.id.clone())
+        .map_err(|err| SyncError::client(err.to_string()))
+}
+
+pub fn customers_stream(
+    pool: sqlx::PgPool,
+) -> SyncResult<impl pocopine_sync::SyncStreamSource> {
+    let runner = postgres(pool.clone());
+    let mutation_log = SqlxCrudMutationLog::<sqlx::Postgres>::new(tenant_scope);
+
+    customers::resource(Customers { pool })?
+        .id(|row: &Customer| row.id)
+        .version(|row: &Customer| row.version)
+        .transactional(runner, mutation_log)
+}
+```
+
+The generated `customers::resource(...)` helper comes from
+`pocopine-sync-crud`. The SQLx crate supplies only the transaction runner
+and mutation log. The app still implements `CrudSource` for reads and
+`TransactionalCrudSource<sqlx::Transaction<'static, sqlx::Postgres>>`
+for writes.
+
+## Transactional Source Shape
+
+The app-owned source writes normal SQLx queries against the active
+transaction handle:
+
+```rust
+#[pocopine_sync_crud::async_trait]
+impl TransactionalCrudSource<sqlx::Transaction<'static, sqlx::Postgres>>
+    for Customers
+{
+    async fn create_in_tx(
+        &self,
+        tx: &mut sqlx::Transaction<'static, sqlx::Postgres>,
+        ctx: &RequestContext,
+        id: uuid::Uuid,
+        draft: CustomerDraft,
+    ) -> SyncResult<Customer> {
+        let tenant_id = tenant_scope(ctx)?;
+
+        sqlx::query_as!(
+            Customer,
+            r#"
+            insert into customers (tenant_id, id, name, email, version)
+            values ($1, $2, $3, $4, 1)
+            returning id, name, email, version
+            "#,
+            tenant_id,
+            id,
+            draft.name,
+            draft.email,
+        )
+        .fetch_one(&mut **tx)
+        .await
+        .map_err(pocopine_sync_sqlx::sync_sqlx_error)
+    }
+
+    // save_in_tx and remove_in_tx perform the same base_version checks
+    // as the non-transactional CrudSource methods, but against `tx`.
+}
+```
+
+The `&mut **tx` form is the SQLx 0.8 pattern for executing against the
+connection inside a borrowed `Transaction`.
+
+## Runtime Flow
+
+For each pushed mutation on a transactional CRUD resource:
+
+```text
+begin SQLx transaction
+  -> read accepted mutation by (scope, mutation_id)
+  -> reject if the mutation id was accepted with different contents
+  -> apply create/save/remove through TransactionalCrudSource
+  -> record accepted mutation by (scope, mutation_id)
+commit
+publish live invalidation after commit
+```
+
+If the source write fails, the transaction rolls back and the accepted
+mutation id is not recorded. If a duplicate retry races with the original
+write, the primary key on `(scope, mutation_id)` is the final concurrency
+boundary.
+
+## Backend Notes
+
+Postgres:
+
+- feature: `postgres`,
+- placeholders: `$1`, `$2`, etc.,
+- `RETURNING` is the preferred write path,
+- `text` primary key columns are acceptable for the default schema.
+
+SQLite:
+
+- feature: `sqlite`,
+- placeholders: `?`,
+- used for local crate tests with an in-memory database,
+- useful for native apps, but browser-local sync still uses
+  `pocopine-sync-sqlite`, not SQLx.
+
+MySQL:
+
+- feature: `mysql`,
+- placeholders: `?`,
+- default schema uses bounded indexed columns,
+- apps often need a write followed by a select inside the same
+  transaction instead of relying on Postgres-style `RETURNING`.
+
+## Non-Goals
+
+`pocopine-sync-sqlx` does not:
+
+- generate SQL or migrations,
+- infer tenant predicates,
+- prove authorization correctness,
+- replace app-level idempotency for payments, inventory, emails, or
+  third-party side effects,
+- provide database changefeed/CDC adapters.
+
+Changefeed adapters are a later roadmap item. This crate only makes the
+current CRUD mutation path durable and easier to wire with SQLx.

--- a/docs/sync-sqlx.md
+++ b/docs/sync-sqlx.md
@@ -1,8 +1,10 @@
 # SQLx Sync Helpers
 
 `pocopine-sync-sqlx` is the host/server SQLx adapter for
-`pocopine-sync-crud`. It gives production CRUD resources a SQLx-backed
-transaction runner and a durable accepted-mutation log helper.
+`pocopine-sync-crud`. Add it as a direct host/server dependency when a
+CRUD resource uses SQLx transactions. It gives production CRUD resources
+a SQLx-backed transaction runner and a durable accepted-mutation log
+helper.
 
 The crate is not an ORM and does not generate application SQL. Apps still
 own schema, migrations, indexes, authorization predicates, conflict
@@ -17,8 +19,8 @@ The first SQLx slice contains:
   `postgres(...)`, `mysql(...)`, and `sqlite(...)`,
 - `SqlxCrudMutationLog<DB>` for durable mutation replay idempotency,
 - default mutation-log schema constants for SQLite, Postgres, and MySQL,
-- SQLite integration tests for commit, rollback, scoped lookup, and
-  durable replay.
+- SQLite integration tests for commit, rollback, scoped lookup,
+  reservation, and durable replay.
 
 The transaction runner is generic over `DB: sqlx::Database` because SQLx
 has a generic `sqlx::Transaction<'c, DB>` type. The mutation log has
@@ -32,6 +34,11 @@ not hide those differences behind a fake portable SQL layer.
 
 ## Dependencies
 
+The `postgres`, `mysql`, and `sqlite` features enable the corresponding
+SQLx backend plus `runtime-tokio` for the helper crate. The app's own
+`sqlx` dependency should still enable the backend, runtime, TLS, and
+`macros` features it uses directly.
+
 Postgres example:
 
 ```toml
@@ -40,7 +47,6 @@ pocopine-sync = "..."
 pocopine-sync-crud = "..."
 pocopine-sync-sqlx = { version = "...", features = [
   "postgres",
-  "runtime-tokio",
   "tls-rustls",
 ] }
 sqlx = { version = "0.8", features = [
@@ -56,7 +62,6 @@ SQLite test/native example:
 ```toml
 pocopine-sync-sqlx = { version = "...", features = [
   "sqlite",
-  "runtime-tokio",
 ] }
 sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio"] }
 ```
@@ -66,7 +71,6 @@ MySQL example:
 ```toml
 pocopine-sync-sqlx = { version = "...", features = [
   "mysql",
-  "runtime-tokio",
   "tls-rustls",
 ] }
 sqlx = { version = "0.8", features = [
@@ -111,7 +115,10 @@ create table if not exists __pocopine_crud_mutations (
 The MySQL default uses bounded indexed columns because MySQL cannot use
 unbounded `text` columns as a primary key. Apps with longer mutation ids
 or scope values should create an app-specific table and point
-`SqlxCrudMutationLog::with_table(...)` at it.
+`SqlxCrudMutationLog::with_table(...)` at it. The default MySQL schema is
+therefore suitable for bounded application ids, not for the full 1024-byte
+sync identifier envelope. Use an app-specific hash/binary key or shorter
+canonical ids when full-length values are possible.
 
 The `scope` value must match the authorization domain of the resource:
 tenant id, organization id, account id, or another app-owned partition.
@@ -133,7 +140,7 @@ pub struct Customers {
 fn tenant_scope(ctx: &RequestContext) -> SyncResult<String> {
     ctx.require_user()
         .map(|user| user.id.clone())
-        .map_err(|err| SyncError::client(err.to_string()))
+        .map_err(|_| SyncError::client("sync tenant scope requires an authenticated user"))
 }
 
 pub fn customers_stream(
@@ -205,18 +212,20 @@ For each pushed mutation on a transactional CRUD resource:
 
 ```text
 begin SQLx transaction
-  -> read accepted mutation by (scope, mutation_id)
-  -> reject if the mutation id was accepted with different contents
+  -> reserve accepted mutation by (scope, mutation_id)
+  -> if already accepted, acknowledge exact replay or reject changed contents
   -> apply create/save/remove through TransactionalCrudSource
-  -> record accepted mutation by (scope, mutation_id)
-commit
+  -> commit accepted writes
+  -> roll back conflicts, rejections, and backend errors
 publish live invalidation after commit
 ```
 
-If the source write fails, the transaction rolls back and the accepted
-mutation id is not recorded. If a duplicate retry races with the original
-write, the primary key on `(scope, mutation_id)` is the final concurrency
-boundary.
+The reservation is inserted before the source write. If the source write
+fails, conflicts, or rejects the mutation, the transaction rolls back and
+the reservation disappears. If a duplicate retry races with the original
+write, the primary key on `(scope, mutation_id)` is the concurrency
+boundary; the loser reads the already accepted mutation and only an exact
+payload replay is acknowledged.
 
 ## Backend Notes
 

--- a/docs/sync-sqlx.md
+++ b/docs/sync-sqlx.md
@@ -233,6 +233,8 @@ Postgres:
 
 - feature: `postgres`,
 - placeholders: `$1`, `$2`, etc.,
+- mutation reservations use `ON CONFLICT ... DO NOTHING` so duplicate
+  replay does not abort the transaction,
 - `RETURNING` is the preferred write path,
 - `text` primary key columns are acceptable for the default schema.
 
@@ -240,6 +242,7 @@ SQLite:
 
 - feature: `sqlite`,
 - placeholders: `?`,
+- mutation reservations use `ON CONFLICT ... DO NOTHING`,
 - used for local crate tests with an in-memory database,
 - useful for native apps, but browser-local sync still uses
   `pocopine-sync-sqlite`, not SQLx.
@@ -248,6 +251,8 @@ MySQL:
 
 - feature: `mysql`,
 - placeholders: `?`,
+- mutation reservations catch duplicate-key errors and then read the
+  accepted row in the same transaction,
 - default schema uses bounded indexed columns,
 - apps often need a write followed by a select inside the same
   transaction instead of relying on Postgres-style `RETURNING`.


### PR DESCRIPTION
## Summary

- Add `pocopine-sync-sqlx` as a host/server SQLx helper crate for transactional CRUD sync resources.
- Add a generic `SqlxCrudTransactionRunner<DB>` over SQLx pools/transactions, with `postgres`, `mysql`, and `sqlite` feature constructors.
- Add `SqlxCrudMutationLog<DB>` for durable accepted-mutation idempotency, with backend-feature implementations and schema constants.
- Document the SQLx contract, backend split, schema shape, and app-owned source SQL boundary.

## Notes

SQLx has a generic transaction type, so the transaction runner is generic over `DB: sqlx::Database`. The app CRUD source SQL and durable schema details remain backend-specific because Postgres/MySQL/SQLite differ on placeholder syntax, `RETURNING`, JSON/text behavior, and index limits.

## Verification

- `cargo fmt --check`
- `cargo check -p pocopine-sync-sqlx`
- `cargo test -p pocopine-sync-sqlx --features sqlite,runtime-tokio`
- `cargo check -p pocopine-sync-sqlx --features postgres,runtime-tokio`
- `cargo check -p pocopine-sync-sqlx --features mysql,runtime-tokio`
- `cargo clippy -p pocopine-sync-sqlx --features sqlite,runtime-tokio -- -D warnings`