### PR TITLE
Make storage uploads tus-compliant

### DIFF
--- a/crates/pocopine-storage/Cargo.toml
+++ b/crates/pocopine-storage/Cargo.toml
@@ -7,6 +7,7 @@ repository.workspace = true
 description = "Storage protocol, browser client, and server plugin extension for Pocopine apps."
 
 [dependencies]
+base64 = "0.22"
 bytes = "1"
 pocopine-core = { workspace = true, default-features = false }
 serde = { workspace = true }
@@ -15,7 +16,6 @@ time = { version = "0.3", features = ["serde", "formatting"] }
 uuid = { version = "1", features = ["v4", "js"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-base64 = "0.22"
 pocopine-server = { workspace = true }
 sha2 = "0.10"
 tracing = { workspace = true }

--- a/crates/pocopine-storage/src/backend_common.rs
+++ b/crates/pocopine-storage/src/backend_common.rs
@@ -93,6 +93,33 @@ pub(crate) fn ensure_size_limit(
     Ok(())
 }
 
+pub(crate) fn ensure_upload_length_can_be_set(
+    max_bytes: u64,
+    session: &UploadSession,
+    committed_offset: u64,
+    size: u64,
+) -> StorageResult<()> {
+    ensure_open(session)?;
+    if let Some(existing) = session.size {
+        if existing == size {
+            return Ok(());
+        }
+        return Err(StorageError::invalid_value(
+            "Upload-Length",
+            "cannot change upload length after it is set",
+        ));
+    }
+    if size > max_bytes {
+        return Err(StorageError::payload_too_large(max_bytes));
+    }
+    if committed_offset > size {
+        return Err(StorageError::policy_rejected(format!(
+            "upload length {size} is smaller than the committed offset {committed_offset}"
+        )));
+    }
+    Ok(())
+}
+
 pub(crate) fn object_ref(
     backend: &str,
     session: &UploadSession,

--- a/crates/pocopine-storage/src/client.rs
+++ b/crates/pocopine-storage/src/client.rs
@@ -26,14 +26,14 @@ pub fn storage_plugin() -> StorageClientPlugin {
     StorageClientPlugin::default()
 }
 
-/// App plugin that provides [`TusClient`] to components.
+/// App plugin that provides [`UploadClient`] to components.
 #[derive(Clone, Debug)]
-pub struct TusClientPlugin {
+pub struct UploadClientPlugin {
     endpoint: String,
     with_credentials: bool,
 }
 
-impl Default for TusClientPlugin {
+impl Default for UploadClientPlugin {
     fn default() -> Self {
         Self {
             endpoint: STORAGE_TUS_ENDPOINT_PREFIX.to_string(),
@@ -42,36 +42,36 @@ impl Default for TusClientPlugin {
     }
 }
 
-/// Build the tus app plugin.
-pub fn tus_plugin() -> TusClientPlugin {
-    TusClientPlugin::default()
+/// Build the browser upload app plugin.
+pub fn upload_plugin() -> UploadClientPlugin {
+    UploadClientPlugin::default()
 }
 
-impl TusClientPlugin {
-    /// Override the tus HTTP endpoint prefix.
+impl UploadClientPlugin {
+    /// Override the resumable-upload HTTP endpoint prefix.
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
         self.endpoint = endpoint.into();
         self
     }
 
-    /// Set browser credentials mode for tus fetches.
+    /// Set browser credentials mode for upload fetches.
     pub fn with_credentials(mut self, enabled: bool) -> Self {
         self.with_credentials = enabled;
         self
     }
 
     /// Build a runtime client without mounting an app.
-    pub fn into_client(self) -> TusClient {
-        TusClient {
+    pub fn into_client(self) -> UploadClient {
+        UploadClient {
             endpoint: self.endpoint,
             with_credentials: self.with_credentials,
         }
     }
 }
 
-impl AppPlugin for TusClientPlugin {
+impl AppPlugin for UploadClientPlugin {
     fn name(&self) -> &'static str {
-        "pocopine-storage-tus"
+        "pocopine-storage-upload"
     }
 
     fn install(self, app: App) -> App {
@@ -152,23 +152,23 @@ impl StorageClient {
     }
 }
 
-/// Runtime tus 1.0 client service installed by [`tus_plugin`].
+/// Runtime browser upload client service installed by [`upload_plugin`].
 #[derive(Clone, Debug)]
-pub struct TusClient {
+pub struct UploadClient {
     endpoint: String,
     with_credentials: bool,
 }
 
-impl Default for TusClient {
+impl Default for UploadClient {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl TusClient {
-    /// Build a tus client using the default storage tus endpoint.
+impl UploadClient {
+    /// Build an upload client using the default storage upload endpoint.
     pub fn new() -> Self {
-        TusClientPlugin::default().into_client()
+        UploadClientPlugin::default().into_client()
     }
 
     /// Override the endpoint on a direct client.
@@ -184,8 +184,8 @@ impl TusClient {
     }
 
     /// Bind this client to a server-registered storage scope.
-    pub fn scope(&self, scope: impl Into<String>) -> TusScopeClient {
-        TusScopeClient {
+    pub fn scope(&self, scope: impl Into<String>) -> UploadScopeClient {
+        UploadScopeClient {
             endpoint: self.endpoint.clone(),
             with_credentials: self.with_credentials,
             scope: scope.into(),
@@ -193,18 +193,18 @@ impl TusClient {
     }
 }
 
-/// Scope-bound tus client.
+/// Scope-bound browser upload client.
 #[derive(Clone, Debug)]
 #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
-pub struct TusScopeClient {
+pub struct UploadScopeClient {
     endpoint: String,
     with_credentials: bool,
     scope: String,
 }
 
-/// Result returned by the native Rust tus client.
+/// Result returned by the browser resumable upload client.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub struct TusUploadResult {
+pub struct ResumableUpload {
     pub upload_url: String,
     pub bytes_uploaded: u64,
 }
@@ -242,7 +242,7 @@ pub struct UploadBuilder;
 
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug)]
-pub struct TusUploadBuilder;
+pub struct ResumableUploadBuilder;
 
 #[cfg(target_arch = "wasm32")]
 mod wasm {
@@ -410,9 +410,9 @@ mod wasm {
         }
     }
 
-    impl super::TusScopeClient {
-        /// Start a tus upload from a browser [`File`].
-        pub fn upload(&self, file: File) -> TusUploadBuilder {
+    impl super::UploadScopeClient {
+        /// Start a resumable upload from a browser [`File`].
+        pub fn upload(&self, file: File) -> ResumableUploadBuilder {
             let name = file.name();
             let size = file.size() as u64;
             let content_type = empty_to_none(file.type_());
@@ -427,8 +427,8 @@ mod wasm {
             })
         }
 
-        /// Start a tus upload from a browser [`Blob`] with an app-provided name.
-        pub fn upload_blob(&self, blob: Blob, name: impl Into<String>) -> TusUploadBuilder {
+        /// Start a resumable upload from a browser [`Blob`] with an app-provided name.
+        pub fn upload_blob(&self, blob: Blob, name: impl Into<String>) -> ResumableUploadBuilder {
             let size = blob.size() as u64;
             let content_type = empty_to_none(blob.type_());
             self.upload_source(UploadSource {
@@ -440,13 +440,13 @@ mod wasm {
             })
         }
 
-        /// Resume a tus upload from a known upload URL.
-        pub fn resume(&self, file: File, upload_url: impl Into<String>) -> TusUploadBuilder {
+        /// Resume an upload from a known upload URL.
+        pub fn resume(&self, file: File, upload_url: impl Into<String>) -> ResumableUploadBuilder {
             self.upload(file).upload_url(upload_url)
         }
 
-        fn upload_source(&self, source: UploadSource) -> TusUploadBuilder {
-            TusUploadBuilder {
+        fn upload_source(&self, source: UploadSource) -> ResumableUploadBuilder {
+            ResumableUploadBuilder {
                 endpoint: self.endpoint.clone(),
                 with_credentials: self.with_credentials,
                 scope: self.scope.clone(),
@@ -749,9 +749,9 @@ mod wasm {
         }
     }
 
-    /// Browser tus upload builder.
+    /// Browser resumable upload builder.
     #[must_use]
-    pub struct TusUploadBuilder {
+    pub struct ResumableUploadBuilder {
         endpoint: String,
         with_credentials: bool,
         scope: String,
@@ -766,18 +766,18 @@ mod wasm {
         chunk_size: u64,
     }
 
-    struct TusHead {
+    struct UploadHead {
         offset: u64,
         length: Option<u64>,
     }
 
-    enum TusPatchOutcome {
+    enum PatchOutcome {
         Advanced(u64),
         Conflict,
     }
 
-    impl TusUploadBuilder {
-        /// Add string metadata to the tus creation request.
+    impl ResumableUploadBuilder {
+        /// Add string metadata to the upload creation request.
         pub fn metadata(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
             self.metadata.insert(key.into(), value.into());
             self
@@ -804,41 +804,41 @@ mod wasm {
             self
         }
 
-        /// Attach a browser abort signal to every tus request in this upload.
+        /// Attach a browser abort signal to every upload request.
         pub fn abort_signal(mut self, signal: AbortSignal) -> Self {
             self.abort_signal = Some(signal);
             self
         }
 
-        /// Resume from an existing tus upload URL.
+        /// Resume from an existing upload URL.
         pub fn upload_url(mut self, upload_url: impl Into<String>) -> Self {
             self.upload_url = Some(upload_url.into());
             self
         }
 
-        /// Opt into browser localStorage tus URL lookup for this source.
+        /// Opt into browser localStorage upload URL lookup for this source.
         ///
         /// This is disabled by default so same-name/same-size files never resume
-        /// implicitly into an unrelated tus upload.
+        /// implicitly into an unrelated upload.
         pub fn auto_resume(mut self, enabled: bool) -> Self {
             self.auto_resume = enabled;
             self
         }
 
-        /// Set the tus PATCH chunk size in bytes.
+        /// Set the resumable upload PATCH chunk size in bytes.
         pub fn chunk_size(mut self, chunk_size: u64) -> Self {
             self.chunk_size = chunk_size.max(1);
             self
         }
 
-        /// Upload the file/blob through the tus 1.0 creation and PATCH flow.
-        pub async fn send(self) -> StorageResult<TusUploadResult> {
+        /// Upload the file/blob through the resumable creation and PATCH flow.
+        pub async fn send(self) -> StorageResult<ResumableUpload> {
             self.emit(UploadPhase::Initiating, 0);
 
             let explicit_resume = self.upload_url.is_some();
             let resume_url = self.upload_url.clone().or_else(|| {
                 self.auto_resume
-                    .then(|| read_tus_resume_url(&self.resume_key()))
+                    .then(|| read_upload_resume_url(&self.resume_key()))
                     .flatten()
             });
             let (upload_url, mut offset) = if let Some(upload_url) = resume_url {
@@ -848,9 +848,9 @@ mod wasm {
                         (upload_url, head.offset)
                     }
                     Err(err) if self.auto_resume && !explicit_resume => {
-                        remove_tus_resume_url(&self.resume_key());
+                        remove_upload_resume_url(&self.resume_key());
                         let created = self.create_upload().await?;
-                        write_tus_resume_url(&self.resume_key(), &created.0);
+                        write_upload_resume_url(&self.resume_key(), &created.0);
                         created
                     }
                     Err(err) => return Err(err),
@@ -858,12 +858,12 @@ mod wasm {
             } else {
                 let created = self.create_upload().await?;
                 if self.auto_resume {
-                    write_tus_resume_url(&self.resume_key(), &created.0);
+                    write_upload_resume_url(&self.resume_key(), &created.0);
                 }
                 created
             };
             if self.auto_resume {
-                write_tus_resume_url(&self.resume_key(), &upload_url);
+                write_upload_resume_url(&self.resume_key(), &upload_url);
             }
 
             while offset < self.source.size {
@@ -873,12 +873,12 @@ mod wasm {
                 let mut attempts = 0;
                 loop {
                     match self.patch_chunk(&upload_url, offset, chunk.clone()).await {
-                        Ok(TusPatchOutcome::Advanced(next_offset)) => {
+                        Ok(PatchOutcome::Advanced(next_offset)) => {
                             offset = next_offset;
                             self.emit(UploadPhase::Uploading, offset);
                             break;
                         }
-                        Ok(TusPatchOutcome::Conflict) => {
+                        Ok(PatchOutcome::Conflict) => {
                             let head = self.head_upload(&upload_url).await?;
                             self.validate_head_length(&head)?;
                             offset = head.offset;
@@ -901,9 +901,9 @@ mod wasm {
 
             self.emit(UploadPhase::Complete, offset);
             if self.auto_resume {
-                remove_tus_resume_url(&self.resume_key());
+                remove_upload_resume_url(&self.resume_key());
             }
-            Ok(TusUploadResult {
+            Ok(ResumableUpload {
                 upload_url,
                 bytes_uploaded: offset,
             })
@@ -919,10 +919,10 @@ mod wasm {
                 self.abort_signal.clone(),
             ))
             .await?;
-            ensure_tus_status(&response, "create tus upload", &[201])?;
+            ensure_tus_status(&response, "create upload", &[201])?;
             let location = response
                 .header("location")
-                .ok_or_else(|| StorageError::client("create tus upload omitted Location"))?;
+                .ok_or_else(|| StorageError::client("create upload omitted Location"))?;
             let upload_url = resolve_tus_location(&create_url, location);
             let offset = response
                 .header("upload-offset")
@@ -932,23 +932,23 @@ mod wasm {
             Ok((upload_url, offset))
         }
 
-        async fn head_upload(&self, upload_url: &str) -> StorageResult<TusHead> {
+        async fn head_upload(&self, upload_url: &str) -> StorageResult<UploadHead> {
             let response = send_request(BrowserStorageRequest::head(
                 upload_url.to_string(),
                 self.with_credentials,
                 self.abort_signal.clone(),
             ))
             .await?;
-            ensure_tus_status(&response, "inspect tus upload", &[200, 204])?;
+            ensure_tus_status(&response, "inspect upload", &[200, 204])?;
             let offset = response
                 .header("upload-offset")
-                .ok_or_else(|| StorageError::client("inspect tus upload omitted Upload-Offset"))
+                .ok_or_else(|| StorageError::client("inspect upload omitted Upload-Offset"))
                 .and_then(parse_upload_offset_header)?;
             let length = response
                 .header("upload-length")
                 .map(parse_upload_length_header)
                 .transpose()?;
-            Ok(TusHead { offset, length })
+            Ok(UploadHead { offset, length })
         }
 
         async fn patch_chunk(
@@ -956,7 +956,7 @@ mod wasm {
             upload_url: &str,
             offset: u64,
             chunk: Blob,
-        ) -> StorageResult<TusPatchOutcome> {
+        ) -> StorageResult<PatchOutcome> {
             let response = send_request(BrowserStorageRequest::tus_patch(
                 upload_url.to_string(),
                 offset,
@@ -966,21 +966,21 @@ mod wasm {
             ))
             .await?;
             if response.status == 409 {
-                return Ok(TusPatchOutcome::Conflict);
+                return Ok(PatchOutcome::Conflict);
             }
-            ensure_tus_status(&response, "patch tus upload", &[204])?;
+            ensure_tus_status(&response, "patch upload", &[204])?;
             let next_offset = response
                 .header("upload-offset")
-                .ok_or_else(|| StorageError::client("patch tus upload omitted Upload-Offset"))
+                .ok_or_else(|| StorageError::client("patch upload omitted Upload-Offset"))
                 .and_then(parse_upload_offset_header)?;
-            Ok(TusPatchOutcome::Advanced(next_offset))
+            Ok(PatchOutcome::Advanced(next_offset))
         }
 
-        fn validate_head_length(&self, head: &TusHead) -> StorageResult<()> {
+        fn validate_head_length(&self, head: &UploadHead) -> StorageResult<()> {
             if let Some(length) = head.length {
                 if length != self.source.size {
                     return Err(StorageError::client(format!(
-                        "tus upload length mismatch: remote {length}, local {}",
+                        "upload length mismatch: remote {length}, local {}",
                         self.source.size
                     )));
                 }
@@ -1005,7 +1005,7 @@ mod wasm {
             self.source
                 .blob
                 .slice_with_f64_and_f64(start as f64, end as f64)
-                .map_err(|err| StorageError::client(format!("slice tus upload blob: {err:?}")))
+                .map_err(|err| StorageError::client(format!("slice upload blob: {err:?}")))
         }
 
         fn emit(&self, phase: UploadPhase, bytes_sent: u64) {
@@ -1021,7 +1021,7 @@ mod wasm {
 
         fn resume_key(&self) -> String {
             format!(
-                "pocopine.storage.tus.resume.v1:{}:{}:{}:{}",
+                "pocopine.storage.upload.resume.v1:{}:{}:{}:{}",
                 self.scope,
                 self.source.name,
                 self.source.size,
@@ -1360,17 +1360,17 @@ mod wasm {
         }
     }
 
-    fn read_tus_resume_url(key: &str) -> Option<String> {
+    fn read_upload_resume_url(key: &str) -> Option<String> {
         local_storage()?.get_item(key).ok().flatten()
     }
 
-    fn write_tus_resume_url(key: &str, upload_url: &str) {
+    fn write_upload_resume_url(key: &str, upload_url: &str) {
         if let Some(storage) = local_storage() {
             let _ = storage.set_item(key, upload_url);
         }
     }
 
-    fn remove_tus_resume_url(key: &str) {
+    fn remove_upload_resume_url(key: &str) {
         if let Some(storage) = local_storage() {
             let _ = storage.remove_item(key);
         }
@@ -1489,6 +1489,6 @@ mod wasm {
 
 #[cfg(target_arch = "wasm32")]
 pub use wasm::{
-    BrowserStorageRequest, BrowserStorageResponse, BrowserStorageTransport, TusUploadBuilder,
+    BrowserStorageRequest, BrowserStorageResponse, BrowserStorageTransport, ResumableUploadBuilder,
     UploadBuilder, __reset_browser_transport_for_test, __set_browser_transport_for_test,
 };

--- a/crates/pocopine-storage/src/client.rs
+++ b/crates/pocopine-storage/src/client.rs
@@ -2,7 +2,7 @@ use pocopine_core::{App, AppPlugin};
 
 use crate::{
     StorageError, StorageResult, UploadPolicyDescriptor, UploadSession, UploadSessionId,
-    STORAGE_ENDPOINT_PREFIX,
+    STORAGE_ENDPOINT_PREFIX, STORAGE_TUS_ENDPOINT_PREFIX,
 };
 
 /// App plugin that provides [`StorageClient`] to components.
@@ -24,6 +24,59 @@ impl Default for StorageClientPlugin {
 /// Build the storage app plugin.
 pub fn storage_plugin() -> StorageClientPlugin {
     StorageClientPlugin::default()
+}
+
+/// App plugin that provides [`TusClient`] to components.
+#[derive(Clone, Debug)]
+pub struct TusClientPlugin {
+    endpoint: String,
+    with_credentials: bool,
+}
+
+impl Default for TusClientPlugin {
+    fn default() -> Self {
+        Self {
+            endpoint: STORAGE_TUS_ENDPOINT_PREFIX.to_string(),
+            with_credentials: false,
+        }
+    }
+}
+
+/// Build the tus app plugin.
+pub fn tus_plugin() -> TusClientPlugin {
+    TusClientPlugin::default()
+}
+
+impl TusClientPlugin {
+    /// Override the tus HTTP endpoint prefix.
+    pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.endpoint = endpoint.into();
+        self
+    }
+
+    /// Set browser credentials mode for tus fetches.
+    pub fn with_credentials(mut self, enabled: bool) -> Self {
+        self.with_credentials = enabled;
+        self
+    }
+
+    /// Build a runtime client without mounting an app.
+    pub fn into_client(self) -> TusClient {
+        TusClient {
+            endpoint: self.endpoint,
+            with_credentials: self.with_credentials,
+        }
+    }
+}
+
+impl AppPlugin for TusClientPlugin {
+    fn name(&self) -> &'static str {
+        "pocopine-storage-tus"
+    }
+
+    fn install(self, app: App) -> App {
+        app.provide_plugin(self.into_client())
+    }
 }
 
 impl StorageClientPlugin {
@@ -99,6 +152,63 @@ impl StorageClient {
     }
 }
 
+/// Runtime tus 1.0 client service installed by [`tus_plugin`].
+#[derive(Clone, Debug)]
+pub struct TusClient {
+    endpoint: String,
+    with_credentials: bool,
+}
+
+impl Default for TusClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TusClient {
+    /// Build a tus client using the default storage tus endpoint.
+    pub fn new() -> Self {
+        TusClientPlugin::default().into_client()
+    }
+
+    /// Override the endpoint on a direct client.
+    pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
+        self.endpoint = endpoint.into();
+        self
+    }
+
+    /// Set browser credentials mode on a direct client.
+    pub fn with_credentials(mut self, enabled: bool) -> Self {
+        self.with_credentials = enabled;
+        self
+    }
+
+    /// Bind this client to a server-registered storage scope.
+    pub fn scope(&self, scope: impl Into<String>) -> TusScopeClient {
+        TusScopeClient {
+            endpoint: self.endpoint.clone(),
+            with_credentials: self.with_credentials,
+            scope: scope.into(),
+        }
+    }
+}
+
+/// Scope-bound tus client.
+#[derive(Clone, Debug)]
+#[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+pub struct TusScopeClient {
+    endpoint: String,
+    with_credentials: bool,
+    scope: String,
+}
+
+/// Result returned by the native Rust tus client.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TusUploadResult {
+    pub upload_url: String,
+    pub bytes_uploaded: u64,
+}
+
 /// Scope-bound storage client.
 #[derive(Clone, Debug)]
 pub struct StorageScopeClient {
@@ -130,6 +240,10 @@ impl StorageScopeClient {
 #[derive(Debug)]
 pub struct UploadBuilder;
 
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug)]
+pub struct TusUploadBuilder;
+
 #[cfg(target_arch = "wasm32")]
 mod wasm {
     use std::cell::RefCell;
@@ -138,6 +252,7 @@ mod wasm {
     use std::pin::Pin;
     use std::rc::Rc;
 
+    use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
     use js_sys::Promise;
     use serde::de::DeserializeOwned;
     use wasm_bindgen::prelude::*;
@@ -154,6 +269,7 @@ mod wasm {
     };
 
     const DEFAULT_CHUNK_SIZE: u64 = 1024 * 1024;
+    const TUS_PROTOCOL_VERSION: &str = "1.0.0";
 
     /// Test hook for the browser upload transport.
     #[doc(hidden)]
@@ -182,7 +298,17 @@ mod wasm {
     #[derive(Clone, Debug)]
     pub struct BrowserStorageResponse {
         pub status: u16,
+        pub headers: Vec<(String, String)>,
         pub body: String,
+    }
+
+    impl BrowserStorageResponse {
+        pub fn header(&self, name: &str) -> Option<&str> {
+            self.headers
+                .iter()
+                .find(|(candidate, _)| candidate.eq_ignore_ascii_case(name))
+                .map(|(_, value)| value.as_str())
+        }
     }
 
     thread_local! {
@@ -280,6 +406,59 @@ mod wasm {
                 abort_signal: None,
                 resume_session: None,
                 auto_resume: false,
+            }
+        }
+    }
+
+    impl super::TusScopeClient {
+        /// Start a tus upload from a browser [`File`].
+        pub fn upload(&self, file: File) -> TusUploadBuilder {
+            let name = file.name();
+            let size = file.size() as u64;
+            let content_type = empty_to_none(file.type_());
+            let last_modified = Some(file.last_modified() as i64);
+            let blob: Blob = file.unchecked_into();
+            self.upload_source(UploadSource {
+                blob,
+                name,
+                size,
+                content_type,
+                last_modified,
+            })
+        }
+
+        /// Start a tus upload from a browser [`Blob`] with an app-provided name.
+        pub fn upload_blob(&self, blob: Blob, name: impl Into<String>) -> TusUploadBuilder {
+            let size = blob.size() as u64;
+            let content_type = empty_to_none(blob.type_());
+            self.upload_source(UploadSource {
+                blob,
+                name: name.into(),
+                size,
+                content_type,
+                last_modified: None,
+            })
+        }
+
+        /// Resume a tus upload from a known upload URL.
+        pub fn resume(&self, file: File, upload_url: impl Into<String>) -> TusUploadBuilder {
+            self.upload(file).upload_url(upload_url)
+        }
+
+        fn upload_source(&self, source: UploadSource) -> TusUploadBuilder {
+            TusUploadBuilder {
+                endpoint: self.endpoint.clone(),
+                with_credentials: self.with_credentials,
+                scope: self.scope.clone(),
+                source,
+                metadata: BTreeMap::new(),
+                progress: None,
+                retry_limit: 2,
+                retry_base_delay_ms: 100,
+                abort_signal: None,
+                upload_url: None,
+                auto_resume: false,
+                chunk_size: DEFAULT_CHUNK_SIZE,
             }
         }
     }
@@ -570,6 +749,290 @@ mod wasm {
         }
     }
 
+    /// Browser tus upload builder.
+    #[must_use]
+    pub struct TusUploadBuilder {
+        endpoint: String,
+        with_credentials: bool,
+        scope: String,
+        source: UploadSource,
+        metadata: BTreeMap<String, String>,
+        progress: Option<Rc<dyn Fn(UploadProgress)>>,
+        retry_limit: u32,
+        retry_base_delay_ms: u32,
+        abort_signal: Option<AbortSignal>,
+        upload_url: Option<String>,
+        auto_resume: bool,
+        chunk_size: u64,
+    }
+
+    struct TusHead {
+        offset: u64,
+        length: Option<u64>,
+    }
+
+    enum TusPatchOutcome {
+        Advanced(u64),
+        Conflict,
+    }
+
+    impl TusUploadBuilder {
+        /// Add string metadata to the tus creation request.
+        pub fn metadata(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+            self.metadata.insert(key.into(), value.into());
+            self
+        }
+
+        /// Observe upload progress.
+        pub fn on_progress<F>(mut self, callback: F) -> Self
+        where
+            F: Fn(UploadProgress) + 'static,
+        {
+            self.progress = Some(Rc::new(callback));
+            self
+        }
+
+        /// Set the number of retries for transient browser transport errors.
+        pub fn retry_limit(mut self, retry_limit: u32) -> Self {
+            self.retry_limit = retry_limit;
+            self
+        }
+
+        /// Set the base retry backoff in milliseconds.
+        pub fn retry_base_delay_ms(mut self, retry_base_delay_ms: u32) -> Self {
+            self.retry_base_delay_ms = retry_base_delay_ms;
+            self
+        }
+
+        /// Attach a browser abort signal to every tus request in this upload.
+        pub fn abort_signal(mut self, signal: AbortSignal) -> Self {
+            self.abort_signal = Some(signal);
+            self
+        }
+
+        /// Resume from an existing tus upload URL.
+        pub fn upload_url(mut self, upload_url: impl Into<String>) -> Self {
+            self.upload_url = Some(upload_url.into());
+            self
+        }
+
+        /// Opt into browser localStorage tus URL lookup for this source.
+        ///
+        /// This is disabled by default so same-name/same-size files never resume
+        /// implicitly into an unrelated tus upload.
+        pub fn auto_resume(mut self, enabled: bool) -> Self {
+            self.auto_resume = enabled;
+            self
+        }
+
+        /// Set the tus PATCH chunk size in bytes.
+        pub fn chunk_size(mut self, chunk_size: u64) -> Self {
+            self.chunk_size = chunk_size.max(1);
+            self
+        }
+
+        /// Upload the file/blob through the tus 1.0 creation and PATCH flow.
+        pub async fn send(self) -> StorageResult<TusUploadResult> {
+            self.emit(UploadPhase::Initiating, 0);
+
+            let explicit_resume = self.upload_url.is_some();
+            let resume_url = self.upload_url.clone().or_else(|| {
+                self.auto_resume
+                    .then(|| read_tus_resume_url(&self.resume_key()))
+                    .flatten()
+            });
+            let (upload_url, mut offset) = if let Some(upload_url) = resume_url {
+                match self.head_upload(&upload_url).await {
+                    Ok(head) => {
+                        self.validate_head_length(&head)?;
+                        (upload_url, head.offset)
+                    }
+                    Err(err) if self.auto_resume && !explicit_resume => {
+                        remove_tus_resume_url(&self.resume_key());
+                        let created = self.create_upload().await?;
+                        write_tus_resume_url(&self.resume_key(), &created.0);
+                        created
+                    }
+                    Err(err) => return Err(err),
+                }
+            } else {
+                let created = self.create_upload().await?;
+                if self.auto_resume {
+                    write_tus_resume_url(&self.resume_key(), &created.0);
+                }
+                created
+            };
+            if self.auto_resume {
+                write_tus_resume_url(&self.resume_key(), &upload_url);
+            }
+
+            while offset < self.source.size {
+                self.emit(UploadPhase::Uploading, offset);
+                let end = offset.saturating_add(self.chunk_size).min(self.source.size);
+                let chunk = self.slice(offset, end)?;
+                let mut attempts = 0;
+                loop {
+                    match self.patch_chunk(&upload_url, offset, chunk.clone()).await {
+                        Ok(TusPatchOutcome::Advanced(next_offset)) => {
+                            offset = next_offset;
+                            self.emit(UploadPhase::Uploading, offset);
+                            break;
+                        }
+                        Ok(TusPatchOutcome::Conflict) => {
+                            let head = self.head_upload(&upload_url).await?;
+                            self.validate_head_length(&head)?;
+                            offset = head.offset;
+                            break;
+                        }
+                        Err(err)
+                            if err.is_retryable_client_error() && attempts < self.retry_limit =>
+                        {
+                            attempts += 1;
+                            self.emit(UploadPhase::Retrying, offset);
+                            retry_delay(self.retry_base_delay_ms, attempts).await?;
+                        }
+                        Err(err) => {
+                            self.emit(UploadPhase::Failed, offset);
+                            return Err(err);
+                        }
+                    }
+                }
+            }
+
+            self.emit(UploadPhase::Complete, offset);
+            if self.auto_resume {
+                remove_tus_resume_url(&self.resume_key());
+            }
+            Ok(TusUploadResult {
+                upload_url,
+                bytes_uploaded: offset,
+            })
+        }
+
+        async fn create_upload(&self) -> StorageResult<(String, u64)> {
+            let create_url = tus_uploads_url(&self.endpoint, &self.scope);
+            let response = send_request(BrowserStorageRequest::tus_create(
+                create_url.clone(),
+                self.source.size,
+                self.tus_metadata_header()?,
+                self.with_credentials,
+                self.abort_signal.clone(),
+            ))
+            .await?;
+            ensure_tus_status(&response, "create tus upload", &[201])?;
+            let location = response
+                .header("location")
+                .ok_or_else(|| StorageError::client("create tus upload omitted Location"))?;
+            let upload_url = resolve_tus_location(&create_url, location);
+            let offset = response
+                .header("upload-offset")
+                .map(parse_upload_offset_header)
+                .transpose()?
+                .unwrap_or(0);
+            Ok((upload_url, offset))
+        }
+
+        async fn head_upload(&self, upload_url: &str) -> StorageResult<TusHead> {
+            let response = send_request(BrowserStorageRequest::head(
+                upload_url.to_string(),
+                self.with_credentials,
+                self.abort_signal.clone(),
+            ))
+            .await?;
+            ensure_tus_status(&response, "inspect tus upload", &[200, 204])?;
+            let offset = response
+                .header("upload-offset")
+                .ok_or_else(|| StorageError::client("inspect tus upload omitted Upload-Offset"))
+                .and_then(parse_upload_offset_header)?;
+            let length = response
+                .header("upload-length")
+                .map(parse_upload_length_header)
+                .transpose()?;
+            Ok(TusHead { offset, length })
+        }
+
+        async fn patch_chunk(
+            &self,
+            upload_url: &str,
+            offset: u64,
+            chunk: Blob,
+        ) -> StorageResult<TusPatchOutcome> {
+            let response = send_request(BrowserStorageRequest::tus_patch(
+                upload_url.to_string(),
+                offset,
+                chunk,
+                self.with_credentials,
+                self.abort_signal.clone(),
+            ))
+            .await?;
+            if response.status == 409 {
+                return Ok(TusPatchOutcome::Conflict);
+            }
+            ensure_tus_status(&response, "patch tus upload", &[204])?;
+            let next_offset = response
+                .header("upload-offset")
+                .ok_or_else(|| StorageError::client("patch tus upload omitted Upload-Offset"))
+                .and_then(parse_upload_offset_header)?;
+            Ok(TusPatchOutcome::Advanced(next_offset))
+        }
+
+        fn validate_head_length(&self, head: &TusHead) -> StorageResult<()> {
+            if let Some(length) = head.length {
+                if length != self.source.size {
+                    return Err(StorageError::client(format!(
+                        "tus upload length mismatch: remote {length}, local {}",
+                        self.source.size
+                    )));
+                }
+            }
+            Ok(())
+        }
+
+        fn tus_metadata_header(&self) -> StorageResult<Option<String>> {
+            let mut metadata = self.metadata.clone();
+            metadata
+                .entry("filename".to_string())
+                .or_insert_with(|| self.source.name.clone());
+            if let Some(content_type) = &self.source.content_type {
+                metadata
+                    .entry("filetype".to_string())
+                    .or_insert_with(|| content_type.clone());
+            }
+            encode_tus_metadata(&metadata)
+        }
+
+        fn slice(&self, start: u64, end: u64) -> StorageResult<Blob> {
+            self.source
+                .blob
+                .slice_with_f64_and_f64(start as f64, end as f64)
+                .map_err(|err| StorageError::client(format!("slice tus upload blob: {err:?}")))
+        }
+
+        fn emit(&self, phase: UploadPhase, bytes_sent: u64) {
+            if let Some(callback) = &self.progress {
+                callback(UploadProgress {
+                    bytes_sent,
+                    bytes_total: Some(self.source.size),
+                    current_part: None,
+                    phase,
+                });
+            }
+        }
+
+        fn resume_key(&self) -> String {
+            format!(
+                "pocopine.storage.tus.resume.v1:{}:{}:{}:{}",
+                self.scope,
+                self.source.name,
+                self.source.size,
+                self.source
+                    .last_modified
+                    .map(|value| value.to_string())
+                    .unwrap_or_else(|| "blob".to_string())
+            )
+        }
+    }
+
     impl BrowserStorageRequest {
         fn get(url: String, with_credentials: bool) -> Self {
             Self {
@@ -580,6 +1043,21 @@ mod wasm {
                 blob_body: None,
                 with_credentials,
                 abort_signal: None,
+            }
+        }
+
+        fn head(url: String, with_credentials: bool, abort_signal: Option<AbortSignal>) -> Self {
+            Self {
+                method: "HEAD".to_string(),
+                url,
+                headers: vec![(
+                    "Tus-Resumable".to_string(),
+                    TUS_PROTOCOL_VERSION.to_string(),
+                )],
+                json_body: None,
+                blob_body: None,
+                with_credentials,
+                abort_signal,
             }
         }
 
@@ -606,6 +1084,34 @@ mod wasm {
             })
         }
 
+        fn tus_create(
+            url: String,
+            upload_length: u64,
+            upload_metadata: Option<String>,
+            with_credentials: bool,
+            abort_signal: Option<AbortSignal>,
+        ) -> Self {
+            let mut headers = vec![
+                (
+                    "Tus-Resumable".to_string(),
+                    TUS_PROTOCOL_VERSION.to_string(),
+                ),
+                ("Upload-Length".to_string(), upload_length.to_string()),
+            ];
+            if let Some(upload_metadata) = upload_metadata {
+                headers.push(("Upload-Metadata".to_string(), upload_metadata));
+            }
+            Self {
+                method: "POST".to_string(),
+                url,
+                headers,
+                json_body: None,
+                blob_body: None,
+                with_credentials,
+                abort_signal,
+            }
+        }
+
         fn patch_blob(
             url: String,
             offset: u64,
@@ -617,6 +1123,34 @@ mod wasm {
                 method: "PATCH".to_string(),
                 url,
                 headers: vec![("Upload-Offset".to_string(), offset.to_string())],
+                json_body: None,
+                blob_body: Some(blob),
+                with_credentials,
+                abort_signal,
+            }
+        }
+
+        fn tus_patch(
+            url: String,
+            offset: u64,
+            blob: Blob,
+            with_credentials: bool,
+            abort_signal: Option<AbortSignal>,
+        ) -> Self {
+            Self {
+                method: "PATCH".to_string(),
+                url,
+                headers: vec![
+                    (
+                        "Tus-Resumable".to_string(),
+                        TUS_PROTOCOL_VERSION.to_string(),
+                    ),
+                    ("Upload-Offset".to_string(), offset.to_string()),
+                    (
+                        "Content-Type".to_string(),
+                        "application/offset+octet-stream".to_string(),
+                    ),
+                ],
                 json_body: None,
                 blob_body: Some(blob),
                 with_credentials,
@@ -660,6 +1194,66 @@ mod wasm {
             )));
         }
         result
+    }
+
+    fn ensure_tus_status(
+        response: &BrowserStorageResponse,
+        operation: &'static str,
+        expected: &[u16],
+    ) -> StorageResult<()> {
+        if expected.contains(&response.status) {
+            Ok(())
+        } else {
+            Err(StorageError::client(format!(
+                "{operation} failed with HTTP {}{}",
+                response.status,
+                if response.body.is_empty() {
+                    String::new()
+                } else {
+                    format!(": {}", response.body)
+                }
+            )))
+        }
+    }
+
+    fn parse_upload_offset_header(value: &str) -> StorageResult<u64> {
+        value
+            .parse::<u64>()
+            .map_err(|_| StorageError::client(format!("invalid tus Upload-Offset: {value}")))
+    }
+
+    fn parse_upload_length_header(value: &str) -> StorageResult<u64> {
+        value
+            .parse::<u64>()
+            .map_err(|_| StorageError::client(format!("invalid tus Upload-Length: {value}")))
+    }
+
+    fn encode_tus_metadata(metadata: &BTreeMap<String, String>) -> StorageResult<Option<String>> {
+        if metadata.is_empty() {
+            return Ok(None);
+        }
+        let mut encoded = Vec::with_capacity(metadata.len());
+        for (key, value) in metadata {
+            if key.is_empty()
+                || key
+                    .bytes()
+                    .any(|byte| byte == b',' || byte.is_ascii_whitespace())
+            {
+                return Err(StorageError::client(format!(
+                    "invalid tus metadata key: {key:?}"
+                )));
+            }
+            if value.is_empty() {
+                encoded.push(key.clone());
+            } else {
+                encoded.push(format!(
+                    "{} {}",
+                    key,
+                    BASE64_STANDARD.encode(value.as_bytes())
+                ));
+            }
+        }
+        Ok(Some(encoded.join(",")))
     }
 
     async fn send_request(request: BrowserStorageRequest) -> StorageResult<BrowserStorageResponse> {
@@ -706,6 +1300,7 @@ mod wasm {
             .dyn_into()
             .map_err(|_| StorageError::client("fetch returned non-Response"))?;
         let status = response.status();
+        let headers = collect_response_headers(&response)?;
         let text = response
             .text()
             .map_err(|err| StorageError::client(format!("read response: {err:?}")))?;
@@ -715,7 +1310,37 @@ mod wasm {
         let body = body_js
             .as_string()
             .ok_or_else(|| StorageError::client("response body was not a string"))?;
-        Ok(BrowserStorageResponse { status, body })
+        Ok(BrowserStorageResponse {
+            status,
+            headers,
+            body,
+        })
+    }
+
+    fn collect_response_headers(response: &Response) -> StorageResult<Vec<(String, String)>> {
+        let headers = response.headers();
+        let mut values = Vec::new();
+        for name in [
+            "location",
+            "upload-offset",
+            "upload-length",
+            "upload-defer-length",
+            "upload-expires",
+            "upload-metadata",
+            "tus-resumable",
+            "tus-version",
+            "tus-extension",
+            "tus-max-size",
+            "cache-control",
+        ] {
+            if let Some(value) = headers
+                .get(name)
+                .map_err(|err| StorageError::client(format!("read response header: {err:?}")))?
+            {
+                values.push((name.to_string(), value));
+            }
+        }
+        Ok(values)
     }
 
     fn read_resume_session(key: &str) -> Option<UploadSession> {
@@ -730,6 +1355,22 @@ mod wasm {
     }
 
     fn remove_resume_session(key: &str) {
+        if let Some(storage) = local_storage() {
+            let _ = storage.remove_item(key);
+        }
+    }
+
+    fn read_tus_resume_url(key: &str) -> Option<String> {
+        local_storage()?.get_item(key).ok().flatten()
+    }
+
+    fn write_tus_resume_url(key: &str, upload_url: &str) {
+        if let Some(storage) = local_storage() {
+            let _ = storage.set_item(key, upload_url);
+        }
+    }
+
+    fn remove_tus_resume_url(key: &str) {
         if let Some(storage) = local_storage() {
             let _ = storage.remove_item(key);
         }
@@ -782,6 +1423,29 @@ mod wasm {
         endpoint.trim_end_matches('/').to_string() + "/uploads"
     }
 
+    fn tus_uploads_url(endpoint: &str, scope: &str) -> String {
+        format!(
+            "{}/{}/uploads",
+            endpoint.trim_end_matches('/'),
+            percent_encode_path_segment(scope)
+        )
+    }
+
+    fn resolve_tus_location(create_url: &str, location: &str) -> String {
+        if location.starts_with('/')
+            || location.starts_with("http://")
+            || location.starts_with("https://")
+        {
+            location.to_string()
+        } else {
+            format!(
+                "{}/{}",
+                create_url.trim_end_matches('/'),
+                location.trim_start_matches('/')
+            )
+        }
+    }
+
     fn scope_url(endpoint: &str, scope: &str) -> String {
         format!(
             "{}/scopes/{}",
@@ -825,6 +1489,6 @@ mod wasm {
 
 #[cfg(target_arch = "wasm32")]
 pub use wasm::{
-    BrowserStorageRequest, BrowserStorageResponse, BrowserStorageTransport, UploadBuilder,
-    __reset_browser_transport_for_test, __set_browser_transport_for_test,
+    BrowserStorageRequest, BrowserStorageResponse, BrowserStorageTransport, TusUploadBuilder,
+    UploadBuilder, __reset_browser_transport_for_test, __set_browser_transport_for_test,
 };

--- a/crates/pocopine-storage/src/lib.rs
+++ b/crates/pocopine-storage/src/lib.rs
@@ -19,8 +19,9 @@ mod memory;
 mod server;
 
 pub use client::{
-    storage_plugin, tus_plugin, StorageClient, StorageClientPlugin, StorageScopeClient, TusClient,
-    TusClientPlugin, TusScopeClient, TusUploadBuilder, TusUploadResult, UploadBuilder,
+    storage_plugin, upload_plugin, ResumableUpload, ResumableUploadBuilder, StorageClient,
+    StorageClientPlugin, StorageScopeClient, UploadBuilder, UploadClient, UploadClientPlugin,
+    UploadScopeClient,
 };
 #[cfg(target_arch = "wasm32")]
 #[doc(hidden)]

--- a/crates/pocopine-storage/src/lib.rs
+++ b/crates/pocopine-storage/src/lib.rs
@@ -19,7 +19,8 @@ mod memory;
 mod server;
 
 pub use client::{
-    storage_plugin, StorageClient, StorageClientPlugin, StorageScopeClient, UploadBuilder,
+    storage_plugin, tus_plugin, StorageClient, StorageClientPlugin, StorageScopeClient, TusClient,
+    TusClientPlugin, TusScopeClient, TusUploadBuilder, TusUploadResult, UploadBuilder,
 };
 #[cfg(target_arch = "wasm32")]
 #[doc(hidden)]
@@ -36,7 +37,8 @@ pub use protocol::{
     UploadPhase, UploadPolicy, UploadPolicyDescriptor, UploadProgress, UploadSession,
     UploadSessionId, UploadSessionStatus, UploadStrategy, UploadTarget, UploadedPartStatus,
     UploadedPartView, MAX_STORAGE_TOKEN_LEN, STORAGE_ANON_COOKIE, STORAGE_ENDPOINT_PREFIX,
-    STORAGE_PROTOCOL_V1, STORAGE_SCOPES_PREFIX, STORAGE_UPLOADS_PATH, STORAGE_UPLOADS_PREFIX,
+    STORAGE_PROTOCOL_V1, STORAGE_SCOPES_PREFIX, STORAGE_TUS_ENDPOINT_PREFIX, STORAGE_UPLOADS_PATH,
+    STORAGE_UPLOADS_PREFIX,
 };
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/pocopine-storage/src/local_fs.rs
+++ b/crates/pocopine-storage/src/local_fs.rs
@@ -6,8 +6,8 @@ use bytes::Bytes;
 use uuid::Uuid;
 
 use crate::backend_common::{
-    checked_new_offset, ensure_open, ensure_owner, ensure_size_limit, expires_at, object_ref,
-    refresh_expired, selected_strategy,
+    checked_new_offset, ensure_open, ensure_owner, ensure_size_limit,
+    ensure_upload_length_can_be_set, expires_at, object_ref, refresh_expired, selected_strategy,
 };
 use crate::checksum::validate_complete_checksum;
 use crate::server::{StorageActor, StorageBackend, StorageBoxFuture, StorageContext};
@@ -169,6 +169,7 @@ impl StorageBackend for LocalFsStorageBackend {
                 file_name: request.file_name.clone(),
                 size: request.size,
                 content_type: request.content_type.clone(),
+                metadata: request.metadata.clone(),
                 strategy,
                 status: UploadSessionStatus::Open,
                 next_offset: Some(0),
@@ -212,6 +213,30 @@ impl StorageBackend for LocalFsStorageBackend {
         Box::pin(async move {
             let stored = self.read_session(&session)?;
             ensure_owner(&ctx.actor, &stored.owner)?;
+            Ok(stored.public)
+        })
+    }
+
+    fn set_upload_length<'a>(
+        &'a self,
+        ctx: &'a StorageContext,
+        session: UploadSessionId,
+        size: u64,
+    ) -> StorageBoxFuture<'a, UploadSession> {
+        Box::pin(async move {
+            let mut stored = self.read_session(&session)?;
+            ensure_owner(&ctx.actor, &stored.owner)?;
+            self.persist_expired_if_needed(&session, &stored)?;
+            let committed_offset = stored.public.next_offset.unwrap_or(0);
+            self.reconcile_temp_len(&session, committed_offset)?;
+            ensure_upload_length_can_be_set(
+                stored.max_bytes,
+                &stored.public,
+                committed_offset,
+                size,
+            )?;
+            stored.public.size = Some(size);
+            self.write_session(&session, &stored)?;
             Ok(stored.public)
         })
     }

--- a/crates/pocopine-storage/src/memory.rs
+++ b/crates/pocopine-storage/src/memory.rs
@@ -5,8 +5,8 @@ use bytes::Bytes;
 use uuid::Uuid;
 
 use crate::backend_common::{
-    checked_new_offset, ensure_open, ensure_owner, ensure_size_limit, expires_at, object_ref,
-    refresh_expired, selected_strategy,
+    checked_new_offset, ensure_open, ensure_owner, ensure_size_limit,
+    ensure_upload_length_can_be_set, expires_at, object_ref, refresh_expired, selected_strategy,
 };
 use crate::checksum::validate_complete_checksum;
 use crate::server::{StorageActor, StorageBackend, StorageBoxFuture, StorageContext};
@@ -104,6 +104,7 @@ impl StorageBackend for MemoryStorageBackend {
                 file_name: request.file_name.clone(),
                 size: request.size,
                 content_type: request.content_type.clone(),
+                metadata: request.metadata.clone(),
                 strategy,
                 status: UploadSessionStatus::Open,
                 next_offset: Some(0),
@@ -153,6 +154,33 @@ impl StorageBackend for MemoryStorageBackend {
                 public.next_offset = Some(stored.bytes.len() as u64);
             }
             Ok(public)
+        })
+    }
+
+    fn set_upload_length<'a>(
+        &'a self,
+        ctx: &'a StorageContext,
+        session: UploadSessionId,
+        size: u64,
+    ) -> StorageBoxFuture<'a, UploadSession> {
+        Box::pin(async move {
+            let mut inner = self.lock()?;
+            let stored = inner
+                .sessions
+                .get_mut(session.as_str())
+                .ok_or_else(|| StorageError::unknown_upload_session(session.to_string()))?;
+            ensure_owner(&ctx.actor, &stored.owner)?;
+            refresh_expired_public(stored);
+            let committed_offset = stored.bytes.len() as u64;
+            ensure_upload_length_can_be_set(
+                stored.max_bytes,
+                &stored.public,
+                committed_offset,
+                size,
+            )?;
+            stored.public.size = Some(size);
+            stored.public.next_offset = Some(committed_offset);
+            Ok(stored.public.clone())
         })
     }
 

--- a/crates/pocopine-storage/src/protocol.rs
+++ b/crates/pocopine-storage/src/protocol.rs
@@ -26,6 +26,8 @@ pub const STORAGE_SCOPES_PREFIX: &str = storage_path!("/scopes");
 pub const STORAGE_UPLOADS_PREFIX: &str = storage_path!("/uploads");
 /// Upload creation route.
 pub const STORAGE_UPLOADS_PATH: &str = storage_path!("/uploads");
+/// Default tus 1.0 endpoint prefix mounted by the tus server plugin.
+pub const STORAGE_TUS_ENDPOINT_PREFIX: &str = "/__pocopine/storage/tus/v1";
 /// Anonymous upload binding cookie read by the storage server.
 pub const STORAGE_ANON_COOKIE: &str = "pocopine_storage_anon";
 
@@ -733,6 +735,8 @@ pub struct UploadSession {
     pub file_name: String,
     pub size: Option<u64>,
     pub content_type: Option<String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub metadata: BTreeMap<String, String>,
     pub strategy: UploadStrategy,
     pub status: UploadSessionStatus,
     pub next_offset: Option<u64>,

--- a/crates/pocopine-storage/src/server.rs
+++ b/crates/pocopine-storage/src/server.rs
@@ -210,6 +210,13 @@ pub trait StorageBackend: Send + Sync + 'static {
         session: UploadSessionId,
     ) -> StorageBoxFuture<'a, UploadSession>;
 
+    fn set_upload_length<'a>(
+        &'a self,
+        ctx: &'a StorageContext,
+        session: UploadSessionId,
+        size: u64,
+    ) -> StorageBoxFuture<'a, UploadSession>;
+
     fn append_upload_bytes<'a>(
         &'a self,
         ctx: &'a StorageContext,
@@ -437,6 +444,22 @@ impl StorageServer {
             .await
             .map_err(storage_auth_error)?;
         Ok(upload)
+    }
+
+    pub async fn set_upload_length(
+        &self,
+        ctx: StorageContext,
+        session: UploadSessionId,
+        size: u64,
+    ) -> StorageResult<UploadSession> {
+        require_bound_actor(&ctx)?;
+        let (backend, upload) = self.backend_for_session(&ctx, session.clone()).await?;
+        let scope = self.scope(&upload.scope)?;
+        scope
+            .authorize_write(ctx.clone())
+            .await
+            .map_err(storage_auth_error)?;
+        backend.set_upload_length(&ctx, session, size).await
     }
 
     pub async fn append_upload_bytes(
@@ -746,6 +769,7 @@ impl ServerPlugin for StorageTusServerPlugin {
                 TUS_UPLOAD_ROUTE,
                 head(tus_head_handler)
                     .patch(tus_patch_handler)
+                    .post(tus_method_override_handler)
                     .delete(tus_delete_handler)
                     .with_state(storage),
             )
@@ -981,16 +1005,7 @@ async fn tus_create_handler(
             )?;
             set_response_header(&mut response, "upload-offset", offset.to_string())?;
             set_tus_upload_length_headers(&mut response, size)?;
-            set_response_header(
-                &mut response,
-                "upload-expires",
-                upload
-                    .expires_at
-                    .format(&time::format_description::well_known::Rfc2822)
-                    .map_err(|err| {
-                        StorageError::backend(format!("format tus expiration: {err}"))
-                    })?,
-            )?;
+            set_tus_upload_expires_header(&mut response, &upload)?;
             apply_set_cookie(&mut response, request.set_cookie);
             Ok(response)
         }
@@ -1000,7 +1015,7 @@ async fn tus_create_handler(
 
 async fn tus_head_handler(
     State(storage): State<StorageServer>,
-    Path((_scope, session)): Path<(String, String)>,
+    Path((scope, session)): Path<(String, String)>,
     request: Request<Body>,
 ) -> Response {
     tus_route_response(
@@ -1009,6 +1024,7 @@ async fn tus_head_handler(
             require_tus_version(request.ctx.request.as_ref().unwrap().headers())?;
             let session = UploadSessionId::new(session)?;
             let upload = storage.inspect_upload(request.ctx, session).await?;
+            require_tus_scope(&scope, &upload)?;
             let mut response = tus_empty_response(StatusCode::NO_CONTENT);
             set_response_header(
                 &mut response,
@@ -1016,19 +1032,9 @@ async fn tus_head_handler(
                 upload.next_offset.unwrap_or(0).to_string(),
             )?;
             set_tus_upload_length_headers(&mut response, upload.size)?;
-            set_response_header(
-                &mut response,
-                "upload-expires",
-                upload
-                    .expires_at
-                    .format(&time::format_description::well_known::Rfc2822)
-                    .map_err(|err| {
-                        StorageError::backend(format!("format tus expiration: {err}"))
-                    })?,
-            )?;
-            response
-                .headers_mut()
-                .insert(CACHE_CONTROL, HeaderValue::from_static("no-store"));
+            set_tus_upload_metadata_header(&mut response, &upload.metadata)?;
+            set_tus_upload_expires_header(&mut response, &upload)?;
+            let mut response = no_store_response(response);
             apply_set_cookie(&mut response, request.set_cookie);
             Ok(response)
         }
@@ -1038,68 +1044,118 @@ async fn tus_head_handler(
 
 async fn tus_patch_handler(
     State(storage): State<StorageServer>,
-    Path((_scope, session)): Path<(String, String)>,
+    Path((scope, session)): Path<(String, String)>,
     request: Request<Body>,
 ) -> Response {
-    tus_route_response(
-        async {
-            let request = bytes_request(request, &storage).await?;
-            require_tus_version(&request.headers)?;
-            require_tus_octet_stream(&request.headers)?;
-            let offset = upload_offset(&request.headers)?;
-            let session = UploadSessionId::new(session)?;
-            let upload = storage
-                .inspect_upload(request.ctx.clone(), session.clone())
-                .await?;
-            let expected_offset = upload.next_offset.unwrap_or(0);
-            if expected_offset != offset {
-                return Err(StorageError::offset_mismatch(expected_offset, offset).into());
-            }
-            storage
-                .scope(&upload.scope)?
-                .authorize_write(request.ctx.clone())
-                .await
-                .map_err(storage_auth_error)?;
-            let max_body_bytes = max_patch_body_bytes(&upload, offset);
-            reject_oversized_content_length(&request.headers, max_body_bytes)?;
-            let bytes = to_bytes(request.body, max_body_bytes as usize)
-                .await
-                .map_err(|_err| StorageError::payload_too_large(max_body_bytes))?;
-            let updated = storage
-                .append_upload_bytes(request.ctx.clone(), session, offset, bytes)
-                .await?;
-            maybe_tus_complete(&storage, request.ctx, &updated).await?;
-
-            let mut response = tus_empty_response(StatusCode::NO_CONTENT);
-            set_response_header(
-                &mut response,
-                "upload-offset",
-                updated.next_offset.unwrap_or(offset).to_string(),
-            )?;
-            apply_set_cookie(&mut response, request.set_cookie);
-            Ok(response)
-        }
-        .await,
-    )
+    tus_route_response(tus_patch_request(storage, scope, session, request).await)
 }
 
 async fn tus_delete_handler(
     State(storage): State<StorageServer>,
-    Path((_scope, session)): Path<(String, String)>,
+    Path((scope, session)): Path<(String, String)>,
     request: Request<Body>,
 ) -> Response {
-    tus_route_response(
-        async {
-            let request = mutation_context_from_request(request, &storage)?;
-            require_tus_version(request.ctx.request.as_ref().unwrap().headers())?;
-            let session = UploadSessionId::new(session)?;
-            storage.abort_upload(request.ctx, session).await?;
-            let mut response = tus_empty_response(StatusCode::NO_CONTENT);
-            apply_set_cookie(&mut response, request.set_cookie);
-            Ok(response)
+    tus_route_response(tus_delete_request(storage, scope, session, request).await)
+}
+
+async fn tus_method_override_handler(
+    State(storage): State<StorageServer>,
+    Path((scope, session)): Path<(String, String)>,
+    request: Request<Body>,
+) -> Response {
+    let override_method = request
+        .headers()
+        .get("x-http-method-override")
+        .and_then(|value| value.to_str().ok())
+        .map(|value| value.to_ascii_uppercase());
+    match override_method.as_deref() {
+        Some("PATCH") => {
+            tus_route_response(tus_patch_request(storage, scope, session, request).await)
         }
-        .await,
-    )
+        Some("DELETE") => {
+            tus_route_response(tus_delete_request(storage, scope, session, request).await)
+        }
+        Some(value) => tus_route_response(Err(StorageError::invalid_value(
+            "X-HTTP-Method-Override",
+            value,
+        )
+        .into())),
+        None => tus_route_response(Err(StorageError::invalid_value(
+            "X-HTTP-Method-Override",
+            "<missing>",
+        )
+        .into())),
+    }
+}
+
+async fn tus_patch_request(
+    storage: StorageServer,
+    scope: String,
+    session: String,
+    request: Request<Body>,
+) -> Result<Response, TusError> {
+    let request = bytes_request(request, &storage).await?;
+    require_tus_version(&request.headers)?;
+    require_tus_octet_stream(&request.headers)?;
+    let offset = upload_offset(&request.headers)?;
+    let upload_length = tus_patch_upload_length(&request.headers)?;
+    let session = UploadSessionId::new(session)?;
+    let mut upload = storage
+        .inspect_upload(request.ctx.clone(), session.clone())
+        .await?;
+    require_tus_scope(&scope, &upload)?;
+    if let Some(size) = upload_length {
+        upload = storage
+            .set_upload_length(request.ctx.clone(), session.clone(), size)
+            .await?;
+    }
+    let expected_offset = upload.next_offset.unwrap_or(0);
+    if expected_offset != offset {
+        return Err(StorageError::offset_mismatch(expected_offset, offset).into());
+    }
+    storage
+        .scope(&upload.scope)?
+        .authorize_write(request.ctx.clone())
+        .await
+        .map_err(storage_auth_error)?;
+    let max_body_bytes = max_patch_body_bytes(&upload, offset);
+    reject_oversized_content_length(&request.headers, max_body_bytes)?;
+    let bytes = to_bytes(request.body, max_body_bytes as usize)
+        .await
+        .map_err(|_err| StorageError::payload_too_large(max_body_bytes))?;
+    let updated = storage
+        .append_upload_bytes(request.ctx.clone(), session, offset, bytes)
+        .await?;
+    maybe_tus_complete(&storage, request.ctx, &updated).await?;
+
+    let mut response = tus_empty_response(StatusCode::NO_CONTENT);
+    set_response_header(
+        &mut response,
+        "upload-offset",
+        updated.next_offset.unwrap_or(offset).to_string(),
+    )?;
+    set_tus_upload_expires_header(&mut response, &updated)?;
+    apply_set_cookie(&mut response, request.set_cookie);
+    Ok(response)
+}
+
+async fn tus_delete_request(
+    storage: StorageServer,
+    scope: String,
+    session: String,
+    request: Request<Body>,
+) -> Result<Response, TusError> {
+    let request = mutation_context_from_request(request, &storage)?;
+    require_tus_version(request.ctx.request.as_ref().unwrap().headers())?;
+    let session = UploadSessionId::new(session)?;
+    let upload = storage
+        .inspect_upload(request.ctx.clone(), session.clone())
+        .await?;
+    require_tus_scope(&scope, &upload)?;
+    storage.abort_upload(request.ctx, session).await?;
+    let mut response = tus_empty_response(StatusCode::NO_CONTENT);
+    apply_set_cookie(&mut response, request.set_cookie);
+    Ok(response)
 }
 
 struct StorageRequest {
@@ -1307,6 +1363,14 @@ async fn maybe_tus_complete(
     Ok(())
 }
 
+fn require_tus_scope(scope: &str, upload: &UploadSession) -> StorageResult<()> {
+    if upload.scope == scope {
+        Ok(())
+    } else {
+        Err(StorageError::unknown_upload_session(upload.id.to_string()))
+    }
+}
+
 fn require_tus_version(headers: &HeaderMap) -> Result<(), TusError> {
     match headers
         .get("tus-resumable")
@@ -1348,6 +1412,27 @@ fn tus_upload_length(headers: &HeaderMap) -> StorageResult<Option<u64>> {
     }
 }
 
+fn tus_patch_upload_length(headers: &HeaderMap) -> StorageResult<Option<u64>> {
+    if let Some(value) = headers
+        .get("upload-defer-length")
+        .and_then(|value| value.to_str().ok())
+    {
+        return Err(StorageError::invalid_value(
+            "Upload-Defer-Length",
+            value.to_string(),
+        ));
+    }
+    headers
+        .get("upload-length")
+        .and_then(|value| value.to_str().ok())
+        .map(|value| {
+            value
+                .parse::<u64>()
+                .map_err(|_| StorageError::invalid_value("Upload-Length", value.to_string()))
+        })
+        .transpose()
+}
+
 fn upload_offset(headers: &HeaderMap) -> StorageResult<u64> {
     headers
         .get("upload-offset")
@@ -1359,20 +1444,31 @@ fn upload_offset(headers: &HeaderMap) -> StorageResult<u64> {
 
 fn tus_metadata(headers: &HeaderMap) -> StorageResult<TusMetadata> {
     let mut values = BTreeMap::new();
-    if let Some(header) = headers
-        .get("upload-metadata")
-        .and_then(|value| value.to_str().ok())
-    {
+    if let Some(header) = headers.get("upload-metadata") {
+        let header = header
+            .to_str()
+            .map_err(|_| StorageError::invalid_value("Upload-Metadata", "<non-ascii>"))?;
         for pair in header.split(',') {
             let pair = pair.trim();
             if pair.is_empty() {
                 continue;
             }
-            let (key, encoded) = pair
-                .split_once(' ')
-                .ok_or_else(|| StorageError::invalid_value("Upload-Metadata", pair.to_string()))?;
-            if key.is_empty() {
-                return Err(StorageError::invalid_value("Upload-Metadata", pair));
+            let (key, encoded) = pair.split_once(' ').unwrap_or((pair, ""));
+            if key.is_empty()
+                || key
+                    .bytes()
+                    .any(|byte| byte == b',' || byte.is_ascii_whitespace())
+            {
+                return Err(StorageError::invalid_value(
+                    "Upload-Metadata",
+                    pair.to_string(),
+                ));
+            }
+            if values.contains_key(key) {
+                return Err(StorageError::invalid_value(
+                    "Upload-Metadata",
+                    format!("duplicate key {key}"),
+                ));
             }
             let bytes = BASE64_STANDARD
                 .decode(encoded)
@@ -1387,6 +1483,49 @@ fn tus_metadata(headers: &HeaderMap) -> StorageResult<TusMetadata> {
         content_type: values.get("filetype").cloned(),
         values,
     })
+}
+
+fn set_tus_upload_metadata_header(
+    response: &mut Response,
+    metadata: &BTreeMap<String, String>,
+) -> StorageResult<()> {
+    if metadata.is_empty() {
+        return Ok(());
+    }
+    let mut values = Vec::with_capacity(metadata.len());
+    for (key, value) in metadata {
+        if key.is_empty()
+            || key
+                .bytes()
+                .any(|byte| byte == b',' || byte.is_ascii_whitespace())
+        {
+            return Err(StorageError::invalid_value("Upload-Metadata", key));
+        }
+        if value.is_empty() {
+            values.push(key.clone());
+        } else {
+            values.push(format!(
+                "{} {}",
+                key,
+                BASE64_STANDARD.encode(value.as_bytes())
+            ));
+        }
+    }
+    set_response_header(response, "upload-metadata", values.join(","))
+}
+
+fn set_tus_upload_expires_header(
+    response: &mut Response,
+    upload: &UploadSession,
+) -> StorageResult<()> {
+    set_response_header(
+        response,
+        "upload-expires",
+        upload
+            .expires_at
+            .format(&time::format_description::well_known::Rfc2822)
+            .map_err(|err| StorageError::backend(format!("format tus expiration: {err}")))?,
+    )
 }
 
 fn content_length(headers: &HeaderMap) -> Option<u64> {

--- a/crates/pocopine-storage/tests/client_browser.rs
+++ b/crates/pocopine-storage/tests/client_browser.rs
@@ -13,9 +13,9 @@ use std::rc::Rc;
 use js_sys::{Array, Promise};
 use pocopine::prelude::*;
 use pocopine_storage::{
-    storage_plugin, tus_plugin, BrowserStorageRequest, BrowserStorageResponse,
+    storage_plugin, upload_plugin, BrowserStorageRequest, BrowserStorageResponse,
     BrowserStorageTransport, ObjectRef, ObjectVisibility, StorageClient, StorageError,
-    StorageResponse, StorageResult, TransferPlan, TusClient, UploadPhase, UploadProgress,
+    StorageResponse, StorageResult, TransferPlan, UploadClient, UploadPhase, UploadProgress,
     UploadSession, UploadSessionId, UploadSessionStatus, UploadStrategy,
 };
 use serde::{Deserialize, Serialize};
@@ -29,7 +29,7 @@ wasm_bindgen_test_configure!(run_in_browser);
 
 thread_local! {
     static PLUGIN_RESOLVED: RefCell<bool> = const { RefCell::new(false) };
-    static TUS_PLUGIN_RESOLVED: RefCell<bool> = const { RefCell::new(false) };
+    static UPLOAD_PLUGIN_RESOLVED: RefCell<bool> = const { RefCell::new(false) };
 }
 
 #[derive(Default, Serialize, Deserialize)]
@@ -49,16 +49,16 @@ impl StoragePluginProbe {
 
 #[derive(Default, Serialize, Deserialize)]
 #[component(
-    name = "tus-plugin-probe",
-    template_inline = r#"<div class="tus-plugin-probe"></div>"#
+    name = "upload-plugin-probe",
+    template_inline = r#"<div class="upload-plugin-probe"></div>"#
 )]
-struct TusPluginProbe;
+struct UploadPluginProbe;
 
 #[handlers]
-impl TusPluginProbe {
+impl UploadPluginProbe {
     pub fn on_mount(&mut self) {
-        let _client = self.plugin::<TusClient>();
-        TUS_PLUGIN_RESOLVED.with(|resolved| *resolved.borrow_mut() = true);
+        let _client = self.plugin::<UploadClient>();
+        UPLOAD_PLUGIN_RESOLVED.with(|resolved| *resolved.borrow_mut() = true);
     }
 }
 
@@ -82,21 +82,21 @@ async fn storage_plugin_installs_client_service() {
 }
 
 #[wasm_bindgen_test(async)]
-async fn tus_plugin_installs_client_service() {
-    TUS_PLUGIN_RESOLVED.with(|resolved| *resolved.borrow_mut() = false);
+async fn upload_plugin_installs_client_service() {
+    UPLOAD_PLUGIN_RESOLVED.with(|resolved| *resolved.borrow_mut() = false);
     let document = window().unwrap().document().unwrap();
     let host = document.create_element("div").unwrap();
     host.set_attribute("pp-app", "").unwrap();
-    host.set_inner_html("<tus-plugin-probe></tus-plugin-probe>");
+    host.set_inner_html("<upload-plugin-probe></upload-plugin-probe>");
     document.body().unwrap().append_child(&host).unwrap();
 
     App::new()
-        .plugin(tus_plugin())
-        .register::<TusPluginProbe>()
+        .plugin(upload_plugin())
+        .register::<UploadPluginProbe>()
         .run();
     settle().await;
 
-    assert!(TUS_PLUGIN_RESOLVED.with(|resolved| *resolved.borrow()));
+    assert!(UPLOAD_PLUGIN_RESOLVED.with(|resolved| *resolved.borrow()));
     host.remove();
 }
 
@@ -252,7 +252,7 @@ async fn abort_signal_stops_upload_request() {
 }
 
 #[wasm_bindgen_test(async)]
-async fn tus_upload_blob_sends_create_and_patch_requests() {
+async fn upload_client_sends_create_and_patch_requests() {
     pocopine_storage::__reset_browser_transport_for_test();
     let fake = FakeStorageTransport::default();
     let state = fake.state.clone();
@@ -260,7 +260,7 @@ async fn tus_upload_blob_sends_create_and_patch_requests() {
 
     let progress = Rc::new(RefCell::new(Vec::<UploadProgress>::new()));
     let progress_for_callback = progress.clone();
-    let result = TusClient::new()
+    let result = UploadClient::new()
         .scope("avatars")
         .upload_blob(blob("hello"), "photo.txt")
         .metadata("filetype", "text/plain")
@@ -305,14 +305,14 @@ async fn tus_upload_blob_sends_create_and_patch_requests() {
 }
 
 #[wasm_bindgen_test(async)]
-async fn tus_offset_conflict_heads_and_resumes() {
+async fn upload_client_heads_and_resumes_on_offset_conflict() {
     pocopine_storage::__reset_browser_transport_for_test();
     let fake = FakeStorageTransport::default();
     fake.state.borrow_mut().tus_conflict_once = true;
     let state = fake.state.clone();
     pocopine_storage::__set_browser_transport_for_test(fake);
 
-    let result = TusClient::new()
+    let result = UploadClient::new()
         .scope("avatars")
         .upload_blob(blob("hello"), "photo.txt")
         .chunk_size(2)
@@ -333,9 +333,9 @@ async fn tus_offset_conflict_heads_and_resumes() {
 }
 
 #[wasm_bindgen_test(async)]
-async fn tus_local_storage_resume_is_opt_in() {
+async fn upload_client_local_storage_resume_is_opt_in() {
     pocopine_storage::__reset_browser_transport_for_test();
-    let key = "pocopine.storage.tus.resume.v1:avatars:photo.txt:5:blob";
+    let key = "pocopine.storage.upload.resume.v1:avatars:photo.txt:5:blob";
     window()
         .unwrap()
         .local_storage()
@@ -351,7 +351,7 @@ async fn tus_local_storage_resume_is_opt_in() {
     let state = fake.state.clone();
     pocopine_storage::__set_browser_transport_for_test(fake);
 
-    TusClient::new()
+    UploadClient::new()
         .scope("avatars")
         .upload_blob(blob("hello"), "photo.txt")
         .chunk_size(2)

--- a/crates/pocopine-storage/tests/client_browser.rs
+++ b/crates/pocopine-storage/tests/client_browser.rs
@@ -13,10 +13,10 @@ use std::rc::Rc;
 use js_sys::{Array, Promise};
 use pocopine::prelude::*;
 use pocopine_storage::{
-    storage_plugin, BrowserStorageRequest, BrowserStorageResponse, BrowserStorageTransport,
-    ObjectRef, ObjectVisibility, StorageClient, StorageError, StorageResponse, StorageResult,
-    TransferPlan, UploadPhase, UploadProgress, UploadSession, UploadSessionId, UploadSessionStatus,
-    UploadStrategy,
+    storage_plugin, tus_plugin, BrowserStorageRequest, BrowserStorageResponse,
+    BrowserStorageTransport, ObjectRef, ObjectVisibility, StorageClient, StorageError,
+    StorageResponse, StorageResult, TransferPlan, TusClient, UploadPhase, UploadProgress,
+    UploadSession, UploadSessionId, UploadSessionStatus, UploadStrategy,
 };
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
@@ -29,6 +29,7 @@ wasm_bindgen_test_configure!(run_in_browser);
 
 thread_local! {
     static PLUGIN_RESOLVED: RefCell<bool> = const { RefCell::new(false) };
+    static TUS_PLUGIN_RESOLVED: RefCell<bool> = const { RefCell::new(false) };
 }
 
 #[derive(Default, Serialize, Deserialize)]
@@ -43,6 +44,21 @@ impl StoragePluginProbe {
     pub fn on_mount(&mut self) {
         let _client = self.plugin::<StorageClient>();
         PLUGIN_RESOLVED.with(|resolved| *resolved.borrow_mut() = true);
+    }
+}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "tus-plugin-probe",
+    template_inline = r#"<div class="tus-plugin-probe"></div>"#
+)]
+struct TusPluginProbe;
+
+#[handlers]
+impl TusPluginProbe {
+    pub fn on_mount(&mut self) {
+        let _client = self.plugin::<TusClient>();
+        TUS_PLUGIN_RESOLVED.with(|resolved| *resolved.borrow_mut() = true);
     }
 }
 
@@ -62,6 +78,25 @@ async fn storage_plugin_installs_client_service() {
     settle().await;
 
     assert!(PLUGIN_RESOLVED.with(|resolved| *resolved.borrow()));
+    host.remove();
+}
+
+#[wasm_bindgen_test(async)]
+async fn tus_plugin_installs_client_service() {
+    TUS_PLUGIN_RESOLVED.with(|resolved| *resolved.borrow_mut() = false);
+    let document = window().unwrap().document().unwrap();
+    let host = document.create_element("div").unwrap();
+    host.set_attribute("pp-app", "").unwrap();
+    host.set_inner_html("<tus-plugin-probe></tus-plugin-probe>");
+    document.body().unwrap().append_child(&host).unwrap();
+
+    App::new()
+        .plugin(tus_plugin())
+        .register::<TusPluginProbe>()
+        .run();
+    settle().await;
+
+    assert!(TUS_PLUGIN_RESOLVED.with(|resolved| *resolved.borrow()));
     host.remove();
 }
 
@@ -216,6 +251,135 @@ async fn abort_signal_stops_upload_request() {
     pocopine_storage::__reset_browser_transport_for_test();
 }
 
+#[wasm_bindgen_test(async)]
+async fn tus_upload_blob_sends_create_and_patch_requests() {
+    pocopine_storage::__reset_browser_transport_for_test();
+    let fake = FakeStorageTransport::default();
+    let state = fake.state.clone();
+    pocopine_storage::__set_browser_transport_for_test(fake);
+
+    let progress = Rc::new(RefCell::new(Vec::<UploadProgress>::new()));
+    let progress_for_callback = progress.clone();
+    let result = TusClient::new()
+        .scope("avatars")
+        .upload_blob(blob("hello"), "photo.txt")
+        .metadata("filetype", "text/plain")
+        .chunk_size(2)
+        .on_progress(move |event| progress_for_callback.borrow_mut().push(event))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        result.upload_url,
+        "/__pocopine/storage/tus/v1/avatars/uploads/tus-session-1"
+    );
+    assert_eq!(result.bytes_uploaded, 5);
+    let state = state.borrow();
+    assert_eq!(
+        state
+            .requests
+            .iter()
+            .filter(|request| request.url.starts_with("/__pocopine/storage/tus/v1"))
+            .map(|request| request.method.as_str())
+            .collect::<Vec<_>>(),
+        ["POST", "PATCH", "PATCH", "PATCH"]
+    );
+    assert_eq!(state.tus_patch_offsets, [0, 2, 4]);
+    let create = state
+        .requests
+        .iter()
+        .find(|request| request.method == "POST" && request.url.contains("/tus/v1/"))
+        .unwrap();
+    assert_eq!(header(create, "Tus-Resumable"), Some("1.0.0"));
+    assert_eq!(header(create, "Upload-Length"), Some("5"));
+    assert_eq!(
+        header(create, "Upload-Metadata"),
+        Some("filename cGhvdG8udHh0,filetype dGV4dC9wbGFpbg==")
+    );
+    assert_eq!(
+        progress.borrow().last().unwrap().phase,
+        UploadPhase::Complete
+    );
+    pocopine_storage::__reset_browser_transport_for_test();
+}
+
+#[wasm_bindgen_test(async)]
+async fn tus_offset_conflict_heads_and_resumes() {
+    pocopine_storage::__reset_browser_transport_for_test();
+    let fake = FakeStorageTransport::default();
+    fake.state.borrow_mut().tus_conflict_once = true;
+    let state = fake.state.clone();
+    pocopine_storage::__set_browser_transport_for_test(fake);
+
+    let result = TusClient::new()
+        .scope("avatars")
+        .upload_blob(blob("hello"), "photo.txt")
+        .chunk_size(2)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(result.bytes_uploaded, 5);
+    let state = state.borrow();
+    assert_eq!(state.tus_patch_offsets, [0, 2, 4]);
+    let head_count = state
+        .requests
+        .iter()
+        .filter(|request| request.method == "HEAD" && request.url.contains("/tus/v1/"))
+        .count();
+    assert_eq!(head_count, 1);
+    pocopine_storage::__reset_browser_transport_for_test();
+}
+
+#[wasm_bindgen_test(async)]
+async fn tus_local_storage_resume_is_opt_in() {
+    pocopine_storage::__reset_browser_transport_for_test();
+    let key = "pocopine.storage.tus.resume.v1:avatars:photo.txt:5:blob";
+    window()
+        .unwrap()
+        .local_storage()
+        .unwrap()
+        .unwrap()
+        .set_item(
+            key,
+            "/__pocopine/storage/tus/v1/avatars/uploads/tus-session-1",
+        )
+        .unwrap();
+    let fake = FakeStorageTransport::default();
+    fake.state.borrow_mut().tus_offset = 2;
+    let state = fake.state.clone();
+    pocopine_storage::__set_browser_transport_for_test(fake);
+
+    TusClient::new()
+        .scope("avatars")
+        .upload_blob(blob("hello"), "photo.txt")
+        .chunk_size(2)
+        .auto_resume(true)
+        .send()
+        .await
+        .unwrap();
+
+    let state = state.borrow();
+    let tus_methods = state
+        .requests
+        .iter()
+        .filter(|request| request.url.starts_with("/__pocopine/storage/tus/v1"))
+        .map(|request| request.method.as_str())
+        .collect::<Vec<_>>();
+    assert_eq!(tus_methods, ["HEAD", "PATCH", "PATCH"]);
+    assert_eq!(state.tus_patch_offsets, [2, 4]);
+    assert!(window()
+        .unwrap()
+        .local_storage()
+        .unwrap()
+        .unwrap()
+        .get_item(key)
+        .unwrap()
+        .is_none());
+    pocopine_storage::__reset_browser_transport_for_test();
+}
+
 #[derive(Clone, Default)]
 struct FakeStorageTransport {
     state: Rc<RefCell<FakeState>>,
@@ -228,11 +392,16 @@ struct FakeState {
     patch_offsets: Vec<u64>,
     mismatch_once: bool,
     client_error_once: bool,
+    tus_offset: u64,
+    tus_patch_offsets: Vec<u64>,
+    tus_conflict_once: bool,
 }
 
 #[derive(Clone, Debug)]
 struct SeenRequest {
     method: String,
+    url: String,
+    headers: Vec<(String, String)>,
 }
 
 impl BrowserStorageTransport for FakeStorageTransport {
@@ -253,6 +422,8 @@ impl BrowserStorageTransport for FakeStorageTransport {
             let mut state = state.borrow_mut();
             state.requests.push(SeenRequest {
                 method: request.method.clone(),
+                url: request.url.clone(),
+                headers: request.headers.clone(),
             });
             match (request.method.as_str(), request.url.as_str()) {
                 ("POST", "/__pocopine/storage/v1/uploads") => {
@@ -297,6 +468,63 @@ impl BrowserStorageTransport for FakeStorageTransport {
                 ("POST", "/__pocopine/storage/v1/uploads/session-1/complete") => {
                     Ok(json_response(Ok(object_ref(state.offset))))
                 }
+                ("POST", "/__pocopine/storage/tus/v1/avatars/uploads") => {
+                    state.tus_offset = 0;
+                    Ok(tus_response(
+                        201,
+                        [
+                            (
+                                "location",
+                                "/__pocopine/storage/tus/v1/avatars/uploads/tus-session-1",
+                            ),
+                            ("upload-offset", "0"),
+                            ("tus-resumable", "1.0.0"),
+                        ],
+                        "",
+                    ))
+                }
+                ("HEAD", "/__pocopine/storage/tus/v1/avatars/uploads/tus-session-1") => {
+                    Ok(tus_response(
+                        204,
+                        vec![
+                            ("upload-offset".to_string(), state.tus_offset.to_string()),
+                            ("upload-length".to_string(), "5".to_string()),
+                            ("tus-resumable".to_string(), "1.0.0".to_string()),
+                        ],
+                        "",
+                    ))
+                }
+                ("PATCH", "/__pocopine/storage/tus/v1/avatars/uploads/tus-session-1") => {
+                    let provided = request
+                        .headers
+                        .iter()
+                        .find(|(name, _)| name.eq_ignore_ascii_case("Upload-Offset"))
+                        .and_then(|(_, value)| value.parse::<u64>().ok())
+                        .unwrap();
+                    state.tus_patch_offsets.push(provided);
+                    if state.tus_conflict_once {
+                        state.tus_conflict_once = false;
+                        state.tus_offset = 2;
+                        return Ok(tus_response(409, [("tus-resumable", "1.0.0")], "conflict"));
+                    }
+                    if provided != state.tus_offset {
+                        return Ok(tus_response(409, [("tus-resumable", "1.0.0")], "conflict"));
+                    }
+                    let size = request
+                        .blob_body
+                        .as_ref()
+                        .map(|blob| blob.size() as u64)
+                        .unwrap_or(0);
+                    state.tus_offset += size;
+                    Ok(tus_response(
+                        204,
+                        vec![
+                            ("upload-offset".to_string(), state.tus_offset.to_string()),
+                            ("tus-resumable".to_string(), "1.0.0".to_string()),
+                        ],
+                        "",
+                    ))
+                }
                 other => Err(StorageError::client(format!(
                     "unexpected storage request: {other:?}"
                 ))),
@@ -312,6 +540,7 @@ fn session(offset: u64) -> UploadSession {
         file_name: "photo.txt".to_string(),
         size: Some(5),
         content_type: None,
+        metadata: Default::default(),
         strategy: UploadStrategy::Sequential,
         status: UploadSessionStatus::Open,
         next_offset: Some(offset),
@@ -357,8 +586,33 @@ fn json_response<T: Serialize>(result: StorageResult<T>) -> BrowserStorageRespon
     };
     BrowserStorageResponse {
         status,
+        headers: Vec::new(),
         body: serde_json::to_string(&StorageResponse::from_result(result)).unwrap(),
     }
+}
+
+fn tus_response<K, V, I>(status: u16, headers: I, body: &str) -> BrowserStorageResponse
+where
+    K: Into<String>,
+    V: Into<String>,
+    I: IntoIterator<Item = (K, V)>,
+{
+    BrowserStorageResponse {
+        status,
+        headers: headers
+            .into_iter()
+            .map(|(name, value)| (name.into(), value.into()))
+            .collect(),
+        body: body.to_string(),
+    }
+}
+
+fn header<'a>(request: &'a SeenRequest, name: &str) -> Option<&'a str> {
+    request
+        .headers
+        .iter()
+        .find(|(candidate, _)| candidate.eq_ignore_ascii_case(name))
+        .map(|(_, value)| value.as_str())
 }
 
 fn blob(text: &str) -> Blob {

--- a/crates/pocopine-storage/tests/storage_host.rs
+++ b/crates/pocopine-storage/tests/storage_host.rs
@@ -340,7 +340,12 @@ async fn tus_create_head_patch_and_delete_use_tus_wire_contract() -> StorageResu
     assert_eq!(response.status(), StatusCode::NO_CONTENT);
     assert_eq!(response.headers().get("upload-offset").unwrap(), "0");
     assert_eq!(response.headers().get("upload-length").unwrap(), "5");
+    assert_eq!(
+        response.headers().get("upload-metadata").unwrap(),
+        "filename cGhvdG8udHh0,filetype dGV4dC9wbGFpbg=="
+    );
     assert_eq!(response.headers().get("cache-control").unwrap(), "no-store");
+    assert_eq!(response.headers().get("vary").unwrap(), "Cookie");
 
     let response = router
         .clone()
@@ -360,6 +365,7 @@ async fn tus_create_head_patch_and_delete_use_tus_wire_contract() -> StorageResu
         .unwrap();
     assert_eq!(response.status(), StatusCode::NO_CONTENT);
     assert_eq!(response.headers().get("upload-offset").unwrap(), "5");
+    assert!(response.headers().contains_key("upload-expires"));
 
     let session = UploadSessionId::new(location.rsplit('/').next().unwrap())?;
     let inspected = storage.inspect_upload(anon_ctx(), session.clone()).await?;
@@ -603,8 +609,10 @@ async fn tus_error_paths_use_tus_status_codes() -> StorageResult<()> {
 
 #[tokio::test]
 async fn tus_accepts_deferred_upload_length() -> StorageResult<()> {
-    let router = finalize_tus(memory_storage()?);
+    let storage = memory_storage()?;
+    let router = finalize_tus(storage.clone());
     let response = router
+        .clone()
         .oneshot(
             Request::builder()
                 .method("POST")
@@ -625,6 +633,176 @@ async fn tus_accepts_deferred_upload_length() -> StorageResult<()> {
 
     assert_eq!(response.status(), StatusCode::CREATED);
     assert_eq!(response.headers().get("upload-defer-length").unwrap(), "1");
+    let location = response
+        .headers()
+        .get("location")
+        .and_then(|value| value.to_str().ok())
+        .unwrap()
+        .to_string();
+
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("PATCH")
+                .uri(&location)
+                .header("tus-resumable", "1.0.0")
+                .header("upload-offset", "0")
+                .header("upload-length", "5")
+                .header("content-type", "application/offset+octet-stream")
+                .header("cookie", anon_cookie())
+                .header("sec-fetch-site", "same-origin")
+                .body(Body::from("hello"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert_eq!(response.headers().get("upload-offset").unwrap(), "5");
+    assert!(response.headers().contains_key("upload-expires"));
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("HEAD")
+                .uri(&location)
+                .header("tus-resumable", "1.0.0")
+                .header("cookie", anon_cookie())
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert_eq!(response.headers().get("upload-length").unwrap(), "5");
+    assert!(response.headers().get("upload-defer-length").is_none());
+
+    let session = UploadSessionId::new(location.rsplit('/').next().unwrap())?;
+    let inspected = storage.inspect_upload(anon_ctx(), session).await?;
+    assert_eq!(inspected.status, UploadSessionStatus::Complete);
+    Ok(())
+}
+
+#[tokio::test]
+async fn tus_accepts_key_only_metadata_and_rejects_duplicate_keys() -> StorageResult<()> {
+    let router = finalize_tus(memory_storage()?);
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(tus_uploads_uri("avatars"))
+                .header("tus-resumable", "1.0.0")
+                .header("upload-length", "5")
+                .header(
+                    "upload-metadata",
+                    "filename cGhvdG8udHh0,filetype dGV4dC9wbGFpbg==,is_confidential",
+                )
+                .header("cookie", anon_cookie())
+                .header("sec-fetch-site", "same-origin")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let location = response
+        .headers()
+        .get("location")
+        .and_then(|value| value.to_str().ok())
+        .unwrap()
+        .to_string();
+
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("HEAD")
+                .uri(&location)
+                .header("tus-resumable", "1.0.0")
+                .header("cookie", anon_cookie())
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert_eq!(
+        response.headers().get("upload-metadata").unwrap(),
+        "filename cGhvdG8udHh0,filetype dGV4dC9wbGFpbg==,is_confidential"
+    );
+
+    let duplicate = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(tus_uploads_uri("avatars"))
+                .header("tus-resumable", "1.0.0")
+                .header("upload-length", "5")
+                .header("upload-metadata", "filename cGhvdG8=,filename b3RoZXI=")
+                .header("cookie", anon_cookie())
+                .header("sec-fetch-site", "same-origin")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(duplicate.status(), StatusCode::BAD_REQUEST);
+    Ok(())
+}
+
+#[tokio::test]
+async fn tus_post_method_override_can_patch_upload_bytes() -> StorageResult<()> {
+    let storage = memory_storage()?;
+    let router = finalize_tus(storage.clone());
+    let create = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(tus_uploads_uri("avatars"))
+                .header("tus-resumable", "1.0.0")
+                .header("upload-length", "5")
+                .header(
+                    "upload-metadata",
+                    "filename cGhvdG8udHh0,filetype dGV4dC9wbGFpbg==",
+                )
+                .header("cookie", anon_cookie())
+                .header("sec-fetch-site", "same-origin")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let location = create
+        .headers()
+        .get("location")
+        .and_then(|value| value.to_str().ok())
+        .unwrap()
+        .to_string();
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(&location)
+                .header("x-http-method-override", "PATCH")
+                .header("tus-resumable", "1.0.0")
+                .header("upload-offset", "0")
+                .header("content-type", "application/offset+octet-stream")
+                .header("cookie", anon_cookie())
+                .header("sec-fetch-site", "same-origin")
+                .body(Body::from("hello"))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    assert_eq!(response.headers().get("upload-offset").unwrap(), "5");
+
+    let session = UploadSessionId::new(location.rsplit('/').next().unwrap())?;
+    let inspected = storage.inspect_upload(anon_ctx(), session).await?;
+    assert_eq!(inspected.status, UploadSessionStatus::Complete);
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- tighten the storage tus server surface for deferred lengths, metadata echoing, method override, expiration headers, and scope checks
- persist upload metadata and add backend support for resolving deferred upload length
- add a browser-native Rust upload client API with upload_plugin(), UploadClient, UploadScopeClient, ResumableUploadBuilder, progress, retry, abort, explicit resume URL, and opt-in localStorage resume

## Tests
- cargo fmt --all -- --check
- git diff --check origin/main...HEAD
- cargo test -p pocopine-storage
- cargo clippy -p pocopine-storage --all-targets -- -D warnings
- cargo check -p pocopine-storage --target wasm32-unknown-unknown
- wasm-pack test --firefox --headless crates/pocopine-storage --test client_browser
- cargo test -p pocopine-storage --test tus_js_client_e2e -- --ignored --nocapture