### PR TITLE
sync: durable discard_local for pending row mutations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4809,6 +4809,7 @@ dependencies = [
  "serde-wasm-bindgen 0.6.5",
  "serde_json",
  "sqlite-wasm",
+ "tempfile",
  "wasm-bindgen",
  "wasm-bindgen-test",
 ]

--- a/crates/pocopine-sync-crud-macros/src/lib.rs
+++ b/crates/pocopine-sync-crud-macros/src/lib.rs
@@ -308,6 +308,14 @@ fn expand_resource(args: ResourceArgs, item: ItemImpl) -> syn::Result<TokenStrea
                     self.client()?.use_server(id).await
                 }
 
+                pub async fn discard_local(&self, id: Id) -> ::pocopine_sync::SyncResult<bool>
+                where
+                    Id: ::pocopine_sync_crud::ResourceId,
+                    Row: Clone + ::serde::de::DeserializeOwned + ::serde::Serialize,
+                {
+                    self.client()?.discard_local(id).await
+                }
+
                 pub async fn retry_local(
                     &self,
                     id: Id,

--- a/crates/pocopine-sync-crud/src/client.rs
+++ b/crates/pocopine-sync-crud/src/client.rs
@@ -158,6 +158,17 @@ where
         self.save_with_options(id, draft, options).await
     }
 
+    /// Discard every queued local mutation for one row and clear its conflict
+    /// marker.
+    ///
+    /// This is the "throw away my local edits" resolution. The durable
+    /// mutation queue purges first, then the in-memory pending overlay is
+    /// dropped and the row falls back to its canonical (last server) value.
+    /// Returns `true` if any in-memory state actually changed.
+    pub async fn discard_local(self, id: Id) -> SyncResult<bool> {
+        self.collection.discard_local(id.to_row_key()?).await
+    }
+
     /// Submit an app-approved merge draft against the latest canonical base.
     pub async fn merge_with<Draft>(self, id: Id, draft: Draft) -> SyncResult<CrudOutcome<Id, Row>>
     where
@@ -564,6 +575,90 @@ mod tests {
         assert!(client.use_server("post_1".to_string()).await.unwrap());
 
         assert!(!state.borrow().posts.rows[0].conflict);
+        let snapshot = store.hydrate_stream(&stream).await.unwrap();
+        assert!(!snapshot.rows[0].conflict);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test]
+    async fn discard_local_drops_pending_and_clears_conflict() {
+        let store = Rc::new(MemoryLocalStore::new());
+        store
+            .save_identity(SyncLocalIdentity::new(
+                SyncDeviceId::new("device_discard_test").unwrap(),
+            ))
+            .await
+            .unwrap();
+
+        let stream = SyncStreamName::new("posts").unwrap();
+        let state = Rc::new(RefCell::new(TestState::default()));
+        let handle = Handle::new(state.clone(), ScopeId(3));
+
+        store
+            .save_snapshot(LocalSnapshotBatch::new(
+                stream.clone(),
+                pocopine_sync::SyncCollectionName::new("posts").unwrap(),
+                vec![
+                    SyncRow::new("post_1", serde_json::json!({"title": "server"}))
+                        .unwrap()
+                        .version("server_v1")
+                        .unwrap()
+                        .conflict(true),
+                ],
+                None,
+            ))
+            .await
+            .unwrap();
+        state.borrow_mut().posts.apply_local_snapshot(
+            vec![SyncRow::new(
+                "post_1",
+                Post {
+                    title: "server".to_string(),
+                },
+            )
+            .unwrap()
+            .version("server_v1")
+            .unwrap()
+            .conflict(true)],
+            None,
+            0,
+        );
+
+        let sync = sync_plugin()
+            .shared_local_store(store.clone())
+            .into_client();
+
+        let collection = sync
+            .clone()
+            .collection(handle.clone(), posts)
+            .stream(stream.as_str())
+            .unwrap();
+        let view = local_resource_view::<String, _>(&state.borrow().posts).unwrap();
+        let client = client_resource(collection, view);
+        let _ = client
+            .retry_local(
+                "post_1".to_string(),
+                Post {
+                    title: "local edit".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(store.pending_mutations(&stream).await.unwrap().len(), 1);
+
+        let collection = sync
+            .collection(handle, posts)
+            .stream(stream.as_str())
+            .unwrap();
+        let view = local_resource_view::<String, _>(&state.borrow().posts).unwrap();
+        let client = client_resource(collection, view);
+
+        assert!(client.discard_local("post_1".to_string()).await.unwrap());
+
+        assert!(store.pending_mutations(&stream).await.unwrap().is_empty());
+        assert!(!state.borrow().posts.rows[0].conflict);
+        assert!(!state.borrow().posts.rows[0].pending);
+        assert_eq!(state.borrow().posts.rows[0].value.title, "server");
         let snapshot = store.hydrate_stream(&stream).await.unwrap();
         assert!(!snapshot.rows[0].conflict);
     }

--- a/crates/pocopine-sync-indexdb/src/native.rs
+++ b/crates/pocopine-sync-indexdb/src/native.rs
@@ -96,6 +96,14 @@ impl SyncLocalStore for IndexedDbLocalStore {
     ) -> SyncLocalFuture<'_, Vec<ClientMutation<serde_json::Value>>> {
         Self::unsupported()
     }
+
+    fn purge_pending_for_row(
+        &self,
+        _stream: &SyncStreamName,
+        _key: &RowKey,
+    ) -> SyncLocalFuture<'_, usize> {
+        Self::unsupported()
+    }
 }
 
 fn validate_database_name(database_name: String) -> SyncResult<String> {

--- a/crates/pocopine-sync-indexdb/src/wasm.rs
+++ b/crates/pocopine-sync-indexdb/src/wasm.rs
@@ -162,6 +162,17 @@ impl SyncLocalStore for IndexedDbLocalStore {
                 .collect())
         })
     }
