### PR TITLE
RFC 084: typed slot props (draft + Phase 1)

### DIFF
--- a/crates/pocopine-core/src/props.rs
+++ b/crates/pocopine-core/src/props.rs
@@ -175,12 +175,20 @@ pub const fn str_slice_contains_const(haystack: &[&str], needle: &str) -> bool {
     false
 }
 
-/// Const-fn set-equality of two `&[&str]`. Order-independent;
-/// caller is responsible for deduplicating inputs if needed.
+/// Const-fn set-equality of two `&[&str]`. Order-independent.
+///
+/// Checks bidirectional containment — `a ⊆ b` **and** `b ⊆ a`.
+/// The reverse check is what catches the duplicate-bypass case:
+/// without it, `a = ["x", "x"]` vs `b = ["x", "y"]` (same length,
+/// every element of `a` in `b`) would pass even though `y` is
+/// uncovered. Treating both inputs as multisets-coerced-to-sets
+/// via mutual containment lets callers pass duplicate-bearing
+/// publications without the function silently approving them.
 pub const fn str_slice_set_eq_const(a: &[&str], b: &[&str]) -> bool {
     if a.len() != b.len() {
         return false;
     }
+    // Every element of `a` must appear in `b`.
     let mut i = 0;
     while i < a.len() {
         if !str_slice_contains_const(b, a[i]) {
@@ -188,5 +196,66 @@ pub const fn str_slice_set_eq_const(a: &[&str], b: &[&str]) -> bool {
         }
         i += 1;
     }
+    // Every element of `b` must appear in `a` — this is what
+    // catches duplicates in `a`. Without this loop,
+    // `a = ["x", "x"]` and `b = ["x", "y"]` would compare equal
+    // because both `a` elements are in `b` and the lengths
+    // matched, even though `y` isn't covered.
+    let mut i = 0;
+    while i < b.len() {
+        if !str_slice_contains_const(a, b[i]) {
+            return false;
+        }
+        i += 1;
+    }
     true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{str_eq_const, str_slice_contains_const, str_slice_set_eq_const};
+
+    #[test]
+    fn str_eq_const_handles_basic_cases() {
+        assert!(str_eq_const("foo", "foo"));
+        assert!(!str_eq_const("foo", "bar"));
+        assert!(!str_eq_const("foo", "fooo"));
+        assert!(str_eq_const("", ""));
+    }
+
+    #[test]
+    fn str_slice_contains_const_finds_present_and_rejects_absent() {
+        assert!(str_slice_contains_const(&["a", "b", "c"], "b"));
+        assert!(!str_slice_contains_const(&["a", "b", "c"], "z"));
+        assert!(!str_slice_contains_const(&[], "anything"));
+    }
+
+    #[test]
+    fn str_slice_set_eq_const_rejects_duplicate_bypass() {
+        // The headline finding from PR #131's code review:
+        // `a = ["x", "x"]` and `b = ["x", "y"]` have the same
+        // length, and every element of `a` is in `b`. Before
+        // the reverse-direction check landed, this returned
+        // `true` even though `y` isn't covered by `a`. The
+        // assertion below pins the fix.
+        assert!(
+            !str_slice_set_eq_const(&["x", "x"], &["x", "y"]),
+            "duplicate bypass: ['x','x'] vs ['x','y'] must NOT compare equal"
+        );
+        // Symmetric case (duplicates in `b`) must also fail.
+        assert!(!str_slice_set_eq_const(&["x", "y"], &["x", "x"]));
+    }
+
+    #[test]
+    fn str_slice_set_eq_const_passes_genuine_equality() {
+        assert!(str_slice_set_eq_const(&["x", "y"], &["y", "x"]));
+        assert!(str_slice_set_eq_const(&["a", "b", "c"], &["c", "a", "b"]));
+        assert!(str_slice_set_eq_const(&[], &[]));
+    }
+
+    #[test]
+    fn str_slice_set_eq_const_fails_on_length_mismatch() {
+        assert!(!str_slice_set_eq_const(&["x"], &["x", "y"]));
+        assert!(!str_slice_set_eq_const(&["x", "y"], &["x"]));
+    }
 }

--- a/crates/pocopine-core/src/props.rs
+++ b/crates/pocopine-core/src/props.rs
@@ -137,3 +137,56 @@ pub trait Props {
     fn prop_set(&mut self, leaf: &str, value: JsValue);
     fn prop_static_kind(leaf: &str) -> StaticPropKind;
 }
+
+// ── RFC 084 — const-eval helpers for typed-slot validation ────────
+//
+// The slot macro emits `const _: () = { ... }` blocks that compare a
+// publication's `:LHS=` keys against a props type's leaf set. Const
+// fns over string slices let those checks run at `cargo check` time
+// without changing the `Props` trait surface.
+
+/// Const-fn byte-wise string equality. Stable replacement for
+/// `str::eq` until that becomes const.
+pub const fn str_eq_const(a: &str, b: &str) -> bool {
+    let a = a.as_bytes();
+    let b = b.as_bytes();
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut i = 0;
+    while i < a.len() {
+        if a[i] != b[i] {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}
+
+/// Const-fn "haystack contains needle" over a `&[&str]`.
+pub const fn str_slice_contains_const(haystack: &[&str], needle: &str) -> bool {
+    let mut i = 0;
+    while i < haystack.len() {
+        if str_eq_const(haystack[i], needle) {
+            return true;
+        }
+        i += 1;
+    }
+    false
+}
+
+/// Const-fn set-equality of two `&[&str]`. Order-independent;
+/// caller is responsible for deduplicating inputs if needed.
+pub const fn str_slice_set_eq_const(a: &[&str], b: &[&str]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut i = 0;
+    while i < a.len() {
+        if !str_slice_contains_const(b, a[i]) {
+            return false;
+        }
+        i += 1;
+    }
+    true
+}

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -807,6 +807,36 @@ fn role_default_display(role: &str) -> Option<&'static str> {
     }
 }
 
+/// Apply RFC 054 row-plan stamps AND RFC 084 slot template edits
+/// to the original template source **in a single sorted pass**.
+///
+/// Both edit sources record `insert_at` byte offsets relative to
+/// the un-mutated `ast.source`. Applying them sequentially (stamps
+/// first, then slot edits) would let stamps shift the byte positions
+/// the slot edits assume, breaking the slot's auto-publish
+/// injection silently when the template contains both
+/// `<template pp-for>` row plans AND iterated-mode typed slots.
+/// Combining the edits and sorting by descending `insert_at` keeps
+/// every offset valid throughout the pass.
+fn apply_combined_template_edits(
+    source: &str,
+    stamps: &[for_plan::TemplateStamp],
+    slot_edits: &[slot::TemplateEdit],
+) -> String {
+    if stamps.is_empty() && slot_edits.is_empty() {
+        return source.to_string();
+    }
+    let mut all: Vec<slot::TemplateEdit> = stamps
+        .iter()
+        .map(|stamp| slot::TemplateEdit {
+            insert_at: stamp.insert_at,
+            text: format!(" data-pp-row-plan=\"{}\"", stamp.plan_id),
+        })
+        .collect();
+    all.extend(slot_edits.iter().cloned());
+    slot::apply_template_edits(source, &all)
+}
+
 fn compile_template_static(raw: &str, name: &str, role: Option<(&str, &str)>) -> String {
     let Some((tag, role_name)) = role else {
         return inject_pp_data_static(raw, name);
@@ -2586,34 +2616,19 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
             .map(|ast| ast.source.as_str())
             .unwrap_or("");
         if !source.is_empty() {
-            source.to_string()
+            apply_combined_template_edits(source, &row_plans.stamps, &slot_template_edits)
         } else {
+            // No AST source — fall back to the raw inline. Row-plan
+            // stamps and slot edits are AST-derived, so they can't
+            // be applied to a string we never parsed.
             inline.value()
         }
-    } else if row_plans.stamps.is_empty() {
-        template_ast
-            .as_ref()
-            .map(|ast| ast.source.as_str().to_string())
-            .unwrap_or_default()
     } else {
         let source = template_ast
             .as_ref()
             .map(|ast| ast.source.as_str())
             .unwrap_or("");
-        for_plan::apply_stamps(source, &row_plans.stamps)
-    };
-
-    // RFC 084 Phase 2 — apply iterated-slot auto-publish edits.
-    // Each `<slot>` element that sits inside a `pp-for` AND
-    // has no explicit `:LHS=` attrs gets a `:VAR="VAR"`
-    // injection (where VAR is the pp-for iter var) just before
-    // the closing `>` of its opening tag. The runtime's
-    // existing `materialize_slot` path then sees a normal
-    // publication; no runtime-side change required.
-    let template_source_for_compile = if slot_template_edits.is_empty() {
-        template_source_for_compile
-    } else {
-        slot::apply_template_edits(&template_source_for_compile, &slot_template_edits)
+        apply_combined_template_edits(source, &row_plans.stamps, &slot_template_edits)
     };
 
     let compiled_template_html = compile_template_static(

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -2509,12 +2509,18 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
     // RFC 084 — typed slot props validation. Emits `const _: ()`
     // blocks that compare each `<slot :LHS=...>` publication
     // against the declared `props = T`'s `#[prop]` field set at
-    // `cargo check` time. Untyped slots (no `props = T`) emit
-    // nothing — backwards-compatible with every existing
-    // `#[slot]` site.
-    let slot_props_validation_tokens = match &template_ast {
-        Some(ast) => slot::emit_slot_props_validation(ast, &slot_decls),
-        None => proc_macro2::TokenStream::new(),
+    // `cargo check` time. Returns both validation tokens AND
+    // byte-level template edits (Phase 2 iterated-mode
+    // auto-publishes the pp-for iter var by inserting
+    // `:VAR="VAR"` into the slot's opening tag). Untyped slots
+    // (no `props = T`) emit nothing — backwards-compatible with
+    // every existing `#[slot]` site.
+    let (slot_props_validation_tokens, slot_template_edits) = match &template_ast {
+        Some(ast) => {
+            let emit = slot::emit_slot_props_validation(ast, &slot_decls);
+            (emit.tokens, emit.template_edits)
+        }
+        None => (proc_macro2::TokenStream::new(), Vec::new()),
     };
 
     // RFC 054 — compile row plans for eligible keyed `pp-for`
@@ -2595,6 +2601,19 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
             .map(|ast| ast.source.as_str())
             .unwrap_or("");
         for_plan::apply_stamps(source, &row_plans.stamps)
+    };
+
+    // RFC 084 Phase 2 — apply iterated-slot auto-publish edits.
+    // Each `<slot>` element that sits inside a `pp-for` AND
+    // has no explicit `:LHS=` attrs gets a `:VAR="VAR"`
+    // injection (where VAR is the pp-for iter var) just before
+    // the closing `>` of its opening tag. The runtime's
+    // existing `materialize_slot` path then sees a normal
+    // publication; no runtime-side change required.
+    let template_source_for_compile = if slot_template_edits.is_empty() {
+        template_source_for_compile
+    } else {
+        slot::apply_template_edits(&template_source_for_compile, &slot_template_edits)
     };
 
     let compiled_template_html = compile_template_static(

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -2506,6 +2506,17 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
         None => proc_macro2::TokenStream::new(),
     };
 
+    // RFC 084 — typed slot props validation. Emits `const _: ()`
+    // blocks that compare each `<slot :LHS=...>` publication
+    // against the declared `props = T`'s `#[prop]` field set at
+    // `cargo check` time. Untyped slots (no `props = T`) emit
+    // nothing — backwards-compatible with every existing
+    // `#[slot]` site.
+    let slot_props_validation_tokens = match &template_ast {
+        Some(ast) => slot::emit_slot_props_validation(ast, &slot_decls),
+        None => proc_macro2::TokenStream::new(),
+    };
+
     // RFC 054 — compile row plans for eligible keyed `pp-for`
     // templates and stamp the source with `data-pp-row-plan`
     // anchors so the runtime can match the directive call back
@@ -3041,6 +3052,11 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
         // Issue #76 — hard `compile_error!` for `<template pp-for>`
         // rows whose direct element child is another `<template>`.
         #pp_for_template_child_diagnostics_tokens
+
+        // RFC 084 — typed slot props validation. `const _: ()`
+        // blocks enforce that `#[slot(name = "...", props = T)]`'s
+        // publication keys match `T`'s `#[prop]` field set.
+        #slot_props_validation_tokens
 
         // Layout-class lint — hard `compile_error!` when the root
         // carries `sticky` / `h-screen` / `min-h-*` / `inset-*` but
@@ -5480,6 +5496,18 @@ pub fn derive_props(input: TokenStream) -> TokenStream {
                     _ => ::pocopine::__private::StaticPropKind::Auto,
                 }
             }
+        }
+
+        // RFC 084 — inherent `const` mirror of `prop_leaves()` for
+        // const-eval consumers (typed-slot validation in particular).
+        // The trait fn `prop_leaves()` returns the same slice but
+        // isn't const, so const blocks can't call it. Exposing the
+        // leaves as an inherent const lets `#[slot(props = T)]`
+        // validation compare publication keys against this slice at
+        // `cargo check` time.
+        impl #impl_generics #struct_ident #ty_generics #where_clause {
+            #[doc(hidden)]
+            pub const __POC_PROP_LEAVES: &'static [&'static str] = &[#(#leaf_names),*];
         }
     };
     out.into()

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -2517,7 +2517,7 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
     // every existing `#[slot]` site.
     let (slot_props_validation_tokens, slot_template_edits) = match &template_ast {
         Some(ast) => {
-            let emit = slot::emit_slot_props_validation(ast, &slot_decls);
+            let emit = slot::emit_slot_props_validation(ast, &slot_decls, &struct_ident);
             (emit.tokens, emit.template_edits)
         }
         None => (proc_macro2::TokenStream::new(), Vec::new()),

--- a/crates/pocopine-macros/src/slot.rs
+++ b/crates/pocopine-macros/src/slot.rs
@@ -391,30 +391,98 @@ pub(crate) fn emit_slot_traits(
 
 // ── RFC 084 — typed slot props validation ────────────────────────
 
-/// Emit `const _: () = { ... }` blocks that validate every typed
-/// slot's publication keys against the declared `props = T`'s
-/// `#[prop]` field set.
+/// Output of [`emit_slot_props_validation`].
 ///
-/// For each `#[slot(name = "X", props = T)]` declared on the
-/// component, the AST is scanned for matching `<slot name="X">`
-/// elements (default slots match a bare `<slot>`). The element's
-/// `:LHS=...` publications become a `&[&str]` const that
-/// [`pocopine_core::props::str_slice_set_eq_const`] compares
-/// against `<T>::__POC_PROP_LEAVES`. Each individual `:LHS=`
-/// also gets a per-key existence check so the error message can
-/// quote the offending key verbatim.
+/// `tokens` are spliced into the `#[component]` macro's output
+/// as `const _: () = { … }` blocks. `template_edits` are
+/// byte-level inserts applied to the template source BEFORE
+/// `compile_template_static` runs — used by iterated mode to
+/// inject `:VAR="VAR"` publications onto `<slot>` elements that
+/// sit inside a `pp-for`, so the runtime's existing publication
+/// path picks them up without a runtime-side change.
+pub(crate) struct SlotValidationEmit {
+    pub tokens: TokenStream,
+    pub template_edits: Vec<TemplateEdit>,
+}
+
+/// Byte-level insert into the template source. Mirrors the
+/// shape of [`crate::for_plan::TemplateStamp`] so the application
+/// strategy stays consistent across macro passes.
+pub(crate) struct TemplateEdit {
+    pub insert_at: usize,
+    pub text: String,
+}
+
+/// `pp-for` context flowing down through the AST walk. Captured
+/// when a `pp-for="X in EXPR"` is parsed; consulted at each
+/// `<slot>` to decide iterated-mode dispatch.
+#[derive(Clone)]
+struct ForContext {
+    iter_var: String,
+    /// Bare field-path RHS of `pp-for="X in <RHS>"`. v1 only
+    /// supports a single identifier (a struct field). Anything
+    /// else stays `None` and forces iterated-mode-needing slots
+    /// to emit a "use static mode" compile error.
+    iter_field: Option<String>,
+}
+
+fn extract_for_context(el: &crate::template_parser::Element) -> Option<ForContext> {
+    let raw = el.attrs.iter().find_map(|(k, v)| {
+        if k == "pp-for" {
+            Some(v.as_str())
+        } else {
+            None
+        }
+    })?;
+    // Shape: `X in EXPR`. Match the literal ` in ` separator.
+    let (var, expr) = raw.split_once(" in ")?;
+    let iter_var = var.trim().to_string();
+    let expr = expr.trim();
+    // v1 — only bare-ident RHS qualifies for iterated-mode
+    // type inference. `pp-for="row in self.rows.iter()"`-style
+    // expressions get `iter_field = None` and the slot is
+    // forced into static mode (with an actionable error).
+    let iter_field =
+        if !expr.is_empty() && expr.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
+            Some(expr.to_string())
+        } else {
+            None
+        };
+    Some(ForContext {
+        iter_var,
+        iter_field,
+    })
+}
+
+/// Per-slot resolution: which mode, and the enclosing `pp-for`
+/// context (if any). Populated by the AST walk.
+struct SlotMatch<'a> {
+    el: &'a crate::template_parser::Element,
+    for_ctx: Option<ForContext>,
+}
+
+/// Emit `const _: () = { … }` blocks that validate every typed
+/// slot's publication shape AND collect byte-level template
+/// edits for iterated-mode auto-publication. Per RFC 084.
 ///
