### PR TITLE
sync: schema versioning — Batch 2 — local cache invalidation on schema mismatch

### DIFF
--- a/crates/pocopine-sync-indexdb/src/native.rs
+++ b/crates/pocopine-sync-indexdb/src/native.rs
@@ -108,6 +108,10 @@ impl SyncLocalStore for IndexedDbLocalStore {
     fn clear_all_streams(&self) -> SyncLocalFuture<'_, ()> {
         Self::unsupported()
     }
+
+    fn clear_stream(&self, _stream: &SyncStreamName) -> SyncLocalFuture<'_, ()> {
+        Self::unsupported()
+    }
 }
 
 fn validate_database_name(database_name: String) -> SyncResult<String> {

--- a/crates/pocopine-sync-indexdb/src/wasm.rs
+++ b/crates/pocopine-sync-indexdb/src/wasm.rs
@@ -178,6 +178,12 @@ impl SyncLocalStore for IndexedDbLocalStore {
         let database_name = self.database_name.clone();
         self.run(clear_all_streams(database_name))
     }
+
+    fn clear_stream(&self, stream: &SyncStreamName) -> SyncLocalFuture<'_, ()> {
+        let database_name = self.database_name.clone();
+        let stream = stream.clone();
+        self.run(clear_stream(database_name, stream))
+    }
 }
 
 async fn load_identity(database_name: String) -> SyncResult<Option<SyncLocalIdentity>> {
@@ -245,6 +251,13 @@ async fn save_snapshot(database_name: String, snapshot: LocalSnapshotBatch) -> S
     state.collection = Some(snapshot.collection);
     state.cursor = snapshot.cursor;
     state.rows = sorted_rows(snapshot.rows);
+    // Only overwrite when the caller carries a value; passing `None`
+    // from a code path that hasn't observed the advertised version yet
+    // must not clobber a previously recorded value. Mirrors the
+    // `coalesce(...)` in the SQLite UPSERT.
+    if let Some(version) = snapshot.application_schema_version {
+        state.application_schema_version = Some(version);
+    }
     put_stream_state(&store, &state).await?;
     await_transaction(done).await?;
     database.close();
@@ -400,6 +413,27 @@ async fn clear_all_streams(database_name: String) -> SyncResult<()> {
     let done = transaction_done(&transaction);
     let store = transaction.object_store(STREAMS_STORE).map_err(js_error)?;
     store.clear().map_err(js_error)?;
+    await_transaction(done).await?;
+    database.close();
+    Ok(())
+}
+
+/// Drop the per-stream record from the IndexedDB streams object
+/// store. The serialized `LocalStreamSnapshot` carries the stream's
+/// rows, cursor, pending mutations, and `application_schema_version`
+/// in one IDB row, so deleting that row wipes everything for the
+/// stream in one atomic IDB transaction. Other streams + the meta
+/// store (device identity) are untouched. Safe to call on a
+/// never-persisted stream — `IdbObjectStore::delete` on a missing key
+/// is a successful no-op.
+async fn clear_stream(database_name: String, stream: SyncStreamName) -> SyncResult<()> {
+    let database = open_database(&database_name).await?;
+    let transaction = transaction(&database, STREAMS_STORE, IdbTransactionMode::Readwrite)?;
+    let done = transaction_done(&transaction);
+    let store = transaction.object_store(STREAMS_STORE).map_err(js_error)?;
+    store
+        .delete(&JsValue::from_str(stream.as_str()))
+        .map_err(js_error)?;
     await_transaction(done).await?;
     database.close();
     Ok(())

--- a/crates/pocopine-sync-sqlite/src/native.rs
+++ b/crates/pocopine-sync-sqlite/src/native.rs
@@ -11,7 +11,7 @@ use pocopine_sync::{
     SyncCollectionName, SyncCursor, SyncDeviceId, SyncError, SyncLocalFuture, SyncLocalIdentity,
     SyncLocalStore, SyncOp, SyncResult, SyncRow, SyncStreamName,
 };
-use rusqlite::{params, Connection, OptionalExtension, Transaction};
+use rusqlite::{params, Connection, OptionalExtension, Transaction, TransactionBehavior};
 
 use crate::schema::{
     BOOTSTRAP_SQL, CLEAR_ALL_STREAMS_SQL, CLEAR_ROW_CONFLICT_SQL, CLEAR_STREAM_SQL,
@@ -202,6 +202,21 @@ fn migrate_schema(tx: &Transaction<'_>) -> SyncResult<()> {
             "invalid sync sqlite schema version in local store: {existing}"
         ))
     })?;
