### PR TITLE
sync: schema versioning — Batch 1 — protocol surface + SyncError::SchemaMigration

### DIFF
--- a/crates/pocopine-sync-crud-macros/src/lib.rs
+++ b/crates/pocopine-sync-crud-macros/src/lib.rs
@@ -61,16 +61,28 @@ impl Parse for ResourceArgs {
                         "`schema_version` must be a u32 integer literal (e.g. `schema_version = 2`)",
                     )
                 })?;
+                // `base10_parse::<u32>` silently strips type suffixes —
+                // `schema_version = 3u64` would otherwise parse as `3`.
+                // Reject anything that's not bare or explicitly `u32`.
+                let suffix = lit.suffix();
+                if !suffix.is_empty() && suffix != "u32" {
+                    return Err(syn::Error::new(
+                        lit.span(),
+                        format!(
+                            "`schema_version` must be a bare integer literal or `u32`-suffixed (got: {lit})"
+                        ),
+                    ));
+                }
                 let value: u32 = lit.base10_parse().map_err(|err| {
                     syn::Error::new(
                         lit.span(),
-                        format!("`schema_version` must fit in u32 (got: {}): {err}", lit),
+                        format!("`schema_version` must fit in u32 (got: {lit}): {err}"),
                     )
                 })?;
                 if value == 0 {
                     return Err(syn::Error::new(
                         lit.span(),
-                        "`schema_version` must be >= 1 (schema versions start at 1)",
+                        "schema_version must be >= 1 (schema versions start at 1)",
                     ));
                 }
                 schema_version = Some(value);
