### PR TITLE
sync: auth & multi-tenant boundaries (sign-out + tenant log scoping)

### DIFF
--- a/crates/pocopine-sync-crud/src/lib.rs
+++ b/crates/pocopine-sync-crud/src/lib.rs
@@ -32,8 +32,9 @@ pub use outcome::{CrudOutcome, Queued, QueuedStatus};
 #[cfg(not(target_arch = "wasm32"))]
 pub use resource::{
     resource, CrudAcceptedMutation, CrudMutationLog, CrudMutationReservation, CrudResource,
-    CrudResourceBuilder, MemoryCrudMutationLog, MissingMutationLog, NoRowVersion, RowVersionValue,
-    TransactionalCrudMutationLog, TransactionalCrudResource, DEFAULT_CRUD_SNAPSHOT_ROW_LIMIT,
+    CrudResourceBuilder, MemoryCrudMutationLog, MemoryCrudScopeFn, MissingMutationLog,
+    NoRowVersion, RowVersionValue, TransactionalCrudMutationLog, TransactionalCrudResource,
+    DEFAULT_CRUD_SNAPSHOT_ROW_LIMIT,
 };
 pub use row::optimistic_row;
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/pocopine-sync-crud/src/resource.rs
+++ b/crates/pocopine-sync-crud/src/resource.rs
@@ -376,11 +376,31 @@ where
     ) -> SyncResult<CrudMutationReservation>;
 }
 
+/// Function used by `MemoryCrudMutationLog::with_scope_fn` to project an
+/// authorization scope (e.g. a tenant id) out of the per-request context.
+pub type MemoryCrudScopeFn =
+    Arc<dyn Fn(&RequestContext) -> SyncResult<String> + Send + Sync + 'static>;
+
 /// Process-local mutation log for tests and single-process demos.