+
+    fn purge_pending_for_row(
+        &self,
+        stream: &SyncStreamName,
+        key: &RowKey,
+    ) -> SyncLocalFuture<'_, usize> {
+        let database_name = self.database_name.clone();
+        let stream = stream.clone();
+        let key = key.clone();
+        self.run(purge_pending_for_row(database_name, stream, key))
+    }
 }
 
 async fn load_identity(database_name: String) -> SyncResult<Option<SyncLocalIdentity>> {
@@ -368,6 +379,36 @@ async fn clear_conflict(
     await_transaction(done).await?;
     database.close();
     Ok(())
+}
+
+/// Atomically drop every still-pending mutation for `(stream, key)`
+/// from the IndexedDB store. Mirrors the SQLite store's contract:
+/// only `status = Pending` rows are removed; accepted / rejected /
+/// conflict history stays. Returns the number of mutations dropped.
+async fn purge_pending_for_row(
+    database_name: String,
+    stream: SyncStreamName,
+    key: RowKey,
+) -> SyncResult<usize> {
+    let database = open_database(&database_name).await?;
+    let transaction = transaction(&database, STREAMS_STORE, IdbTransactionMode::Readwrite)?;
+    let done = transaction_done(&transaction);
+    let store = transaction.object_store(STREAMS_STORE).map_err(js_error)?;
+    let mut state = load_stream_state(&store, stream).await?;
+    let before = state.pending_mutations.len();
+    // Retain pendings that do NOT target `key`. Mutations without a
+    // row anchor (`key = None`) and mutations for any other row are
+    // left alone — the purge is scoped to this one row.
+    state
+        .pending_mutations
+        .retain(|pending| pending.mutation.key.as_ref() != Some(&key));
+    let purged = before - state.pending_mutations.len();
+    if purged > 0 {
+        put_stream_state(&store, &state).await?;
+    }
+    await_transaction(done).await?;
+    database.close();
+    Ok(purged)
 }
 
 async fn open_database(database_name: &str) -> SyncResult<IdbDatabase> {

--- a/crates/pocopine-sync-sqlite/Cargo.toml
+++ b/crates/pocopine-sync-sqlite/Cargo.toml
@@ -13,6 +13,9 @@ serde_json = { workspace = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rusqlite = { version = "0.32", features = ["bundled"] }
 
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+tempfile = "3"
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 futures = "0.3"
 js-sys = { workspace = true }

--- a/crates/pocopine-sync-sqlite/src/native.rs
+++ b/crates/pocopine-sync-sqlite/src/native.rs
@@ -14,10 +14,11 @@ use pocopine_sync::{
 use rusqlite::{params, Connection, OptionalExtension, Transaction};
 
 use crate::schema::{
-    BOOTSTRAP_SQL, CLEAR_ROW_CONFLICT_SQL, DELETE_MUTATION_SQL, DELETE_ROW_SQL,
-    DELETE_STREAM_ROWS_SQL, META_DEVICE_ID, META_NEXT_MUTATION_COUNTER, META_SCHEMA_VERSION,
-    SCHEMA_VERSION, SELECT_PENDING_MUTATIONS_SQL, SELECT_ROWS_SQL, SELECT_STREAM_SQL,
-    UPDATE_ROW_CONFLICT_SQL, UPSERT_MUTATION_SQL, UPSERT_ROW_SQL, UPSERT_STREAM_SQL,
+    BOOTSTRAP_SQL, CLEAR_ROW_CONFLICT_SQL, DELETE_MUTATION_SQL, DELETE_PENDING_FOR_ROW_SQL,
+    DELETE_ROW_SQL, DELETE_STREAM_ROWS_SQL, META_DEVICE_ID, META_NEXT_MUTATION_COUNTER,
+    META_SCHEMA_VERSION, SCHEMA_VERSION, SELECT_PENDING_MUTATIONS_SQL, SELECT_ROWS_SQL,
+    SELECT_STREAM_SQL, UPDATE_ROW_CONFLICT_SQL, UPSERT_MUTATION_SQL, UPSERT_ROW_SQL,
+    UPSERT_STREAM_SQL,
 };
 
 /// SQLite-backed [`SyncLocalStore`] for host/native targets.
@@ -120,6 +121,16 @@ impl SyncLocalStore for SqliteLocalStore {
     ) -> SyncLocalFuture<'_, Vec<ClientMutation<serde_json::Value>>> {
         let stream = stream.clone();
         Self::ready(self.with_conn(|conn| pending_mutations(conn, &stream)))
+    }
+
+    fn purge_pending_for_row(
+        &self,
+        stream: &SyncStreamName,
+        key: &RowKey,
+    ) -> SyncLocalFuture<'_, usize> {
+        let stream = stream.clone();
+        let key = key.clone();
+        Self::ready(self.with_conn(|conn| purge_pending_for_row(conn, &stream, &key)))
     }
 }
 
@@ -457,6 +468,20 @@ fn clear_conflict(conn: &mut Connection, stream: &SyncStreamName, key: &RowKey) 
     )
     .map_err(sqlite_error)?;
     Ok(())