@@ -554,7 +566,8 @@ mod tests {
     fn rejects_zero_schema_version() {
         let err = parse_args(r#"name = "customers", schema_version = 0"#).unwrap_err();
 
-        assert!(err.to_string().contains("must be >= 1"));
+        // Matches the message used by the runtime builder error too.
+        assert!(err.to_string().contains("schema_version must be >= 1"));
     }
 
     #[test]
@@ -570,6 +583,27 @@ mod tests {
             .unwrap_err();
 
         assert!(err.to_string().contains("duplicate `schema_version`"));
+    }
+
+    #[test]
+    fn rejects_suffixed_non_u32_schema_version() {
+        // `base10_parse::<u32>` strips suffixes silently, so a user
+        // writing `3u64` would otherwise parse as `3`. Flag explicitly.
+        let err = parse_args(r#"name = "customers", schema_version = 3u64"#).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("must be a bare integer literal or `u32`-suffixed"));
+
+        let err = parse_args(r#"name = "customers", schema_version = 3i32"#).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("must be a bare integer literal or `u32`-suffixed"));
+    }
+
+    #[test]
+    fn accepts_u32_suffixed_schema_version() {
+        let args = parse_args(r#"name = "customers", schema_version = 5u32"#).unwrap();
+        assert_eq!(args.schema_version, 5);
     }
 
     #[test]

--- a/crates/pocopine-sync-crud-macros/src/lib.rs
+++ b/crates/pocopine-sync-crud-macros/src/lib.rs
@@ -8,7 +8,7 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
-use syn::{parse_macro_input, Ident, ImplItem, ItemImpl, LitStr, Token, Type};
+use syn::{parse_macro_input, Ident, ImplItem, ItemImpl, LitInt, LitStr, Token, Type};
 
 // Matches the sync protocol's stream and row-key token budget.
 const MAX_SYNC_TOKEN_LEN: usize = 1024;
@@ -17,12 +17,14 @@ const MAX_SYNC_TOKEN_LEN: usize = 1024;
 struct ResourceArgs {
     name: LitStr,
     module: Ident,
+    schema_version: u32,
 }
 
 impl Parse for ResourceArgs {
     fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         let mut name = None;
         let mut module = None;
+        let mut schema_version: Option<u32> = None;
 
         while !input.is_empty() {
             let key: Ident = input.parse()?;
@@ -45,10 +47,37 @@ impl Parse for ResourceArgs {
                 }
                 input.parse::<Token![=]>()?;
                 module = Some(input.parse()?);
+            } else if key == "schema_version" {
+                if schema_version.is_some() {
+                    return Err(syn::Error::new(
+                        key.span(),
+                        "duplicate `schema_version` in CRUD resource attribute",
+                    ));
+                }
+                input.parse::<Token![=]>()?;
+                let lit: LitInt = input.parse().map_err(|err| {
+                    syn::Error::new(
+                        err.span(),
+                        "`schema_version` must be a u32 integer literal (e.g. `schema_version = 2`)",
+                    )
+                })?;
+                let value: u32 = lit.base10_parse().map_err(|err| {
+                    syn::Error::new(
+                        lit.span(),
+                        format!("`schema_version` must fit in u32 (got: {}): {err}", lit),
+                    )
+                })?;
+                if value == 0 {
+                    return Err(syn::Error::new(
+                        lit.span(),
+                        "`schema_version` must be >= 1 (schema versions start at 1)",
+                    ));
+                }
+                schema_version = Some(value);
             } else {
                 return Err(syn::Error::new(
                     key.span(),
-                    "expected `name = \"...\"` or `module = ident` in CRUD resource attribute",
+                    "expected `name = \"...\"`, `module = ident`, or `schema_version = N` in CRUD resource attribute",
                 ));
             }
 
@@ -66,7 +95,12 @@ impl Parse for ResourceArgs {
             Some(module) => module,
             None => module_ident_from_name(&name)?,
         };
-        Ok(Self { name, module })
+        let schema_version = schema_version.unwrap_or(1);
+        Ok(Self {
+            name,
+            module,
+            schema_version,
+        })
     }
 }
 
@@ -109,6 +143,7 @@ fn expand_resource(args: ResourceArgs, item: ItemImpl) -> syn::Result<TokenStrea
     let types = extract_resource_types(&item)?;
     let module = args.module;
     let name = args.name;
+    let schema_version = args.schema_version;
     let source = &item.self_ty;
     let id = types.id;
     let row = types.row;
@@ -123,6 +158,11 @@ fn expand_resource(args: ResourceArgs, item: ItemImpl) -> syn::Result<TokenStrea
             use super::*;
 
             pub const NAME: &str = #name;
+            /// Application-level schema version this resource serves.
+            /// Bumped via `#[resource(schema_version = N)]` whenever the
+            /// row, draft, or payload shape changes in a way that older
+            /// cached data or queued mutations cannot deserialize into.
+            pub const SCHEMA_VERSION: u32 = #schema_version;
 
             pub type Id = #id;
             pub type Row = #row;
@@ -386,7 +426,8 @@ fn expand_resource(args: ResourceArgs, item: ItemImpl) -> syn::Result<TokenStrea
             pub fn resource(
                 source: #source,
             ) -> ::pocopine_sync::SyncResult<::pocopine_sync_crud::CrudResourceBuilder<#source>> {
-                ::pocopine_sync_crud::resource(NAME, source)
+                ::pocopine_sync_crud::resource(NAME, source)?
+                    .schema_version(SCHEMA_VERSION)
             }
 
             pub fn new_id() -> ::pocopine_sync::SyncResult<Id> {
@@ -498,6 +539,37 @@ mod tests {
 
         assert_eq!(args.name.value(), "customers");
         assert_eq!(args.module.to_string(), "customers");
+        assert_eq!(args.schema_version, 1);
+    }
+
+    #[test]
+    fn parses_schema_version_attribute() {
+        let args = parse_args(r#"name = "customers", schema_version = 3"#).unwrap();
+
+        assert_eq!(args.name.value(), "customers");
+        assert_eq!(args.schema_version, 3);
+    }
+
+    #[test]
+    fn rejects_zero_schema_version() {
+        let err = parse_args(r#"name = "customers", schema_version = 0"#).unwrap_err();
+
+        assert!(err.to_string().contains("must be >= 1"));
+    }
+
+    #[test]
+    fn rejects_non_integer_schema_version() {
+        let err = parse_args(r#"name = "customers", schema_version = "two""#).unwrap_err();
+
+        assert!(err.to_string().contains("must be a u32 integer literal"));
+    }
+
+    #[test]
+    fn rejects_duplicate_schema_version() {
+        let err = parse_args(r#"name = "customers", schema_version = 1, schema_version = 2"#)
+            .unwrap_err();
+
+        assert!(err.to_string().contains("duplicate `schema_version`"));
     }
 
     #[test]

--- a/crates/pocopine-sync-crud-macros/tests/resource.rs
+++ b/crates/pocopine-sync-crud-macros/tests/resource.rs
@@ -145,6 +145,10 @@ fn resource_attribute_preserves_crud_source_impl() {
 #[test]
 fn resource_attribute_generates_module_contract() {
     assert_eq!(customers::NAME, "customers");
+    // The default schema_version when `#[resource(...)]` omits the
+    // attribute is 1; the macro emits a `pub const SCHEMA_VERSION` in
+    // the generated module so apps can read it for migration logic.
+    assert_eq!(customers::SCHEMA_VERSION, 1);
 
     let state = CollectionState::<Customer>::default();
     let view = customers::view(&state).unwrap();

--- a/crates/pocopine-sync-crud-macros/tests/resource_ui.rs
+++ b/crates/pocopine-sync-crud-macros/tests/resource_ui.rs
@@ -11,4 +11,7 @@ fn resource_attribute_compile_failures() {
     cases.compile_fail("tests/ui/resource_name_requires_module.rs");
     cases.compile_fail("tests/ui/resource_missing_draft.rs");
     cases.compile_fail("tests/ui/resource_generic_impl.rs");
+    cases.compile_fail("tests/ui/resource_schema_version_zero.rs");
+    cases.compile_fail("tests/ui/resource_schema_version_non_integer.rs");
+    cases.compile_fail("tests/ui/resource_schema_version_suffixed.rs");
 }

--- a/crates/pocopine-sync-crud-macros/tests/ui/resource_extra_tokens.stderr
+++ b/crates/pocopine-sync-crud-macros/tests/ui/resource_extra_tokens.stderr
@@ -1,4 +1,4 @@
-error: expected `name = "..."` or `module = ident` in CRUD resource attribute
+error: expected `name = "..."`, `module = ident`, or `schema_version = N` in CRUD resource attribute
  --> tests/ui/resource_extra_tokens.rs:3:52
   |
 3 | #[pocopine_sync_crud::resource(name = "customers", unexpected)]

--- a/crates/pocopine-sync-crud-macros/tests/ui/resource_schema_version_non_integer.rs
+++ b/crates/pocopine-sync-crud-macros/tests/ui/resource_schema_version_non_integer.rs
@@ -1,0 +1,6 @@
+struct Customers;
+
+#[pocopine_sync_crud::resource(name = "customers", schema_version = "two")]
+impl Customers {}
+
+fn main() {}

--- a/crates/pocopine-sync-crud-macros/tests/ui/resource_schema_version_non_integer.stderr
+++ b/crates/pocopine-sync-crud-macros/tests/ui/resource_schema_version_non_integer.stderr
@@ -1,0 +1,5 @@
+error: `schema_version` must be a u32 integer literal (e.g. `schema_version = 2`)
+ --> tests/ui/resource_schema_version_non_integer.rs:3:69
+  |
+3 | #[pocopine_sync_crud::resource(name = "customers", schema_version = "two")]
+  |                                                                     ^^^^^

--- a/crates/pocopine-sync-crud-macros/tests/ui/resource_schema_version_suffixed.rs
+++ b/crates/pocopine-sync-crud-macros/tests/ui/resource_schema_version_suffixed.rs
@@ -1,0 +1,6 @@
+struct Customers;
+
+#[pocopine_sync_crud::resource(name = "customers", schema_version = 3u64)]
+impl Customers {}
+
+fn main() {}

--- a/crates/pocopine-sync-crud-macros/tests/ui/resource_schema_version_suffixed.stderr
+++ b/crates/pocopine-sync-crud-macros/tests/ui/resource_schema_version_suffixed.stderr
@@ -1,0 +1,5 @@
+error: `schema_version` must be a bare integer literal or `u32`-suffixed (got: 3u64)
+ --> tests/ui/resource_schema_version_suffixed.rs:3:69
+  |
+3 | #[pocopine_sync_crud::resource(name = "customers", schema_version = 3u64)]
+  |                                                                     ^^^^

--- a/crates/pocopine-sync-crud-macros/tests/ui/resource_schema_version_zero.rs
+++ b/crates/pocopine-sync-crud-macros/tests/ui/resource_schema_version_zero.rs
@@ -1,0 +1,6 @@
+struct Customers;
+
+#[pocopine_sync_crud::resource(name = "customers", schema_version = 0)]
+impl Customers {}
+
+fn main() {}

--- a/crates/pocopine-sync-crud-macros/tests/ui/resource_schema_version_zero.stderr
+++ b/crates/pocopine-sync-crud-macros/tests/ui/resource_schema_version_zero.stderr
@@ -1,0 +1,5 @@
+error: schema_version must be >= 1 (schema versions start at 1)
+ --> tests/ui/resource_schema_version_zero.rs:3:69
+  |
+3 | #[pocopine_sync_crud::resource(name = "customers", schema_version = 0)]
+  |                                                                     ^

--- a/crates/pocopine-sync-crud-macros/tests/ui/resource_unknown_key.stderr
+++ b/crates/pocopine-sync-crud-macros/tests/ui/resource_unknown_key.stderr
@@ -1,4 +1,4 @@
-error: expected `name = "..."` or `module = ident` in CRUD resource attribute
+error: expected `name = "..."`, `module = ident`, or `schema_version = N` in CRUD resource attribute
  --> tests/ui/resource_unknown_key.rs:3:32
   |
 3 | #[pocopine_sync_crud::resource(stream = "customers")]

--- a/crates/pocopine-sync-crud/src/resource.rs
+++ b/crates/pocopine-sync-crud/src/resource.rs
@@ -32,6 +32,7 @@ where
         collection: SyncCollectionName::new(name)?,
         source,
         max_snapshot_rows: DEFAULT_CRUD_SNAPSHOT_ROW_LIMIT,
+        schema_version: 1,
     })
 }
 
@@ -41,6 +42,7 @@ pub struct CrudResourceBuilder<S> {
     collection: SyncCollectionName,
     source: S,
     max_snapshot_rows: usize,
+    schema_version: u32,
 }
 
 impl<S> CrudResourceBuilder<S>
@@ -58,6 +60,24 @@ where
         Ok(self)
     }
 
+    /// Set the application-level schema version this resource serves.
+    ///
+    /// Bump this whenever the row, draft, or payload shape changes in a
+    /// way that older cached data or queued mutations cannot deserialize
+    /// into. Defaults to `1`. The server advertises this on every `/open`
+    /// response; clients compare against their cached value and clear
+    /// the stream when they differ. `0` is rejected — versions start at
+    /// `1`.
+    pub fn schema_version(mut self, version: u32) -> SyncResult<Self> {
+        if version == 0 {
+            return Err(SyncError::client(
+                "CRUD schema_version must be >= 1 (schema versions start at 1)",
+            ));
+        }
+        self.schema_version = version;
+        Ok(self)
+    }
+
     /// Attach the row id extractor for this resource.
     pub fn id<IdOf>(self, id_of: IdOf) -> CrudResource<S, IdOf>
     where
@@ -68,6 +88,7 @@ where
             collection: self.collection,
             source: self.source,
             max_snapshot_rows: self.max_snapshot_rows,
+            schema_version: self.schema_version,
             id_of,
             version_of: NoRowVersion,
             mutation_log: MissingMutationLog,
@@ -81,6 +102,7 @@ pub struct CrudResource<S, IdOf, VersionOf = NoRowVersion, Log = MissingMutation
     collection: SyncCollectionName,
     source: S,
     max_snapshot_rows: usize,
+    schema_version: u32,
     id_of: IdOf,
     version_of: VersionOf,
     mutation_log: Log,
@@ -104,6 +126,7 @@ where
             collection: self.collection,
             source: self.source,
             max_snapshot_rows: self.max_snapshot_rows,
+            schema_version: self.schema_version,
             id_of: self.id_of,
             version_of,
             mutation_log: self.mutation_log,
@@ -130,6 +153,7 @@ where
             collection: self.collection,
             source: self.source,
             max_snapshot_rows: self.max_snapshot_rows,
+            schema_version: self.schema_version,
             id_of: self.id_of,
             version_of: self.version_of,
             mutation_log,
@@ -167,6 +191,7 @@ where
             collection: self.collection,
             source: self.source,
             max_snapshot_rows: self.max_snapshot_rows,
+            schema_version: self.schema_version,
             id_of: self.id_of,
             version_of: self.version_of,
             mutation_log,
@@ -182,6 +207,7 @@ pub struct TransactionalCrudResource<S, IdOf, VersionOf, Log, Runner> {
     collection: SyncCollectionName,
     source: S,
     max_snapshot_rows: usize,
+    schema_version: u32,
     id_of: IdOf,
     version_of: VersionOf,
     mutation_log: Log,
@@ -491,6 +517,10 @@ where
         &self.collection
     }
 
+    fn schema_version(&self) -> u32 {
+        self.schema_version
+    }
+
     fn pull<'a>(
         &'a self,
         ctx: RequestContext,
@@ -765,6 +795,10 @@ where
 
     fn collection(&self) -> &SyncCollectionName {
         &self.collection
+    }
+
+    fn schema_version(&self) -> u32 {
+        self.schema_version
     }
 
     fn pull<'a>(

--- a/crates/pocopine-sync-crud/src/resource.rs
+++ b/crates/pocopine-sync-crud/src/resource.rs
@@ -3,9 +3,9 @@ use std::sync::{Arc, Mutex};
 
 use pocopine_auth::RequestContext;
 use pocopine_sync::{
-    MutationId, RowKey, RowVersion, SyncBoxFuture, SyncCollectionName, SyncConflict, SyncError,
-    SyncOp, SyncPullRequest, SyncPullResponse, SyncPushRequest, SyncPushResponse,
-    SyncRejectedMutation, SyncResult, SyncRow, SyncStreamName, SyncStreamSource,
+    default_schema_version_one, MutationId, RowKey, RowVersion, SyncBoxFuture, SyncCollectionName,
+    SyncConflict, SyncError, SyncOp, SyncPullRequest, SyncPullResponse, SyncPushRequest,
+    SyncPushResponse, SyncRejectedMutation, SyncResult, SyncRow, SyncStreamName, SyncStreamSource,
 };
 use serde::Serialize;
 use serde_json::Value;
@@ -32,7 +32,10 @@ where
         collection: SyncCollectionName::new(name)?,
         source,
         max_snapshot_rows: DEFAULT_CRUD_SNAPSHOT_ROW_LIMIT,
-        schema_version: 1,
+        // Pull the default from one source-of-truth: future changes to
+        // the wire/trait default (e.g. switching to an `Option<u32>`
+        // 'unspecified' sentinel) propagate here without a separate edit.
+        schema_version: default_schema_version_one(),
     })
 }
 
@@ -71,7 +74,7 @@ where
     pub fn schema_version(mut self, version: u32) -> SyncResult<Self> {
         if version == 0 {
             return Err(SyncError::client(
-                "CRUD schema_version must be >= 1 (schema versions start at 1)",
+                "schema_version must be >= 1 (schema versions start at 1)",
             ));
         }
         self.schema_version = version;
@@ -1620,6 +1623,75 @@ mod tests {
             SyncStreamName::new("posts").unwrap(),
             mutations.into_iter().map(value_mutation),
         )
+    }
+
+    #[test]
+    fn resource_defaults_schema_version_to_one() {
+        let r = posts_resource(Posts::default());
+        // SyncStreamSource::schema_version flows through every wrapping
+        // layer (builder -> .id -> .version -> .memory_mutation_log).
+        assert_eq!(
+            <CrudResource<_, _, _, _> as SyncStreamSource>::schema_version(&r),
+            1
+        );
+    }
+
+    #[test]
+    fn resource_builder_propagates_explicit_schema_version() {
+        // Set a non-default version, then walk the full wrapping chain
+        // (.id -> .version -> .memory_mutation_log) and assert the
+        // SyncStreamSource impl returns it. A regression that drops the
+        // `schema_version: self.schema_version` propagation from any
+        // single constructor would silently revert this to 1 — this
+        // test pins the contract.
+        let r = resource("posts", Posts::default())
+            .unwrap()
+            .schema_version(7)
+            .unwrap()
+            .id(|post: &Post| post.id.clone())
+            .version(|post: &Post| post.version)
+            .memory_mutation_log();
+        assert_eq!(
+            <CrudResource<_, _, _, _> as SyncStreamSource>::schema_version(&r),
+            7
+        );
+    }
+
+    #[test]
+    fn transactional_resource_propagates_explicit_schema_version() {
+        // Same end-to-end propagation test, but through the
+        // transactional path (.transactional consumes a CrudResource).
+        let harness = TxHarness::default();
+        let r = resource("posts", harness.clone())
+            .unwrap()
+            .schema_version(11)
+            .unwrap()
+            .id(|post: &Post| post.id.clone())
+            .version(|post: &Post| post.version)
+            .transactional(harness.clone(), harness);
+        assert_eq!(
+            <TransactionalCrudResource<_, _, _, _, _> as SyncStreamSource>::schema_version(&r),
+            11
+        );
+    }
+
+    #[test]
+    fn resource_builder_rejects_zero_schema_version() {
+        let result = resource("posts", Posts::default())
+            .unwrap()
+            .schema_version(0);
+        match result {
+            Ok(_) => panic!("expected error for schema_version=0"),
+            Err(err) => {
+                // Matches the macro's parser-time error message exactly
+                // so grep / docs / error-catalog tooling sees one
+                // canonical wording for the same logical failure.
+                assert!(
+                    err.to_string().contains("schema_version must be >= 1"),
+                    "unexpected error: {err}"
+                );
+            }
+        }
     }
 
     #[tokio::test]

--- a/crates/pocopine-sync/src/client.rs
+++ b/crates/pocopine-sync/src/client.rs
@@ -1256,9 +1256,15 @@ fn open_live_wakeup<C, T>(
     }
 }
 
-#[cfg(target_arch = "wasm32")]
+// The function body is pure (no fetch / no DOM); we compile it on
+// host targets too so the test module below can exercise the new
+// domain checks. Production callers live in the wasm-only
+// `start_open_then_pull`, so on host outside tests this is dead-code
+// and warned-as-error by `-D warnings`; the cfg below mirrors the
+// trybuild pattern of "wasm prod OR host test".
+#[cfg(any(target_arch = "wasm32", test))]
 fn validate_open_response(
-    response: SyncOpenResponse,
+    response: crate::SyncOpenResponse,
     stream: &SyncStreamName,
 ) -> Result<u32, pocopine_core::ServerError> {
     if response.protocol != crate::SYNC_PROTOCOL_V1 {
@@ -1268,17 +1274,38 @@ fn validate_open_response(
         )));
     }
 
-    if let Some(accepted) = response
+    // Reject a server that lists the same stream twice. The match is
+    // load-bearing for cache invalidation in Batch 2 — picking the
+    // first arbitrarily on duplicates would let a buggy server pin the
+    // client to a stale schema_version.
+    let matches: Vec<&crate::SyncOpenStream> = response
         .streams
         .iter()
-        .find(|accepted| accepted.stream == *stream)
-    {
-        Ok(accepted.schema_version)
-    } else {
-        Err(pocopine_core::ServerError::Forbidden(format!(
-            "sync stream was not opened: {stream}"
-        )))
+        .filter(|accepted| accepted.stream == *stream)
+        .collect();
+    let accepted = match matches.as_slice() {
+        [] => {
+            return Err(pocopine_core::ServerError::Forbidden(format!(
+                "sync stream was not opened: {stream}"
+            )));
+        }
+        [one] => *one,
+        _ => {
+            return Err(pocopine_core::ServerError::BadRequest(format!(
+                "server returned duplicate open entries for stream: {stream}"
+            )));
+        }
+    };
+    // Enforce the same `>= 1` invariant the macro + builder enforce on
+    // the producing side. A buggy/malicious server advertising 0 would
+    // otherwise collide with the planned `Option<u32>::None ==
+    // 'never observed'` sentinel in Batch 2's cache-version compare.
+    if accepted.schema_version == 0 {
+        return Err(pocopine_core::ServerError::BadRequest(format!(
+            "server advertised schema_version=0 for stream {stream}: versions start at 1"
+        )));
     }
+    Ok(accepted.schema_version)
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -1926,7 +1953,8 @@ mod tests {
     use super::*;
     use crate::{
         ClientMutationDraft, CollectionState, LocalSnapshotBatch, MemoryLocalStore, RowKey,
-        SyncCollectionName, SyncDeviceId, SyncLocalIdentity, SyncOp, SyncRow,
+        SyncCollectionName, SyncDeviceId, SyncLocalIdentity, SyncOp, SyncOpenResponse,
+        SyncOpenStream, SyncRow,
     };
 
     #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -2130,6 +2158,72 @@ mod tests {
         // Host stub: should not panic, returns a guard, dropping is fine.
         let guard = client.watch_sign_outs(|| {});
         drop(guard);
+    }
+
+    #[test]
+    fn validate_open_response_rejects_zero_schema_version() {
+        // Wire defense — symmetric with macro + builder which both
+        // reject 0. A buggy server advertising 0 would otherwise pin
+        // the client to an invalid version that collides with future
+        // sentinel encodings.
+        let stream = SyncStreamName::new("posts").unwrap();
+        let mut response = SyncOpenResponse::new(vec![SyncOpenStream {
+            stream: stream.clone(),
+            collection: SyncCollectionName::new("posts").unwrap(),
+            cursor: None,
+            schema_version: 0,
+        }]);
+        // Sanity: protocol field is already set by `new`.
+        response.protocol = crate::SYNC_PROTOCOL_V1.to_string();
+        let err = validate_open_response(response, &stream).unwrap_err();
+        match err {
+            pocopine_core::ServerError::BadRequest(msg) => {
+                assert!(msg.contains("schema_version=0"), "unexpected error: {msg}");
+            }
+            other => panic!("expected BadRequest, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_open_response_rejects_duplicate_stream_entries() {
+        // Wire defense — a duplicate stream entry would make the
+        // version-pick ambiguous; reject rather than silently pick the
+        // first.
+        let stream = SyncStreamName::new("posts").unwrap();
+        let response = SyncOpenResponse::new(vec![
+            SyncOpenStream {
+                stream: stream.clone(),
+                collection: SyncCollectionName::new("posts").unwrap(),
+                cursor: None,
+                schema_version: 2,
+            },
+            SyncOpenStream {
+                stream: stream.clone(),
+                collection: SyncCollectionName::new("posts").unwrap(),
+                cursor: None,
+                schema_version: 1,
+            },
+        ]);
+        let err = validate_open_response(response, &stream).unwrap_err();
+        match err {
+            pocopine_core::ServerError::BadRequest(msg) => {
+                assert!(msg.contains("duplicate"), "unexpected error: {msg}");
+            }
+            other => panic!("expected BadRequest, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn validate_open_response_accepts_advertised_schema_version() {
+        let stream = SyncStreamName::new("posts").unwrap();
+        let response = SyncOpenResponse::new(vec![SyncOpenStream {
+            stream: stream.clone(),
+            collection: SyncCollectionName::new("posts").unwrap(),
+            cursor: None,
+            schema_version: 3,
+        }]);
+        let v = validate_open_response(response, &stream).unwrap();
+        assert_eq!(v, 3);
     }
 }
 

--- a/crates/pocopine-sync/src/client.rs
+++ b/crates/pocopine-sync/src/client.rs
@@ -1088,12 +1088,18 @@ fn start_open_then_pull<C, T>(
         if epoch.is_stale() {
             return;
         }
-        if let Err(err) = open_result.and_then(|response| validate_open_response(response, &stream))
-        {
-            handle.update(|state| {
-                selector(state).apply_error(token, err);
-            });
-            return;
+        // Capture the advertised schema_version. Batch 2 will compare this
+        // against the cached value and clear the stream on mismatch; for
+        // Batch 1 we just receive it (and the `_` silences the unused-var
+        // lint until the next batch wires it up).
+        match open_result.and_then(|response| validate_open_response(response, &stream)) {
+            Ok(_advertised_schema_version) => {}
+            Err(err) => {
+                handle.update(|state| {
+                    selector(state).apply_error(token, err);
+                });
+                return;
+            }
         }
 
         if let Some(live_wakeup) = live_wakeup {
@@ -1254,7 +1260,7 @@ fn open_live_wakeup<C, T>(
 fn validate_open_response(
     response: SyncOpenResponse,
     stream: &SyncStreamName,
-) -> Result<(), pocopine_core::ServerError> {
+) -> Result<u32, pocopine_core::ServerError> {
     if response.protocol != crate::SYNC_PROTOCOL_V1 {
         return Err(pocopine_core::ServerError::BadRequest(format!(
             "unsupported sync protocol: {}",
@@ -1262,12 +1268,12 @@ fn validate_open_response(
         )));
     }
 
-    if response
+    if let Some(accepted) = response
         .streams
         .iter()
-        .any(|accepted| accepted.stream == *stream)
+        .find(|accepted| accepted.stream == *stream)
     {
-        Ok(())
+        Ok(accepted.schema_version)
     } else {
         Err(pocopine_core::ServerError::Forbidden(format!(
             "sync stream was not opened: {stream}"

--- a/crates/pocopine-sync/src/error.rs
+++ b/crates/pocopine-sync/src/error.rs
@@ -32,13 +32,15 @@ pub enum SyncError {
     /// version for a stream, and the source has not registered a migrator
     /// that can bridge the two.
     ///
-    /// Returned by `SyncStreamSource::migrate_payload` (default impl) when a
-    /// push arrives carrying an older `schema_version` than the source
-    /// advertises; the framework can also surface this on the client when
-    /// cached rows can't be rehydrated against the new schema. Surfaces as
-    /// `ServerError::BadRequest` on the wire so the client knows the
-    /// mutation will never accept and should be dropped (or retried after
-    /// re-encoding against the new shape).
+    /// Surfaces as `ServerError::BadRequest` on the wire so the client
+    /// knows the mutation will never accept and should be dropped (or
+    /// retried after re-encoding against the new shape). The follow-up
+    /// batches will return this from a `SyncStreamSource::migrate_payload`
+    /// default impl on the server side when a push arrives carrying an
+    /// older `schema_version` than the source advertises, and from the
+    /// client when cached rows can't be rehydrated against the new
+    /// schema. The variant is introduced here so downstream callers can
+    /// already typecheck against it.
     SchemaMigration { stream: String, from: u32, to: u32 },
 }
 

--- a/crates/pocopine-sync/src/error.rs
+++ b/crates/pocopine-sync/src/error.rs
@@ -28,6 +28,18 @@ pub enum SyncError {
     /// Surfaces as `ServerError::Unauthorized` so the wire response and
     /// the existing framework-level guard responses share one shape.
     Unauthorized(String),
+    /// The client and server disagree on the application-level schema
+    /// version for a stream, and the source has not registered a migrator
+    /// that can bridge the two.
+    ///
+    /// Returned by `SyncStreamSource::migrate_payload` (default impl) when a
+    /// push arrives carrying an older `schema_version` than the source
+    /// advertises; the framework can also surface this on the client when
+    /// cached rows can't be rehydrated against the new schema. Surfaces as
+    /// `ServerError::BadRequest` on the wire so the client knows the
+    /// mutation will never accept and should be dropped (or retried after
+    /// re-encoding against the new shape).
+    SchemaMigration { stream: String, from: u32, to: u32 },
 }
 
 impl SyncError {
@@ -58,6 +70,16 @@ impl SyncError {
     pub fn unauthorized(msg: impl Into<String>) -> Self {
         Self::Unauthorized(msg.into())
     }
+
+    /// Build a schema-version mismatch error for a stream. Maps to
+    /// `ServerError::BadRequest` on the wire.
+    pub fn schema_migration(stream: impl Into<String>, from: u32, to: u32) -> Self {
+        Self::SchemaMigration {
+            stream: stream.into(),
+            from,
+            to,
+        }
+    }
 }
 
 impl fmt::Display for SyncError {
@@ -73,6 +95,10 @@ impl fmt::Display for SyncError {
             Self::Client(msg) => write!(f, "sync client error: {msg}"),
             Self::Backend(msg) => write!(f, "sync backend error: {msg}"),
             Self::Unauthorized(msg) => write!(f, "sync unauthorized: {msg}"),
+            Self::SchemaMigration { stream, from, to } => write!(
+                f,
+                "sync schema migration required for stream {stream}: client at v{from}, server at v{to}"
+            ),
         }
     }
 }

--- a/crates/pocopine-sync/src/lib.rs
+++ b/crates/pocopine-sync/src/lib.rs
@@ -26,9 +26,9 @@ pub use local_store::{
     SyncLocalIdentity, SyncLocalStore,
 };
 pub use protocol::{
-    sync_stream_tag, ClientMutation, ClientMutationDraft, MutationId, RowKey, RowVersion,
-    SyncChange, SyncCollectionName, SyncConflict, SyncCursor, SyncDeviceId, SyncOp,
-    SyncOpenRequest, SyncOpenResponse, SyncOpenStream, SyncPullMode, SyncPullRequest,
+    default_schema_version_one, sync_stream_tag, ClientMutation, ClientMutationDraft, MutationId,
+    RowKey, RowVersion, SyncChange, SyncCollectionName, SyncConflict, SyncCursor, SyncDeviceId,
+    SyncOp, SyncOpenRequest, SyncOpenResponse, SyncOpenStream, SyncPullMode, SyncPullRequest,
     SyncPullResponse, SyncPushRequest, SyncPushResponse, SyncRejectedMutation, SyncRow,
     SyncSessionId, SyncStreamName, MAX_SYNC_TOKEN_LEN, SYNC_ENDPOINT_PREFIX, SYNC_OPEN_PATH,
     SYNC_PROTOCOL_V1, SYNC_PULL_PATH, SYNC_PUSH_PATH,

--- a/crates/pocopine-sync/src/protocol.rs
+++ b/crates/pocopine-sync/src/protocol.rs
@@ -260,6 +260,23 @@ pub struct SyncOpenStream {
     pub stream: SyncStreamName,
     pub collection: SyncCollectionName,
     pub cursor: Option<SyncCursor>,
+    /// Application-level schema version the server is serving for this
+    /// stream. Authors declare it via `#[resource(schema_version = N)]`
+    /// (or directly on `SyncStreamSource::schema_version`); the client
+    /// compares against its cached value to decide whether the local cache
+    /// is still valid. The `#[serde(default)]` makes the wire field
+    /// backwards-compatible: an old server response without the field
+    /// deserializes as `1`, and an old client reading a field-bearing
+    /// response just ignores it (serde drops unknown fields).
+    #[serde(default = "default_schema_version_one")]
+    pub schema_version: u32,
+}
+
+/// Default schema version when the wire field is missing or the source
+/// doesn't override the trait default. `1` means "first version of the
+/// schema" — apps that have never bumped never observe this field.
+pub fn default_schema_version_one() -> u32 {
+    1
 }
 
 /// Open response.

--- a/crates/pocopine-sync/src/server.rs
+++ b/crates/pocopine-sync/src/server.rs
@@ -597,16 +597,13 @@ mod tests {
     #[test]
     fn open_response_without_schema_version_field_deserializes_as_one() {
         // Backwards-compat: an old server response that omits the field
-        // must round-trip through serde with schema_version = 1.
-        let payload = serde_json::json!({
-            "protocol": SYNC_PROTOCOL_V1,
-            "streams": [{
-                "stream": "posts_for_tenant",
-                "collection": "posts",
-                "cursor": null,
-            }],
-        });
-        let response: SyncOpenResponse = serde_json::from_value(payload).unwrap();
+        // must round-trip through serde with schema_version = 1. Use a
+        // literal JSON string (not the `json!{}` macro) so the test
+        // exercises the actual wire-deserialization path.
+        let payload = format!(
+            r#"{{"protocol":"{SYNC_PROTOCOL_V1}","streams":[{{"stream":"posts_for_tenant","collection":"posts","cursor":null}}]}}"#
+        );
+        let response: SyncOpenResponse = serde_json::from_str(&payload).unwrap();
         assert_eq!(response.streams[0].schema_version, 1);
     }
 

--- a/crates/pocopine-sync/src/server.rs
+++ b/crates/pocopine-sync/src/server.rs
@@ -73,6 +73,23 @@ pub trait SyncStreamSource: Send + Sync + 'static {
         None
     }
 
+    /// Application-level schema version for this stream's row/draft shape.
+    ///
+    /// Bump this whenever the row, draft, or payload shape changes in a way
+    /// that older cached data or queued mutations cannot deserialize into.
+    /// The version is advertised on every `/open` response so the client
+    /// can detect mismatches and either drop its cache + queue (default
+    /// from `SyncLocalStore::clear_stream`) or migrate via the opt-in
+    /// `migrate_payload` path on this trait (shipping in a follow-up).
+    ///
+    /// Defaults to `1` — apps that never bump never need to think about
+    /// this. Authors using `#[resource]` set this through the
+    /// `schema_version = N` attribute; bare `SyncStreamSource` impls
+    /// override this method directly.
+    fn schema_version(&self) -> u32 {
+        crate::protocol::default_schema_version_one()
+    }
+
     /// Pull changes or a snapshot for this stream.
     fn pull<'a>(
         &'a self,
@@ -298,6 +315,7 @@ async fn open(
             stream: stream.source.stream().clone(),
             collection: stream.source.collection().clone(),
             cursor: stream.source.current_cursor(&ctx),
+            schema_version: stream.source.schema_version(),
         });
     }
     Ok(SyncOpenResponse::new(streams))
@@ -373,6 +391,7 @@ fn server_error(error: SyncError) -> ServerError {
         SyncError::UnknownStream(_) => ServerError::Forbidden(error.to_string()),
         SyncError::Unsupported(_) => ServerError::BadRequest(error.to_string()),
         SyncError::Gap(_) => ServerError::BadRequest(error.to_string()),
+        SyncError::SchemaMigration { .. } => ServerError::BadRequest(error.to_string()),
         SyncError::Unauthorized(msg) => ServerError::Unauthorized(msg),
         SyncError::Json(err) => {
             tracing::error!(target: "pocopine.log", error = %err, "sync json error");
@@ -547,6 +566,48 @@ mod tests {
             server_error(SyncError::Json(json_err)),
             ServerError::App(message) if message == "sync internal error"
         ));
+    }
+
+    #[test]
+    fn schema_migration_error_maps_to_bad_request() {
+        let err = server_error(SyncError::schema_migration("posts", 1, 2));
+        match err {
+            ServerError::BadRequest(msg) => {
+                assert!(msg.contains("posts"), "unexpected message: {msg}");
+                assert!(msg.contains("v1"), "missing from-version: {msg}");
+                assert!(msg.contains("v2"), "missing to-version: {msg}");
+            }
+            other => panic!("expected BadRequest, got: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn open_response_includes_schema_version_from_source() {
+        // Default MemorySyncStream returns schema_version = 1 via the
+        // trait default. The wire response should carry that explicitly.
+        let router = router_with_posts_stream();
+        let open = SyncOpenRequest::new([SyncStreamName::new("posts_for_tenant").unwrap()]);
+        let opened: SyncOpenResponse = post_json(router, SYNC_OPEN_PATH, &open, None)
+            .await
+            .unwrap();
+        assert_eq!(opened.streams.len(), 1);
+        assert_eq!(opened.streams[0].schema_version, 1);
+    }
+
+    #[test]
+    fn open_response_without_schema_version_field_deserializes_as_one() {
+        // Backwards-compat: an old server response that omits the field
+        // must round-trip through serde with schema_version = 1.
+        let payload = serde_json::json!({
+            "protocol": SYNC_PROTOCOL_V1,
+            "streams": [{
+                "stream": "posts_for_tenant",
+                "collection": "posts",
+                "cursor": null,
+            }],
+        });
+        let response: SyncOpenResponse = serde_json::from_value(payload).unwrap();
+        assert_eq!(response.streams[0].schema_version, 1);
     }
 
     fn router_with_posts_stream() -> pocopine_server::axum::Router {

--- a/crates/pocopine-sync/tests/client_browser.rs
+++ b/crates/pocopine-sync/tests/client_browser.rs
@@ -190,6 +190,7 @@ async fn open_validates_stream_then_pull_renders_snapshot() {
                             stream: SyncStreamName::new(STREAM).unwrap(),
                             collection: SyncCollectionName::new(COLLECTION).unwrap(),
                             cursor: None,
+                            schema_version: 1,
                         }]);
                         Ok(json_response(response))
                     }
@@ -298,6 +299,7 @@ async fn open_hydrates_local_store_and_pulls_from_cached_cursor() {
                             stream: SyncStreamName::new(STREAM).unwrap(),
                             collection: SyncCollectionName::new(COLLECTION).unwrap(),
                             cursor: None,
+                            schema_version: 1,
                         }]);
                         Ok(json_response(response))
                     }
@@ -426,6 +428,7 @@ async fn open_replays_pending_mutations_before_pull() {
                             stream: SyncStreamName::new(STREAM).unwrap(),
                             collection: SyncCollectionName::new(COLLECTION).unwrap(),
                             cursor: None,
+                            schema_version: 1,
                         }])))
                     }
                     SYNC_PUSH_PATH => {
@@ -587,6 +590,7 @@ async fn open_keeps_hydrated_pending_overlay_when_replay_fails() {
                             stream: SyncStreamName::new(STREAM).unwrap(),
                             collection: SyncCollectionName::new(COLLECTION).unwrap(),
                             cursor: None,
+                            schema_version: 1,
                         }])))
                     }
                     SYNC_PUSH_PATH => {


### PR DESCRIPTION
Closes #124. Part 1 of 3 implementing gap #1 from \`docs/sync-local-first-gaps.md\` (Axis 1). Plan in \`~/.claude/plans/lazy-dreaming-pizza.md\`; gap-analysis doc at #123.

## Summary

Lights up the contract surface every subsequent batch consumes. **No behaviour change for existing apps** — \`schema_version\` defaults to \`1\` everywhere and the wire field is \`#[serde(default)]\` so old clients/servers interop cleanly with new ones.

## What ships

- **Protocol:** \`SyncOpenStream.schema_version: u32\` — server advertises per-stream on every \`/open\`. Wire field is backwards-compatible via \`#[serde(default)]\`.
- **Server contract:** \`SyncStreamSource::schema_version(&self) -> u32\` trait method, default impl returns \`1\`. \`open_handler\` threads through into the response.
- **Client contract:** \`validate_open_response\` returns \`Result<u32, ServerError>\` — the u32 is the advertised version. Batch 2 will compare against the cached value; Batch 1 just captures.
- **Error variant:** \`SyncError::SchemaMigration { stream, from, to }\` surfaces as \`ServerError::BadRequest\`.
- **Macro:** \`#[resource(schema_version = N)]\` attribute (defaults to \`1\`, rejects \`0\` and non-integer literals).
- **CRUD adapter:** \`CrudResourceBuilder::schema_version(u32)\` builder method; threaded through \`CrudResource\` + \`TransactionalCrudResource\`.

## Tests

- \`schema_migration_error_maps_to_bad_request\` — variant + Display contents through \`server_error\`.
- \`open_response_includes_schema_version_from_source\` — wire-format end-to-end via the existing test router.
- \`open_response_without_schema_version_field_deserializes_as_one\` — serde backward-compat for old server responses missing the field.
- 4 new macro attribute parser tests (parse v3, reject 0, reject non-integer, reject duplicate).
- Existing trybuild stderrs updated for the broadened error message.

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy -p pocopine-sync -p pocopine-sync-sqlite -p pocopine-sync-indexdb -p pocopine-sync-crud -p pocopine-sync-crud-macros -p pocopine-sync-sqlx --all-targets -- -D warnings\` clean
- [x] Same \`--target wasm32-unknown-unknown\` clean
- [x] \`cargo test -p pocopine-sync -p pocopine-sync-crud --lib\` — 110 + 52 pass
- [x] \`cargo test -p pocopine-sync-crud --test tenant_boundary --test resource_server\` — 4 pass
- [x] \`cargo test -p pocopine-sync-crud-macros --tests\` (trybuild) — 1 pass