+    // Allow forward migration only from versions whose alter steps are
+    // explicitly implemented below. A v1 store predates the
+    // mutations-PK rewrite (v2's enqueue_seq autoincrement + mutation_id
+    // unique) which is not implemented here, so it must fall through
+    // to `validate_schema_version`'s reject path rather than being
+    // silently stamped as v4 (which would compile but explode at first
+    // `UPSERT_MUTATION_SQL`).
+    match version {
+        2 | 3 => {}
+        v if v == SCHEMA_VERSION => return Ok(()),
+        // Any other version (e.g. v1 or a future v5+) falls through to
+        // validate_schema_version which returns
+        // `incompatible sync sqlite schema version`.
+        _ => return Ok(()),
+    }
     // v2 -> v3: optimistic_row column on the mutations table.
     if version == 2 && !column_exists(tx, "__pocopine_mutations", "optimistic_row")? {
         tx.execute(
@@ -210,20 +225,17 @@ fn migrate_schema(tx: &Transaction<'_>) -> SyncResult<()> {
         )
         .map_err(sqlite_error)?;
     }
-    // v3 -> v4: app_schema_version column on the streams table.
+    // v3 -> v4 (also runs for v2 stores after the v2 -> v3 alter
+    // above): app_schema_version column on the streams table.
     // Existing rows observe `NULL`, which the client treats as "never
     // observed; adopt server value silently on next save" rather than
     // as a forced wipe — so this migration is non-destructive.
-    if version <= 3 && !column_exists(tx, "__pocopine_streams", "app_schema_version")? {
+    if !column_exists(tx, "__pocopine_streams", "app_schema_version")? {
         tx.execute(MIGRATION_V3_TO_V4_ADD_APP_SCHEMA_VERSION, [])
             .map_err(sqlite_error)?;
     }
     // Only stamp the new version when we actually migrated forward.
-    // A higher-than-current version (e.g. opened by a future build)
-    // must fall through to `validate_schema_version`'s reject path.
-    if version < SCHEMA_VERSION {
-        upsert_meta(tx, META_SCHEMA_VERSION, &SCHEMA_VERSION.to_string())?;
-    }
+    upsert_meta(tx, META_SCHEMA_VERSION, &SCHEMA_VERSION.to_string())?;
     Ok(())
 }
 
@@ -525,7 +537,13 @@ fn purge_pending_for_row(
 }
 
 fn clear_all_streams(conn: &mut Connection) -> SyncResult<()> {
-    let tx = conn.transaction().map_err(sqlite_error)?;
+    // BEGIN IMMEDIATE so we acquire the write lock up-front rather
+    // than upgrading mid-transaction. Matches the wasm path's
+    // `BEGIN IMMEDIATE TRANSACTION` so the documented atomicity story
+    // is the same on both targets.
+    let tx = conn
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error)?;
     for sql in CLEAR_ALL_STREAMS_SQL {
         tx.execute(sql, []).map_err(sqlite_error)?;
     }
@@ -536,7 +554,9 @@ fn clear_stream(conn: &mut Connection, stream: &SyncStreamName) -> SyncResult<()
     // BEGIN IMMEDIATE TRANSACTION mirrors `clear_all_streams` — a
     // mid-wipe failure must either revert entirely or complete
     // entirely so other tabs observing OPFS never see a partial wipe.
-    let tx = conn.transaction().map_err(sqlite_error)?;
+    let tx = conn
+        .transaction_with_behavior(TransactionBehavior::Immediate)
+        .map_err(sqlite_error)?;
     for sql in CLEAR_STREAM_SQL {
         tx.execute(sql, params![stream.as_str()])
             .map_err(sqlite_error)?;
@@ -1554,6 +1574,115 @@ mod tests {
     }
 
     #[test]
+    fn sqlite_store_rejects_v1_store_rather_than_silently_bumping_to_v4() {
+        // A v1 store predates the v1->v2 mutations-PK rewrite. The
+        // migrate_schema gate must NOT silently stamp it as v4 (which
+        // would compile but explode at first UPSERT_MUTATION_SQL
+        // because the v1 mutations table lacks `enqueue_seq` /
+        // `mutation_id UNIQUE`). Open must fail with an
+        // incompatible-schema-version error.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "create table __pocopine_meta (key text primary key, value text not null);
+             insert into __pocopine_meta (key, value) values ('schema_version', '1');",
+        )
+        .unwrap();
+
+        let err = match SqliteLocalStore::from_connection(conn) {
+            Ok(_) => panic!("v1 store should be rejected, not silently upgraded"),
+            Err(err) => err,
+        };
+        assert!(
+            err.to_string()
+                .contains("incompatible sync sqlite schema version"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn sqlite_store_migrates_v2_to_v4_chained() {
+        // v2 -> v3 (optimistic_row alter) AND v3 -> v4
+        // (app_schema_version alter) must both run for a v2 store. The
+        // single open call should produce a fully v4-shaped DB.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "create table __pocopine_meta (key text primary key, value text not null);
+             create table __pocopine_streams (
+                stream text primary key,
+                collection text not null,
+                cursor text,
+                schema_version integer not null,
+                updated_at_ms integer not null
+             );
+             create table __pocopine_rows (
+                stream text not null,
+                row_key text not null,
+                version text,
+                payload text not null,
+                pending integer not null default 0,
+                conflict integer not null default 0,
+                updated_at_ms integer not null,
+                primary key (stream, row_key)
+             );
+             create table __pocopine_mutations (
+                enqueue_seq integer primary key autoincrement,
+                stream text not null,
+                mutation_id text not null unique,
+                row_key text,
+                base_version text,
+                op text not null,
+                payload text,
+                status text not null,
+                error text,
+                created_at_ms integer not null,
+                updated_at_ms integer not null
+             );
+             insert into __pocopine_meta (key, value) values ('schema_version', '2');",
+        )
+        .unwrap();
+
+        let store = SqliteLocalStore::from_connection(conn).unwrap();
+        let stream = SyncStreamName::new("posts").unwrap();
+        // Round-trip: write a snapshot with a non-default schema_version,
+        // hydrate, and confirm both v2->v3 (optimistic_row works) and
+        // v3->v4 (app_schema_version recorded) are live.
+        block(
+            store.save_snapshot(
+                LocalSnapshotBatch::new(
+                    stream.clone(),
+                    SyncCollectionName::new("posts").unwrap(),
+                    vec![],
+                    None,
+                )
+                .with_application_schema_version(Some(9)),
+            ),
+        )
+        .unwrap();
+        let s = block(store.hydrate_stream(&stream)).unwrap();
+        assert_eq!(s.application_schema_version, Some(9));
+        // Enqueue a mutation carrying optimistic_row — exercises the
+        // v2->v3 alter.
+        block(
+            store.enqueue_pending_mutation(
+                &stream,
+                LocalPendingMutation::new(ClientMutation {
+                    id: MutationId::new("device_abc:1").unwrap(),
+                    key: Some(RowKey::new("p1").unwrap()),
+                    op: SyncOp::Upsert,
+                    base_version: None,
+                    payload: serde_json::json!({"op": "create"}),
+                })
+                .with_optimistic_row(Some(
+                    SyncRow::new("p1", serde_json::json!({"title": "p1"})).unwrap(),
+                )),
+            ),
+        )
+        .unwrap();
+        let s = block(store.hydrate_stream(&stream)).unwrap();
+        assert!(s.pending_mutations[0].optimistic_row.is_some());
+    }
+
+    #[test]
     fn sqlite_store_migrates_v3_to_v4_app_schema_version_column() {
         // Simulate a v3 store: explicitly create the tables with the
         // pre-v4 streams shape (no app_schema_version column), seed
@@ -1609,15 +1738,17 @@ mod tests {
         assert_eq!(s.application_schema_version, None);
 
         // Writing a snapshot with an explicit version stamps it.
-        block(store.save_snapshot(
-            LocalSnapshotBatch::new(
-                stream.clone(),
-                SyncCollectionName::new("posts").unwrap(),
-                vec![],
-                None,
-            )
-            .with_application_schema_version(Some(7)),
-        ))
+        block(
+            store.save_snapshot(
+                LocalSnapshotBatch::new(
+                    stream.clone(),
+                    SyncCollectionName::new("posts").unwrap(),
+                    vec![],
+                    None,
+                )
+                .with_application_schema_version(Some(7)),
+            ),
+        )
         .unwrap();
         let s = block(store.hydrate_stream(&stream)).unwrap();
         assert_eq!(s.application_schema_version, Some(7));

--- a/crates/pocopine-sync-sqlite/src/native.rs
+++ b/crates/pocopine-sync-sqlite/src/native.rs
@@ -14,9 +14,10 @@ use pocopine_sync::{
 use rusqlite::{params, Connection, OptionalExtension, Transaction};
 
 use crate::schema::{
-    BOOTSTRAP_SQL, CLEAR_ALL_STREAMS_SQL, CLEAR_ROW_CONFLICT_SQL, DELETE_MUTATION_SQL,
-    DELETE_PENDING_FOR_ROW_SQL, DELETE_ROW_SQL, DELETE_STREAM_ROWS_SQL, META_DEVICE_ID,
-    META_NEXT_MUTATION_COUNTER, META_SCHEMA_VERSION, SCHEMA_VERSION, SELECT_PENDING_MUTATIONS_SQL,
+    BOOTSTRAP_SQL, CLEAR_ALL_STREAMS_SQL, CLEAR_ROW_CONFLICT_SQL, CLEAR_STREAM_SQL,
+    DELETE_MUTATION_SQL, DELETE_PENDING_FOR_ROW_SQL, DELETE_ROW_SQL, DELETE_STREAM_ROWS_SQL,
+    META_DEVICE_ID, META_NEXT_MUTATION_COUNTER, META_SCHEMA_VERSION,
+    MIGRATION_V3_TO_V4_ADD_APP_SCHEMA_VERSION, SCHEMA_VERSION, SELECT_PENDING_MUTATIONS_SQL,
     SELECT_ROWS_SQL, SELECT_STREAM_SQL, UPDATE_ROW_CONFLICT_SQL, UPSERT_MUTATION_SQL,
     UPSERT_ROW_SQL, UPSERT_STREAM_SQL,
 };
@@ -136,6 +137,11 @@ impl SyncLocalStore for SqliteLocalStore {
     fn clear_all_streams(&self) -> SyncLocalFuture<'_, ()> {
         Self::ready(self.with_conn(clear_all_streams))
     }
+
+    fn clear_stream(&self, stream: &SyncStreamName) -> SyncLocalFuture<'_, ()> {
+        let stream = stream.clone();
+        Self::ready(self.with_conn(|conn| clear_stream(conn, &stream)))
+    }
 }
 
 fn bootstrap_schema(conn: &mut Connection) -> SyncResult<()> {
@@ -196,6 +202,7 @@ fn migrate_schema(tx: &Transaction<'_>) -> SyncResult<()> {
             "invalid sync sqlite schema version in local store: {existing}"
         ))
     })?;
+    // v2 -> v3: optimistic_row column on the mutations table.
     if version == 2 && !column_exists(tx, "__pocopine_mutations", "optimistic_row")? {
         tx.execute(
             "alter table __pocopine_mutations add column optimistic_row text",
@@ -203,7 +210,18 @@ fn migrate_schema(tx: &Transaction<'_>) -> SyncResult<()> {
         )
         .map_err(sqlite_error)?;
     }
-    if version == 2 {
+    // v3 -> v4: app_schema_version column on the streams table.
+    // Existing rows observe `NULL`, which the client treats as "never
+    // observed; adopt server value silently on next save" rather than
+    // as a forced wipe — so this migration is non-destructive.
+    if version <= 3 && !column_exists(tx, "__pocopine_streams", "app_schema_version")? {
+        tx.execute(MIGRATION_V3_TO_V4_ADD_APP_SCHEMA_VERSION, [])
+            .map_err(sqlite_error)?;
+    }
+    // Only stamp the new version when we actually migrated forward.
+    // A higher-than-current version (e.g. opened by a future build)
+    // must fall through to `validate_schema_version`'s reject path.
+    if version < SCHEMA_VERSION {
         upsert_meta(tx, META_SCHEMA_VERSION, &SCHEMA_VERSION.to_string())?;
     }
     Ok(())
@@ -294,14 +312,18 @@ fn hydrate_stream(
 ) -> SyncResult<LocalStreamSnapshot> {
     let stream_meta = conn
         .query_row(SELECT_STREAM_SQL, params![stream.as_str()], |row| {
-            Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
+            Ok((
+                row.get::<_, String>(0)?,
+                row.get::<_, Option<String>>(1)?,
+                row.get::<_, Option<u32>>(2)?,
+            ))
         })
         .optional()
         .map_err(sqlite_error)?;
 
     let rows = load_rows(conn, &stream)?;
     let pending_mutations = pending_mutation_records(conn, &stream)?;
-    let Some((collection, cursor)) = stream_meta else {
+    let Some((collection, cursor, application_schema_version)) = stream_meta else {
         if rows.is_empty() && pending_mutations.is_empty() {
             return Ok(LocalStreamSnapshot::empty(stream));
         }
@@ -312,6 +334,7 @@ fn hydrate_stream(
             cursor: None,
             rows,
             pending_mutations,
+            application_schema_version: None,
         });
     };
 
@@ -321,6 +344,7 @@ fn hydrate_stream(
         cursor: cursor.map(SyncCursor::new).transpose()?,
         rows,
         pending_mutations,
+        application_schema_version,
     })
 }
 
@@ -333,6 +357,7 @@ fn save_snapshot(conn: &mut Connection, snapshot: LocalSnapshotBatch) -> SyncRes
         &snapshot.collection,
         snapshot.cursor.as_ref(),
         now,
+        snapshot.application_schema_version,
     )?;
     tx.execute(DELETE_STREAM_ROWS_SQL, params![snapshot.stream.as_str()])
         .map_err(sqlite_error)?;
@@ -346,12 +371,16 @@ fn apply_changes(conn: &mut Connection, changes: LocalChangeBatch) -> SyncResult
     let tx = conn.transaction().map_err(sqlite_error)?;
     let now = epoch_ms();
     let stream = changes.stream;
+    // apply_changes doesn't carry an advertised schema_version (it's a
+    // post-open delta path), so pass None — the coalesce in the UPSERT
+    // preserves whatever value `save_snapshot` already recorded.
     upsert_stream(
         &tx,
         &stream,
         &changes.collection,
         changes.cursor.as_ref(),
         now,
+        None,
     )?;
     let changes = changes_after_last_reset(changes.changes);
     if changes.had_reset {
@@ -417,7 +446,14 @@ fn mark_push_result(conn: &mut Connection, result: LocalPushResult) -> SyncResul
     let now = epoch_ms();
 
     if let Some(collection) = result.collection.as_ref() {
-        upsert_stream(&tx, &result.stream, collection, result.cursor.as_ref(), now)?;
+        upsert_stream(
+            &tx,
+            &result.stream,
+            collection,
+            result.cursor.as_ref(),
+            now,
+            None,
+        )?;
     } else if let Some(cursor) = result.cursor.as_ref() {
         let updated = tx
             .execute(
@@ -492,6 +528,18 @@ fn clear_all_streams(conn: &mut Connection) -> SyncResult<()> {
     let tx = conn.transaction().map_err(sqlite_error)?;
     for sql in CLEAR_ALL_STREAMS_SQL {
         tx.execute(sql, []).map_err(sqlite_error)?;
+    }
+    tx.commit().map_err(sqlite_error)
+}
+
+fn clear_stream(conn: &mut Connection, stream: &SyncStreamName) -> SyncResult<()> {
+    // BEGIN IMMEDIATE TRANSACTION mirrors `clear_all_streams` — a
+    // mid-wipe failure must either revert entirely or complete
+    // entirely so other tabs observing OPFS never see a partial wipe.
+    let tx = conn.transaction().map_err(sqlite_error)?;
+    for sql in CLEAR_STREAM_SQL {
+        tx.execute(sql, params![stream.as_str()])
+            .map_err(sqlite_error)?;
     }
     tx.commit().map_err(sqlite_error)
 }
@@ -591,7 +639,13 @@ fn upsert_stream(
     collection: &SyncCollectionName,
     cursor: Option<&SyncCursor>,
     updated_at_ms: i64,
+    application_schema_version: Option<u32>,
 ) -> SyncResult<()> {
+    // The UPSERT uses `coalesce(excluded.app_schema_version,
+    // __pocopine_streams.app_schema_version)` so passing `None` here
+    // doesn't clobber a previously recorded value. The storage-level
+    // `schema_version` column at ?4 still records this constant for
+    // historical reasons.
     tx.execute(
         UPSERT_STREAM_SQL,
         params![
@@ -600,6 +654,7 @@ fn upsert_stream(
             cursor.map(SyncCursor::as_str),
             SCHEMA_VERSION,
             updated_at_ms,
+            application_schema_version,
         ],
     )
     .map_err(sqlite_error)?;
@@ -1436,6 +1491,165 @@ mod tests {
         let surviving_identity = block(reopened.load_identity()).unwrap().unwrap();
         assert_eq!(surviving_identity.device_id.as_str(), "device_abc");
         assert_eq!(surviving_identity.next_mutation_counter, 17);
+    }
+
+    #[test]
+    fn sqlite_clear_stream_wipes_one_stream_and_leaves_others_intact() {
+        let path = tempfile::NamedTempFile::new().unwrap().into_temp_path();
+        let store = SqliteLocalStore::open_path(&path).unwrap();
+        let posts = SyncStreamName::new("posts").unwrap();
+        let comments = SyncStreamName::new("comments").unwrap();
+
+        block(
+            store.save_snapshot(
+                LocalSnapshotBatch::new(
+                    posts.clone(),
+                    SyncCollectionName::new("posts").unwrap(),
+                    vec![SyncRow::new("p1", serde_json::json!({"t": "p1"})).unwrap()],
+                    Some(SyncCursor::new("cp").unwrap()),
+                )
+                .with_application_schema_version(Some(3)),
+            ),
+        )
+        .unwrap();
+        block(
+            store.save_snapshot(
+                LocalSnapshotBatch::new(
+                    comments.clone(),
+                    SyncCollectionName::new("comments").unwrap(),
+                    vec![SyncRow::new("c1", serde_json::json!({"b": "hi"})).unwrap()],
+                    Some(SyncCursor::new("cc").unwrap()),
+                )
+                .with_application_schema_version(Some(2)),
+            ),
+        )
+        .unwrap();
+        block(store.enqueue_mutation(
+            &posts,
+            ClientMutation {
+                id: MutationId::new("device_abc:1").unwrap(),
+                key: Some(RowKey::new("p1").unwrap()),
+                op: SyncOp::Upsert,
+                base_version: None,
+                payload: serde_json::json!({"t": "edit"}),
+            },
+        ))
+        .unwrap();
+
+        block(store.clear_stream(&posts)).unwrap();
+
+        // Drop + reopen against the same file to prove durability of
+        // the per-stream wipe.
+        drop(store);
+        let reopened = SqliteLocalStore::open_path(&path).unwrap();
+        let posts_after = block(reopened.hydrate_stream(&posts)).unwrap();
+        let comments_after = block(reopened.hydrate_stream(&comments)).unwrap();
+        assert!(posts_after.rows.is_empty());
+        assert!(posts_after.pending_mutations.is_empty());
+        assert!(posts_after.cursor.is_none());
+        assert!(posts_after.application_schema_version.is_none());
+        // Other stream untouched.
+        assert_eq!(comments_after.rows.len(), 1);
+        assert_eq!(comments_after.application_schema_version, Some(2));
+    }
+
+    #[test]
+    fn sqlite_store_migrates_v3_to_v4_app_schema_version_column() {
+        // Simulate a v3 store: explicitly create the tables with the
+        // pre-v4 streams shape (no app_schema_version column), seed
+        // schema_version=3, and verify open succeeds + the new column
+        // is added + existing rows observe NULL for app_schema_version.
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "create table __pocopine_meta (
+                key text primary key,
+                value text not null
+            );
+            create table __pocopine_streams (
+                stream text primary key,
+                collection text not null,
+                cursor text,
+                schema_version integer not null,
+                updated_at_ms integer not null
+            );
+            create table __pocopine_rows (
+                stream text not null,
+                row_key text not null,
+                version text,
+                payload text not null,
+                pending integer not null default 0,
+                conflict integer not null default 0,
+                updated_at_ms integer not null,
+                primary key (stream, row_key)
+            );
+            create table __pocopine_mutations (
+                enqueue_seq integer primary key autoincrement,
+                stream text not null,
+                mutation_id text not null unique,
+                row_key text,
+                base_version text,
+                op text not null,
+                payload text,
+                optimistic_row text,
+                status text not null,
+                error text,
+                created_at_ms integer not null,
+                updated_at_ms integer not null
+            );
+            insert into __pocopine_meta (key, value) values ('schema_version', '3');
+            insert into __pocopine_streams (stream, collection, cursor, schema_version, updated_at_ms)
+                values ('posts', 'posts', null, 3, 0);",
+        )
+        .unwrap();
+
+        let store = SqliteLocalStore::from_connection(conn).unwrap();
+        let stream = SyncStreamName::new("posts").unwrap();
+        // Existing row pre-migration → app_schema_version observes None.
+        let s = block(store.hydrate_stream(&stream)).unwrap();
+        assert_eq!(s.application_schema_version, None);
+
+        // Writing a snapshot with an explicit version stamps it.
+        block(store.save_snapshot(
+            LocalSnapshotBatch::new(
+                stream.clone(),
+                SyncCollectionName::new("posts").unwrap(),
+                vec![],
+                None,
+            )
+            .with_application_schema_version(Some(7)),
+        ))
+        .unwrap();
+        let s = block(store.hydrate_stream(&stream)).unwrap();
+        assert_eq!(s.application_schema_version, Some(7));
+    }
+
+    #[test]
+    fn sqlite_save_snapshot_records_and_preserves_application_schema_version() {
+        let store = SqliteLocalStore::open_in_memory().unwrap();
+        let stream = SyncStreamName::new("posts").unwrap();
+        block(
+            store.save_snapshot(
+                LocalSnapshotBatch::new(
+                    stream.clone(),
+                    SyncCollectionName::new("posts").unwrap(),
+                    vec![],
+                    None,
+                )
+                .with_application_schema_version(Some(5)),
+            ),
+        )
+        .unwrap();
+        // Save a second time WITHOUT the version — UPSERT's coalesce
+        // preserves the prior value.
+        block(store.save_snapshot(LocalSnapshotBatch::new(
+            stream.clone(),
+            SyncCollectionName::new("posts").unwrap(),
+            vec![],
+            None,
+        )))
+        .unwrap();
+        let s = block(store.hydrate_stream(&stream)).unwrap();
+        assert_eq!(s.application_schema_version, Some(5));
     }
 
     fn block<T>(future: SyncLocalFuture<'_, T>) -> SyncResult<T> {

--- a/crates/pocopine-sync-sqlite/src/schema.rs
+++ b/crates/pocopine-sync-sqlite/src/schema.rs
@@ -1,5 +1,17 @@
 /// Current Pocopine sync SQLite schema version.
-pub const SCHEMA_VERSION: u32 = 3;
+///
+/// History:
+/// * v3: added `__pocopine_mutations.optimistic_row` for optimistic row
+///   reconstruction after reload.
+/// * v4: added `__pocopine_streams.app_schema_version` for client-side
+///   cache invalidation on application-level schema bumps. The new
+///   column lives alongside the storage-level `schema_version` (which
+///   only records this constant for historical reasons); the two are
+///   distinct concepts. Existing v3 stores migrate in place via
+///   `ALTER TABLE … ADD COLUMN`; existing rows observe `NULL` and the
+///   client treats `NULL` as "never observed, adopt server value
+///   silently on next save" rather than as a forced wipe.
+pub const SCHEMA_VERSION: u32 = 4;
 
 /// Metadata table for device identity and internal settings.
 pub const META_TABLE: &str = "__pocopine_meta";
@@ -28,6 +40,7 @@ pub const BOOTSTRAP_SQL: &[&str] = &[
         collection text not null,
         cursor text,
         schema_version integer not null,
+        app_schema_version integer,
         updated_at_ms integer not null
     )",
     "create table if not exists __pocopine_rows (
@@ -60,14 +73,19 @@ pub const BOOTSTRAP_SQL: &[&str] = &[
         on __pocopine_mutations (stream, status, enqueue_seq)",
 ];
 
-/// SQL upsert used for stream cursor metadata.
+/// SQL upsert used for stream cursor metadata. `app_schema_version`
+/// (?6) is the APPLICATION-level schema version the server most
+/// recently advertised for this stream; `NULL` means "not yet
+/// observed". On conflict we use `coalesce(excluded, existing)` so a
+/// caller passing `NULL` doesn't clobber a previously-recorded value.
 pub const UPSERT_STREAM_SQL: &str = "insert into __pocopine_streams
-    (stream, collection, cursor, schema_version, updated_at_ms)
-    values (?1, ?2, ?3, ?4, ?5)
+    (stream, collection, cursor, schema_version, app_schema_version, updated_at_ms)
+    values (?1, ?2, ?3, ?4, ?6, ?5)
     on conflict(stream) do update set
         collection = excluded.collection,
         cursor = excluded.cursor,
         schema_version = excluded.schema_version,
+        app_schema_version = coalesce(excluded.app_schema_version, __pocopine_streams.app_schema_version),
         updated_at_ms = excluded.updated_at_ms";
 
 /// SQL statements used to clear one stream before saving a replacement snapshot.
@@ -146,9 +164,29 @@ pub const SELECT_ROWS_SQL: &str = "select row_key, version, payload, pending, co
     where stream = ?1
     order by row_key asc";
 
-/// SQL query used to hydrate stream metadata.
+/// SQL query used to hydrate stream metadata. Returns `NULL` for
+/// `app_schema_version` on rows that pre-date the v3→v4 migration —
+/// the client treats `NULL` as "never observed; adopt server value
+/// silently on next save" rather than as a forced wipe.
 pub const SELECT_STREAM_SQL: &str =
-    "select collection, cursor from __pocopine_streams where stream = ?1";
+    "select collection, cursor, app_schema_version from __pocopine_streams where stream = ?1";
+
+/// SQL statements used by `SyncLocalStore::clear_stream`. Drops every
+/// row, mutation queue entry, and the stream metadata row for ONE
+/// stream — leaving every other stream untouched. The order matters
+/// only for foreign-key-free correctness (none exists), but mirroring
+/// `CLEAR_ALL_STREAMS_SQL` (children before parent) keeps the
+/// behaviour reviewable.
+pub const CLEAR_STREAM_SQL: &[&str] = &[
+    "delete from __pocopine_mutations where stream = ?1",
+    "delete from __pocopine_rows where stream = ?1",
+    "delete from __pocopine_streams where stream = ?1",
+];
+
+/// SQL used by the v3 -> v4 migration to add the
+/// `app_schema_version` column. Existing rows observe `NULL`.
+pub const MIGRATION_V3_TO_V4_ADD_APP_SCHEMA_VERSION: &str =
+    "alter table __pocopine_streams add column app_schema_version integer";
 
 #[cfg(test)]
 mod tests {

--- a/crates/pocopine-sync-sqlite/src/wasm.rs
+++ b/crates/pocopine-sync-sqlite/src/wasm.rs
@@ -257,6 +257,14 @@ async fn migrate_schema() -> SyncResult<()> {
             "invalid sync sqlite schema version in local store: {existing}"
         ))
     })?;
+    // Allow forward migration only from explicitly handled versions —
+    // see native.rs::migrate_schema for the full rationale. A v1 store
+    // must fall through to the reject path in validate_schema_version.
+    match version {
+        2 | 3 => {}
+        v if v == SCHEMA_VERSION => return Ok(()),
+        _ => return Ok(()),
+    }
     // v2 -> v3: optimistic_row column on the mutations table.
     if version == 2 && !column_exists("__pocopine_mutations", "optimistic_row").await? {
         exec(
@@ -265,16 +273,13 @@ async fn migrate_schema() -> SyncResult<()> {
         )
         .await?;
     }
-    // v3 -> v4: app_schema_version column on the streams table.
-    // Existing rows observe `NULL`, which the client treats as "never
-    // observed; adopt server value silently on next save".
-    if version <= 3 && !column_exists("__pocopine_streams", "app_schema_version").await? {
+    // v3 -> v4 (also runs for v2 stores after the v2 -> v3 alter
+    // above): app_schema_version column on the streams table.
+    if !column_exists("__pocopine_streams", "app_schema_version").await? {
         exec(MIGRATION_V3_TO_V4_ADD_APP_SCHEMA_VERSION, Vec::new()).await?;
     }
-    // Only stamp the new version when we actually migrated forward.
-    if version < SCHEMA_VERSION {
-        upsert_meta(META_SCHEMA_VERSION, &SCHEMA_VERSION.to_string()).await?;
-    }
+    // Stamp the current version — we only reach here from v2 or v3.
+    upsert_meta(META_SCHEMA_VERSION, &SCHEMA_VERSION.to_string()).await?;
     Ok(())
 }
 

--- a/crates/pocopine-sync-sqlite/src/wasm.rs
+++ b/crates/pocopine-sync-sqlite/src/wasm.rs
@@ -12,9 +12,10 @@ use serde_json::Value;
 use wasm_bindgen::{JsCast, JsValue};
 
 use crate::schema::{
-    BOOTSTRAP_SQL, CLEAR_ALL_STREAMS_SQL, CLEAR_ROW_CONFLICT_SQL, DELETE_MUTATION_SQL,
-    DELETE_PENDING_FOR_ROW_SQL, DELETE_ROW_SQL, DELETE_STREAM_ROWS_SQL, META_DEVICE_ID,
-    META_NEXT_MUTATION_COUNTER, META_SCHEMA_VERSION, SCHEMA_VERSION, SELECT_PENDING_MUTATIONS_SQL,
+    BOOTSTRAP_SQL, CLEAR_ALL_STREAMS_SQL, CLEAR_ROW_CONFLICT_SQL, CLEAR_STREAM_SQL,
+    DELETE_MUTATION_SQL, DELETE_PENDING_FOR_ROW_SQL, DELETE_ROW_SQL, DELETE_STREAM_ROWS_SQL,
+    META_DEVICE_ID, META_NEXT_MUTATION_COUNTER, META_SCHEMA_VERSION,
+    MIGRATION_V3_TO_V4_ADD_APP_SCHEMA_VERSION, SCHEMA_VERSION, SELECT_PENDING_MUTATIONS_SQL,
     SELECT_ROWS_SQL, SELECT_STREAM_SQL, UPDATE_ROW_CONFLICT_SQL, UPSERT_MUTATION_SQL,
     UPSERT_ROW_SQL, UPSERT_STREAM_SQL,
 };
@@ -157,6 +158,10 @@ impl SyncLocalStore for SqliteLocalStore {
     fn clear_all_streams(&self) -> SyncLocalFuture<'_, ()> {
         self.run(clear_all_streams())
     }
+
+    fn clear_stream(&self, stream: &SyncStreamName) -> SyncLocalFuture<'_, ()> {
+        self.run(clear_stream(stream.clone()))
+    }
 }
 
 async fn ensure_database(database_name: &str) -> SyncResult<()> {
@@ -252,6 +257,7 @@ async fn migrate_schema() -> SyncResult<()> {
             "invalid sync sqlite schema version in local store: {existing}"
         ))
     })?;
+    // v2 -> v3: optimistic_row column on the mutations table.
     if version == 2 && !column_exists("__pocopine_mutations", "optimistic_row").await? {
         exec(
             "alter table __pocopine_mutations add column optimistic_row text",
@@ -259,7 +265,14 @@ async fn migrate_schema() -> SyncResult<()> {
         )
         .await?;
     }
-    if version == 2 {
+    // v3 -> v4: app_schema_version column on the streams table.
+    // Existing rows observe `NULL`, which the client treats as "never
+    // observed; adopt server value silently on next save".
+    if version <= 3 && !column_exists("__pocopine_streams", "app_schema_version").await? {
+        exec(MIGRATION_V3_TO_V4_ADD_APP_SCHEMA_VERSION, Vec::new()).await?;
+    }
+    // Only stamp the new version when we actually migrated forward.
+    if version < SCHEMA_VERSION {
         upsert_meta(META_SCHEMA_VERSION, &SCHEMA_VERSION.to_string()).await?;
     }
     Ok(())
@@ -327,6 +340,7 @@ async fn hydrate_stream(stream: SyncStreamName) -> SyncResult<LocalStreamSnapsho
             cursor: None,
             rows,
             pending_mutations,
+            application_schema_version: None,
         });
     };
 