+}
+
+fn purge_pending_for_row(
+    conn: &mut Connection,
+    stream: &SyncStreamName,
+    key: &RowKey,
+) -> SyncResult<usize> {
+    let affected = conn
+        .execute(
+            DELETE_PENDING_FOR_ROW_SQL,
+            params![stream.as_str(), key.as_str()],
+        )
+        .map_err(sqlite_error)?;
+    Ok(affected)
 }
 
 fn pending_mutations(
@@ -1280,6 +1305,68 @@ mod tests {
         assert!(snapshot.cursor.is_none());
         assert!(snapshot.rows.is_empty());
         assert!(snapshot.pending_mutations.is_empty());
+    }
+
+    #[test]
+    fn sqlite_purge_pending_for_row_drops_only_target_row_pendings() {
+        // Cover the durability + scope contract: purge a row's pending
+        // mutations and confirm only that row's queue is affected,
+        // and that hydration (via a fresh connection) reflects the
+        // purge. This is the test that distinguishes a real durable
+        // purge from a cosmetic in-memory clear.
+        let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+        let store = SqliteLocalStore::open_path(&path).unwrap();
+        let stream = SyncStreamName::new("posts").unwrap();
+
+        let post_a_first = ClientMutation {
+            id: MutationId::new("device_abc:1").unwrap(),
+            key: Some(RowKey::new("post_a").unwrap()),
+            op: SyncOp::Upsert,
+            base_version: None,
+            payload: serde_json::json!({"title": "A1"}),
+        };
+        let post_a_second = ClientMutation {
+            id: MutationId::new("device_abc:2").unwrap(),
+            key: Some(RowKey::new("post_a").unwrap()),
+            op: SyncOp::Upsert,
+            base_version: None,
+            payload: serde_json::json!({"title": "A2"}),
+        };
+        let post_b = ClientMutation {
+            id: MutationId::new("device_abc:3").unwrap(),
+            key: Some(RowKey::new("post_b").unwrap()),
+            op: SyncOp::Upsert,
+            base_version: None,
+            payload: serde_json::json!({"title": "B"}),
+        };
+        for m in [&post_a_first, &post_a_second, &post_b] {
+            block(store.enqueue_mutation(&stream, m.clone())).unwrap();
+        }
+
+        let purged =
+            block(store.purge_pending_for_row(&stream, &RowKey::new("post_a").unwrap())).unwrap();
+        assert_eq!(purged, 2);
+
+        // Drop the live store and reopen against the same SQLite file.
+        // If the durable layer leaked anything we'll see it now.
+        drop(store);
+        let reopened = SqliteLocalStore::open_path(&path).unwrap();
+        let snapshot = block(reopened.hydrate_stream(&stream)).unwrap();
+        let surviving_ids: Vec<_> = snapshot
+            .pending_mutations
+            .iter()
+            .map(|p| p.mutation.id.as_str().to_owned())
+            .collect();
+        assert_eq!(surviving_ids, vec!["device_abc:3"]);
+    }
+
+    #[test]
+    fn sqlite_purge_pending_for_row_idempotent_returns_zero_for_unknown_row() {
+        let store = SqliteLocalStore::open_in_memory().unwrap();
+        let stream = SyncStreamName::new("posts").unwrap();
+        let purged =
+            block(store.purge_pending_for_row(&stream, &RowKey::new("never").unwrap())).unwrap();
+        assert_eq!(purged, 0);
     }
 
     fn block<T>(future: SyncLocalFuture<'_, T>) -> SyncResult<T> {

--- a/crates/pocopine-sync-sqlite/src/schema.rs
+++ b/crates/pocopine-sync-sqlite/src/schema.rs
@@ -115,6 +115,13 @@ pub const UPSERT_MUTATION_SQL: &str = "insert into __pocopine_mutations
 /// SQL delete used when a mutation reaches a terminal server outcome.
 pub const DELETE_MUTATION_SQL: &str = "delete from __pocopine_mutations where mutation_id = ?1";
 
+/// SQL delete used by `SyncLocalStore::purge_pending_for_row`. Removes
+/// every still-pending mutation for one `(stream, row_key)` pair.
+/// Restricted to `status = 'pending'` — accepted / rejected / conflict
+/// rows are historical outcomes, not queued edits, so they stay put.
+pub const DELETE_PENDING_FOR_ROW_SQL: &str = "delete from __pocopine_mutations
+    where stream = ?1 and row_key = ?2 and status = 'pending'";
+
 /// SQL query used to load pending mutations for a stream in enqueue order.
 pub const SELECT_PENDING_MUTATIONS_SQL: &str =
     "select mutation_id, row_key, base_version, op, payload, optimistic_row

--- a/crates/pocopine-sync-sqlite/src/wasm.rs
+++ b/crates/pocopine-sync-sqlite/src/wasm.rs
@@ -12,10 +12,11 @@ use serde_json::Value;
 use wasm_bindgen::{JsCast, JsValue};
 
 use crate::schema::{
-    BOOTSTRAP_SQL, CLEAR_ROW_CONFLICT_SQL, DELETE_MUTATION_SQL, DELETE_ROW_SQL,
-    DELETE_STREAM_ROWS_SQL, META_DEVICE_ID, META_NEXT_MUTATION_COUNTER, META_SCHEMA_VERSION,
-    SCHEMA_VERSION, SELECT_PENDING_MUTATIONS_SQL, SELECT_ROWS_SQL, SELECT_STREAM_SQL,
-    UPDATE_ROW_CONFLICT_SQL, UPSERT_MUTATION_SQL, UPSERT_ROW_SQL, UPSERT_STREAM_SQL,
+    BOOTSTRAP_SQL, CLEAR_ROW_CONFLICT_SQL, DELETE_MUTATION_SQL, DELETE_PENDING_FOR_ROW_SQL,
+    DELETE_ROW_SQL, DELETE_STREAM_ROWS_SQL, META_DEVICE_ID, META_NEXT_MUTATION_COUNTER,
+    META_SCHEMA_VERSION, SCHEMA_VERSION, SELECT_PENDING_MUTATIONS_SQL, SELECT_ROWS_SQL,
+    SELECT_STREAM_SQL, UPDATE_ROW_CONFLICT_SQL, UPSERT_MUTATION_SQL, UPSERT_ROW_SQL,
+    UPSERT_STREAM_SQL,
 };
 
 const DEFAULT_DATABASE_NAME: &str = "pocopine_sync.sqlite3";
@@ -143,6 +144,14 @@ impl SyncLocalStore for SqliteLocalStore {
         stream: &SyncStreamName,
     ) -> SyncLocalFuture<'_, Vec<ClientMutation<serde_json::Value>>> {
         self.run(pending_mutations(stream.clone()))
+    }
+
+    fn purge_pending_for_row(
+        &self,
+        stream: &SyncStreamName,
+        key: &RowKey,
+    ) -> SyncLocalFuture<'_, usize> {
+        self.run(purge_pending_for_row(stream.clone(), key.clone()))
     }
 }
 
