### PR TITLE
pine DX: expression convention, macro hygiene, boot diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4525,6 +4525,7 @@ dependencies = [
 name = "pocopine-core"
 version = "0.1.0"
 dependencies = [
+ "console_error_panic_hook",
  "js-sys",
  "once_cell",
  "phf 0.13.1",

--- a/crates/pocopine-core/Cargo.toml
+++ b/crates/pocopine-core/Cargo.toml
@@ -23,6 +23,13 @@ runtime-expr-fallback = []
 [dependencies]
 pocopine-expr = { workspace = true }
 wasm-bindgen = { workspace = true }
+# Hooks `std::panic` so wasm panics surface their message via
+# `console.error` instead of the browser-default
+# "RuntimeError: unreachable executed" with no message. Installed
+# once at `App::run()` so users get the directive `.expect()`
+# strings authored throughout the framework without having to
+# remember `console_error_panic_hook::set_once()` themselves.
+console_error_panic_hook = "0.1"
 wasm-bindgen-futures = { workspace = true }
 js-sys = { workspace = true }
 serde = { workspace = true }
@@ -56,19 +63,27 @@ features = [
     "DomRect",
     "DomRectReadOnly",
     "DomTokenList",
+    "DataTransfer",
     "DragEvent",
     "Element",
     "ErrorEvent",
     "Event",
     "EventTarget",
+    "Blob",
+    "File",
+    "FileList",
     "FocusEvent",
+    "FormData",
     "HashChangeEvent",
     "Headers",
     "History",
     "HtmlAnchorElement",
+    "HtmlButtonElement",
     "HtmlCollection",
     "HtmlElement",
+    "HtmlFormElement",
     "HtmlHeadElement",
+    "HtmlImageElement",
     "HtmlInputElement",
     "HtmlSelectElement",
     "HtmlTemplateElement",
@@ -108,6 +123,7 @@ features = [
     "TouchEvent",
     "TransitionEvent",
     "UiEvent",
+    "Url",
     "WheelEvent",
     "Window",
 ]

--- a/crates/pocopine-core/src/app.rs
+++ b/crates/pocopine-core/src/app.rs
@@ -576,6 +576,72 @@ mod route_config_tests {
         assert!(config.guards.is_empty());
     }
 
+    // ── Store-reference scanner (RFC: missing-store boot-error) ──
+
+    #[test]
+    fn collect_store_names_extracts_single_ref() {
+        let mut into = Vec::new();
+        super::collect_store_names("$store.preferences.theme", &mut into);
+        assert_eq!(into, vec!["preferences".to_string()]);
+    }
+
+    #[test]
+    fn collect_store_names_handles_multiple_and_dedupes() {
+        let mut into = Vec::new();
+        // Walks every path in the AST — both ternary branches and
+        // the condition. The repeated `$store.a` is deduped.
+        super::collect_store_names("$store.a == $store.b ? $store.a : $store.b", &mut into);
+        assert_eq!(into, vec!["a".to_string(), "b".to_string()]);
+    }
+
+    #[test]
+    fn collect_store_names_ignores_bare_store_token() {
+        // `$store` without a `.` is the container object, not a
+        // specific store. Don't claim it as a missing reference.
+        let mut into = Vec::new();
+        super::collect_store_names("$store", &mut into);
+        assert!(into.is_empty());
+    }
+
+    #[test]
+    fn collect_store_names_ignores_string_literal_lookalike() {
+        // The whole point of the AST-based scanner: text that looks
+        // like `$store.X` inside a string literal must NOT be picked
+        // up as a missing-store reference. A substring scanner would
+        // false-positive here.
+        let mut into = Vec::new();
+        super::collect_store_names("'$store.example was renamed'", &mut into);
+        assert!(into.is_empty());
+    }
+
+    #[test]
+    fn collect_store_names_finds_refs_in_call_arguments() {
+        // Refs nested inside call arguments / binops must still be
+        // discovered.
+        let mut into = Vec::new();
+        super::collect_store_names("debug($store.flags.verbose)", &mut into);
+        assert_eq!(into, vec!["flags".to_string()]);
+    }
+
+    #[test]
+    fn collect_store_names_silent_on_parse_failure() {
+        // Macro-time parse failures are surfaced by the template
+        // pipeline as `compile_error!`. This scanner runs at boot
+        // on `&'static str` plan sources that already survived the
+        // macro, but stays defensive: a parse failure here just
+        // means "no refs to add", never a panic.
+        let mut into = Vec::new();
+        super::collect_store_names("status === 'queued'", &mut into);
+        assert!(into.is_empty());
+    }
+
+    #[test]
+    fn check_store_registrations_passes_when_complete() {
+        // No vtables → no scanned refs → no missing.
+        let result = super::check_store_registrations(&[], &["preferences"]);
+        assert!(result.is_ok());
+    }
+
     #[test]
     fn route_config_stores_sync_guards() {
         let config = RouteConfig::<TestRoute>::new()
@@ -1161,9 +1227,17 @@ impl App {
     /// when collisions exist the boot error surface is rendered and
     /// no further mount work runs.
     pub fn run(self) {
+        // Install the panic-to-`console.error` hook before anything
+        // else. The framework authors directive `.expect(...)`
+        // messages throughout (`#[store]` "not registered — call
+        // App::store::<_>() first" being the canonical example),
+        // and without this hook a wasm panic surfaces as
+        // "RuntimeError: unreachable executed" with no message.
+        // `set_once()` is safe to call from every App::run().
+        console_error_panic_hook::set_once();
         let Self {
             components,
-            stores: _,
+            stores,
             routes,
             before_mount,
             after_mount,
@@ -1218,6 +1292,19 @@ impl App {
                 reason: "component_registry",
             });
             crate::registry::render_boot_error(&errors);
+            return;
+        }
+        // Cross-check $store.X references in compiled component
+        // templates against `App::store::<T>()` registrations.
+        // Without this, a missing `.store::<T>()` call deferred-
+        // panics at first $store access with a stack trace that
+        // looks like a framework bug. Fail loud at boot with the
+        // exact missing names instead.
+        if let Err(missing) = check_store_registrations(&components, &stores) {
+            crate::plugin::emit(crate::plugin::AppBootFailed {
+                reason: "missing_store_registration",
+            });
+            render_missing_store_boot_error(&missing);
             return;
         }
         // Inject the animate-preset atom stylesheet before any
@@ -1320,6 +1407,151 @@ impl App {
             host: host.clone(),
             active: true,
         }
+    }
+}
+
+/// Parse a compile-time expression source with `pocopine_expr` and
+/// collect every `$store.<name>` path reference into `into`.
+///
+/// AST-based (not substring-based) so the same literal text inside
+/// a string literal (e.g. `pp-text="'$store.example missing'"`)
+/// can't trip the boot check — the parser sees that occurrence as
+/// a `Literal::String`, not an `Expr::Path`. A parse failure means
+/// the macro-time pipeline already surfaced a compile error for
+/// that expression, so silently skipping it here is fine.
+fn collect_store_names(src: &str, into: &mut Vec<String>) {
+    let Ok(ast) = pocopine_expr::parse(src) else {
+        return;
+    };
+    visit_paths(&ast.value, &mut |segments| {
+        if segments.len() >= 2 && segments[0] == "$store" {
+            let name = segments[1].clone();
+            if !into.contains(&name) {
+                into.push(name);
+            }
+        }
+    });
+}
+
+/// Walk every `Expr::Path` (including the LHS of `Expr::Assign`)
+/// in the AST, including paths inside nested binops / ternaries /
+/// call arguments / statement sequences. Used by
+/// [`collect_store_names`] to find every `$store.X` reference
+/// regardless of where it sits in the expression tree.
+fn visit_paths(expr: &pocopine_expr::Expr, sink: &mut impl FnMut(&[String])) {
+    use pocopine_expr::Expr;
+    match expr {
+        Expr::Literal(_) => {}
+        Expr::Path(segs) => sink(segs),
+        Expr::Not(inner) => visit_paths(&inner.value, sink),
+        Expr::BinOp(_, lhs, rhs) => {
+            visit_paths(&lhs.value, sink);
+            visit_paths(&rhs.value, sink);
+        }
+        Expr::Ternary(cond, then_branch, else_branch) => {
+            visit_paths(&cond.value, sink);
+            visit_paths(&then_branch.value, sink);
+            visit_paths(&else_branch.value, sink);
+        }
+        Expr::Call(_, args) => {
+            for arg in args {
+                visit_paths(&arg.value, sink);
+            }
+        }
+        Expr::Assign(lhs_segs, rhs) => {
+            sink(lhs_segs);
+            visit_paths(&rhs.value, sink);
+        }
+        Expr::Seq(stmts) => {
+            for stmt in stmts {
+                visit_paths(&stmt.value, sink);
+            }
+        }
+    }
+}
+
+/// Scan a compiled template plan's expression sources for
+/// `$store.<name>` references, accumulating into `into`. Covers
+/// the plan slices that carry plain `expr_src` strings —
+/// bindings, listeners, `pp-if`, native models — which is where
+/// store references appear in practice.
+fn collect_plan_store_names(
+    plan: &'static crate::templates_plan::StaticTemplatePlan,
+    into: &mut Vec<String>,
+) {
+    for b in plan.bindings {
+        collect_store_names(b.expr_src, into);
+    }
+    for l in plan.listeners {
+        collect_store_names(l.expr_src, into);
+    }
+    for p in plan.if_plans {
+        collect_store_names(p.expr_src, into);
+    }
+    for m in plan.native_models {
+        collect_store_names(m.expr_src, into);
+    }
+}
+
+/// Cross-check `$store.X` references across registered components'
+/// plans against the stores actually registered with
+/// `App::store::<T>()`. Returns the sorted, deduplicated list of
+/// missing store names; an empty `Ok(())` means every reference
+/// has a matching registration.
+///
+/// Plan lookup goes through
+/// [`crate::templates_plan::template_plan_for`], which tries the
+/// active PHF registry first (only set by
+/// [`App::run_with_registry`]) and falls back to the
+/// `TEMPLATE_PLANS` thread-local that every component's macro-
+/// emitted `register()` populates. Without the fallback this
+/// check is silently no-op for the canonical
+/// `App::new()…run()` flow — that path never installs a PHF
+/// registry, so every per-component vtable lookup returns `None`.
+fn check_store_registrations(
+    components: &[&'static str],
+    stores: &[&'static str],
+) -> Result<(), Vec<String>> {
+    let mut needed: Vec<String> = Vec::new();
+    for &name in components {
+        if let Some(plan) = crate::templates_plan::template_plan_for(name) {
+            collect_plan_store_names(plan, &mut needed);
+        }
+    }
+    let mut missing: Vec<String> = needed
+        .into_iter()
+        .filter(|name| !stores.contains(&name.as_str()))
+        .collect();
+    missing.sort_unstable();
+    missing.dedup();
+    if missing.is_empty() {
+        Ok(())
+    } else {
+        Err(missing)
+    }
+}
+
+fn render_missing_store_boot_error(missing: &[String]) {
+    let list = missing.join(", ");
+    let msg = format!(
+        "pocopine: components reference store(s) not registered with \
+         `App::store::<T>()`: {list}. Add the missing `.store::<T>()` calls \
+         to your `App::new()…run()` chain before mount."
+    );
+    web_sys::console::error_1(&JsValue::from_str(&msg));
+    let Some(win) = web_sys::window() else { return };
+    let Some(doc) = win.document() else { return };
+    let Some(body) = doc.body() else { return };
+    if let Ok(banner) = doc.create_element("div") {
+        let _ = banner.set_attribute("data-pocopine-boot-error", "missing-store");
+        let _ = banner.set_attribute(
+            "style",
+            "all: initial; display: block; background: #b00020; color: #fff; \
+             font-family: system-ui, sans-serif; padding: 12px 16px; \
+             font-size: 14px; line-height: 1.4;",
+        );
+        banner.set_text_content(Some(&msg));
+        let _ = body.insert_before(banner.as_ref(), body.first_child().as_ref());
     }
 }
 

--- a/crates/pocopine-core/src/handler.rs
+++ b/crates/pocopine-core/src/handler.rs
@@ -10,7 +10,10 @@
 
 use js_sys::Array;
 use wasm_bindgen::{JsCast, JsValue};
-use web_sys::{CustomEvent, Event, FocusEvent, InputEvent, KeyboardEvent, MouseEvent, UiEvent};
+use web_sys::{
+    ClipboardEvent, CustomEvent, DragEvent, Event, FocusEvent, InputEvent, KeyboardEvent,
+    MouseEvent, PointerEvent, SubmitEvent, TouchEvent, UiEvent, WheelEvent,
+};
 
 pub trait HandlerDispatch {
     fn invoke_handler(&mut self, key: &str, args: &Array) -> JsValue;
@@ -224,5 +227,13 @@ impl_event_handler_arg!(
     KeyboardEvent,
     InputEvent,
     FocusEvent,
-    CustomEvent
+    CustomEvent,
+    // Pointer / drag / wheel / touch — direct manipulation flows.
+    PointerEvent,
+    DragEvent,
+    WheelEvent,
+    TouchEvent,
+    // Form + clipboard — common UI plumbing.
+    SubmitEvent,
+    ClipboardEvent
 );

--- a/crates/pocopine-core/src/lib.rs
+++ b/crates/pocopine-core/src/lib.rs
@@ -57,6 +57,7 @@ pub mod text;
 pub mod tick;
 pub mod timers;
 pub mod watch;
+pub mod web;
 
 pub use app::{
     App, AppPlugin, Component, Loader, LoaderContext, LoaderError, RouteComponent, RouteConfig,

--- a/crates/pocopine-core/src/web.rs
+++ b/crates/pocopine-core/src/web.rs
@@ -1,0 +1,67 @@
+//! Curated browser-API surface for Pine compounds.
+//!
+//! Re-exports the `web_sys` types Pine primitives reach for most
+//! often, so authors don't have to maintain their own `web-sys`
+//! `features = [...]` list every time they touch a new browser
+//! API. Import from here:
+//!
+//! ```ignore
+//! use pocopine_core::web::{DragEvent, DataTransfer, FileList};
+//! ```
+//!
+//! Anything not in this list either (a) belongs in `pocopine-core`
+//! proper because it's load-bearing for the framework, or (b) is
+//! niche enough that the consuming crate should add its own
+//! `web-sys` feature.
+//!
+//! ## Handler-typed vs read-only events
+//!
+//! The types in [`handler_events`] implement
+//! [`crate::handler::FromHandlerArg`] and can appear directly as a
+//! parameter on a `#[handlers]` method
+//! (e.g. `fn on_click(&mut self, ev: MouseEvent)`). The types in
+//! [`read_only_events`] are re-exported for handlers that take the
+//! `Event` supertype and downcast, or for code that consumes the
+//! event outside handler dispatch — typing a handler parameter
+//! against one of those directly produces a
+//! `trait FromHandlerArg is not implemented` compile error.
+//!
+//! The two groups are exposed as nested modules (not just doc
+//! sections) so the distinction is enforceable by `rustfmt` — a
+//! single `pub use` list gets sorted alphabetically and loses the
+//! grouping.
+
+/// Events that implement [`crate::handler::FromHandlerArg`] and
+/// can appear directly as a `#[handlers]` method parameter.
+pub mod handler_events {
+    pub use web_sys::{
+        ClipboardEvent, CustomEvent, DragEvent, Event, FocusEvent, InputEvent, KeyboardEvent,
+        MouseEvent, PointerEvent, SubmitEvent, TouchEvent, UiEvent, WheelEvent,
+    };
+}
+
+/// Events NOT in the `FromHandlerArg` impl list — accept via the
+/// `Event` supertype + downcast, or consume outside handler dispatch.
+pub mod read_only_events {
+    pub use web_sys::{
+        AnimationEvent, CompositionEvent, ErrorEvent, HashChangeEvent, MessageEvent,
+        PageTransitionEvent, PopStateEvent, ProgressEvent, StorageEvent, TransitionEvent,
+    };
+}
+
+// Re-export both event groups at the module root so authors can
+// `use pocopine_core::web::DragEvent` directly without remembering
+// which subgroup it sits in. The grouping above is documentation;
+// the flat surface here is the ergonomic path.
+pub use handler_events::*;
+pub use read_only_events::*;
+
+// Drag-and-drop + file flows.
+pub use web_sys::{Blob, DataTransfer, File, FileList, FormData};
+
+// DOM essentials.
+pub use web_sys::{
+    Document, Element, EventTarget, HtmlAnchorElement, HtmlButtonElement, HtmlElement,
+    HtmlFormElement, HtmlImageElement, HtmlInputElement, HtmlSelectElement, HtmlTextAreaElement,
+    Node, Url, Window,
+};

--- a/crates/pocopine-expr/src/lib.rs
+++ b/crates/pocopine-expr/src/lib.rs
@@ -196,8 +196,53 @@ impl<'a> Lexer<'a> {
                 self.pos += 1;
                 Tok::Plus
             }
+            // Arithmetic beyond `+` is not supported. Compute Rust-side
+            // as a `#[computed]` field and bind by name. See
+            // docs/poco/04-expressions.md.
+            b'*' | b'/' | b'%' => {
+                return Err(self.err(
+                    start..start + 1,
+                    &format!(
+                        "arithmetic operator `{}` is not supported in pine-expr",
+                        c as char
+                    ),
+                    Some(
+                        "compute Rust-side as a `#[computed]` field and bind by name — see docs/poco/04-expressions.md",
+                    ),
+                ));
+            }
+            // Bare `-` (not part of a number literal) is unsupported
+            // arithmetic. The number-literal case is the guarded arm
+            // below this one; the match-first-wins rule means we
+            // need the same guard inverted here so `-42` still
+            // lexes as a number.
+            b'-' if !matches!(self.peek(1), Some(b'0'..=b'9')) => {
+                return Err(self.err(
+                    start..start + 1,
+                    "arithmetic subtraction is not supported in pine-expr",
+                    Some(
+                        "compute Rust-side as a `#[computed]` field and bind by name — see docs/poco/04-expressions.md",
+                    ),
+                ));
+            }
             b'?' => {
                 self.pos += 1;
+                if self.peek(0) == Some(b'?') {
+                    return Err(self.err(
+                        start..self.pos + 1,
+                        "nullish coalescing `??` is not supported in pine-expr",
+                        Some("use a ternary (`x == null ? fallback : x`) or compute Rust-side"),
+                    ));
+                }
+                if self.peek(0) == Some(b'.') {
+                    return Err(self.err(
+                        start..self.pos + 1,
+                        "optional chaining `?.` is not supported in pine-expr",
+                        Some(
+                            "compute Rust-side as a `#[computed]` field that handles the null case",
+                        ),
+                    ));
+                }
                 Tok::Question
             }
             b':' => {
@@ -206,12 +251,26 @@ impl<'a> Lexer<'a> {
             }
             b'.' => {
                 self.pos += 1;
+                if self.peek(0) == Some(b'.') {
+                    return Err(self.err(
+                        start..self.pos + 1,
+                        "spread `...` is not supported in pine-expr",
+                        Some("pass arguments explicitly or compute Rust-side"),
+                    ));
+                }
                 Tok::Dot
             }
             b'!' => {
                 self.pos += 1;
                 if self.peek(0) == Some(b'=') {
                     self.pos += 1;
+                    if self.peek(0) == Some(b'=') {
+                        return Err(self.err(
+                            start..self.pos + 1,
+                            "`!==` is not supported in pine-expr",
+                            Some("use `!=` (pine-expr uses Rust-style equality)"),
+                        ));
+                    }
                     Tok::BangEq
                 } else {
                     Tok::Bang
@@ -220,10 +279,27 @@ impl<'a> Lexer<'a> {
             b'=' => {
                 // `==` wins over `=` — peek the next byte before
                 // committing. Single `=` is assignment (RFC-024);
-                // `==` is equality (RFC-012).
+                // `==` is equality (RFC-012). `===`, `!==`, and `=>`
+                // are rejected with directive messages so JS muscle
+                // memory fails loud at compile time.
                 if self.peek(1) == Some(b'=') {
+                    if self.peek(2) == Some(b'=') {
+                        return Err(self.err(
+                            start..self.pos + 3,
+                            "`===` is not supported in pine-expr",
+                            Some("use `==` (pine-expr uses Rust-style equality)"),
+                        ));
+                    }
                     self.pos += 2;
                     Tok::EqEq
+                } else if self.peek(1) == Some(b'>') {
+                    return Err(self.err(
+                        start..self.pos + 2,
+                        "arrow functions are not supported in pine-expr",
+                        Some(
+                            "define a handler method on the component — see docs/poco/04-expressions.md",
+                        ),
+                    ));
                 } else {
                     self.pos += 1;
                     Tok::Eq
@@ -659,6 +735,22 @@ impl Parser {
                         }
                     }
                 }
+                // `obj.method(…)` — only plain identifiers can be
+                // called. A path followed by `(` is the JS muscle
+                // memory we want to teach against: define a plain
+                // identifier handler that takes the object as an
+                // argument instead.
+                if matches!(self.peek().0, Tok::LParen) && segments.len() > 1 {
+                    return Err(ParseError {
+                        message: "method calls on objects are not supported in pine-expr"
+                            .to_string(),
+                        span: self.peek().1.clone(),
+                        hint: Some(
+                            "define a plain identifier handler, or a `#[computed]` field, that takes the object as an argument — see docs/poco/04-expressions.md"
+                                .to_string(),
+                        ),
+                    });
+                }
                 Ok(Spanned {
                     value: Expr::Path(segments),
                     span: start..end,
@@ -1043,5 +1135,102 @@ mod tests {
     fn plus_with_string_literal_parses() {
         let e = parse_ok("$id + '-title'");
         assert!(matches!(e.value, Expr::BinOp(BinOp::Plus, _, _)));
+    }
+
+    // ── Teaching errors: JS muscle memory rejected at compile time ──
+    //
+    // Every case below was already a parse error with a less helpful
+    // message. These tests pin the directive wording so future edits
+    // don't regress the diagnostic.
+
+    fn assert_err_says(src: &str, needle: &str) {
+        let err = parse(src).expect_err(&format!("expected parse error for {src:?}"));
+        assert!(
+            err.message.contains(needle) || err.hint.as_deref().unwrap_or("").contains(needle),
+            "error for {src:?} should mention {needle:?}; got message={:?} hint={:?}",
+            err.message,
+            err.hint,
+        );
+    }
+
+    #[test]
+    fn reject_arithmetic_star() {
+        assert_err_says("progress * 100", "arithmetic operator");
+        assert_err_says("progress * 100", "#[computed]");
+    }
+
+    #[test]
+    fn reject_arithmetic_slash() {
+        assert_err_says("total / count", "arithmetic operator");
+    }
+
+    #[test]
+    fn reject_arithmetic_percent() {
+        assert_err_says("idx % 2", "arithmetic operator");
+    }
+
+    #[test]
+    fn reject_arithmetic_minus() {
+        assert_err_says("count - 1", "subtraction");
+        assert_err_says("count - 1", "#[computed]");
+    }
+
+    #[test]
+    fn reject_triple_equals() {
+        assert_err_says("status === 'queued'", "`===`");
+        assert_err_says("status === 'queued'", "use `==`");
+    }
+
+    #[test]
+    fn reject_strict_inequality() {
+        assert_err_says("status !== 'queued'", "`!==`");
+        assert_err_says("status !== 'queued'", "use `!=`");
+    }
+
+    #[test]
+    fn reject_arrow_function() {
+        assert_err_says("x => x", "arrow functions");
+        assert_err_says("x => x", "handler method");
+    }
+
+    #[test]
+    fn reject_nullish_coalescing() {
+        assert_err_says("a ?? b", "nullish coalescing");
+    }
+
+    #[test]
+    fn reject_optional_chaining() {
+        assert_err_says("user?.name", "optional chaining");
+    }
+
+    #[test]
+    fn reject_spread() {
+        assert_err_says("...rest", "spread");
+    }
+
+    #[test]
+    fn reject_method_call_on_path() {
+        // `files.filter(...)` — a path of length >= 2 followed by `(`
+        // is the JS muscle-memory case we want to flag.
+        assert_err_says("files.filter(f)", "method calls on objects");
+        assert_err_says("files.filter(f)", "#[computed]");
+    }
+
+    #[test]
+    fn negative_number_literal_still_parses() {
+        // The `-` rejection must not break `-42` as a number literal.
+        let e = parse_ok("-42");
+        assert!(matches!(
+            e.value,
+            Expr::Literal(Literal::Number(n)) if n == -42.0
+        ));
+    }
+
+    #[test]
+    fn plain_identifier_call_still_parses() {
+        // `obj.method(...)` is rejected, but `method(obj)` is the
+        // canonical replacement and must still parse.
+        let e = parse_ok("filter_done(files)");
+        assert!(matches!(e.value, Expr::Call(_, _)));
     }
 }

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -792,6 +792,21 @@ fn role_to_tag(role: &str) -> Option<&'static str> {
     }
 }
 
+/// Default `display` value for a role when the author didn't set
+/// `display = "..."` explicitly. Layout-bearing roles (`panel`,
+/// `scope`) default to `contents` so the custom-element wrapper
+/// elides its own layout box — without this, the inner `<root>`'s
+/// flex / grid / sticky positioning binds to a `display: inline`
+/// custom element and silently breaks. Other roles keep the
+/// browser's custom-element default (`inline`) until the author
+/// overrides.
+fn role_default_display(role: &str) -> Option<&'static str> {
+    match role {
+        "panel" | "scope" => Some("contents"),
+        _ => None,
+    }
+}
+
 fn compile_template_static(raw: &str, name: &str, role: Option<(&str, &str)>) -> String {
     let Some((tag, role_name)) = role else {
         return inject_pp_data_static(raw, name);
@@ -1348,6 +1363,17 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
         Err(e) => return e.to_compile_error().into(),
     };
     let mut input = parse_macro_input!(item as ItemStruct);
+
+    // Bake a host-side `allow(dead_code)` onto the component struct.
+    // Fields that only feed `#[cfg(target_arch = "wasm32")]` code
+    // paths look unread on host; CI's `-D warnings` then fails for
+    // patterns the framework actively encourages (Pine primitives
+    // wrap `web_sys`). Pair this with the inner attribute baked into
+    // `#[handlers]` blocks — together they cover the struct and the
+    // helper fns in its impl.
+    input.attrs.push(syn::parse_quote!(
+        #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+    ));
 
     let struct_ident = input.ident.clone();
     let ident_str = struct_ident.to_string();
@@ -2693,9 +2719,63 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
     // custom tag's layout display without authors repeating
     // `pine-foo { display: contents; }` across every demo
     // stylesheet. Any valid CSS display value works.
-    let register_display_stmt: proc_macro2::TokenStream = match args.display.as_ref() {
-        Some(lit) => {
-            let value = lit.value();
+    //
+    // When `display` is unset, layout-bearing roles (`panel`,
+    // `scope`) default to `contents` so the wrapper elides its
+    // layout box — see `role_default_display`. Other roles keep
+    // the browser's custom-element default (`inline`).
+    let effective_display: Option<String> =
+        args.display.as_ref().map(|lit| lit.value()).or_else(|| {
+            args.role
+                .as_ref()
+                .and_then(|lit| role_default_display(&lit.value()).map(|s| s.to_string()))
+        });
+    // Layout-class lint — if the root element carries a layout-
+    // bearing utility class (`sticky`, `h-screen`, `min-h-*`,
+    // `inset-*`) and the component didn't set `display` explicitly
+    // *and* the role didn't default one, fail compilation with a
+    // directive message. The custom element defaults to
+    // `display: inline`, which silently breaks the offending
+    // utility — see RFC docs/poco/04-expressions.md companion.
+    let layout_lint_tokens: proc_macro2::TokenStream = if effective_display.is_none() {
+        template_ast
+            .as_ref()
+            .and_then(|ast| ast.element_roots().next())
+            .and_then(|root| {
+                root.attrs
+                    .iter()
+                    .find(|(k, _)| k == "class")
+                    .map(|(_, v)| v.clone())
+            })
+            .and_then(|classes| {
+                classes
+                    .split_whitespace()
+                    .find(|cls| {
+                        *cls == "sticky"
+                            || *cls == "h-screen"
+                            || cls.starts_with("min-h-")
+                            || cls.starts_with("inset-")
+                    })
+                    .map(|cls| cls.to_string())
+            })
+            .map(|trigger| {
+                let msg = format!(
+                    "pocopine: component `{name_str}` has root class `{trigger}` but no \
+                         `display` set. A bare custom element defaults to `display: inline`, \
+                         which silently breaks `{trigger}` (the containing block becomes a \
+                         tiny inline box). Set `display = \"contents\"` to elide the \
+                         custom-element layout box, or pick a role that defaults it \
+                         (role = \"panel\" / \"scope\")."
+                );
+                quote! { ::core::compile_error!(#msg); }
+            })
+            .unwrap_or_default()
+    } else {
+        proc_macro2::TokenStream::new()
+    };
+
+    let register_display_stmt: proc_macro2::TokenStream = match effective_display {
+        Some(value) => {
             let css = format!("{name_str} {{ display: {value}; }}");
             let sentinel = format!("{name_str}-display");
             quote! {
@@ -2962,6 +3042,13 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
         // rows whose direct element child is another `<template>`.
         #pp_for_template_child_diagnostics_tokens
 
+        // Layout-class lint — hard `compile_error!` when the root
+        // carries `sticky` / `h-screen` / `min-h-*` / `inset-*` but
+        // the component doesn't declare a `display` (and the role
+        // didn't default one). The custom element's default
+        // `display: inline` silently breaks those utilities.
+        #layout_lint_tokens
+
         #observe_impl
 
         impl ::pocopine::__private::ComponentState for #struct_ident {
@@ -3193,6 +3280,17 @@ pub fn handlers(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut input = parse_macro_input!(item as ItemImpl);
     let ty = input.self_ty.clone();
 
+    // Bake a host-side `allow(dead_code)` into the user's impl block.
+    // Pine primitives that wrap `web_sys` routinely keep helper fns
+    // (validate, mint_id, accept_allows, …) that are only reached
+    // from `#[cfg(target_arch = "wasm32")]` handlers; on the host
+    // build those helpers look unreferenced and trip CI's
+    // `-D warnings`. The inner attribute applied here covers every
+    // item the user puts in the same `#[handlers] impl` block.
+    input.attrs.push(syn::parse_quote!(
+        #![cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+    ));
+
     let mut arms = Vec::new();
     let mut has_on_setup = false;
     let mut has_on_mount = false;
@@ -3404,7 +3502,20 @@ pub fn handlers(_attr: TokenStream, item: TokenStream) -> TokenStream {
             }
         });
         let bindings = typed_args.iter().map(|(bind, _)| quote!(#bind));
+        // Forward conditional-compilation attributes from the method
+        // onto the emitted dispatch arm. Without this, a method
+        // annotated `#[cfg(target_arch = "wasm32")]` would compile
+        // away on host while the arm — which still references the
+        // method and its arg types — would not, breaking the host
+        // build. Restricted to `cfg`/`cfg_attr` so unrelated attrs
+        // (e.g. `#[doc]`, `#[allow]`) don't leak onto the arm.
+        let cfg_attrs: Vec<&syn::Attribute> = method
+            .attrs
+            .iter()
+            .filter(|attr| attr.path().is_ident("cfg") || attr.path().is_ident("cfg_attr"))
+            .collect();
         arms.push(quote! {
+            #(#cfg_attrs)*
             #name => {
                 #(#conversions)*
                 Self::#ident(self #(, #bindings)*);

--- a/crates/pocopine-macros/src/template_plan.rs
+++ b/crates/pocopine-macros/src/template_plan.rs
@@ -1145,12 +1145,32 @@ fn emit_ref(r: &RefLite) -> TokenStream {
 }
 
 fn emit_compiled_expr_option(src: &str) -> TokenStream {
-    match pocopine_expr::parse(src)
-        .ok()
-        .and_then(|expr| emit_compiled_expr(&expr))
-    {
-        Some(expr) => quote! { ::core::option::Option::Some(#expr) },
-        None => quote! { ::core::option::Option::None },
+    // Parse failures are surfaced as compile errors so the directive
+    // messages from `pocopine-expr` (e.g. "`===` is not supported")
+    // fail the build instead of silently emitting `compiled: None`
+    // and panicking at runtime via `templates_plan::fail()`. Valid
+    // expressions that simply aren't compile-time-representable
+    // (multi-segment paths, ternaries, calls, …) still fall through
+    // to runtime evaluation by emitting `Option::None`.
+    match pocopine_expr::parse(src) {
+        Ok(expr) => match emit_compiled_expr(&expr) {
+            Some(compiled) => quote! { ::core::option::Option::Some(#compiled) },
+            None => quote! { ::core::option::Option::None },
+        },
+        Err(err) => {
+            let hint = err
+                .hint
+                .as_deref()
+                .map(|h| format!("\n  hint: {h}"))
+                .unwrap_or_default();
+            let msg = format!(
+                "pocopine: pine-expr parse error in `{src}`: {message} (at {start}..{end}){hint}",
+                message = err.message,
+                start = err.span.start,
+                end = err.span.end,
+            );
+            quote! { ::core::compile_error!(#msg) }
+        }
     }
 }
 
@@ -3025,7 +3045,71 @@ fn escape_attr(s: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{is_lift_eligible_opaque, is_supported_modifier, parse_pp_directive_name};
+    use super::{
+        emit_compiled_expr_option, is_lift_eligible_opaque, is_supported_modifier,
+        parse_pp_directive_name,
+    };
+
+    #[test]
+    fn parse_failure_emits_compile_error_with_directive_hint() {
+        // The Group 1 teaching errors from `pocopine-expr` must reach
+        // the user at `cargo check` time — not silently fall through
+        // to a runtime panic via `templates_plan::fail()`. Pin the
+        // emitted token shape.
+        let out = emit_compiled_expr_option("status === 'queued'").to_string();
+        assert!(
+            out.contains("compile_error"),
+            "parse failure should emit a `compile_error!` token, got: {out}"
+        );
+        assert!(
+            out.contains("===") && out.contains("=="),
+            "compile_error message should quote the offending operator and suggest `==`: {out}"
+        );
+    }
+
+    #[test]
+    fn parse_failure_emits_arithmetic_directive() {
+        let out = emit_compiled_expr_option("progress * 100").to_string();
+        assert!(
+            out.contains("compile_error"),
+            "arithmetic should emit compile_error, got: {out}"
+        );
+        assert!(
+            out.contains("computed"),
+            "arithmetic hint should point at `#[computed]`: {out}"
+        );
+    }
+
+    #[test]
+    fn valid_but_not_compile_time_representable_falls_through() {
+        // `a + b` parses fine but `emit_compiled_expr` can't lower a
+        // non-literal `+` to a `StaticExpr`. The fallthrough path
+        // must still emit `Option::None` (runtime evaluation), NOT a
+        // compile error.
+        let out = emit_compiled_expr_option("a + b").to_string();
+        assert!(
+            !out.contains("compile_error"),
+            "valid expression must not emit compile_error, got: {out}"
+        );
+        assert!(
+            out.contains("None"),
+            "non-representable expression must fall through to Option::None: {out}"
+        );
+    }
+
+    #[test]
+    fn literal_expression_compiles_to_static() {
+        // Sanity: simple literal stays on the compile-time fast path.
+        let out = emit_compiled_expr_option("true").to_string();
+        assert!(
+            !out.contains("compile_error"),
+            "literal must not emit compile_error: {out}"
+        );
+        assert!(
+            out.contains("Some") && out.contains("StaticExpr"),
+            "literal must compile to a `Some(StaticExpr::...)`: {out}"
+        );
+    }
 
     #[test]
     fn supported_listener_modifiers_include_runtime_named_keys() {

--- a/docs/components/02-state.md
+++ b/docs/components/02-state.md
@@ -326,6 +326,10 @@ need a long one:
    addressed by `ScopeId` through the walker; user code doesn't get
    scope ids. If you're tempted, promote to a store.
 4. **Derived state stored as a field you manually keep in sync.**
-   Today: compute it inside the handler that changed the inputs, or in
-   the directive. After signals land: `computed()`. Never two fields
-   with an "update both" invariant.
+   Don't write `progress_label` updates into every handler that
+   touches `progress`. Use `#[computed]` for pure derivations and
+   `#[watch(field)]` for derivations that need `self`. The framework
+   keeps the derived value up to date for you. Templates bind by
+   name (`pp-text="progress_label"`). See
+   [`docs/poco/04-expressions.md`](../poco/04-expressions.md) for
+   the full pattern and the canonical examples.

--- a/docs/components/03-composition.md
+++ b/docs/components/03-composition.md
@@ -133,6 +133,84 @@ marker. Same tag name, same mental model, no Shadow DOM cost.
 * **Shadow DOM is not used.** Slots are a flat DOM move; CSS scoping
   still works because scoping is attribute-based, not shadow-based.
 
+### Why doesn't my `pp-text` work inside a compound's slot?
+
+The single most common gotcha for authors coming from Vue or Svelte.
+This **does not work**:
+
+```html
+<!-- UploadItem.poco -->
+<div class="row">
+  <slot></slot>
+</div>
+```
+
+```html
+<!-- Caller.poco -->
+<upload-item :name="file.name" :status="file.status">
+  <span pp-text="name"></span>           <!-- ❌ resolves to caller's `name` -->
+  <span pp-show="status == 'uploading'">…</span>  <!-- ❌ same -->
+</upload-item>
+```
+
+Inside the slot, `name` and `status` resolve in **the caller's
+scope**, not the `UploadItem`'s scope. The child's props are
+invisible to the slot content. (Search the runtime for the comment
+in `crates/pocopine-core/src/slot_scope.rs` if you want to see why —
+slot handlers are deliberately delegated to the caller so a
+`@click="parent_handler"` inside the slot reaches the right scope.)
+
+The fix is **scoped slots**: the child's template `<slot>` exposes
+the fields it wants to share, and the caller's `<template pp-slot>`
+names them with `pp-let`:
+
+```html
+<!-- UploadItem.poco — expose child state on the slot -->
+<div class="row">
+  <slot :name="name" :status="status" :progress="progress"></slot>
+</div>
+```
+
+```html
+<!-- Caller.poco — bind the exposed fields with pp-let -->
+<upload-item :name="file.name" :status="file.status" :progress="file.progress">
+  <template pp-slot="default" pp-let="row">
+    <span pp-text="row.name"></span>
+    <span pp-show="row.status == 'uploading'">
+      <span pp-text="row.progress"></span>
+    </span>
+  </template>
+</upload-item>
+```
+
+Inside the `<template pp-slot>`, `row` is a lexical binding to the
+object the child exposed on its `<slot>`. The caller's own scope
+(e.g. `file` from a `pp-for`) is still in reach as before — scoped
+slots add a name, they don't replace the caller's scope.
+
+**Rules:**
+
+* The child template's `<slot :foo="…" :bar="…">` decides what
+  goes on the exposed object. The fields are named by attribute, so
+  `:name="name"` exposes a `name` field whose value is the child's
+  `name`.
+* The caller's `<template pp-slot="default" pp-let="X">` names the
+  exposed object as `X`. Pick any identifier — `row`, `item`,
+  `state`, `slot_scope`.
+* Without `pp-let`, the slot content stays in the caller's scope
+  with no exposed object. That's the right shape when the slot
+  doesn't need anything from the child.
+* Don't enumerate the child's fields one by one with `:name=name
+  :id=id :progress=progress …`. Expose one object (`:row="{…}"`-style
+  — wrap on the child side if you want) or just expose each field —
+  but choose, don't mix.
+
+This pattern also unblocks rendering the child's primary collection
+from slot content (the upload queue, the tabs in a `<tabs>`, the
+options in a `<select>`): the child exposes the collection on its
+`<slot>` and the caller writes a normal `pp-for` over the
+`pp-let`-named binding.
+
 ## Iteration (`pp-for`, deferred)
 
 Planned syntax for the array-reactivity milestone:

--- a/docs/poco/04-expressions.md
+++ b/docs/poco/04-expressions.md
@@ -1,0 +1,168 @@
+# `.poco` expressions — surface and convention
+
+Every `pp-*="..."` attribute value is a **pine-expr** expression. The
+surface is deliberately small. If you need more than this page lists,
+the answer is to compute Rust-side and bind to a field by name —
+not to write a bigger expression.
+
+## What pine-expr supports
+
+**Reads**
+
+* Identifiers and dotted paths: `count`, `user.name`, `file.status`
+* Literals: `true`, `false`, `null`, numbers, single- or double-quoted strings
+
+**Operators**
+
+* Comparison: `==`, `!=`, `<`, `<=`, `>`, `>=`
+* Logical: `&&`, `||`, `!`
+* Ternary: `cond ? a : b`
+* `+` — string concatenation when either operand is a string;
+  numeric add when both coerce to `f64` (this is the *only*
+  arithmetic operator)
+
+**Calls**
+
+* Plain identifier calls only: `upper(name)`, `format_id(id)`
+* The callee must be a Rust-side handler or `#[computed]` registered
+  on the component
+
+**Assignment and sequences** (handler context only)
+
+* `count = count + 1`
+* `a; b; c`
+
+That's the whole surface. There's a complete grammar reference in
+`crates/pocopine-expr/src/lib.rs` — but the rule of thumb is: if it
+looks like it needs more than reading or comparing, it doesn't belong
+in the template.
+
+## What pine-expr does NOT support
+
+* Arithmetic beyond `+`: no `-`, `*`, `/`, `%`, `**`
+* JS-style strict equality: no `===`/`!==` — use `==`/`!=`
+* Method calls on objects: no `obj.method()`, no `.length`, no
+  `.toFixed()`, no `.slice()`, no `.map()` / `.filter()`
+* Globals: no `Math.*`, no `Date.*`, no `console.*`, no `JSON.*`
+* Arrow functions / lambdas: no `x => x + 1`
+* Spread, optional chaining, nullish coalescing: no `...`, `?.`, `??`
+* Regular expressions
+
+These aren't oversights. They are not coming. Read the next section.
+
+## Where computation lives
+
+The opinionated answer: **derived display state is a Rust field**,
+named for what it represents, kept up to date by the component.
+
+There are three canonical shapes for keeping a derived field up to
+date. Pick the one that matches the dependency.
+
+### 1. `#[computed]` — depends only on other fields
+
+```rust
+#[handlers]
+impl PineUploadItem {
+    #[computed]
+    pub fn progress_label(progress: f64) -> String {
+        format!("{}%", (progress * 100.0).round() as i32)
+    }
+}
+```
+
+```html
+<span pp-text="progress_label"></span>
+```
+
+`#[computed]` methods are **static** (no `self`), take the fields they
+depend on as parameters, and are exposed to templates as read-only
+synthetic fields. The framework recomputes them when their inputs
+change. Use this for any pure derivation: labels, formatted numbers,
+truncated strings, percent strings, derived class names.
+
+### 2. `#[watch(field)]` — needs `self`, recomputes on prop change
+
+```rust
+#[handlers]
+impl PineUploadItem {
+    #[watch(extension)]
+    fn update_thumb_label(&mut self) {
+        self.thumb_label = self.extension
+            .chars()
+            .take(3)
+            .collect::<String>()
+            .to_uppercase();
+    }
+}
+```
+
+Reach for `#[watch]` when the derivation isn't a pure function of its
+inputs — for example, when it touches another field on `self`, calls
+out to a store, or has side effects (logging, telemetry).
+
+### 3. Plain handler — derives on user action
+
+```rust
+#[handlers]
+impl Counter {
+    pub fn increment(&mut self) {
+        self.count = self.count + 1;
+        self.count_label = self.count.to_string();
+    }
+}
+```
+
+If the only way a field changes is through user input, just write the
+derived state into the same handler that changes the input. No
+attribute needed.
+
+## Why pine-expr stays small
+
+The smaller pine-expr is, the more your logic lives in Rust where
+**rust-analyzer, clippy, tests, fmt, and rename** can all reach it.
+Every operator added to pine-expr is logic the toolchain can't see.
+
+Concretely:
+
+* `Math.round(progress * 100)` in a template is a string. A typo
+  silently renders nothing. The same expression Rust-side is a
+  compile error and a clippy hint.
+* `files.filter(f => f.status === 'done').length` in a template
+  would need an interpreter for arrow functions, method dispatch,
+  and JS equality semantics. Rust-side it is a one-line `iter()`
+  chain with full type inference.
+* A `#[computed] done_count` field is named for what it represents.
+  The template binds `pp-text="done_count"`. A reader who has never
+  seen the file knows what it does.
+
+Pocopine is opinionated. The convention is: **templates declare,
+Rust computes.** When a JS muscle-memory expression doesn't parse,
+the compiler will tell you, and the fix is to give the derivation
+a name.
+
+## Compile-time errors you may see
+
+The pine-expr parser rejects common JS patterns with a directive
+message. If you see any of these, the fix is to compute the value
+as a `#[computed]` field (or `#[watch]`, or in a handler) and bind
+to it by name:
+
+* `arithmetic in templates is not supported — compute Rust-side as
+  a #[computed] field`
+* `=== is not supported; use == (pine-expr uses Rust-style equality)`
+* `method calls on objects are not supported — compute Rust-side`
+* `JS globals (Math.*, Date.*, JSON.*) are not available — compute
+  Rust-side`
+* `arrow functions are not supported`
+
+These errors fire at compile time when the framework parses your
+`.poco` template, with the file and span pointing at the offending
+expression.
+
+## Related
+
+* `docs/components/02-state.md` — state management conventions; the
+  anti-pattern on manually-mirrored derived fields ties directly to
+  this page.
+* `docs/poco/01-format.md` — the broader `.poco` format.
+* `crates/pocopine-expr/src/lib.rs` — grammar reference.

--- a/docs/poco/README.md
+++ b/docs/poco/README.md
@@ -20,3 +20,7 @@ Docs in this folder:
    three files together at compile time.
 3. [`03-scoped-styles.md`](./03-scoped-styles.md) — the
    `data-pp-<hash>` + selector-rewrite strategy for CSS scoping.
+4. [`04-expressions.md`](./04-expressions.md) — the pine-expr
+   surface inside `pp-*="..."` attributes, what doesn't belong
+   there, and the `#[computed]` / `#[watch]` patterns for
+   derived state.

--- a/examples/tailwind/src/lib.rs
+++ b/examples/tailwind/src/lib.rs
@@ -2,7 +2,7 @@ use pocopine::prelude::*;
 use serde::{Deserialize, Serialize};
 
 #[derive(Default, Serialize, Deserialize)]
-#[component]
+#[component(display = "contents")]
 pub struct AppDemo {
     pub count: i32,
     pub show_details: bool,


### PR DESCRIPTION
## Summary

Three coherent groups of DX fixes hit while building a Pine upload primitive. Each group addresses a recurring silent-failure pattern that costs authors a debug session.

### Group 1 — pine-expr convention, taught at compile time
Templates get comparisons / ternary / `+` / identifier reads / plain calls. Arithmetic, `===`, method calls (`obj.method()`), arrow functions, `??`, `?.`, `...` are rejected by the lexer/parser with directive messages pointing at `#[computed]` and `docs/poco/04-expressions.md`. The `#[component]` macro now propagates parse failures as `compile_error!` instead of swallowing with `.ok()` and letting the runtime panic at first access. New doc page covers the surface + `#[computed]` / `#[watch]` patterns; `docs/components/02-state.md` anti-pattern #4 (still describing `computed()` as future work) is rewritten to point at the existing `#[computed]`.

### Group 2 — macro hygiene
- `#[handlers]` propagates method `#[cfg]` attrs onto the emitted dispatch arm (no more "second impl block" workaround for wasm-only handlers).
- `FromHandlerArg` adds `DragEvent`, `PointerEvent`, `WheelEvent`, `TouchEvent`, `SubmitEvent`, `ClipboardEvent`.
- `#[component]` + `#[handlers]` bake `#[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]` so Pine primitives wrapping `web_sys` stop tripping `-D warnings`.
- New `pocopine_core::web` curated re-export with `handler_events` / `read_only_events` submodules whose distinction is documented (the read-only group does NOT implement `FromHandlerArg`). Plus `web-sys` feature additions: `DataTransfer`, `File`, `FileList`, `Blob`, `FormData`, `Url`, button/form/image element types.
- `role = "panel" | "scope"` defaults to `display: contents`; explicit `display = "..."` still wins.
- Layout-class lint: a root with `sticky` / `h-screen` / `min-h-*` / `inset-*` and no `display` set fails compile with a directive message. Caught a real silent failure in `examples/tailwind`.

### Group 3 — composition + diagnostics
- New `docs/components/03-composition.md` section: _"Why doesn't my pp-text work inside a compound's slot?"_ with broken/fixed scoped-slot side-by-side.
- `App::run()` cross-references `$store.<name>` refs in every component's template plan against `.store::<T>()` registrations. Missing stores surface a single startup boot-error banner naming every missing call. AST-based scan (via `pocopine_expr::parse`) so string-literal lookalikes can't false-positive; plan lookup via `template_plan_for` so the check works on the canonical `App::new()…run()` path (no PHF registry installed).
- `App::run()` calls `console_error_panic_hook::set_once()` so the directive `.expect(...)` messages authored throughout the framework actually reach the user.

## Code-review fixes applied
The branch went through a high-effort code review. Three findings were fixed in this PR:

1. **`check_store_registrations` silently no-op for direct `App::run()`** — switched from `active_component_vtable` (PHF-only) to `template_plan_for` (PHF + thread-local fallback). The fallback is what `register::<C>()` populates, so the canonical builder path now actually runs the check.
2. **AST-based store-name extraction** — substring matching for `$store.X` was vulnerable to false positives inside string literals. Now walks the parsed expression AST and only counts `Expr::Path` segments whose first element is literally `$store`.
3. **`web.rs` docstring accuracy** — original docstring claimed every re-exported event implements `FromHandlerArg`; 10 of them don't. Split into `handler_events` and `read_only_events` submodules with explicit distinction.

## Test plan
- [x] `cargo check --workspace` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy -p pocopine-core -p pocopine-expr -p pocopine-macros -- -D warnings` (host) — clean
- [x] `cargo clippy -p pocopine-core -p pocopine-expr -p pocopine-macros --target wasm32-unknown-unknown -- -D warnings` — clean
- [x] `cargo test -p pocopine-expr` — 42 tests pass (11 new for teaching errors)
- [x] `cargo test -p pocopine-core --lib route_config_tests` — 23 tests pass (6 new for AST-based store scanner)
- [x] `cargo test -p pocopine-macros` — 8 tests pass (4 new for `compile_error!` propagation)
- [ ] Manual: confirm `console_error_panic_hook` is wired in an example app (verifies the directive `.expect(...)` strings now reach the dev console)
- [ ] Manual: confirm the missing-store boot banner renders with the right message when `.store::<T>()` is forgotten in a referencing app