@@ -341,6 +355,7 @@ async fn hydrate_stream(stream: SyncStreamName) -> SyncResult<LocalStreamSnapsho
             .transpose()?,
         rows,
         pending_mutations,
+        application_schema_version: optional_u32(meta, "app_schema_version")?,
     })
 }
 
@@ -353,6 +368,7 @@ async fn save_snapshot(snapshot: LocalSnapshotBatch) -> SyncResult<()> {
             &snapshot.collection,
             snapshot.cursor.as_ref(),
             now,
+            snapshot.application_schema_version,
         )
         .await?;
         exec(
@@ -374,7 +390,17 @@ async fn apply_changes(changes: LocalChangeBatch) -> SyncResult<()> {
     let result = async {
         let now = epoch_ms();
         let stream = changes.stream;
-        upsert_stream(&stream, &changes.collection, changes.cursor.as_ref(), now).await?;
+        // apply_changes doesn't carry an advertised schema_version (it
+        // is a post-open delta path); pass None — the UPSERT's coalesce
+        // preserves whatever value `save_snapshot` already recorded.
+        upsert_stream(
+            &stream,
+            &changes.collection,
+            changes.cursor.as_ref(),
+            now,
+            None,
+        )
+        .await?;
         let changes = changes_after_last_reset(changes.changes);
         if changes.had_reset {
             exec(
@@ -445,7 +471,14 @@ async fn mark_push_result(result: LocalPushResult) -> SyncResult<()> {
         let now = epoch_ms();
 
         if let Some(collection) = result.collection.as_ref() {
-            upsert_stream(&result.stream, collection, result.cursor.as_ref(), now).await?;
+            upsert_stream(
+                &result.stream,
+                collection,
+                result.cursor.as_ref(),
+                now,
+                None,
+            )
+            .await?;
         } else if let Some(cursor) = result.cursor.as_ref() {
             exec(
                 "update __pocopine_streams set cursor = ?2, updated_at_ms = ?3 where stream = ?1",
@@ -543,6 +576,20 @@ async fn clear_all_streams() -> SyncResult<()> {
     finish_transaction(result).await
 }
 
+async fn clear_stream(stream: SyncStreamName) -> SyncResult<()> {
+    // Same atomicity rationale as `clear_all_streams`, scoped to one
+    // stream: other streams + the device identity row stay untouched.
+    exec("BEGIN IMMEDIATE TRANSACTION", Vec::new()).await?;
+    let result = async {
+        for sql in CLEAR_STREAM_SQL {
+            exec(sql, vec![JsValue::from_str(stream.as_str())]).await?;
+        }
+        Ok::<(), SyncError>(())
+    }
+    .await;
+    finish_transaction(result).await
+}
+
 async fn purge_pending_for_row(stream: SyncStreamName, key: RowKey) -> SyncResult<usize> {
     // SQLite WASM's exec wrapper doesn't return an affected-rows
     // count, so SELECT-then-DELETE the matching rows in the same
@@ -629,7 +676,15 @@ async fn upsert_stream(
     collection: &SyncCollectionName,
     cursor: Option<&SyncCursor>,
     updated_at_ms: i64,
+    application_schema_version: Option<u32>,
 ) -> SyncResult<()> {
+    // The UPSERT uses `coalesce(excluded.app_schema_version,
+    // __pocopine_streams.app_schema_version)` so passing `None` here
+    // doesn't clobber a previously recorded value.
+    let app_schema_version_param = match application_schema_version {
+        Some(v) => JsValue::from_f64(v as f64),
+        None => JsValue::NULL,
+    };
     exec(
         UPSERT_STREAM_SQL,
         vec![
@@ -638,6 +693,7 @@ async fn upsert_stream(
             optional_param(cursor.map(SyncCursor::as_str)),
             JsValue::from_f64(SCHEMA_VERSION as f64),
             JsValue::from_f64(updated_at_ms as f64),
+            app_schema_version_param,
         ],
     )
     .await
@@ -756,6 +812,27 @@ fn optional_string(row: &Value, field: &'static str) -> SyncResult<Option<String
         Some(Value::String(value)) => Ok(Some(value.clone())),
         Some(other) => Err(SyncError::backend(format!(
             "invalid sqlite sync local-store field {field}: expected string, got {other}"
+        ))),
+    }
+}
+
+fn optional_u32(row: &Value, field: &'static str) -> SyncResult<Option<u32>> {
+    match row.get(field) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Number(n)) => {
+            let value = n.as_u64().ok_or_else(|| {
+                SyncError::backend(format!(
+                    "invalid sqlite sync local-store field {field}: not a u64"
+                ))
+            })?;
+            u32::try_from(value).map(Some).map_err(|_| {
+                SyncError::backend(format!(
+                    "invalid sqlite sync local-store field {field}: does not fit in u32"
+                ))
+            })
+        }
+        Some(other) => Err(SyncError::backend(format!(
+            "invalid sqlite sync local-store field {field}: expected number, got {other}"
         ))),
     }
 }

--- a/crates/pocopine-sync/src/client.rs
+++ b/crates/pocopine-sync/src/client.rs
@@ -627,6 +627,10 @@ where
             reason,
             live_event,
             self.epoch,
+            // Explicit refresh path: no fresh /open, so we don't have
+            // an advertised version to stamp. The UPSERT's coalesce
+            // preserves whatever `start_open_then_pull` already wrote.
+            None,
         );
         Ok(())
     }
@@ -1109,6 +1113,8 @@ fn start_open_then_pull<C, T>(
         // == None` means the store has never observed an advertised
         // version (fresh install, or pre-v4 row) — adopt the
         // advertised value silently on the next snapshot save.
+        let mut cursor = cursor;
+        let mut token = token;
         if let Some(cached) = cached_schema_version {
             if cached != advertised_schema_version {
                 tracing::info!(
@@ -1119,34 +1125,49 @@ fn start_open_then_pull<C, T>(
                     "sync stream schema_version changed; clearing local cache + pending mutations",
                 );
                 if let Err(err) = local_store.clear_stream(&stream).await {
-                    // Best-effort: the durable wipe failed. Log it
-                    // and still drop the in-memory state, because
-                    // leaving stale rows around is worse than the
-                    // user re-pulling.
-                    local_error = Some(format!(
-                        "local sync cache wipe-on-schema-bump failed: {err}"
-                    ));
+                    // Fail loud: if the durable wipe failed, do NOT
+                    // proceed to pull + persist. A successful pull
+                    // would stamp the NEW app_schema_version via the
+                    // UPSERT coalesce, silently masking the wipe
+                    // failure forever. Surfacing the error keeps
+                    // cached at the OLD value so the next open
+                    // re-detects the mismatch and retries.
+                    handle.update(|state| {
+                        selector(state).apply_error(
+                            token,
+                            format!("local sync cache wipe-on-schema-bump failed: {err}"),
+                        );
+                    });
+                    return;
                 }
                 if epoch.is_stale() {
                     return;
                 }
-                // In-memory side: clear the rows we hydrated and the
-                // pending replay queue so the upcoming pull starts
-                // from canonical fresh state.
+                // In-memory side: hard reset via
+                // `reset_for_schema_invalidation`. Unlike
+                // `apply_local_snapshot_with_pending(empty, None, empty)`
+                // (which short-circuits in `apply_local_snapshot_inner`
+                // because all inputs are empty), this unconditionally
+                // drops canonical_rows, rows, pending_mutations, cursor,
+                // and bumps request_generation — so any in-flight token
+                // becomes a no-op via `is_current`.
                 pending_mutations.clear();
-                handle.update(|state| {
-                    selector(state).apply_local_snapshot_with_pending(Vec::new(), None, Vec::new());
+                let new_token = handle.update(|state| {
+                    let collection = selector(state);
+                    collection.reset_for_schema_invalidation();
+                    // Re-issue a token; the prior `request_token` was
+                    // invalidated by the reset's generation bump.
+                    collection.begin_initial()
                 });
+                token = new_token;
+                // Force a Snapshot pull by nulling the cursor — the
+                // OLD-schema cursor was wiped durably; sending it to
+                // the server would yield an Incremental response that
+                // merges new-schema deltas onto an empty canonical
+                // set, leaving most rows missing until the next pull.
+                cursor = None;
             }
         }
-        // Stamp the advertised version onto the next snapshot save so
-        // future opens observe it. The hop happens via thread_local
-        // overlay because save_snapshot is invoked deep inside the
-        // server-driven pull/push path; instead we use the
-        // LocalSnapshotBatch's `application_schema_version` field
-        // directly on each save site that runs after this point.
-        let advertised_schema_version_for_persist = advertised_schema_version;
-
         if let Some(live_wakeup) = live_wakeup {
             open_live_wakeup(
                 scope_id,
@@ -1157,6 +1178,7 @@ fn start_open_then_pull<C, T>(
                 stream.clone(),
                 live_wakeup,
                 epoch.clone(),
+                advertised_schema_version,
             );
         }
 
@@ -1196,12 +1218,9 @@ fn start_open_then_pull<C, T>(
         }
         let result = match result {
             Ok(response) => {
-                if let Err(err) = persist_pull_response(
-                    &local_store,
-                    &response,
-                    Some(advertised_schema_version_for_persist),
-                )
-                .await
+                if let Err(err) =
+                    persist_pull_response(&local_store, &response, Some(advertised_schema_version))
+                        .await
                 {
                     local_error = Some(format!("local sync cache persist failed: {err}"));
                 }
@@ -1240,6 +1259,7 @@ fn open_live_wakeup<C, T>(
     stream: SyncStreamName,
     options: LiveWakeupOptions,
     epoch: SyncEpoch,
+    advertised_schema_version: u32,
 ) where
     C: 'static,
     T: Clone + serde::de::DeserializeOwned + serde::Serialize + 'static,
@@ -1260,6 +1280,15 @@ fn open_live_wakeup<C, T>(
                 } else {
                     SyncReason::Live
                 };
+                // Pass the captured-at-open advertised schema_version
+                // through so the live-pull's `persist_pull_response`
+                // stamps the durable `app_schema_version` if the
+                // post-/open pull hasn't done so yet. Without this,
+                // a live event firing before `start_open_then_pull`'s
+                // persist completes would write rows + cursor without
+                // the schema_version, leaving the durable column NULL
+                // — and the next session would skip the mismatch
+                // check because cached == None.
                 start_pull(
                     scope_id,
                     handle.clone(),
@@ -1271,6 +1300,7 @@ fn open_live_wakeup<C, T>(
                     reason,
                     true,
                     epoch.clone(),
+                    Some(advertised_schema_version),
                 );
             }
         })
@@ -1372,6 +1402,7 @@ fn start_pull<C, T>(
     reason: SyncReason,
     live_event: bool,
     epoch: SyncEpoch,
+    application_schema_version: Option<u32>,
 ) where
     C: 'static,
     T: Clone + serde::de::DeserializeOwned + serde::Serialize + 'static,
@@ -1402,12 +1433,17 @@ fn start_pull<C, T>(
         let mut local_error = None;
         let result = match result {
             Ok(response) => {
-                // `start_pull` is invoked by live-wakeup / explicit
-                // refresh after the initial open has already recorded
-                // the advertised schema_version, so we pass None here.
-                // The UPSERT's coalesce preserves the value
+                // Callers that ran AFTER a successful /open pass
+                // `Some(advertised)` so the durable
+                // `app_schema_version` gets stamped even if the
+                // post-/open pull never runs. Callers without an
+                // advertised version (explicit refresh without
+                // re-opening) pass None and rely on the UPSERT's
+                // coalesce to preserve whatever value
                 // `start_open_then_pull` already persisted.
-                if let Err(err) = persist_pull_response(&local_store, &response, None).await {
+                if let Err(err) =
+                    persist_pull_response(&local_store, &response, application_schema_version).await
+                {
                     local_error = Some(format!("local sync cache persist failed: {err}"));
                 }
                 Ok(response)
@@ -1741,6 +1777,9 @@ where
             SyncReason::Push,
             false,
             epoch,
+            // Post-push pull: no advertised version known here; rely
+            // on UPSERT coalesce to preserve the existing value.
+            None,
         );
     }
 

--- a/crates/pocopine-sync/src/client.rs
+++ b/crates/pocopine-sync/src/client.rs
@@ -1025,6 +1025,7 @@ fn start_open_then_pull<C, T>(
         let mut local_cursor = None;
         let mut pending_mutations = Vec::new();
         let mut local_error = None;
+        let mut cached_schema_version: Option<u32> = None;
 
         let hydrate_result = local_store.hydrate_stream(&stream).await;
         // Sign-out can fire while we're awaiting hydrate; if so, drop
@@ -1037,6 +1038,7 @@ fn start_open_then_pull<C, T>(
         match hydrate_result {
             Ok(snapshot) => {
                 local_cursor = snapshot.cursor.clone();
+                cached_schema_version = snapshot.application_schema_version;
                 pending_mutations = snapshot
                     .pending_mutations
                     .iter()
@@ -1088,19 +1090,62 @@ fn start_open_then_pull<C, T>(
         if epoch.is_stale() {
             return;
         }
-        // Capture the advertised schema_version. Batch 2 will compare this
-        // against the cached value and clear the stream on mismatch; for
-        // Batch 1 we just receive it (and the `_` silences the unused-var
-        // lint until the next batch wires it up).
-        match open_result.and_then(|response| validate_open_response(response, &stream)) {
-            Ok(_advertised_schema_version) => {}
-            Err(err) => {
+        let advertised_schema_version =
+            match open_result.and_then(|response| validate_open_response(response, &stream)) {
+                Ok(v) => v,
+                Err(err) => {
+                    handle.update(|state| {
+                        selector(state).apply_error(token, err);
+                    });
+                    return;
+                }
+            };
+
+        // If the cached schema_version differs from what the server is
+        // now advertising, the local cache (rows + pending mutations)
+        // is encoded against a shape the server no longer accepts.
+        // Drop it durably AND in memory so the upcoming pull rebuilds
+        // canonical state against the new shape. `cached_schema_version
+        // == None` means the store has never observed an advertised
+        // version (fresh install, or pre-v4 row) — adopt the
+        // advertised value silently on the next snapshot save.
+        if let Some(cached) = cached_schema_version {
+            if cached != advertised_schema_version {
+                tracing::info!(
+                    target: "pocopine.log",
+                    stream = stream.as_str(),
+                    cached_schema_version = cached,
+                    advertised_schema_version,
+                    "sync stream schema_version changed; clearing local cache + pending mutations",
+                );
+                if let Err(err) = local_store.clear_stream(&stream).await {
+                    // Best-effort: the durable wipe failed. Log it
+                    // and still drop the in-memory state, because
+                    // leaving stale rows around is worse than the
+                    // user re-pulling.
+                    local_error = Some(format!(
+                        "local sync cache wipe-on-schema-bump failed: {err}"
+                    ));
+                }
+                if epoch.is_stale() {
+                    return;
+                }
+                // In-memory side: clear the rows we hydrated and the
+                // pending replay queue so the upcoming pull starts
+                // from canonical fresh state.
+                pending_mutations.clear();
                 handle.update(|state| {
-                    selector(state).apply_error(token, err);
+                    selector(state).apply_local_snapshot_with_pending(Vec::new(), None, Vec::new());
                 });
-                return;
             }
         }
+        // Stamp the advertised version onto the next snapshot save so
+        // future opens observe it. The hop happens via thread_local
+        // overlay because save_snapshot is invoked deep inside the
+        // server-driven pull/push path; instead we use the
+        // LocalSnapshotBatch's `application_schema_version` field
+        // directly on each save site that runs after this point.
+        let advertised_schema_version_for_persist = advertised_schema_version;
 
         if let Some(live_wakeup) = live_wakeup {
             open_live_wakeup(
@@ -1151,7 +1196,13 @@ fn start_open_then_pull<C, T>(
         }
         let result = match result {
             Ok(response) => {
-                if let Err(err) = persist_pull_response(&local_store, &response).await {
+                if let Err(err) = persist_pull_response(
+                    &local_store,
+                    &response,
+                    Some(advertised_schema_version_for_persist),
+                )
+                .await
+                {
                     local_error = Some(format!("local sync cache persist failed: {err}"));
                 }
                 Ok(response)
@@ -1351,7 +1402,12 @@ fn start_pull<C, T>(
         let mut local_error = None;
         let result = match result {
             Ok(response) => {
-                if let Err(err) = persist_pull_response(&local_store, &response).await {
+                // `start_pull` is invoked by live-wakeup / explicit
+                // refresh after the initial open has already recorded
+                // the advertised schema_version, so we pass None here.
+                // The UPSERT's coalesce preserves the value
+                // `start_open_then_pull` already persisted.
+                if let Err(err) = persist_pull_response(&local_store, &response, None).await {
                     local_error = Some(format!("local sync cache persist failed: {err}"));
                 }
                 Ok(response)
@@ -1801,6 +1857,7 @@ where
 async fn persist_pull_response<T>(
     local_store: &SyncLocalStoreHandle,
     response: &SyncPullResponse<T>,
+    application_schema_version: Option<u32>,
 ) -> SyncResult<()>
 where
     T: serde::Serialize,
@@ -1813,12 +1870,15 @@ where
                 .map(row_to_value)
                 .collect::<SyncResult<Vec<_>>>()?;
             local_store
-                .save_snapshot(LocalSnapshotBatch::new(
-                    response.stream.clone(),
-                    response.collection.clone(),
-                    rows,
-                    response.cursor.clone(),
-                ))
+                .save_snapshot(
+                    LocalSnapshotBatch::new(
+                        response.stream.clone(),
+                        response.collection.clone(),
+                        rows,
+                        response.cursor.clone(),
+                    )
+                    .with_application_schema_version(application_schema_version),
+                )
                 .await
         }
         SyncPullMode::Incremental => {

--- a/crates/pocopine-sync/src/local_memory.rs
+++ b/crates/pocopine-sync/src/local_memory.rs
@@ -32,6 +32,7 @@ struct MemoryStreamState {
     cursor: Option<crate::SyncCursor>,
     rows: BTreeMap<RowKey, SyncRow<serde_json::Value>>,
     pending: Vec<LocalPendingMutation>,
+    application_schema_version: Option<u32>,
 }
 
 impl MemoryLocalStore {
@@ -92,6 +93,7 @@ impl SyncLocalStore for MemoryLocalStore {
                 cursor: state.cursor.clone(),
                 rows: state.rows.values().cloned().collect(),
                 pending_mutations: state.pending.clone(),
+                application_schema_version: state.application_schema_version,
             })
         }))
     }
@@ -106,6 +108,13 @@ impl SyncLocalStore for MemoryLocalStore {
                 .into_iter()
                 .map(|row| (row.key.clone(), row))
                 .collect();
+            // Only overwrite when the caller carries a value; passing
+            // `None` from a code path that hasn't observed the
+            // advertised version yet must not clobber a previously
+            // recorded value.
+            if let Some(version) = snapshot.application_schema_version {
+                state.application_schema_version = Some(version);
+            }
             Ok(())
         }))
     }
@@ -277,6 +286,19 @@ impl SyncLocalStore for MemoryLocalStore {
     fn clear_all_streams(&self) -> SyncLocalFuture<'_, ()> {
         Self::ready(self.with_inner(|inner| {
             inner.streams.clear();
+            Ok(())
+        }))
+    }
+
+    fn clear_stream(&self, stream: &SyncStreamName) -> SyncLocalFuture<'_, ()> {
+        let stream = stream.clone();
+        Self::ready(self.with_inner(|inner| {
+            // Removing the entry drops every cached row, pending
+            // mutation, conflict marker, cursor, and the cached
+            // schema_version in one step. Other streams + the device
+            // identity are untouched. Safe to call on a never-seen
+            // stream: BTreeMap::remove returns None and we ignore it.
+            inner.streams.remove(&stream);
             Ok(())
         }))
     }
@@ -1234,5 +1256,114 @@ mod tests {
         let stream = SyncStreamName::new("posts").unwrap();
         let snapshot = store.hydrate_stream(&stream).await.unwrap();
         assert!(snapshot.rows.is_empty());
+    }
+
+    #[tokio::test]
+    async fn clear_stream_wipes_one_stream_and_leaves_others_intact() {
+        let store = MemoryLocalStore::new();
+        let posts = SyncStreamName::new("posts").unwrap();
+        let comments = SyncStreamName::new("comments").unwrap();
+        store
+            .save_snapshot(LocalSnapshotBatch::new(
+                posts.clone(),
+                SyncCollectionName::new("posts").unwrap(),
+                vec![SyncRow::new("post_1", serde_json::json!({"title": "p1"})).unwrap()],
+                Some(SyncCursor::new("c_posts").unwrap()),
+            ))
+            .await
+            .unwrap();
+        store
+            .save_snapshot(LocalSnapshotBatch::new(
+                comments.clone(),
+                SyncCollectionName::new("comments").unwrap(),
+                vec![SyncRow::new("c_1", serde_json::json!({"body": "hi"})).unwrap()],
+                Some(SyncCursor::new("c_comments").unwrap()),
+            ))
+            .await
+            .unwrap();
+        store
+            .enqueue_mutation(
+                &posts,
+                ClientMutation {
+                    id: MutationId::new("device_a:1").unwrap(),
+                    key: Some(RowKey::new("post_1").unwrap()),
+                    op: SyncOp::Upsert,
+                    base_version: None,
+                    payload: serde_json::json!({"title": "edit"}),
+                },
+            )
+            .await
+            .unwrap();
+
+        store.clear_stream(&posts).await.unwrap();
+
+        let posts_after = store.hydrate_stream(&posts).await.unwrap();
+        let comments_after = store.hydrate_stream(&comments).await.unwrap();
+        assert!(posts_after.rows.is_empty());
+        assert!(posts_after.pending_mutations.is_empty());
+        assert!(posts_after.cursor.is_none());
+        assert!(posts_after.application_schema_version.is_none());
+        // The other stream is untouched.
+        assert_eq!(comments_after.rows.len(), 1);
+        assert_eq!(comments_after.rows[0].key.as_str(), "c_1");
+    }
+
+    #[tokio::test]
+    async fn clear_stream_is_safe_on_never_observed_stream() {
+        let store = MemoryLocalStore::new();
+        let unknown = SyncStreamName::new("unknown").unwrap();
+        store.clear_stream(&unknown).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn save_snapshot_records_application_schema_version() {
+        let store = MemoryLocalStore::new();
+        let stream = SyncStreamName::new("posts").unwrap();
+        store
+            .save_snapshot(
+                LocalSnapshotBatch::new(
+                    stream.clone(),
+                    SyncCollectionName::new("posts").unwrap(),
+                    vec![],
+                    None,
+                )
+                .with_application_schema_version(Some(7)),
+            )
+            .await
+            .unwrap();
+        let s = store.hydrate_stream(&stream).await.unwrap();
+        assert_eq!(s.application_schema_version, Some(7));
+    }
+
+    #[tokio::test]
+    async fn save_snapshot_with_none_preserves_existing_application_schema_version() {
+        // `save_snapshot` with `application_schema_version = None` must
+        // NOT clobber a previously-recorded value — only an explicit
+        // `Some` overwrites. Mirrors the SQLite UPSERT's coalesce.
+        let store = MemoryLocalStore::new();
+        let stream = SyncStreamName::new("posts").unwrap();
+        store
+            .save_snapshot(
+                LocalSnapshotBatch::new(
+                    stream.clone(),
+                    SyncCollectionName::new("posts").unwrap(),
+                    vec![],
+                    None,
+                )
+                .with_application_schema_version(Some(3)),
+            )
+            .await
+            .unwrap();
+        store
+            .save_snapshot(LocalSnapshotBatch::new(
+                stream.clone(),
+                SyncCollectionName::new("posts").unwrap(),
+                vec![],
+                None,
+            ))
+            .await
+            .unwrap();
+        let s = store.hydrate_stream(&stream).await.unwrap();
+        assert_eq!(s.application_schema_version, Some(3));
     }
 }

--- a/crates/pocopine-sync/src/local_store.rs
+++ b/crates/pocopine-sync/src/local_store.rs
@@ -189,6 +189,17 @@ pub struct LocalStreamSnapshot {
     pub rows: Vec<SyncRow<serde_json::Value>>,
     #[serde(default)]
     pub pending_mutations: Vec<LocalPendingMutation>,
+    /// Application-level schema version this snapshot was cached under,
+    /// captured from the server's most recent `/open` response. `None`
+    /// means "the store has never observed an advertised version for
+    /// this stream" — typically a fresh install or a `__pocopine_streams`
+    /// row that existed before the v3→v4 storage migration added the
+    /// column. The client compares this against the freshly-advertised
+    /// version on every open: if they differ (and cached is `Some`),
+    /// the stream is wiped via `clear_stream`; if cached is `None`, the
+    /// advertised value is adopted silently on the next snapshot save.
+    #[serde(default)]
+    pub application_schema_version: Option<u32>,
 }
 
 impl LocalStreamSnapshot {
@@ -200,6 +211,7 @@ impl LocalStreamSnapshot {
             cursor: None,
             rows: Vec::new(),
             pending_mutations: Vec::new(),
+            application_schema_version: None,
         }
     }
 }
@@ -212,6 +224,12 @@ pub struct LocalSnapshotBatch {
     pub cursor: Option<SyncCursor>,
     #[serde(default)]
     pub rows: Vec<SyncRow<serde_json::Value>>,
+    /// Application-level schema version to record alongside this
+    /// snapshot. `None` means the caller hasn't observed an advertised
+    /// version yet and the store should leave the column NULL; the next
+    /// open with a known advertised version will set it.
+    #[serde(default)]
+    pub application_schema_version: Option<u32>,
 }
 
 impl LocalSnapshotBatch {
@@ -226,7 +244,16 @@ impl LocalSnapshotBatch {
             collection,
             cursor,
             rows,
+            application_schema_version: None,
         }
+    }
+
+    /// Fluent setter for the application schema version. Use this when
+    /// the snapshot is being saved in response to a successful `/open`
+    /// that advertised the version.
+    pub fn with_application_schema_version(mut self, version: Option<u32>) -> Self {
+        self.application_schema_version = version;
+        self
     }
 }
 
@@ -419,6 +446,40 @@ pub trait SyncLocalStore {
     fn clear_all_streams(&self) -> SyncLocalFuture<'_, ()> {
         Box::pin(std::future::ready(Err(SyncError::unsupported(
             "SyncLocalStore::clear_all_streams is not implemented for this store",
+        ))))
+    }
+
+    /// Durably drop every persisted row, pending mutation, conflict
+    /// marker, and stream-metadata row for ONE stream — leaving every
+    /// other stream and the device identity row intact.
+    ///
+    /// This is the storage primitive behind the client-side schema-bump
+    /// cache invalidation: when `/open` advertises a `schema_version`
+    /// different from the cached `application_schema_version` for the
+    /// stream, the client awaits `clear_stream` before hydrating so
+    /// stale rows + queued mutations encoded against the old shape
+    /// don't reach the in-memory `CollectionState`. Authors that opt
+    /// into the per-stream wipe also use it for tenant-switcher UIs
+    /// that re-scope a stream without a full sign-out.
+    ///
+    /// Implementations MUST:
+    ///
+    /// * Persist the wipe before returning. Reload must observe an empty
+    ///   cache for this stream, not the pre-wipe state.
+    /// * Leave other streams' rows + pending mutations untouched.
+    /// * Leave the device identity row untouched.
+    /// * Be safe to call on a stream that's never been persisted — a
+    ///   per-stream wipe on a fresh install is a successful no-op.
+    /// * Wipe atomically: a mid-wipe failure must either revert
+    ///   entirely or complete entirely (SQLite-WAL backed stores wrap
+    ///   the deletes in `BEGIN IMMEDIATE TRANSACTION`).
+    ///
+    /// The default implementation returns `SyncError::Unsupported` so
+    /// an out-of-tree store that hasn't opted in cannot silently leave
+    /// durable data behind on a schema bump.
+    fn clear_stream(&self, _stream: &SyncStreamName) -> SyncLocalFuture<'_, ()> {
+        Box::pin(std::future::ready(Err(SyncError::unsupported(
+            "SyncLocalStore::clear_stream is not implemented for this store",
         ))))
     }
 }

--- a/crates/pocopine-sync/src/state.rs
+++ b/crates/pocopine-sync/src/state.rs
@@ -216,6 +216,44 @@ impl<T> CollectionState<T> {
         true
     }
 
+    /// Hard reset of the in-memory state for a schema-version invalidation.
+    ///
+    /// Used by `start_open_then_pull` when the server's advertised
+    /// `schema_version` differs from the cached value: after the durable
+    /// `clear_stream` succeeds, the in-memory `CollectionState` must
+    /// observe the same wipe so the upcoming pull rebuilds canonical
+    /// state under the new shape. Unlike `apply_local_snapshot_*`, this
+    /// method unconditionally drops every field — rows, canonical_rows,
+    /// pending_mutations, cursor, counters, errors — and bumps
+    /// `request_generation` so any in-flight pull/push token issued
+    /// before the reset is invalidated and its `apply_*` calls become
+    /// no-ops via `is_current`.
+    ///
+    /// Note: this is intentionally NOT `*self = CollectionState::default()`
+    /// because `version` is preserved at its current value — the
+    /// collection has "loaded once", just with a now-empty canonical
+    /// set. The next pull will write fresh rows via `apply_pull`.
+    pub fn reset_for_schema_invalidation(&mut self) {
+        self.canonical_rows.clear();
+        self.rows.clear();
+        self.pending_mutations.clear();
+        self.cursor = None;
+        self.pending_count = 0;
+        self.conflict_count = 0;
+        self.rejected_count = 0;
+        self.error.clear();
+        self.stale = false;
+        self.loading = false;
+        self.syncing = false;
+        self.last_reason = SyncReason::Initial;
+        // Invalidate any token issued before the reset so a stale
+        // `apply_pull` (e.g. a pull that was already in flight when the
+        // schema mismatch was detected) becomes a no-op via
+        // `is_current`. Spawned tasks must call `begin_initial` /
+        // `begin_pull` again after the reset to get a fresh token.
+        self.request_generation = self.request_generation.saturating_add(1);
+    }
+
     pub fn set_error(&mut self, error: impl Into<String>) {
         self.loading = false;
         self.syncing = false;
@@ -1674,6 +1712,115 @@ mod tests {
         assert!(!state.rows[0].conflict);
         assert_eq!(state.pending_count, 1);
         assert_eq!(state.conflict_count, 0);
+    }
+
+    #[test]
+    fn reset_for_schema_invalidation_drops_state_and_invalidates_in_flight_tokens() {
+        // Seed a populated state: canonical rows, rendered rows,
+        // pending mutations, cursor, counters, last error, and an
+        // outstanding pull token. The wipe must drop them all AND
+        // invalidate the token so a late `apply_pull` becomes a no-op.
+        let mut state = CollectionState::<String>::default();
+        let initial = state.begin_initial();
+        state.apply_pull(
+            initial,
+            SyncPullResponse::snapshot(
+                SyncStreamName::new("posts").unwrap(),
+                SyncCollectionName::new("posts").unwrap(),
+                vec![SyncRow::new("post_1", "v1".to_string()).unwrap()],
+                Some(SyncCursor::new("cursor_v1").unwrap()),
+            ),
+        );
+        state.apply_optimistic_mutation(
+            MutationId::new("device_1:1").unwrap(),
+            SyncOp::Upsert,
+            Some(RowKey::new("post_1").unwrap()),
+            Some(SyncRow::new("post_1", "local".to_string()).unwrap()),
+        );
+        let stale_token = state.begin_pull(SyncReason::Manual);
+        state.set_error("transient");
+
+        assert!(!state.rows.is_empty());
+        assert!(!state.pending_mutations.is_empty());
+        assert!(state.cursor.is_some());
+        assert!(state.pending_count > 0);
+
+        state.reset_for_schema_invalidation();
+
+        // Hard reset observed everywhere.
+        assert!(state.rows.is_empty(), "rows not cleared");
+        assert!(
+            state.canonical_rows.is_empty(),
+            "canonical_rows not cleared"
+        );
+        assert!(
+            state.pending_mutations.is_empty(),
+            "pending_mutations not cleared"
+        );
+        assert!(state.cursor.is_none(), "cursor not cleared");
+        assert_eq!(state.pending_count, 0);
+        assert_eq!(state.conflict_count, 0);
+        assert_eq!(state.rejected_count, 0);
+        assert!(state.error.is_empty(), "error not cleared");
+        assert!(!state.stale);
+        assert!(!state.loading);
+        assert!(!state.syncing);
+        // The stale token from before the reset must NOT apply.
+        let response = SyncPullResponse::snapshot(
+            SyncStreamName::new("posts").unwrap(),
+            SyncCollectionName::new("posts").unwrap(),
+            vec![SyncRow::new("ghost", "from_stale_token".to_string()).unwrap()],
+            Some(SyncCursor::new("ghost").unwrap()),
+        );
+        let applied = state.apply_pull(stale_token, response);
+        assert!(
+            !applied,
+            "stale token should no-op via is_current after reset"
+        );
+        assert!(
+            state.rows.is_empty(),
+            "stale apply_pull must not write rows after reset"
+        );
+    }
+
+    #[test]
+    fn reset_for_schema_invalidation_preserves_version_for_post_reset_pulls() {
+        // After the reset, `version` stays at its pre-reset value so
+        // `start_open_then_pull` can re-issue `begin_initial` (which
+        // requires version == 0 to take the Initial path) OR
+        // `begin_pull` if it's incrementing on an already-loaded
+        // collection. The reset bumps `request_generation`, not
+        // `version`.
+        let mut state = CollectionState::<String>::default();
+        let initial = state.begin_initial();
+        state.apply_pull(
+            initial,
+            SyncPullResponse::snapshot(
+                SyncStreamName::new("posts").unwrap(),
+                SyncCollectionName::new("posts").unwrap(),
+                vec![SyncRow::new("post_1", "v1".to_string()).unwrap()],
+                Some(SyncCursor::new("cursor_v1").unwrap()),
+            ),
+        );
+        let version_before_reset = state.version;
+        assert!(version_before_reset > 0);
+
+        state.reset_for_schema_invalidation();
+
+        assert_eq!(state.version, version_before_reset);
+        // begin_pull post-reset issues a fresh request_generation token.
+        let post_reset = state.begin_pull(SyncReason::Manual);
+        // Confirm the token is fresh: apply_pull with it works.
+        let response = SyncPullResponse::snapshot(
+            SyncStreamName::new("posts").unwrap(),
+            SyncCollectionName::new("posts").unwrap(),
+            vec![SyncRow::new("post_1", "v2".to_string()).unwrap()],
+            Some(SyncCursor::new("cursor_v2").unwrap()),
+        );
+        let applied = state.apply_pull(post_reset, response);
+        assert!(applied);
+        assert_eq!(state.rows.len(), 1);
+        assert_eq!(state.rows[0].value, "v2");
     }
 
     #[test]


### PR DESCRIPTION
Closes #125. Part 2 of 3 implementing gap #1 from \`docs/sync-local-first-gaps.md\` (Axis 1). Builds on Batch 1 (#128 → merged at adf1682c).

## Summary

Batch 1 advertised \`schema_version\` per stream on the wire. This batch makes the client **react**: when the cached \`application_schema_version\` for a stream differs from what the server now advertises on \`/open\`, durably wipe the stream's rows + pending mutations BEFORE applying any in-memory state, then let the upcoming pull rebuild canonical state against the new shape.

The default for existing apps is **safe**: \`schema_version = 1\` (Batch 1's default) is the cached value too, so the comparison is no-op until an app actually bumps the version.

## What ships

- **\`SyncLocalStore::clear_stream(stream)\`** trait method, default returns \`Unsupported\` so out-of-tree stores can't silently fail open (mirrors round-2 \`clear_all_streams\` decision).
- **\`LocalStreamSnapshot.application_schema_version: Option<u32>\`** + \`LocalSnapshotBatch::with_application_schema_version(...)\` builder.
- **SQLite native + wasm:** \`SCHEMA_VERSION\` bumped 3 → 4; new \`app_schema_version\` column on \`__pocopine_streams\`; non-destructive migration (existing rows observe \`NULL\`); \`CLEAR_STREAM_SQL\` runs inside \`BEGIN IMMEDIATE TRANSACTION\` for atomicity; \`UPSERT_STREAM_SQL\` uses \`coalesce(excluded, existing)\` so post-open writes don't clobber the recorded version.
- **IndexedDB wasm:** \`clear_stream\` issues \`IdbObjectStore::delete(stream)\`; \`save_snapshot\` records the version with the same coalesce semantics as SQLite. Native stub stays \`unsupported()\`.
- **Memory store:** field on \`MemoryStreamState\`; \`clear_stream\` removes the BTreeMap entry; \`save_snapshot\` only overwrites on \`Some\` (parity with SQLite + IDB).
- **\`start_open_then_pull\`:** after \`/open\` returns the advertised version, compare with the cached value, durably wipe + reset in-memory state on mismatch, emit \`tracing::info!\` event. \`persist_pull_response\` takes the advertised version so the next snapshot save records it.

## Bonus fix

The pre-existing \`migrate_schema\` would have stamped \`SCHEMA_VERSION\` onto a future store opened by an older build, silently overwriting a higher version. Now the meta upsert is gated on \`version < SCHEMA_VERSION\` so a future-stored DB still hits \`validate_schema_version\`'s reject path (existing test \`sqlite_store_rejects_incompatible_schema_version\` would otherwise have masked this).

## Tests added

- Memory:
  - \`clear_stream_wipes_one_stream_and_leaves_others_intact\`
  - \`clear_stream_is_safe_on_never_observed_stream\`
  - \`save_snapshot_records_application_schema_version\`
  - \`save_snapshot_with_none_preserves_existing_application_schema_version\`
- SQLite native (durability + UPSERT coalesce + migration):
  - \`sqlite_clear_stream_wipes_one_stream_and_leaves_others_intact\` — file-backed, drop + reopen, prove durability
  - \`sqlite_save_snapshot_records_and_preserves_application_schema_version\` — UPSERT coalesce
  - \`sqlite_store_migrates_v3_to_v4_app_schema_version_column\` — seed v3 schema, open, hydrate observes \`None\`, snapshot save can stamp

## Test plan

- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy -p pocopine-sync -p pocopine-sync-sqlite -p pocopine-sync-indexdb -p pocopine-sync-crud -p pocopine-sync-crud-macros -p pocopine-sync-sqlx --all-targets -- -D warnings\` clean
- [x] Same \`--target wasm32-unknown-unknown\` clean
- [x] \`cargo test -p pocopine-sync -p pocopine-sync-crud --lib\` — 117 + 56
- [x] \`cargo test -p pocopine-sync-sqlite --lib\` — 25
- [x] \`cargo test -p pocopine-sync-crud --test tenant_boundary --test resource_server\` — 4