-#[derive(Clone, Debug)]
+///
+/// The default constructor uses one global scope — accepted mutations across
+/// every tenant share one keyspace. Multi-tenant resources should use
+/// [`MemoryCrudMutationLog::with_scope_fn`] to derive the authorization scope
+/// from the request context; this mirrors `SqlxCrudMutationLog`'s scoping
+/// model so the same boundary that protects production logs is what the tests
+/// exercise.
+#[derive(Clone)]
 pub struct MemoryCrudMutationLog<Row> {
-    accepted: Arc<Mutex<BTreeMap<String, CrudAcceptedMutation>>>,
+    accepted: Arc<Mutex<BTreeMap<(String, String), CrudAcceptedMutation>>>,
+    scope: MemoryCrudScopeFn,
     _marker: std::marker::PhantomData<fn() -> Row>,
+}
+
+impl<Row> std::fmt::Debug for MemoryCrudMutationLog<Row> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MemoryCrudMutationLog")
+            .finish_non_exhaustive()
+    }
 }
 
 impl<Row> Default for MemoryCrudMutationLog<Row> {
@@ -390,9 +410,32 @@ impl<Row> Default for MemoryCrudMutationLog<Row> {
 }
 
 impl<Row> MemoryCrudMutationLog<Row> {
+    /// Build a single-scope memory log. Every accepted mutation lives in one
+    /// global keyspace; use [`with_scope_fn`](Self::with_scope_fn) for
+    /// multi-tenant tests.
     pub fn new() -> Self {
         Self {
             accepted: Arc::new(Mutex::new(BTreeMap::new())),
+            scope: Arc::new(|_ctx| Ok(String::new())),
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    /// Build a memory log that derives its authorization scope from the
+    /// request context — the same shape as
+    /// [`SqlxCrudMutationLog::new`](https://docs.rs/pocopine-sync-sqlx).
+    ///
+    /// The scope function is invoked on every `accepted_mutation` lookup and
+    /// every `record_accepted_mutation`. Returning an error from the function
+    /// fails the log call (typically surfaced as `SyncError::Unauthorized`
+    /// from the request handler).
+    pub fn with_scope_fn<F>(scope: F) -> Self
+    where
+        F: Fn(&RequestContext) -> SyncResult<String> + Send + Sync + 'static,
+    {
+        Self {
+            accepted: Arc::new(Mutex::new(BTreeMap::new())),
+            scope: Arc::new(scope),
             _marker: std::marker::PhantomData,
         }
     }
@@ -408,12 +451,14 @@ where
         ctx: &RequestContext,
         mutation_id: &MutationId,
     ) -> SyncResult<Option<CrudAcceptedMutation>> {
-        let _ = ctx;
+        let scope = (self.scope)(ctx)?;
         let accepted = self
             .accepted
             .lock()
             .map_err(|_| SyncError::backend("memory CRUD mutation log lock poisoned"))?;
-        Ok(accepted.get(mutation_id.as_str()).cloned())
+        Ok(accepted
+            .get(&(scope, mutation_id.as_str().to_string()))
+            .cloned())
     }
 
     async fn record_accepted_mutation(
@@ -421,12 +466,12 @@ where
         ctx: &RequestContext,
         accepted: CrudAcceptedMutation,
     ) -> SyncResult<()> {
-        let _ = ctx;
+        let scope = (self.scope)(ctx)?;
         let mut entries = self
             .accepted
             .lock()
             .map_err(|_| SyncError::backend("memory CRUD mutation log lock poisoned"))?;
-        entries.insert(accepted.mutation_id.as_str().to_string(), accepted);
+        entries.insert((scope, accepted.mutation_id.as_str().to_string()), accepted);
         Ok(())
     }
 }

--- a/crates/pocopine-sync-crud/tests/tenant_boundary.rs
+++ b/crates/pocopine-sync-crud/tests/tenant_boundary.rs
@@ -1,0 +1,414 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+//! End-to-end example for roadmap §7 (Auth & Multi-Tenant Boundaries).
+//!
+//! Demonstrates the contract the sync-local-first roadmap calls out:
+//!
+//! > Mutation logs must be scoped to the same authorization domain as the
+//! > source query, for example `(tenant_id, mutation_id)`, not only
+//! > `mutation_id`.
+//!
+//! Pattern:
+//!
+//! * `Customers` reads `x-tenant-id` from the per-request context and
+//!   partitions its in-memory rows by tenant — so a `/pull` from tenant A
+//!   cannot see tenant B's rows.
+//! * `MemoryCrudMutationLog::with_scope_fn` derives its accepted-mutation
+//!   key from the same header — so the same `MutationId` value can be used
+//!   independently by two tenants without colliding on the log's unique
+//!   key. (This mirrors `SqlxCrudMutationLog::new(scope_fn)` for callers
+//!   that need a durable production log.)
+//! * The source guard returns `Unauthorized` when the request omits the
+//!   tenant header.
+//!
+//! What this proves:
+//!
+//! * **Server-side partitioning.** A pull as tenant A returns A's rows;
+//!   B's pull cannot read A's data.
+//! * **Mutation-id reuse is safe across tenants.** Both tenants push the
+//!   same `MutationId` value with independent payloads; the log records
+//!   each under its tenant scope and the accepted-row maps to the writer.
+//! * **Anonymous requests are rejected at the framework boundary.** The
+//!   source's per-request guard turns "no `x-tenant-id` header" into
+//!   `SyncError::client("missing tenant")`, which surfaces as an error
+//!   response.
+
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, Mutex},
+};
+
+use http_body_util::BodyExt;
+use pocopine_auth::RequestContext;
+use pocopine_server::{
+    axum::{
+        body::Body,
+        http::{Request, StatusCode},
+        Router,
+    },
+    Server,
+};
+use pocopine_sync::{
+    sync_server_plugin, ClientMutation, MutationId, RowVersion, SyncError, SyncPullRequest,
+    SyncPullResponse, SyncPushRequest, SyncPushResponse, SyncStreamName, SYNC_PULL_PATH,
+    SYNC_PUSH_PATH,
+};
+use pocopine_sync_crud::{
+    async_trait, resource, CrudMutationPayload, CrudRemoveResult, CrudSource, CrudWriteResult,
+    MemoryCrudMutationLog,
+};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::Value;
+use tower::ServiceExt;
+
+const STREAM: &str = "customers";
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+struct Customer {
+    id: String,
+    name: String,
+    version: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+struct CustomerDraft {
+    name: String,
+}
+
+/// Tenant-scoped customers source. Rows are partitioned by tenant id in
+/// memory; every read and write requires the `x-tenant-id` header.
+#[derive(Clone, Default)]
+struct TenantCustomers {
+    by_tenant: Arc<Mutex<BTreeMap<String, BTreeMap<String, Customer>>>>,
+}
+
+impl TenantCustomers {
+    fn seed(&self, tenant: &str, customer: Customer) {
+        let mut by_tenant = self.by_tenant.lock().unwrap();
+        by_tenant
+            .entry(tenant.to_string())
+            .or_default()
+            .insert(customer.id.clone(), customer);
+    }
+
+    fn tenant_of(ctx: &RequestContext) -> pocopine_sync::SyncResult<String> {
+        ctx.header("x-tenant-id")
+            .map(str::to_string)
+            .ok_or_else(|| SyncError::client("missing tenant"))
+    }
+
+    fn tenant_rows(
+        &self,
+        tenant: &str,
+        f: impl FnOnce(&BTreeMap<String, Customer>) -> Vec<Customer>,
+    ) -> Vec<Customer> {
+        let by_tenant = self.by_tenant.lock().unwrap();
+        by_tenant.get(tenant).map(f).unwrap_or_default()
+    }
+}
+
+#[async_trait]
+impl CrudSource for TenantCustomers {
+    type Id = String;
+    type Row = Customer;
+    type Draft = CustomerDraft;
+
+    async fn list(
+        &self,
+        ctx: RequestContext,
+        limit: usize,
+    ) -> pocopine_sync::SyncResult<Vec<Self::Row>> {
+        let tenant = Self::tenant_of(&ctx)?;
+        Ok(self.tenant_rows(&tenant, |rows| rows.values().take(limit).cloned().collect()))
+    }
+
+    async fn get(
+        &self,
+        ctx: RequestContext,
+        id: Self::Id,
+    ) -> pocopine_sync::SyncResult<Option<Self::Row>> {
+        let tenant = Self::tenant_of(&ctx)?;
+        let by_tenant = self.by_tenant.lock().unwrap();
+        Ok(by_tenant
+            .get(&tenant)
+            .and_then(|rows| rows.get(&id))
+            .cloned())
+    }
+
+    async fn create(
+        &self,
+        ctx: RequestContext,
+        id: Self::Id,
+        draft: Self::Draft,
+    ) -> pocopine_sync::SyncResult<Self::Row> {
+        let tenant = Self::tenant_of(&ctx)?;
+        let customer = Customer {
+            id: id.clone(),
+            name: draft.name,
+            version: 1,
+        };
+        let mut by_tenant = self.by_tenant.lock().unwrap();
+        by_tenant
+            .entry(tenant)
+            .or_default()
+            .insert(id, customer.clone());
+        Ok(customer)
+    }
+
+    async fn save(
+        &self,
+        ctx: RequestContext,
+        id: Self::Id,
+        draft: Self::Draft,
+        base_version: Option<RowVersion>,
+    ) -> pocopine_sync::SyncResult<CrudWriteResult<Self::Row>> {
+        let tenant = Self::tenant_of(&ctx)?;
+        let mut by_tenant = self.by_tenant.lock().unwrap();
+        let rows = by_tenant.entry(tenant).or_default();
+        let row = rows
+            .get_mut(&id)
+            .ok_or_else(|| SyncError::backend("missing customer"))?;
+        if let Some(base_version) = &base_version {
+            if base_version.as_str() != row.version.to_string() {
+                return Ok(CrudWriteResult::stale(Some(row.clone())));
+            }
+        }
+        row.name = draft.name;
+        row.version = row.version.saturating_add(1);
+        Ok(CrudWriteResult::applied(row.clone()))
+    }
+
+    async fn remove(
+        &self,
+        ctx: RequestContext,
+        id: Self::Id,
+        base_version: Option<RowVersion>,
+    ) -> pocopine_sync::SyncResult<CrudRemoveResult<Self::Row>> {
+        let tenant = Self::tenant_of(&ctx)?;
+        let mut by_tenant = self.by_tenant.lock().unwrap();
+        let rows = by_tenant.entry(tenant).or_default();
+        if let Some(base_version) = &base_version {
+            let Some(row) = rows.get(&id) else {
+                return Ok(CrudRemoveResult::stale(None));
+            };
+            if base_version.as_str() != row.version.to_string() {
+                return Ok(CrudRemoveResult::stale(Some(row.clone())));
+            }
+        }
+        rows.remove(&id);
+        Ok(CrudRemoveResult::applied())
+    }
+}
+
+#[tokio::test]
+async fn tenant_pull_does_not_leak_across_tenants() {
+    let customers = TenantCustomers::default();
+    customers.seed(
+        "tenant_a",
+        Customer {
+            id: "cust_a1".to_string(),
+            name: "Tenant A only".to_string(),
+            version: 1,
+        },
+    );
+    customers.seed(
+        "tenant_b",
+        Customer {
+            id: "cust_b1".to_string(),
+            name: "Tenant B only".to_string(),
+            version: 1,
+        },
+    );
+    let app = router(customers);
+
+    let pulled_a = post_json::<_, SyncPullResponse<Value>>(
+        app.clone(),
+        SYNC_PULL_PATH,
+        Some("tenant_a"),
+        &SyncPullRequest::new(SyncStreamName::new(STREAM).unwrap()),
+    )
+    .await;
+    assert_eq!(pulled_a.rows.len(), 1);
+    assert_eq!(pulled_a.rows[0].key.as_str(), "cust_a1");
+
+    let pulled_b = post_json::<_, SyncPullResponse<Value>>(
+        app,
+        SYNC_PULL_PATH,
+        Some("tenant_b"),
+        &SyncPullRequest::new(SyncStreamName::new(STREAM).unwrap()),
+    )
+    .await;
+    assert_eq!(pulled_b.rows.len(), 1);
+    assert_eq!(pulled_b.rows[0].key.as_str(), "cust_b1");
+}
+
+#[tokio::test]
+async fn same_mutation_id_is_safe_across_distinct_tenants() {
+    let customers = TenantCustomers::default();
+    let app = router(customers.clone());
+    let mutation_id = MutationId::new("device_shared:1").unwrap();
+
+    // tenant_a creates customer "shared" with mutation id "device_shared:1".
+    let create_a = CrudMutationPayload::create(
+        "shared".to_string(),
+        CustomerDraft {
+            name: "From tenant A".to_string(),
+        },
+    )
+    .into_sync_draft()
+    .unwrap()
+    .with_id(mutation_id.clone());
+    let pushed_a = post_json::<_, SyncPushResponse<Value>>(
+        app.clone(),
+        SYNC_PUSH_PATH,
+        Some("tenant_a"),
+        &SyncPushRequest::new(SyncStreamName::new(STREAM).unwrap(), [to_value(create_a)]),
+    )
+    .await;
+    assert_eq!(pushed_a.accepted[0], mutation_id);
+
+    // tenant_b uses the SAME mutation id for an unrelated write.
+    // Without per-tenant log scoping this would be rejected as a duplicate;
+    // with `with_scope_fn(tenant)` the accepted-log key is
+    // `(tenant, mutation_id)` so it accepts cleanly.
+    let create_b = CrudMutationPayload::create(
+        "shared".to_string(),
+        CustomerDraft {
+            name: "From tenant B".to_string(),
+        },
+    )
+    .into_sync_draft()
+    .unwrap()
+    .with_id(mutation_id.clone());
+    let pushed_b = post_json::<_, SyncPushResponse<Value>>(
+        app,
+        SYNC_PUSH_PATH,
+        Some("tenant_b"),
+        &SyncPushRequest::new(SyncStreamName::new(STREAM).unwrap(), [to_value(create_b)]),
+    )
+    .await;
+    assert_eq!(pushed_b.accepted[0], mutation_id);
+    assert!(pushed_b.rejected.is_empty());
+    assert!(pushed_b.conflicts.is_empty());
+
+    // Each tenant's row stays in its own partition.
+    let stored = customers.by_tenant.lock().unwrap();
+    assert_eq!(
+        stored.get("tenant_a").unwrap().get("shared").unwrap().name,
+        "From tenant A"
+    );
+    assert_eq!(
+        stored.get("tenant_b").unwrap().get("shared").unwrap().name,
+        "From tenant B"
+    );
+}
+
+#[tokio::test]
+async fn requests_missing_tenant_header_are_rejected_at_source() {
+    let customers = TenantCustomers::default();
+    customers.seed(
+        "tenant_a",
+        Customer {
+            id: "cust_a1".to_string(),
+            name: "Tenant A only".to_string(),
+            version: 1,
+        },
+    );
+    let app = router(customers);
+
+    let envelope = post_envelope::<_, SyncPullResponse<Value>>(
+        app,
+        SYNC_PULL_PATH,
+        None, // no x-tenant-id header
+        &SyncPullRequest::new(SyncStreamName::new(STREAM).unwrap()),
+    )
+    .await;
+    // The source-side guard returns `SyncError::client("missing tenant")`,
+    // which surfaces as a `ServerResult::Err` inside the response envelope.
+    // Treating "no tenant" the same as "wrong tenant" keeps anonymous
+    // reads from ever touching tenant rows.
+    assert!(
+        envelope.is_err(),
+        "anonymous /pull leaked a successful response: {envelope:?}"
+    );
+}
+
+fn router(customers: TenantCustomers) -> Router {
+    pocopine_server::__reset_for_test();
+    let customers = resource(STREAM, customers)
+        .unwrap()
+        .id(|row: &Customer| row.id.clone())
+        .version(|row: &Customer| row.version)
+        .mutation_log(MemoryCrudMutationLog::<Customer>::with_scope_fn(
+            TenantCustomers::tenant_of,
+        ));
+    let sync = pocopine_sync::SyncServer::builder()
+        .public_stream(customers)
+        .build();
+    Server::new(Router::new())
+        .plugin(sync_server_plugin(sync))
+        .try_finalize()
+        .unwrap()
+}
+
+fn to_value(
+    mutation: ClientMutation<CrudMutationPayload<String, CustomerDraft>>,
+) -> ClientMutation<Value> {
+    ClientMutation {
+        id: mutation.id,
+        key: mutation.key,
+        op: mutation.op,
+        base_version: mutation.base_version,
+        payload: serde_json::to_value(mutation.payload).unwrap(),
+    }
+}
+
+async fn post_json<T, R>(router: Router, uri: &str, tenant: Option<&str>, payload: &T) -> R
+where
+    T: Serialize,
+    R: DeserializeOwned,
+{
+    let response = send(router, uri, tenant, payload).await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let outer: pocopine_core::ServerResult<R> = serde_json::from_slice(&bytes).unwrap();
+    outer.unwrap()
+}
+
+async fn post_envelope<T, R>(
+    router: Router,
+    uri: &str,
+    tenant: Option<&str>,
+    payload: &T,
+) -> pocopine_core::ServerResult<R>
+where
+    T: Serialize,
+    R: DeserializeOwned,
+{
+    let response = send(router, uri, tenant, payload).await;
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+async fn send<T: Serialize>(
+    router: Router,
+    uri: &str,
+    tenant: Option<&str>,
+    payload: &T,
+) -> pocopine_server::axum::http::Response<Body> {
+    let mut builder = Request::builder()
+        .method("POST")
+        .uri(uri)
+        .header("content-type", "application/json");
+    if let Some(tenant) = tenant {
+        builder = builder.header("x-tenant-id", tenant);
+    }
+    router
+        .oneshot(
+            builder
+                .body(Body::from(serde_json::to_string(payload).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}

--- a/crates/pocopine-sync-crud/tests/tenant_boundary.rs
+++ b/crates/pocopine-sync-crud/tests/tenant_boundary.rs
@@ -94,7 +94,7 @@ impl TenantCustomers {
     fn tenant_of(ctx: &RequestContext) -> pocopine_sync::SyncResult<String> {
         ctx.header("x-tenant-id")
             .map(str::to_string)
-            .ok_or_else(|| SyncError::client("missing tenant"))
+            .ok_or_else(|| SyncError::unauthorized("missing tenant"))
     }
 
     fn tenant_rows(
@@ -323,13 +323,21 @@ async fn requests_missing_tenant_header_are_rejected_at_source() {
         &SyncPullRequest::new(SyncStreamName::new(STREAM).unwrap()),
     )
     .await;
-    // The source-side guard returns `SyncError::client("missing tenant")`,
-    // which surfaces as a `ServerResult::Err` inside the response envelope.
-    // Treating "no tenant" the same as "wrong tenant" keeps anonymous
-    // reads from ever touching tenant rows.
+    // The source-side guard returns `SyncError::unauthorized("missing
+    // tenant")`, which the server mapper turns into
+    // `ServerError::Unauthorized` — the same shape framework-level
+    // stream guards use. The envelope error is a string-tagged variant;
+    // we accept either Unauthorized or the legacy server error shapes
+    // by matching on the rendered Debug. The point is that the body
+    // does NOT carry a successful pull response.
     assert!(
         envelope.is_err(),
         "anonymous /pull leaked a successful response: {envelope:?}"
+    );
+    let err_text = format!("{:?}", envelope.unwrap_err());
+    assert!(
+        err_text.contains("Unauthorized") || err_text.contains("unauthorized"),
+        "expected an unauthorized error, got: {err_text}"
     );
 }
 

--- a/crates/pocopine-sync-indexdb/src/native.rs
+++ b/crates/pocopine-sync-indexdb/src/native.rs
@@ -104,6 +104,10 @@ impl SyncLocalStore for IndexedDbLocalStore {
     ) -> SyncLocalFuture<'_, usize> {
         Self::unsupported()
     }
+
+    fn clear_all_streams(&self) -> SyncLocalFuture<'_, ()> {
+        Self::unsupported()
+    }
 }
 
 fn validate_database_name(database_name: String) -> SyncResult<String> {

--- a/crates/pocopine-sync-indexdb/src/wasm.rs
+++ b/crates/pocopine-sync-indexdb/src/wasm.rs
@@ -173,6 +173,11 @@ impl SyncLocalStore for IndexedDbLocalStore {
         let key = key.clone();
         self.run(purge_pending_for_row(database_name, stream, key))
     }
+
+    fn clear_all_streams(&self) -> SyncLocalFuture<'_, ()> {
+        let database_name = self.database_name.clone();
+        self.run(clear_all_streams(database_name))
+    }
 }
 
 async fn load_identity(database_name: String) -> SyncResult<Option<SyncLocalIdentity>> {
@@ -385,6 +390,21 @@ async fn clear_conflict(
 /// from the IndexedDB store. Mirrors the SQLite store's contract:
 /// only `status = Pending` rows are removed; accepted / rejected /
 /// conflict history stays. Returns the number of mutations dropped.
+/// Clears every entry from the IndexedDB streams object store. The
+/// `meta` store (device identity, mutation counter) is intentionally
+/// left intact so future mutation ids stay globally unique against
+/// any server log entry this device has already produced.
+async fn clear_all_streams(database_name: String) -> SyncResult<()> {
+    let database = open_database(&database_name).await?;
+    let transaction = transaction(&database, STREAMS_STORE, IdbTransactionMode::Readwrite)?;
+    let done = transaction_done(&transaction);
+    let store = transaction.object_store(STREAMS_STORE).map_err(js_error)?;
+    store.clear().map_err(js_error)?;
+    await_transaction(done).await?;
+    database.close();
+    Ok(())
+}
+
 async fn purge_pending_for_row(
     database_name: String,
     stream: SyncStreamName,

--- a/crates/pocopine-sync-sqlite/src/native.rs
+++ b/crates/pocopine-sync-sqlite/src/native.rs
@@ -14,11 +14,11 @@ use pocopine_sync::{
 use rusqlite::{params, Connection, OptionalExtension, Transaction};
 
 use crate::schema::{
-    BOOTSTRAP_SQL, CLEAR_ROW_CONFLICT_SQL, DELETE_MUTATION_SQL, DELETE_PENDING_FOR_ROW_SQL,
-    DELETE_ROW_SQL, DELETE_STREAM_ROWS_SQL, META_DEVICE_ID, META_NEXT_MUTATION_COUNTER,
-    META_SCHEMA_VERSION, SCHEMA_VERSION, SELECT_PENDING_MUTATIONS_SQL, SELECT_ROWS_SQL,
-    SELECT_STREAM_SQL, UPDATE_ROW_CONFLICT_SQL, UPSERT_MUTATION_SQL, UPSERT_ROW_SQL,
-    UPSERT_STREAM_SQL,
+    BOOTSTRAP_SQL, CLEAR_ALL_STREAMS_SQL, CLEAR_ROW_CONFLICT_SQL, DELETE_MUTATION_SQL,
+    DELETE_PENDING_FOR_ROW_SQL, DELETE_ROW_SQL, DELETE_STREAM_ROWS_SQL, META_DEVICE_ID,
+    META_NEXT_MUTATION_COUNTER, META_SCHEMA_VERSION, SCHEMA_VERSION, SELECT_PENDING_MUTATIONS_SQL,
+    SELECT_ROWS_SQL, SELECT_STREAM_SQL, UPDATE_ROW_CONFLICT_SQL, UPSERT_MUTATION_SQL,
+    UPSERT_ROW_SQL, UPSERT_STREAM_SQL,
 };
 
 /// SQLite-backed [`SyncLocalStore`] for host/native targets.
@@ -131,6 +131,10 @@ impl SyncLocalStore for SqliteLocalStore {
         let stream = stream.clone();
         let key = key.clone();
         Self::ready(self.with_conn(|conn| purge_pending_for_row(conn, &stream, &key)))
+    }
+
+    fn clear_all_streams(&self) -> SyncLocalFuture<'_, ()> {
+        Self::ready(self.with_conn(clear_all_streams))
     }
 }
 
@@ -482,6 +486,14 @@ fn purge_pending_for_row(
         )
         .map_err(sqlite_error)?;
     Ok(affected)
+}
+
+fn clear_all_streams(conn: &mut Connection) -> SyncResult<()> {
+    let tx = conn.transaction().map_err(sqlite_error)?;
+    for sql in CLEAR_ALL_STREAMS_SQL {
+        tx.execute(sql, []).map_err(sqlite_error)?;
+    }
+    tx.commit().map_err(sqlite_error)
 }
 
 fn pending_mutations(
@@ -1367,6 +1379,63 @@ mod tests {
         let purged =
             block(store.purge_pending_for_row(&stream, &RowKey::new("never").unwrap())).unwrap();
         assert_eq!(purged, 0);
+    }
+
+    #[test]
+    fn sqlite_clear_all_streams_wipes_durable_state_but_preserves_identity() {
+        // Sign-out semantics: drop every stream/row/mutation across
+        // the whole store, but leave the device id and counter alone.
+        // Drop + reopen against the same file proves the wipe is
+        // durable and the identity meta row survives.
+        let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+        let store = SqliteLocalStore::open_path(&path).unwrap();
+        let identity =
+            SyncLocalIdentity::with_next_counter(SyncDeviceId::new("device_abc").unwrap(), 17)
+                .unwrap();
+        block(store.save_identity(identity.clone())).unwrap();
+
+        let posts = SyncStreamName::new("posts").unwrap();
+        let comments = SyncStreamName::new("comments").unwrap();
+        block(store.save_snapshot(LocalSnapshotBatch::new(
+            posts.clone(),
+            SyncCollectionName::new("posts").unwrap(),
+            vec![SyncRow::new("post_1", serde_json::json!({"title": "p"})).unwrap()],
+            Some(SyncCursor::new("c1").unwrap()),
+        )))
+        .unwrap();
+        block(store.save_snapshot(LocalSnapshotBatch::new(
+            comments.clone(),
+            SyncCollectionName::new("comments").unwrap(),
+            vec![SyncRow::new("c_1", serde_json::json!({"body": "hi"})).unwrap()],
+            Some(SyncCursor::new("c2").unwrap()),
+        )))
+        .unwrap();
+        block(store.enqueue_mutation(
+            &posts,
+            ClientMutation {
+                id: MutationId::new("device_abc:1").unwrap(),
+                key: Some(RowKey::new("post_1").unwrap()),
+                op: SyncOp::Upsert,
+                base_version: None,
+                payload: serde_json::json!({"title": "edit"}),
+            },
+        ))
+        .unwrap();
+
+        block(store.clear_all_streams()).unwrap();
+
+        drop(store);
+        let reopened = SqliteLocalStore::open_path(&path).unwrap();
+        let posts_after = block(reopened.hydrate_stream(&posts)).unwrap();
+        let comments_after = block(reopened.hydrate_stream(&comments)).unwrap();
+        assert!(posts_after.rows.is_empty());
+        assert!(posts_after.pending_mutations.is_empty());
+        assert!(posts_after.cursor.is_none());
+        assert!(comments_after.rows.is_empty());
+
+        let surviving_identity = block(reopened.load_identity()).unwrap().unwrap();
+        assert_eq!(surviving_identity.device_id.as_str(), "device_abc");
+        assert_eq!(surviving_identity.next_mutation_counter, 17);
     }
 
     fn block<T>(future: SyncLocalFuture<'_, T>) -> SyncResult<T> {

--- a/crates/pocopine-sync-sqlite/src/schema.rs
+++ b/crates/pocopine-sync-sqlite/src/schema.rs
@@ -122,6 +122,17 @@ pub const DELETE_MUTATION_SQL: &str = "delete from __pocopine_mutations where mu
 pub const DELETE_PENDING_FOR_ROW_SQL: &str = "delete from __pocopine_mutations
     where stream = ?1 and row_key = ?2 and status = 'pending'";
 
+/// SQL statements used by `SyncLocalStore::clear_all_streams`. Drops
+/// every stream snapshot, cached row, and mutation queue entry across
+/// the store. `__pocopine_meta` is intentionally NOT touched: the
+/// device identity row and mutation counter must survive a sign-out so
+/// future mutation ids stay globally unique against the server log.
+pub const CLEAR_ALL_STREAMS_SQL: &[&str] = &[
+    "delete from __pocopine_mutations",
+    "delete from __pocopine_rows",
+    "delete from __pocopine_streams",
+];
+
 /// SQL query used to load pending mutations for a stream in enqueue order.
 pub const SELECT_PENDING_MUTATIONS_SQL: &str =
     "select mutation_id, row_key, base_version, op, payload, optimistic_row

--- a/crates/pocopine-sync-sqlite/src/wasm.rs
+++ b/crates/pocopine-sync-sqlite/src/wasm.rs
@@ -12,11 +12,11 @@ use serde_json::Value;
 use wasm_bindgen::{JsCast, JsValue};
 
 use crate::schema::{
-    BOOTSTRAP_SQL, CLEAR_ROW_CONFLICT_SQL, DELETE_MUTATION_SQL, DELETE_PENDING_FOR_ROW_SQL,
-    DELETE_ROW_SQL, DELETE_STREAM_ROWS_SQL, META_DEVICE_ID, META_NEXT_MUTATION_COUNTER,
-    META_SCHEMA_VERSION, SCHEMA_VERSION, SELECT_PENDING_MUTATIONS_SQL, SELECT_ROWS_SQL,
-    SELECT_STREAM_SQL, UPDATE_ROW_CONFLICT_SQL, UPSERT_MUTATION_SQL, UPSERT_ROW_SQL,
-    UPSERT_STREAM_SQL,
+    BOOTSTRAP_SQL, CLEAR_ALL_STREAMS_SQL, CLEAR_ROW_CONFLICT_SQL, DELETE_MUTATION_SQL,
+    DELETE_PENDING_FOR_ROW_SQL, DELETE_ROW_SQL, DELETE_STREAM_ROWS_SQL, META_DEVICE_ID,
+    META_NEXT_MUTATION_COUNTER, META_SCHEMA_VERSION, SCHEMA_VERSION, SELECT_PENDING_MUTATIONS_SQL,
+    SELECT_ROWS_SQL, SELECT_STREAM_SQL, UPDATE_ROW_CONFLICT_SQL, UPSERT_MUTATION_SQL,
+    UPSERT_ROW_SQL, UPSERT_STREAM_SQL,
 };
 
 const DEFAULT_DATABASE_NAME: &str = "pocopine_sync.sqlite3";
@@ -152,6 +152,10 @@ impl SyncLocalStore for SqliteLocalStore {
         key: &RowKey,
     ) -> SyncLocalFuture<'_, usize> {
         self.run(purge_pending_for_row(stream.clone(), key.clone()))
+    }
+
+    fn clear_all_streams(&self) -> SyncLocalFuture<'_, ()> {
+        self.run(clear_all_streams())
     }
 }
 
@@ -519,6 +523,17 @@ async fn pending_mutations(
         .into_iter()
         .map(|pending| pending.mutation)
         .collect())
+}
+
+async fn clear_all_streams() -> SyncResult<()> {
+    // SQLite WASM exposes no transaction-block primitive. The three
+    // table wipes run sequentially on the single-threaded event loop;
+    // the gate at the SqliteLocalStore layer keeps other adapter calls
+    // from interleaving.
+    for sql in CLEAR_ALL_STREAMS_SQL {
+        exec(sql, Vec::new()).await?;
+    }
+    Ok(())
 }
 
 async fn purge_pending_for_row(stream: SyncStreamName, key: RowKey) -> SyncResult<usize> {

--- a/crates/pocopine-sync-sqlite/src/wasm.rs
+++ b/crates/pocopine-sync-sqlite/src/wasm.rs
@@ -526,14 +526,21 @@ async fn pending_mutations(
 }
 
 async fn clear_all_streams() -> SyncResult<()> {
-    // SQLite WASM exposes no transaction-block primitive. The three
-    // table wipes run sequentially on the single-threaded event loop;
-    // the gate at the SqliteLocalStore layer keeps other adapter calls
-    // from interleaving.
-    for sql in CLEAR_ALL_STREAMS_SQL {
-        exec(sql, Vec::new()).await?;
+    // Wrap the three table deletes in one SQLite transaction so a mid-
+    // wipe failure can't leave a partial state visible to another tab
+    // observing the OPFS file. The per-tab gate prevents same-tab
+    // adapter interleaving but is not a cross-tab transaction boundary,
+    // so the SQLite transaction is what guarantees atomicity across
+    // browsing contexts.
+    exec("BEGIN IMMEDIATE TRANSACTION", Vec::new()).await?;
+    let result = async {
+        for sql in CLEAR_ALL_STREAMS_SQL {
+            exec(sql, Vec::new()).await?;
+        }
+        Ok::<(), SyncError>(())
     }
-    Ok(())
+    .await;
+    finish_transaction(result).await
 }
 
 async fn purge_pending_for_row(stream: SyncStreamName, key: RowKey) -> SyncResult<usize> {

--- a/crates/pocopine-sync/Cargo.toml
+++ b/crates/pocopine-sync/Cargo.toml
@@ -23,10 +23,13 @@ http-body-util = "0.1"
 tokio = { version = "1", features = ["macros", "rt"] }
 tower = { version = "0.5", features = ["util"] }
 
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = { workspace = true }
+web-sys = { version = "0.3", features = ["BroadcastChannel", "MessageEvent"] }
+
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 js-sys = { workspace = true }
 pocopine = { path = "../pocopine" }
-wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 wasm-bindgen-test = "0.3"
-web-sys = { version = "0.3", features = ["Document", "Element", "HtmlInputElement", "Window"] }
+web-sys = { version = "0.3", features = ["BroadcastChannel", "Document", "Element", "HtmlInputElement", "MessageEvent", "Window"] }

--- a/crates/pocopine-sync/src/client.rs
+++ b/crates/pocopine-sync/src/client.rs
@@ -1,4 +1,4 @@
-use std::{marker::PhantomData, rc::Rc};
+use std::{cell::Cell, marker::PhantomData, rc::Rc};
 
 use pocopine_core::{App, AppPlugin, Handle};
 use serde_json::Value;
@@ -9,6 +9,57 @@ use crate::{
     MutationId, RowKey, SyncCursor, SyncError, SyncLocalStore, SyncPushResponse, SyncReason,
     SyncResult, SyncRow, SyncStreamName, SYNC_ENDPOINT_PREFIX,
 };
+
+/// In-tab sign-out generation counter shared between [`SyncClient`] and every
+/// [`SyncCollection`] it builds. `sign_out` bumps the inner cell before
+/// touching the durable store, so any spawned pull/push task that completes
+/// after the bump can observe staleness and drop its persist + state update
+/// instead of repopulating the just-wiped cache.
+///
+/// On host targets the `started` snapshot and `is_stale` check are unused
+/// because the host-side sync methods don't spawn background tasks — they
+/// are sync stubs. The struct compiles on both targets so the field can be
+/// stored uniformly on `SyncCollection` without `#[cfg]` plumbing.
+#[derive(Clone)]
+pub(crate) struct SyncEpoch {
+    current: Rc<Cell<u64>>,
+    #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+    started: u64,
+}
+
+impl SyncEpoch {
+    fn new() -> Self {
+        Self {
+            current: Rc::new(Cell::new(0)),
+            started: 0,
+        }
+    }
+
+    /// Capture the current generation as the snapshot value for a new
+    /// collection or spawned task.
+    pub(crate) fn snapshot(&self) -> Self {
+        Self {
+            current: self.current.clone(),
+            started: self.current.get(),
+        }
+    }
+
+    /// `true` when a sign-out has happened since this snapshot was captured.
+    /// Spawned tasks check this before any post-fetch persist or state
+    /// update. Reachable from host code only via tests; host runtime
+    /// methods are sync stubs that don't spawn.
+    #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+    pub(crate) fn is_stale(&self) -> bool {
+        self.current.get() != self.started
+    }
+
+    /// Advance the shared generation. Called by `SyncClient::sign_out` before
+    /// touching the durable store so a concurrent task that's about to check
+    /// the gate sees the new value.
+    fn bump(&self) {
+        self.current.set(self.current.get().wrapping_add(1));
+    }
+}
 
 #[cfg(target_arch = "wasm32")]
 use crate::{
@@ -30,6 +81,7 @@ pub struct SyncClientPlugin {
     live_wakeup: bool,
     with_credentials: bool,
     local_store: SyncLocalStoreHandle,
+    epoch: SyncEpoch,
 }
 
 impl Default for SyncClientPlugin {
@@ -40,6 +92,7 @@ impl Default for SyncClientPlugin {
             live_wakeup: false,
             with_credentials: false,
             local_store: Rc::new(MemoryLocalStore::new()),
+            epoch: SyncEpoch::new(),
         }
     }
 }
@@ -104,6 +157,7 @@ impl SyncClientPlugin {
             live_wakeup: self.live_wakeup,
             with_credentials: self.with_credentials,
             local_store: self.local_store,
+            epoch: self.epoch,
         }
     }
 }
@@ -126,6 +180,7 @@ pub struct SyncClient {
     live_wakeup: bool,
     with_credentials: bool,
     local_store: SyncLocalStoreHandle,
+    epoch: SyncEpoch,
 }
 
 impl SyncClient {
@@ -149,6 +204,7 @@ impl SyncClient {
             local_store: self.local_store.clone(),
             stream: None,
             cursor: None,
+            epoch: self.epoch.snapshot(),
             _marker: PhantomData,
         }
     }
@@ -168,6 +224,12 @@ impl SyncClient {
     /// [`watch_sign_outs`](Self::watch_sign_outs) receive a notification so
     /// they can do the same.
     pub async fn sign_out(&self) -> SyncResult<()> {
+        // Bump the epoch BEFORE awaiting the durable wipe. Any spawned
+        // pull/push task that yields here and resumes later will compare
+        // the new shared value against its captured snapshot and abort its
+        // persist + state update — so a slow in-flight server response
+        // cannot repopulate the cache after the sign-out wipe runs.
+        self.epoch.bump();
         self.local_store.clear_all_streams().await?;
         broadcast_sign_out();
         Ok(())
@@ -208,6 +270,8 @@ pub struct SyncCollection<C: 'static, T> {
     local_store: SyncLocalStoreHandle,
     stream: Option<SyncStreamName>,
     cursor: Option<SyncCursor>,
+    #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+    epoch: SyncEpoch,
     _marker: PhantomData<fn(C) -> T>,
 }
 
@@ -517,6 +581,7 @@ where
             self.cursor.clone(),
             SyncReason::Initial,
             live_wakeup,
+            self.epoch.clone(),
         );
         Ok(())
     }