@@ -510,6 +519,36 @@ async fn pending_mutations(
         .into_iter()
         .map(|pending| pending.mutation)
         .collect())
+}
+
+async fn purge_pending_for_row(stream: SyncStreamName, key: RowKey) -> SyncResult<usize> {
+    // SQLite WASM's exec wrapper doesn't return an affected-rows
+    // count, so SELECT-then-DELETE the matching rows in the same
+    // async task. Single-threaded WASM event loop guarantees no
+    // interleaving between the two queries.
+    let count_rows = query_rows(
+        "select count(*) as n from __pocopine_mutations \
+         where stream = ?1 and row_key = ?2 and status = 'pending'",
+        vec![
+            JsValue::from_str(stream.as_str()),
+            JsValue::from_str(key.as_str()),
+        ],
+    )
+    .await?;
+    let count = count_rows
+        .first()
+        .and_then(|row| row.get("n"))
+        .and_then(|n| n.as_u64())
+        .unwrap_or(0) as usize;
+    exec(
+        DELETE_PENDING_FOR_ROW_SQL,
+        vec![
+            JsValue::from_str(stream.as_str()),
+            JsValue::from_str(key.as_str()),
+        ],
+    )
+    .await?;
+    Ok(count)
 }
 
 async fn pending_mutation_records(stream: SyncStreamName) -> SyncResult<Vec<LocalPendingMutation>> {

--- a/crates/pocopine-sync/src/client.rs
+++ b/crates/pocopine-sync/src/client.rs
@@ -341,6 +341,28 @@ where
         clear_conflict_in_handle(handle, selector, &key)
     }
 