-/// **v1 scope (Phase 1 of RFC 084):** static-mode only. A
-/// `<slot>` sitting inside a `pp-for` (the iterated-mode case)
-/// is still validated as static here; Phase 2 layers the
-/// auto-publish + iteration-type assertion on top. Both modes
-/// share the same `T: Props` boundary so Phase 2 doesn't have
-/// to revisit it.
+/// Mode resolution per `<slot>` element:
+///
+/// * Any `:LHS=…` attr → **static mode** (publications must
+///   cover every `#[prop]` field on `T`).
+/// * No `:LHS=…` AND a `pp-for` ancestor with a bare-ident RHS
+///   → **iterated mode** (auto-publish the iteration variable;
+///   emit a Rust type assertion verifying the iter item
+///   matches `T`).
+/// * No `:LHS=…` AND no usable `pp-for` ancestor → **static
+///   mode with empty publication** (errors if `T` has any
+///   `#[prop]` fields).
 pub(crate) fn emit_slot_props_validation(
     ast: &crate::template_parser::TemplateAst,
     slots: &[SlotDecl],
-) -> TokenStream {
+) -> SlotValidationEmit {
     let mut out = TokenStream::new();
+    let mut template_edits = Vec::new();
+
     for decl in slots {
         let Some(props_ty) = decl.props.as_ref() else {
             continue;
@@ -436,11 +504,12 @@ pub(crate) fn emit_slot_props_validation(
         };
 
         // Scan every element in the template AST for matching
-        // `<slot>` elements. A `<slot>` with no `name` attribute
-        // is the default slot.
-        let mut found: Vec<&crate::template_parser::Element> = Vec::new();
+        // `<slot>` elements, threading the nearest enclosing
+        // `pp-for` context as we descend. A `<slot>` with no
+        // `name` attribute is the default slot.
+        let mut found: Vec<SlotMatch<'_>> = Vec::new();
         for root in &ast.roots {
-            collect_slot_elements(root, &target_name, &mut found);
+            collect_slot_matches(root, &target_name, None, &mut found);
         }
 
         if found.is_empty() {
@@ -461,42 +530,149 @@ pub(crate) fn emit_slot_props_validation(
             continue;
         }
 
-        // Phase 1: every found `<slot>` element is treated as
-        // static-mode. Phase 2 layers iterated-mode dispatch
-        // (mode resolved per element by `:LHS=` presence and
-        // `pp-for` ancestry).
-        for el in &found {
-            emit_static_publication_validation(&target_name, props_ty, &props_ty_str, el, &mut out);
+        for SlotMatch { el, for_ctx } in &found {
+            let has_publications = el.attrs.iter().any(|(k, _)| k.starts_with(':'));
+            if !has_publications && for_ctx.is_some() {
+                emit_iterated_mode(
+                    &target_name,
+                    props_ty,
+                    &props_ty_str,
+                    el,
+                    for_ctx.as_ref().unwrap(),
+                    &mut out,
+                    &mut template_edits,
+                );
+            } else {
+                emit_static_publication_validation(
+                    &target_name,
+                    props_ty,
+                    &props_ty_str,
+                    el,
+                    &mut out,
+                );
+            }
         }
     }
-    out
+
+    SlotValidationEmit {
+        tokens: out,
+        template_edits,
+    }
 }
 
-/// Recursive walk: collect every `<slot>` element whose `name`
-/// matches `target_name` (or has no `name` attribute when
-/// `target_name == "default"`).
-fn collect_slot_elements<'a>(
+/// Recursive walk with `pp-for` ancestor tracking. Records every
+/// matching `<slot>` paired with the nearest enclosing
+/// `pp-for`'s context (or `None` if none).
+fn collect_slot_matches<'a>(
     node: &'a crate::template_parser::Node,
     target_name: &str,
-    out: &mut Vec<&'a crate::template_parser::Element>,
+    enclosing_for: Option<ForContext>,
+    out: &mut Vec<SlotMatch<'a>>,
 ) {
     let crate::template_parser::Node::Element(el) = node else {
         return;
     };
+    // If THIS element has pp-for, its context applies to its
+    // descendants (replacing the enclosing one, if any).
+    let descend_ctx = extract_for_context(el).or_else(|| enclosing_for.clone());
+
     if el.tag == "slot" {
         let name_attr = el.attrs.iter().find(|(k, _)| k == "name");
         let this_name = name_attr.map(|(_, v)| v.as_str()).unwrap_or("default");
         if this_name == target_name {
-            out.push(el);
+            out.push(SlotMatch {
+                el,
+                for_ctx: enclosing_for.clone(),
+            });
         }
-        // A `<slot>` is a leaf in the rendered DOM but
-        // syntactically may have children (fallback content);
-        // we still walk to be safe — nested `<slot>` inside
-        // fallback isn't a real pattern but the recursion is
-        // cheap.
     }
     for child in &el.children {
-        collect_slot_elements(child, target_name, out);
+        collect_slot_matches(child, target_name, descend_ctx.clone(), out);
+    }
+}
+
+/// Emit the iterated-mode artifacts for one `<slot>` element:
+/// the Rust type assertion that the iter item matches `T`, plus
+/// a template edit that injects `:VAR="VAR"` into the slot's
+/// opening tag so the runtime sees the auto-publication.
+fn emit_iterated_mode(
+    target_name: &str,
+    props_ty: &Path,
+    props_ty_str: &str,
+    el: &crate::template_parser::Element,
+    for_ctx: &ForContext,
+    out: &mut TokenStream,
+    template_edits: &mut Vec<TemplateEdit>,
+) {
+    // No usable iteration source → emit a directive error and
+    // skip the type assertion / edit. The author should either
+    // simplify the `pp-for` expression or write `<slot :LHS=…>`
+    // attributes explicitly (static mode).
+    let Some(iter_field) = for_ctx.iter_field.as_deref() else {
+        let msg = format!(
+            "pocopine: slot `{target_name}` sits inside a `pp-for` whose iteration source isn't a bare field path — iterated-mode auto-publish needs `pp-for=\"X in field_name\"`. Either simplify the pp-for expression, or write the publications explicitly on the `<slot>` element (static mode)."
+        );
+        out.extend(quote! { ::core::compile_error!(#msg); });
+        return;
+    };
+
+    let iter_var = &for_ctx.iter_var;
+    let iter_var_ident = match syn::parse_str::<syn::Ident>(iter_var) {
+        Ok(i) => i,
+        Err(_) => {
+            // Defensive: pp-for parsed an iter var that isn't a
+            // Rust ident. Skip — the directive registry should
+            // already have flagged this elsewhere.
+            return;
+        }
+    };
+    let iter_field_ident = match syn::parse_str::<syn::Ident>(iter_field) {
+        Ok(i) => i,
+        Err(_) => return,
+    };
+
+    // Rust type assertion: walking `this.<iter_field>` must
+    // yield items of type `&T`. Lives in a `const _: fn(&Self)`
+    // closure so the typechecker sees it at `cargo check` time
+    // without running anything at runtime.
+    let mismatch_note = format!(
+        "the iteration source `{iter_field}` for slot `{target_name}` must yield items of type `{props_ty_str}` (matching `#[slot(name = \"{target_name}\", props = {props_ty_str})]`)"
+    );
+    out.extend(quote! {
+        const _: fn(&Self) = |__poco_this: &Self| {
+            // Force-resolve the iter item's type via a `match`
+            // on `IntoIterator`. The `unreachable!()` branch is
+            // never executed (the assertion is in const-fn
+            // closure position, never called) — Rust still
+            // typechecks the branch and reports the mismatch
+            // with this `let` binding's `&#props_ty` annotation.
+            let _: &#props_ty = match (&__poco_this.#iter_field_ident).into_iter().next() {
+                ::core::option::Option::Some(__poco_item) => __poco_item,
+                ::core::option::Option::None => {
+                    let _ = #mismatch_note;
+                    ::core::unreachable!();
+                }
+            };
+            let _ = stringify!(#iter_var_ident);
+        };
+    });
+
+    // Template edit: inject ` :VAR="VAR"` just before the
+    // closing `>` of the slot's opening tag. The runtime's
+    // existing `materialize_slot` path (mount.rs:920-928)
+    // picks it up identically to an explicit static-mode
+    // publication.
+    //
+    // `opening_tag_range.end` points just past `>`; insert at
+    // `end - 1` so we land before the angle bracket. Skip if
+    // the range is the placeholder `0..0` (foster-parented
+    // element with no real source position).
+    if el.opening_tag_range.end > el.opening_tag_range.start {
+        let insert_at = el.opening_tag_range.end.saturating_sub(1);
+        template_edits.push(TemplateEdit {
+            insert_at,
+            text: format!(" :{iter_var}=\"{iter_var}\""),
+        });
     }
 }
 
@@ -555,6 +731,32 @@ fn emit_static_publication_validation(
             }
         };
     });
+}
+
+/// Apply byte-level inserts to a template source. Same shape as
+/// [`crate::for_plan::apply_stamps`] — sort by descending
+/// `insert_at` then splice each text in, so earlier byte offsets
+/// stay valid as edits accumulate.
+pub(crate) fn apply_template_edits(source: &str, edits: &[TemplateEdit]) -> String {
+    if edits.is_empty() {
+        return source.to_string();
+    }
+    let mut sorted: Vec<&TemplateEdit> = edits.iter().collect();
+    sorted.sort_by_key(|e| std::cmp::Reverse(e.insert_at));
+    let mut out = source.to_string();
+    for edit in sorted {
+        if edit.insert_at > out.len() {
+            continue;
+        }
+        // Defensive: only insert at a char boundary. Templates
+        // are typically ASCII at HTML-syntax positions, but
+        // safer to skip than to panic.
+        if !out.is_char_boundary(edit.insert_at) {
+            continue;
+        }
+        out.insert_str(edit.insert_at, &edit.text);
+    }
+    out
 }
 
 fn pascal_case(s: &str) -> String {
@@ -869,5 +1071,179 @@ mod tests {
             "duplicate `props =` should error: {}",
             err
         );
+    }
+
+    // ── RFC 084 Phase 2 — iterated-mode tests ──────────────────
+
+    fn ast(src: &str) -> crate::template_parser::TemplateAst {
+        crate::template_parser::parse_strict(src, "test.poco")
+            .expect("template should parse cleanly")
+    }
+
+    fn props_path(s: &str) -> Path {
+        syn::parse_str(s).expect("path parses")
+    }
+
+    fn iter_decl(name: &str, props: &str) -> SlotDecl {
+        SlotDecl {
+            name: SlotName::Named(name.to_string()),
+            mode: SlotMode::Accepts,
+            accepts: Vec::new(),
+            props: Some(props_path(props)),
+            span: proc_macro2::Span::call_site(),
+        }
+    }
+
+    #[test]
+    fn iterated_slot_emits_template_edit() {
+        let src = r#"<root>
+<ul>
+  <li pp-for="file in files">
+    <slot name="row"></slot>
+  </li>
+</ul>
+</root>"#;
+        let slots = vec![iter_decl("row", "UploadFile")];
+        let emit = emit_slot_props_validation(&ast(src), &slots);
+        assert_eq!(
+            emit.template_edits.len(),
+            1,
+            "expected one auto-publish edit, got {:?}",
+            emit.template_edits.len()
+        );
+        let edit = &emit.template_edits[0];
+        assert!(
+            edit.text.contains(":file=\"file\""),
+            "edit should inject :file=\"file\": {:?}",
+            edit.text
+        );
+        // The type-assertion closure should also appear in tokens.
+        let s = emit.tokens.to_string();
+        assert!(
+            s.contains("__poco_this"),
+            "type assertion missing from tokens: {s}"
+        );
+    }
+
+    #[test]
+    fn iterated_slot_skips_static_set_equality_check() {
+        // Iterated mode auto-publishes a single key (the iter
+        // var). Static-mode's set-equality check would error
+        // ("publication doesn't cover every #[prop] field"); the
+        // iterated path must NOT emit that check.
+        let src = r#"<root>
+<li pp-for="file in files">
+  <slot name="row"></slot>
+</li>
+</root>"#;
+        let slots = vec![iter_decl("row", "UploadFile")];
+        let emit = emit_slot_props_validation(&ast(src), &slots);
+        let s = emit.tokens.to_string();
+        assert!(
+            !s.contains("str_slice_set_eq_const"),
+            "iterated slot must not emit static-mode set-equality check: {s}"
+        );
+    }
+
+    #[test]
+    fn static_slot_emits_no_template_edit() {
+        // Static mode (any `:LHS=` present) must NOT trigger an
+        // auto-publish template edit.
+        let src = r#"<root>
+<div>
+  <slot name="header" :queue_size="queue_size"></slot>
+</div>
+</root>"#;
+        let slots = vec![iter_decl("header", "HeaderProps")];
+        let emit = emit_slot_props_validation(&ast(src), &slots);
+        assert!(
+            emit.template_edits.is_empty(),
+            "static slot should yield no template edits: {:?}",
+            emit.template_edits.len()
+        );
+    }
+
+    #[test]
+    fn slot_with_publications_inside_pp_for_is_static() {
+        // §5.4 rule: presence of any `:LHS=` forces static mode
+        // even when inside a `pp-for`. The macro must NOT
+        // auto-publish (no template edit), AND must validate
+        // the explicit publication against the props type.
+        let src = r#"<root>
+<li pp-for="file in files">
+  <slot name="row" :file="file"></slot>
+</li>
+</root>"#;
+        let slots = vec![iter_decl("row", "UploadFile")];
+        let emit = emit_slot_props_validation(&ast(src), &slots);
+        assert!(
+            emit.template_edits.is_empty(),
+            "static-mode (has :LHS=) must not emit an auto-publish edit"
+        );
+        let s = emit.tokens.to_string();
+        assert!(
+            s.contains("str_slice_set_eq_const"),
+            "static-mode should emit set-equality coverage check: {s}"
+        );
+    }
+
+    #[test]
+    fn iterated_slot_outside_pp_for_falls_back_to_static() {
+        // No pp-for ancestor AND no `:LHS=` → static-empty.
+        // The coverage check fires because UploadFile has props.
+        // (We can't run the const-eval check at test time but we
+        // can confirm the tokens take the static path — no
+        // template edit.)
+        let src = r#"<root>
+<slot name="row"></slot>
+</root>"#;
+        let slots = vec![iter_decl("row", "UploadFile")];
+        let emit = emit_slot_props_validation(&ast(src), &slots);
+        assert!(
+            emit.template_edits.is_empty(),
+            "no pp-for ancestor → no auto-publish edit"
+        );
+    }
+
+    #[test]
+    fn pp_for_complex_expression_errors_with_directive_message() {
+        // §5.6 / §7 — `pp-for` over anything other than a bare
+        // ident falls back to "use static mode" with an
+        // actionable error.
+        let src = r#"<root>
+<li pp-for="file in user.files">
+  <slot name="row"></slot>
+</li>
+</root>"#;
+        let slots = vec![iter_decl("row", "UploadFile")];
+        let emit = emit_slot_props_validation(&ast(src), &slots);
+        let s = emit.tokens.to_string();
+        assert!(
+            s.contains("compile_error") && s.contains("bare field path"),
+            "complex pp-for expression should emit a directive compile_error: {s}"
+        );
+        assert!(
+            emit.template_edits.is_empty(),
+            "no edit when iterated-mode bails"
+        );
+    }
+
+    #[test]
+    fn apply_template_edits_inserts_in_reverse_order() {
+        // Two edits at different positions should both land
+        // intact without shifting each other.
+        let src = "<slot></slot><slot></slot>";
+        let edits = vec![
+            TemplateEdit {
+                insert_at: 5, // before first `>`
+                text: " :a=\"a\"".to_string(),
+            },
+            TemplateEdit {
+                insert_at: 18, // before second `>`
+                text: " :b=\"b\"".to_string(),
+            },
+        ];
+        let out = apply_template_edits(src, &edits);
+        assert_eq!(out, r#"<slot :a="a"></slot><slot :b="b"></slot>"#);
     }
 }

--- a/crates/pocopine-macros/src/slot.rs
+++ b/crates/pocopine-macros/src/slot.rs
@@ -408,6 +408,7 @@ pub(crate) struct SlotValidationEmit {
 /// Byte-level insert into the template source. Mirrors the
 /// shape of [`crate::for_plan::TemplateStamp`] so the application
 /// strategy stays consistent across macro passes.
+#[derive(Clone)]
 pub(crate) struct TemplateEdit {
     pub insert_at: usize,
     pub text: String,
@@ -442,12 +443,21 @@ fn extract_for_context(el: &crate::template_parser::Element) -> Option<ForContex
     // type inference. `pp-for="row in self.rows.iter()"`-style
     // expressions get `iter_field = None` and the slot is
     // forced into static mode (with an actionable error).
-    let iter_field =
-        if !expr.is_empty() && expr.chars().all(|c| c.is_ascii_alphanumeric() || c == '_') {
-            Some(expr.to_string())
-        } else {
-            None
-        };
+    //
+    // First-char check enforces the Rust-ident shape — leading
+    // digits like `"2ndItems"` are alphanumeric but not valid
+    // idents. Without the first-char gate, those would survive
+    // here and later fail `syn::parse_str::<Ident>` silently.
+    let is_bare_ident = expr
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_alphabetic() || c == '_')
+        && expr.chars().all(|c| c.is_ascii_alphanumeric() || c == '_');
+    let iter_field = if is_bare_ident {
+        Some(expr.to_string())
+    } else {
+        None
+    };
     Some(ForContext {
         iter_var,
         iter_field,
@@ -541,6 +551,7 @@ pub(crate) fn emit_slot_props_validation(
                     el,
                     for_ctx.as_ref().unwrap(),
                     struct_ident,
+                    &ast.source,
                     &mut out,
                     &mut template_edits,
                 );
@@ -597,6 +608,7 @@ fn collect_slot_matches<'a>(
 /// the Rust type assertion that the iter item matches `T`, plus
 /// a template edit that injects `:VAR="VAR"` into the slot's
 /// opening tag so the runtime sees the auto-publication.
+#[allow(clippy::too_many_arguments)]
 fn emit_iterated_mode(
     target_name: &str,
     props_ty: &Path,
@@ -604,6 +616,7 @@ fn emit_iterated_mode(
     el: &crate::template_parser::Element,
     for_ctx: &ForContext,
     struct_ident: &Ident,
+    source: &str,
     out: &mut TokenStream,
     template_edits: &mut Vec<TemplateEdit>,
 ) {
@@ -623,15 +636,34 @@ fn emit_iterated_mode(
     let iter_var_ident = match syn::parse_str::<syn::Ident>(iter_var) {
         Ok(i) => i,
         Err(_) => {
-            // Defensive: pp-for parsed an iter var that isn't a
-            // Rust ident. Skip — the directive registry should
-            // already have flagged this elsewhere.
+            // pp-for parsed an iter var that isn't a valid Rust
+            // identifier. Surface a directive error here rather
+            // than returning silently — without this, the slot
+            // gets neither a template edit nor a type assertion
+            // and the user sees no diagnostic pointing at the
+            // bad `pp-for`.
+            let msg = format!(
+                "pocopine: slot `{target_name}` sits inside `pp-for=\"{iter_var} in {iter_field}\"` but the iteration variable `{iter_var}` isn't a valid Rust identifier. Rename it to a bare ascii identifier (e.g. `file`, `row`, `_item`)."
+            );
+            out.extend(quote! { ::core::compile_error!(#msg); });
             return;
         }
     };
     let iter_field_ident = match syn::parse_str::<syn::Ident>(iter_field) {
         Ok(i) => i,
-        Err(_) => return,
+        Err(_) => {
+            // Same shape as above — surface a directive error
+            // instead of returning silently. With the tightened
+            // `extract_for_context` first-char check, this branch
+            // is rarely reachable (the iter_field would've been
+            // set to `None` upstream), but keeping a real
+            // diagnostic here is the safer end-state.
+            let msg = format!(
+                "pocopine: slot `{target_name}` sits inside `pp-for=\"{iter_var} in {iter_field}\"` but `{iter_field}` isn't a valid Rust identifier referring to a struct field. Iterated-mode auto-publish needs `pp-for=\"X in field_name\"`; either rename the source, or write `<slot :LHS=…>` publications explicitly (static mode)."
+            );
+            out.extend(quote! { ::core::compile_error!(#msg); });
+            return;
+        }
     };
 
     // Rust type assertion: walking `this.<iter_field>` must
@@ -669,17 +701,69 @@ fn emit_iterated_mode(
     // picks it up identically to an explicit static-mode
     // publication.
     //
-    // `opening_tag_range.end` points just past `>`; insert at
-    // `end - 1` so we land before the angle bracket. Skip if
-    // the range is the placeholder `0..0` (foster-parented
-    // element with no real source position).
-    if el.opening_tag_range.end > el.opening_tag_range.start {
-        let insert_at = el.opening_tag_range.end.saturating_sub(1);
+    // `opening_tag_range.end` points just past `>`. The naive
+    // `end - 1` lands on `>` for paired tags (`<slot>`) but on
+    // `/` for self-closing (`<slot/>`), which would yield the
+    // malformed `<slot/ :file="file">`. Scan backwards from
+    // `end` for the actual `>` byte, then back up past any `/`
+    // and trailing whitespace so the injection sits inside the
+    // tag attribute span.
+    if let Some(insert_at) = find_slot_attr_insert_position(source, &el.opening_tag_range) {
         template_edits.push(TemplateEdit {
             insert_at,
             text: format!(" :{iter_var}=\"{iter_var}\""),
         });
     }
+}
+
+/// Find the byte offset within `source` at which to insert a new
+/// attribute on `<slot>`'s opening tag. Handles three shapes:
+///
+/// * `<slot>` — insert at the `>` position (paired tag).
+/// * `<slot />` — insert before the `/` (and any whitespace),
+///   not between `/` and `>`.
+/// * `<slot/>` — insert before the `/`, producing
+///   `<slot :foo="foo"/>` rather than the malformed
+///   `<slot/ :foo="foo">`.
+///
+/// Returns `None` when the range is the foster-parented
+/// placeholder `0..0` or when no `>` is found in the expected
+/// position (defensive — should never happen on well-formed
+/// AST input).
+fn find_slot_attr_insert_position(
+    source: &str,
+    opening_tag_range: &std::ops::Range<usize>,
+) -> Option<usize> {
+    if opening_tag_range.end <= opening_tag_range.start {
+        return None;
+    }
+    let bytes = source.as_bytes();
+    if opening_tag_range.end > bytes.len() {
+        return None;
+    }
+    // Scan backwards from `end - 1` to find `>`.
+    let mut pos = opening_tag_range.end;
+    while pos > opening_tag_range.start {
+        pos -= 1;
+        if bytes[pos] == b'>' {
+            break;
+        }
+    }
+    if pos == opening_tag_range.start || bytes[pos] != b'>' {
+        return None;
+    }
+    // Walk back past whitespace and the optional `/` so the
+    // insertion lands before any self-closing marker.
+    let mut insert_at = pos;
+    while insert_at > opening_tag_range.start {
+        let prev = bytes[insert_at - 1];
+        if prev == b'/' || prev.is_ascii_whitespace() {
+            insert_at -= 1;
+        } else {
+            break;
+        }
+    }
+    Some(insert_at)
 }
 
 /// Emit per-publication-key existence checks plus a coverage
@@ -1276,4 +1360,136 @@ mod tests {
         let out = apply_template_edits(src, &edits);
         assert_eq!(out, r#"<slot :a="a"></slot><slot :b="b"></slot>"#);
     }
+
+    // ── Code-review fixups (post PR #131 review) ───────────────
+
+    #[test]
+    fn invalid_pp_for_iter_var_surfaces_compile_error() {
+        // Review-2: emit_iterated_mode must NOT return silently
+        // when the iter var fails Ident parsing. Use a variable
+        // name that is alphanumeric (so the bare-ident gate
+        // passes) but starts with a digit so `syn::parse_str`
+        // rejects it.
+        let src = r#"<root>
+<li pp-for="2bad in files">
+  <slot name="row"></slot>
+</li>
+</root>"#;
+        let slots = vec![iter_decl("row", "UploadFile")];
+        let emit = emit_slot_props_validation(
+            &ast(src),
+            &slots,
+            &syn::Ident::new("TestHost", proc_macro2::Span::call_site()),
+        );
+        // With Review-5 (tightened iter_field check) it's the
+        // iter-FIELD path that's hit when the FIELD is invalid;
+        // here the iter-VAR is the offender. Either way, the
+        // user must see a compile_error explaining the bad ident.
+        let s = emit.tokens.to_string();
+        assert!(
+            s.contains("compile_error"),
+            "invalid pp-for ident should surface a compile_error: {s}"
+        );
+        assert!(
+            !s.contains("__poco_this"),
+            "type assertion shouldn't fire when ident parse fails: {s}"
+        );
+        assert!(
+            emit.template_edits.is_empty(),
+            "no template edit when ident parse fails"
+        );
+    }
+
+    #[test]
+    fn iter_field_first_char_must_be_alpha_or_underscore() {
+        // Review-5: `extract_for_context` must classify
+        // "2ndItems" as a non-bare-ident, routing the slot to
+        // the "use static mode" error path rather than the
+        // silent ident-parse return.
+        use crate::template_parser::Element;
+        let el = Element {
+            tag: "li".to_string(),
+            attrs: vec![("pp-for".to_string(), "x in 2ndItems".to_string())],
+            children: Vec::new(),
+            byte_range: 0..0,
+            opening_tag_range: 0..0,
+            synthetic: false,
+        };
+        let ctx = extract_for_context(&el).expect("pp-for parses");
+        assert_eq!(ctx.iter_var, "x");
+        assert!(
+            ctx.iter_field.is_none(),
+            "leading-digit `2ndItems` must be classified as non-bare-ident, got {:?}",
+            ctx.iter_field
+        );
+    }
+
+    #[test]
+    fn self_closing_slot_insertion_lands_inside_tag() {
+        // Review-6: `<slot/>` must yield `<slot :file="file"/>`,
+        // not `<slot/ :file="file">`.
+        let src = "<slot/>";
+        let range = 0..src.len();
+        let pos = find_slot_attr_insert_position(src, &range)
+            .expect("paired-or-self-closing slot must have an insert position");
+        // pos should be 5 (the `/` byte), so insertion lands as
+        // `<slot` + ` :file="file"` + `/>`.
+        assert_eq!(pos, 5, "expected insertion before `/`, got {pos}");
+        // End-to-end via apply_template_edits.
+        let out = apply_template_edits(
+            src,
+            &[TemplateEdit {
+                insert_at: pos,
+                text: " :file=\"file\"".to_string(),
+            }],
+        );
+        assert_eq!(out, r#"<slot :file="file"/>"#);
+    }
+
+    #[test]
+    fn self_closing_slot_with_space_insertion_lands_inside_tag() {
+        // Variant: `<slot />` (with trailing space). Insertion
+        // must come before both the `/` AND any whitespace
+        // between attrs and `/`.
+        let src = "<slot />";
+        let range = 0..src.len();
+        let pos =
+            find_slot_attr_insert_position(src, &range).expect("range yields insert position");
+        let out = apply_template_edits(
+            src,
+            &[TemplateEdit {
+                insert_at: pos,
+                text: " :file=\"file\"".to_string(),
+            }],
+        );
+        // Acceptable shapes: `<slot :file="file" />` or
+        // `<slot :file="file"/>` — both keep the attr inside the
+        // tag. The current impl produces the former by walking
+        // back through whitespace.
+        assert!(
+            out == r#"<slot :file="file" />"# || out == r#"<slot :file="file"/>"#,
+            "self-closing slot insertion landed wrong: {out:?}"
+        );
+    }
+
+    #[test]
+    fn paired_slot_insertion_lands_before_close_angle() {
+        // Sanity: the paired-tag case (`<slot>`) still works.
+        let src = "<slot></slot>";
+        let range = 0..6; // covers `<slot>`
+        let pos = find_slot_attr_insert_position(src, &range).expect("paired tag insert position");
+        let out = apply_template_edits(
+            src,
+            &[TemplateEdit {
+                insert_at: pos,
+                text: " :file=\"file\"".to_string(),
+            }],
+        );
+        assert_eq!(out, r#"<slot :file="file"></slot>"#);
+    }
+
+    // Note: the `str_slice_set_eq_const` duplicate-bypass test
+    // (Review-3) lives in `pocopine-core::props::tests` — the
+    // macros crate doesn't depend on pocopine-core at compile
+    // time, so it can't reach the const fn directly.
 }

--- a/crates/pocopine-macros/src/slot.rs
+++ b/crates/pocopine-macros/src/slot.rs
@@ -43,6 +43,12 @@ pub(crate) struct SlotDecl {
     pub mode: SlotMode,
     /// Accepted child component types.
     pub accepts: Vec<Path>,
+    /// RFC 084 — typed slot props. When `Some(T)`, the macro
+    /// validates the compound's `<slot :LHS=...>` publications
+    /// against `T`'s `#[prop]` field set, and the caller's
+    /// `pp-let` binding is typed as `T`. `T` must
+    /// `#[derive(Props)]`.
+    pub props: Option<Path>,
     /// Span of the `#[slot(...)]` attribute for diagnostics.
     /// Currently unused at emit time; kept so future diagnostic
     /// paths can anchor errors at the declaration.
@@ -124,6 +130,7 @@ fn parse_slot_attr(attr: &Attribute) -> syn::Result<SlotDecl> {
     let mut name: Option<SlotName> = None;
     let mut mode: Option<SlotMode> = None;
     let mut accepts: Vec<Path> = Vec::new();
+    let mut props: Option<Path> = None;
 
     // Parse the parenthesised body. `Meta`-list parsing is
     // comma-separated; first entry is the selector.
@@ -175,6 +182,15 @@ fn parse_slot_attr(attr: &Attribute) -> syn::Result<SlotDecl> {
                 mode = Some(SlotMode::Only);
                 accepts = paths;
             }
+            SlotArg::Props(path) => {
+                if props.is_some() {
+                    return Err(syn::Error::new(
+                        span,
+                        "#[slot]: `props = T` may appear at most once per slot declaration",
+                    ));
+                }
+                props = Some(path);
+            }
         }
     }
 
@@ -193,17 +209,20 @@ fn parse_slot_attr(attr: &Attribute) -> syn::Result<SlotDecl> {
         // consumer-side scan does nothing.
         mode: mode.unwrap_or(SlotMode::Accepts),
         accepts,
+        props,
         span,
     })
 }
 
 /// One argument inside `#[slot(...)]` — `default`,
-/// `name = "..."`, `accepts = [...]`, or `only = [...]`.
+/// `name = "..."`, `accepts = [...]`, `only = [...]`, or
+/// `props = TypeName` (RFC 084).
 enum SlotArg {
     Default,
     Name(LitStr),
     Accepts(Vec<Path>),
     Only(Vec<Path>),
+    Props(Path),
 }
 
 impl Parse for SlotArg {
@@ -229,11 +248,17 @@ impl Parse for SlotArg {
                     Ok(SlotArg::Only(paths))
                 }
             }
+            "props" => {
+                input.parse::<Token![=]>()?;
+                let path: Path = input.parse()?;
+                Ok(SlotArg::Props(path))
+            }
             other => Err(syn::Error::new(
                 ident.span(),
                 format!(
                     "#[slot]: unknown argument `{other}` — expected \
-                     `default`, `name = \"...\"`, `accepts = [...]`, or `only = [...]`"
+                     `default`, `name = \"...\"`, `accepts = [...]`, \
+                     `only = [...]`, or `props = TypeName`"
                 ),
             )),
         }
@@ -362,6 +387,174 @@ pub(crate) fn emit_slot_traits(
         });
     }
     out
+}
+
+// ── RFC 084 — typed slot props validation ────────────────────────
+
+/// Emit `const _: () = { ... }` blocks that validate every typed
+/// slot's publication keys against the declared `props = T`'s
+/// `#[prop]` field set.
+///
+/// For each `#[slot(name = "X", props = T)]` declared on the
+/// component, the AST is scanned for matching `<slot name="X">`
+/// elements (default slots match a bare `<slot>`). The element's
+/// `:LHS=...` publications become a `&[&str]` const that
+/// [`pocopine_core::props::str_slice_set_eq_const`] compares
+/// against `<T>::__POC_PROP_LEAVES`. Each individual `:LHS=`
+/// also gets a per-key existence check so the error message can
+/// quote the offending key verbatim.
+///
+/// **v1 scope (Phase 1 of RFC 084):** static-mode only. A
+/// `<slot>` sitting inside a `pp-for` (the iterated-mode case)
+/// is still validated as static here; Phase 2 layers the
+/// auto-publish + iteration-type assertion on top. Both modes
+/// share the same `T: Props` boundary so Phase 2 doesn't have
+/// to revisit it.
+pub(crate) fn emit_slot_props_validation(
+    ast: &crate::template_parser::TemplateAst,
+    slots: &[SlotDecl],
+) -> TokenStream {
+    let mut out = TokenStream::new();
+    for decl in slots {
+        let Some(props_ty) = decl.props.as_ref() else {
+            continue;
+        };
+        // T: Props boundary — fires a clear "the type is not
+        // Props" error at the slot's props arg if the user passes
+        // a non-Props type.
+        let props_ty_str = quote!(#props_ty).to_string();
+        out.extend(quote! {
+            const _: fn() = || {
+                fn __pocopine_assert_props<__T: ::pocopine::__private::Props>() {}
+                __pocopine_assert_props::<#props_ty>();
+            };
+        });
+
+        let target_name: String = match &decl.name {
+            SlotName::Default => "default".into(),
+            SlotName::Named(s) => s.clone(),
+        };
+
+        // Scan every element in the template AST for matching
+        // `<slot>` elements. A `<slot>` with no `name` attribute
+        // is the default slot.
+        let mut found: Vec<&crate::template_parser::Element> = Vec::new();
+        for root in &ast.roots {
+            collect_slot_elements(root, &target_name, &mut found);
+        }
+
+        if found.is_empty() {
+            // The decl mentions a slot the template never
+            // exposes — fail fast with a clear directive
+            // message. This isn't strictly typed-props-specific
+            // but it's the right place to surface it: the
+            // author opted into a typed slot, so they should
+            // also have a matching `<slot>` in the template.
+            let msg = format!(
+                "pocopine: `#[slot(name = \"{target_name}\", props = {props_ty_str})]` declared on this component but no matching `<slot{name_attr}>` element appears in the template",
+                name_attr = match &decl.name {
+                    SlotName::Default => "".to_string(),
+                    SlotName::Named(s) => format!(" name=\"{s}\""),
+                },
+            );
+            out.extend(quote! { ::core::compile_error!(#msg); });
+            continue;
+        }
+
+        // Phase 1: every found `<slot>` element is treated as
+        // static-mode. Phase 2 layers iterated-mode dispatch
+        // (mode resolved per element by `:LHS=` presence and
+        // `pp-for` ancestry).
+        for el in &found {
+            emit_static_publication_validation(&target_name, props_ty, &props_ty_str, el, &mut out);
+        }
+    }
+    out
+}
+
+/// Recursive walk: collect every `<slot>` element whose `name`
+/// matches `target_name` (or has no `name` attribute when
+/// `target_name == "default"`).
+fn collect_slot_elements<'a>(
+    node: &'a crate::template_parser::Node,
+    target_name: &str,
+    out: &mut Vec<&'a crate::template_parser::Element>,
+) {
+    let crate::template_parser::Node::Element(el) = node else {
+        return;
+    };
+    if el.tag == "slot" {
+        let name_attr = el.attrs.iter().find(|(k, _)| k == "name");
+        let this_name = name_attr.map(|(_, v)| v.as_str()).unwrap_or("default");
+        if this_name == target_name {
+            out.push(el);
+        }
+        // A `<slot>` is a leaf in the rendered DOM but
+        // syntactically may have children (fallback content);
+        // we still walk to be safe — nested `<slot>` inside
+        // fallback isn't a real pattern but the recursion is
+        // cheap.
+    }
+    for child in &el.children {
+        collect_slot_elements(child, target_name, out);
+    }
+}
+
+/// Emit per-publication-key existence checks plus a coverage
+/// (set-equality) check for one `<slot>` element in static mode.
+fn emit_static_publication_validation(
+    target_name: &str,
+    props_ty: &Path,
+    props_ty_str: &str,
+    el: &crate::template_parser::Element,
+    out: &mut TokenStream,
+) {
+    let publications: Vec<(String, String)> = el
+        .attrs
+        .iter()
+        .filter_map(|(k, _v)| k.strip_prefix(':').map(|lhs| (lhs.to_string(), _v.clone())))
+        .collect();
+
+    // Per-publication existence: each LHS must be a `#[prop]`
+    // field on the props type. Quotes the offending key so the
+    // error message is actionable.
+    for (lhs, _rhs) in &publications {
+        let msg = format!(
+            "pocopine: slot `{target_name}` publishes `{lhs}` which isn't a `#[prop]` field on `{props_ty_str}`. Add `#[prop] pub {lhs}: …` to the props struct or remove the `:{lhs}=…` publication from the `<slot>` element."
+        );
+        let lhs_lit = lhs.as_str();
+        out.extend(quote! {
+            const _: () = {
+                if !::pocopine::__private::str_slice_contains_const(
+                    <#props_ty>::__POC_PROP_LEAVES,
+                    #lhs_lit,
+                ) {
+                    ::core::panic!(#msg);
+                }
+            };
+        });
+    }
+
+    // Coverage: every `#[prop]` field on T must be published.
+    // Const-fn set-equality (both directions) gives one diagnostic
+    // if anything is missing; combined with the per-key checks
+    // above, the author sees per-extra-key errors AND a generic
+    // "missing fields" error pointing at the props struct.
+    let lhs_lits: Vec<&str> = publications.iter().map(|(k, _)| k.as_str()).collect();
+    let coverage_msg = format!(
+        "pocopine: slot `{target_name}` publication doesn't cover every `#[prop]` field declared on `{props_ty_str}`. Inspect the struct's `#[prop]` fields and add a `:field=…` publication on the `<slot>` element for each."
+    );
+    out.extend(quote! {
+        const _: () = {
+            const __POCO_PUB: &[&str] = &[#(#lhs_lits),*];
+            if !::pocopine::__private::str_slice_set_eq_const(
+                <#props_ty>::__POC_PROP_LEAVES,
+                __POCO_PUB,
+            ) {
+                ::core::panic!(#coverage_msg);
+            }
+        };
+    });
 }
 
 fn pascal_case(s: &str) -> String {
@@ -537,6 +730,7 @@ mod tests {
                 syn::parse_str::<Path>("PineItem").unwrap(),
                 syn::parse_str::<Path>("PineSeparator").unwrap(),
             ],
+            props: None,
             span: proc_macro2::Span::call_site(),
         }];
         let out = emit_slot_traits(
@@ -565,6 +759,7 @@ mod tests {
                 syn::parse_str::<Path>("PineDialogTitle").unwrap(),
                 syn::parse_str::<Path>("PineDialogDescription").unwrap(),
             ],
+            props: None,
             span: proc_macro2::Span::call_site(),
         }];
         let out = emit_slot_traits(
@@ -589,6 +784,7 @@ mod tests {
             name: SlotName::Named("footer".to_string()),
             mode: SlotMode::Only,
             accepts: vec![syn::parse_str::<Path>("PineTitle").unwrap()],
+            props: None,
             span: proc_macro2::Span::call_site(),
         }];
         let out = emit_slot_traits(
@@ -604,5 +800,74 @@ mod tests {
         assert_eq!(pascal_case("footer"), "Footer");
         assert_eq!(pascal_case("my-named-slot"), "MyNamedSlot");
         assert_eq!(pascal_case("other_name"), "OtherName");
+    }
+
+    // ── RFC 084 — typed slot props parser tests ─────────────────
+
+    #[test]
+    fn slot_props_parses_as_path() {
+        let mut st = parse_struct_with_attr(quote! {
+            #[slot(name = "header", props = UploadHeaderProps)]
+            struct Foo;
+        });
+        let slots = parse_and_strip_slots(&mut st.attrs).unwrap();
+        assert_eq!(slots.len(), 1);
+        let props = slots[0].props.as_ref().expect("props should be Some");
+        let rendered = quote::quote!(#props).to_string();
+        assert_eq!(rendered.replace(' ', ""), "UploadHeaderProps");
+    }
+
+    #[test]
+    fn slot_props_accepts_module_qualified_path() {
+        // `props = some::module::Type` should round-trip.
+        let mut st = parse_struct_with_attr(quote! {
+            #[slot(default, props = crate::upload::UploadItemProps)]
+            struct Foo;
+        });
+        let slots = parse_and_strip_slots(&mut st.attrs).unwrap();
+        let props = slots[0].props.as_ref().expect("props should be Some");
+        let rendered = quote::quote!(#props).to_string();
+        assert!(
+            rendered.contains("UploadItemProps") && rendered.contains("crate"),
+            "props path should preserve qualifier: {rendered}"
+        );
+    }
+
+    #[test]
+    fn slot_props_default_is_none() {
+        let mut st = parse_struct_with_attr(quote! {
+            #[slot(default)]
+            struct Foo;
+        });
+        let slots = parse_and_strip_slots(&mut st.attrs).unwrap();
+        assert!(slots[0].props.is_none());
+    }
+
+    #[test]
+    fn slot_props_coexists_with_accepts_or_only() {
+        // RFC 084 doesn't change the accepts/only contract; both
+        // can sit alongside `props = T`.
+        let mut st = parse_struct_with_attr(quote! {
+            #[slot(name = "row", only = [UploadFile], props = UploadItemProps)]
+            struct Foo;
+        });
+        let slots = parse_and_strip_slots(&mut st.attrs).unwrap();
+        assert_eq!(slots[0].mode, SlotMode::Only);
+        assert_eq!(slots[0].accepts.len(), 1);
+        assert!(slots[0].props.is_some());
+    }
+
+    #[test]
+    fn slot_props_duplicate_rejected() {
+        let attr_tokens: syn::ItemStruct = parse_struct_with_attr(quote! {
+            #[slot(name = "row", props = A, props = B)]
+            struct Foo;
+        });
+        let err = parse_slot_for_test(&attr_tokens.attrs[0]).unwrap_err();
+        assert!(
+            err.to_string().contains("at most once"),
+            "duplicate `props =` should error: {}",
+            err
+        );
     }
 }

--- a/crates/pocopine-macros/src/slot.rs
+++ b/crates/pocopine-macros/src/slot.rs
@@ -479,6 +479,7 @@ struct SlotMatch<'a> {
 pub(crate) fn emit_slot_props_validation(
     ast: &crate::template_parser::TemplateAst,
     slots: &[SlotDecl],
+    struct_ident: &Ident,
 ) -> SlotValidationEmit {
     let mut out = TokenStream::new();
     let mut template_edits = Vec::new();
@@ -539,6 +540,7 @@ pub(crate) fn emit_slot_props_validation(
                     &props_ty_str,
                     el,
                     for_ctx.as_ref().unwrap(),
+                    struct_ident,
                     &mut out,
                     &mut template_edits,
                 );
@@ -601,6 +603,7 @@ fn emit_iterated_mode(
     props_ty_str: &str,
     el: &crate::template_parser::Element,
     for_ctx: &ForContext,
+    struct_ident: &Ident,
     out: &mut TokenStream,
     template_edits: &mut Vec<TemplateEdit>,
 ) {
@@ -638,8 +641,11 @@ fn emit_iterated_mode(
     let mismatch_note = format!(
         "the iteration source `{iter_field}` for slot `{target_name}` must yield items of type `{props_ty_str}` (matching `#[slot(name = \"{target_name}\", props = {props_ty_str})]`)"
     );
+    // Type assertion lives at module-item position (alongside
+    // the emitted struct), so `Self` isn't in scope — name the
+    // struct explicitly via `#struct_ident`.
     out.extend(quote! {
-        const _: fn(&Self) = |__poco_this: &Self| {
+        const _: fn(&#struct_ident) = |__poco_this: &#struct_ident| {
             // Force-resolve the iter item's type via a `match`
             // on `IntoIterator`. The `unreachable!()` branch is
             // never executed (the assertion is in const-fn
@@ -1104,7 +1110,11 @@ mod tests {
 </ul>
 </root>"#;
         let slots = vec![iter_decl("row", "UploadFile")];
-        let emit = emit_slot_props_validation(&ast(src), &slots);
+        let emit = emit_slot_props_validation(
+            &ast(src),
+            &slots,
+            &syn::Ident::new("TestHost", proc_macro2::Span::call_site()),
+        );
         assert_eq!(
             emit.template_edits.len(),
             1,
@@ -1137,7 +1147,11 @@ mod tests {
 </li>
 </root>"#;
         let slots = vec![iter_decl("row", "UploadFile")];
-        let emit = emit_slot_props_validation(&ast(src), &slots);
+        let emit = emit_slot_props_validation(
+            &ast(src),
+            &slots,
+            &syn::Ident::new("TestHost", proc_macro2::Span::call_site()),
+        );
         let s = emit.tokens.to_string();
         assert!(
             !s.contains("str_slice_set_eq_const"),
@@ -1155,7 +1169,11 @@ mod tests {
 </div>
 </root>"#;
         let slots = vec![iter_decl("header", "HeaderProps")];
-        let emit = emit_slot_props_validation(&ast(src), &slots);
+        let emit = emit_slot_props_validation(
+            &ast(src),
+            &slots,
+            &syn::Ident::new("TestHost", proc_macro2::Span::call_site()),
+        );
         assert!(
             emit.template_edits.is_empty(),
             "static slot should yield no template edits: {:?}",
@@ -1175,7 +1193,11 @@ mod tests {
 </li>
 </root>"#;
         let slots = vec![iter_decl("row", "UploadFile")];
-        let emit = emit_slot_props_validation(&ast(src), &slots);
+        let emit = emit_slot_props_validation(
+            &ast(src),
+            &slots,
+            &syn::Ident::new("TestHost", proc_macro2::Span::call_site()),
+        );
         assert!(
             emit.template_edits.is_empty(),
             "static-mode (has :LHS=) must not emit an auto-publish edit"
@@ -1198,7 +1220,11 @@ mod tests {
 <slot name="row"></slot>
 </root>"#;
         let slots = vec![iter_decl("row", "UploadFile")];
-        let emit = emit_slot_props_validation(&ast(src), &slots);
+        let emit = emit_slot_props_validation(
+            &ast(src),
+            &slots,
+            &syn::Ident::new("TestHost", proc_macro2::Span::call_site()),
+        );
         assert!(
             emit.template_edits.is_empty(),
             "no pp-for ancestor → no auto-publish edit"
@@ -1216,7 +1242,11 @@ mod tests {
 </li>
 </root>"#;
         let slots = vec![iter_decl("row", "UploadFile")];
-        let emit = emit_slot_props_validation(&ast(src), &slots);
+        let emit = emit_slot_props_validation(
+            &ast(src),
+            &slots,
+            &syn::Ident::new("TestHost", proc_macro2::Span::call_site()),
+        );
         let s = emit.tokens.to_string();
         assert!(
             s.contains("compile_error") && s.contains("bare field path"),

--- a/crates/pocopine/src/lib.rs
+++ b/crates/pocopine/src/lib.rs
@@ -128,6 +128,12 @@ pub mod __private {
         LifecycleContext, PropValue, Props, Scope, StaticBinOp, StaticBinding, StaticExpr,
         StaticListener, StaticLiteral, StaticPropKind, StaticRowPlan, Store, WriteOrigin,
     };
+    // RFC 084 — const-eval helpers the `#[slot(props = T)]`
+    // validation tokens call to compare publication keys against
+    // a props type's `#[prop]` field set at `cargo check` time.
+    pub use pocopine_core::props::{
+        str_eq_const, str_slice_contains_const, str_slice_set_eq_const,
+    };
     // RFC 081 — typed ref accessor used by the macro-generated
     // `<ComponentName>Refs` struct.
     pub use pocopine_core::reactive::ScopeId;

--- a/crates/pocopine/tests/typed_slot_props.rs
+++ b/crates/pocopine/tests/typed_slot_props.rs
@@ -1,0 +1,164 @@
+//! RFC 084 — typed slot props end-to-end compilation fixture.
+//!
+//! These types exercise the `#[slot(props = T)]` arg + the
+//! macro's static- and iterated-mode publication validation
+//! against real `#[component]` invocations. The assertion is
+//! compilation success: every component below must reach the
+//! `cargo check` step without the macro emitting a
+//! `compile_error!` or a const-block panic.
+//!
+//! Run with:
+//!   `cargo check --tests -p pocopine`
+//!   `wasm-pack test --firefox --headless crates/pocopine --test typed_slot_props`
+//!   (the wasm target is the canonical one; host also compiles
+//!   since the macro expansion happens at host compile time)
+
+#![cfg(target_arch = "wasm32")]
+// Compilation IS the test — the structs below are exercised by
+// the macro expansion path, not by runtime construction.
+#![allow(dead_code)]
+
+use pocopine::prelude::*;
+use serde::{Deserialize, Serialize};
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+// ── Static-mode fixture ────────────────────────────────────────
+
+#[derive(Default, Props, Serialize, Deserialize)]
+struct StaticHeaderProps {
+    #[prop]
+    queue_size: usize,
+    #[prop]
+    all_done: bool,
+}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "typed-slot-static-host",
+    template_inline = r#"
+<section class="typed-slot-static-host">
+  <slot name="header" :queue_size="queue_size" :all_done="all_done"></slot>
+  <div class="body">content</div>
+</section>
+"#
+)]
+#[slot(name = "header", props = StaticHeaderProps)]
+struct TypedSlotStaticHost {
+    queue_size: usize,
+    all_done: bool,
+}
+
+#[handlers]
+impl TypedSlotStaticHost {}
+
+// ── Iterated-mode fixture ──────────────────────────────────────
+//
+// `<slot name="row">` sits inside `pp-for="file in files"` and
+// has zero `:LHS=` attrs — Phase 2 dispatches to iterated mode,
+// auto-publishes `:file="file"`, and emits the Rust type
+// assertion that `files`'s element type matches `UploadFileLite`.
+
+#[derive(Default, Clone, Props, Serialize, Deserialize)]
+struct UploadFileLite {
+    #[prop]
+    name: String,
+    #[prop]
+    progress: f64,
+}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "typed-slot-iterated-host",
+    template_inline = r#"
+<section class="typed-slot-iterated-host">
+  <ul>
+    <li pp-for="file in files">
+      <slot name="row"></slot>
+    </li>
+  </ul>
+</section>
+"#
+)]
+#[slot(name = "row", props = UploadFileLite)]
+struct TypedSlotIteratedHost {
+    files: Vec<UploadFileLite>,
+}
+
+#[handlers]
+impl TypedSlotIteratedHost {}
+
+// ── Mixed-mode fixture (§5.4) ──────────────────────────────────
+//
+// `<slot>` sits inside `pp-for` AND has explicit `:LHS=` attrs:
+// presence of any publication forces static mode. The macro must
+// validate every `#[prop]` field on `IteratedRowFlat` is covered
+// by the publication. The Props struct stays flat (one `#[prop]`
+// per leaf) — `#[prop(flatten)]` is a `#[component]`-side
+// concept, not a `#[derive(Props)]` arg.
+
+#[derive(Default, Clone, Props, Serialize, Deserialize)]
+struct IteratedRowFlat {
+    #[prop]
+    name: String,
+    #[prop]
+    progress: f64,
+    #[prop]
+    is_last: bool,
+}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "typed-slot-mixed-host",
+    template_inline = r#"
+<section class="typed-slot-mixed-host">
+  <ul>
+    <li pp-for="file in files">
+      <slot name="row" :name="file.name" :progress="file.progress" :is_last="$last"></slot>
+    </li>
+  </ul>
+</section>
+"#
+)]
+#[slot(name = "row", props = IteratedRowFlat)]
+struct TypedSlotMixedHost {
+    files: Vec<UploadFileLite>,
+}
+
+#[handlers]
+impl TypedSlotMixedHost {}
+
+// ── Backwards-compatibility fixture ────────────────────────────
+//
+// Existing `#[slot]` sites without `props = T` must keep
+// compiling unchanged — no validation runs, no const blocks
+// emitted.
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "untyped-slot-host",
+    template_inline = r#"
+<section class="untyped-slot-host">
+  <slot></slot>
+  <slot name="footer"></slot>
+</section>
+"#
+)]
+#[slot(default)]
+#[slot(name = "footer")]
+struct UntypedSlotHost {}
+
+#[handlers]
+impl UntypedSlotHost {}
+
+// ── Sentinel test ──────────────────────────────────────────────
+//
+// Reaching this point means every `#[component]` + `#[slot]`
+// invocation above expanded without emitting `compile_error!`
+// or a const-block panic. That IS the end-to-end assertion.
+
+#[wasm_bindgen_test]
+fn typed_slot_fixtures_compile() {
+    // No-op — compilation success is the test.
+}

--- a/crates/pocopine/tests/typed_slot_props.rs
+++ b/crates/pocopine/tests/typed_slot_props.rs
@@ -7,21 +7,26 @@
 //! `cargo check` step without the macro emitting a
 //! `compile_error!` or a const-block panic.
 //!
+//! Macro expansion happens at host compile time, so this file
+//! deliberately is **not** gated on `target_arch = "wasm32"` —
+//! `cargo check --tests -p pocopine` on a host runs the macro,
+//! exercising every validation path. Only the runtime sentinel
+//! `#[wasm_bindgen_test]` itself needs the wasm gate.
+//!
 //! Run with:
 //!   `cargo check --tests -p pocopine`
 //!   `wasm-pack test --firefox --headless crates/pocopine --test typed_slot_props`
-//!   (the wasm target is the canonical one; host also compiles
-//!   since the macro expansion happens at host compile time)
 
-#![cfg(target_arch = "wasm32")]
 // Compilation IS the test — the structs below are exercised by
 // the macro expansion path, not by runtime construction.
 #![allow(dead_code)]
 
 use pocopine::prelude::*;
 use serde::{Deserialize, Serialize};
+#[cfg(target_arch = "wasm32")]
 use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 
+#[cfg(target_arch = "wasm32")]
 wasm_bindgen_test_configure!(run_in_browser);
 
 // ── Static-mode fixture ────────────────────────────────────────
@@ -158,6 +163,7 @@ impl UntypedSlotHost {}
 // invocation above expanded without emitting `compile_error!`
 // or a const-block panic. That IS the end-to-end assertion.
 
+#[cfg(target_arch = "wasm32")]
 #[wasm_bindgen_test]
 fn typed_slot_fixtures_compile() {
     // No-op — compilation success is the test.

--- a/docs/components/03-composition.md
+++ b/docs/components/03-composition.md
@@ -211,6 +211,127 @@ options in a `<select>`): the child exposes the collection on its
 `<slot>` and the caller writes a normal `pp-for` over the
 `pp-let`-named binding.
 
+### Typed slot props (RFC 084)
+
+The untyped form above ships and works, but **typed slot props
+are the recommended form going forward.** Authors opt in by
+adding one keyword to `#[slot]` and declaring the publication
+shape as a `Props` struct:
+
+```rust
+// UploadItem.rs
+#[derive(Default, Props, Serialize, Deserialize)]
+pub struct UploadItemSlotProps {
+    #[prop] pub name: String,
+    #[prop] pub status: String,
+    #[prop] pub progress: f64,
+}
+
+#[component(template = "UploadItem.poco", role = "panel")]
+#[slot(default, props = UploadItemSlotProps)]
+pub struct UploadItem {
+    pub name: String,
+    pub status: String,
+    pub progress: f64,
+}
+```
+
+```html
+<!-- UploadItem.poco — same shape as the untyped form -->
+<div class="row">
+  <slot :name="name" :status="status" :progress="progress"></slot>
+</div>
+```
+
+What the macro now checks at `cargo check` time:
+
+* `UploadItemSlotProps` derives `Props`. If you forget the
+  derive, the slot decl errors with the missing trait bound.
+* The `<slot :LHS=...>` publication covers every `#[prop]` field
+  on `UploadItemSlotProps`. A missing `:status="status"` errors
+  at the slot element. An extra `:notes="..."` not on the
+  Props struct errors with the offending key quoted.
+* (Future Phase 3) The caller's `row.X` reads will be checked
+  against `UploadItemSlotProps`'s prop set.
+
+**Iterated slots** — the same `#[slot(props = T)]` decl + a
+`<slot>` element sitting inside a `pp-for` automatically
+publishes the iteration variable. No `:LHS=` attributes
+needed:
+
+```rust
+#[component(template = "UploadRoot.poco", role = "scope")]
+#[slot(name = "row", props = UploadFile)]      // UploadFile must derive Props
+pub struct UploadRoot {
+    pub files: Vec<UploadFile>,
+}
+```
+
+```html
+<!-- UploadRoot.poco — macro auto-publishes `file` as the slot binding -->
+<ul>
+  <li pp-for="file in files">
+    <slot name="row"></slot>
+  </li>
+</ul>
+```
+
+```html
+<!-- Caller -->
+<upload-root>
+  <template pp-slot="row" pp-let="file">
+    <span pp-text="file.name"></span>
+  </template>
+</upload-root>
+```
+
+Rules for iterated mode:
+
+* The `<slot>` sits inside a `pp-for`, has zero `:LHS=` attrs,
+  and the `pp-for`'s iteration source is a bare field path
+  (e.g. `pp-for="X in files"`). All three together → iterated
+  mode.
+* The macro emits a Rust type assertion that the iteration
+  item's type matches the declared `props = T`. Mismatch is a
+  `cargo check` error.
+* `pp-for` over a more complex expression (method calls, dotted
+  paths beyond a single field) errors with "use static mode";
+  write the publications explicitly.
+
+**Iteration with metadata** (`$index`, `$last`, derived
+labels): drop back to static mode. Define a Props struct
+flattening the item fields plus the metadata, and publish
+explicitly:
+
+```rust
+#[derive(Default, Props, Serialize, Deserialize)]
+pub struct UploadRow {
+    #[prop] pub name: String,
+    #[prop] pub progress: f64,
+    #[prop] pub index: u32,
+    #[prop] pub is_last: bool,
+}
+
+#[slot(name = "row", props = UploadRow)]
+```
+
+```html
+<li pp-for="file in files">
+  <slot name="row"
+    :name="file.name" :progress="file.progress"
+    :index="$index" :is_last="$last"></slot>
+</li>
+```
+
+Any presence of `:LHS=` on the slot element forces static
+mode — there's no "iterated + extras" middle case to learn,
+just one rule.
+
+See RFC 084 for the full design rationale and the seven
+alternatives that were considered and rejected (Ctx wrapper
+types, `$host`/`#[expose]` magics, slot-name-as-binding,
+inline template type annotations, etc.).
+
 ## Iteration (`pp-for`, deferred)
 
 Planned syntax for the array-reactivity milestone:

--- a/docs/poco/04-expressions.md
+++ b/docs/poco/04-expressions.md
@@ -164,5 +164,10 @@ expression.
 * `docs/components/02-state.md` — state management conventions; the
   anti-pattern on manually-mirrored derived fields ties directly to
   this page.
+* `docs/components/03-composition.md` — **typed slot props** (RFC
+  084) apply the same Rust-side-computation pattern to the
+  parent↔child slot edge: declare the slot's exposed shape as a
+  `Props` struct so the same compile-time validation applies to
+  slot publications.
 * `docs/poco/01-format.md` — the broader `.poco` format.
 * `crates/pocopine-expr/src/lib.rs` — grammar reference.

--- a/rfcs/rfc-084-typed-slot-props.md
+++ b/rfcs/rfc-084-typed-slot-props.md
@@ -1,0 +1,727 @@
+# RFC 084 - Typed slot props
+
+| Field | Value |
+|---|---|
+| **Status** | Draft |
+| **Author** | pocopine team |
+| **Created** | 2026-05-26 |
+| **Related** | [`rfc-044-props.md`](./rfc-044-props.md), [`rfc-049-slot-contracts.md`](./rfc-049-slot-contracts.md), [`rfc-050-template-ast.md`](./rfc-050-template-ast.md), [`rfc-081-component-handle-refs.md`](./rfc-081-component-handle-refs.md) |
+| **Supersedes** | - |
+
+## 1. Summary
+
+Scoped-slot publications are stringly-typed today. The compound's
+template publishes string-keyed JS values via
+`<slot :name="name" :status="status">`, the caller reads them via
+`<template pp-slot="default" pp-let="row">` + `row.name` /
+`row.status`, and nothing in between checks that keys match,
+value types are right, or that publication covers every field
+the caller reads. Typos surface as silent `undefined`s.
+
+This RFC extends `#[slot(...)]` with **one** optional argument —
+`props = T` — that types the publication. `T` is declared with
+the existing `#[derive(Props)]` (the same wire surface the
+parent→child prop pipeline uses), and the macro verifies that:
+
+1. The compound's `<slot :foo="…">` publications cover every
+   `#[prop]` field on `T`.
+2. The caller's `pp-let` binding is typed as `T`; `row.X` reads
+   resolve against `T`'s prop set at macro time.
+
+There is **no separate `iterates` argument and no wrapper type**.
+The macro dispatches **static vs iterated by template context**:
+when the `<slot>` element sits inside a `pp-for`, the iteration
+binding is auto-published as the slot binding and the Rust
+typechecker verifies the iteration item matches `T`. When the
+slot sits outside any `pp-for`, the author writes explicit
+`<slot :foo="…" :bar="…">` publications. One rule, one arg, two
+template contexts.
+
+```rust
+#[derive(Default, Props, Serialize, Deserialize)]
+pub struct UploadHeaderProps {
+    #[prop] pub queue_size: usize,
+    #[prop] pub all_done: bool,
+}
+
+#[component(template = "UploadRoot.poco", role = "scope")]
+#[slot(name = "header", props = UploadHeaderProps)]   // static slot
+#[slot(name = "row",    props = UploadFile)]          // iterated slot — binding type
+#[slot(name = "footer", props = UploadFooterProps)]
+pub struct UploadRoot { /* ... */ }
+```
+
+## 2. Motivation
+
+PR #127 shipped the `03-composition.md` "Why doesn't my pp-text
+work inside a compound's slot?" section that nailed down the
+existing scoped-slot pattern: `<slot :LHS="RHS">` + `pp-let="X"`,
+where LHS is the caller-visible key and RHS is an expression in
+the compound's scope. The pattern works end-to-end, but the same
+PR's review surfaced that the binding edges are entirely
+string-keyed:
+
+- A typo on the compound side (`<slot :nmae="name">`) parses
+  cleanly and publishes an `nmae` key the caller's `row.name`
+  silently misses.
+- A typo on the caller side (`row.nmae`) reads `undefined` with
+  no diagnostic.
+- A field-type mismatch (compound publishes `status: String` but
+  caller reads it via `pp-show="row.status"`) is evaluated as JS
+  truthiness without warning.
+- Renaming a published key on the compound silently breaks every
+  caller reading the old key.
+
+The framework treats every other binding edge as typed at the
+macro boundary — `#[component]` props go through
+`#[derive(Props)]` + `PropValue`, handler arguments go through
+`FromHandlerArg`, event names go through compile-time directive
+validation. Slot publications are the one major reactive edge
+still stringly-typed. This RFC closes that gap by reusing the
+existing Props surface rather than inventing a parallel
+`Ctx`/`SlotProps`/`SlotContext` vocabulary or wrapper type.
+
+## 3. Goals
+
+1. **Compile-time validation of slot publication shape.** The
+   compound's `<slot :foo=…>` publications are checked against
+   the declared `Props` type at macro expansion. Missing key →
+   compile error. Extra key not on the type → compile error
+   (with a hint to add it to the props struct or remove the
+   stray publication).
+2. **Compile-time validation of caller access** to the extent
+   reasonable. `pp-let="row"` + `row.foo` in the caller's
+   `<template pp-slot>` resolves `foo` against the declared
+   props type; an unknown key is a compile error pointing at
+   the props struct.
+3. **Reuse the existing Props plumbing.** Same
+   `#[derive(Props)]`, same `PropValue` leaf-type constraints,
+   same `#[prop(flatten)]` for nested structs. No new traits,
+   no new derives, no wrapper type.
+4. **Single decl per slot, single rule for the macro.** No
+   parallel `iterates =`, no `SlotContext<T>` /
+   `PropsIterator<T>` wrappers. The decl says one thing: the
+   binding type. The template's `pp-for` context — which the
+   macro already walks — decides static vs iterated.
+5. **Backwards compatible.** Existing untyped `#[slot(default)]`
+   and `#[slot(name = "...")]` keep working unchanged. Adding
+   `props = T` is opt-in.
+
+## 4. Non-goals
+
+1. **Replacing the `<slot :LHS="RHS">` syntax.** The publication
+   syntax stays the same. The RFC only adds a *type* to validate
+   it against.
+2. **Inline type annotations in templates.** Per the `.poco`
+   format rule, types live in Rust. No `<slot :name@type<String>>`
+   or similar.
+3. **A wrapper type to mark iteration.** Considered (`Each<T>`,
+   `ItemOf<T>`, `PropsIterator<T>`) and rejected; see §8.2.
+4. **A `iterates = field` parallel macro arg.** Considered and
+   rejected; see §8.1.
+5. **Built-in iteration metadata** (`$index`, `$last`,
+   `$first`) as fields on the props type. Authors define their
+   own Props struct flattening the item plus the metadata and
+   publish explicitly — see §5.4.
+6. **Generic slots** (a typed slot whose props type is generic
+   over the compound's own generics). Ship monomorphic slots
+   first; revisit in a follow-up RFC.
+7. **Caller-side destructuring sugar** (e.g.
+   `pp-let="{ name }"`). `pp-let="row"` + `row.name` remains
+   the v1 form.
+8. **Cross-instance reach via slot props.** Use RFC 081's
+   `pp-ref` + `$ref.name.X` for that — slot props are scoped to
+   the slot content, by design.
+9. **Runtime type checking.** The publication is a JS object on
+   the wire; runtime cost stays zero. Validation is macro-time.
+
+## 5. Design
+
+### 5.1 The single arg
+
+`#[slot(name = "...", ...)]` accepts one new optional argument:
+
+| Argument | Meaning |
+|---|---|
+| `props = Type` | The binding type the caller's `pp-let="X"` exposes. `Type` must derive `Props`. |
+
+The macro dispatches **static vs iterated by the template-AST
+position of the `<slot>` element**:
+
+- The `<slot>` is **not** an descendant of any `pp-for` → **static
+  mode**. The compound's template MUST publish explicitly via
+  `<slot :LHS="RHS">` attributes covering every `#[prop]` field
+  on `Type`.
+- The `<slot>` **is** a descendant of a `pp-for="X in expr"` →
+  **iterated mode**. The macro auto-emits a publication where
+  the slot binding is `X` itself. No explicit `:LHS="RHS"` on
+  `<slot>` is required (the macro errors if any are present —
+  the two modes don't mix; see §5.4). The Rust typechecker
+  verifies that `X`'s type matches `Type` via an emitted type
+  assertion (see §5.6).
+
+That's the entire rule. Everything else falls out from "single
+arg + template-AST dispatch."
+
+### 5.2 Static-mode example
+
+```rust
+// UploadRoot.rs
+#[derive(Default, Props, Serialize, Deserialize)]
+pub struct UploadHeaderProps {
+    #[prop] pub queue_size: usize,
+    #[prop] pub all_done: bool,
+}
+
+#[component(template = "UploadRoot.poco", role = "scope")]
+#[slot(name = "header", props = UploadHeaderProps)]
+pub struct UploadRoot {
+    pub queue_size: usize,
+    pub all_done: bool,
+    /* ... */
+}
+```
+
+```html
+<!-- UploadRoot.poco -->
+<div>
+  <slot name="header" :queue_size="queue_size" :all_done="all_done"></slot>
+  <!-- ... -->
+</div>
+```
+
+```html
+<!-- caller -->
+<upload-root>
+  <template pp-slot="header" pp-let="hdr">
+    <h2>{{ hdr.queue_size }} files</h2>
+    <span pp-show="hdr.all_done">All uploaded</span>
+  </template>
+</upload-root>
+```
+
+The macro validates:
+
+- Every `#[prop]` field on `UploadHeaderProps` is published by a
+  matching `:foo=…` on the `<slot name="header">` element.
+  Missing one → compile error: *"slot 'header' publication
+  doesn't cover prop `all_done` declared on
+  `UploadHeaderProps`."*
+- Each published `:foo="expr"` resolves `foo` to a declared
+  `#[prop]` field on `UploadHeaderProps`. Extra key → compile
+  error: *"slot 'header' publishes `notes` which isn't a prop
+  on `UploadHeaderProps`; add `#[prop] pub notes: …` or remove
+  the publication."*
+- Each `hdr.X` read inside the caller's
+  `<template pp-slot="header">` resolves `X` against
+  `UploadHeaderProps`'s prop set; unknown keys → compile error.
+
+### 5.3 Iterated-mode example
+
+```rust
+// UploadRoot.rs
+#[component(template = "UploadRoot.poco", role = "scope")]
+#[slot(name = "row", props = UploadFile)]
+pub struct UploadRoot {
+    pub files: Vec<UploadFile>,
+    /* ... */
+}
+```
+
+```html
+<!-- UploadRoot.poco — slot inside pp-for; publication is auto-emitted -->
+<ul>
+  <li pp-for="file in files">
+    <slot name="row"></slot>
+  </li>
+</ul>
+```
+
+```html
+<!-- caller -->
+<upload-root>
+  <template pp-slot="row" pp-let="file">
+    <span pp-text="file.name"></span>
+    <span pp-show="file.status == 'uploading'">
+      <span pp-text="file.progress_label"></span>
+    </span>
+  </template>
+</upload-root>
+```
+
+The macro:
+
+- Walks the template AST and locates the `<slot name="row">`
+  element.
+- Sees it's a descendant of `<li pp-for="file in files">`.
+- Dispatches to iterated mode: auto-emits the publication of
+  `file` as the slot binding.
+- Emits a Rust type assertion that verifies
+  `typeof(file) == UploadFile` (the props type). If the
+  iteration variable's type doesn't match, Rust errors point
+  at the emitted assertion, the `#[slot]` attr, and the
+  `pp-for` site.
+- Errors at macro time if any `<slot :foo="…">` attrs are
+  present on a `<slot>` in iterated mode — the two modes are
+  mutually exclusive at the per-`<slot>`-element level (see
+  §5.4).
+- On the caller side, `pp-let="file"` binds an object whose
+  shape is `UploadFile`'s `#[prop]` field set. `file.bogus` →
+  compile error.
+
+`UploadFile` must `#[derive(Props)]` — i.e., be defined with
+`#[derive(Default, Props, Serialize, Deserialize)]` and `#[prop]`
+on the leaves the caller can read. If it doesn't, the macro
+errors: *"`UploadFile` must `#[derive(Props)]` to serve as a
+slot publication type; see RFC 044."*
+
+### 5.4 Iteration with metadata — back to static mode
+
+Authors who need iteration metadata (`$index`, `$last`,
+`$first`, derived labels) declare a Props struct that flattens
+the iteration item plus the extra fields and publish explicitly
+— that's static mode, and it's the SAME rule as §5.2:
+
+```rust
+#[derive(Default, Props, Serialize, Deserialize)]
+pub struct UploadRow {
+    #[prop(flatten)] pub file: UploadFile,
+    #[prop] pub index: usize,
+    #[prop] pub is_last: bool,
+}
+
+#[slot(name = "row", props = UploadRow)]
+```
+
+```html
+<ul>
+  <li pp-for="file in files">
+    <slot name="row" :file="file" :index="$index" :is_last="$last"></slot>
+  </li>
+</ul>
+```
+
+The macro sees the `<slot>` is inside a `pp-for` AND has explicit
+publications, which would be a mode mix; instead the rule is:
+**presence of any `:LHS=` on the `<slot>` element forces static
+mode**, regardless of whether the element sits inside a
+`pp-for`. The author is opting into "I'm publishing explicitly,
+the iteration variable is just one of the inputs."
+
+This gives a single role-split: **iterated mode is sugar for
+"just publish the iteration item, no metadata"** (zero `:LHS=`
+on `<slot>`); **static mode is everything else** (one or more
+`:LHS=` on `<slot>`). Same `props = T` arg in both cases.
+
+### 5.5 Validation rules
+
+The macro emits checks at component expansion time. Concrete
+rule set:
+
+**On the compound side** (the component declaring `#[slot]`):
+
+1. `props = T` requires `T: pocopine::__private::Props` —
+   verified via an emitted `const _: () = { fn _assert<T:
+   Props>(){} _assert::<#T>(); }`-style boundary so the
+   diagnostic points at the `#[slot]` attribute, not at a
+   downstream macro.
+2. AST scan locates every `<slot name="X">` element in the
+   compound's template. (Default slot — `<slot>` with no name
+   — is treated as `name = "default"`.)
+3. **Mode resolution per element**: if the element has any
+   `:LHS=…` attributes → static mode. Else if the element is a
+   descendant of `pp-for="VAR in EXPR"` → iterated mode. Else
+   → static mode with an empty publication set (errors if T
+   has any `#[prop]` fields the publication doesn't cover).
+4. **Static mode validation** (set-equality on publications):
+   - Missing publication for a `#[prop]` field on T → error
+     per missing field.
+   - Extra publication for a key not on T → error per stray
+     key.
+5. **Iterated mode validation**:
+   - The `<slot>` element MUST have zero `:LHS=…` attrs (else
+     mode is static — see rule 3).
+   - The enclosing `pp-for`'s iteration variable's type MUST
+     equal T. This is verified by emitting a Rust assertion
+     like `let _: T = #iter_var.clone();` (or a `let _: &T =
+     &#iter_var;`) into a hidden function the macro generates,
+     so the Rust typechecker reports the mismatch with the
+     emitted assertion's span on one side and the `#[slot]`
+     attr on the other.
+6. **Multiple `<slot name="X">` elements with the same X**:
+   each is mode-resolved independently and validated; the
+   per-slot props type stays the same. The fallback-slot
+   pattern (a second `<slot name="X">` deeper in the tree as a
+   fallback) keeps working.
+
+**On the caller side** (the component instantiating the
+compound and writing `<template pp-slot="…" pp-let="…">`):
+
+1. The caller's `pp-let` binding (`row`, `hdr`, `file`, etc.)
+   is registered with the props type from the resolved
+   `#[slot(name = "X", props = T)]` of the child component
+   (looked up via `uses = […]` per RFC 060, or via type
+   inference when the child component is the immediate
+   target).
+2. Every `binding.X` read inside the `<template pp-slot>`
+   resolves `X` against the bound type's `#[prop]` field set;
+   unknown keys → error.
+3. Leaf types are checked transitively for compatibility with
+   the directive consuming them (e.g., `pp-show="row.flag"`
+   requires `flag` to be `bool`-coercible; this is already the
+   pp-show contract and isn't new).
+4. Caller-side typing is best-effort in v1: it requires the
+   caller's component to declare `uses = [UploadRoot]` (the
+   existing typed-tag opt-in). Without `uses`, the caller is
+   untyped (same as today) and runtime resolution applies.
+
+### 5.6 Type-checking the iteration item via Rust
+
+The `pp-for` iteration variable's type isn't always statically
+inferrable from the template alone — `pp-for="X in foo.bar"`
+might involve method calls (no, see RFC 012 — but field paths
+exist). Rather than build a parallel type-inference pipeline in
+the macro, the macro emits a Rust assertion and lets rustc do
+the work:
+
+For a `<slot name="row">` sitting inside `pp-for="file in
+files"` declared `#[slot(name = "row", props = UploadFile)]`,
+the macro emits — into the component's generated mount body or
+a hidden `const _: fn()` boundary — code morally equivalent to:
+
+```rust
+const _: fn(&Self) = |this: &Self| {
+    // Assert the iteration variable's resolved type matches
+    // the declared props.
+    let _: &UploadFile = match this.files.iter().next() {
+        Some(file) => file,
+        None => unreachable!(),
+    };
+};
+```
+
+Rust's typechecker emits the mismatch error if `files`'s
+element type isn't `UploadFile`. The diagnostic includes both
+the emitted assertion's span and the `#[slot]` attr's span via
+`syn::Error::new_spanned`.
+
+For `pp-for` over an expression more complex than a bare field
+path — the macro emits the same assertion but parameterized on
+the parsed pine-expr's evaluated type. The simplest v1
+implementation handles bare field paths only; complex
+expressions fall back to "static mode required" with a clear
+error message ("`pp-for` over a complex expression isn't
+supported for iterated slot inference; use static mode with
+explicit publications").
+
+### 5.7 Wire encoding
+
+Slot publications today are JS objects (built lazily inside
+`SlotScope::get` per `crates/pocopine-core/src/slot_scope.rs`).
+Nothing in this RFC changes the wire shape — typing is
+macro-only. The runtime continues to:
+
+- Build the object from `(prop, path)` pairs in
+  `SlotScope::bindings`.
+- Resolve each `path` against the compound's proxy
+  (`bind_source`).
+- Fall through to the caller's proxy for non-binding keys.
+
+For iterated mode, the macro emits exactly one `(prop, path)`
+pair internally — `(VAR, VAR)` — so the runtime path is
+identical to static mode with a single publication. The author
+just doesn't write that publication; the macro does.
+
+The `Props` trait already exposes `prop_leaves()` and the
+serialization layer the macro uses to emit `:foo=` ↔
+`PropValue` glue elsewhere; the slot-publication path reuses
+that machinery.
+
+### 5.8 Backwards compatibility
+
+Every existing `#[slot]` site keeps working. The new arg is
+optional; absent it, the macro's behavior is identical to v0
+(no publication-shape validation, no caller-side prop checking).
+
+Migration is one struct definition + one attribute argument per
+slot:
+
+```rust
+// Before
+#[slot(name = "row")]
+
+// After (typed, opt-in)
+#[slot(name = "row", props = UploadFile)]
+```
+
+Apps that don't migrate continue to compile and run. The
+opinionated docs (`02-state.md`, `03-composition.md`) recommend
+the typed form once it lands.
+
+## 6. Implementation phasing
+
+### Phase 1 — `props = T` + static-mode validation
+
+- Extend `slot::SlotArg` parser in
+  `crates/pocopine-macros/src/slot.rs` with a `Props(Path)`
+  variant.
+- Extend `SlotDecl` to carry the optional props type.
+- Macro emits the `T: Props` boundary so the diagnostic
+  anchors at the `#[slot]` attribute on non-`Props` types.
+- AST scan of the component template finds the matching
+  `<slot name="X">` element(s); collect `:foo=…` publications.
+- Set-equality check against `T`'s prop field set; emit
+  per-key compile errors for missing/extra.
+- One pine primitive (suggested: a Tabs trigger or similar
+  short-publication-list compound) migrated as the inaugural
+  consumer.
+
+### Phase 2 — Iterated mode via template-AST dispatch
+
+- Extend the per-`<slot>`-element mode-resolution in the macro
+  (per §5.5 rule 3) to detect "no `:LHS=` attrs AND inside a
+  `pp-for`."
+- AST scan walks ancestors of `<slot name="X">` looking for
+  the nearest `pp-for` ancestor; resolve the iteration
+  variable name from `pp-for="VAR in EXPR"`.
+- Macro auto-emits the `(VAR, VAR)` publication pair the
+  runtime needs.
+- Macro emits the Rust type assertion (per §5.6) so rustc
+  validates the iteration item's type matches `props = T`.
+- `PineUploadRoot` (or the next iterated primitive that
+  lands) migrated as the second consumer.
+
+### Phase 3 — Caller-side type checking
+
+- Hook into the existing RFC 060 `uses = [...]` consumer-side
+  scan in `crates/pocopine-macros/src/lib.rs` (search for
+  `slot_assertions`).
+- For each `<template pp-slot="X">` in a typed-consumer
+  template, look up the child's `#[slot(name = "X", props =
+  T)]` and bind `pp-let="ID"` to `ID: T`.
+- Validate `ID.field` reads against `T`'s prop set.
+- Emit `compile_error!` for unknown keys, pointing at the
+  caller's `.poco` line *and* at the declared props type.
+
+### Phase 4 — Docs + migration sweep
+
+- Update `docs/components/03-composition.md` "Slots" section
+  with the typed form alongside the existing untyped form;
+  recommend the typed form as the default going forward.
+- Sweep pine primitives (`pine/src/tabs/`, `pine/src/combobox/`,
+  upload primitive from PR #127 follow-up, etc.) migrating to
+  `props = T`.
+- Cross-link from `docs/poco/04-expressions.md` to the
+  typed-slot pattern (it's the formal version of the
+  "compute Rust-side, expose by name" reflex).
+
+## 7. Open questions
+
+1. **Template-AST scan for the `pp-for` ancestor.** RFC 050's
+   element walker already supports walking ancestors via the
+   AST. Pin the exact rule for which `pp-for` "owns" a `<slot>`
+   when multiple `pp-for`s are nested — the nearest enclosing
+   one, or the outermost? Nearest is the cleaner default;
+   confirm before Phase 2.
+2. **Default slot in iterated position.** `<slot>` (no name)
+   inside a `pp-for` is the most common shape for list
+   compounds. Treat it identically to a named slot at the
+   AST level (mode resolution applies the same way).
+3. **`pp-for` over complex expressions.** §5.6 punts on
+   anything other than a bare field path. What's the right
+   error message and what does the user do? Two options:
+   (a) fail with "use static mode," (b) allow the macro to
+   try harder via a stricter Rust type assertion. Lean (a)
+   for v1.
+4. **Generic compounds.** A `DataTable<R>` with
+   `#[slot(name = "row", props = R)]` where `R` is a generic
+   on the struct — does this work? The `T: Props` boundary
+   becomes `R: Props` (a `where` clause on the struct). v1
+   scope per non-goal 4.6.
+5. **Errors landing at the right span.** RFC 050's diagnostic
+   renderer should highlight the offending `<slot>` element
+   or `#[slot]` attribute — not the surrounding `#[component]`.
+   Reuse the byte-span machinery already in place for
+   forbidden-directive diagnostics.
+
+## 8. Alternatives considered
+
+### 8.1 Separate `iterates = field` macro argument
+
+Earlier draft of this RFC. Rejected because it introduced a
+**parallel mechanism** for what is fundamentally the same
+question: "does this slot publish the iteration variable?" The
+template's `pp-for` context already answers that; making the
+author repeat the answer as a macro arg is redundant and adds
+a way for the macro arg and template to disagree.
+
+Concretely the rejected shape was:
+
+```rust
+#[slot(name = "row", iterates = files)]
+// or as two-arg combination:
+#[slot(name = "row", props = UploadRow, iterates = files)]
+```
+
+Versus the accepted shape:
+
+```rust
+#[slot(name = "row", props = UploadFile)]
+// template's <li pp-for="file in files"><slot name="row"></slot></li> tells the macro the rest
+```
+
+### 8.2 Wrapper type to mark iteration
+
+Considered `Each<T>`, `ItemOf<T>`, `PropsIterator<T>`,
+`SlotContext<T>` as type-level markers of "this slot iterates
+over T." Rejected because the wrapper encodes at the **type
+level** what is actually a **template-level** concern: where
+the `<slot>` element sits relative to a `pp-for`. The macro
+already has to scan the template AST for that; a marker type
+duplicates information and forces the author to keep two
+things in sync (the marker AND the template position).
+
+The naming friction we hit during design was the tell — every
+candidate wrapper name (`PropsIterator`, `Each`, `ItemOf`,
+`For`) felt off because the wrapper was trying to name "the
+iteration source" while the slot's per-iteration binding is
+"the item." The right answer was to drop the wrapper and have
+the decl describe the binding directly.
+
+### 8.3 Separate `Ctx` / `SlotContext` vocabulary
+
+Initial brainstorm during PR #127's review: declare a
+`UploadItemCtx` struct via `#[derive(Serialize)]` and
+reference it from `#[slot(name = "row", ctx =
+UploadItemCtx)]`. Rejected because the framework already has
+Props as the typed-wire concept; a parallel "Ctx" vocabulary
+splits the mental model (*"is this a prop or a ctx?"*) for no
+implementation gain. Slot publication and parent→child prop
+passing are the same shape going opposite directions; one
+vocabulary covers both.
+
+### 8.4 Implicit `$host.X` from `#[expose]`
+
+Considered: make slot content automatically see the compound's
+`#[expose]`'d fields via a `$host.X` magic. Rejected because
+(a) it conflates slot scoping with RFC 081's
+component-handle refs surface (which *does* the cross-instance
+reach the magic implies), and (b) the per-slot explicit
+publication is more type-discoverable — readers see exactly
+what each slot publishes by looking at the compound's `<slot>`
+element, without having to cross-reference an `#[expose]`
+list.
+
+### 8.5 Slot name as binding identifier
+
+Considered: drop `pp-let="row"` and infer the binding name
+from the slot name (`pp-slot="row"` binds `row` automatically).
+Rejected because it couples slot identity with caller-side
+variable identity (a rename ripples into every caller) and
+forecloses the "two slots publishing similar shapes" case.
+`pp-let` stays explicit.
+
+### 8.6 Inline type annotations on `<slot>`
+
+Proposed: `<slot :name@type<String>>`. Rejected per the
+`.poco`-format rule (RFC 008 §"no mixed files"): types live in
+Rust, not in template attribute values. The macro can
+synthesize the same validation by reading the props type
+declared in Rust.
+
+### 8.7 Drop slot props entirely; require RFC 081 refs
+
+Considered: skip the typed-slot mechanism and tell authors to
+expose state via `pp-ref="instance_name"` + `$ref.X` (RFC 081).
+Rejected because RFC 081 forces the caller to name every
+instance even when the slot's content is the natural
+consumer — friction on the common path. Typed slot props keep
+the implicit (no naming required) slot-content path working
+while opting into type safety.
+
+## 9. Risks
+
+1. **Set-equality strictness on `:LHS=` publications.** A
+   typed static slot with 12 `#[prop]` fields means the
+   compound author writes 12 `:foo="expr"` attributes on
+   `<slot>`. Mitigation: `#[prop(flatten)]` on the props type
+   already lets a single `:user="user"` flatten into 8 leaves;
+   the leaf-coverage check follows the flatten unwinding.
+   Watch for whether real components push toward looser
+   "subset is fine" semantics during Phase 1.
+2. **Mode is implicit.** A reader scanning the `#[slot]` attr
+   doesn't see "iterated vs static" — they have to look at the
+   template to know which. Mitigation: the doc page in
+   Phase 4 leads with two side-by-side examples; the
+   distinction is one keystroke (presence of `pp-for` ancestor)
+   so readers learn it fast. The simplicity of "one arg, two
+   contexts" justifies the implicitness.
+3. **Mode-mix detection error message clarity.** The rule
+   "presence of any `:LHS=` on the `<slot>` element forces
+   static mode" needs a clean diagnostic when authors
+   inadvertently mix (e.g., they expect iterated auto-publish
+   AND add a `:label=...` for derived data). The error should
+   say "this slot has explicit publications, so it's in static
+   mode; iterated mode means zero `:LHS=` on the `<slot>`
+   element."
+4. **Caller-side typing requires `uses = [...]`**. Apps that
+   don't declare `uses` get no caller-side validation. Same
+   constraint applies to other RFC 060 features; not new, but
+   worth highlighting in the migration doc.
+5. **Macro-emitted boundary assertions slow `cargo check`.**
+   Each `#[slot(props = T)]` emits a `T: Props` boundary plus
+   (in iterated mode) an iteration-type assertion. Watch for
+   incremental-rebuild times on apps with many typed slots;
+   if it becomes a problem, fold the assertions into a single
+   per-component emit rather than per-slot.
+6. **Renaming a prop on the props struct breaks the
+   compound's `<slot :LHS="…">` publications.** This is the
+   intended behavior (the rename should surface), but it
+   means slot props are part of the compound's public API
+   surface — name them as carefully as Rust function
+   parameters.
+
+## 10. Verification
+
+Phase 1 (`props = T` + static mode):
+
+- Existing `#[slot(default)]` + `#[slot(default, only=[…])]`
+  call sites in `pine/` compile unchanged (no opt-in).
+- A test fixture under `crates/pocopine/tests/typed_slots.rs`
+  declares `#[slot(name = "header", props = HeaderProps)]` and
+  asserts the macro emits the expected validation tokens.
+- Compile-fail UI tests (matching the
+  `pocopine-sync-crud-macros/tests/ui/` trybuild pattern) for:
+  - Missing `:foo=` publication.
+  - Extra `:foo=` publication.
+  - Props type without `#[derive(Props)]`.
+
+Phase 2 (iterated mode via template-AST dispatch):
+
+- Fixture with `<slot>` inside `pp-for`, no `:LHS=` attrs, and
+  `#[slot(name = "row", props = UploadFile)]` where
+  `files: Vec<UploadFile>` — should compile and auto-publish.
+- Compile-fail tests for:
+  - `pp-for` iteration item type ≠ props type (e.g.,
+    `files: Vec<OtherFile>`).
+  - `<slot>` with `:LHS=` attrs sitting inside a `pp-for`
+    (mode-mix detection — must error saying "static mode is
+    in force because of the explicit publications, so all
+    `#[prop]` fields on T must be published").
+  - Props element type without `#[derive(Props)]`.
+  - `pp-for` over an unsupported expression shape (per §5.6).
+
+Phase 3 (caller-side type checking):
+
+- Caller fixture under `crates/pocopine/tests/` declaring
+  `uses = [UploadRoot]` + `<template pp-slot="row" pp-let="file">`;
+  compile-fail tests for `file.unknown_field` reads.
+- Positive test for `file.X` reads against the declared
+  props type compiling cleanly.
+
+Phase 4 (docs + migration):
+
+- `03-composition.md` and `04-expressions.md` link to the
+  typed-slot pattern.
+- At least two pine primitives migrated and used as
+  canonical examples.


### PR DESCRIPTION
## Summary

Closes the only major reactive edge in pocopine that's still stringly-typed: scoped-slot publications. Extends `#[slot(...)]` with one new arg — `props = T` where `T: Props` — and validates publication shape at macro time.

Two commits:

1. **RFC 084 draft** (`rfcs/rfc-084-typed-slot-props.md`, 727 lines) — the design spec covering the locked-in shape (single `props =` arg, template-AST mode dispatch, no wrapper types, no parallel `iterates =`). §8 documents seven rejected alternatives with rationale.
2. **Phase 1 — static-mode validation** — parser extension + validation emit + const-eval helpers + tests.

This PR is **draft** until Phases 2–4 land. Phase 1 alone is shippable (validates static-mode slot publications end-to-end; iterated slots fall back to explicit publication until Phase 2's auto-publish lands), but the full RFC value comes with all four phases.

## Phase 1 — what's in this PR

### Parser (`pocopine-macros/src/slot.rs`)

- New `SlotArg::Props(syn::Path)` variant; `parse_slot_attr` accepts `props = TypeName` alongside `default` / `name` / `accepts` / `only`.
- `SlotDecl` carries an `Option<Path>`; untyped slots stay byte-identical.
- Duplicate `props =` rejected. Unknown-arg error message updated.

### Validation emission

For every `#[slot(name = "X", props = T)]`:

1. `T: Props` boundary via a `const _: fn() = || { … }` closure — non-`Props` types error at the `props =` arg.
2. Template AST scan for matching `<slot>` elements; `compile_error!` if the decl mentions a slot the template never exposes.
3. Per-published-key check: each `:LHS=…` on the `<slot>` element compared against `<T>::__POC_PROP_LEAVES`; mismatch panics at `cargo check` with the offending key quoted.
4. Coverage check: const-fn set-equality (both directions) against T's full prop list; fires the "missing publication" case.

### Const-eval helpers (`pocopine-core::props`)

New `pub const fn` helpers — `str_eq_const`, `str_slice_contains_const`, `str_slice_set_eq_const` — stable-Rust `const`-friendly so the validation runs at compile time without changing the `Props` trait. Re-exported via `pocopine::__private`.

### `#[derive(Props)]`

Emits an inherent `pub const __POC_PROP_LEAVES: &'static [&'static str]` alongside the trait impl. Mirrors `prop_leaves()` but in const context — slot validation can compare against it without making the trait `const`.

### Backwards compatibility

Every existing `#[slot]` site compiles unchanged. Workspace `cargo check` clean. Touched crates (`pocopine-core`, `pocopine-macros`) clippy clean on both host AND wasm32 with `-D warnings`. `cargo fmt --all --check` clean.

## Follow-up phases (separate PRs)

- **Phase 2: iterated-mode dispatch** — `<slot>` inside `pp-for` with no `:LHS=` attrs becomes iterated mode. Macro auto-publishes the iteration variable + emits a Rust type assertion that the iter item type matches T. Requires template-rewrite infrastructure for the auto-publish injection.
- **Phase 3: caller-side type checking** — for `<template pp-slot="X" pp-let="row">` in a `uses = [...]`-declaring consumer, bind `row: T` and validate `row.field` reads against T's prop set.
- **Phase 4: docs sweep + pine-primitive migration** — update `03-composition.md` and `04-expressions.md`; migrate at least one pine primitive (likely Tabs) as the canonical example; trybuild compile-fail tests covering all the validation error paths.

## Test plan

- [x] `cargo test -p pocopine-macros --lib slot::` — 16 tests pass (5 new for the `props =` parser)
- [x] `cargo check --workspace` — clean
- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy -p pocopine-core -p pocopine-macros -- -D warnings` (host) — clean
- [x] `cargo clippy -p pocopine-core -p pocopine-macros --target wasm32-unknown-unknown -- -D warnings` — clean
- [ ] (Phase 4) trybuild compile-fail tests for: missing publication, extra publication, props type without `#[derive(Props)]`
- [ ] (Phase 4) canonical typed-slot pine primitive migrated as an example