@@ -538,6 +603,7 @@ where
             self.cursor,
             reason,
             live_event,
+            self.epoch,
         );
         Ok(())
     }
@@ -568,6 +634,7 @@ where
             optimistic,
             !self.live_wakeup,
             true,
+            self.epoch,
         );
         Ok(())
     }
@@ -598,6 +665,7 @@ where
             optimistic,
             !self.live_wakeup,
             false,
+            self.epoch,
         );
         Ok(())
     }
@@ -628,6 +696,7 @@ where
             optimistic,
             !self.live_wakeup,
             true,
+            self.epoch,
         );
         Ok(())
     }
@@ -658,6 +727,7 @@ where
             optimistic,
             !self.live_wakeup,
             false,
+            self.epoch,
         );
         Ok(())
     }
@@ -682,6 +752,7 @@ where
             .await?;
         apply_optimistic_mutation(&self.handle, self.selector, &mutation, optimistic);
 
+        let epoch = self.epoch.clone();
         pocopine_core::spawn_for_scope(scope_id, async move {
             let _ = send_push_and_reconcile(
                 scope_id,
@@ -694,6 +765,7 @@ where
                 mutation,
                 pull_after_accept,
                 true,
+                epoch,
             )
             .await;
         });
@@ -729,6 +801,7 @@ where
             mutation,
             pull_after_accept,
             false,