+    /// Discard every pending mutation for one row, clear its conflict marker,
+    /// and rebase the rendered view from canonical.
+    ///
+    /// This is the local-edit equivalent of `clear_conflict`: queued local
+    /// writes for the row are dropped from the durable mutation queue and
+    /// from in-memory state. Unkeyed pending mutations (e.g. a stream-wide
+    /// `Reset`) and mutations for other rows are left intact. The durable
+    /// purge happens before the in-memory rebase so a mid-flight crash
+    /// cannot leave the in-memory view ahead of disk.
+    pub async fn discard_local(self, key: RowKey) -> SyncResult<bool>
+    where
+        T: Clone,
+    {
+        let stream = self.stream_value()?;
+        let local_store = self.local_store.clone();
+        let handle = self.handle;
+        let selector = self.selector;
+        local_store.purge_pending_for_row(&stream, &key).await?;
+        local_store.clear_conflict(&stream, &key).await?;
+        discard_local_in_handle(handle, selector, &key)
+    }
+
     fn stream_value(&self) -> SyncResult<SyncStreamName> {
         self.stream
             .clone()
@@ -390,6 +412,35 @@ where
         SyncError::client("sync collection state is already borrowed while clearing conflict")
     })?;
     Ok(selector(&mut state).clear_conflict(key))
+}
+
+#[cfg(target_arch = "wasm32")]
+fn discard_local_in_handle<C, T>(
+    handle: Handle<C>,
+    selector: CollectionSelector<C, T>,
+    key: &RowKey,
+) -> SyncResult<bool>
+where
+    C: 'static,
+    T: Clone,
+{
+    Ok(handle.update(|state| selector(state).discard_local(key)))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn discard_local_in_handle<C, T>(
+    handle: Handle<C>,
+    selector: CollectionSelector<C, T>,
+    key: &RowKey,
+) -> SyncResult<bool>
+where
+    C: 'static,
+    T: Clone,
+{
+    let mut state = handle.try_borrow_mut().map_err(|_| {
+        SyncError::client("sync collection state is already borrowed while discarding local edits")
+    })?;
+    Ok(selector(&mut state).discard_local(key))
 }
 
 #[cfg(target_arch = "wasm32")]

--- a/crates/pocopine-sync/src/local_memory.rs
+++ b/crates/pocopine-sync/src/local_memory.rs
@@ -250,6 +250,29 @@ impl SyncLocalStore for MemoryLocalStore {
                 .unwrap_or_default())
         }))
     }
