### PR TITLE
pocopine-storage: drop identity Promise::from in wasm browser client

### DIFF
--- a/crates/pocopine-storage/src/client.rs
+++ b/crates/pocopine-storage/src/client.rs
@@ -1304,7 +1304,7 @@ mod wasm {
         let text = response
             .text()
             .map_err(|err| StorageError::client(format!("read response: {err:?}")))?;
-        let body_js = JsFuture::from(Promise::from(text))
+        let body_js = JsFuture::from(text)
             .await
             .map_err(|err| StorageError::client(format!("read response: {err:?}")))?;
         let body = body_js


### PR DESCRIPTION
## Summary
Single-line fix to restore the `clippy-wasm` CI gate.

\`response.text()\` already returns \`js_sys::Promise\`, so \`Promise::from(text)\` was a no-op conversion that tripped \`clippy::useless_conversion\` under \`-D warnings\`. Dropping the wrapper restores the green build.

Confirmed reproducible on \`origin/main\` before this PR — every workflow run since the offending code landed has been failing the \`clippy-wasm\` job. Splitting this out as its own focused PR rather than bundling it into a feature branch.

## Test plan
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy -p pocopine-storage --target wasm32-unknown-unknown --all-targets -- -D warnings\` — clean
- [x] \`cargo clippy --workspace --exclude pocopine-cli --target wasm32-unknown-unknown --all-targets -- -D warnings\` — full workspace clean
- [x] \`cargo test -p pocopine-storage\` — 36 tests pass