### PR TITLE
Add S3-compatible storage backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,7 +175,7 @@ checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
 dependencies = [
  "base64ct",
  "blake2",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "password-hash",
 ]
 
@@ -339,6 +339,361 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-credential-types"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f20799b373a1be121fe3005fba0c2090af9411573878f224df44b42727fcaf7"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
+name = "aws-runtime"
+version = "1.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ed8e8c52d2dc2390ad9f15647fe663f71e9780b4262c190fbb823a32721566"
+dependencies = [
+ "aws-credential-types",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "bytes-utils",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "percent-encoding",
+ "pin-project-lite",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "1.133.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "237aba2985e3c0a83e199cc7aa9a64a16c599875bc98170f00932f6199f19922"
+dependencies = [
+ "aws-credential-types",
+ "aws-runtime",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-checksums",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-json",
+ "aws-smithy-observability",
+ "aws-smithy-runtime",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "fastrand",
+ "hex",
+ "hmac 0.13.0",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "lru",
+ "percent-encoding",
+ "regex-lite",
+ "sha2 0.11.0",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "1.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7083fb918b38474ac65ffbf8a69fc8792d36879f4ac5f1667b43aec61efe9a5"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "crypto-bigint",
+ "form_urlencoded",
+ "hex",
+ "hmac 0.13.0",
+ "http 0.2.12",
+ "http 1.4.0",
+ "p256",
+ "percent-encoding",
+ "sha2 0.11.0",
+ "subtle",
+ "time",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "1.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ffcaf626bdda484571968400c326a244598634dc75fd451325a54ad1a59acfc"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "aws-smithy-checksums"
+version = "0.64.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e8e65f4f81fcccdeb6c3eca2af17ac21d421a1786a26a394aecf421d616d3a"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "bytes",
+ "crc-fast",
+ "hex",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "md-5 0.11.0",
+ "pin-project-lite",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.60.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf09d74e5e32f76b8762da505a3cd59303e367a664ca67295387baa8c1d7548"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.63.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba1ab2dc1c2c3749ead27180d333c42f11be8b0e934058fb4b2258ee8dbe5231"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "percent-encoding",
+ "pin-project-lite",
+ "pin-utils",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-client"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a2f165a7feee6f263028b899d0a181987f4fa7179a6411a32a439fba7c5f769"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "h2 0.3.27",
+ "h2 0.4.13",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper 1.9.0",
+ "hyper-rustls 0.24.2",
+ "hyper-rustls 0.27.9",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls 0.23.38",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.62.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "517089205f18ab4adc5a3e02888cb139bbbbb2e168eac9f396216925d1fbeaf5"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-observability"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06c2315d173edbf1920da8ba3a7189695827002e4c0fc961973ab1c54abca9c"
+dependencies = [
+ "aws-smithy-runtime-api",
+]
+
+[[package]]
+name = "aws-smithy-runtime"
+version = "1.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e6f5caf6fea86f8c2206541ab5857cfcda9013426cdbe8fa0098b9e2d32182"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-client",
+ "aws-smithy-observability",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
+ "pin-utils",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc117c179ecf39a62a0a3f49f600e9ac26a7ad7dd172177999f83933af776c32"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-runtime-api-macros",
+ "aws-smithy-types",
+ "bytes",
+ "http 0.2.12",
+ "http 1.4.0",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-smithy-runtime-api-macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d7396fd9500589e62e460e987ecb671bad374934e55ec3b5f498cc7a8a8a7b7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "aws-smithy-schema"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7442cb268338f0eb8278140a107c046756aa01093d8ef5e99628d34ae09c94f5"
+dependencies = [
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
+ "http 1.4.0",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056b66dbce2f81cc0c1e2b05bb402eb58f8a3530479d650efadd5bbae9a4050b"
+dependencies = [
+ "base64-simd",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http 0.2.12",
+ "http 1.4.0",
+ "http-body 0.4.6",
+ "http-body 1.0.1",
+ "http-body-util",
+ "itoa",
+ "num-integer",
+ "pin-project-lite",
+ "pin-utils",
+ "ryu",
+ "serde",
+ "time",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.60.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce02add1aa3677d022f8adf81dcbe3046a95f17a1b1e8979c145cd21d3d22b3"
+dependencies = [
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "1.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16bf10b03a3c01e6b3b7d47cd964e873ffe9e7d4e80fad16bd4c077cb068531"
+dependencies = [
+ "aws-credential-types",
+ "aws-smithy-async",
+ "aws-smithy-runtime-api",
+ "aws-smithy-schema",
+ "aws-smithy-types",
+ "rustc_version",
+ "tracing",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,9 +704,9 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.4.0",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
  "itoa",
  "matchit 0.7.3",
@@ -382,7 +737,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.4.0",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
  "itoa",
  "matchit 0.8.4",
@@ -407,7 +762,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.4.0",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -427,7 +782,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.4.0",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
@@ -443,10 +798,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d27c3610c36aee21ce8ac510e6224498de4228ad772a171ed65643a24693a5a8"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
+dependencies = [
+ "outref",
+ "vsimd",
+]
 
 [[package]]
 name = "base64ct"
@@ -519,7 +890,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
 dependencies = [
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -529,6 +900,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -559,14 +939,14 @@ dependencies = [
  "home",
  "http 1.4.0",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-named-pipe",
- "hyper-rustls",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "hyperlocal",
  "log",
  "pin-project-lite",
- "rustls",
+ "rustls 0.23.38",
  "rustls-native-certs",
  "rustls-pemfile",
  "rustls-pki-types",
@@ -686,6 +1066,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
+
+[[package]]
 name = "camino"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,6 +1123,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -844,6 +1236,21 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
 
 [[package]]
 name = "codee"
@@ -959,6 +1366,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
 name = "const-str"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1059,6 +1472,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc"
 version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1072,6 +1494,16 @@ name = "crc-catalog"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crc-fast"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e75b2483e97a5a7da73ac68a05b629f9c53cff58d8ed1c77866079e18b00dba5"
+dependencies = [
+ "digest 0.10.7",
+ "spin 0.10.0",
+]
 
 [[package]]
 name = "crc32fast"
@@ -1182,6 +1614,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1189,6 +1633,24 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
@@ -1322,7 +1784,7 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
- "const-oid",
+ "const-oid 0.9.6",
  "pem-rfc7468",
  "zeroize",
 ]
@@ -1354,10 +1816,22 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "const-oid",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "const-oid 0.9.6",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "const-oid 0.10.2",
+ "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -1469,10 +1943,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "669a445ee724c5c69b1b06fe0b63e70a1c84bc9bb7d9696cd4f4e3ec45050408"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
 
 [[package]]
 name = "either"
@@ -1491,6 +1985,26 @@ checksum = "5060e0a4cbf26a87550792688ade88e6b8aec9208613631a7a363bda7bc2d4cd"
 dependencies = [
  "paste",
  "pin-project-lite",
+]
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1572,6 +2086,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "file-browser-example"
 version = "0.1.0"
 dependencies = [
@@ -1622,7 +2146,7 @@ checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -1636,6 +2160,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -1655,6 +2185,12 @@ dependencies = [
  "swc_macros_common",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -1788,6 +2324,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -2265,10 +2802,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "guardian"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17e2ac29387b1aa07a1e448f7bb4f35b500787971e965b02842b900afa5c8f6f"
+
+[[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
 
 [[package]]
 name = "h2"
@@ -2333,7 +2900,18 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -2397,7 +2975,7 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
 ]
 
 [[package]]
@@ -2406,7 +2984,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2495,6 +3082,17 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
@@ -2512,7 +3110,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.4.0",
- "http-body",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -2535,6 +3133,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hydration_context"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2550,6 +3157,30 @@ dependencies = [
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
@@ -2558,9 +3189,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
+ "h2 0.4.13",
  "http 1.4.0",
- "http-body",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -2577,7 +3208,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
 dependencies = [
  "hex",
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2587,16 +3218,32 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "log",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.0",
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
- "rustls",
+ "rustls 0.23.38",
+ "rustls-native-certs",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
  "webpki-roots 1.0.7",
 ]
@@ -2607,7 +3254,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2625,8 +3272,8 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.4.0",
- "http-body",
- "hyper",
+ "http-body 1.0.1",
+ "hyper 1.9.0",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -2645,7 +3292,7 @@ checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
 dependencies = [
  "hex",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -3002,6 +3649,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3128,7 +3785,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -3352,6 +4009,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3440,7 +4106,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3801,6 +4477,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
+
+[[package]]
 name = "owo-colors"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4008,6 +4690,18 @@ dependencies = [
  "oxc_str",
  "phf 0.13.1",
  "unicode-id-start",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -4232,6 +4926,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pine"
@@ -4475,7 +5175,7 @@ dependencies = [
  "pocopine-server",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tokio",
  "tower",
  "tracing",
@@ -4582,7 +5282,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tokio",
  "toml 0.8.23",
  "tracing",
@@ -4618,7 +5318,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tokio",
  "toml 0.8.23",
  "tracing",
@@ -4752,7 +5452,7 @@ dependencies = [
  "pocopine-server",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tempfile",
  "time",
  "tokio",
@@ -4763,6 +5463,22 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
+]
+
+[[package]]
+name = "pocopine-storage-s3"
+version = "0.1.0"
+dependencies = [
+ "aws-sdk-s3",
+ "bytes",
+ "pocopine-storage",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "time",
+ "tokio",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -4962,6 +5678,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5132,7 +5857,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.38",
  "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
@@ -5152,7 +5877,7 @@ dependencies = [
  "rand 0.9.4",
  "ring",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.38",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -5432,6 +6157,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab834c73d247e67f4fae452806d17d3c7501756d98c8808d7c9c7aa7d18f973"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5449,24 +6180,24 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.4.0",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.9.0",
+ "hyper-rustls 0.27.9",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.38",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower",
  "tower-http",
  "tower-service",
@@ -5475,6 +6206,16 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac 0.12.1",
+ "subtle",
 ]
 
 [[package]]
@@ -5510,8 +6251,8 @@ version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
 dependencies = [
- "const-oid",
- "digest",
+ "const-oid 0.9.6",
+ "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
  "num-traits",
@@ -5583,15 +6324,28 @@ dependencies = [
 
 [[package]]
 name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
+]
+
+[[package]]
+name = "rustls"
 version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.12",
  "subtle",
  "zeroize",
 ]
@@ -5629,10 +6383,21 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
 version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -5703,6 +6468,30 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -5987,8 +6776,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -6004,8 +6804,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -6039,7 +6850,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -6176,6 +6987,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6245,10 +7062,10 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rustls",
+ "rustls 0.23.38",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "thiserror 2.0.18",
  "tokio",
@@ -6286,7 +7103,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "sqlx-core",
  "sqlx-mysql",
  "sqlx-postgres",
@@ -6308,7 +7125,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "crc",
- "digest",
+ "digest 0.10.7",
  "dotenvy",
  "either",
  "futures-channel",
@@ -6318,18 +7135,18 @@ dependencies = [
  "generic-array",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "once_cell",
  "percent-encoding",
  "rand 0.8.6",
  "rsa",
  "serde",
- "sha1",
- "sha2",
+ "sha1 0.10.6",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -6356,17 +7173,17 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac",
+ "hmac 0.12.1",
  "home",
  "itoa",
  "log",
- "md-5",
+ "md-5 0.10.6",
  "memchr",
  "once_cell",
  "rand 0.8.6",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -7040,11 +7857,21 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.38",
  "tokio",
 ]
 
@@ -7188,11 +8015,11 @@ dependencies = [
  "axum 0.8.9",
  "base64",
  "bytes",
- "h2",
+ "h2 0.4.13",
  "http 1.4.0",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -7248,7 +8075,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.4.0",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
  "http-range-header",
  "httpdate",
@@ -7504,7 +8331,7 @@ dependencies = [
  "flate2",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.23.38",
  "rustls-pki-types",
  "url",
  "webpki-roots 0.26.11",
@@ -7576,6 +8403,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "walkdir"
@@ -7773,7 +8606,7 @@ checksum = "d0a659ffe5c7f4538aa6357c07e3d73221cc61eba03bd9a081e14bc91ed09b8c"
 dependencies = [
  "base16",
  "quote",
- "sha2",
+ "sha2 0.10.9",
  "syn 2.0.117",
 ]
 
@@ -8215,7 +9048,7 @@ dependencies = [
  "futures",
  "http 1.4.0",
  "http-body-util",
- "hyper",
+ "hyper 1.9.0",
  "hyper-util",
  "log",
  "once_cell",
@@ -8355,6 +9188,12 @@ dependencies = [
  "mac",
  "markup5ever",
 ]
+
+[[package]]
+name = "xmlparser"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
 
 [[package]]
 name = "xxhash-rust"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5475,6 +5475,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "testcontainers",
+ "testcontainers-modules",
  "time",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "crates/pocopine-observe",
     "crates/pocopine-server",
     "crates/pocopine-storage",
+    "crates/pocopine-storage-s3",
     "crates/pocopine-sync",
     "crates/pocopine-sync-crud",
     "crates/pocopine-sync-crud-macros",
@@ -97,6 +98,7 @@ pocopine-macros = { path = "crates/pocopine-macros", version = "0.1.0" }
 pocopine-observe = { path = "crates/pocopine-observe", version = "0.1.0" }
 pocopine-server = { path = "crates/pocopine-server", version = "0.1.0" }
 pocopine-storage = { path = "crates/pocopine-storage", version = "0.1.0" }
+pocopine-storage-s3 = { path = "crates/pocopine-storage-s3", version = "0.1.0" }
 pocopine-sync = { path = "crates/pocopine-sync", version = "0.1.0" }
 pocopine-sync-crud = { path = "crates/pocopine-sync-crud", version = "0.1.0" }
 pocopine-sync-crud-macros = { path = "crates/pocopine-sync-crud-macros", version = "0.1.0" }

--- a/crates/pocopine-storage-s3/Cargo.toml
+++ b/crates/pocopine-storage-s3/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "pocopine-storage-s3"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "S3-compatible backend adapter for pocopine-storage."
+
+[dependencies]
+aws-sdk-s3 = "1"
+bytes = "1"
+pocopine-storage = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+sha2 = "0.10"
+time = { version = "0.3", features = ["serde"] }
+tokio = { version = "1", default-features = false, features = ["sync"] }
+tracing = { workspace = true }
+uuid = { version = "1", features = ["v4"] }

--- a/crates/pocopine-storage-s3/Cargo.toml
+++ b/crates/pocopine-storage-s3/Cargo.toml
@@ -17,3 +17,8 @@ time = { version = "0.3", features = ["serde"] }
 tokio = { version = "1", default-features = false, features = ["sync"] }
 tracing = { workspace = true }
 uuid = { version = "1", features = ["v4"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+testcontainers = "0.23"
+testcontainers-modules = { version = "0.11", features = ["minio"] }
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/crates/pocopine-storage-s3/src/lib.rs
+++ b/crates/pocopine-storage-s3/src/lib.rs
@@ -1,0 +1,822 @@
+//! S3-compatible backend adapter for `pocopine-storage`.
+//!
+//! This crate intentionally implements Pocopine's current sequential proxy
+//! upload contract. Completed objects are written to the configured bucket by
+//! `SafeObjectKey`, while upload-session metadata and staging bytes live under
+//! an internal prefix in the same bucket.
+//!
+//! For S3-compatible services such as MinIO, build an `aws_sdk_s3::Client`
+//! with the provider-specific endpoint/path-style settings and pass it to
+//! [`S3StorageBackend::new`].
+
+use std::collections::{BTreeMap, HashMap};
+use std::sync::{Arc, Mutex as StdMutex};
+
+use aws_sdk_s3::primitives::ByteStream;
+use aws_sdk_s3::Client;
+use bytes::Bytes;
+use pocopine_storage::{
+    ChecksumAlgorithm, ChecksumPolicy, CompleteUpload, InitiateUpload, ObjectChecksum, ObjectRef,
+    ObjectVisibility, StorageActor, StorageBackend, StorageBoxFuture, StorageContext, StorageError,
+    StorageKey, StorageResult, TransferPlan, UploadSession, UploadSessionId, UploadSessionStatus,
+    UploadStrategy,
+};
+use sha2::{Digest, Sha256};
+use time::OffsetDateTime;
+use tokio::sync::Mutex as TokioMutex;
+use uuid::Uuid;
+
+const DEFAULT_BACKEND_NAME: &str = "s3";
+const DEFAULT_INTERNAL_PREFIX: &str = "__pocopine/storage/sessions";
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+struct StoredUploadSession {
+    public: UploadSession,
+    owner: StorageActor,
+    storage_key: StorageKey,
+    visibility: ObjectVisibility,
+    max_bytes: u64,
+    checksum_policy: ChecksumPolicy,
+    request_metadata: BTreeMap<String, String>,
+    object: Option<ObjectRef>,
+}
+
+/// Storage backend backed by an S3-compatible object store.
+///
+/// The adapter stores temporary upload bytes as an internal object and rewrites
+/// that object on each sequential `PATCH`. That keeps the first S3 backend
+/// compatible with Pocopine's existing resumable upload protocol, but it is
+/// not the high-throughput/direct multipart path. A later direct/multipart
+/// backend can add provider-side multipart uploads without changing the public
+/// `StorageBackend` contract.
+#[derive(Clone)]
+pub struct S3StorageBackend {
+    name: &'static str,
+    client: Client,
+    layout: S3KeyLayout,
+    session_locks: Arc<StdMutex<HashMap<String, Arc<TokioMutex<()>>>>>,
+}
+
+impl std::fmt::Debug for S3StorageBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("S3StorageBackend")
+            .field("name", &self.name)
+            .field("bucket", &self.layout.bucket)
+            .field("object_prefix", &self.layout.object_prefix)
+            .field("internal_prefix", &self.layout.internal_prefix)
+            .finish_non_exhaustive()
+    }
+}
+
+impl S3StorageBackend {
+    /// Build a backend named `s3` for the given bucket.
+    pub fn new(client: Client, bucket: impl Into<String>) -> StorageResult<Self> {
+        Self::named(DEFAULT_BACKEND_NAME, client, bucket)
+    }
+
+    /// Build a backend with an explicit registry name.
+    pub fn named(
+        name: &'static str,
+        client: Client,
+        bucket: impl Into<String>,
+    ) -> StorageResult<Self> {
+        Ok(Self {
+            name,
+            client,
+            layout: S3KeyLayout::new(bucket.into(), None, DEFAULT_INTERNAL_PREFIX.to_string())?,
+            session_locks: Arc::new(StdMutex::new(HashMap::new())),
+        })
+    }
+
+    /// Store completed objects below a bucket prefix.
+    ///
+    /// The internal session prefix is also nested under this prefix to keep all
+    /// Pocopine-owned keys together.
+    pub fn with_prefix(mut self, prefix: impl Into<String>) -> StorageResult<Self> {
+        self.layout = self.layout.with_prefix(prefix.into())?;
+        Ok(self)
+    }
+
+    /// Override the internal upload-session prefix.
+    pub fn with_internal_prefix(mut self, prefix: impl Into<String>) -> StorageResult<Self> {
+        self.layout = self.layout.with_internal_prefix(prefix.into())?;
+        Ok(self)
+    }
+
+    pub fn bucket(&self) -> &str {
+        &self.layout.bucket
+    }
+
+    pub fn object_prefix(&self) -> Option<&str> {
+        self.layout.object_prefix.as_deref()
+    }
+
+    pub fn internal_prefix(&self) -> &str {
+        &self.layout.internal_prefix
+    }
+
+    fn session_lock(&self, session: &UploadSessionId) -> Arc<TokioMutex<()>> {
+        let mut locks = self
+            .session_locks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        locks
+            .entry(session.as_str().to_string())
+            .or_insert_with(|| Arc::new(TokioMutex::new(())))
+            .clone()
+    }
+
+    fn drop_session_lock(&self, session: &UploadSessionId) {
+        let mut locks = self
+            .session_locks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if let Some(existing) = locks.get(session.as_str()) {
+            if Arc::strong_count(existing) <= 2 {
+                locks.remove(session.as_str());
+            }
+        }
+    }
+
+    async fn read_session(&self, session: &UploadSessionId) -> StorageResult<StoredUploadSession> {
+        let key = self.layout.session_meta_key(session);
+        let bytes = match self.get_object_bytes(&key).await {
+            Ok(bytes) => bytes,
+            Err(StorageError::UnknownUploadSession { .. }) => {
+                return Err(StorageError::unknown_upload_session(session.to_string()));
+            }
+            Err(err) => return Err(err),
+        };
+        let mut stored: StoredUploadSession = serde_json::from_slice(&bytes)
+            .map_err(|err| StorageError::backend(format!("read s3 upload metadata: {err}")))?;
+        refresh_expired(&mut stored.public);
+        Ok(stored)
+    }
+
+    async fn write_session(
+        &self,
+        session: &UploadSessionId,
+        stored: &StoredUploadSession,
+    ) -> StorageResult<()> {
+        let key = self.layout.session_meta_key(session);
+        let bytes = serde_json::to_vec_pretty(stored)
+            .map_err(|err| StorageError::backend(format!("encode s3 upload metadata: {err}")))?;
+        self.put_object_bytes(&key, bytes, Some("application/json"))
+            .await
+            .map(|_| ())
+    }
+
+    async fn get_staged_bytes(&self, session: &UploadSessionId) -> StorageResult<Vec<u8>> {
+        let key = self.layout.session_bytes_key(session);
+        match self.get_object_bytes(&key).await {
+            Ok(bytes) => Ok(bytes),
+            Err(StorageError::UnknownUploadSession { .. }) => Ok(Vec::new()),
+            Err(err) => Err(err),
+        }
+    }
+
+    async fn reconcile_staged_bytes(
+        &self,
+        session: &UploadSessionId,
+        trusted_len: u64,
+    ) -> StorageResult<Vec<u8>> {
+        let mut staged = self.get_staged_bytes(session).await?;
+        let actual = staged.len() as u64;
+        if actual == trusted_len {
+            return Ok(staged);
+        }
+        if actual > trusted_len {
+            tracing::warn!(
+                target: "pocopine.log",
+                event_name = "pocopine.storage.truncate_uncommitted_s3_bytes",
+                session = %session,
+                actual,
+                trusted = trusted_len,
+            );
+            staged.truncate(trusted_len as usize);
+            self.put_staged_bytes(session, staged.clone()).await?;
+            return Ok(staged);
+        }
+        Err(StorageError::backend(format!(
+            "S3 staged upload object is shorter than committed metadata: expected {trusted_len} bytes, got {actual}"
+        )))
+    }
+
+    async fn put_staged_bytes(
+        &self,
+        session: &UploadSessionId,
+        bytes: Vec<u8>,
+    ) -> StorageResult<()> {
+        let key = self.layout.session_bytes_key(session);
+        self.put_object_bytes(&key, bytes, Some("application/octet-stream"))
+            .await
+            .map(|_| ())
+    }
+
+    async fn get_object_bytes(&self, key: &str) -> StorageResult<Vec<u8>> {
+        let output = self
+            .client
+            .get_object()
+            .bucket(&self.layout.bucket)
+            .key(key)
+            .send()
+            .await
+            .map_err(|err| {
+                if is_s3_not_found(&err) {
+                    StorageError::unknown_upload_session(key.to_string())
+                } else {
+                    s3_error("get object", err)
+                }
+            })?;
+        let bytes = output
+            .body
+            .collect()
+            .await
+            .map_err(|err| s3_error("read object body", err))?
+            .into_bytes();
+        Ok(bytes.to_vec())
+    }
+
+    async fn put_object_bytes(
+        &self,
+        key: &str,
+        bytes: Vec<u8>,
+        content_type: Option<&str>,
+    ) -> StorageResult<Option<String>> {
+        let mut request = self
+            .client
+            .put_object()
+            .bucket(&self.layout.bucket)
+            .key(key)
+            .body(ByteStream::from(bytes));
+        if let Some(content_type) = content_type {
+            request = request.content_type(content_type);
+        }
+        let output = request
+            .send()
+            .await
+            .map_err(|err| s3_error("put object", err))?;
+        Ok(output.e_tag.map(normalize_etag))
+    }
+
+    async fn delete_object(&self, key: &str) -> StorageResult<()> {
+        self.client
+            .delete_object()
+            .bucket(&self.layout.bucket)
+            .key(key)
+            .send()
+            .await
+            .map_err(|err| s3_error("delete object", err))?;
+        Ok(())
+    }
+
+    async fn persist_expired_if_needed(
+        &self,
+        session: &UploadSessionId,
+        stored: &StoredUploadSession,
+    ) -> StorageResult<()> {
+        if stored.public.status == UploadSessionStatus::Expired {
+            self.write_session(session, stored).await?;
+        }
+        Ok(())
+    }
+
+    fn object_ref(
+        &self,
+        stored: &StoredUploadSession,
+        size: u64,
+        etag: Option<String>,
+        checksum: Option<ObjectChecksum>,
+    ) -> ObjectRef {
+        let mut metadata = stored.storage_key.metadata.0.clone();
+        metadata.extend(stored.request_metadata.clone());
+        ObjectRef {
+            backend: self.name.to_string(),
+            scope: stored.public.scope.clone(),
+            key: stored.storage_key.key.to_string(),
+            version: None,
+            etag,
+            checksum,
+            content_type: stored.public.content_type.clone(),
+            size,
+            visibility: stored.visibility,
+            metadata,
+        }
+    }
+}
+
+impl StorageBackend for S3StorageBackend {
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    fn initiate_upload<'a>(
+        &'a self,
+        ctx: &'a StorageContext,
+        request: InitiateUpload,
+    ) -> StorageBoxFuture<'a, UploadSession> {
+        Box::pin(async move {
+            let strategy = selected_strategy(request.requested_strategy)?;
+            let id = UploadSessionId::new(Uuid::new_v4().to_string())?;
+            let session = UploadSession {
+                id: id.clone(),
+                scope: request.scope.clone(),
+                file_name: request.file_name.clone(),
+                size: request.size,
+                content_type: request.content_type.clone(),
+                metadata: request.metadata.clone(),
+                strategy,
+                status: UploadSessionStatus::Open,
+                next_offset: Some(0),
+                part_size: request.policy.preferred_chunk_size,
+                plan: TransferPlan {
+                    min_part_size: request.policy.min_part_size,
+                    preferred_part_size: request.policy.preferred_chunk_size,
+                    max_part_size: request.policy.max_part_size,
+                    max_parts: request.policy.max_parts,
+                    max_concurrent_parts: 1,
+                    resumable: true,
+                },
+                uploaded_parts: Vec::new(),
+                expires_at: expires_at(request.policy.expires_after),
+            };
+            let stored = StoredUploadSession {
+                public: session.clone(),
+                owner: ctx.actor.clone(),
+                storage_key: request.storage_key,
+                visibility: request.policy.visibility,
+                max_bytes: request.policy.max_bytes,
+                checksum_policy: request.policy.checksum,
+                request_metadata: request.metadata,
+                object: None,
+            };
+            self.put_staged_bytes(&id, Vec::new()).await?;
+            self.write_session(&id, &stored).await?;
+            Ok(session)
+        })
+    }
+
+    fn inspect_upload<'a>(
+        &'a self,
+        ctx: &'a StorageContext,
+        session: UploadSessionId,
+    ) -> StorageBoxFuture<'a, UploadSession> {
+        Box::pin(async move {
+            let lock = self.session_lock(&session);
+            let _guard = lock.lock().await;
+            let stored = self.read_session(&session).await?;
+            ensure_owner(&ctx.actor, &stored.owner)?;
+            Ok(stored.public)
+        })
+    }
+
+    fn set_upload_length<'a>(
+        &'a self,
+        ctx: &'a StorageContext,
+        session: UploadSessionId,
+        size: u64,
+    ) -> StorageBoxFuture<'a, UploadSession> {
+        Box::pin(async move {
+            let lock = self.session_lock(&session);
+            let _guard = lock.lock().await;
+            let mut stored = self.read_session(&session).await?;
+            ensure_owner(&ctx.actor, &stored.owner)?;
+            self.persist_expired_if_needed(&session, &stored).await?;
+            let committed_offset = stored.public.next_offset.unwrap_or(0);
+            let staged_len = self
+                .reconcile_staged_bytes(&session, committed_offset)
+                .await?
+                .len() as u64;
+            ensure_upload_length_can_be_set(stored.max_bytes, &stored.public, staged_len, size)?;
+            stored.public.size = Some(size);
+            stored.public.next_offset = Some(staged_len);
+            self.write_session(&session, &stored).await?;
+            Ok(stored.public)
+        })
+    }
+
+    fn append_upload_bytes<'a>(
+        &'a self,
+        ctx: &'a StorageContext,
+        session: UploadSessionId,
+        offset: u64,
+        bytes: Bytes,
+    ) -> StorageBoxFuture<'a, UploadSession> {
+        Box::pin(async move {
+            let lock = self.session_lock(&session);
+            let _guard = lock.lock().await;
+            let mut stored = self.read_session(&session).await?;
+            ensure_owner(&ctx.actor, &stored.owner)?;
+            self.persist_expired_if_needed(&session, &stored).await?;
+            ensure_open(&stored.public)?;
+            if stored.public.strategy != UploadStrategy::Sequential {
+                return Err(StorageError::unsupported(
+                    "S3 backend currently supports sequential proxy uploads only",
+                ));
+            }
+            let expected = stored.public.next_offset.unwrap_or(0);
+            if expected != offset {
+                tracing::debug!(
+                    target: "pocopine.log",
+                    event_name = "pocopine.storage.offset_mismatch",
+                    session = %session,
+                    expected,
+                    provided = offset,
+                );
+                return Err(StorageError::offset_mismatch(expected, offset));
+            }
+            let mut staged = self.reconcile_staged_bytes(&session, expected).await?;
+            let new_offset = checked_new_offset(offset, bytes.len())?;
+            ensure_size_limit(stored.max_bytes, stored.public.size, new_offset)?;
+            staged.extend_from_slice(&bytes);
+            self.put_staged_bytes(&session, staged).await?;
+            stored.public.next_offset = Some(new_offset);
+            self.write_session(&session, &stored).await?;
+            Ok(stored.public)
+        })
+    }
+
+    fn complete_upload<'a>(
+        &'a self,
+        ctx: &'a StorageContext,
+        request: CompleteUpload,
+    ) -> StorageBoxFuture<'a, ObjectRef> {
+        Box::pin(async move {
+            let lock = self.session_lock(&request.session);
+            let _guard = lock.lock().await;
+            let mut stored = self.read_session(&request.session).await?;
+            ensure_owner(&ctx.actor, &stored.owner)?;
+            if let Some(object) = &stored.object {
+                return Ok(object.clone());
+            }
+            self.persist_expired_if_needed(&request.session, &stored)
+                .await?;
+            ensure_open(&stored.public)?;
+            let actual = stored.public.next_offset.unwrap_or(0);
+            let staged = self
+                .reconcile_staged_bytes(&request.session, actual)
+                .await?;
+            if let Some(expected) = stored.public.size {
+                if actual != expected {
+                    return Err(StorageError::policy_rejected(format!(
+                        "upload is incomplete: expected {expected} bytes, got {actual}"
+                    )));
+                }
+            }
+            ensure_size_limit(stored.max_bytes, stored.public.size, actual)?;
+            let checksum =
+                validate_complete_checksum(&stored.checksum_policy, &staged, request.checksum)?;
+            let object_key = self.layout.object_key(stored.storage_key.key.as_str());
+            let etag = self
+                .put_object_bytes(&object_key, staged, stored.public.content_type.as_deref())
+                .await?;
+            let object = self.object_ref(&stored, actual, etag, checksum);
+            stored.public.status = UploadSessionStatus::Complete;
+            stored.public.next_offset = Some(actual);
+            stored.object = Some(object.clone());
+            self.write_session(&request.session, &stored).await?;
+            let _ = self
+                .delete_object(&self.layout.session_bytes_key(&request.session))
+                .await;
+            Ok(object)
+        })
+    }
+
+    fn abort_upload<'a>(
+        &'a self,
+        ctx: &'a StorageContext,
+        session: UploadSessionId,
+    ) -> StorageBoxFuture<'a, ()> {
+        Box::pin(async move {
+            let lock = self.session_lock(&session);
+            let guard = lock.lock().await;
+            match self.read_session(&session).await {
+                Ok(stored) => ensure_owner(&ctx.actor, &stored.owner)?,
+                Err(StorageError::UnknownUploadSession { .. }) => return Ok(()),
+                Err(err) => return Err(err),
+            }
+            let meta_key = self.layout.session_meta_key(&session);
+            let bytes_key = self.layout.session_bytes_key(&session);
+            self.delete_object(&meta_key).await?;
+            self.delete_object(&bytes_key).await?;
+            drop(guard);
+            self.drop_session_lock(&session);
+            Ok(())
+        })
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct S3KeyLayout {
+    bucket: String,
+    object_prefix: Option<String>,
+    internal_prefix: String,
+}
+
+impl S3KeyLayout {
+    fn new(
+        bucket: String,
+        object_prefix: Option<String>,
+        internal_prefix: String,
+    ) -> StorageResult<Self> {
+        let bucket = bucket.trim().to_string();
+        if bucket.is_empty() {
+            return Err(StorageError::policy_rejected(
+                "S3 bucket name must not be empty",
+            ));
+        }
+        let object_prefix = object_prefix.and_then(normalize_prefix);
+        let internal_prefix = normalize_prefix(internal_prefix)
+            .ok_or_else(|| StorageError::policy_rejected("S3 internal prefix must not be empty"))?;
+        Ok(Self {
+            bucket,
+            object_prefix,
+            internal_prefix,
+        })
+    }
+
+    fn with_prefix(&self, prefix: String) -> StorageResult<Self> {
+        let object_prefix = normalize_prefix(prefix);
+        let internal_prefix = match &object_prefix {
+            Some(prefix) => format!("{prefix}/{DEFAULT_INTERNAL_PREFIX}"),
+            None => DEFAULT_INTERNAL_PREFIX.to_string(),
+        };
+        Self::new(self.bucket.clone(), object_prefix, internal_prefix)
+    }
+
+    fn with_internal_prefix(&self, prefix: String) -> StorageResult<Self> {
+        Self::new(
+            self.bucket.clone(),
+            self.object_prefix.clone(),
+            prefix.trim_matches('/').to_string(),
+        )
+    }
+
+    fn object_key(&self, key: &str) -> String {
+        join_optional_prefix(self.object_prefix.as_deref(), key)
+    }
+
+    fn session_meta_key(&self, session: &UploadSessionId) -> String {
+        format!("{}/{}/session.json", self.internal_prefix, session.as_str())
+    }
+
+    fn session_bytes_key(&self, session: &UploadSessionId) -> String {
+        format!("{}/{}/bytes.tmp", self.internal_prefix, session.as_str())
+    }
+}
+
+fn selected_strategy(strategy: UploadStrategy) -> StorageResult<UploadStrategy> {
+    match strategy {
+        UploadStrategy::Auto | UploadStrategy::Sequential => Ok(UploadStrategy::Sequential),
+        UploadStrategy::SingleRequest | UploadStrategy::Multipart => {
+            Err(StorageError::unsupported(
+                "S3 backend currently supports sequential proxy uploads only",
+            ))
+        }
+        _ => Err(StorageError::unsupported(
+            "S3 backend currently supports sequential proxy uploads only",
+        )),
+    }
+}
+
+fn expires_at(duration: std::time::Duration) -> OffsetDateTime {
+    OffsetDateTime::now_utc()
+        + time::Duration::seconds(duration.as_secs().min(i64::MAX as u64) as i64)
+}
+
+fn ensure_owner(actor: &StorageActor, owner: &StorageActor) -> StorageResult<()> {
+    if actor.same_owner(owner) {
+        Ok(())
+    } else {
+        Err(StorageError::forbidden(
+            "upload session belongs to a different storage actor",
+        ))
+    }
+}
+
+fn ensure_open(session: &UploadSession) -> StorageResult<()> {
+    match session.status {
+        UploadSessionStatus::Open => Ok(()),
+        UploadSessionStatus::Complete => Err(StorageError::UploadComplete {
+            session: session.id.to_string(),
+        }),
+        UploadSessionStatus::Aborted
+        | UploadSessionStatus::Expired
+        | UploadSessionStatus::Completing => Err(StorageError::UploadClosed {
+            session: session.id.to_string(),
+        }),
+        _ => Err(StorageError::UploadClosed {
+            session: session.id.to_string(),
+        }),
+    }
+}
+
+fn refresh_expired(session: &mut UploadSession) -> bool {
+    if session.status == UploadSessionStatus::Open
+        && OffsetDateTime::now_utc() >= session.expires_at
+    {
+        session.status = UploadSessionStatus::Expired;
+        true
+    } else {
+        false
+    }
+}
+
+fn checked_new_offset(offset: u64, byte_count: usize) -> StorageResult<u64> {
+    offset
+        .checked_add(byte_count as u64)
+        .ok_or_else(|| StorageError::policy_rejected("upload byte offset overflowed"))
+}
+
+fn ensure_size_limit(
+    max_bytes: u64,
+    declared_size: Option<u64>,
+    new_offset: u64,
+) -> StorageResult<()> {
+    if new_offset > max_bytes {
+        return Err(StorageError::policy_rejected(format!(
+            "upload exceeds scope max of {max_bytes} bytes"
+        )));
+    }
+    if let Some(size) = declared_size {
+        if new_offset > size {
+            return Err(StorageError::policy_rejected(format!(
+                "upload exceeds declared size of {size} bytes"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn ensure_upload_length_can_be_set(
+    max_bytes: u64,
+    session: &UploadSession,
+    committed_offset: u64,
+    size: u64,
+) -> StorageResult<()> {
+    ensure_open(session)?;
+    if let Some(existing) = session.size {
+        if existing == size {
+            return Ok(());
+        }
+        return Err(StorageError::policy_rejected(
+            "cannot change upload length after it is set",
+        ));
+    }
+    if size > max_bytes {
+        return Err(StorageError::payload_too_large(max_bytes));
+    }
+    if committed_offset > size {
+        return Err(StorageError::policy_rejected(format!(
+            "upload length {size} is smaller than the committed offset {committed_offset}"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_complete_checksum(
+    policy: &ChecksumPolicy,
+    bytes: &[u8],
+    provided: Option<ObjectChecksum>,
+) -> StorageResult<Option<ObjectChecksum>> {
+    match policy {
+        ChecksumPolicy::None => Ok(None),
+        ChecksumPolicy::Optional(allowed) => {
+            if let Some(checksum) = &provided {
+                if !allowed.contains(&checksum.algorithm) {
+                    return Err(StorageError::policy_rejected(
+                        "checksum algorithm is not allowed",
+                    ));
+                }
+                let computed = compute_checksum(checksum.algorithm, bytes)?;
+                if !checksum.value.eq_ignore_ascii_case(&computed.value) {
+                    return Err(StorageError::policy_rejected(
+                        "upload checksum does not match uploaded bytes",
+                    ));
+                }
+                return Ok(Some(computed));
+            }
+            Ok(None)
+        }
+        ChecksumPolicy::Required(algorithm) => {
+            let provided = provided.ok_or_else(|| {
+                StorageError::policy_rejected("required upload checksum is missing")
+            })?;
+            if provided.algorithm != *algorithm {
+                return Err(StorageError::policy_rejected(
+                    "required upload checksum algorithm does not match policy",
+                ));
+            }
+            let computed = compute_checksum(*algorithm, bytes)?;
+            if !provided.value.eq_ignore_ascii_case(&computed.value) {
+                return Err(StorageError::policy_rejected(
+                    "required upload checksum does not match uploaded bytes",
+                ));
+            }
+            Ok(Some(computed))
+        }
+        _ => Err(StorageError::unsupported(
+            "unsupported checksum policy for S3 backend",
+        )),
+    }
+}
+
+fn compute_checksum(algorithm: ChecksumAlgorithm, bytes: &[u8]) -> StorageResult<ObjectChecksum> {
+    match algorithm {
+        ChecksumAlgorithm::Sha256 => {
+            let digest = Sha256::digest(bytes);
+            let mut value = String::with_capacity(digest.len() * 2);
+            for byte in digest {
+                use std::fmt::Write as _;
+                write!(&mut value, "{byte:02x}")
+                    .map_err(|err| StorageError::backend(format!("format checksum: {err}")))?;
+            }
+            Ok(ObjectChecksum { algorithm, value })
+        }
+        ChecksumAlgorithm::Crc32c | ChecksumAlgorithm::Md5 => Err(StorageError::unsupported(
+            "only sha256 checksum verification is implemented for S3 backend checksums",
+        )),
+        _ => Err(StorageError::unsupported(
+            "only sha256 checksum verification is implemented for S3 backend checksums",
+        )),
+    }
+}
+
+fn normalize_prefix(prefix: String) -> Option<String> {
+    let prefix = prefix.trim().trim_matches('/');
+    if prefix.is_empty() {
+        None
+    } else {
+        Some(prefix.to_string())
+    }
+}
+
+fn join_optional_prefix(prefix: Option<&str>, key: &str) -> String {
+    match prefix {
+        Some(prefix) => format!("{prefix}/{}", key.trim_start_matches('/')),
+        None => key.trim_start_matches('/').to_string(),
+    }
+}
+
+fn normalize_etag(etag: String) -> String {
+    etag.trim_matches('"').to_string()
+}
+
+fn is_s3_not_found(err: &impl std::fmt::Display) -> bool {
+    let message = err.to_string();
+    message.contains("NoSuchKey")
+        || message.contains("NotFound")
+        || message.contains("404")
+        || message.contains("status code: 404")
+}
+
+fn s3_error(operation: &'static str, err: impl std::fmt::Display) -> StorageError {
+    tracing::error!(
+        target: "pocopine.log",
+        event_name = "pocopine.storage.s3_error",
+        operation,
+        error = %err,
+    );
+    StorageError::backend(format!("S3 {operation}: {err}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn prefix_layout_keeps_internal_objects_out_of_app_keyspace() {
+        let layout = S3KeyLayout::new(
+            "bucket".to_string(),
+            Some("tenant-a/".to_string()),
+            "tenant-a/__pocopine/storage/sessions".to_string(),
+        )
+        .unwrap();
+        let session = UploadSessionId::new("session-1").unwrap();
+
+        assert_eq!(
+            layout.object_key("files/avatar.png"),
+            "tenant-a/files/avatar.png"
+        );
+        assert_eq!(
+            layout.session_meta_key(&session),
+            "tenant-a/__pocopine/storage/sessions/session-1/session.json"
+        );
+        assert_eq!(
+            layout.session_bytes_key(&session),
+            "tenant-a/__pocopine/storage/sessions/session-1/bytes.tmp"
+        );
+    }
+
+    #[test]
+    fn empty_bucket_is_rejected() {
+        assert!(
+            S3KeyLayout::new("  ".to_string(), None, DEFAULT_INTERNAL_PREFIX.to_string()).is_err()
+        );
+    }
+
+    #[test]
+    fn etag_quotes_are_removed() {
+        assert_eq!(normalize_etag("\"abc123\"".to_string()), "abc123");
+    }
+}

--- a/crates/pocopine-storage-s3/src/lib.rs
+++ b/crates/pocopine-storage-s3/src/lib.rs
@@ -8,26 +8,39 @@
 //! For S3-compatible services such as MinIO, build an `aws_sdk_s3::Client`
 //! with the provider-specific endpoint/path-style settings and pass it to
 //! [`S3StorageBackend::new`].
+//!
+//! This first adapter is deliberately a bounded sequential proxy backend. It
+//! keeps staging bytes in memory while appending/completing and relies on
+//! in-process per-session locks, so route a given upload session to one server
+//! replica or wait for the future provider-side multipart backend before using
+//! it for large or horizontally written uploads.
 
 use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, Mutex as StdMutex};
 
+use aws_sdk_s3::error::SdkError;
+use aws_sdk_s3::operation::get_object::GetObjectError;
+use aws_sdk_s3::operation::put_object::PutObjectError;
 use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::Client;
 use bytes::Bytes;
+use pocopine_storage::backend_common::{
+    checked_new_offset, ensure_open, ensure_owner, ensure_size_limit,
+    ensure_upload_length_can_be_set, expires_at, refresh_expired, selected_strategy,
+};
+use pocopine_storage::checksum::{ensure_supported_checksum_policy, validate_complete_checksum};
 use pocopine_storage::{
-    ChecksumAlgorithm, ChecksumPolicy, CompleteUpload, InitiateUpload, ObjectChecksum, ObjectRef,
-    ObjectVisibility, StorageActor, StorageBackend, StorageBoxFuture, StorageContext, StorageError,
-    StorageKey, StorageResult, TransferPlan, UploadSession, UploadSessionId, UploadSessionStatus,
+    ChecksumPolicy, CompleteUpload, InitiateUpload, ObjectChecksum, ObjectRef, ObjectVisibility,
+    StorageActor, StorageBackend, StorageBoxFuture, StorageContext, StorageError, StorageKey,
+    StorageResult, TransferPlan, UploadSession, UploadSessionId, UploadSessionStatus,
     UploadStrategy,
 };
-use sha2::{Digest, Sha256};
-use time::OffsetDateTime;
 use tokio::sync::Mutex as TokioMutex;
 use uuid::Uuid;
 
 const DEFAULT_BACKEND_NAME: &str = "s3";
 const DEFAULT_INTERNAL_PREFIX: &str = "__pocopine/storage/sessions";
+const DEFAULT_MAX_PROXY_UPLOAD_BYTES: u64 = 64 * 1024 * 1024;
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 struct StoredUploadSession {
@@ -39,21 +52,24 @@ struct StoredUploadSession {
     checksum_policy: ChecksumPolicy,
     request_metadata: BTreeMap<String, String>,
     object: Option<ObjectRef>,
+    #[serde(default)]
+    cleanup_pending: bool,
 }
 
 /// Storage backend backed by an S3-compatible object store.
 ///
 /// The adapter stores temporary upload bytes as an internal object and rewrites
 /// that object on each sequential `PATCH`. That keeps the first S3 backend
-/// compatible with Pocopine's existing resumable upload protocol, but it is
-/// not the high-throughput/direct multipart path. A later direct/multipart
-/// backend can add provider-side multipart uploads without changing the public
-/// `StorageBackend` contract.
+/// compatible with Pocopine's existing resumable upload protocol for bounded
+/// uploads, but it is not the high-throughput/direct multipart path. A later
+/// direct/multipart backend can add provider-side multipart uploads without
+/// changing the public `StorageBackend` contract.
 #[derive(Clone)]
 pub struct S3StorageBackend {
     name: &'static str,
     client: Client,
     layout: S3KeyLayout,
+    max_proxy_upload_bytes: u64,
     session_locks: Arc<StdMutex<HashMap<String, Arc<TokioMutex<()>>>>>,
 }
 
@@ -64,6 +80,7 @@ impl std::fmt::Debug for S3StorageBackend {
             .field("bucket", &self.layout.bucket)
             .field("object_prefix", &self.layout.object_prefix)
             .field("internal_prefix", &self.layout.internal_prefix)
+            .field("max_proxy_upload_bytes", &self.max_proxy_upload_bytes)
             .finish_non_exhaustive()
     }
 }
@@ -84,6 +101,7 @@ impl S3StorageBackend {
             name,
             client,
             layout: S3KeyLayout::new(bucket.into(), None, DEFAULT_INTERNAL_PREFIX.to_string())?,
+            max_proxy_upload_bytes: DEFAULT_MAX_PROXY_UPLOAD_BYTES,
             session_locks: Arc::new(StdMutex::new(HashMap::new())),
         })
     }
@@ -103,6 +121,22 @@ impl S3StorageBackend {
         Ok(self)
     }
 
+    /// Override the maximum size accepted by this sequential proxy backend.
+    ///
+    /// The default is 64 MiB because each append rewrites the staged object and
+    /// completion loads the staged bytes before the final S3 write. Larger
+    /// values are possible, but applications should prefer the future multipart
+    /// backend for large uploads.
+    pub fn with_max_proxy_upload_bytes(mut self, max_bytes: u64) -> StorageResult<Self> {
+        if max_bytes == 0 {
+            return Err(StorageError::policy_rejected(
+                "S3 max proxy upload bytes must be greater than zero",
+            ));
+        }
+        self.max_proxy_upload_bytes = max_bytes;
+        Ok(self)
+    }
+
     pub fn bucket(&self) -> &str {
         &self.layout.bucket
     }
@@ -113,6 +147,10 @@ impl S3StorageBackend {
 
     pub fn internal_prefix(&self) -> &str {
         &self.layout.internal_prefix
+    }
+
+    pub fn max_proxy_upload_bytes(&self) -> u64 {
+        self.max_proxy_upload_bytes
     }
 
     fn session_lock(&self, session: &UploadSessionId) -> Arc<TokioMutex<()>> {
@@ -180,21 +218,19 @@ impl S3StorageBackend {
         session: &UploadSessionId,
         trusted_len: u64,
     ) -> StorageResult<Vec<u8>> {
-        let mut staged = self.get_staged_bytes(session).await?;
+        let staged = self.get_staged_bytes(session).await?;
         let actual = staged.len() as u64;
-        if actual == trusted_len {
-            return Ok(staged);
-        }
         if actual > trusted_len {
             tracing::warn!(
                 target: "pocopine.log",
-                event_name = "pocopine.storage.truncate_uncommitted_s3_bytes",
+                event_name = "pocopine.storage.s3_staged_bytes_ahead",
                 session = %session,
                 actual,
                 trusted = trusted_len,
             );
-            staged.truncate(trusted_len as usize);
-            self.put_staged_bytes(session, staged.clone()).await?;
+            return Ok(staged);
+        }
+        if actual == trusted_len {
             return Ok(staged);
         }
         Err(StorageError::backend(format!(
@@ -214,6 +250,15 @@ impl S3StorageBackend {
     }
 
     async fn get_object_bytes(&self, key: &str) -> StorageResult<Vec<u8>> {
+        self.get_object_bytes_with_etag(key)
+            .await
+            .map(|(bytes, _etag)| bytes)
+    }
+
+    async fn get_object_bytes_with_etag(
+        &self,
+        key: &str,
+    ) -> StorageResult<(Vec<u8>, Option<String>)> {
         let output = self
             .client
             .get_object()
@@ -222,7 +267,7 @@ impl S3StorageBackend {
             .send()
             .await
             .map_err(|err| {
-                if is_s3_not_found(&err) {
+                if is_get_object_not_found(&err) {
                     StorageError::unknown_upload_session(key.to_string())
                 } else {
                     s3_error("get object", err)
@@ -234,7 +279,7 @@ impl S3StorageBackend {
             .await
             .map_err(|err| s3_error("read object body", err))?
             .into_bytes();
-        Ok(bytes.to_vec())
+        Ok((bytes.to_vec(), output.e_tag.map(normalize_etag)))
     }
 
     async fn put_object_bytes(
@@ -259,6 +304,50 @@ impl S3StorageBackend {
         Ok(output.e_tag.map(normalize_etag))
     }
 
+    async fn put_completed_object(
+        &self,
+        key: &str,
+        bytes: &[u8],
+        content_type: Option<&str>,
+    ) -> StorageResult<Option<String>> {
+        match self.get_object_bytes_with_etag(key).await {
+            Ok((existing, etag)) => {
+                if existing == bytes {
+                    return Ok(etag);
+                }
+                return Err(StorageError::policy_rejected(format!(
+                    "S3 object key already exists with different bytes: {key}"
+                )));
+            }
+            Err(StorageError::UnknownUploadSession { .. }) => {}
+            Err(err) => return Err(err),
+        }
+        let mut request = self
+            .client
+            .put_object()
+            .bucket(&self.layout.bucket)
+            .key(key)
+            .if_none_match("*")
+            .body(ByteStream::from(bytes.to_vec()));
+        if let Some(content_type) = content_type {
+            request = request.content_type(content_type);
+        }
+        match request.send().await {
+            Ok(output) => Ok(output.e_tag.map(normalize_etag)),
+            Err(err) if is_put_precondition_failed(&err) => {
+                let (existing, etag) = self.get_object_bytes_with_etag(key).await?;
+                if existing == bytes {
+                    Ok(etag)
+                } else {
+                    Err(StorageError::policy_rejected(format!(
+                        "S3 object key already exists with different bytes: {key}"
+                    )))
+                }
+            }
+            Err(err) => Err(s3_error("put completed object", err)),
+        }
+    }
+
     async fn delete_object(&self, key: &str) -> StorageResult<()> {
         self.client
             .delete_object()
@@ -277,6 +366,29 @@ impl S3StorageBackend {
     ) -> StorageResult<()> {
         if stored.public.status == UploadSessionStatus::Expired {
             self.write_session(session, stored).await?;
+        }
+        Ok(())
+    }
+
+    async fn cleanup_staged_bytes(
+        &self,
+        session: &UploadSessionId,
+        stored: &mut StoredUploadSession,
+    ) -> StorageResult<()> {
+        if !stored.cleanup_pending {
+            return Ok(());
+        }
+        self.delete_object(&self.layout.session_bytes_key(session))
+            .await?;
+        stored.cleanup_pending = false;
+        self.write_session(session, stored).await
+    }
+
+    fn ensure_requested_size_is_supported(&self, size: Option<u64>) -> StorageResult<()> {
+        if let Some(size) = size {
+            if size > self.max_proxy_upload_bytes {
+                return Err(StorageError::payload_too_large(self.max_proxy_upload_bytes));
+            }
         }
         Ok(())
     }
@@ -305,6 +417,26 @@ impl S3StorageBackend {
     }
 }
 
+struct SessionLockCleanup<'a> {
+    backend: &'a S3StorageBackend,
+    session: UploadSessionId,
+}
+
+impl<'a> SessionLockCleanup<'a> {
+    fn new(backend: &'a S3StorageBackend, session: &UploadSessionId) -> Self {
+        Self {
+            backend,
+            session: session.clone(),
+        }
+    }
+}
+
+impl Drop for SessionLockCleanup<'_> {
+    fn drop(&mut self) {
+        self.backend.drop_session_lock(&self.session);
+    }
+}
+
 impl StorageBackend for S3StorageBackend {
     fn name(&self) -> &'static str {
         self.name
@@ -317,6 +449,8 @@ impl StorageBackend for S3StorageBackend {
     ) -> StorageBoxFuture<'a, UploadSession> {
         Box::pin(async move {
             let strategy = selected_strategy(request.requested_strategy)?;
+            ensure_supported_checksum_policy(&request.policy.checksum)?;
+            self.ensure_requested_size_is_supported(request.size)?;
             let id = UploadSessionId::new(Uuid::new_v4().to_string())?;
             let session = UploadSession {
                 id: id.clone(),
@@ -345,13 +479,17 @@ impl StorageBackend for S3StorageBackend {
                 owner: ctx.actor.clone(),
                 storage_key: request.storage_key,
                 visibility: request.policy.visibility,
-                max_bytes: request.policy.max_bytes,
+                max_bytes: request.policy.max_bytes.min(self.max_proxy_upload_bytes),
                 checksum_policy: request.policy.checksum,
                 request_metadata: request.metadata,
                 object: None,
+                cleanup_pending: false,
             };
-            self.put_staged_bytes(&id, Vec::new()).await?;
             self.write_session(&id, &stored).await?;
+            if let Err(err) = self.put_staged_bytes(&id, Vec::new()).await {
+                let _ = self.delete_object(&self.layout.session_meta_key(&id)).await;
+                return Err(err);
+            }
             Ok(session)
         })
     }
@@ -363,9 +501,20 @@ impl StorageBackend for S3StorageBackend {
     ) -> StorageBoxFuture<'a, UploadSession> {
         Box::pin(async move {
             let lock = self.session_lock(&session);
+            let _cleanup = SessionLockCleanup::new(self, &session);
             let _guard = lock.lock().await;
-            let stored = self.read_session(&session).await?;
+            let mut stored = self.read_session(&session).await?;
             ensure_owner(&ctx.actor, &stored.owner)?;
+            if stored.public.status == UploadSessionStatus::Open {
+                let staged = self
+                    .reconcile_staged_bytes(&session, stored.public.next_offset.unwrap_or(0))
+                    .await?;
+                let staged_len = staged.len() as u64;
+                if stored.public.next_offset != Some(staged_len) {
+                    stored.public.next_offset = Some(staged_len);
+                    self.write_session(&session, &stored).await?;
+                }
+            }
             Ok(stored.public)
         })
     }
@@ -378,7 +527,9 @@ impl StorageBackend for S3StorageBackend {
     ) -> StorageBoxFuture<'a, UploadSession> {
         Box::pin(async move {
             let lock = self.session_lock(&session);
+            let _cleanup = SessionLockCleanup::new(self, &session);
             let _guard = lock.lock().await;
+            self.ensure_requested_size_is_supported(Some(size))?;
             let mut stored = self.read_session(&session).await?;
             ensure_owner(&ctx.actor, &stored.owner)?;
             self.persist_expired_if_needed(&session, &stored).await?;
@@ -404,6 +555,7 @@ impl StorageBackend for S3StorageBackend {
     ) -> StorageBoxFuture<'a, UploadSession> {
         Box::pin(async move {
             let lock = self.session_lock(&session);
+            let _cleanup = SessionLockCleanup::new(self, &session);
             let _guard = lock.lock().await;
             let mut stored = self.read_session(&session).await?;
             ensure_owner(&ctx.actor, &stored.owner)?;
@@ -414,7 +566,14 @@ impl StorageBackend for S3StorageBackend {
                     "S3 backend currently supports sequential proxy uploads only",
                 ));
             }
-            let expected = stored.public.next_offset.unwrap_or(0);
+            let mut expected = stored.public.next_offset.unwrap_or(0);
+            let mut staged = self.reconcile_staged_bytes(&session, expected).await?;
+            let staged_len = staged.len() as u64;
+            if staged_len > expected {
+                expected = staged_len;
+                stored.public.next_offset = Some(staged_len);
+                self.write_session(&session, &stored).await?;
+            }
             if expected != offset {
                 tracing::debug!(
                     target: "pocopine.log",
@@ -425,7 +584,6 @@ impl StorageBackend for S3StorageBackend {
                 );
                 return Err(StorageError::offset_mismatch(expected, offset));
             }
-            let mut staged = self.reconcile_staged_bytes(&session, expected).await?;
             let new_offset = checked_new_offset(offset, bytes.len())?;
             ensure_size_limit(stored.max_bytes, stored.public.size, new_offset)?;
             staged.extend_from_slice(&bytes);
@@ -443,19 +601,24 @@ impl StorageBackend for S3StorageBackend {
     ) -> StorageBoxFuture<'a, ObjectRef> {
         Box::pin(async move {
             let lock = self.session_lock(&request.session);
+            let _cleanup = SessionLockCleanup::new(self, &request.session);
             let _guard = lock.lock().await;
             let mut stored = self.read_session(&request.session).await?;
             ensure_owner(&ctx.actor, &stored.owner)?;
             if let Some(object) = &stored.object {
-                return Ok(object.clone());
+                let object = object.clone();
+                self.cleanup_staged_bytes(&request.session, &mut stored)
+                    .await?;
+                return Ok(object);
             }
             self.persist_expired_if_needed(&request.session, &stored)
                 .await?;
-            ensure_open(&stored.public)?;
-            let actual = stored.public.next_offset.unwrap_or(0);
+            ensure_completable(&stored.public)?;
+            let trusted = stored.public.next_offset.unwrap_or(0);
             let staged = self
-                .reconcile_staged_bytes(&request.session, actual)
+                .reconcile_staged_bytes(&request.session, trusted)
                 .await?;
+            let actual = staged.len() as u64;
             if let Some(expected) = stored.public.size {
                 if actual != expected {
                     return Err(StorageError::policy_rejected(format!(
@@ -467,17 +630,24 @@ impl StorageBackend for S3StorageBackend {
             let checksum =
                 validate_complete_checksum(&stored.checksum_policy, &staged, request.checksum)?;
             let object_key = self.layout.object_key(stored.storage_key.key.as_str());
+            if stored.public.status == UploadSessionStatus::Open
+                || stored.public.next_offset != Some(actual)
+            {
+                stored.public.status = UploadSessionStatus::Completing;
+                stored.public.next_offset = Some(actual);
+                self.write_session(&request.session, &stored).await?;
+            }
             let etag = self
-                .put_object_bytes(&object_key, staged, stored.public.content_type.as_deref())
+                .put_completed_object(&object_key, &staged, stored.public.content_type.as_deref())
                 .await?;
             let object = self.object_ref(&stored, actual, etag, checksum);
             stored.public.status = UploadSessionStatus::Complete;
             stored.public.next_offset = Some(actual);
             stored.object = Some(object.clone());
+            stored.cleanup_pending = true;
             self.write_session(&request.session, &stored).await?;
-            let _ = self
-                .delete_object(&self.layout.session_bytes_key(&request.session))
-                .await;
+            self.cleanup_staged_bytes(&request.session, &mut stored)
+                .await?;
             Ok(object)
         })
     }
@@ -489,18 +659,22 @@ impl StorageBackend for S3StorageBackend {
     ) -> StorageBoxFuture<'a, ()> {
         Box::pin(async move {
             let lock = self.session_lock(&session);
-            let guard = lock.lock().await;
-            match self.read_session(&session).await {
-                Ok(stored) => ensure_owner(&ctx.actor, &stored.owner)?,
-                Err(StorageError::UnknownUploadSession { .. }) => return Ok(()),
+            let _cleanup = SessionLockCleanup::new(self, &session);
+            let _guard = lock.lock().await;
+            let known_session = match self.read_session(&session).await {
+                Ok(stored) => {
+                    ensure_owner(&ctx.actor, &stored.owner)?;
+                    true
+                }
+                Err(StorageError::UnknownUploadSession { .. }) => false,
                 Err(err) => return Err(err),
-            }
+            };
             let meta_key = self.layout.session_meta_key(&session);
             let bytes_key = self.layout.session_bytes_key(&session);
-            self.delete_object(&meta_key).await?;
             self.delete_object(&bytes_key).await?;
-            drop(guard);
-            self.drop_session_lock(&session);
+            if known_session {
+                self.delete_object(&meta_key).await?;
+            }
             Ok(())
         })
     }
@@ -510,6 +684,7 @@ impl StorageBackend for S3StorageBackend {
 struct S3KeyLayout {
     bucket: String,
     object_prefix: Option<String>,
+    internal_prefix_base: String,
     internal_prefix: String,
 }
 
@@ -526,22 +701,25 @@ impl S3KeyLayout {
             ));
         }
         let object_prefix = object_prefix.and_then(normalize_prefix);
-        let internal_prefix = normalize_prefix(internal_prefix)
+        let internal_prefix_base = normalize_prefix(internal_prefix)
             .ok_or_else(|| StorageError::policy_rejected("S3 internal prefix must not be empty"))?;
+        let internal_prefix =
+            join_optional_prefix(object_prefix.as_deref(), internal_prefix_base.as_str());
         Ok(Self {
             bucket,
             object_prefix,
+            internal_prefix_base,
             internal_prefix,
         })
     }
 
     fn with_prefix(&self, prefix: String) -> StorageResult<Self> {
         let object_prefix = normalize_prefix(prefix);
-        let internal_prefix = match &object_prefix {
-            Some(prefix) => format!("{prefix}/{DEFAULT_INTERNAL_PREFIX}"),
-            None => DEFAULT_INTERNAL_PREFIX.to_string(),
-        };
-        Self::new(self.bucket.clone(), object_prefix, internal_prefix)
+        Self::new(
+            self.bucket.clone(),
+            object_prefix,
+            self.internal_prefix_base.clone(),
+        )
     }
 
     fn with_internal_prefix(&self, prefix: String) -> StorageResult<Self> {
@@ -565,180 +743,11 @@ impl S3KeyLayout {
     }
 }
 
-fn selected_strategy(strategy: UploadStrategy) -> StorageResult<UploadStrategy> {
-    match strategy {
-        UploadStrategy::Auto | UploadStrategy::Sequential => Ok(UploadStrategy::Sequential),
-        UploadStrategy::SingleRequest | UploadStrategy::Multipart => {
-            Err(StorageError::unsupported(
-                "S3 backend currently supports sequential proxy uploads only",
-            ))
-        }
-        _ => Err(StorageError::unsupported(
-            "S3 backend currently supports sequential proxy uploads only",
-        )),
-    }
-}
-
-fn expires_at(duration: std::time::Duration) -> OffsetDateTime {
-    OffsetDateTime::now_utc()
-        + time::Duration::seconds(duration.as_secs().min(i64::MAX as u64) as i64)
-}
-
-fn ensure_owner(actor: &StorageActor, owner: &StorageActor) -> StorageResult<()> {
-    if actor.same_owner(owner) {
+fn ensure_completable(session: &UploadSession) -> StorageResult<()> {
+    if session.status == UploadSessionStatus::Completing {
         Ok(())
     } else {
-        Err(StorageError::forbidden(
-            "upload session belongs to a different storage actor",
-        ))
-    }
-}
-
-fn ensure_open(session: &UploadSession) -> StorageResult<()> {
-    match session.status {
-        UploadSessionStatus::Open => Ok(()),
-        UploadSessionStatus::Complete => Err(StorageError::UploadComplete {
-            session: session.id.to_string(),
-        }),
-        UploadSessionStatus::Aborted
-        | UploadSessionStatus::Expired
-        | UploadSessionStatus::Completing => Err(StorageError::UploadClosed {
-            session: session.id.to_string(),
-        }),
-        _ => Err(StorageError::UploadClosed {
-            session: session.id.to_string(),
-        }),
-    }
-}
-
-fn refresh_expired(session: &mut UploadSession) -> bool {
-    if session.status == UploadSessionStatus::Open
-        && OffsetDateTime::now_utc() >= session.expires_at
-    {
-        session.status = UploadSessionStatus::Expired;
-        true
-    } else {
-        false
-    }
-}
-
-fn checked_new_offset(offset: u64, byte_count: usize) -> StorageResult<u64> {
-    offset
-        .checked_add(byte_count as u64)
-        .ok_or_else(|| StorageError::policy_rejected("upload byte offset overflowed"))
-}
-
-fn ensure_size_limit(
-    max_bytes: u64,
-    declared_size: Option<u64>,
-    new_offset: u64,
-) -> StorageResult<()> {
-    if new_offset > max_bytes {
-        return Err(StorageError::policy_rejected(format!(
-            "upload exceeds scope max of {max_bytes} bytes"
-        )));
-    }
-    if let Some(size) = declared_size {
-        if new_offset > size {
-            return Err(StorageError::policy_rejected(format!(
-                "upload exceeds declared size of {size} bytes"
-            )));
-        }
-    }
-    Ok(())
-}
-
-fn ensure_upload_length_can_be_set(
-    max_bytes: u64,
-    session: &UploadSession,
-    committed_offset: u64,
-    size: u64,
-) -> StorageResult<()> {
-    ensure_open(session)?;
-    if let Some(existing) = session.size {
-        if existing == size {
-            return Ok(());
-        }
-        return Err(StorageError::policy_rejected(
-            "cannot change upload length after it is set",
-        ));
-    }
-    if size > max_bytes {
-        return Err(StorageError::payload_too_large(max_bytes));
-    }
-    if committed_offset > size {
-        return Err(StorageError::policy_rejected(format!(
-            "upload length {size} is smaller than the committed offset {committed_offset}"
-        )));
-    }
-    Ok(())
-}
-
-fn validate_complete_checksum(
-    policy: &ChecksumPolicy,
-    bytes: &[u8],
-    provided: Option<ObjectChecksum>,
-) -> StorageResult<Option<ObjectChecksum>> {
-    match policy {
-        ChecksumPolicy::None => Ok(None),
-        ChecksumPolicy::Optional(allowed) => {
-            if let Some(checksum) = &provided {
-                if !allowed.contains(&checksum.algorithm) {
-                    return Err(StorageError::policy_rejected(
-                        "checksum algorithm is not allowed",
-                    ));
-                }
-                let computed = compute_checksum(checksum.algorithm, bytes)?;
-                if !checksum.value.eq_ignore_ascii_case(&computed.value) {
-                    return Err(StorageError::policy_rejected(
-                        "upload checksum does not match uploaded bytes",
-                    ));
-                }
-                return Ok(Some(computed));
-            }
-            Ok(None)
-        }
-        ChecksumPolicy::Required(algorithm) => {
-            let provided = provided.ok_or_else(|| {
-                StorageError::policy_rejected("required upload checksum is missing")
-            })?;
-            if provided.algorithm != *algorithm {
-                return Err(StorageError::policy_rejected(
-                    "required upload checksum algorithm does not match policy",
-                ));
-            }
-            let computed = compute_checksum(*algorithm, bytes)?;
-            if !provided.value.eq_ignore_ascii_case(&computed.value) {
-                return Err(StorageError::policy_rejected(
-                    "required upload checksum does not match uploaded bytes",
-                ));
-            }
-            Ok(Some(computed))
-        }
-        _ => Err(StorageError::unsupported(
-            "unsupported checksum policy for S3 backend",
-        )),
-    }
-}
-
-fn compute_checksum(algorithm: ChecksumAlgorithm, bytes: &[u8]) -> StorageResult<ObjectChecksum> {
-    match algorithm {
-        ChecksumAlgorithm::Sha256 => {
-            let digest = Sha256::digest(bytes);
-            let mut value = String::with_capacity(digest.len() * 2);
-            for byte in digest {
-                use std::fmt::Write as _;
-                write!(&mut value, "{byte:02x}")
-                    .map_err(|err| StorageError::backend(format!("format checksum: {err}")))?;
-            }
-            Ok(ObjectChecksum { algorithm, value })
-        }
-        ChecksumAlgorithm::Crc32c | ChecksumAlgorithm::Md5 => Err(StorageError::unsupported(
-            "only sha256 checksum verification is implemented for S3 backend checksums",
-        )),
-        _ => Err(StorageError::unsupported(
-            "only sha256 checksum verification is implemented for S3 backend checksums",
-        )),
+        ensure_open(session)
     }
 }
 
@@ -762,12 +771,15 @@ fn normalize_etag(etag: String) -> String {
     etag.trim_matches('"').to_string()
 }
 
-fn is_s3_not_found(err: &impl std::fmt::Display) -> bool {
-    let message = err.to_string();
-    message.contains("NoSuchKey")
-        || message.contains("NotFound")
-        || message.contains("404")
-        || message.contains("status code: 404")
+fn is_get_object_not_found(err: &SdkError<GetObjectError>) -> bool {
+    err.as_service_error()
+        .is_some_and(GetObjectError::is_no_such_key)
+}
+
+fn is_put_precondition_failed(err: &SdkError<PutObjectError>) -> bool {
+    err.as_service_error()
+        .and_then(|err| err.meta().code())
+        .is_some_and(|code| code == "PreconditionFailed")
 }
 
 fn s3_error(operation: &'static str, err: impl std::fmt::Display) -> StorageError {
@@ -789,7 +801,7 @@ mod tests {
         let layout = S3KeyLayout::new(
             "bucket".to_string(),
             Some("tenant-a/".to_string()),
-            "tenant-a/__pocopine/storage/sessions".to_string(),
+            DEFAULT_INTERNAL_PREFIX.to_string(),
         )
         .unwrap();
         let session = UploadSessionId::new("session-1").unwrap();
@@ -806,6 +818,33 @@ mod tests {
             layout.session_bytes_key(&session),
             "tenant-a/__pocopine/storage/sessions/session-1/bytes.tmp"
         );
+    }
+
+    #[test]
+    fn prefix_and_internal_prefix_are_order_independent() {
+        let first = S3KeyLayout::new(
+            "bucket".to_string(),
+            None,
+            DEFAULT_INTERNAL_PREFIX.to_string(),
+        )
+        .unwrap()
+        .with_internal_prefix("custom/sessions".to_string())
+        .unwrap()
+        .with_prefix("tenant-a".to_string())
+        .unwrap();
+        let second = S3KeyLayout::new(
+            "bucket".to_string(),
+            None,
+            DEFAULT_INTERNAL_PREFIX.to_string(),
+        )
+        .unwrap()
+        .with_prefix("tenant-a".to_string())
+        .unwrap()
+        .with_internal_prefix("custom/sessions".to_string())
+        .unwrap();
+
+        assert_eq!(first.internal_prefix, "tenant-a/custom/sessions");
+        assert_eq!(second.internal_prefix, first.internal_prefix);
     }
 
     #[test]

--- a/crates/pocopine-storage-s3/tests/minio.rs
+++ b/crates/pocopine-storage-s3/tests/minio.rs
@@ -1,0 +1,212 @@
+// MinIO-backed integration tests for `pocopine-storage-s3`.
+//
+// Requires a working Docker daemon. Local contributors without Docker can skip
+// these with `cargo test -p pocopine-storage-s3 --lib`.
+//
+// Host-only.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use aws_sdk_s3::config::{Credentials, Region};
+use aws_sdk_s3::Client;
+use bytes::Bytes;
+use pocopine_storage::{
+    CompleteUpload, InitiateUpload, SafeObjectKey, StorageBackend, StorageContext, StorageError,
+    StorageKey, StorageResult, UploadPolicy, UploadSession, UploadStrategy,
+};
+use pocopine_storage_s3::S3StorageBackend;
+use testcontainers::runners::AsyncRunner;
+use testcontainers::ContainerAsync;
+use testcontainers_modules::minio::MinIO;
+use tokio::sync::OnceCell;
+
+const MINIO_PORT: u16 = 9000;
+const MINIO_ROOT_USER: &str = "minioadmin";
+const MINIO_ROOT_PASSWORD: &str = "minioadmin";
+
+static MINIO: OnceCell<ContainerAsync<MinIO>> = OnceCell::const_new();
+static BUCKET_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+async fn minio_client() -> Client {
+    let container = MINIO
+        .get_or_init(|| async {
+            MinIO::default()
+                .start()
+                .await
+                .expect("start minio testcontainer")
+        })
+        .await;
+    let port = container
+        .get_host_port_ipv4(MINIO_PORT)
+        .await
+        .expect("minio container port");
+    let endpoint = format!("http://127.0.0.1:{port}");
+    s3_client(endpoint)
+}
+
+fn s3_client(endpoint: String) -> Client {
+    let config = aws_sdk_s3::Config::builder()
+        .behavior_version_latest()
+        .endpoint_url(endpoint)
+        .force_path_style(true)
+        .region(Region::new("us-east-1"))
+        .credentials_provider(Credentials::new(
+            MINIO_ROOT_USER,
+            MINIO_ROOT_PASSWORD,
+            None,
+            None,
+            "minio-test",
+        ))
+        .build();
+    Client::from_conf(config)
+}
+
+async fn create_bucket(client: &Client, prefix: &str) -> String {
+    let bucket = unique_bucket(prefix);
+    client
+        .create_bucket()
+        .bucket(&bucket)
+        .send()
+        .await
+        .expect("create minio bucket");
+    bucket
+}
+
+fn unique_bucket(prefix: &str) -> String {
+    format!(
+        "pocopine-it-{prefix}-{}-{}",
+        std::process::id(),
+        BUCKET_COUNTER.fetch_add(1, Ordering::SeqCst)
+    )
+}
+
+fn ctx() -> StorageContext {
+    StorageContext::system("s3-minio-it")
+}
+
+fn policy() -> StorageResult<UploadPolicy> {
+    let mut policy = UploadPolicy::new("s3")?
+        .max_bytes(1024 * 1024)
+        .preferred_chunk_size(4);
+    policy.expires_after = Duration::from_secs(60 * 60);
+    Ok(policy)
+}
+
+async fn initiate(backend: &S3StorageBackend, size: Option<u64>) -> StorageResult<UploadSession> {
+    backend
+        .initiate_upload(
+            &ctx(),
+            InitiateUpload {
+                scope: "files".to_string(),
+                storage_key: StorageKey::new(SafeObjectKey::parse("files/hello.txt")?),
+                file_name: "hello.txt".to_string(),
+                size,
+                content_type: Some("text/plain".to_string()),
+                metadata: BTreeMap::from([("purpose".to_string(), "integration".to_string())]),
+                requested_strategy: UploadStrategy::Auto,
+                policy: policy()?,
+            },
+        )
+        .await
+}
+
+async fn object_bytes(client: &Client, bucket: &str, key: &str) -> Vec<u8> {
+    client
+        .get_object()
+        .bucket(bucket)
+        .key(key)
+        .send()
+        .await
+        .expect("get completed object")
+        .body
+        .collect()
+        .await
+        .expect("read completed object")
+        .into_bytes()
+        .to_vec()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sequential_upload_resumes_and_completes_against_minio() -> StorageResult<()> {
+    let client = minio_client().await;
+    let bucket = create_bucket(&client, "resume").await;
+    let backend = S3StorageBackend::new(client.clone(), bucket.clone())?.with_prefix("tenant-a")?;
+    let session = initiate(&backend, Some(11)).await?;
+
+    let updated = backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, Bytes::from_static(b"hello "))
+        .await?;
+    assert_eq!(updated.next_offset, Some(6));
+
+    let reloaded =
+        S3StorageBackend::new(client.clone(), bucket.clone())?.with_prefix("tenant-a")?;
+    let inspected = reloaded.inspect_upload(&ctx(), session.id.clone()).await?;
+    assert_eq!(inspected.next_offset, Some(6));
+
+    let updated = reloaded
+        .append_upload_bytes(&ctx(), session.id.clone(), 6, Bytes::from_static(b"world"))
+        .await?;
+    assert_eq!(updated.next_offset, Some(11));
+
+    let object = reloaded
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id.clone(),
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(object.backend, "s3");
+    assert_eq!(object.scope, "files");
+    assert_eq!(object.key, "files/hello.txt");
+    assert_eq!(object.content_type.as_deref(), Some("text/plain"));
+    assert_eq!(object.size, 11);
+    assert_eq!(
+        object.metadata.get("purpose").map(String::as_str),
+        Some("integration")
+    );
+    assert_eq!(
+        object_bytes(&client, &bucket, "tenant-a/files/hello.txt").await,
+        b"hello world"
+    );
+
+    let repeated = reloaded
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(repeated, object);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wrong_offset_returns_typed_mismatch_against_minio() -> StorageResult<()> {
+    let client = minio_client().await;
+    let bucket = create_bucket(&client, "offset").await;
+    let backend = S3StorageBackend::new(client, bucket)?;
+    let session = initiate(&backend, Some(5)).await?;
+
+    backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, Bytes::from_static(b"hel"))
+        .await?;
+
+    let rejected = backend
+        .append_upload_bytes(&ctx(), session.id, 1, Bytes::from_static(b"lo"))
+        .await;
+    assert!(matches!(
+        rejected,
+        Err(StorageError::OffsetMismatch {
+            expected: 3,
+            provided: 1
+        })
+    ));
+    Ok(())
+}

--- a/crates/pocopine-storage-s3/tests/minio.rs
+++ b/crates/pocopine-storage-s3/tests/minio.rs
@@ -11,6 +11,7 @@ use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use aws_sdk_s3::config::{Credentials, Region};
+use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::Client;
 use bytes::Bytes;
 use pocopine_storage::{
@@ -208,5 +209,77 @@ async fn wrong_offset_returns_typed_mismatch_against_minio() -> StorageResult<()
             provided: 1
         })
     ));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unknown_session_and_repeated_abort_are_typed_against_minio() -> StorageResult<()> {
+    let client = minio_client().await;
+    let bucket = create_bucket(&client, "unknown").await;
+    let backend = S3StorageBackend::new(client, bucket)?;
+    let missing = pocopine_storage::UploadSessionId::new("missing-session")?;
+
+    let inspected = backend.inspect_upload(&ctx(), missing.clone()).await;
+    assert!(matches!(
+        inspected,
+        Err(StorageError::UnknownUploadSession { .. })
+    ));
+
+    backend.abort_upload(&ctx(), missing.clone()).await?;
+    backend.abort_upload(&ctx(), missing).await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn changing_upload_length_uses_shared_invalid_value_error() -> StorageResult<()> {
+    let client = minio_client().await;
+    let bucket = create_bucket(&client, "length").await;
+    let backend = S3StorageBackend::new(client, bucket)?;
+    let session = initiate(&backend, None).await?;
+
+    backend
+        .set_upload_length(&ctx(), session.id.clone(), 5)
+        .await?;
+    let rejected = backend.set_upload_length(&ctx(), session.id, 6).await;
+    assert!(matches!(
+        rejected,
+        Err(StorageError::InvalidValue { field, .. }) if field == "Upload-Length"
+    ));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn complete_does_not_overwrite_existing_object_key() -> StorageResult<()> {
+    let client = minio_client().await;
+    let bucket = create_bucket(&client, "collision").await;
+    client
+        .put_object()
+        .bucket(&bucket)
+        .key("files/hello.txt")
+        .body(ByteStream::from_static(b"existing"))
+        .send()
+        .await
+        .expect("seed existing object");
+
+    let backend = S3StorageBackend::new(client.clone(), bucket.clone())?;
+    let session = initiate(&backend, Some(5)).await?;
+    backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, Bytes::from_static(b"hello"))
+        .await?;
+
+    let rejected = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await;
+    assert!(matches!(rejected, Err(StorageError::PolicyRejected { .. })));
+    assert_eq!(
+        object_bytes(&client, &bucket, "files/hello.txt").await,
+        b"existing"
+    );
     Ok(())
 }

--- a/crates/pocopine-storage/src/backend_common.rs
+++ b/crates/pocopine-storage/src/backend_common.rs
@@ -8,7 +8,9 @@ use crate::{
     UploadSession, UploadSessionStatus, UploadStrategy,
 };
 
-pub(crate) fn selected_strategy(strategy: UploadStrategy) -> StorageResult<UploadStrategy> {
+const MAX_UPLOAD_EXPIRES_AFTER_SECS: u64 = 100 * 365 * 24 * 60 * 60;
+
+pub fn selected_strategy(strategy: UploadStrategy) -> StorageResult<UploadStrategy> {
     match strategy {
         UploadStrategy::Auto | UploadStrategy::Sequential => Ok(UploadStrategy::Sequential),
         UploadStrategy::SingleRequest | UploadStrategy::Multipart => {
@@ -19,12 +21,14 @@ pub(crate) fn selected_strategy(strategy: UploadStrategy) -> StorageResult<Uploa
     }
 }
 
-pub(crate) fn expires_at(duration: std::time::Duration) -> OffsetDateTime {
-    OffsetDateTime::now_utc()
-        + time::Duration::seconds(duration.as_secs().min(i64::MAX as u64) as i64)
+pub fn expires_at(duration: std::time::Duration) -> OffsetDateTime {
+    let capped = duration.as_secs().min(MAX_UPLOAD_EXPIRES_AFTER_SECS);
+    let now = OffsetDateTime::now_utc();
+    now.checked_add(time::Duration::seconds(capped as i64))
+        .unwrap_or(now)
 }
 
-pub(crate) fn ensure_owner(actor: &StorageActor, owner: &StorageActor) -> StorageResult<()> {
+pub fn ensure_owner(actor: &StorageActor, owner: &StorageActor) -> StorageResult<()> {
     if actor.same_owner(owner) {
         Ok(())
     } else {
@@ -34,7 +38,7 @@ pub(crate) fn ensure_owner(actor: &StorageActor, owner: &StorageActor) -> Storag
     }
 }
 
-pub(crate) fn ensure_open(session: &UploadSession) -> StorageResult<()> {
+pub fn ensure_open(session: &UploadSession) -> StorageResult<()> {
     match session.status {
         UploadSessionStatus::Open => Ok(()),
         UploadSessionStatus::Complete => Err(StorageError::UploadComplete {
@@ -56,7 +60,7 @@ pub(crate) fn ensure_open(session: &UploadSession) -> StorageResult<()> {
     }
 }
 
-pub(crate) fn refresh_expired(session: &mut UploadSession) -> bool {
+pub fn refresh_expired(session: &mut UploadSession) -> bool {
     if session.status == UploadSessionStatus::Open
         && OffsetDateTime::now_utc() >= session.expires_at
     {
@@ -67,13 +71,13 @@ pub(crate) fn refresh_expired(session: &mut UploadSession) -> bool {
     }
 }
 
-pub(crate) fn checked_new_offset(offset: u64, byte_count: usize) -> StorageResult<u64> {
+pub fn checked_new_offset(offset: u64, byte_count: usize) -> StorageResult<u64> {
     offset
         .checked_add(byte_count as u64)
         .ok_or_else(|| StorageError::policy_rejected("upload byte offset overflowed"))
 }
 
-pub(crate) fn ensure_size_limit(
+pub fn ensure_size_limit(
     max_bytes: u64,
     declared_size: Option<u64>,
     new_offset: u64,
@@ -93,7 +97,7 @@ pub(crate) fn ensure_size_limit(
     Ok(())
 }
 
-pub(crate) fn ensure_upload_length_can_be_set(
+pub fn ensure_upload_length_can_be_set(
     max_bytes: u64,
     session: &UploadSession,
     committed_offset: u64,

--- a/crates/pocopine-storage/src/checksum.rs
+++ b/crates/pocopine-storage/src/checksum.rs
@@ -1,15 +1,29 @@
 use sha2::{Digest, Sha256};
 
-use crate::{ChecksumAlgorithm, ObjectChecksum, StorageError, StorageResult};
+use crate::{ChecksumAlgorithm, ChecksumPolicy, ObjectChecksum, StorageError, StorageResult};
 
-pub(crate) fn validate_complete_checksum(
-    policy: &crate::ChecksumPolicy,
+pub fn ensure_supported_checksum_policy(policy: &ChecksumPolicy) -> StorageResult<()> {
+    match policy {
+        ChecksumPolicy::None => Ok(()),
+        ChecksumPolicy::Optional(allowed) => {
+            for algorithm in allowed {
+                ensure_supported_checksum_algorithm(*algorithm)?;
+            }
+            Ok(())
+        }
+        ChecksumPolicy::Required(algorithm) => ensure_supported_checksum_algorithm(*algorithm),
+    }
+}
+
+pub fn validate_complete_checksum(
+    policy: &ChecksumPolicy,
     bytes: &[u8],
     provided: Option<ObjectChecksum>,
 ) -> StorageResult<Option<ObjectChecksum>> {
+    ensure_supported_checksum_policy(policy)?;
     match policy {
-        crate::ChecksumPolicy::None => Ok(None),
-        crate::ChecksumPolicy::Optional(allowed) => {
+        ChecksumPolicy::None => Ok(None),
+        ChecksumPolicy::Optional(allowed) => {
             if let Some(checksum) = &provided {
                 if !allowed.contains(&checksum.algorithm) {
                     return Err(StorageError::policy_rejected(
@@ -26,7 +40,7 @@ pub(crate) fn validate_complete_checksum(
             }
             Ok(None)
         }
-        crate::ChecksumPolicy::Required(algorithm) => {
+        ChecksumPolicy::Required(algorithm) => {
             let provided = provided.ok_or_else(|| {
                 StorageError::policy_rejected("required upload checksum is missing")
             })?;
@@ -43,6 +57,15 @@ pub(crate) fn validate_complete_checksum(
             }
             Ok(Some(computed))
         }
+    }
+}
+
+fn ensure_supported_checksum_algorithm(algorithm: ChecksumAlgorithm) -> StorageResult<()> {
+    match algorithm {
+        ChecksumAlgorithm::Sha256 => Ok(()),
+        ChecksumAlgorithm::Crc32c | ChecksumAlgorithm::Md5 => Err(StorageError::unsupported(
+            "only sha256 checksum verification is implemented in pocopine-storage PR 1",
+        )),
     }
 }
 

--- a/crates/pocopine-storage/src/lib.rs
+++ b/crates/pocopine-storage/src/lib.rs
@@ -4,9 +4,11 @@
 //! app plugin and the host server plugin.
 
 #[cfg(not(target_arch = "wasm32"))]
-mod backend_common;
+#[doc(hidden)]
+pub mod backend_common;
 #[cfg(not(target_arch = "wasm32"))]
-mod checksum;
+#[doc(hidden)]
+pub mod checksum;
 mod client;
 mod error;
 mod protocol;

--- a/crates/pocopine-storage/src/local_fs.rs
+++ b/crates/pocopine-storage/src/local_fs.rs
@@ -12,7 +12,7 @@ use crate::backend_common::{
     checked_new_offset, ensure_open, ensure_owner, ensure_size_limit,
     ensure_upload_length_can_be_set, expires_at, object_ref, refresh_expired, selected_strategy,
 };
-use crate::checksum::validate_complete_checksum;
+use crate::checksum::{ensure_supported_checksum_policy, validate_complete_checksum};
 use crate::server::{StorageActor, StorageBackend, StorageBoxFuture, StorageContext};
 use crate::{
     ChecksumPolicy, CompleteUpload, InitiateUpload, ObjectRef, SafeObjectKey, StorageError,
@@ -299,6 +299,7 @@ impl LocalFsStorageBackend {
     ) -> StorageResult<UploadSession> {
         fs::create_dir_all(&self.root).map_err(|err| local_io_error("create storage root", err))?;
         let strategy = selected_strategy(request.requested_strategy)?;
+        ensure_supported_checksum_policy(&request.policy.checksum)?;
         let id = UploadSessionId::new(Uuid::new_v4().to_string())?;
         let session = UploadSession {
             id: id.clone(),

--- a/crates/pocopine-storage/src/memory.rs
+++ b/crates/pocopine-storage/src/memory.rs
@@ -8,7 +8,7 @@ use crate::backend_common::{
     checked_new_offset, ensure_open, ensure_owner, ensure_size_limit,
     ensure_upload_length_can_be_set, expires_at, object_ref, refresh_expired, selected_strategy,
 };
-use crate::checksum::validate_complete_checksum;
+use crate::checksum::{ensure_supported_checksum_policy, validate_complete_checksum};
 use crate::server::{StorageActor, StorageBackend, StorageBoxFuture, StorageContext};
 use crate::{
     ChecksumPolicy, CompleteUpload, InitiateUpload, ObjectRef, StorageError, StorageKey,
@@ -97,6 +97,7 @@ impl StorageBackend for MemoryStorageBackend {
     ) -> StorageBoxFuture<'a, UploadSession> {
         Box::pin(async move {
             let strategy = selected_strategy(request.requested_strategy)?;
+            ensure_supported_checksum_policy(&request.policy.checksum)?;
             let id = UploadSessionId::new(Uuid::new_v4().to_string())?;
             let session = UploadSession {
                 id: id.clone(),


### PR DESCRIPTION
## Summary
- add pocopine-storage-s3 with a bounded sequential proxy backend for S3-compatible object stores
- persist upload session metadata/staged bytes in S3 and complete into SafeObjectKey paths
- harden S3 error handling, completion idempotency, cleanup, builder ordering, and shared checksum/upload-length validation
- add MinIO testcontainers integration coverage

## Verification
- cargo fmt --all -- --check
- cargo test -p pocopine-storage
- cargo clippy -p pocopine-storage --all-targets -- -D warnings
- cargo check -p pocopine-storage --target wasm32-unknown-unknown
- cargo clippy -p pocopine-storage-s3 --all-targets -- -D warnings
- sg docker -c 'cargo test -p pocopine-storage-s3'
- git diff --check origin/main...HEAD