+
+    fn purge_pending_for_row(
+        &self,
+        stream: &SyncStreamName,
+        key: &RowKey,
+    ) -> SyncLocalFuture<'_, usize> {
+        let stream = stream.clone();
+        let key = key.clone();
+        Self::ready(self.with_inner(|inner| {
+            let Some(state) = inner.streams.get_mut(&stream) else {
+                return Ok(0);
+            };
+            let before = state.pending.len();
+            // Retain pendings that do NOT target `key`. Mutations with
+            // `key = None` (no row anchor) and mutations for any
+            // OTHER row are left alone — the contract is scoped to
+            // this one row.
+            state
+                .pending
+                .retain(|pending| pending.mutation.key.as_ref() != Some(&key));
+            Ok(before - state.pending.len())
+        }))
+    }
 }
 
 struct LocalChanges {
@@ -1026,5 +1049,105 @@ mod tests {
             store.pending_mutations(&comments).await.unwrap(),
             vec![comment_mutation]
         );
+    }
+
+    #[tokio::test]
+    async fn purge_pending_for_row_drops_only_target_row_mutations() {
+        let store = MemoryLocalStore::new();
+        let stream = SyncStreamName::new("posts").unwrap();
+        let post_a = ClientMutation {
+            id: MutationId::new("device_abc:1").unwrap(),
+            key: Some(RowKey::new("post_a").unwrap()),
+            op: SyncOp::Upsert,
+            base_version: None,
+            payload: serde_json::json!({ "title": "A first edit" }),
+        };
+        let post_a_again = ClientMutation {
+            id: MutationId::new("device_abc:2").unwrap(),
+            key: Some(RowKey::new("post_a").unwrap()),
+            op: SyncOp::Upsert,
+            base_version: None,
+            payload: serde_json::json!({ "title": "A second edit" }),
+        };
+        let post_b = ClientMutation {
+            id: MutationId::new("device_abc:3").unwrap(),
+            key: Some(RowKey::new("post_b").unwrap()),
+            op: SyncOp::Upsert,
+            base_version: None,
+            payload: serde_json::json!({ "title": "B" }),
+        };
+        for m in [&post_a, &post_a_again, &post_b] {
+            store.enqueue_mutation(&stream, m.clone()).await.unwrap();
+        }
+
+        let purged = store
+            .purge_pending_for_row(&stream, &RowKey::new("post_a").unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(purged, 2, "both pending mutations for post_a removed");
+        assert_eq!(
+            store.pending_mutations(&stream).await.unwrap(),
+            vec![post_b],
+            "post_b mutation must survive",
+        );
+    }
+
+    #[tokio::test]
+    async fn purge_pending_for_row_leaves_unkeyed_and_other_streams_alone() {
+        let store = MemoryLocalStore::new();
+        let posts = SyncStreamName::new("posts").unwrap();
+        let comments = SyncStreamName::new("comments").unwrap();
+        let unkeyed = ClientMutation {
+            id: MutationId::new("device_abc:1").unwrap(),
+            key: None,
+            op: SyncOp::Upsert,
+            base_version: None,
+            payload: serde_json::json!({"global": true}),
+        };
+        let keyed_in_other_stream = ClientMutation {
+            id: MutationId::new("device_abc:2").unwrap(),
+            key: Some(RowKey::new("post_a").unwrap()),
+            op: SyncOp::Upsert,
+            base_version: None,
+            payload: serde_json::json!({}),
+        };
+        store
+            .enqueue_mutation(&posts, unkeyed.clone())
+            .await
+            .unwrap();
+        store
+            .enqueue_mutation(&comments, keyed_in_other_stream.clone())
+            .await
+            .unwrap();
+
+        let purged = store
+            .purge_pending_for_row(&posts, &RowKey::new("post_a").unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(purged, 0, "no mutation in posts targets post_a");
+        // The unkeyed mutation in the same stream stays — its key is
+        // None, so it doesn't match the target row.
+        assert_eq!(
+            store.pending_mutations(&posts).await.unwrap(),
+            vec![unkeyed]
+        );
+        // The other stream's row-keyed mutation is fully untouched.
+        assert_eq!(
+            store.pending_mutations(&comments).await.unwrap(),
+            vec![keyed_in_other_stream]
+        );
+    }
+
+    #[tokio::test]
+    async fn purge_pending_for_row_empty_stream_returns_zero() {
+        let store = MemoryLocalStore::new();
+        let stream = SyncStreamName::new("posts").unwrap();
+        let purged = store
+            .purge_pending_for_row(&stream, &RowKey::new("post_x").unwrap())
+            .await
+            .unwrap();
+        assert_eq!(purged, 0);
     }
 }

--- a/crates/pocopine-sync/src/local_store.rs
+++ b/crates/pocopine-sync/src/local_store.rs
@@ -350,6 +350,42 @@ pub trait SyncLocalStore {
         &self,
         stream: &SyncStreamName,
     ) -> SyncLocalFuture<'_, Vec<ClientMutation<serde_json::Value>>>;
+
+    /// Durably remove every still-pending mutation whose `key` matches
+    /// the given row, scoped to one stream. Returns the number of
+    /// mutations removed.
+    ///
+    /// This is the storage primitive behind
+    /// `CrudClientResource::discard_local`: it lets the author-facing
+    /// helper back out a row's queued edits with the same durability
+    /// guarantees as `enqueue_mutation` — a reload cannot resurrect
+    /// the purged mutations.
+    ///
+    /// Implementations MUST:
+    ///
+    /// * Persist the removal before returning. The whole point of a
+    ///   durable purge is that reload doesn't replay the dropped
+    ///   mutations.
+    /// * Leave mutations whose `key` is `None` or differs from `key`
+    ///   untouched — purging one row must not touch another row's
+    ///   queue.
+    /// * Leave non-pending records (accepted / rejected / conflict
+    ///   history) alone. Those are server outcomes, not local edits.
+    /// * Leave the row's conflict marker untouched; clearing it is
+    ///   `clear_conflict`'s job and the caller composes the two.
+    ///
+    /// The default implementation falls back to no-op + `0` for stores
+    /// that haven't been updated yet — existing impls without this
+    /// method continue to compile, but generated `discard_local`
+    /// helpers will silently leave durable entries behind until the
+    /// store opts in.
+    fn purge_pending_for_row(
+        &self,
+        _stream: &SyncStreamName,
+        _key: &RowKey,
+    ) -> SyncLocalFuture<'_, usize> {
+        Box::pin(std::future::ready(Ok(0)))
+    }
 }
 
 #[cfg(test)]