+            self.epoch,
         )
         .await?;
         Ok((mutation_id, response))
@@ -870,6 +943,7 @@ fn start_open_then_pull<C, T>(
     cursor: Option<SyncCursor>,
     reason: SyncReason,
     live_wakeup: Option<LiveWakeupOptions>,
+    epoch: SyncEpoch,
 ) where
     C: 'static,
     T: Clone + serde::de::DeserializeOwned + serde::Serialize + 'static,
@@ -948,6 +1022,7 @@ fn start_open_then_pull<C, T>(
                 local_store.clone(),
                 stream.clone(),
                 live_wakeup,
+                epoch.clone(),
             );
         }
 
@@ -961,6 +1036,9 @@ fn start_open_then_pull<C, T>(
             .await
             {
                 Ok(response) => {
+                    if epoch.is_stale() {
+                        return;
+                    }
                     handle.update(|state| {
                         selector(state).apply_push(response);
                     });
@@ -975,6 +1053,9 @@ fn start_open_then_pull<C, T>(
         let result =
             pocopine_core::fetch::call::<SyncPullRequest, SyncPullResponse<T>>(&pull_url, &request)
                 .await;
+        if epoch.is_stale() {
+            return;
+        }
         let result = match result {
             Ok(response) => {
                 if let Err(err) = persist_pull_response(&local_store, &response).await {
@@ -984,6 +1065,9 @@ fn start_open_then_pull<C, T>(
             }
             Err(err) => Err(err),
         };
+        if epoch.is_stale() {
+            return;
+        }
         handle.update(|state| {
             let collection = selector(state);
             match result {
@@ -1002,6 +1086,7 @@ fn start_open_then_pull<C, T>(
 }
 
 #[cfg(target_arch = "wasm32")]
+#[allow(clippy::too_many_arguments)]
 fn open_live_wakeup<C, T>(
     scope_id: pocopine_core::ScopeId,
     handle: Handle<C>,
@@ -1010,6 +1095,7 @@ fn open_live_wakeup<C, T>(
     local_store: SyncLocalStoreHandle,
     stream: SyncStreamName,
     options: LiveWakeupOptions,
+    epoch: SyncEpoch,
 ) where
     C: 'static,
     T: Clone + serde::de::DeserializeOwned + serde::Serialize + 'static,
@@ -1020,7 +1106,11 @@ fn open_live_wakeup<C, T>(
             let handle = handle.clone();
             let endpoint = endpoint.clone();
             let stream = stream.clone();
+            let epoch = epoch.clone();
             move |event| {
+                if epoch.is_stale() {
+                    return;
+                }
                 let reason = if matches!(event.live_event, pocopine_live::LiveEvent::Gap { .. }) {
                     SyncReason::Gap
                 } else {
@@ -1036,6 +1126,7 @@ fn open_live_wakeup<C, T>(
                     None,
                     reason,
                     true,
+                    epoch.clone(),
                 );
             }
         })
@@ -1102,6 +1193,7 @@ fn start_pull<C, T>(
     cursor: Option<SyncCursor>,
     reason: SyncReason,
     live_event: bool,
+    epoch: SyncEpoch,
 ) where
     C: 'static,
     T: Clone + serde::de::DeserializeOwned + serde::Serialize + 'static,
@@ -1126,6 +1218,9 @@ fn start_pull<C, T>(
         let result =
             pocopine_core::fetch::call::<SyncPullRequest, SyncPullResponse<T>>(&pull_url, &request)
                 .await;
+        if epoch.is_stale() {
+            return;
+        }
         let mut local_error = None;
         let result = match result {
             Ok(response) => {
@@ -1136,6 +1231,9 @@ fn start_pull<C, T>(
             }
             Err(err) => Err(err),
         };
+        if epoch.is_stale() {
+            return;
+        }
         handle.update(|state| {
             let collection = selector(state);
             match result {
@@ -1166,6 +1264,7 @@ fn start_push<C, T, M>(
     optimistic: Option<SyncRow<T>>,
     pull_after_accept: bool,
     queue_offline: bool,
+    epoch: SyncEpoch,
 ) where
     C: 'static,
     T: Clone + serde::de::DeserializeOwned + serde::Serialize + 'static,
@@ -1187,6 +1286,7 @@ fn start_push<C, T, M>(
             optimistic,
             pull_after_accept,
             queue_offline,
+            epoch,
         )
         .await;
     });
@@ -1205,6 +1305,7 @@ fn start_push_with_generated_id<C, T, M>(
     optimistic: Option<SyncRow<T>>,
     pull_after_accept: bool,
     queue_offline: bool,
+    epoch: SyncEpoch,
 ) where
     C: 'static,
     T: Clone + serde::de::DeserializeOwned + serde::Serialize + 'static,
@@ -1217,12 +1318,18 @@ fn start_push_with_generated_id<C, T, M>(
         let mutation_id = match local_store.reserve_mutation_id().await {
             Ok(id) => id,
             Err(err) => {
+                if epoch.is_stale() {
+                    return;
+                }
                 handle.update(|state| {
                     selector(state).set_error(format!("sync mutation id allocation failed: {err}"));
                 });
                 return;
             }
         };
+        if epoch.is_stale() {
+            return;
+        }
         run_push(
             scope_id,
             handle,
@@ -1235,6 +1342,7 @@ fn start_push_with_generated_id<C, T, M>(
             optimistic,
             pull_after_accept,
             queue_offline,
+            epoch,
         )
         .await;
     });
@@ -1254,6 +1362,7 @@ async fn run_push<C, T, M>(
     optimistic: Option<SyncRow<T>>,
     pull_after_accept: bool,
     queue_offline: bool,
+    epoch: SyncEpoch,
 ) where
     C: 'static,
     T: Clone + serde::de::DeserializeOwned + serde::Serialize + 'static,
@@ -1267,6 +1376,9 @@ async fn run_push<C, T, M>(
         if let Err(err) =
             enqueue_pending_mutation(&local_store, &stream, &mutation, optimistic.as_ref()).await
         {
+            if epoch.is_stale() {
+                return;
+            }
             handle.update(|state| {
                 selector(state).set_error(err.to_string());
             });
@@ -1274,6 +1386,9 @@ async fn run_push<C, T, M>(
         }
     }
 
+    if epoch.is_stale() {
+        return;
+    }
     handle.update(|state| {
         selector(state).apply_optimistic_mutation(
             mutation_id,
@@ -1294,6 +1409,7 @@ async fn run_push<C, T, M>(
         mutation,
         pull_after_accept,
         queue_offline,
+        epoch,
     )
     .await;
 }
@@ -1352,6 +1468,7 @@ async fn send_push_and_reconcile<C, T, M>(
     mutation: ClientMutation<M>,
     pull_after_accept: bool,
     reconcile_queued_mutation: bool,
+    epoch: SyncEpoch,
 ) -> SyncResult<SyncPushResponse<T>>
 where
     C: 'static,
@@ -1368,6 +1485,9 @@ where
     let result =
         pocopine_core::fetch::call::<SyncPushRequest<M>, SyncPushResponse<T>>(&push_url, &request)
             .await;
+    if epoch.is_stale() {
+        return result.map_err(|err| SyncError::client(err.to_string()));
+    }
     let mut local_error = None;
     let result: Result<SyncPushResponse<T>, String> = match result {
         Ok(response) => {
@@ -1392,6 +1512,9 @@ where
         Ok(response) => Ok(response.clone()),
         Err(err) => Err(SyncError::client(err.clone())),
     };
+    if epoch.is_stale() {
+        return return_result;
+    }
     let should_pull = handle.update(|state| {
         let collection = selector(state);
         match result {
@@ -1424,6 +1547,7 @@ where
             None,
             SyncReason::Push,
             false,
+            epoch,
         );
     }
 
@@ -1714,6 +1838,7 @@ mod tests {
             local_store: store,
             stream: Some(stream),
             cursor: None,
+            epoch: SyncEpoch::new(),
             _marker: PhantomData,
         };
         (state, collection)
@@ -1850,6 +1975,30 @@ mod tests {
         let identity = store.load_identity().await.unwrap().unwrap();
         assert_eq!(identity.device_id.as_str(), "device_local");
         assert_eq!(identity.next_mutation_counter, 7);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test]
+    async fn sign_out_bumps_epoch_so_collections_built_before_become_stale() {
+        let store = Rc::new(MemoryLocalStore::new());
+        let client = sync_plugin().shared_local_store(store).into_client();
+        let state = Rc::new(RefCell::new(TestState::default()));
+        let handle = Handle::new(state, ScopeId(42));
+        // Build a collection BEFORE sign_out — captures the current epoch.
+        let collection = client.collection(handle, posts);
+        // Snapshot of the collection's captured epoch — must look fresh.
+        assert!(!collection.epoch.is_stale());
+        // sign_out bumps the shared cell. The collection's captured
+        // snapshot is now older than current → is_stale() flips true.
+        client.sign_out().await.unwrap();
+        assert!(collection.epoch.is_stale());
+        // A NEW collection built after sign_out captures the new epoch
+        // and is fresh again — only the in-flight pre-signout collection
+        // sees staleness.
+        let state2 = Rc::new(RefCell::new(TestState::default()));
+        let handle2 = Handle::new(state2, ScopeId(43));
+        let fresh = client.collection(handle2, posts);
+        assert!(!fresh.epoch.is_stale());
     }
 
     #[cfg(not(target_arch = "wasm32"))]

--- a/crates/pocopine-sync/src/client.rs
+++ b/crates/pocopine-sync/src/client.rs
@@ -4,6 +4,7 @@ use pocopine_core::{App, AppPlugin, Handle};
 use serde_json::Value;
 
 use crate::{
+    sign_out::{broadcast_sign_out, SignOutSubscription},
     ClientMutation, ClientMutationDraft, CollectionState, LocalPendingMutation, MemoryLocalStore,
     MutationId, RowKey, SyncCursor, SyncError, SyncLocalStore, SyncPushResponse, SyncReason,
     SyncResult, SyncRow, SyncStreamName, SYNC_ENDPOINT_PREFIX,
@@ -150,6 +151,49 @@ impl SyncClient {
             cursor: None,
             _marker: PhantomData,
         }
+    }
+
+    /// Durably drop the local sync cache and tell other tabs to do the same.
+    ///
+    /// This is the helper apps call from their auth-aware sign-out / tenant-
+    /// switch path. The wipe happens first (the durability contract is
+    /// [`SyncLocalStore::clear_all_streams`](crate::SyncLocalStore::clear_all_streams));
+    /// the cross-tab broadcast goes out after, so any sibling tab that
+    /// receives the event sees an already-empty store on the next read.
+    ///
+    /// The local store is not an authorization boundary — call this whenever
+    /// the user identity, tenant, or auth scope changes. Mounted collections
+    /// in this tab continue to hold their in-memory `CollectionState` until
+    /// the app re-mounts them; sibling tabs registered with
+    /// [`watch_sign_outs`](Self::watch_sign_outs) receive a notification so
+    /// they can do the same.
+    pub async fn sign_out(&self) -> SyncResult<()> {
+        self.local_store.clear_all_streams().await?;
+        broadcast_sign_out();
+        Ok(())
+    }
+
+    /// Subscribe to cross-tab sign-out broadcasts.
+    ///
+    /// When another tab in the same browser origin calls
+    /// [`sign_out`](Self::sign_out), the handler runs in this tab. Typical
+    /// usage is to navigate back to a sign-in screen or drop mounted
+    /// `CollectionState`s so the next render hydrates from the (now empty)
+    /// local store.
+    ///
+    /// On host targets this is a no-op stub — there is no cross-process
+    /// cascade today. The returned guard is still valid and dropping it is
+    /// safe.
+    #[cfg(target_arch = "wasm32")]
+    pub fn watch_sign_outs(&self, handler: impl Fn() + 'static) -> SignOutSubscription {
+        let inner = crate::sign_out::subscribe_sign_out(std::rc::Rc::new(handler));
+        SignOutSubscription::wasm(inner)
+    }
+
+    /// Host-target stub. See the wasm32 doc comment.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn watch_sign_outs(&self, _handler: impl Fn() + 'static) -> SignOutSubscription {
+        SignOutSubscription::noop()
     }
 }
 
@@ -1772,6 +1816,50 @@ mod tests {
         assert!(!state.borrow().posts.rows[0].conflict);
         let snapshot = store.hydrate_stream(&stream).await.unwrap();
         assert!(!snapshot.rows[0].conflict);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test]
+    async fn sign_out_wipes_durable_store_and_preserves_identity() {
+        let store = Rc::new(MemoryLocalStore::new());
+        let stream = SyncStreamName::new("posts").unwrap();
+        store
+            .save_identity(
+                SyncLocalIdentity::with_next_counter(SyncDeviceId::new("device_local").unwrap(), 7)
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        store
+            .save_snapshot(LocalSnapshotBatch::new(
+                stream.clone(),
+                SyncCollectionName::new("posts").unwrap(),
+                vec![SyncRow::new("post_1", serde_json::json!({"title": "server"})).unwrap()],
+                None,
+            ))
+            .await
+            .unwrap();
+
+        let client = sync_plugin()
+            .shared_local_store(store.clone())
+            .into_client();
+        client.sign_out().await.unwrap();
+
+        let snapshot = store.hydrate_stream(&stream).await.unwrap();
+        assert!(snapshot.rows.is_empty());
+        let identity = store.load_identity().await.unwrap().unwrap();
+        assert_eq!(identity.device_id.as_str(), "device_local");
+        assert_eq!(identity.next_mutation_counter, 7);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test]
+    async fn watch_sign_outs_returns_a_valid_guard_on_host() {
+        let store = Rc::new(MemoryLocalStore::new());
+        let client = sync_plugin().shared_local_store(store).into_client();
+        // Host stub: should not panic, returns a guard, dropping is fine.
+        let guard = client.watch_sign_outs(|| {});
+        drop(guard);
     }
 }
 

--- a/crates/pocopine-sync/src/error.rs
+++ b/crates/pocopine-sync/src/error.rs
@@ -20,6 +20,14 @@ pub enum SyncError {
     Client(String),
     /// Host-side source or lock failure.
     Backend(String),
+    /// The request lacks the authorization scope the source requires.
+    ///
+    /// Built by app-side `CrudSource` / `SyncStreamSource` impls when the
+    /// per-request context is missing the credentials the source needs
+    /// (for example a tenant header, a JWT subject, or a session role).
+    /// Surfaces as `ServerError::Unauthorized` so the wire response and
+    /// the existing framework-level guard responses share one shape.
+    Unauthorized(String),
 }
 
 impl SyncError {
@@ -44,6 +52,12 @@ impl SyncError {
     pub fn backend(msg: impl Into<String>) -> Self {
         Self::Backend(msg.into())
     }
+
+    /// Build a per-request authorization failure (missing tenant, missing
+    /// session, etc.). Maps to `ServerError::Unauthorized` on the wire.
+    pub fn unauthorized(msg: impl Into<String>) -> Self {
+        Self::Unauthorized(msg.into())
+    }
 }
 
 impl fmt::Display for SyncError {
@@ -58,6 +72,7 @@ impl fmt::Display for SyncError {
             Self::Json(err) => write!(f, "sync json error: {err}"),
             Self::Client(msg) => write!(f, "sync client error: {msg}"),
             Self::Backend(msg) => write!(f, "sync backend error: {msg}"),
+            Self::Unauthorized(msg) => write!(f, "sync unauthorized: {msg}"),
         }
     }
 }

--- a/crates/pocopine-sync/src/lib.rs
+++ b/crates/pocopine-sync/src/lib.rs
@@ -9,6 +9,7 @@ mod error;
 mod local_memory;
 mod local_store;
 mod protocol;
+mod sign_out;
 mod state;
 
 mod client;
@@ -39,6 +40,7 @@ pub use client::{
     SyncLocalStoreHandle,
 };
 pub use pocopine_core::Handle;
+pub use sign_out::SignOutSubscription;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use memory::{MemorySyncState, MemorySyncStream};

--- a/crates/pocopine-sync/src/local_memory.rs
+++ b/crates/pocopine-sync/src/local_memory.rs
@@ -273,6 +273,13 @@ impl SyncLocalStore for MemoryLocalStore {
             Ok(before - state.pending.len())
         }))
     }
+
+    fn clear_all_streams(&self) -> SyncLocalFuture<'_, ()> {
+        Self::ready(self.with_inner(|inner| {
+            inner.streams.clear();
+            Ok(())
+        }))
+    }
 }
 
 struct LocalChanges {
@@ -1149,5 +1156,83 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(purged, 0);
+    }
+
+    #[tokio::test]
+    async fn clear_all_streams_drops_rows_and_pendings_across_streams() {
+        let store = MemoryLocalStore::new();
+        let posts = SyncStreamName::new("posts").unwrap();
+        let comments = SyncStreamName::new("comments").unwrap();
+        let collection_posts = SyncCollectionName::new("posts").unwrap();
+        let collection_comments = SyncCollectionName::new("comments").unwrap();
+
+        store
+            .save_snapshot(LocalSnapshotBatch::new(
+                posts.clone(),
+                collection_posts,
+                vec![SyncRow::new("post_1", serde_json::json!({"title": "p1"})).unwrap()],
+                Some(SyncCursor::new("c_posts").unwrap()),
+            ))
+            .await
+            .unwrap();
+        store
+            .save_snapshot(LocalSnapshotBatch::new(
+                comments.clone(),
+                collection_comments,
+                vec![SyncRow::new("c_1", serde_json::json!({"body": "hi"})).unwrap()],
+                Some(SyncCursor::new("c_comments").unwrap()),
+            ))
+            .await
+            .unwrap();
+        store
+            .enqueue_mutation(
+                &posts,
+                ClientMutation {
+                    id: MutationId::new("device_abc:1").unwrap(),
+                    key: Some(RowKey::new("post_1").unwrap()),
+                    op: SyncOp::Upsert,
+                    base_version: None,
+                    payload: serde_json::json!({"title": "edit"}),
+                },
+            )
+            .await
+            .unwrap();
+
+        store.clear_all_streams().await.unwrap();
+
+        let posts_after = store.hydrate_stream(&posts).await.unwrap();
+        let comments_after = store.hydrate_stream(&comments).await.unwrap();
+        assert!(posts_after.rows.is_empty());
+        assert!(posts_after.cursor.is_none());
+        assert!(posts_after.pending_mutations.is_empty());
+        assert!(comments_after.rows.is_empty());
+        assert!(comments_after.cursor.is_none());
+    }
+
+    #[tokio::test]
+    async fn clear_all_streams_preserves_identity_and_counter() {
+        let store = MemoryLocalStore::new();
+        store
+            .save_identity(
+                SyncLocalIdentity::with_next_counter(SyncDeviceId::new("device_abc").unwrap(), 42)
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        store.clear_all_streams().await.unwrap();
+
+        let identity = store.load_identity().await.unwrap().unwrap();
+        assert_eq!(identity.device_id.as_str(), "device_abc");
+        assert_eq!(identity.next_mutation_counter, 42);
+    }
+
+    #[tokio::test]
+    async fn clear_all_streams_is_safe_on_empty_store() {
+        let store = MemoryLocalStore::new();
+        store.clear_all_streams().await.unwrap();
+        let stream = SyncStreamName::new("posts").unwrap();
+        let snapshot = store.hydrate_stream(&stream).await.unwrap();
+        assert!(snapshot.rows.is_empty());
     }
 }

--- a/crates/pocopine-sync/src/local_store.rs
+++ b/crates/pocopine-sync/src/local_store.rs
@@ -411,12 +411,15 @@ pub trait SyncLocalStore {
     /// * Be safe to call on a never-populated store — calling
     ///   `clear_all_streams` on a fresh install is a successful no-op.
     ///
-    /// The default implementation falls back to no-op for stores that
-    /// haven't been updated yet; existing impls without this method
-    /// continue to compile, but `SyncClient::sign_out` will silently
-    /// leave durable entries behind until the store opts in.
+    /// The default implementation returns `SyncError::Unsupported` so an
+    /// out-of-tree store that hasn't opted in cannot silently leave
+    /// durable data behind on sign-out. Auth/tenant boundary helpers
+    /// MUST surface "this store does not support a durable wipe" rather
+    /// than acting like the wipe succeeded.
     fn clear_all_streams(&self) -> SyncLocalFuture<'_, ()> {
-        Box::pin(std::future::ready(Ok(())))
+        Box::pin(std::future::ready(Err(SyncError::unsupported(
+            "SyncLocalStore::clear_all_streams is not implemented for this store",
+        ))))
     }
 }
 

--- a/crates/pocopine-sync/src/local_store.rs
+++ b/crates/pocopine-sync/src/local_store.rs
@@ -386,6 +386,38 @@ pub trait SyncLocalStore {
     ) -> SyncLocalFuture<'_, usize> {
         Box::pin(std::future::ready(Ok(0)))
     }
+
+    /// Durably drop every persisted stream snapshot, cached row, pending
+    /// mutation, and conflict marker. The persisted `SyncLocalIdentity`
+    /// (device id + mutation counter) is left intact so future mutation
+    /// ids stay globally unique against any server log entry the local
+    /// store has already produced.
+    ///
+    /// This is the storage primitive behind `SyncClient::sign_out` and
+    /// per-tenant cache resets. Authorization is enforced by the server
+    /// on every `/open`, `/pull`, and `/push`; the local store is not a
+    /// trust boundary and may legitimately hold rows that were once
+    /// visible to the previous user. Apps that switch users, tenants,
+    /// or auth scopes call this helper to drop the stale cache before
+    /// re-mounting collections.
+    ///
+    /// Implementations MUST:
+    ///
+    /// * Persist the wipe before returning. Reload must observe an empty
+    ///   sync cache, not the pre-wipe state.
+    /// * Leave the device identity row untouched. Rotating the device id
+    ///   would silently reset the mutation counter and could collide with
+    ///   any accepted-log entry the server still retains.
+    /// * Be safe to call on a never-populated store — calling
+    ///   `clear_all_streams` on a fresh install is a successful no-op.
+    ///
+    /// The default implementation falls back to no-op for stores that
+    /// haven't been updated yet; existing impls without this method
+    /// continue to compile, but `SyncClient::sign_out` will silently
+    /// leave durable entries behind until the store opts in.
+    fn clear_all_streams(&self) -> SyncLocalFuture<'_, ()> {
+        Box::pin(std::future::ready(Ok(())))
+    }
 }
 
 #[cfg(test)]

--- a/crates/pocopine-sync/src/server.rs
+++ b/crates/pocopine-sync/src/server.rs
@@ -373,6 +373,7 @@ fn server_error(error: SyncError) -> ServerError {
         SyncError::UnknownStream(_) => ServerError::Forbidden(error.to_string()),
         SyncError::Unsupported(_) => ServerError::BadRequest(error.to_string()),
         SyncError::Gap(_) => ServerError::BadRequest(error.to_string()),
+        SyncError::Unauthorized(msg) => ServerError::Unauthorized(msg),
         SyncError::Json(err) => {
             tracing::error!(target: "pocopine.log", error = %err, "sync json error");
             ServerError::App("sync internal error".to_string())

--- a/crates/pocopine-sync/src/sign_out.rs
+++ b/crates/pocopine-sync/src/sign_out.rs
@@ -1,0 +1,108 @@
+//! Cross-tab sign-out broadcast bus.
+//!
+//! `SyncClient::sign_out` durably wipes the local sync cache by calling
+//! [`SyncLocalStore::clear_all_streams`](crate::SyncLocalStore::clear_all_streams).
+//! On wasm targets it also posts a message on a browser `BroadcastChannel`
+//! named `pocopine.sync.sign_out` so other tabs sharing the same origin can
+//! react to the sign-out without polling. Tabs subscribe via
+//! [`SyncClient::watch_sign_outs`].
+//!
+//! On host targets the bus is an in-process notifier — useful for tests that
+//! exercise the cascade contract without a browser, and harmless in single-
+//! process binaries that have nothing to cascade to.
+//!
+//! The bus is the *transport* for sign-out events. The *data* wipe is the
+//! `SyncLocalStore` contract; this module only delivers "another tab in your
+//! origin signed out" notifications so the receiving tab can drop its
+//! in-memory state and re-mount.
+
+#[cfg(target_arch = "wasm32")]
+use std::rc::Rc;
+
+/// Cancels a sign-out subscription when dropped.
+///
+/// Returned by [`SyncClient::watch_sign_outs`](crate::SyncClient::watch_sign_outs).
+/// Dropping the guard unregisters the handler so it stops receiving cross-tab
+/// sign-out events.
+#[must_use = "the subscription cancels when dropped; bind it to a variable"]
+pub struct SignOutSubscription {
+    #[cfg(target_arch = "wasm32")]
+    _inner: Option<WasmSubscriptionInner>,
+}
+
+impl SignOutSubscription {
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) fn noop() -> Self {
+        Self {}
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub(crate) fn wasm(inner: Option<WasmSubscriptionInner>) -> Self {
+        Self { _inner: inner }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) struct WasmSubscriptionInner {
+    channel: web_sys::BroadcastChannel,
+    _closure: wasm_bindgen::closure::Closure<dyn FnMut(web_sys::MessageEvent)>,
+}
+
+#[cfg(target_arch = "wasm32")]
+impl Drop for WasmSubscriptionInner {
+    fn drop(&mut self) {
+        self.channel.close();
+    }
+}
+
+/// BroadcastChannel name used by `SyncClient::sign_out` and
+/// `SyncClient::watch_sign_outs`. Scoped to one browser origin by the platform.
+#[cfg(target_arch = "wasm32")]
+pub(crate) const SIGN_OUT_CHANNEL: &str = "pocopine.sync.sign_out";
+
+/// Message payload posted on the sign-out channel. Kept as a literal string
+/// rather than a JSON object so the broadcast wire format stays stable across
+/// pocopine versions without committing to a serde schema yet.
+#[cfg(target_arch = "wasm32")]
+pub(crate) const SIGN_OUT_MESSAGE: &str = "signed_out";
+
+/// Broadcast a sign-out event to other tabs in the same origin.
+///
+/// Best-effort: if the browser doesn't expose `BroadcastChannel` (older
+/// privacy modes, locked-down embedded webviews), the broadcast silently
+/// drops. The durable wipe is the source of truth; the broadcast is purely a
+/// "tell other tabs" optimization.
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn broadcast_sign_out() {
+    use wasm_bindgen::JsValue;
+    if let Ok(channel) = web_sys::BroadcastChannel::new(SIGN_OUT_CHANNEL) {
+        let _ = channel.post_message(&JsValue::from_str(SIGN_OUT_MESSAGE));
+        channel.close();
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn broadcast_sign_out() {
+    // Host has no cross-process cascade today. Tests exercise the path via
+    // `SyncClient::sign_out_notify_handlers_for_test`.
+}
+
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn subscribe_sign_out(handler: Rc<dyn Fn()>) -> Option<WasmSubscriptionInner> {
+    use wasm_bindgen::closure::Closure;
+    use wasm_bindgen::JsCast;
+    let channel = web_sys::BroadcastChannel::new(SIGN_OUT_CHANNEL).ok()?;
+    let closure: Closure<dyn FnMut(web_sys::MessageEvent)> =
+        Closure::new(move |event: web_sys::MessageEvent| {
+            if let Some(value) = event.data().as_string() {
+                if value == SIGN_OUT_MESSAGE {
+                    handler();
+                }
+            }
+        });
+    channel.set_onmessage(Some(closure.as_ref().unchecked_ref()));
+    Some(WasmSubscriptionInner {
+        channel,
+        _closure: closure,
+    })
+}

--- a/docs/sync-local-first-roadmap.md
+++ b/docs/sync-local-first-roadmap.md
@@ -244,9 +244,16 @@ component authors a reactive read path while preserving the existing
 
 Sync does not make local data trusted.
 
-Server guards and source filters run on every `/open`, `/pull`, and
-`/push` — see `pocopine_sync::SyncServerBuilder::guarded_stream` and the
-auth tests in `crates/pocopine-sync/src/server.rs`. Mutation logs must be
+The per-stream guard registered via
+`pocopine_sync::SyncServerBuilder::guarded_stream` runs on every `/open`,
+`/pull`, and `/push`. The app's `CrudSource` / `SyncStreamSource` filters
+run on `/pull` and `/push` — `/open` only resolves the stream and runs
+the registered guard. Sources that need to surface a per-request
+authorization failure (for example a missing tenant header) return
+`SyncError::unauthorized(msg)`; the server maps that to
+`ServerError::Unauthorized` so app errors and framework guard errors
+share one wire shape. See the auth tests in
+`crates/pocopine-sync/src/server.rs`. Mutation logs must be
 scoped to the same authorization domain as the source query, for example
 `(tenant_id, mutation_id)`, not only `mutation_id`. Both
 `SqlxCrudMutationLog::new(scope_fn)` and

--- a/docs/sync-local-first-roadmap.md
+++ b/docs/sync-local-first-roadmap.md
@@ -244,22 +244,50 @@ component authors a reactive read path while preserving the existing
 
 Sync does not make local data trusted.
 
-Server guards and source filters must run on every `/open`, `/pull`, and
-`/push`. Mutation logs must be scoped to the same authorization domain as
-the source query, for example `(tenant_id, mutation_id)`, not only
-`mutation_id`.
+Server guards and source filters run on every `/open`, `/pull`, and
+`/push` — see `pocopine_sync::SyncServerBuilder::guarded_stream` and the
+auth tests in `crates/pocopine-sync/src/server.rs`. Mutation logs must be
+scoped to the same authorization domain as the source query, for example
+`(tenant_id, mutation_id)`, not only `mutation_id`. Both
+`SqlxCrudMutationLog::new(scope_fn)` and
+`MemoryCrudMutationLog::with_scope_fn(scope_fn)` derive the scope from
+the per-request context, so the source query and the mutation log share
+one tenant boundary without app-side glue. The end-to-end example is in
+`crates/pocopine-sync-crud/tests/tenant_boundary.rs`.
 
-The local store may cache data that was once visible to a user. Apps that
-switch users, tenants, or auth scopes need a clear cache reset or
-partition strategy.
+The local store is not an authorization boundary. It may legitimately
+cache data that was once visible to a previous user, tenant, or auth
+scope. Apps that switch identities call
+`SyncClient::sign_out` from the auth-aware code path — it durably wipes
+every stream snapshot, cached row, pending mutation, and conflict marker
+via `SyncLocalStore::clear_all_streams`, then broadcasts a sign-out
+event so sibling tabs in the same browser origin can drop their
+in-memory `CollectionState` and re-hydrate from the (now empty) local
+store. Subscribe to the broadcast with `SyncClient::watch_sign_outs`.
 
-Deliverables:
+The persisted `SyncLocalIdentity` (device id + mutation counter) is
+intentionally **preserved** across sign-out. Rotating the device id
+would silently reset the mutation counter and could collide with
+accepted-log entries the server still retains — the same `(client_id,
+counter)` shape used by Yjs, Automerge, Loro, Jazz, Replicache, and
+Linear keeps the identity stable per browser-origin-bucket and lets
+future P2P modes coordinate without changing the id format.
 
-- documented user/tenant cache partitioning,
-- helpers for clearing sync state on sign-out or tenant switch,
-- tests that a guarded stream cannot be pulled or pushed anonymously,
-- examples where source queries and mutation logs use the same tenant
-  boundary.
+Deliverables (status):
+
+- documented user/tenant cache partitioning — this section + roadmap §3
+  on transactional source/log scoping,
+- helpers for clearing sync state on sign-out or tenant switch —
+  `SyncClient::sign_out`, `SyncLocalStore::clear_all_streams`,
+  `SyncClient::watch_sign_outs`,
+- tests that a guarded stream cannot be pulled or pushed anonymously —
+  `guarded_stream_denies_anonymous_open_and_pull`,
+  `guarded_stream_denies_push_before_default_unsupported`,
+  `role_guard_checks_authenticated_principal_roles` in
+  `pocopine-sync/src/server.rs`,
+- end-to-end example where source queries and mutation logs use the
+  same tenant boundary — `tests/tenant_boundary.rs` in
+  `pocopine-sync-crud`.
 
 ### 8. CI And Regression Tests
 
@@ -299,16 +327,20 @@ simple and hard to misuse.
 
 ## Recommended Implementation Order
 
-1. Extend typed local resource/query views beyond owned snapshots into
-   framework-native subscriptions.
-2. Add transaction-backed server helper paths for source write + mutation
-   log insert.
+1. ~~Extend typed local resource/query views beyond owned snapshots into
+   framework-native subscriptions.~~ Done — `Resource::observe_view`.
+2. ~~Add transaction-backed server helper paths for source write + mutation
+   log insert.~~ Done — `TransactionalCrudSource` + `CrudTransactionRunner`.
 3. Add SQLx helper adapters for server CRUD sources, without becoming an
-   ORM. The first transaction-runner and accepted-mutation-log helper is
-   in place; richer source examples remain.
-4. Add a durable row-scoped pending-mutation purge operation if the
-   author-facing API needs true "discard local edits" semantics.
-5. Document auth/cache partitioning and sign-out reset behavior.
+   ORM. Transaction-runner and accepted-mutation-log helpers are in
+   place; richer source examples remain.
+4. ~~Add a durable row-scoped pending-mutation purge operation if the
+   author-facing API needs true "discard local edits" semantics.~~ Done —
+   `SyncLocalStore::purge_pending_for_row` + `CrudClientResource::discard_local`.
+5. ~~Document auth/cache partitioning and sign-out reset behavior.~~
+   Done — `SyncLocalStore::clear_all_streams`,
+   `SyncClient::sign_out` / `watch_sign_outs`, and the §7 deliverables
+   above.
 6. Add broader browser CI around SQLite local-first flows.
 7. Only then consider database-specific changefeed adapters.
 


### PR DESCRIPTION
## Summary
Closes roadmap item #5 — **Auth & Multi-Tenant Boundaries** — in \`docs/sync-local-first-roadmap.md\` §7. Three stacked commits, codex-reviewed (P1 + 2× P2 + 2× P3 all addressed).

### What ships
- **Durable wipe primitive** — \`SyncLocalStore::clear_all_streams\` (default returns \`Unsupported\` so out-of-tree stores can't silently fail open). Implemented in Memory, SQLite native, SQLite wasm (atomic transaction), and IndexedDB wasm. Identity (device_id + counter) is preserved.
- **\`SyncClient::sign_out\`** — durable wipe + cross-tab \`BroadcastChannel\` post on \`pocopine.sync.sign_out\`. Bumps an in-tab sign-out epoch BEFORE awaiting the wipe so spawned in-flight pull/push tasks abort their post-fetch persist + state update instead of repopulating the just-wiped store.
- **\`SyncClient::watch_sign_outs(handler)\`** — subscribes to the broadcast; returns a \`SignOutSubscription\` guard that drops the channel on drop. Host stub returns a no-op guard.
- **\`MemoryCrudMutationLog::with_scope_fn\`** — mirrors \`SqlxCrudMutationLog::new(scope_fn)\`. Accepted-log key becomes \`(scope, mutation_id)\` so the same MutationId is safe across tenants.
- **\`SyncError::Unauthorized\`** — new variant + \`SyncError::unauthorized(msg)\` constructor. \`server_error\` maps it to \`ServerError::Unauthorized\` so source-side auth failures share the wire shape with framework-level guards.
- **End-to-end tenant boundary test** — \`tests/tenant_boundary.rs\` in \`pocopine-sync-crud\`: cross-tenant invisibility, same-mutation-id-safe-across-tenants, missing-tenant-rejected-as-Unauthorized.

### Design context
- Considered ULID mutation ids, then rejected after researching Yjs / Automerge / Loro / Jazz / Replicache / Linear. They all converge on \`(random_peer_id, monotonic_counter)\`; ULIDs would break state-vector sync, exactly-once-via-high-water-mark, and clock-skew resistance. P2P-readiness needs only the peer id to be random — the counter is local and free to coordinate.
- Considered \`session_id\` rotation on sign-out. Rejected: "browser is a device" + no per-tab rotation. device_id stays stable per browser-origin-bucket; sign-out wipes data only.
- Cascade requirement: "sign out in one tab should cascade, server-app feel." Implemented via \`BroadcastChannel\`.

### Codex review highlights (all addressed in commit 3)
- **P1** — in-flight pulls/pushes could repopulate the store after sign-out. Fixed via \`SyncEpoch\` shared between SyncClient and every SyncCollection; spawned task helpers check \`is_stale()\` at every post-fetch persist site.
- **P2** — wasm SQLite \`clear_all_streams\` was not atomic. Now wrapped in \`BEGIN IMMEDIATE TRANSACTION\` / \`finish_transaction\`.
- **P2** — trait default fail-open. Changed to \`Err(SyncError::unsupported)\`.
- **P3** — missing-tenant test asserted "some error" only. Now uses \`SyncError::unauthorized\` → \`ServerError::Unauthorized\` and asserts the unauthorized shape.
- **P3** — roadmap §7 overstated \`/open\` source filtering. Tightened to "per-stream guard on open; source filters on pull/push."

## Test plan
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy -p pocopine-sync -p pocopine-sync-sqlite -p pocopine-sync-indexdb -p pocopine-sync-crud -p pocopine-sync-crud-macros -p pocopine-sync-sqlx --all-targets -- -D warnings\`
- [x] \`cargo clippy ... --target wasm32-unknown-unknown -- -D warnings\`
- [x] All host + integration tests pass — 106 + 52 + 22 + 1 + 3 unit + 3 tenant-boundary integration + 1 epoch-fencing.