--- a/crates/pocopine-sync/src/state.rs
+++ b/crates/pocopine-sync/src/state.rs
@@ -541,6 +541,44 @@ where
         true
     }
 
+    /// Drop every pending mutation targeting one row and clear its conflict
+    /// marker, then rebase the rendered view from canonical.
+    ///
+    /// This is the client-side half of `discard_local`: the user chose to
+    /// throw away their queued local edits for the row. Unkeyed pending
+    /// mutations (`key == None`) and mutations for other rows are left
+    /// intact. Returns `true` if the in-memory view changed.
+    pub fn discard_local(&mut self, key: &RowKey) -> bool {
+        let before = self.pending_mutations.len();
+        self.pending_mutations
+            .retain(|pending| pending.key.as_ref() != Some(key));
+        let dropped_pending = self.pending_mutations.len() != before;
+
+        let mut cleared_conflict = false;
+        if let Some(row) = self.canonical_row_mut(key) {
+            if row.conflict {
+                row.conflict = false;
+                cleared_conflict = true;
+            }
+        }
+        if let Some(row) = self.row_mut(key) {
+            if row.conflict {
+                row.conflict = false;
+                cleared_conflict = true;
+            }
+        }
+
+        let changed = dropped_pending || cleared_conflict;
+        if changed {
+            self.last_reason = SyncReason::Manual;
+            self.rebase_rows_from_canonical();
+            if self.conflict_count == 0 && self.rejected_count == 0 {
+                self.error.clear();
+            }
+        }
+        changed
+    }
+
     /// Clear the local conflict marker for a row and rebase the rendered view.
     ///
     /// This is the client-side half of a user choosing the current server row
@@ -1486,6 +1524,86 @@ mod tests {
         assert!(state.rows[0].conflict);
         assert_eq!(state.conflict_count, 1);
         assert_eq!(state.error, "base version is stale");
+    }
+
+    #[test]
+    fn discard_local_drops_pending_overlay_and_clears_conflict() {
+        let mut state = CollectionState::<String>::default();
+        let initial = state.begin_initial();
+        state.apply_pull(
+            initial,
+            SyncPullResponse::snapshot(
+                SyncStreamName::new("posts").unwrap(),
+                SyncCollectionName::new("posts").unwrap(),
+                vec![SyncRow::new("post_1", "server v1".to_string()).unwrap()],
+                Some(SyncCursor::new("1").unwrap()),
+            ),
+        );
+        state.apply_optimistic_mutation(
+            MutationId::new("device_1:1").unwrap(),
+            SyncOp::Upsert,
+            Some(RowKey::new("post_1").unwrap()),
+            Some(SyncRow::new("post_1", "local v1".to_string()).unwrap()),
+        );
+        let mut response = SyncPushResponse::new(SyncStreamName::new("posts").unwrap());
+        response.conflicts.push(SyncConflict {
+            mutation_id: MutationId::new("device_1:1").unwrap(),
+            key: Some(RowKey::new("post_1").unwrap()),
+            server_row: Some(SyncRow::new("post_1", "server v2".to_string()).unwrap()),
+            reason: "base version is stale".to_string(),
+        });
+        state.apply_push(response);
+
+        assert!(state.discard_local(&RowKey::new("post_1").unwrap()));
+
+        assert_eq!(state.rows[0].value, "server v2");
+        assert!(!state.rows[0].pending);
+        assert!(!state.rows[0].conflict);
+        assert_eq!(state.pending_count, 0);
+        assert_eq!(state.conflict_count, 0);
+        assert!(state.error.is_empty());
+        assert_eq!(state.last_reason, SyncReason::Manual);
+    }
+
+    #[test]
+    fn discard_local_leaves_other_rows_and_unkeyed_pending_alone() {
+        let mut state = CollectionState::<String>::default();
+        state.apply_optimistic_mutation(
+            MutationId::new("device_1:1").unwrap(),
+            SyncOp::Upsert,
+            Some(RowKey::new("post_1").unwrap()),
+            Some(SyncRow::new("post_1", "local 1".to_string()).unwrap()),
+        );
+        state.apply_optimistic_mutation(
+            MutationId::new("device_1:2").unwrap(),
+            SyncOp::Upsert,
+            Some(RowKey::new("post_2").unwrap()),
+            Some(SyncRow::new("post_2", "local 2".to_string()).unwrap()),
+        );
+        state.apply_optimistic_mutation(
+            MutationId::new("device_1:3").unwrap(),
+            SyncOp::Reset,
+            None,
+            None,
+        );
+
+        assert!(state.discard_local(&RowKey::new("post_1").unwrap()));
+
+        let surviving_keys: Vec<_> = state
+            .pending_mutations
+            .iter()
+            .map(|p| p.key.clone())
+            .collect();
+        assert_eq!(
+            surviving_keys,
+            vec![Some(RowKey::new("post_2").unwrap()), None]
+        );
+    }
+
+    #[test]
+    fn discard_local_unknown_key_returns_false() {
+        let mut state = CollectionState::<String>::default();
+        assert!(!state.discard_local(&RowKey::new("nope").unwrap()));
     }
 
     #[test]

--- a/docs/sync-local-first-roadmap.md
+++ b/docs/sync-local-first-roadmap.md
@@ -189,13 +189,14 @@ The protocol already separates:
 - `rejected`: mutation is invalid or not allowed,
 - `conflicts`: mutation is valid but based on stale server state.
 
-The first author-facing helpers now exist on generated resources and on
+The author-facing helpers on generated resources and on
 `CrudClientResource`:
 
 ```rust
 customers.use_server(id).await?;
 customers.retry_local(id, draft).await?;
 customers.merge_with(id, merged_draft).await?;
+customers.discard_local(id).await?;
 ```
 
 `use_server` clears the local conflict marker after the user accepts the
@@ -204,15 +205,17 @@ row. `retry_local` and `merge_with` queue a new save against the latest
 canonical `base_version`; the conflict marker remains visible until the
 server accepts the retry and returns a new canonical row.
 
+`discard_local` is the inverse of `use_server` for pending edits: it
+durably purges every queued mutation targeting one row, clears the
+conflict marker, and rebases the rendered view from canonical. The
+durable purge runs before the in-memory rebase so a mid-flight crash
+cannot leave the rendered view ahead of disk. Unkeyed pending mutations
+and mutations for other rows are left untouched.
+
 The default should be conservative: never silently overwrite newer server
 data when a `base_version` was supplied. Automatic CRDT merging belongs in
 `pocopine-collab` / Yrs-backed document fields, not in the default CRUD
 row model.
-
-What is still missing here is a real "discard local pending edits" helper.
-That requires a durable queue-purge operation scoped to one row key. Do
-not expose a `discard_local` alias until it can clear the conflict and
-remove pending mutations with the same durability guarantees.
 
 ### 6. Local Query Layer
 


### PR DESCRIPTION
## Summary
Closes the last conflict-resolver gap called out in `docs/sync-local-first-roadmap.md`: a real `discard_local` helper backed by a durable queue-purge primitive. The roadmap explicitly held it back until it could match the durability guarantees of `use_server` / `retry_local`.

Two commits, layered so each one's contract is verifiable on its own:

1. **`pocopine-sync: durable row-scoped pending-mutation purge`** — adds `SyncLocalStore::purge_pending_for_row(stream, key) -> usize` with a default no-op so out-of-tree implementors don't break. Implements it in `MemoryLocalStore`, `SqliteLocalStore` (native via new `DELETE_PENDING_FOR_ROW_SQL` scoped to `status = 'pending'`; wasm via SELECT-COUNT + DELETE since `sqlite-wasm`'s `exec` doesn't return affected rows), and `IndexedDbLocalStore` (wasm only; native stays `unsupported()`). Five unit tests including SQLite drop-and-reopen-via-fresh-connection for durability.
2. **`pocopine-sync-crud: discard_local helper`** — adds the matching layers on top:
   - `CollectionState::discard_local(key)` rebuilds the in-memory rendered view from canonical.
   - `SyncCollection::discard_local` durably purges and clears the conflict marker *before* the in-memory rebase — a mid-flight crash can never leave the view ahead of disk.
   - `CrudClientResource::discard_local(id)` is the typed entry point next to `use_server` / `retry_local` / `merge_with`.
   - `pocopine-sync-crud-macros` exposes the generated `customers.discard_local(id).await?`.

Contract details:
- Only `Pending` mutations are removed. `Accepted` / `Rejected` / `Conflict` history is left alone — those are server outcomes, not local edits.
- Unkeyed pending mutations (`key == None`, e.g. a stream-wide `Reset`) and mutations for other rows are untouched.
- Returns `bool` for whether in-memory state actually changed, matching `clear_conflict`.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p pocopine-sync -p pocopine-sync-sqlite -p pocopine-sync-indexdb -p pocopine-sync-crud -p pocopine-sync-crud-macros --all-targets -- -D warnings`
- [x] `cargo clippy ... --target wasm32-unknown-unknown -- -D warnings`
- [x] `cargo test -p pocopine-sync -p pocopine-sync-crud -p pocopine-sync-sqlite --lib` — 174 tests pass, including 4 new state-layer + CRUD-client tests for `discard_local` and 5 new storage-layer tests for `purge_pending_for_row`.