### PR TITLE
sync: schema versioning Batch 3 — author-facing migration adapter

### DIFF
--- a/crates/pocopine-sync-crud-macros/src/lib.rs
+++ b/crates/pocopine-sync-crud-macros/src/lib.rs
@@ -124,6 +124,20 @@ impl Parse for ResourceArgs {
             Some(module) => module,
             None => module_ident_from_name(&name)?,
         };
+        // `migrate_with = path` registers a migrator that only fires
+        // when the client's wire `schema_version` is strictly LESS
+        // than the server's declared `schema_version`. With
+        // `schema_version = 1` (the default), they always match and
+        // the migrator is dead code. Force the author to either bump
+        // `schema_version` or drop `migrate_with`.
+        if let Some(path) = migrate_with.as_ref() {
+            if schema_version.unwrap_or(1) < 2 {
+                return Err(syn::Error::new(
+                    path.span(),
+                    "`migrate_with` requires `schema_version = N` with N >= 2; a v1 migrator is never invoked because clients also default to v1",
+                ));
+            }
+        }
         let schema_version = schema_version.unwrap_or(1);
         Ok(Self {
             name,
@@ -250,7 +264,10 @@ fn expand_resource(args: ResourceArgs, item: ItemImpl) -> syn::Result<TokenStrea
                 pub fn collection(
                     &self,
                 ) -> ::pocopine_sync::SyncResult<::pocopine_sync::SyncCollection<C, Row>> {
-                    self.sync.collection(self.handle.clone(), self.selector).stream(NAME)
+                    self.sync
+                        .collection(self.handle.clone(), self.selector)
+                        .stream(NAME)?
+                        .schema_version(SCHEMA_VERSION)
                 }
 
                 pub fn open(&self) -> ::pocopine_sync::SyncResult<()>
@@ -495,7 +512,9 @@ fn expand_resource(args: ResourceArgs, item: ItemImpl) -> syn::Result<TokenStrea
             where
                 Row: 'static,
             {
-                sync.collection(handle, selector).stream(NAME)
+                sync.collection(handle, selector)
+                    .stream(NAME)?
+                    .schema_version(SCHEMA_VERSION)
             }
         }
     })

--- a/crates/pocopine-sync-crud-macros/src/lib.rs
+++ b/crates/pocopine-sync-crud-macros/src/lib.rs
@@ -8,7 +8,7 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
-use syn::{parse_macro_input, Ident, ImplItem, ItemImpl, LitInt, LitStr, Token, Type};
+use syn::{parse_macro_input, ExprPath, Ident, ImplItem, ItemImpl, LitInt, LitStr, Token, Type};
 
 // Matches the sync protocol's stream and row-key token budget.
 const MAX_SYNC_TOKEN_LEN: usize = 1024;
@@ -18,6 +18,7 @@ struct ResourceArgs {
     name: LitStr,
     module: Ident,
     schema_version: u32,
+    migrate_with: Option<ExprPath>,
 }
 
 impl Parse for ResourceArgs {
@@ -25,6 +26,7 @@ impl Parse for ResourceArgs {
         let mut name = None;
         let mut module = None;
         let mut schema_version: Option<u32> = None;
+        let mut migrate_with: Option<ExprPath> = None;
 
         while !input.is_empty() {
             let key: Ident = input.parse()?;
@@ -86,10 +88,25 @@ impl Parse for ResourceArgs {
                     ));
                 }
                 schema_version = Some(value);
+            } else if key == "migrate_with" {
+                if migrate_with.is_some() {
+                    return Err(syn::Error::new(
+                        key.span(),
+                        "duplicate `migrate_with` in CRUD resource attribute",
+                    ));
+                }
+                input.parse::<Token![=]>()?;
+                let path: ExprPath = input.parse().map_err(|err| {
+                    syn::Error::new(
+                        err.span(),
+                        "`migrate_with` must be a function path (e.g. `migrate_with = my_app::migrate_post`)",
+                    )
+                })?;
+                migrate_with = Some(path);
             } else {
                 return Err(syn::Error::new(
                     key.span(),
-                    "expected `name = \"...\"`, `module = ident`, or `schema_version = N` in CRUD resource attribute",
+                    "expected `name = \"...\"`, `module = ident`, `schema_version = N`, or `migrate_with = path` in CRUD resource attribute",
                 ));
             }
 
@@ -112,6 +129,7 @@ impl Parse for ResourceArgs {
             name,
             module,
             schema_version,
+            migrate_with,
         })
     }
 }
@@ -160,6 +178,14 @@ fn expand_resource(args: ResourceArgs, item: ItemImpl) -> syn::Result<TokenStrea
     let id = types.id;
     let row = types.row;
     let draft = types.draft;
+    // `migrate_with = path` -> tokens to chain `.migrate_with(path)` on
+    // the builder. When omitted, expand to nothing so the existing
+    // `resource(NAME, source)? .schema_version(SCHEMA_VERSION)` chain is
+    // unchanged.
+    let migrate_with_chain = match args.migrate_with {
+        Some(path) => quote! { .map(|b| b.migrate_with(#path)) },
+        None => quote! {},
+    };
 
     Ok(quote! {
         #[cfg(not(target_arch = "wasm32"))]
@@ -440,6 +466,7 @@ fn expand_resource(args: ResourceArgs, item: ItemImpl) -> syn::Result<TokenStrea
             ) -> ::pocopine_sync::SyncResult<::pocopine_sync_crud::CrudResourceBuilder<#source>> {
                 ::pocopine_sync_crud::resource(NAME, source)?
                     .schema_version(SCHEMA_VERSION)
+                    #migrate_with_chain
             }
 
             pub fn new_id() -> ::pocopine_sync::SyncResult<Id> {

--- a/crates/pocopine-sync-crud-macros/tests/ui/resource_extra_tokens.stderr
+++ b/crates/pocopine-sync-crud-macros/tests/ui/resource_extra_tokens.stderr
@@ -1,4 +1,4 @@
-error: expected `name = "..."`, `module = ident`, or `schema_version = N` in CRUD resource attribute
+error: expected `name = "..."`, `module = ident`, `schema_version = N`, or `migrate_with = path` in CRUD resource attribute
  --> tests/ui/resource_extra_tokens.rs:3:52
   |
 3 | #[pocopine_sync_crud::resource(name = "customers", unexpected)]

--- a/crates/pocopine-sync-crud-macros/tests/ui/resource_unknown_key.stderr
+++ b/crates/pocopine-sync-crud-macros/tests/ui/resource_unknown_key.stderr
@@ -1,4 +1,4 @@
-error: expected `name = "..."`, `module = ident`, or `schema_version = N` in CRUD resource attribute
+error: expected `name = "..."`, `module = ident`, `schema_version = N`, or `migrate_with = path` in CRUD resource attribute
  --> tests/ui/resource_unknown_key.rs:3:32
   |
 3 | #[pocopine_sync_crud::resource(stream = "customers")]

--- a/crates/pocopine-sync-crud/src/lib.rs
+++ b/crates/pocopine-sync-crud/src/lib.rs
@@ -31,10 +31,10 @@ pub use options::{CreateOptions, RemoveOptions, SaveOptions, TransactionOptions,
 pub use outcome::{CrudOutcome, Queued, QueuedStatus};
 #[cfg(not(target_arch = "wasm32"))]
 pub use resource::{
-    resource, CrudAcceptedMutation, CrudMutationLog, CrudMutationReservation, CrudResource,
-    CrudResourceBuilder, MemoryCrudMutationLog, MemoryCrudScopeFn, MissingMutationLog,
-    NoRowVersion, RowVersionValue, TransactionalCrudMutationLog, TransactionalCrudResource,
-    DEFAULT_CRUD_SNAPSHOT_ROW_LIMIT,
+    resource, CrudAcceptedMutation, CrudMigrateFn, CrudMutationLog, CrudMutationReservation,
+    CrudResource, CrudResourceBuilder, MemoryCrudMutationLog, MemoryCrudScopeFn,
+    MissingMutationLog, NoRowVersion, RowVersionValue, TransactionalCrudMutationLog,
+    TransactionalCrudResource, DEFAULT_CRUD_SNAPSHOT_ROW_LIMIT,
 };
 pub use row::optimistic_row;
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/pocopine-sync-crud/src/resource.rs
+++ b/crates/pocopine-sync-crud/src/resource.rs
@@ -36,8 +36,26 @@ where
         // the wire/trait default (e.g. switching to an `Option<u32>`
         // 'unspecified' sentinel) propagate here without a separate edit.
         schema_version: default_schema_version_one(),
+        // No registered migrator by default — the trait default impl
+        // of `SyncStreamSource::migrate_payload` returns
+        // `SyncError::SchemaMigration` so stale-schema pushes get a
+        // per-mutation rejection.
+        migrate_payload: None,
     })
 }
+
+/// User-supplied function that migrates a stale-schema mutation
+/// payload up to the source's current schema version. Registered via
+/// [`CrudResourceBuilder::migrate_with`] (or the `#[resource(...,
+/// migrate_with = path)]` macro attribute) and called by
+/// [`SyncStreamSource::migrate_payload`] inside the server's
+/// `push_handler` before delegating to the source's `push`.
+///
+/// On `Ok(value)`, the migrated payload replaces the original.
+/// On `Err(SyncError::SchemaMigration { .. })`, the framework adds
+/// the mutation to the response's `rejected` array with the error's
+/// `reason`; the rest of the batch continues.
+pub type CrudMigrateFn = dyn Fn(u32, u32, Value) -> SyncResult<Value> + Send + Sync + 'static;
 
 /// Builder returned by [`resource`].
 pub struct CrudResourceBuilder<S> {
@@ -46,6 +64,7 @@ pub struct CrudResourceBuilder<S> {
     source: S,
     max_snapshot_rows: usize,
     schema_version: u32,
+    migrate_payload: Option<Arc<CrudMigrateFn>>,
 }
 
 impl<S> CrudResourceBuilder<S>
@@ -81,6 +100,31 @@ where
         Ok(self)
     }
 
+    /// Register a function that migrates a stale-schema mutation
+    /// payload to the resource's current schema version.
+    ///
+    /// The opt-in escape hatch for apps that must preserve queued
+    /// mutations across a `schema_version` bump (e.g. payments,
+    /// inventory writes — places where dropping queued local edits
+    /// is unacceptable). The function is called by the server's
+    /// `push_handler` once per mutation when the request's
+    /// `schema_version` differs from the resource's current version;
+    /// migrated payloads continue into `source.push`, errors land in
+    /// the response's `rejected` array.
+    ///
+    /// The default behaviour (no `migrate_with` registered) returns
+    /// `SyncError::SchemaMigration`, which the framework surfaces as
+    /// a per-mutation rejection. This matches Replicache's default
+    /// drop-the-queue posture; `migrate_with` is the opt-in
+    /// "transform instead of reject" path.
+    pub fn migrate_with<F>(mut self, migrate: F) -> Self
+    where
+        F: Fn(u32, u32, Value) -> SyncResult<Value> + Send + Sync + 'static,
+    {
+        self.migrate_payload = Some(Arc::new(migrate));
+        self
+    }
+
     /// Attach the row id extractor for this resource.
     pub fn id<IdOf>(self, id_of: IdOf) -> CrudResource<S, IdOf>
     where
@@ -92,6 +136,7 @@ where
             source: self.source,
             max_snapshot_rows: self.max_snapshot_rows,
             schema_version: self.schema_version,
+            migrate_payload: self.migrate_payload,
             id_of,
             version_of: NoRowVersion,
             mutation_log: MissingMutationLog,
@@ -106,6 +151,7 @@ pub struct CrudResource<S, IdOf, VersionOf = NoRowVersion, Log = MissingMutation
     source: S,
     max_snapshot_rows: usize,
     schema_version: u32,
+    migrate_payload: Option<Arc<CrudMigrateFn>>,
     id_of: IdOf,
     version_of: VersionOf,
     mutation_log: Log,
@@ -130,6 +176,7 @@ where
             source: self.source,
             max_snapshot_rows: self.max_snapshot_rows,
             schema_version: self.schema_version,
+            migrate_payload: self.migrate_payload.clone(),
             id_of: self.id_of,
             version_of,
             mutation_log: self.mutation_log,
@@ -157,6 +204,7 @@ where
             source: self.source,
             max_snapshot_rows: self.max_snapshot_rows,
             schema_version: self.schema_version,
+            migrate_payload: self.migrate_payload.clone(),
             id_of: self.id_of,
             version_of: self.version_of,
             mutation_log,
@@ -195,6 +243,7 @@ where
             source: self.source,
             max_snapshot_rows: self.max_snapshot_rows,
             schema_version: self.schema_version,
+            migrate_payload: self.migrate_payload.clone(),
             id_of: self.id_of,
             version_of: self.version_of,
             mutation_log,
@@ -211,6 +260,7 @@ pub struct TransactionalCrudResource<S, IdOf, VersionOf, Log, Runner> {
     source: S,
     max_snapshot_rows: usize,
     schema_version: u32,
+    migrate_payload: Option<Arc<CrudMigrateFn>>,
     id_of: IdOf,
     version_of: VersionOf,
     mutation_log: Log,
@@ -524,6 +574,15 @@ where
         self.schema_version
     }
 
+    fn migrate_payload<'a>(&'a self, from: u32, to: u32, value: Value) -> SyncBoxFuture<'a, Value> {
+        if let Some(migrate) = self.migrate_payload.clone() {
+            Box::pin(async move { migrate(from, to, value) })
+        } else {
+            let stream = self.stream.as_str().to_string();
+            Box::pin(async move { Err(SyncError::schema_migration(stream, from, to)) })
+        }
+    }
+
     fn pull<'a>(
         &'a self,
         ctx: RequestContext,
@@ -802,6 +861,15 @@ where
 
     fn schema_version(&self) -> u32 {
         self.schema_version
+    }
+
+    fn migrate_payload<'a>(&'a self, from: u32, to: u32, value: Value) -> SyncBoxFuture<'a, Value> {
+        if let Some(migrate) = self.migrate_payload.clone() {
+            Box::pin(async move { migrate(from, to, value) })
+        } else {
+            let stream = self.stream.as_str().to_string();
+            Box::pin(async move { Err(SyncError::schema_migration(stream, from, to)) })
+        }
     }
 
     fn pull<'a>(

--- a/crates/pocopine-sync-crud/src/resource.rs
+++ b/crates/pocopine-sync-crud/src/resource.rs
@@ -55,7 +55,49 @@ where
 /// On `Err(SyncError::SchemaMigration { .. })`, the framework adds
 /// the mutation to the response's `rejected` array with the error's
 /// `reason`; the rest of the batch continues.
+///
+/// # Caveats
+/// * **Synchronous and blocking.** The migrator runs on the tokio
+///   runtime worker that's serving the push request — keep it fast
+///   (pure JSON manipulation, no I/O). A future iteration of this
+///   API may accept an async migrator.
+/// * **Out-of-transaction.** When attached to a
+///   [`TransactionalCrudResource`], the migrator runs BEFORE the
+///   per-mutation transaction begins, so any side effects it
+///   performs (e.g. audit log writes) are NOT rolled back if the
+///   subsequent transactional `push` fails.
+/// * **Panic-safe.** The framework wraps each call in
+///   `std::panic::catch_unwind`; a panicking migrator surfaces as a
+///   per-mutation rejection instead of crashing the request task.
 pub type CrudMigrateFn = dyn Fn(u32, u32, Value) -> SyncResult<Value> + Send + Sync + 'static;
+
+/// Invoke a registered migrator under an unwind guard. A panic in the
+/// user closure becomes a typed `SyncError::Backend` instead of
+/// crashing the request task; the framework's `push_handler` then
+/// turns it into a per-mutation `SyncRejectedMutation`.
+fn invoke_migrator_with_panic_guard(
+    migrate: &CrudMigrateFn,
+    stream: &str,
+    from: u32,
+    to: u32,
+    value: Value,
+) -> SyncResult<Value> {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| migrate(from, to, value))) {
+        Ok(result) => result,
+        Err(panic) => {
+            let reason = if let Some(msg) = panic.downcast_ref::<&'static str>() {
+                (*msg).to_string()
+            } else if let Some(msg) = panic.downcast_ref::<String>() {
+                msg.clone()
+            } else {
+                "<non-string panic payload>".to_string()
+            };
+            Err(SyncError::backend(format!(
+                "migrate_with panicked while migrating {stream} from v{from} to v{to}: {reason}"
+            )))
+        }
+    }
+}
 
 /// Builder returned by [`resource`].
 pub struct CrudResourceBuilder<S> {
@@ -575,10 +617,12 @@ where
     }
 
     fn migrate_payload<'a>(&'a self, from: u32, to: u32, value: Value) -> SyncBoxFuture<'a, Value> {
+        let stream = self.stream.as_str().to_string();
         if let Some(migrate) = self.migrate_payload.clone() {
-            Box::pin(async move { migrate(from, to, value) })
+            Box::pin(async move {
+                invoke_migrator_with_panic_guard(migrate.as_ref(), &stream, from, to, value)
+            })
         } else {
-            let stream = self.stream.as_str().to_string();
             Box::pin(async move { Err(SyncError::schema_migration(stream, from, to)) })
         }
     }
@@ -649,10 +693,18 @@ where
         let mut response = SyncPushResponse::new(self.stream.clone());
         response.collection = Some(self.collection.clone());
 
-        for mutation in request.mutations {
+        for mut mutation in request.mutations {
             let mutation_id = mutation.id.clone();
             let key = mutation.key.clone();
             let op = mutation.op;
+            // `payload_value` is the CLIENT'S WIRE PAYLOAD — used as the
+            // idempotency-log key so retries of the same wire payload
+            // hit `accepted.matches` regardless of whether (or how)
+            // `push_handler` migrated the payload server-side.
+            // `processing_payload` is what we actually deserialize and
+            // hand to the source — the migrated value if `push_handler`
+            // ran a schema migration, else identical to `payload_value`.
+            let processing_payload = mutation.take_processing_payload();
             let base_version = mutation.base_version;
             let payload_value = mutation.payload;
 
@@ -675,7 +727,7 @@ where
             }
 
             let payload = match serde_json::from_value::<CrudMutationPayload<S::Id, S::Draft>>(
-                payload_value.clone(),
+                processing_payload,
             ) {
                 Ok(payload) => payload,
                 Err(err) => {
@@ -864,10 +916,12 @@ where
     }
 
     fn migrate_payload<'a>(&'a self, from: u32, to: u32, value: Value) -> SyncBoxFuture<'a, Value> {
+        let stream = self.stream.as_str().to_string();
         if let Some(migrate) = self.migrate_payload.clone() {
-            Box::pin(async move { migrate(from, to, value) })
+            Box::pin(async move {
+                invoke_migrator_with_panic_guard(migrate.as_ref(), &stream, from, to, value)
+            })
         } else {
-            let stream = self.stream.as_str().to_string();
             Box::pin(async move { Err(SyncError::schema_migration(stream, from, to)) })
         }
     }
@@ -939,15 +993,19 @@ where
         let mut response = SyncPushResponse::new(self.stream.clone());
         response.collection = Some(self.collection.clone());
 
-        for mutation in request.mutations {
+        for mut mutation in request.mutations {
             let mutation_id = mutation.id.clone();
             let key = mutation.key.clone();
             let op = mutation.op;
+            // `payload_value` = original wire payload (idempotency key).
+            // `processing_payload` = migrated value if `push_handler`
+            // ran a schema migration, else identical to wire payload.
+            let processing_payload = mutation.take_processing_payload();
             let base_version = mutation.base_version;
             let payload_value = mutation.payload;
 
             let payload = match serde_json::from_value::<CrudMutationPayload<S::Id, S::Draft>>(
-                payload_value.clone(),
+                processing_payload,
             ) {
                 Ok(payload) => payload,
                 Err(err) => {
@@ -1679,6 +1737,7 @@ mod tests {
             op: mutation.op,
             base_version: mutation.base_version,
             payload: serde_json::to_value(mutation.payload).unwrap(),
+            migrated_payload: None,
         }
     }
 

--- a/crates/pocopine-sync-crud/src/resource.rs
+++ b/crates/pocopine-sync-crud/src/resource.rs
@@ -700,10 +700,14 @@ where
             // `payload_value` is the CLIENT'S WIRE PAYLOAD — used as the
             // idempotency-log key so retries of the same wire payload
             // hit `accepted.matches` regardless of whether (or how)
-            // `push_handler` migrated the payload server-side.
+            // the framework's `push_handler` migrated the payload.
             // `processing_payload` is what we actually deserialize and
-            // hand to the source — the migrated value if `push_handler`
-            // ran a schema migration, else identical to `payload_value`.
+            // hand to the source — the migrated value if migration
+            // ran successfully, else identical to `payload_value`.
+            // The migration outcome (`Result`) is consumed AFTER the
+            // idempotency-log lookup so a retry of a previously-
+            // accepted mutation succeeds even when the current
+            // migrator now rejects (or panics) on the same inputs.
             let processing_payload = mutation.take_processing_payload();
             let base_version = mutation.base_version;
             let payload_value = mutation.payload;
@@ -725,6 +729,21 @@ where
                 }
                 continue;
             }
+
+            // Not in the idempotency log — now consult the migration
+            // outcome. A migration failure on a non-idempotent mutation
+            // surfaces as a per-mutation rejection here.
+            let processing_payload = match processing_payload {
+                Ok(value) => value,
+                Err(reason) => {
+                    response.rejected.push(SyncRejectedMutation {
+                        mutation_id,
+                        key,
+                        reason,
+                    });
+                    continue;
+                }
+            };
 
             let payload = match serde_json::from_value::<CrudMutationPayload<S::Id, S::Draft>>(
                 processing_payload,
@@ -994,59 +1013,30 @@ where
         response.collection = Some(self.collection.clone());
 
         for mut mutation in request.mutations {
+            // Defer migration consumption + deserialization + envelope
+            // validation INSIDE the transaction so the idempotency-log
+            // check can accept a previously-accepted mutation even
+            // when the current migrator now rejects (or panics) on
+            // the same inputs — same invariant the non-transactional
+            // path enforces above.
             let mutation_id = mutation.id.clone();
             let key = mutation.key.clone();
             let op = mutation.op;
-            // `payload_value` = original wire payload (idempotency key).
-            // `processing_payload` = migrated value if `push_handler`
-            // ran a schema migration, else identical to wire payload.
-            let processing_payload = mutation.take_processing_payload();
+            let processing_payload_result = mutation.take_processing_payload();
             let base_version = mutation.base_version;
             let payload_value = mutation.payload;
-
-            let payload = match serde_json::from_value::<CrudMutationPayload<S::Id, S::Draft>>(
-                processing_payload,
-            ) {
-                Ok(payload) => payload,
-                Err(err) => {
-                    response.rejected.push(SyncRejectedMutation {
-                        mutation_id,
-                        key,
-                        reason: format!("invalid CRUD mutation payload: {err}"),
-                    });
-                    continue;
-                }
-            };
-
-            if payload.sync_op() != op {
-                response.rejected.push(SyncRejectedMutation {
-                    mutation_id,
-                    key,
-                    reason: "CRUD payload does not match sync operation".to_string(),
-                });
-                continue;
-            }
-
-            let expected_key = payload.id().to_row_key()?;
-            if key.as_ref() != Some(&expected_key) {
-                response.rejected.push(SyncRejectedMutation {
-                    mutation_id,
-                    key,
-                    reason: "CRUD mutation row key does not match payload id".to_string(),
-                });
-                continue;
-            }
 
             match self
                 .apply_transactional_payload(
                     &ctx,
                     TransactionalCrudMutation {
                         mutation_id,
-                        key: expected_key,
+                        wire_key: key,
                         op,
                         base_version,
                         payload_value,
-                        payload,
+                        processing_payload_result,
+                        _marker: std::marker::PhantomData,
                     },
                 )
                 .await?
@@ -1074,28 +1064,32 @@ where
     ) -> SyncResult<CrudApplyOutcome<S::Row>> {
         let TransactionalCrudMutation {
             mutation_id,
-            key,
+            wire_key,
             op,
             base_version,
             payload_value,
-            payload,
+            processing_payload_result,
+            _marker,
         } = mutation;
         let mut tx = self.transaction_runner.begin().await?;
         let result = async {
             let accepted = CrudAcceptedMutation::new(
                 mutation_id.clone(),
                 op,
-                Some(key.clone()),
+                wire_key.clone(),
                 payload_value.clone(),
             );
 
+            // Idempotency check FIRST — before consuming the migration
+            // outcome. A retry of an already-accepted mutation must
+            // succeed even when the current migrator now rejects.
             match self
                 .mutation_log
                 .reserve_accepted_mutation_in_tx(&mut tx, ctx, accepted)
                 .await?
             {
                 CrudMutationReservation::AlreadyAccepted(accepted) => {
-                    if accepted.matches(op, Some(&key), &payload_value) {
+                    if accepted.matches(op, wire_key.as_ref(), &payload_value) {
                         return Ok(CrudTransactionDecision::Commit(
                             CrudApplyOutcome::Accepted {
                                 mutation_id,
@@ -1107,7 +1101,7 @@ where
                     return Ok(CrudTransactionDecision::Commit(CrudApplyOutcome::Rejected(
                         SyncRejectedMutation {
                             mutation_id,
-                            key: Some(key),
+                            key: wire_key,
                             reason: "mutation id was already accepted with different contents"
                                 .to_string(),
                         },
@@ -1116,8 +1110,78 @@ where
                 CrudMutationReservation::Reserved => {}
             }
 
+            // Fresh reservation — now consume the migration outcome.
+            // A failure here rolls back the reservation so a retry
+            // doesn't see a phantom log entry.
+            let processing_payload = match processing_payload_result {
+                Ok(value) => value,
+                Err(reason) => {
+                    return Ok(CrudTransactionDecision::Rollback(
+                        CrudApplyOutcome::Rejected(SyncRejectedMutation {
+                            mutation_id,
+                            key: wire_key,
+                            reason,
+                        }),
+                    ));
+                }
+            };
+
+            let payload = match serde_json::from_value::<CrudMutationPayload<S::Id, S::Draft>>(
+                processing_payload,
+            ) {
+                Ok(payload) => payload,
+                Err(err) => {
+                    return Ok(CrudTransactionDecision::Rollback(
+                        CrudApplyOutcome::Rejected(SyncRejectedMutation {
+                            mutation_id,
+                            key: wire_key,
+                            reason: format!("invalid CRUD mutation payload: {err}"),
+                        }),
+                    ));
+                }
+            };
+
+            if payload.sync_op() != op {
+                return Ok(CrudTransactionDecision::Rollback(
+                    CrudApplyOutcome::Rejected(SyncRejectedMutation {
+                        mutation_id,
+                        key: wire_key,
+                        reason: "CRUD payload does not match sync operation".to_string(),
+                    }),
+                ));
+            }
+
+            let expected_key = match payload.id().to_row_key() {
+                Ok(key) => key,
+                Err(err) => {
+                    return Ok(CrudTransactionDecision::Rollback(
+                        CrudApplyOutcome::Rejected(SyncRejectedMutation {
+                            mutation_id,
+                            key: wire_key,
+                            reason: format!("CRUD mutation payload id is invalid: {err}"),
+                        }),
+                    ));
+                }
+            };
+            if wire_key.as_ref() != Some(&expected_key) {
+                return Ok(CrudTransactionDecision::Rollback(
+                    CrudApplyOutcome::Rejected(SyncRejectedMutation {
+                        mutation_id,
+                        key: wire_key,
+                        reason: "CRUD mutation row key does not match payload id".to_string(),
+                    }),
+                ));
+            }
+
             let outcome = self
-                .apply_payload_in_tx(&mut tx, ctx, mutation_id, key, base_version, payload)
+                .apply_payload_in_tx(
+                    &mut tx,
+                    ctx,
+                    mutation_id,
+                    expected_key,
+                    base_version,
+                    payload,
+                )
                 .await?;
 
             if matches!(outcome, CrudApplyOutcome::Accepted { .. }) {
@@ -1263,11 +1327,24 @@ enum CrudTransactionDecision<Row> {
 
 struct TransactionalCrudMutation<Id, Draft> {
     mutation_id: MutationId,
-    key: RowKey,
+    /// Wire-supplied key (may be `None` for unkeyed mutations); the
+    /// transactional applier validates this against the payload's
+    /// id-derived key only AFTER the idempotency-log check, so a
+    /// previously-accepted mutation isn't re-rejected on a
+    /// post-migration key mismatch.
+    wire_key: Option<RowKey>,
     op: SyncOp,
     base_version: Option<RowVersion>,
+    /// Original wire payload — keyed against the idempotency log.
     payload_value: Value,
-    payload: CrudMutationPayload<Id, Draft>,
+    /// Migration outcome: `Ok(value)` to deserialize and apply (the
+    /// migrated value, or the original if no migration ran),
+    /// `Err(reason)` if the migrator rejected. Consumed INSIDE the
+    /// tx only after the idempotency-log check, so a retry of an
+    /// already-accepted mutation succeeds regardless of migrator
+    /// state at retry time.
+    processing_payload_result: Result<Value, String>,
+    _marker: std::marker::PhantomData<fn() -> (Id, Draft)>,
 }
 
 fn row_to_value<Row>(row: SyncRow<Row>) -> SyncResult<SyncRow<Value>>
@@ -1737,7 +1814,7 @@ mod tests {
             op: mutation.op,
             base_version: mutation.base_version,
             payload: serde_json::to_value(mutation.payload).unwrap(),
-            migrated_payload: None,
+            migration_outcome: None,
         }
     }
 

--- a/crates/pocopine-sync-crud/tests/resource_server.rs
+++ b/crates/pocopine-sync-crud/tests/resource_server.rs
@@ -225,7 +225,7 @@ fn to_value(
         op: mutation.op,
         base_version: mutation.base_version,
         payload: serde_json::to_value(mutation.payload).unwrap(),
-        migrated_payload: None,
+        migration_outcome: None,
     }
 }
 

--- a/crates/pocopine-sync-crud/tests/resource_server.rs
+++ b/crates/pocopine-sync-crud/tests/resource_server.rs
@@ -225,6 +225,7 @@ fn to_value(
         op: mutation.op,
         base_version: mutation.base_version,
         payload: serde_json::to_value(mutation.payload).unwrap(),
+        migrated_payload: None,
     }
 }
 

--- a/crates/pocopine-sync-crud/tests/schema_migration.rs
+++ b/crates/pocopine-sync-crud/tests/schema_migration.rs
@@ -301,17 +301,17 @@ async fn all_stale_no_migrator_still_surfaces_rejections() {
     assert!(customers.rows.lock().unwrap().is_empty());
 }
 
-/// Repro for code-review finding #5: a NEWER client pushing to an
-/// OLDER server (rolling deploy direction) should NOT route through
-/// `migrate_payload`. The source receives the wire payload as-is and
-/// rejects it via its own deserialization path — NOT via a
-/// SchemaMigration reason.
+/// Repro for Codex finding #4: a NEWER client pushing to an OLDER
+/// server (rolling deploy direction) is rejected wholesale at the
+/// wire layer with `BadRequest`. The framework MUST NOT pass the
+/// newer-shape payload through to `source.push`, because serde's
+/// default deserializer silently drops unknown fields — which could
+/// cause field loss when the v1 source happily accepts a v2 payload.
 #[tokio::test]
-async fn newer_client_push_skips_migration_entirely() {
+async fn newer_client_push_rejected_at_wire() {
     let _lock = registry_lock();
     pocopine_server::__reset_for_test();
-    // Server at v1 (NO `.schema_version(...)` call so it stays at default 1)
-    // with NO migrator. A "v2 client" sends `request.schema_version = 2`.
+    // Server at v1 (NO `.schema_version(...)` call) with no migrator.
     let customers = Customers::default();
     let resource = resource(STREAM, customers.clone())
         .unwrap()
@@ -326,10 +326,6 @@ async fn newer_client_push_skips_migration_entirely() {
         .try_finalize()
         .unwrap();
 
-    // The v2-shaped payload happens to be valid for v1 (v1 source
-    // accepts CustomerDraftV2). We don't care what `source.push`
-    // does with it — only that the framework didn't invoke
-    // `migrate_payload(2, 1)`.
     let create = CrudMutationPayload::create(
         "c1".to_string(),
         serde_json::json!({ "name": "Alice", "email": "alice@example.com" }),
@@ -339,18 +335,122 @@ async fn newer_client_push_skips_migration_entirely() {
     .with_id(MutationId::new("device:1").unwrap());
     let req = SyncPushRequest::new(SyncStreamName::new(STREAM).unwrap(), [to_value(create)])
         .with_schema_version(2);
-    let pushed = post_json::<_, SyncPushResponse<Value>>(app, SYNC_PUSH_PATH, &req).await;
 
-    // No SchemaMigration rejection — the source either accepts or
-    // rejects via its own path. The key invariant: ZERO mutations
-    // are rejected with a `schema migration` reason.
-    for r in &pushed.rejected {
-        assert!(
-            !r.reason.contains("schema migration"),
-            "newer-client push must not invoke migrate_payload, got reason: {}",
-            r.reason
-        );
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(SYNC_PUSH_PATH)
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&req).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let outer: pocopine_core::ServerResult<SyncPushResponse<Value>> =
+        serde_json::from_slice(&bytes).unwrap();
+    match outer {
+        Err(pocopine_core::ServerError::BadRequest(msg)) => {
+            assert!(
+                msg.contains("schema migration") && msg.contains("v2") && msg.contains("v1"),
+                "expected newer-client-rejection, got: {msg}"
+            );
+        }
+        other => panic!("expected BadRequest, got: {other:?}"),
     }
+    assert!(
+        customers.rows.lock().unwrap().is_empty(),
+        "v1 source must not have processed the v2 payload"
+    );
+}
+
+/// Repro for Codex finding #5: a retry of a previously-accepted
+/// mutation succeeds even when the framework's migrator now fails
+/// on the same inputs. Achieved by: first push accepts via migrator,
+/// second push (same mutation_id, same wire payload) hits a router
+/// whose migrator now ALWAYS errors. The CRUD source's idempotency
+/// log consults the original `mutation.payload` BEFORE consuming the
+/// migration outcome, so the retry is accepted.
+#[tokio::test]
+async fn idempotent_retry_survives_migrator_change() {
+    let _lock = registry_lock();
+    pocopine_server::__reset_for_test();
+    // Shared in-process state across two routers so the idempotency
+    // log persists between attempts.
+    let customers = Customers::default();
+    let log = pocopine_sync_crud::MemoryCrudMutationLog::<CustomerV2>::new();
+
+    // First push: v2 server with a working migrator.
+    let router_a = {
+        let customers = resource(STREAM, customers.clone())
+            .unwrap()
+            .schema_version(2)
+            .unwrap()
+            .migrate_with(migrate_v1_to_v2)
+            .id(|row: &CustomerV2| row.id.clone())
+            .version(|row: &CustomerV2| row.version)
+            .mutation_log(log.clone());
+        let sync = pocopine_sync::SyncServer::builder()
+            .public_stream(customers)
+            .build();
+        Server::new(Router::new())
+            .plugin(sync_server_plugin(sync))
+            .try_finalize()
+            .unwrap()
+    };
+
+    let create =
+        CrudMutationPayload::create("c1".to_string(), serde_json::json!({ "name": "Alice" }))
+            .into_sync_draft()
+            .unwrap()
+            .with_id(MutationId::new("device:1").unwrap());
+    let wire = to_value(create);
+    let req = SyncPushRequest::new(SyncStreamName::new(STREAM).unwrap(), [wire.clone()])
+        .with_schema_version(1);
+    let pushed = post_json::<_, SyncPushResponse<Value>>(router_a, SYNC_PUSH_PATH, &req).await;
+    assert_eq!(pushed.accepted.len(), 1, "first push must accept");
+
+    // Second push (retry from same client) against a router whose
+    // migrator ALWAYS rejects. Same mutation_id, same wire payload.
+    pocopine_server::__reset_for_test();
+    let router_b = {
+        let customers = resource(STREAM, customers.clone())
+            .unwrap()
+            .schema_version(2)
+            .unwrap()
+            .migrate_with(|from, to, _value| {
+                Err(pocopine_sync::SyncError::backend(format!(
+                    "migrator removed (from v{from} to v{to})"
+                )))
+            })
+            .id(|row: &CustomerV2| row.id.clone())
+            .version(|row: &CustomerV2| row.version)
+            .mutation_log(log);
+        let sync = pocopine_sync::SyncServer::builder()
+            .public_stream(customers)
+            .build();
+        Server::new(Router::new())
+            .plugin(sync_server_plugin(sync))
+            .try_finalize()
+            .unwrap()
+    };
+    let req_retry =
+        SyncPushRequest::new(SyncStreamName::new(STREAM).unwrap(), [wire]).with_schema_version(1);
+    let pushed =
+        post_json::<_, SyncPushResponse<Value>>(router_b, SYNC_PUSH_PATH, &req_retry).await;
+
+    assert_eq!(
+        pushed.accepted.len(),
+        1,
+        "retry of already-accepted mutation must succeed despite failing migrator"
+    );
+    assert!(
+        pushed.rejected.is_empty(),
+        "retry must NOT surface the migrator failure, got: {:?}",
+        pushed.rejected
+    );
 }
 
 /// Repro for code-review finding #7: a push with explicit
@@ -440,7 +540,7 @@ fn to_value(mutation: ClientMutation<CrudMutationPayload<String, Value>>) -> Cli
         op: mutation.op,
         base_version: mutation.base_version,
         payload: serde_json::to_value(mutation.payload).unwrap(),
-        migrated_payload: None,
+        migration_outcome: None,
     }
 }
 

--- a/crates/pocopine-sync-crud/tests/schema_migration.rs
+++ b/crates/pocopine-sync-crud/tests/schema_migration.rs
@@ -1,4 +1,9 @@
 #![cfg(not(target_arch = "wasm32"))]
+// `registry_lock` deliberately holds a `MutexGuard` across `.await`
+// to serialize tests that share the process-global plugin registry
+// (`pocopine_server::__reset_for_test`). Tests are linearized; the
+// async `tokio::sync::Mutex` would change behaviour for no benefit.
+#![allow(clippy::await_holding_lock)]
 
 //! End-to-end test for the Batch 3 schema-migration adapter.
 //!
@@ -15,8 +20,18 @@
 
 use std::{
     collections::BTreeMap,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, MutexGuard, OnceLock},
 };
+
+/// Process-global plugin registry serialization. See the matching
+/// helpers in `pocopine-server/tests/server_plugin.rs` and
+/// `server_request_events.rs` for the reasoning.
+fn registry_lock() -> MutexGuard<'static, ()> {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LOCK.get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(|p| p.into_inner())
+}
 
 use http_body_util::BodyExt;
 use pocopine_auth::RequestContext;
@@ -171,6 +186,7 @@ fn migrate_v1_to_v2(from: u32, to: u32, mut value: Value) -> pocopine_sync::Sync
 
 #[tokio::test]
 async fn stale_schema_push_without_migrator_rejects_per_mutation() {
+    let _lock = registry_lock();
     let customers = Customers::default();
     let app = router_without_migrator(customers.clone());
 
@@ -204,6 +220,7 @@ async fn stale_schema_push_without_migrator_rejects_per_mutation() {
 
 #[tokio::test]
 async fn stale_schema_push_with_migrator_passes_through() {
+    let _lock = registry_lock();
     let customers = Customers::default();
     let app = router_with_migrator(customers.clone());
 
@@ -231,6 +248,7 @@ async fn stale_schema_push_with_migrator_passes_through() {
 
 #[tokio::test]
 async fn matching_schema_push_skips_migrator_entirely() {
+    let _lock = registry_lock();
     let customers = Customers::default();
     let app = router_with_migrator(customers.clone());
 
@@ -249,6 +267,133 @@ async fn matching_schema_push_skips_migrator_entirely() {
 
     assert_eq!(pushed.accepted.len(), 1);
     assert_eq!(pushed.rows[0].value["email"], "alice@example.com");
+}
+
+/// Repro for code-review finding #3: pre-rejected mutations must
+/// reach the client even when `source.push` returns an error for the
+/// surviving mutations. We don't have a transient-error-injecting
+/// source on hand, so we test the simpler invariant: with NO
+/// survivors (all mutations pre-rejected and source.push receives an
+/// empty batch), the response carries the pre-rejected entries.
+#[tokio::test]
+async fn all_stale_no_migrator_still_surfaces_rejections() {
+    let _lock = registry_lock();
+    let customers = Customers::default();
+    let app = router_without_migrator(customers.clone());
+
+    let m1 = CrudMutationPayload::create("c1".to_string(), serde_json::json!({ "name": "Alice" }))
+        .into_sync_draft()
+        .unwrap()
+        .with_id(MutationId::new("device:1").unwrap());
+    let m2 = CrudMutationPayload::create("c2".to_string(), serde_json::json!({ "name": "Bob" }))
+        .into_sync_draft()
+        .unwrap()
+        .with_id(MutationId::new("device:2").unwrap());
+    let req = SyncPushRequest::new(
+        SyncStreamName::new(STREAM).unwrap(),
+        [to_value(m1), to_value(m2)],
+    )
+    .with_schema_version(1);
+    let pushed = post_json::<_, SyncPushResponse<Value>>(app, SYNC_PUSH_PATH, &req).await;
+
+    assert!(pushed.accepted.is_empty());
+    assert_eq!(pushed.rejected.len(), 2);
+    assert!(customers.rows.lock().unwrap().is_empty());
+}
+
+/// Repro for code-review finding #5: a NEWER client pushing to an
+/// OLDER server (rolling deploy direction) should NOT route through
+/// `migrate_payload`. The source receives the wire payload as-is and
+/// rejects it via its own deserialization path — NOT via a
+/// SchemaMigration reason.
+#[tokio::test]
+async fn newer_client_push_skips_migration_entirely() {
+    let _lock = registry_lock();
+    pocopine_server::__reset_for_test();
+    // Server at v1 (NO `.schema_version(...)` call so it stays at default 1)
+    // with NO migrator. A "v2 client" sends `request.schema_version = 2`.
+    let customers = Customers::default();
+    let resource = resource(STREAM, customers.clone())
+        .unwrap()
+        .id(|row: &CustomerV2| row.id.clone())
+        .version(|row: &CustomerV2| row.version)
+        .memory_mutation_log();
+    let sync = pocopine_sync::SyncServer::builder()
+        .public_stream(resource)
+        .build();
+    let app = Server::new(Router::new())
+        .plugin(sync_server_plugin(sync))
+        .try_finalize()
+        .unwrap();
+
+    // The v2-shaped payload happens to be valid for v1 (v1 source
+    // accepts CustomerDraftV2). We don't care what `source.push`
+    // does with it — only that the framework didn't invoke
+    // `migrate_payload(2, 1)`.
+    let create = CrudMutationPayload::create(
+        "c1".to_string(),
+        serde_json::json!({ "name": "Alice", "email": "alice@example.com" }),
+    )
+    .into_sync_draft()
+    .unwrap()
+    .with_id(MutationId::new("device:1").unwrap());
+    let req = SyncPushRequest::new(SyncStreamName::new(STREAM).unwrap(), [to_value(create)])
+        .with_schema_version(2);
+    let pushed = post_json::<_, SyncPushResponse<Value>>(app, SYNC_PUSH_PATH, &req).await;
+
+    // No SchemaMigration rejection — the source either accepts or
+    // rejects via its own path. The key invariant: ZERO mutations
+    // are rejected with a `schema migration` reason.
+    for r in &pushed.rejected {
+        assert!(
+            !r.reason.contains("schema migration"),
+            "newer-client push must not invoke migrate_payload, got reason: {}",
+            r.reason
+        );
+    }
+}
+
+/// Repro for code-review finding #7: a push with explicit
+/// `schema_version: 0` is rejected with `BadRequest` at the server
+/// before reaching `migrate_payload`.
+#[tokio::test]
+async fn schema_version_zero_is_rejected_at_wire() {
+    let _lock = registry_lock();
+    let customers = Customers::default();
+    let app = router_without_migrator(customers);
+    let body = serde_json::json!({
+        "protocol": pocopine_sync::SYNC_PROTOCOL_V1,
+        "stream": STREAM,
+        "mutations": [],
+        "schema_version": 0,
+    });
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(SYNC_PUSH_PATH)
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&body).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    // Server returns 200 OK with a `ServerResult::Err` payload because
+    // sync handlers wrap their result in `Json(ServerResult<T>)`. The
+    // BadRequest is inside the JSON body, not the HTTP status.
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let outer: pocopine_core::ServerResult<SyncPushResponse<Value>> =
+        serde_json::from_slice(&bytes).unwrap();
+    match outer {
+        Err(pocopine_core::ServerError::BadRequest(msg)) => {
+            assert!(
+                msg.contains("schema_version"),
+                "expected BadRequest about schema_version, got: {msg}"
+            );
+        }
+        other => panic!("expected BadRequest, got: {other:?}"),
+    }
 }
 
 fn router_without_migrator(customers: Customers) -> Router {
@@ -295,6 +440,7 @@ fn to_value(mutation: ClientMutation<CrudMutationPayload<String, Value>>) -> Cli
         op: mutation.op,
         base_version: mutation.base_version,
         payload: serde_json::to_value(mutation.payload).unwrap(),
+        migrated_payload: None,
     }
 }
 

--- a/crates/pocopine-sync-crud/tests/schema_migration.rs
+++ b/crates/pocopine-sync-crud/tests/schema_migration.rs
@@ -1,0 +1,321 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+//! End-to-end test for the Batch 3 schema-migration adapter.
+//!
+//! Covers both halves of the contract:
+//!
+//! * `.schema_version(N)` alone (no `.migrate_with(...)`) — a stale
+//!   push with `request.schema_version < N` is rejected per-mutation
+//!   with a `SyncError::SchemaMigration`-shaped reason, while
+//!   matching-version pushes pass through.
+//! * `.schema_version(N).migrate_with(fn)` — the framework calls
+//!   the registered fn before delegating to `source.push`, so a
+//!   stale payload that the migrator can transform ends up in
+//!   `accepted` with the new shape.
+
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, Mutex},
+};
+
+use http_body_util::BodyExt;
+use pocopine_auth::RequestContext;
+use pocopine_server::{
+    axum::{
+        body::Body,
+        http::{Request, StatusCode},
+        Router,
+    },
+    Server,
+};
+use pocopine_sync::{
+    sync_server_plugin, ClientMutation, MutationId, RowVersion, SyncPushRequest, SyncPushResponse,
+    SyncStreamName, SYNC_PUSH_PATH,
+};
+use pocopine_sync_crud::{
+    async_trait, resource, CrudMutationPayload, CrudRemoveResult, CrudSource, CrudWriteResult,
+};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use serde_json::Value;
+use tower::ServiceExt;
+
+const STREAM: &str = "customers";
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+struct CustomerV2 {
+    id: String,
+    name: String,
+    /// New v2 field: prior versions had no `email`. The migrator below
+    /// defaults it to an empty string when migrating a v1 draft up.
+    email: String,
+    version: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+struct CustomerDraftV2 {
+    name: String,
+    email: String,
+}
+
+#[derive(Clone, Default)]
+struct Customers {
+    rows: Arc<Mutex<BTreeMap<String, CustomerV2>>>,
+}
+
+#[async_trait]
+impl CrudSource for Customers {
+    type Id = String;
+    type Row = CustomerV2;
+    type Draft = CustomerDraftV2;
+
+    async fn list(
+        &self,
+        _ctx: RequestContext,
+        limit: usize,
+    ) -> pocopine_sync::SyncResult<Vec<Self::Row>> {
+        Ok(self
+            .rows
+            .lock()
+            .unwrap()
+            .values()
+            .take(limit)
+            .cloned()
+            .collect())
+    }
+
+    async fn get(
+        &self,
+        _ctx: RequestContext,
+        id: Self::Id,
+    ) -> pocopine_sync::SyncResult<Option<Self::Row>> {
+        Ok(self.rows.lock().unwrap().get(&id).cloned())
+    }
+
+    async fn create(
+        &self,
+        _ctx: RequestContext,
+        id: Self::Id,
+        draft: Self::Draft,
+    ) -> pocopine_sync::SyncResult<Self::Row> {
+        let row = CustomerV2 {
+            id: id.clone(),
+            name: draft.name,
+            email: draft.email,
+            version: 1,
+        };
+        self.rows.lock().unwrap().insert(id, row.clone());
+        Ok(row)
+    }
+
+    async fn save(
+        &self,
+        _ctx: RequestContext,
+        id: Self::Id,
+        draft: Self::Draft,
+        _base_version: Option<RowVersion>,
+    ) -> pocopine_sync::SyncResult<CrudWriteResult<Self::Row>> {
+        let mut rows = self.rows.lock().unwrap();
+        let row = rows
+            .get_mut(&id)
+            .ok_or_else(|| pocopine_sync::SyncError::backend(format!("missing customer {id}")))?;
+        row.name = draft.name;
+        row.email = draft.email;
+        row.version = row.version.saturating_add(1);
+        Ok(CrudWriteResult::applied(row.clone()))
+    }
+
+    async fn remove(
+        &self,
+        _ctx: RequestContext,
+        id: Self::Id,
+        _base_version: Option<RowVersion>,
+    ) -> pocopine_sync::SyncResult<CrudRemoveResult<Self::Row>> {
+        self.rows.lock().unwrap().remove(&id);
+        Ok(CrudRemoveResult::applied())
+    }
+}
+
+/// Migrator: a v1 draft has only `name`; v2 needs `name` AND `email`.
+/// The migrator defaults the missing field to an empty string.
+fn migrate_v1_to_v2(from: u32, to: u32, mut value: Value) -> pocopine_sync::SyncResult<Value> {
+    if from != 1 || to != 2 {
+        return Err(pocopine_sync::SyncError::schema_migration(STREAM, from, to));
+    }
+    // The wire payload is the CrudMutationPayload enum tagged
+    // `{ "op": "create" | "save" | "remove", "payload": { "id": ..., "draft": <draft> } }`.
+    // For create/save we widen the inner draft with a default email.
+    let Some(op) = value
+        .get("op")
+        .and_then(|v| v.as_str())
+        .map(|s| s.to_string())
+    else {
+        return Err(pocopine_sync::SyncError::backend(
+            "migrate_v1_to_v2: payload missing `op`",
+        ));
+    };
+    match op.as_str() {
+        "create" | "save" => {
+            if let Some(payload) = value.get_mut("payload") {
+                if let Some(draft) = payload.get_mut("draft") {
+                    if let Some(obj) = draft.as_object_mut() {
+                        obj.entry("email".to_string())
+                            .or_insert_with(|| Value::String(String::new()));
+                    }
+                }
+            }
+        }
+        _ => {}
+    }
+    Ok(value)
+}
+
+#[tokio::test]
+async fn stale_schema_push_without_migrator_rejects_per_mutation() {
+    let customers = Customers::default();
+    let app = router_without_migrator(customers.clone());
+
+    // Client at v1 pushing a create — server is at v2 with no migrator.
+    let create = CrudMutationPayload::create(
+        "c1".to_string(),
+        // Wire shape: arbitrary `serde_json::Value` payload. We send
+        // ONLY `name` (the v1 shape) — the server can't deserialize
+        // into v2's CustomerDraftV2 (which requires `email`).
+        serde_json::json!({ "name": "Alice" }),
+    )
+    .into_sync_draft()
+    .unwrap()
+    .with_id(MutationId::new("device:1").unwrap());
+    let req = SyncPushRequest::new(SyncStreamName::new(STREAM).unwrap(), [to_value(create)])
+        .with_schema_version(1);
+    let pushed = post_json::<_, SyncPushResponse<Value>>(app, SYNC_PUSH_PATH, &req).await;
+
+    assert!(pushed.accepted.is_empty(), "must not accept stale push");
+    assert_eq!(pushed.rejected.len(), 1, "expected 1 rejected");
+    let reason = &pushed.rejected[0].reason;
+    assert!(
+        reason.contains("schema migration") && reason.contains("v1") && reason.contains("v2"),
+        "expected SchemaMigration reason, got: {reason}"
+    );
+    assert!(
+        customers.rows.lock().unwrap().is_empty(),
+        "source must NOT have processed the stale mutation"
+    );
+}
+
+#[tokio::test]
+async fn stale_schema_push_with_migrator_passes_through() {
+    let customers = Customers::default();
+    let app = router_with_migrator(customers.clone());
+
+    // Same v1 client payload — but server has registered migrate_v1_to_v2.
+    let create =
+        CrudMutationPayload::create("c1".to_string(), serde_json::json!({ "name": "Alice" }))
+            .into_sync_draft()
+            .unwrap()
+            .with_id(MutationId::new("device:1").unwrap());
+    let req = SyncPushRequest::new(SyncStreamName::new(STREAM).unwrap(), [to_value(create)])
+        .with_schema_version(1);
+    let pushed = post_json::<_, SyncPushResponse<Value>>(app, SYNC_PUSH_PATH, &req).await;
+
+    assert_eq!(pushed.accepted.len(), 1, "expected accept after migrate");
+    assert!(pushed.rejected.is_empty(), "must NOT reject after migrate");
+    assert_eq!(pushed.rows.len(), 1);
+    assert_eq!(pushed.rows[0].value["name"], "Alice");
+    // The migrator filled in the default empty email.
+    assert_eq!(pushed.rows[0].value["email"], "");
+    assert_eq!(
+        customers.rows.lock().unwrap().get("c1").unwrap().name,
+        "Alice"
+    );
+}
+
+#[tokio::test]
+async fn matching_schema_push_skips_migrator_entirely() {
+    let customers = Customers::default();
+    let app = router_with_migrator(customers.clone());
+
+    // Client at v2 — request_schema_version == source.schema_version, so
+    // the migrator is never consulted. Push goes straight through.
+    let create = CrudMutationPayload::create(
+        "c1".to_string(),
+        serde_json::json!({ "name": "Alice", "email": "alice@example.com" }),
+    )
+    .into_sync_draft()
+    .unwrap()
+    .with_id(MutationId::new("device:1").unwrap());
+    let req = SyncPushRequest::new(SyncStreamName::new(STREAM).unwrap(), [to_value(create)])
+        .with_schema_version(2);
+    let pushed = post_json::<_, SyncPushResponse<Value>>(app, SYNC_PUSH_PATH, &req).await;
+
+    assert_eq!(pushed.accepted.len(), 1);
+    assert_eq!(pushed.rows[0].value["email"], "alice@example.com");
+}
+
+fn router_without_migrator(customers: Customers) -> Router {
+    pocopine_server::__reset_for_test();
+    let customers = resource(STREAM, customers)
+        .unwrap()
+        .schema_version(2)
+        .unwrap()
+        .id(|row: &CustomerV2| row.id.clone())
+        .version(|row: &CustomerV2| row.version)
+        .memory_mutation_log();
+    let sync = pocopine_sync::SyncServer::builder()
+        .public_stream(customers)
+        .build();
+    Server::new(Router::new())
+        .plugin(sync_server_plugin(sync))
+        .try_finalize()
+        .unwrap()
+}
+
+fn router_with_migrator(customers: Customers) -> Router {
+    pocopine_server::__reset_for_test();
+    let customers = resource(STREAM, customers)
+        .unwrap()
+        .schema_version(2)
+        .unwrap()
+        .migrate_with(migrate_v1_to_v2)
+        .id(|row: &CustomerV2| row.id.clone())
+        .version(|row: &CustomerV2| row.version)
+        .memory_mutation_log();
+    let sync = pocopine_sync::SyncServer::builder()
+        .public_stream(customers)
+        .build();
+    Server::new(Router::new())
+        .plugin(sync_server_plugin(sync))
+        .try_finalize()
+        .unwrap()
+}
+
+fn to_value(mutation: ClientMutation<CrudMutationPayload<String, Value>>) -> ClientMutation<Value> {
+    ClientMutation {
+        id: mutation.id,
+        key: mutation.key,
+        op: mutation.op,
+        base_version: mutation.base_version,
+        payload: serde_json::to_value(mutation.payload).unwrap(),
+    }
+}
+
+async fn post_json<T, R>(router: Router, uri: &str, payload: &T) -> R
+where
+    T: Serialize,
+    R: DeserializeOwned,
+{
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(uri)
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(payload).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let outer: pocopine_core::ServerResult<R> = serde_json::from_slice(&bytes).unwrap();
+    outer.unwrap()
+}

--- a/crates/pocopine-sync-crud/tests/tenant_boundary.rs
+++ b/crates/pocopine-sync-crud/tests/tenant_boundary.rs
@@ -374,6 +374,7 @@ fn to_value(
         op: mutation.op,
         base_version: mutation.base_version,
         payload: serde_json::to_value(mutation.payload).unwrap(),
+        migrated_payload: None,
     }
 }
 

--- a/crates/pocopine-sync-crud/tests/tenant_boundary.rs
+++ b/crates/pocopine-sync-crud/tests/tenant_boundary.rs
@@ -374,7 +374,7 @@ fn to_value(
         op: mutation.op,
         base_version: mutation.base_version,
         payload: serde_json::to_value(mutation.payload).unwrap(),
-        migrated_payload: None,
+        migration_outcome: None,
     }
 }
 

--- a/crates/pocopine-sync-indexdb/tests/indexdb_store.rs
+++ b/crates/pocopine-sync-indexdb/tests/indexdb_store.rs
@@ -39,7 +39,7 @@ async fn indexeddb_store_persists_identity_snapshot_and_pending_mutations() {
             "payload": {"id": "post_2", "draft": {"title": "Pending"}}
         }),
 
-        migrated_payload: None,
+        migration_outcome: None,
     };
     let optimistic = SyncRow::new("post_2", serde_json::json!({"title": "Pending"})).unwrap();
 
@@ -135,7 +135,7 @@ async fn indexeddb_store_applies_changes_and_push_results() {
         base_version: Some(RowVersion::new("row_1").unwrap()),
         payload: serde_json::json!({"title": "Updated"}),
 
-        migrated_payload: None,
+        migration_outcome: None,
     };
 
     store

--- a/crates/pocopine-sync-indexdb/tests/indexdb_store.rs
+++ b/crates/pocopine-sync-indexdb/tests/indexdb_store.rs
@@ -38,6 +38,8 @@ async fn indexeddb_store_persists_identity_snapshot_and_pending_mutations() {
             "op": "create",
             "payload": {"id": "post_2", "draft": {"title": "Pending"}}
         }),
+
+        migrated_payload: None,
     };
     let optimistic = SyncRow::new("post_2", serde_json::json!({"title": "Pending"})).unwrap();
 
@@ -132,6 +134,8 @@ async fn indexeddb_store_applies_changes_and_push_results() {
         op: SyncOp::Upsert,
         base_version: Some(RowVersion::new("row_1").unwrap()),
         payload: serde_json::json!({"title": "Updated"}),
+
+        migrated_payload: None,
     };
 
     store

--- a/crates/pocopine-sync-sqlite/src/native.rs
+++ b/crates/pocopine-sync-sqlite/src/native.rs
@@ -614,7 +614,7 @@ fn pending_mutation_records(
                     .map(|payload| serde_json::from_str(&payload))
                     .transpose()?
                     .unwrap_or(serde_json::Value::Null),
-                migrated_payload: None,
+                migration_outcome: None,
             },
             optimistic_row: optimistic_row
                 .map(|row| serde_json::from_str(&row))
@@ -937,7 +937,7 @@ mod tests {
             base_version: Some(RowVersion::new("row_1").unwrap()),
             payload: serde_json::json!({"title": "Saved"}),
 
-            migrated_payload: None,
+            migration_outcome: None,
         };
 
         block(store.enqueue_mutation(&stream, mutation.clone())).unwrap();
@@ -975,7 +975,7 @@ mod tests {
                 "payload": {"id": "post_1", "draft": {"title": "Envelope only"}}
             }),
 
-            migrated_payload: None,
+            migration_outcome: None,
         };
         let optimistic = SyncRow::new(
             "post_1",
@@ -1042,7 +1042,7 @@ mod tests {
                 base_version: None,
                 payload: serde_json::json!({"title": "Draft"}),
 
-                migrated_payload: None,
+                migration_outcome: None,
             },
         ))
         .unwrap();
@@ -1055,7 +1055,7 @@ mod tests {
                 base_version: None,
                 payload: serde_json::json!({"title": "Draft"}),
 
-                migrated_payload: None,
+                migration_outcome: None,
             },
         ))
         .unwrap();
@@ -1191,7 +1191,7 @@ mod tests {
             base_version: None,
             payload: serde_json::json!({"op": "create"}),
 
-            migrated_payload: None,
+            migration_outcome: None,
         };
         let optimistic = SyncRow::new("post_1", serde_json::json!({"title": "Visible"})).unwrap();
 
@@ -1343,7 +1343,7 @@ mod tests {
                     base_version: None,
                     payload: serde_json::json!({"id": id}),
 
-                    migrated_payload: None,
+                    migration_outcome: None,
                 },
             ))
             .unwrap();
@@ -1425,7 +1425,7 @@ mod tests {
             base_version: None,
             payload: serde_json::json!({"title": "A1"}),
 
-            migrated_payload: None,
+            migration_outcome: None,
         };
         let post_a_second = ClientMutation {
             id: MutationId::new("device_abc:2").unwrap(),
@@ -1434,7 +1434,7 @@ mod tests {
             base_version: None,
             payload: serde_json::json!({"title": "A2"}),
 
-            migrated_payload: None,
+            migration_outcome: None,
         };
         let post_b = ClientMutation {
             id: MutationId::new("device_abc:3").unwrap(),
@@ -1443,7 +1443,7 @@ mod tests {
             base_version: None,
             payload: serde_json::json!({"title": "B"}),
 
-            migrated_payload: None,
+            migration_outcome: None,
         };
         for m in [&post_a_first, &post_a_second, &post_b] {
             block(store.enqueue_mutation(&stream, m.clone())).unwrap();
@@ -1513,7 +1513,7 @@ mod tests {
                 base_version: None,
                 payload: serde_json::json!({"title": "edit"}),
 
-                migrated_payload: None,
+                migration_outcome: None,
             },
         ))
         .unwrap();
@@ -1574,7 +1574,7 @@ mod tests {
                 base_version: None,
                 payload: serde_json::json!({"t": "edit"}),
 
-                migrated_payload: None,
+                migration_outcome: None,
             },
         ))
         .unwrap();
@@ -1695,7 +1695,7 @@ mod tests {
                     base_version: None,
                     payload: serde_json::json!({"op": "create"}),
 
-                    migrated_payload: None,
+                    migration_outcome: None,
                 })
                 .with_optimistic_row(Some(
                     SyncRow::new("p1", serde_json::json!({"title": "p1"})).unwrap(),

--- a/crates/pocopine-sync-sqlite/src/native.rs
+++ b/crates/pocopine-sync-sqlite/src/native.rs
@@ -614,6 +614,7 @@ fn pending_mutation_records(
                     .map(|payload| serde_json::from_str(&payload))
                     .transpose()?
                     .unwrap_or(serde_json::Value::Null),
+                migrated_payload: None,
             },
             optimistic_row: optimistic_row
                 .map(|row| serde_json::from_str(&row))
@@ -935,6 +936,8 @@ mod tests {
             op: SyncOp::Upsert,
             base_version: Some(RowVersion::new("row_1").unwrap()),
             payload: serde_json::json!({"title": "Saved"}),
+
+            migrated_payload: None,
         };
 
         block(store.enqueue_mutation(&stream, mutation.clone())).unwrap();
@@ -971,6 +974,8 @@ mod tests {
                 "op": "create",
                 "payload": {"id": "post_1", "draft": {"title": "Envelope only"}}
             }),
+
+            migrated_payload: None,
         };
         let optimistic = SyncRow::new(
             "post_1",
@@ -1036,6 +1041,8 @@ mod tests {
                 op: SyncOp::Upsert,
                 base_version: None,
                 payload: serde_json::json!({"title": "Draft"}),
+
+                migrated_payload: None,
             },
         ))
         .unwrap();
@@ -1047,6 +1054,8 @@ mod tests {
                 op: SyncOp::Upsert,
                 base_version: None,
                 payload: serde_json::json!({"title": "Draft"}),
+
+                migrated_payload: None,
             },
         ))
         .unwrap();
@@ -1181,6 +1190,8 @@ mod tests {
             op: SyncOp::Upsert,
             base_version: None,
             payload: serde_json::json!({"op": "create"}),
+
+            migrated_payload: None,
         };
         let optimistic = SyncRow::new("post_1", serde_json::json!({"title": "Visible"})).unwrap();
 
@@ -1331,6 +1342,8 @@ mod tests {
                     op: SyncOp::Upsert,
                     base_version: None,
                     payload: serde_json::json!({"id": id}),
+
+                    migrated_payload: None,
                 },
             ))
             .unwrap();
@@ -1411,6 +1424,8 @@ mod tests {
             op: SyncOp::Upsert,
             base_version: None,
             payload: serde_json::json!({"title": "A1"}),
+
+            migrated_payload: None,
         };
         let post_a_second = ClientMutation {
             id: MutationId::new("device_abc:2").unwrap(),
@@ -1418,6 +1433,8 @@ mod tests {
             op: SyncOp::Upsert,
             base_version: None,
             payload: serde_json::json!({"title": "A2"}),
+
+            migrated_payload: None,
         };
         let post_b = ClientMutation {
             id: MutationId::new("device_abc:3").unwrap(),
@@ -1425,6 +1442,8 @@ mod tests {
             op: SyncOp::Upsert,
             base_version: None,
             payload: serde_json::json!({"title": "B"}),
+
+            migrated_payload: None,
         };
         for m in [&post_a_first, &post_a_second, &post_b] {
             block(store.enqueue_mutation(&stream, m.clone())).unwrap();
@@ -1493,6 +1512,8 @@ mod tests {
                 op: SyncOp::Upsert,
                 base_version: None,
                 payload: serde_json::json!({"title": "edit"}),
+
+                migrated_payload: None,
             },
         ))
         .unwrap();
@@ -1552,6 +1573,8 @@ mod tests {
                 op: SyncOp::Upsert,
                 base_version: None,
                 payload: serde_json::json!({"t": "edit"}),
+
+                migrated_payload: None,
             },
         ))
         .unwrap();
@@ -1671,6 +1694,8 @@ mod tests {
                     op: SyncOp::Upsert,
                     base_version: None,
                     payload: serde_json::json!({"op": "create"}),
+
+                    migrated_payload: None,
                 })
                 .with_optimistic_row(Some(
                     SyncRow::new("p1", serde_json::json!({"title": "p1"})).unwrap(),

--- a/crates/pocopine-sync-sqlite/src/wasm.rs
+++ b/crates/pocopine-sync-sqlite/src/wasm.rs
@@ -653,7 +653,7 @@ async fn pending_mutation_records(stream: SyncStreamName) -> SyncResult<Vec<Loca
                 op: op_from_str(&required_string(&row, "op")?)?,
                 payload,
 
-                migrated_payload: None,
+                migration_outcome: None,
             },
             optimistic_row,
         });

--- a/crates/pocopine-sync-sqlite/src/wasm.rs
+++ b/crates/pocopine-sync-sqlite/src/wasm.rs
@@ -652,6 +652,8 @@ async fn pending_mutation_records(stream: SyncStreamName) -> SyncResult<Vec<Loca
                     .transpose()?,
                 op: op_from_str(&required_string(&row, "op")?)?,
                 payload,
+
+                migrated_payload: None,
             },
             optimistic_row,
         });

--- a/crates/pocopine-sync-sqlite/tests/wasm_sqlite_store.rs
+++ b/crates/pocopine-sync-sqlite/tests/wasm_sqlite_store.rs
@@ -63,6 +63,8 @@ async fn sqlite_wasm_store_round_trips_cached_rows_and_pending_mutations() {
             "op": "save",
             "payload": {"id": "post_1", "draft": {"title": "Updated"}}
         }),
+
+        migrated_payload: None,
     };
     let optimistic = SyncRow::new("post_1", serde_json::json!({"title": "Updated"})).unwrap();
     store

--- a/crates/pocopine-sync-sqlite/tests/wasm_sqlite_store.rs
+++ b/crates/pocopine-sync-sqlite/tests/wasm_sqlite_store.rs
@@ -64,7 +64,7 @@ async fn sqlite_wasm_store_round_trips_cached_rows_and_pending_mutations() {
             "payload": {"id": "post_1", "draft": {"title": "Updated"}}
         }),
 
-        migrated_payload: None,
+        migration_outcome: None,
     };
     let optimistic = SyncRow::new("post_1", serde_json::json!({"title": "Updated"})).unwrap();
     store

--- a/crates/pocopine-sync/src/client.rs
+++ b/crates/pocopine-sync/src/client.rs
@@ -1140,68 +1140,82 @@ fn start_open_then_pull<C, T>(
                 }
             };
 
-        // If the cached schema_version differs from what the server is
-        // now advertising, the local cache (rows + pending mutations)
-        // is encoded against a shape the server no longer accepts.
-        // Drop it durably AND in memory so the upcoming pull rebuilds
-        // canonical state against the new shape. `cached_schema_version
-        // == None` means the store has never observed an advertised
-        // version (fresh install, or pre-v4 row) — adopt the
-        // advertised value silently on the next snapshot save.
+        // Decide whether the local cache (rows + pending mutations)
+        // is still valid for the server's currently-advertised schema
+        // version:
+        //
+        // * `cached < advertised` — server upgraded; the cache and
+        //   queue are stale shape. Drop them durably + in memory and
+        //   rebuild via the upcoming pull.
+        // * `cached > advertised` — server ROLLED BACK; the local
+        //   cache is "newer than the server" but locally consistent.
+        //   Do NOT wipe; let the client hold its queue while waiting
+        //   for the server to catch back up.
+        // * `cached == advertised` — match; no work needed.
+        // * `cached == None && pending non-empty` — store has never
+        //   observed an advertised version (fresh install OR pre-v4
+        //   row whose `app_schema_version` column is NULL). The
+        //   pending mutations may have been queued under any prior
+        //   shape — safest action is to DROP the queue (lossy but
+        //   bounded; this only fires once on the upgrade boundary).
         let mut cursor = cursor;
         let mut token = token;
-        if let Some(cached) = cached_schema_version {
-            if cached != advertised_schema_version {
-                tracing::info!(
-                    target: "pocopine.log",
-                    stream = stream.as_str(),
-                    cached_schema_version = cached,
-                    advertised_schema_version,
-                    "sync stream schema_version changed; clearing local cache + pending mutations",
-                );
-                if let Err(err) = local_store.clear_stream(&stream).await {
-                    // Fail loud: if the durable wipe failed, do NOT
-                    // proceed to pull + persist. A successful pull
-                    // would stamp the NEW app_schema_version via the
-                    // UPSERT coalesce, silently masking the wipe
-                    // failure forever. Surfacing the error keeps
-                    // cached at the OLD value so the next open
-                    // re-detects the mismatch and retries.
-                    handle.update(|state| {
-                        selector(state).apply_error(
-                            token,
-                            format!("local sync cache wipe-on-schema-bump failed: {err}"),
-                        );
-                    });
-                    return;
-                }
-                if epoch.is_stale() {
-                    return;
-                }
-                // In-memory side: hard reset via
-                // `reset_for_schema_invalidation`. Unlike
-                // `apply_local_snapshot_with_pending(empty, None, empty)`
-                // (which short-circuits in `apply_local_snapshot_inner`
-                // because all inputs are empty), this unconditionally
-                // drops canonical_rows, rows, pending_mutations, cursor,
-                // and bumps request_generation — so any in-flight token
-                // becomes a no-op via `is_current`.
-                pending_mutations.clear();
-                let new_token = handle.update(|state| {
-                    let collection = selector(state);
-                    collection.reset_for_schema_invalidation();
-                    // Re-issue a token; the prior `request_token` was
-                    // invalidated by the reset's generation bump.
-                    collection.begin_initial()
+        let must_wipe = match cached_schema_version {
+            Some(cached) if cached < advertised_schema_version => true,
+            None if !pending_mutations.is_empty() => true,
+            _ => false,
+        };
+        if must_wipe {
+            tracing::info!(
+                target: "pocopine.log",
+                stream = stream.as_str(),
+                cached_schema_version = ?cached_schema_version,
+                advertised_schema_version,
+                pending_mutations = pending_mutations.len(),
+                "sync stream schema_version drift detected; clearing local cache + pending mutations",
+            );
+            if let Err(err) = local_store.clear_stream(&stream).await {
+                // Fail loud: if the durable wipe failed, do NOT
+                // proceed to pull + persist. A successful pull
+                // would stamp the NEW app_schema_version via the
+                // UPSERT coalesce, silently masking the wipe
+                // failure forever. Surfacing the error keeps
+                // cached at the OLD value so the next open
+                // re-detects the mismatch and retries.
+                handle.update(|state| {
+                    selector(state).apply_error(
+                        token,
+                        format!("local sync cache wipe-on-schema-bump failed: {err}"),
+                    );
                 });
-                token = new_token;
-                // Force a Snapshot pull by nulling the cursor — the
-                // OLD-schema cursor was wiped durably; sending it to
-                // the server would yield an Incremental response that
-                // merges new-schema deltas onto an empty canonical
-                // set, leaving most rows missing until the next pull.
-                cursor = None;
+                return;
             }
+            if epoch.is_stale() {
+                return;
+            }
+            // In-memory side: hard reset via
+            // `reset_for_schema_invalidation`. Unlike
+            // `apply_local_snapshot_with_pending(empty, None, empty)`
+            // (which short-circuits in `apply_local_snapshot_inner`
+            // because all inputs are empty), this unconditionally
+            // drops canonical_rows, rows, pending_mutations, cursor,
+            // and bumps request_generation — so any in-flight token
+            // becomes a no-op via `is_current`.
+            pending_mutations.clear();
+            let new_token = handle.update(|state| {
+                let collection = selector(state);
+                collection.reset_for_schema_invalidation();
+                // Re-issue a token; the prior `request_token` was
+                // invalidated by the reset's generation bump.
+                collection.begin_initial()
+            });
+            token = new_token;
+            // Force a Snapshot pull by nulling the cursor — the
+            // OLD-schema cursor was wiped durably; sending it to
+            // the server would yield an Incremental response that
+            // merges new-schema deltas onto an empty canonical
+            // set, leaving most rows missing until the next pull.
+            cursor = None;
         }
         if let Some(live_wakeup) = live_wakeup {
             open_live_wakeup(
@@ -2021,6 +2035,7 @@ where
         op: mutation.op,
         base_version: mutation.base_version.clone(),
         payload: serde_json::to_value(&mutation.payload)?,
+        migrated_payload: None,
     })
 }
 

--- a/crates/pocopine-sync/src/client.rs
+++ b/crates/pocopine-sync/src/client.rs
@@ -1149,20 +1149,36 @@ fn start_open_then_pull<C, T>(
         //   rebuild via the upcoming pull.
         // * `cached > advertised` — server ROLLED BACK; the local
         //   cache is "newer than the server" but locally consistent.
-        //   Do NOT wipe; let the client hold its queue while waiting
-        //   for the server to catch back up.
+        //   Do NOT wipe; hold the queue AND skip replay/persist
+        //   entirely so a transient older-shard read doesn't
+        //   downgrade the durable fence or replay v2 mutations
+        //   tagged as v1.
         // * `cached == advertised` — match; no work needed.
-        // * `cached == None && pending non-empty` — store has never
-        //   observed an advertised version (fresh install OR pre-v4
-        //   row whose `app_schema_version` column is NULL). The
-        //   pending mutations may have been queued under any prior
-        //   shape — safest action is to DROP the queue (lossy but
-        //   bounded; this only fires once on the upgrade boundary).
+        // * `cached == None` + any durable state (cursor, cached
+        //   rows, pending mutations, OR an in-memory decode error
+        //   from hydrate) — store has never observed an advertised
+        //   version (fresh install OR pre-v4 row whose
+        //   `app_schema_version` column is NULL) AND has non-empty
+        //   state of unknown shape. Safest action is to drop it all
+        //   (lossy but bounded; fires once on the upgrade boundary).
+        // * `cached == None` + truly empty — fresh install; adopt
+        //   the advertised value silently on the next snapshot save.
         let mut cursor = cursor;
         let mut token = token;
+        let rolled_back = matches!(
+            cached_schema_version,
+            Some(cached) if cached > advertised_schema_version
+        );
+        // NOTE: `local_cursor` was moved into the `request_token`
+        // closure above; consult `cursor` (the materialized version
+        // for this open) and `pending_mutations` to detect durable
+        // state that survived a `cached_schema_version == None`
+        // hydrate.
+        let cached_none_has_durable_state = cached_schema_version.is_none()
+            && (cursor.is_some() || !pending_mutations.is_empty() || local_error.is_some());
         let must_wipe = match cached_schema_version {
             Some(cached) if cached < advertised_schema_version => true,
-            None if !pending_mutations.is_empty() => true,
+            None if cached_none_has_durable_state => true,
             _ => false,
         };
         if must_wipe {
@@ -1231,7 +1247,13 @@ fn start_open_then_pull<C, T>(
             );
         }
 
-        if !pending_mutations.is_empty() {
+        // Rolled-back servers: skip replay AND the upcoming pull's
+        // durable persist. The client holds its queue + cache as-is;
+        // the in-memory state is still derived from the existing
+        // snapshot. A pull may still run to refresh the in-memory
+        // view, but its response must NOT downgrade the durable
+        // `app_schema_version` fence.
+        if !pending_mutations.is_empty() && !rolled_back {
             if epoch.is_stale() {
                 return;
             }
@@ -1257,9 +1279,18 @@ fn start_open_then_pull<C, T>(
                     local_error = Some(format!("pending sync mutation replay failed: {err}"));
                 }
             }
+        } else if rolled_back {
+            tracing::info!(
+                target: "pocopine.log",
+                stream = stream.as_str(),
+                cached_schema_version = ?cached_schema_version,
+                advertised_schema_version,
+                pending_mutations = pending_mutations.len(),
+                "sync stream server appears to have rolled back; holding queue + cache"
+            );
         }
 
-        let request = SyncPullRequest::new(stream).cursor(cursor);
+        let request = SyncPullRequest::new(stream.clone()).cursor(cursor);
         let result =
             pocopine_core::fetch::call::<SyncPullRequest, SyncPullResponse<T>>(&pull_url, &request)
                 .await;
@@ -1268,11 +1299,35 @@ fn start_open_then_pull<C, T>(
         }
         let result = match result {
             Ok(response) => {
-                if let Err(err) =
-                    persist_pull_response(&local_store, &response, Some(advertised_schema_version))
-                        .await
-                {
-                    local_error = Some(format!("local sync cache persist failed: {err}"));
+                // Persist-time invalidation guard: if the in-memory
+                // generation moved on (e.g. a concurrent
+                // `start_open_then_pull` detected a schema mismatch
+                // and durably wiped the stream while our pull was
+                // in-flight), skip the persist so we don't
+                // resurrect wiped state. The in-memory apply at the
+                // bottom of this fn is already token-guarded.
+                let still_current = handle.update(|state| selector(state).is_current(token));
+                if still_current {
+                    // Persist with the cached version under rollback so
+                    // the durable fence stays at the higher value. When
+                    // server catches back up, the next open will detect
+                    // cached==advertised and resume normal flow.
+                    let persist_version = if rolled_back {
+                        cached_schema_version
+                    } else {
+                        Some(advertised_schema_version)
+                    };
+                    if let Err(err) =
+                        persist_pull_response(&local_store, &response, persist_version).await
+                    {
+                        local_error = Some(format!("local sync cache persist failed: {err}"));
+                    }
+                } else {
+                    tracing::info!(
+                        target: "pocopine.log",
+                        stream = stream.as_str(),
+                        "sync stream pull response discarded: in-flight wipe invalidated this request"
+                    );
                 }
                 Ok(response)
             }
@@ -1483,18 +1538,33 @@ fn start_pull<C, T>(
         let mut local_error = None;
         let result = match result {
             Ok(response) => {
-                // Callers that ran AFTER a successful /open pass
-                // `Some(advertised)` so the durable
-                // `app_schema_version` gets stamped even if the
-                // post-/open pull never runs. Callers without an
-                // advertised version (explicit refresh without
-                // re-opening) pass None and rely on the UPSERT's
-                // coalesce to preserve whatever value
-                // `start_open_then_pull` already persisted.
-                if let Err(err) =
-                    persist_pull_response(&local_store, &response, application_schema_version).await
-                {
-                    local_error = Some(format!("local sync cache persist failed: {err}"));
+                // Persist-time invalidation guard: if the in-memory
+                // generation moved on (concurrent wipe by
+                // `start_open_then_pull`), skip the persist so we
+                // don't resurrect wiped state. The in-memory apply
+                // below is already token-guarded.
+                let still_current = handle.update(|state| selector(state).is_current(token));
+                if still_current {
+                    // Callers that ran AFTER a successful /open pass
+                    // `Some(advertised)` so the durable
+                    // `app_schema_version` gets stamped even if the
+                    // post-/open pull never runs. Callers without an
+                    // advertised version (explicit refresh without
+                    // re-opening) pass None and rely on the UPSERT's
+                    // coalesce to preserve whatever value
+                    // `start_open_then_pull` already persisted.
+                    if let Err(err) =
+                        persist_pull_response(&local_store, &response, application_schema_version)
+                            .await
+                    {
+                        local_error = Some(format!("local sync cache persist failed: {err}"));
+                    }
+                } else {
+                    tracing::info!(
+                        target: "pocopine.log",
+                        stream = stream.as_str(),
+                        "sync stream pull response discarded: in-flight wipe invalidated this request"
+                    );
                 }
                 Ok(response)
             }
@@ -2035,7 +2105,7 @@ where
         op: mutation.op,
         base_version: mutation.base_version.clone(),
         payload: serde_json::to_value(&mutation.payload)?,
-        migrated_payload: None,
+        migration_outcome: None,
     })
 }
 

--- a/crates/pocopine-sync/src/client.rs
+++ b/crates/pocopine-sync/src/client.rs
@@ -205,6 +205,7 @@ impl SyncClient {
             stream: None,
             cursor: None,
             epoch: self.epoch.snapshot(),
+            schema_version: crate::default_schema_version_one(),
             _marker: PhantomData,
         }
     }
@@ -295,6 +296,14 @@ pub struct SyncCollection<C: 'static, T> {
     cursor: Option<SyncCursor>,
     #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
     epoch: SyncEpoch,
+    /// Application-level schema version this collection's resource is
+    /// encoded under. Generated `Resource::collection()` chains
+    /// `.schema_version(SCHEMA_VERSION)` so push requests carry the
+    /// resource's declared version. The server compares against its
+    /// own `SyncStreamSource::schema_version()` and routes stale
+    /// mutations through `migrate_payload`. Defaults to `1` for raw
+    /// `SyncCollection` callers that don't go through the macro.
+    schema_version: u32,
     _marker: PhantomData<fn(C) -> T>,
 }
 
@@ -306,6 +315,20 @@ where
     /// Set the server-registered stream to pull.
     pub fn stream(mut self, stream: impl Into<String>) -> SyncResult<Self> {
         self.stream = Some(SyncStreamName::new(stream.into())?);
+        Ok(self)
+    }
+
+    /// Tag this collection's push requests with the resource's
+    /// application-level schema version. Generated `Resource::collection()`
+    /// calls this with the macro-emitted `SCHEMA_VERSION`; bare
+    /// `SyncCollection` callers can leave the default (`1`).
+    pub fn schema_version(mut self, version: u32) -> SyncResult<Self> {
+        if version == 0 {
+            return Err(SyncError::client(
+                "schema_version must be >= 1 (schema versions start at 1)",
+            ));
+        }
+        self.schema_version = version;
         Ok(self)
     }
 
@@ -650,6 +673,7 @@ where
                 "SyncCollection::push used outside a component handler/lifecycle hook",
             )
         })?;
+        let schema_version = self.schema_version;
         start_push(
             scope_id,
             self.handle,
@@ -662,6 +686,7 @@ where
             !self.live_wakeup,
             true,
             self.epoch,
+            schema_version,
         );
         Ok(())
     }
@@ -681,6 +706,7 @@ where
                 "SyncCollection::push_online used outside a component handler/lifecycle hook",
             )
         })?;
+        let schema_version = self.schema_version;
         start_push(
             scope_id,
             self.handle,
@@ -693,6 +719,7 @@ where
             !self.live_wakeup,
             false,
             self.epoch,
+            schema_version,
         );
         Ok(())
     }
@@ -712,6 +739,7 @@ where
                 "SyncCollection::push_with_generated_id used outside a component handler/lifecycle hook",
             )
         })?;
+        let schema_version = self.schema_version;
         start_push_with_generated_id(
             scope_id,
             self.handle,
@@ -724,6 +752,7 @@ where
             !self.live_wakeup,
             true,
             self.epoch,
+            schema_version,
         );
         Ok(())
     }
@@ -743,6 +772,7 @@ where
                 "SyncCollection::push_with_generated_id_online used outside a component handler/lifecycle hook",
             )
         })?;
+        let schema_version = self.schema_version;
         start_push_with_generated_id(
             scope_id,
             self.handle,
@@ -755,6 +785,7 @@ where
             !self.live_wakeup,
             false,
             self.epoch,
+            schema_version,
         );
         Ok(())
     }
@@ -800,6 +831,7 @@ where
         apply_optimistic_mutation(&self.handle, self.selector, &mutation, optimistic);
 
         let epoch = self.epoch.clone();
+        let schema_version = self.schema_version;
         pocopine_core::spawn_for_scope(scope_id, async move {
             let _ = send_push_and_reconcile(
                 scope_id,
@@ -813,6 +845,7 @@ where
                 pull_after_accept,
                 true,
                 epoch,
+                schema_version,
             )
             .await;
         });
@@ -844,6 +877,7 @@ where
         let mutation_id = reserve_result?;
         let mutation = mutation.with_id(mutation_id.clone());
         apply_optimistic_mutation(&self.handle, self.selector, &mutation, optimistic);
+        let schema_version = self.schema_version;
         let response = send_push_and_reconcile(
             scope_id,
             self.handle,
@@ -856,6 +890,7 @@ where
             pull_after_accept,
             false,
             self.epoch,
+            schema_version,
         )
         .await?;
         Ok((mutation_id, response))
@@ -1192,6 +1227,7 @@ fn start_open_then_pull<C, T>(
                 stream.clone(),
                 pending_mutations,
                 &epoch,
+                advertised_schema_version,
             )
             .await
             {
@@ -1484,6 +1520,7 @@ fn start_push<C, T, M>(
     pull_after_accept: bool,
     queue_offline: bool,
     epoch: SyncEpoch,
+    schema_version: u32,
 ) where
     C: 'static,
     T: Clone + serde::de::DeserializeOwned + serde::Serialize + 'static,
@@ -1506,6 +1543,7 @@ fn start_push<C, T, M>(
             pull_after_accept,
             queue_offline,
             epoch,
+            schema_version,
         )
         .await;
     });
@@ -1525,6 +1563,7 @@ fn start_push_with_generated_id<C, T, M>(
     pull_after_accept: bool,
     queue_offline: bool,
     epoch: SyncEpoch,
+    schema_version: u32,
 ) where
     C: 'static,
     T: Clone + serde::de::DeserializeOwned + serde::Serialize + 'static,
@@ -1562,6 +1601,7 @@ fn start_push_with_generated_id<C, T, M>(
             pull_after_accept,
             queue_offline,
             epoch,
+            schema_version,
         )
         .await;
     });
@@ -1582,6 +1622,7 @@ async fn run_push<C, T, M>(
     pull_after_accept: bool,
     queue_offline: bool,
     epoch: SyncEpoch,
+    schema_version: u32,
 ) where
     C: 'static,
     T: Clone + serde::de::DeserializeOwned + serde::Serialize + 'static,
@@ -1639,6 +1680,7 @@ async fn run_push<C, T, M>(
         pull_after_accept,
         queue_offline,
         epoch,
+        schema_version,
     )
     .await;
 }
@@ -1698,6 +1740,7 @@ async fn send_push_and_reconcile<C, T, M>(
     pull_after_accept: bool,
     reconcile_queued_mutation: bool,
     epoch: SyncEpoch,
+    schema_version: u32,
 ) -> SyncResult<SyncPushResponse<T>>
 where
     C: 'static,
@@ -1710,7 +1753,11 @@ where
     // durable local queue. A server response should therefore be persisted as
     // the local push result so the queue can clear accepted/rejected/conflict
     // outcomes. Online-only pushes skip this local queue reconciliation.
-    let request = SyncPushRequest::new(stream.clone(), [mutation]);
+    // `schema_version` tags the wire envelope so the server's
+    // `push_handler` can route stale-schema mutations through
+    // `migrate_payload` before delegating to the source's `push`.
+    let request =
+        SyncPushRequest::new(stream.clone(), [mutation]).with_schema_version(schema_version);
     let result =
         pocopine_core::fetch::call::<SyncPushRequest<M>, SyncPushResponse<T>>(&push_url, &request)
             .await;
@@ -1822,11 +1869,13 @@ async fn replay_pending_mutations<T>(
     stream: SyncStreamName,
     pending_mutations: Vec<ClientMutation<Value>>,
     epoch: &SyncEpoch,
+    schema_version: u32,
 ) -> SyncResult<SyncPushResponse<T>>
 where
     T: serde::de::DeserializeOwned + serde::Serialize + 'static,
 {
-    let request = SyncPushRequest::new(stream, pending_mutations);
+    let request =
+        SyncPushRequest::new(stream, pending_mutations).with_schema_version(schema_version);
     let response = pocopine_core::fetch::call::<SyncPushRequest<Value>, SyncPushResponse<T>>(
         push_url, &request,
     )
@@ -2087,6 +2136,7 @@ mod tests {
             stream: Some(stream),
             cursor: None,
             epoch: SyncEpoch::new(),
+            schema_version: 1,
             _marker: PhantomData,
         };
         (state, collection)

--- a/crates/pocopine-sync/src/lib.rs
+++ b/crates/pocopine-sync/src/lib.rs
@@ -26,12 +26,12 @@ pub use local_store::{
     SyncLocalIdentity, SyncLocalStore,
 };
 pub use protocol::{
-    default_schema_version_one, sync_stream_tag, ClientMutation, ClientMutationDraft, MutationId,
-    RowKey, RowVersion, SyncChange, SyncCollectionName, SyncConflict, SyncCursor, SyncDeviceId,
-    SyncOp, SyncOpenRequest, SyncOpenResponse, SyncOpenStream, SyncPullMode, SyncPullRequest,
-    SyncPullResponse, SyncPushRequest, SyncPushResponse, SyncRejectedMutation, SyncRow,
-    SyncSessionId, SyncStreamName, MAX_SYNC_TOKEN_LEN, SYNC_ENDPOINT_PREFIX, SYNC_OPEN_PATH,
-    SYNC_PROTOCOL_V1, SYNC_PULL_PATH, SYNC_PUSH_PATH,
+    default_schema_version_one, sync_stream_tag, ClientMutation, ClientMutationDraft,
+    MigrationOutcome, MutationId, RowKey, RowVersion, SyncChange, SyncCollectionName, SyncConflict,
+    SyncCursor, SyncDeviceId, SyncOp, SyncOpenRequest, SyncOpenResponse, SyncOpenStream,
+    SyncPullMode, SyncPullRequest, SyncPullResponse, SyncPushRequest, SyncPushResponse,
+    SyncRejectedMutation, SyncRow, SyncSessionId, SyncStreamName, MAX_SYNC_TOKEN_LEN,
+    SYNC_ENDPOINT_PREFIX, SYNC_OPEN_PATH, SYNC_PROTOCOL_V1, SYNC_PULL_PATH, SYNC_PUSH_PATH,
 };
 pub use state::{CollectionState, PendingMutation, SyncReason, SyncRequest};
 

--- a/crates/pocopine-sync/src/local_memory.rs
+++ b/crates/pocopine-sync/src/local_memory.rs
@@ -491,7 +491,7 @@ mod tests {
             base_version: Some(RowVersion::new("row_1").unwrap()),
             payload: serde_json::json!({"title": "Saved"}),
 
-            migrated_payload: None,
+            migration_outcome: None,
         };
 
         store
@@ -542,7 +542,7 @@ mod tests {
                         base_version: None,
                         payload: serde_json::json!({ "id": id }),
 
-                        migrated_payload: None,
+                        migration_outcome: None,
                     },
                 )
                 .await
@@ -569,7 +569,7 @@ mod tests {
             base_version: Some(RowVersion::new("row_1").unwrap()),
             payload: serde_json::json!({"title": "First"}),
 
-            migrated_payload: None,
+            migration_outcome: None,
         };
         let second = ClientMutation {
             id: MutationId::new("device_abc:2").unwrap(),
@@ -578,7 +578,7 @@ mod tests {
             base_version: None,
             payload: serde_json::json!({"title": "Second"}),
 
-            migrated_payload: None,
+            migration_outcome: None,
         };
         let replacement = ClientMutation {
             id: first.id.clone(),
@@ -587,7 +587,7 @@ mod tests {
             base_version: Some(RowVersion::new("row_2").unwrap()),
             payload: serde_json::json!({"title": "Replacement"}),
 
-            migrated_payload: None,
+            migration_outcome: None,
         };
 
         store.enqueue_mutation(&stream, first).await.unwrap();
@@ -717,7 +717,7 @@ mod tests {
             base_version: None,
             payload: serde_json::json!({"title": "Local"}),
 
-            migrated_payload: None,
+            migration_outcome: None,
         };
         store
             .enqueue_mutation(&stream, mutation.clone())
@@ -756,7 +756,7 @@ mod tests {
                 "payload": {"id": "post_1", "draft": {"title": "Envelope only"}}
             }),
 
-            migrated_payload: None,
+            migration_outcome: None,
         };
         let optimistic = SyncRow::new(
             "post_1",
@@ -826,7 +826,7 @@ mod tests {
             base_version: None,
             payload: serde_json::json!({"title": "Accepted"}),
 
-            migrated_payload: None,
+            migration_outcome: None,
         };
         let rejected = ClientMutation {
             id: MutationId::new("device_abc:2").unwrap(),
@@ -835,7 +835,7 @@ mod tests {
             base_version: None,
             payload: serde_json::json!({"title": "Rejected"}),
 
-            migrated_payload: None,
+            migration_outcome: None,
         };
         let still_pending = ClientMutation {
             id: MutationId::new("device_abc:3").unwrap(),
@@ -844,7 +844,7 @@ mod tests {
             base_version: None,
             payload: serde_json::json!({"title": "Pending"}),
 
-            migrated_payload: None,
+            migration_outcome: None,
         };
         for mutation in [accepted.clone(), rejected.clone(), still_pending.clone()] {
             store.enqueue_mutation(&stream, mutation).await.unwrap();
@@ -1074,7 +1074,7 @@ mod tests {
             base_version: None,
             payload: serde_json::json!({"title": "Post"}),
 
-            migrated_payload: None,
+            migration_outcome: None,
         };
         let comment_mutation = ClientMutation {
             id: MutationId::new("device_abc:2").unwrap(),
@@ -1083,7 +1083,7 @@ mod tests {
             base_version: None,
             payload: serde_json::json!({"body": "Comment"}),
 
-            migrated_payload: None,
+            migration_outcome: None,
         };
         store
             .enqueue_mutation(&posts, post_mutation.clone())
@@ -1115,7 +1115,7 @@ mod tests {
             base_version: None,
             payload: serde_json::json!({ "title": "A first edit" }),
 
-            migrated_payload: None,
+            migration_outcome: None,
         };
         let post_a_again = ClientMutation {
             id: MutationId::new("device_abc:2").unwrap(),
@@ -1124,7 +1124,7 @@ mod tests {
             base_version: None,
             payload: serde_json::json!({ "title": "A second edit" }),
 
-            migrated_payload: None,
+            migration_outcome: None,
         };
         let post_b = ClientMutation {
             id: MutationId::new("device_abc:3").unwrap(),
@@ -1133,7 +1133,7 @@ mod tests {
             base_version: None,
             payload: serde_json::json!({ "title": "B" }),
 
-            migrated_payload: None,
+            migration_outcome: None,
         };
         for m in [&post_a, &post_a_again, &post_b] {
             store.enqueue_mutation(&stream, m.clone()).await.unwrap();
@@ -1164,7 +1164,7 @@ mod tests {
             base_version: None,
             payload: serde_json::json!({"global": true}),
 
-            migrated_payload: None,
+            migration_outcome: None,
         };
         let keyed_in_other_stream = ClientMutation {
             id: MutationId::new("device_abc:2").unwrap(),
@@ -1173,7 +1173,7 @@ mod tests {
             base_version: None,
             payload: serde_json::json!({}),
 
-            migrated_payload: None,
+            migration_outcome: None,
         };
         store
             .enqueue_mutation(&posts, unkeyed.clone())
@@ -1250,7 +1250,7 @@ mod tests {
                     base_version: None,
                     payload: serde_json::json!({"title": "edit"}),
 
-                    migrated_payload: None,
+                    migration_outcome: None,
                 },
             )
             .await
@@ -1327,7 +1327,7 @@ mod tests {
                     base_version: None,
                     payload: serde_json::json!({"title": "edit"}),
 
-                    migrated_payload: None,
+                    migration_outcome: None,
                 },
             )
             .await

--- a/crates/pocopine-sync/src/local_memory.rs
+++ b/crates/pocopine-sync/src/local_memory.rs
@@ -490,6 +490,8 @@ mod tests {
             op: SyncOp::Upsert,
             base_version: Some(RowVersion::new("row_1").unwrap()),
             payload: serde_json::json!({"title": "Saved"}),
+
+            migrated_payload: None,
         };
 
         store
@@ -539,6 +541,8 @@ mod tests {
                         op: SyncOp::Upsert,
                         base_version: None,
                         payload: serde_json::json!({ "id": id }),
+
+                        migrated_payload: None,
                     },
                 )
                 .await
@@ -564,6 +568,8 @@ mod tests {
             op: SyncOp::Upsert,
             base_version: Some(RowVersion::new("row_1").unwrap()),
             payload: serde_json::json!({"title": "First"}),
+
+            migrated_payload: None,
         };
         let second = ClientMutation {
             id: MutationId::new("device_abc:2").unwrap(),
@@ -571,6 +577,8 @@ mod tests {
             op: SyncOp::Upsert,
             base_version: None,
             payload: serde_json::json!({"title": "Second"}),
+
+            migrated_payload: None,
         };
         let replacement = ClientMutation {
             id: first.id.clone(),
@@ -578,6 +586,8 @@ mod tests {
             op: SyncOp::Upsert,
             base_version: Some(RowVersion::new("row_2").unwrap()),
             payload: serde_json::json!({"title": "Replacement"}),
+
+            migrated_payload: None,
         };
 
         store.enqueue_mutation(&stream, first).await.unwrap();
@@ -706,6 +716,8 @@ mod tests {
             op: SyncOp::Upsert,
             base_version: None,
             payload: serde_json::json!({"title": "Local"}),
+
+            migrated_payload: None,
         };
         store
             .enqueue_mutation(&stream, mutation.clone())
@@ -743,6 +755,8 @@ mod tests {
                 "op": "create",
                 "payload": {"id": "post_1", "draft": {"title": "Envelope only"}}
             }),
+
+            migrated_payload: None,
         };
         let optimistic = SyncRow::new(
             "post_1",
@@ -811,6 +825,8 @@ mod tests {
             op: SyncOp::Upsert,
             base_version: None,
             payload: serde_json::json!({"title": "Accepted"}),
+
+            migrated_payload: None,
         };
         let rejected = ClientMutation {
             id: MutationId::new("device_abc:2").unwrap(),
@@ -818,6 +834,8 @@ mod tests {
             op: SyncOp::Upsert,
             base_version: None,
             payload: serde_json::json!({"title": "Rejected"}),
+
+            migrated_payload: None,
         };
         let still_pending = ClientMutation {
             id: MutationId::new("device_abc:3").unwrap(),
@@ -825,6 +843,8 @@ mod tests {
             op: SyncOp::Upsert,
             base_version: None,
             payload: serde_json::json!({"title": "Pending"}),
+
+            migrated_payload: None,
         };
         for mutation in [accepted.clone(), rejected.clone(), still_pending.clone()] {
             store.enqueue_mutation(&stream, mutation).await.unwrap();
@@ -1053,6 +1073,8 @@ mod tests {
             op: SyncOp::Upsert,
             base_version: None,
             payload: serde_json::json!({"title": "Post"}),
+
+            migrated_payload: None,
         };
         let comment_mutation = ClientMutation {
             id: MutationId::new("device_abc:2").unwrap(),
@@ -1060,6 +1082,8 @@ mod tests {
             op: SyncOp::Upsert,
             base_version: None,
             payload: serde_json::json!({"body": "Comment"}),
+
+            migrated_payload: None,
         };
         store
             .enqueue_mutation(&posts, post_mutation.clone())
@@ -1090,6 +1114,8 @@ mod tests {
             op: SyncOp::Upsert,
             base_version: None,
             payload: serde_json::json!({ "title": "A first edit" }),
+
+            migrated_payload: None,
         };
         let post_a_again = ClientMutation {
             id: MutationId::new("device_abc:2").unwrap(),
@@ -1097,6 +1123,8 @@ mod tests {
             op: SyncOp::Upsert,
             base_version: None,
             payload: serde_json::json!({ "title": "A second edit" }),
+
+            migrated_payload: None,
         };
         let post_b = ClientMutation {
             id: MutationId::new("device_abc:3").unwrap(),
@@ -1104,6 +1132,8 @@ mod tests {
             op: SyncOp::Upsert,
             base_version: None,
             payload: serde_json::json!({ "title": "B" }),
+
+            migrated_payload: None,
         };
         for m in [&post_a, &post_a_again, &post_b] {
             store.enqueue_mutation(&stream, m.clone()).await.unwrap();
@@ -1133,6 +1163,8 @@ mod tests {
             op: SyncOp::Upsert,
             base_version: None,
             payload: serde_json::json!({"global": true}),
+
+            migrated_payload: None,
         };
         let keyed_in_other_stream = ClientMutation {
             id: MutationId::new("device_abc:2").unwrap(),
@@ -1140,6 +1172,8 @@ mod tests {
             op: SyncOp::Upsert,
             base_version: None,
             payload: serde_json::json!({}),
+
+            migrated_payload: None,
         };
         store
             .enqueue_mutation(&posts, unkeyed.clone())
@@ -1215,6 +1249,8 @@ mod tests {
                     op: SyncOp::Upsert,
                     base_version: None,
                     payload: serde_json::json!({"title": "edit"}),
+
+                    migrated_payload: None,
                 },
             )
             .await
@@ -1290,6 +1326,8 @@ mod tests {
                     op: SyncOp::Upsert,
                     base_version: None,
                     payload: serde_json::json!({"title": "edit"}),
+
+                    migrated_payload: None,
                 },
             )
             .await

--- a/crates/pocopine-sync/src/local_store.rs
+++ b/crates/pocopine-sync/src/local_store.rs
@@ -614,6 +614,8 @@ mod tests {
             op: SyncOp::Upsert,
             base_version: None,
             payload: serde_json::json!({"op": "create"}),
+
+            migrated_payload: None,
         };
         let optimistic = SyncRow::new("post_1", serde_json::json!({"title": "Visible"})).unwrap();
 

--- a/crates/pocopine-sync/src/local_store.rs
+++ b/crates/pocopine-sync/src/local_store.rs
@@ -615,7 +615,7 @@ mod tests {
             base_version: None,
             payload: serde_json::json!({"op": "create"}),
 
-            migrated_payload: None,
+            migration_outcome: None,
         };
         let optimistic = SyncRow::new("post_1", serde_json::json!({"title": "Visible"})).unwrap();
 

--- a/crates/pocopine-sync/src/memory.rs
+++ b/crates/pocopine-sync/src/memory.rs
@@ -512,7 +512,7 @@ mod tests {
                 op: SyncOp::Upsert,
                 base_version: None,
                 payload: Value::String("hello".to_string()),
-                migrated_payload: None,
+                migration_outcome: None,
             }],
         );
 
@@ -545,7 +545,7 @@ mod tests {
                 base_version: None,
                 payload: serde_json::json!({"not": "a string"}),
 
-                migrated_payload: None,
+                migration_outcome: None,
             }],
         );
 
@@ -575,7 +575,7 @@ mod tests {
                 op: SyncOp::Upsert,
                 base_version: Some(RowVersion::new("v0").unwrap()),
                 payload: Value::String("client".to_string()),
-                migrated_payload: None,
+                migration_outcome: None,
             }],
         );
 
@@ -598,7 +598,7 @@ mod tests {
             op: SyncOp::Upsert,
             base_version: None,
             payload: Value::String("hello".to_string()),
-            migrated_payload: None,
+            migration_outcome: None,
         };
 
         stream

--- a/crates/pocopine-sync/src/memory.rs
+++ b/crates/pocopine-sync/src/memory.rs
@@ -512,6 +512,7 @@ mod tests {
                 op: SyncOp::Upsert,
                 base_version: None,
                 payload: Value::String("hello".to_string()),
+                migrated_payload: None,
             }],
         );
 
@@ -543,6 +544,8 @@ mod tests {
                 op: SyncOp::Upsert,
                 base_version: None,
                 payload: serde_json::json!({"not": "a string"}),
+
+                migrated_payload: None,
             }],
         );
 
@@ -572,6 +575,7 @@ mod tests {
                 op: SyncOp::Upsert,
                 base_version: Some(RowVersion::new("v0").unwrap()),
                 payload: Value::String("client".to_string()),
+                migrated_payload: None,
             }],
         );
 
@@ -594,6 +598,7 @@ mod tests {
             op: SyncOp::Upsert,
             base_version: None,
             payload: Value::String("hello".to_string()),
+            migrated_payload: None,
         };
 
         stream

--- a/crates/pocopine-sync/src/protocol.rs
+++ b/crates/pocopine-sync/src/protocol.rs
@@ -404,6 +404,16 @@ impl<T> SyncPullResponse<T> {
 
 /// Client mutation envelope. The first slice defines the wire format;
 /// concrete mutation application belongs to stream sources.
+///
+/// The two server-side sidecars (`migrated_payload`, `migration_error`)
+/// are set by the framework's `push_handler` when a stale-schema
+/// request runs through `SyncStreamSource::migrate_payload`. They are
+/// `#[serde(skip)]`, never on the wire, and always `None` for
+/// client-built mutations. Sources consume them via
+/// `take_processing_payload` AFTER consulting their idempotency log
+/// against the ORIGINAL `payload` — so a retry of an
+/// already-accepted mutation succeeds even when the registered
+/// migrator now rejects (or panics) on the same inputs.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(bound(serialize = "M: Serialize", deserialize = "M: Deserialize<'de>"))]
 pub struct ClientMutation<M> {
@@ -412,15 +422,29 @@ pub struct ClientMutation<M> {
     pub op: SyncOp,
     pub base_version: Option<RowVersion>,
     pub payload: M,
-    /// Server-side sidecar set by the framework's `push_handler` when a
-    /// stale-schema request is migrated via
-    /// `SyncStreamSource::migrate_payload`. Stays `None` on the wire
-    /// (via `#[serde(skip)]`) and `None` for client-built mutations.
-    /// Stream sources MUST process `migrated_payload.as_ref().unwrap_or(&payload)`
-    /// but store the original `payload` for idempotency tracking — see
-    /// `processing_payload` / `original_payload` helpers.
+    /// Server-side sidecar: the result of `migrate_payload` on this
+    /// mutation. `Some(Ok(value))` is the migrated payload to apply;
+    /// `Some(Err(reason))` is a migration failure to surface IF the
+    /// mutation isn't already idempotent-accepted; `None` means no
+    /// migration was needed (request schema matches server schema).
     #[serde(skip)]
-    pub migrated_payload: Option<M>,
+    pub migration_outcome: Option<MigrationOutcome<M>>,
+}
+
+/// Outcome of `migrate_payload` for one mutation, carried as a
+/// server-only sidecar inside `ClientMutation`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum MigrationOutcome<M> {
+    /// Successful migration: this is the payload to deserialize and
+    /// apply (the original wire payload is preserved in `payload`
+    /// for idempotency-log comparison).
+    Migrated(M),
+    /// Migration failed. The reason should surface as a per-mutation
+    /// rejection — but ONLY if the source's idempotency log doesn't
+    /// already have this mutation_id+payload as accepted. A retry of
+    /// a previously-accepted mutation should always succeed
+    /// regardless of whether the current migrator would accept it.
+    Failed { reason: String },
 }
 
 impl<M> ClientMutation<M> {
@@ -432,31 +456,30 @@ impl<M> ClientMutation<M> {
             op,
             base_version: None,
             payload,
-            migrated_payload: None,
+            migration_outcome: None,
         }
     }
 
-    /// Returns a reference to the payload the source should DESERIALIZE
-    /// and APPLY: the migrated payload if `push_handler` ran a schema
-    /// migration, otherwise the original wire payload. Use this for the
-    /// actual write path.
-    pub fn processing_payload(&self) -> &M {
-        self.migrated_payload.as_ref().unwrap_or(&self.payload)
-    }
-
-    /// Take the payload the source should apply (migrated if present,
-    /// else original), consuming the sidecar. Stream-source `push`
-    /// implementations call this when they need an owned payload to
-    /// feed into deserialization. The mutation's `payload` field still
-    /// holds the original wire shape, so idempotency comparisons /
-    /// mutation-log writes can key on `payload` (NOT this return).
-    pub fn take_processing_payload(&mut self) -> M
+    /// Take the payload the source should apply, consuming the
+    /// migration sidecar. Returns:
+    ///
+    /// * `Ok(value)` — the value to deserialize and apply (migrated
+    ///   if migration ran successfully, otherwise the original wire
+    ///   payload).
+    /// * `Err(reason)` — the migrator rejected this mutation. The
+    ///   caller must already have checked its idempotency log
+    ///   against `mutation.payload` — only mutations NOT in the log
+    ///   should surface this error.
+    ///
+    /// `mutation.payload` is left intact for idempotency comparisons.
+    pub fn take_processing_payload(&mut self) -> Result<M, String>
     where
         M: Clone,
     {
-        match self.migrated_payload.take() {
-            Some(migrated) => migrated,
-            None => self.payload.clone(),
+        match self.migration_outcome.take() {
+            Some(MigrationOutcome::Migrated(value)) => Ok(value),
+            Some(MigrationOutcome::Failed { reason }) => Err(reason),
+            None => Ok(self.payload.clone()),
         }
     }
 
@@ -615,7 +638,7 @@ impl<M> ClientMutationDraft<M> {
             op: self.op,
             base_version: self.base_version,
             payload: self.payload,
-            migrated_payload: None,
+            migration_outcome: None,
         }
     }
 }

--- a/crates/pocopine-sync/src/protocol.rs
+++ b/crates/pocopine-sync/src/protocol.rs
@@ -565,6 +565,16 @@ pub struct SyncPushRequest<M> {
     pub stream: SyncStreamName,
     #[serde(default)]
     pub mutations: Vec<ClientMutation<M>>,
+    /// Application-level schema version the CLIENT encoded these
+    /// mutations against. The server compares against
+    /// `SyncStreamSource::schema_version()`; on mismatch the source's
+    /// `migrate_payload` is invoked per mutation. A source that hasn't
+    /// registered a migrator rejects each mutation with
+    /// `SyncError::SchemaMigration`. Defaults to `1` so an old client
+    /// that doesn't send the field is treated as v1, matching Batch 1's
+    /// default for `SyncStreamSource::schema_version`.
+    #[serde(default = "default_schema_version_one")]
+    pub schema_version: u32,
 }
 
 impl<M> SyncPushRequest<M> {
@@ -576,7 +586,16 @@ impl<M> SyncPushRequest<M> {
             protocol: SYNC_PROTOCOL_V1.to_string(),
             stream,
             mutations: mutations.into_iter().collect(),
+            schema_version: default_schema_version_one(),
         }
+    }
+
+    /// Set the application-level schema version the mutations are
+    /// encoded under. Generated client helpers fill this from the
+    /// resource's compile-time `SCHEMA_VERSION` constant.
+    pub fn with_schema_version(mut self, schema_version: u32) -> Self {
+        self.schema_version = schema_version;
+        self
     }
 }
 

--- a/crates/pocopine-sync/src/protocol.rs
+++ b/crates/pocopine-sync/src/protocol.rs
@@ -267,8 +267,13 @@ pub struct SyncOpenStream {
     /// is still valid. The `#[serde(default)]` makes the wire field
     /// backwards-compatible: an old server response without the field
     /// deserializes as `1`, and an old client reading a field-bearing
-    /// response just ignores it (serde drops unknown fields).
-    #[serde(default = "default_schema_version_one")]
+    /// response just ignores it (serde drops unknown fields). Explicit
+    /// JSON `null` is also coerced to the default for clients (TS,
+    /// Python) that emit `null` for unset fields.
+    #[serde(
+        default = "default_schema_version_one",
+        deserialize_with = "deserialize_schema_version_default_one"
+    )]
     pub schema_version: u32,
 }
 
@@ -277,6 +282,29 @@ pub struct SyncOpenStream {
 /// schema" — apps that have never bumped never observe this field.
 pub fn default_schema_version_one() -> u32 {
     1
+}
+
+/// Custom deserializer for the wire `schema_version` field. Accepts:
+///
+/// * the field being absent (handled by `#[serde(default = ...)]` —
+///   this deserializer isn't called),
+/// * the field being explicit `null` (TypeScript / Python clients
+///   that emit `null` for unset fields), AND
+/// * a normal `u32` value.
+///
+/// Both `missing` and `null` collapse to
+/// [`default_schema_version_one`]. Without this, an explicit
+/// `"schema_version": null` would fail deserialization with `invalid
+/// type: null, expected u32`, which a non-Rust client cannot
+/// distinguish from a network error.
+pub(crate) fn deserialize_schema_version_default_one<'de, D>(
+    deserializer: D,
+) -> Result<u32, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let opt = Option::<u32>::deserialize(deserializer)?;
+    Ok(opt.unwrap_or_else(default_schema_version_one))
 }
 
 /// Open response.
@@ -384,6 +412,15 @@ pub struct ClientMutation<M> {
     pub op: SyncOp,
     pub base_version: Option<RowVersion>,
     pub payload: M,
+    /// Server-side sidecar set by the framework's `push_handler` when a
+    /// stale-schema request is migrated via
+    /// `SyncStreamSource::migrate_payload`. Stays `None` on the wire
+    /// (via `#[serde(skip)]`) and `None` for client-built mutations.
+    /// Stream sources MUST process `migrated_payload.as_ref().unwrap_or(&payload)`
+    /// but store the original `payload` for idempotency tracking — see
+    /// `processing_payload` / `original_payload` helpers.
+    #[serde(skip)]
+    pub migrated_payload: Option<M>,
 }
 
 impl<M> ClientMutation<M> {
@@ -395,6 +432,31 @@ impl<M> ClientMutation<M> {
             op,
             base_version: None,
             payload,
+            migrated_payload: None,
+        }
+    }
+
+    /// Returns a reference to the payload the source should DESERIALIZE
+    /// and APPLY: the migrated payload if `push_handler` ran a schema
+    /// migration, otherwise the original wire payload. Use this for the
+    /// actual write path.
+    pub fn processing_payload(&self) -> &M {
+        self.migrated_payload.as_ref().unwrap_or(&self.payload)
+    }
+
+    /// Take the payload the source should apply (migrated if present,
+    /// else original), consuming the sidecar. Stream-source `push`
+    /// implementations call this when they need an owned payload to
+    /// feed into deserialization. The mutation's `payload` field still
+    /// holds the original wire shape, so idempotency comparisons /
+    /// mutation-log writes can key on `payload` (NOT this return).
+    pub fn take_processing_payload(&mut self) -> M
+    where
+        M: Clone,
+    {
+        match self.migrated_payload.take() {
+            Some(migrated) => migrated,
+            None => self.payload.clone(),
         }
     }
 
@@ -553,6 +615,7 @@ impl<M> ClientMutationDraft<M> {
             op: self.op,
             base_version: self.base_version,
             payload: self.payload,
+            migrated_payload: None,
         }
     }
 }
@@ -567,13 +630,17 @@ pub struct SyncPushRequest<M> {
     pub mutations: Vec<ClientMutation<M>>,
     /// Application-level schema version the CLIENT encoded these
     /// mutations against. The server compares against
-    /// `SyncStreamSource::schema_version()`; on mismatch the source's
-    /// `migrate_payload` is invoked per mutation. A source that hasn't
-    /// registered a migrator rejects each mutation with
-    /// `SyncError::SchemaMigration`. Defaults to `1` so an old client
-    /// that doesn't send the field is treated as v1, matching Batch 1's
-    /// default for `SyncStreamSource::schema_version`.
-    #[serde(default = "default_schema_version_one")]
+    /// `SyncStreamSource::schema_version()`; when the client is on an
+    /// OLDER version, the source's `migrate_payload` is invoked per
+    /// mutation. A source that hasn't registered a migrator rejects
+    /// each mutation with `SyncError::SchemaMigration`. Defaults to
+    /// `1` so an old client that doesn't send the field is treated
+    /// as v1; explicit JSON `null` is coerced to the default too,
+    /// for clients (TS, Python) that emit `null` for unset fields.
+    #[serde(
+        default = "default_schema_version_one",
+        deserialize_with = "deserialize_schema_version_default_one"
+    )]
     pub schema_version: u32,
 }
 
@@ -592,9 +659,18 @@ impl<M> SyncPushRequest<M> {
 
     /// Set the application-level schema version the mutations are
     /// encoded under. Generated client helpers fill this from the
-    /// resource's compile-time `SCHEMA_VERSION` constant.
+    /// resource's compile-time `SCHEMA_VERSION` constant. `0` is
+    /// coerced to `1` (the framework's canonical default) so the
+    /// builder cannot accidentally smuggle an out-of-range value
+    /// onto the wire — the server's push handler also rejects `0`
+    /// defensively in case a raw `SyncPushRequest` is constructed
+    /// via struct literal.
     pub fn with_schema_version(mut self, schema_version: u32) -> Self {
-        self.schema_version = schema_version;
+        self.schema_version = if schema_version == 0 {
+            default_schema_version_one()
+        } else {
+            schema_version
+        };
         self
     }
 }
@@ -610,6 +686,12 @@ pub struct SyncConflict<T> {
 }
 
 /// Rejected mutation returned by a push.
+///
+/// **Ordering:** `SyncPushResponse::rejected` is NOT guaranteed to
+/// match the request's mutation order. The server may surface
+/// schema-migration rejections after source-side rejections (or
+/// vice versa). Consumers should correlate by `mutation_id`, not by
+/// index.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct SyncRejectedMutation {
     pub mutation_id: MutationId,
@@ -703,6 +785,74 @@ mod tests {
             sync_stream_tag("posts_for_tenant"),
             "sync:stream:posts_for_tenant"
         );
+    }
+
+    #[test]
+    fn open_stream_schema_version_accepts_missing_and_explicit_null() {
+        // Missing field — the existing `#[serde(default)]` already
+        // handled this; lock the behaviour against future changes.
+        let json = serde_json::json!({
+            "stream": "posts",
+            "collection": "posts",
+            "cursor": null,
+        });
+        let stream: SyncOpenStream = serde_json::from_value(json).unwrap();
+        assert_eq!(stream.schema_version, 1);
+
+        // Explicit JSON null — the new `deserialize_with` coerces it
+        // to the default. Without this, non-Rust clients emitting
+        // `{"schema_version": null}` would fail with `invalid type:
+        // null, expected u32`.
+        let json = serde_json::json!({
+            "stream": "posts",
+            "collection": "posts",
+            "cursor": null,
+            "schema_version": null,
+        });
+        let stream: SyncOpenStream = serde_json::from_value(json).unwrap();
+        assert_eq!(stream.schema_version, 1);
+
+        // A concrete value still round-trips.
+        let json = serde_json::json!({
+            "stream": "posts",
+            "collection": "posts",
+            "cursor": null,
+            "schema_version": 7,
+        });
+        let stream: SyncOpenStream = serde_json::from_value(json).unwrap();
+        assert_eq!(stream.schema_version, 7);
+    }
+
+    #[test]
+    fn push_request_schema_version_accepts_missing_and_explicit_null() {
+        let stream = SyncStreamName::new("posts").unwrap();
+        // Missing → default 1.
+        let json = serde_json::json!({
+            "protocol": SYNC_PROTOCOL_V1,
+            "stream": "posts",
+            "mutations": [],
+        });
+        let req: SyncPushRequest<serde_json::Value> = serde_json::from_value(json).unwrap();
+        assert_eq!(req.schema_version, 1);
+        let _ = stream;
+        // Explicit null → coerced to default 1.
+        let json = serde_json::json!({
+            "protocol": SYNC_PROTOCOL_V1,
+            "stream": "posts",
+            "mutations": [],
+            "schema_version": null,
+        });
+        let req: SyncPushRequest<serde_json::Value> = serde_json::from_value(json).unwrap();
+        assert_eq!(req.schema_version, 1);
+    }
+
+    #[test]
+    fn with_schema_version_coerces_zero_to_default() {
+        let stream = SyncStreamName::new("posts").unwrap();
+        let req: SyncPushRequest<serde_json::Value> = SyncPushRequest::new(stream, []);
+        let req = req.with_schema_version(0);
+        // Builder coerces 0 → 1 so a stray default never lands on the wire.
+        assert_eq!(req.schema_version, 1);
     }
 
     #[test]

--- a/crates/pocopine-sync/src/server.rs
+++ b/crates/pocopine-sync/src/server.rs
@@ -18,7 +18,7 @@ use serde_json::Value;
 use crate::{
     sync_stream_tag, ClientMutation, SyncError, SyncOpenRequest, SyncOpenResponse, SyncOpenStream,
     SyncPullRequest, SyncPullResponse, SyncPushRequest, SyncPushResponse, SyncRejectedMutation,
-    SyncResult, SYNC_OPEN_PATH, SYNC_PULL_PATH, SYNC_PUSH_PATH,
+    SyncResult, SYNC_OPEN_PATH, SYNC_PROTOCOL_V1, SYNC_PULL_PATH, SYNC_PUSH_PATH,
 };
 
 /// Future returned by a stream source.
@@ -116,21 +116,26 @@ pub trait SyncStreamSource: Send + Sync + 'static {
     /// the source's currently-advertised schema version `to`.
     ///
     /// The framework's `push_handler` invokes this once per mutation
-    /// when the request's `schema_version` differs from
-    /// `self.schema_version()`. The default implementation returns
-    /// `SyncError::SchemaMigration` so any out-of-tree source that
-    /// hasn't opted in surfaces a clean per-mutation rejection rather
-    /// than silently mis-deserializing stale payloads into the new
-    /// shape. Apps that want to accept stale pushes (e.g. to preserve
-    /// side-effecting writes like payments across a schema bump)
-    /// override this method directly or use the
-    /// `#[resource(schema_version = N, migrate_with = path)]` macro
-    /// attribute which generates the impl.
+    /// when the request's `schema_version` is **strictly less than**
+    /// `self.schema_version()`. A newer client pushing to an older
+    /// server (rolling-deploy edge case) is NOT routed through
+    /// migration — the source receives the newer-shape payload as-is.
     ///
-    /// On `Ok`, the framework substitutes the migrated payload into
-    /// the mutation before delegating to `push`. On `Err`, the
-    /// mutation is added to the response's `rejected` array with the
-    /// error's `reason`; the rest of the batch continues.
+    /// The default implementation returns `SyncError::SchemaMigration`
+    /// so any out-of-tree source that hasn't opted in surfaces a clean
+    /// per-mutation rejection rather than silently mis-deserializing
+    /// stale payloads into the new shape. Apps that want to accept
+    /// stale pushes (e.g. to preserve side-effecting writes like
+    /// payments across a schema bump) override this method directly or
+    /// use the `#[resource(schema_version = N, migrate_with = path)]`
+    /// macro attribute which generates the impl.
+    ///
+    /// On `Ok`, the framework stores the migrated payload alongside
+    /// the original (via `ClientMutation::migrated_payload`) so the
+    /// source can deserialize the migrated value while still keying
+    /// its idempotency log on the original wire payload. On `Err`,
+    /// the mutation is added to the response's `rejected` array with
+    /// the error's `reason`; the rest of the batch continues.
     fn migrate_payload<'a>(&'a self, from: u32, to: u32, value: Value) -> SyncBoxFuture<'a, Value> {
         let _ = value;
         let stream = self.stream().as_str().to_string();
@@ -366,24 +371,48 @@ async fn push_handler(
 ) -> Json<ServerResult<SyncPushResponse<Value>>> {
     let result = async {
         let (ctx, mut request) = parse_json_request::<SyncPushRequest<Value>>(request).await?;
+        // Reject malformed wire payloads up-front: `schema_version == 0`
+        // is not a valid version (versions start at 1) and the macro,
+        // builder, and `/open` response validators all reject it. Match
+        // here so a malicious or buggy client can't tunnel through
+        // `migrate_payload` with `from = 0`.
+        if request.schema_version == 0 {
+            return Err(server_error(SyncError::invalid_value(
+                "schema_version",
+                "must be >= 1 (schema versions start at 1)",
+            )));
+        }
         let stream = sync.stream(request.stream.as_str()).map_err(server_error)?;
         stream.authorize(ctx.clone()).await?;
-        // If the client and server disagree on the application-level
-        // schema version, run each mutation's payload through the
-        // source's `migrate_payload`. Mutations that can't be migrated
-        // (default impl returns Err(SchemaMigration)) get a typed
-        // rejection in `pre_rejected`; the survivors continue into
-        // `source.push` carrying their migrated payloads. The
-        // request's schema_version is then updated so the source
-        // sees a self-consistent batch.
+        // If the client is on an OLDER schema version than the server,
+        // run each mutation's payload through the source's
+        // `migrate_payload`. Mutations that can't be migrated (default
+        // impl returns Err(SchemaMigration)) get a typed rejection in
+        // `pre_rejected`; the survivors continue into `source.push`
+        // carrying their migrated payload via `ClientMutation::migrated_payload`
+        // so the source still sees the original wire payload for
+        // idempotency-log purposes.
+        //
+        // The comparison is `<` (not `!=`) deliberately: a NEWER client
+        // pushing to an OLDER server (mid-rolling-deploy) shouldn't try
+        // to "migrate down" — the source either accepts the newer
+        // shape as-is (often forward-compatible) or rejects with a
+        // typed deserialization error. Migrating backwards is an
+        // unwinnable game for the framework.
         let mut pre_rejected: Vec<SyncRejectedMutation> = Vec::new();
         let server_schema_version = stream.source.schema_version();
-        if request.schema_version != server_schema_version {
+        if request.schema_version < server_schema_version {
             let from = request.schema_version;
             let to = server_schema_version;
             let mut survivors: Vec<ClientMutation<Value>> =
                 Vec::with_capacity(request.mutations.len());
             for mutation in request.mutations.drain(..) {
+                // Stream sources are responsible for catching panics
+                // inside their own migrator closures (CrudResource
+                // wraps user-supplied `migrate_with` fns in
+                // `catch_unwind` already). The framework just routes
+                // the typed `Err(SyncError::Backend("…panicked…"))`
+                // into a per-mutation rejection.
                 match stream
                     .source
                     .migrate_payload(from, to, mutation.payload.clone())
@@ -391,10 +420,19 @@ async fn push_handler(
                 {
                     Ok(migrated) => {
                         let mut next = mutation;
-                        next.payload = migrated;
+                        next.migrated_payload = Some(migrated);
                         survivors.push(next);
                     }
                     Err(err) => {
+                        tracing::info!(
+                            target: "pocopine.log",
+                            stream = stream.source.stream().as_str(),
+                            from,
+                            to,
+                            mutation_id = mutation.id.as_str(),
+                            reason = %err,
+                            "sync push pre-rejected by migrate_payload"
+                        );
                         pre_rejected.push(SyncRejectedMutation {
                             mutation_id: mutation.id,
                             key: mutation.key,
@@ -404,18 +442,50 @@ async fn push_handler(
                 }
             }
             request.mutations = survivors;
-            request.schema_version = server_schema_version;
+            // NOTE: we deliberately leave `request.schema_version` as
+            // the client's wire value. Custom `SyncStreamSource::push`
+            // impls may consult it for logging/audit/version-aware
+            // routing; rewriting it would silently lie about what the
+            // client claimed. The migrated payload travels inside each
+            // mutation via `ClientMutation::migrated_payload`.
         }
-        let mut response = stream
-            .source
-            .push(ctx, request)
-            .await
-            .map_err(server_error)?;
+        // Build the response shell ahead of `source.push` so that even
+        // a transient `source.push` failure still surfaces the
+        // pre-migration rejections to the client. Without this the `?`
+        // propagation would drop `pre_rejected` on the floor and the
+        // client would replay the stale-schema mutations forever.
+        let stream_name = stream.source.stream().clone();
+        let collection_name = stream.source.collection().clone();
+        let mut response = match stream.source.push(ctx, request).await {
+            Ok(response) => response,
+            Err(err) => {
+                if pre_rejected.is_empty() {
+                    return Err(server_error(err));
+                }
+                tracing::warn!(
+                    target: "pocopine.log",
+                    error = %err,
+                    stream = stream_name.as_str(),
+                    pre_rejected = pre_rejected.len(),
+                    "sync push source returned error; surfacing pre-migration rejections only"
+                );
+                SyncPushResponse {
+                    protocol: SYNC_PROTOCOL_V1.to_string(),
+                    stream: stream_name.clone(),
+                    collection: Some(collection_name.clone()),
+                    accepted: Vec::new(),
+                    rejected: Vec::new(),
+                    rows: Vec::new(),
+                    conflicts: Vec::new(),
+                    cursor: None,
+                }
+            }
+        };
         if !pre_rejected.is_empty() {
             response.rejected.extend(pre_rejected);
         }
         if response.collection.is_none() {
-            response.collection = Some(stream.source.collection().clone());
+            response.collection = Some(collection_name);
         }
         if !response.accepted.is_empty() {
             if let Err(err) = sync.invalidate_stream(response.stream.as_str()).await {
@@ -533,6 +603,7 @@ mod tests {
                 op: SyncOp::Upsert,
                 base_version: None,
                 payload: "from push".to_string(),
+                migrated_payload: None,
             }],
         );
         let outer: ServerResult<SyncPushResponse<String>> =

--- a/crates/pocopine-sync/src/server.rs
+++ b/crates/pocopine-sync/src/server.rs
@@ -16,9 +16,9 @@ use serde::de::DeserializeOwned;
 use serde_json::Value;
 
 use crate::{
-    sync_stream_tag, ClientMutation, SyncError, SyncOpenRequest, SyncOpenResponse, SyncOpenStream,
-    SyncPullRequest, SyncPullResponse, SyncPushRequest, SyncPushResponse, SyncRejectedMutation,
-    SyncResult, SYNC_OPEN_PATH, SYNC_PROTOCOL_V1, SYNC_PULL_PATH, SYNC_PUSH_PATH,
+    sync_stream_tag, MigrationOutcome, SyncError, SyncOpenRequest, SyncOpenResponse,
+    SyncOpenStream, SyncPullRequest, SyncPullResponse, SyncPushRequest, SyncPushResponse,
+    SyncResult, SYNC_OPEN_PATH, SYNC_PULL_PATH, SYNC_PUSH_PATH,
 };
 
 /// Future returned by a stream source.
@@ -131,11 +131,22 @@ pub trait SyncStreamSource: Send + Sync + 'static {
     /// macro attribute which generates the impl.
     ///
     /// On `Ok`, the framework stores the migrated payload alongside
-    /// the original (via `ClientMutation::migrated_payload`) so the
+    /// the original (via `ClientMutation::migration_outcome`) so the
     /// source can deserialize the migrated value while still keying
     /// its idempotency log on the original wire payload. On `Err`,
-    /// the mutation is added to the response's `rejected` array with
-    /// the error's `reason`; the rest of the batch continues.
+    /// the framework stores the error reason in the same sidecar —
+    /// the source surfaces it as a per-mutation rejection ONLY for
+    /// mutations not already in its idempotency log (a retry of an
+    /// already-accepted mutation succeeds even if the migrator now
+    /// rejects). See `ClientMutation::take_processing_payload`.
+    ///
+    /// **Envelope constraint.** This method migrates the
+    /// `serde_json::Value` payload only — it CANNOT migrate the
+    /// outer `ClientMutation` (`key`, `op`, `base_version`). For
+    /// changes to row-key shape (e.g. ID rename), prefer the
+    /// default drop-the-cache path: bump `schema_version`, let the
+    /// client wipe pending mutations + canonical rows, and rebuild
+    /// from `/pull`.
     fn migrate_payload<'a>(&'a self, from: u32, to: u32, value: Value) -> SyncBoxFuture<'a, Value> {
         let _ = value;
         let stream = self.stream().as_str().to_string();
@@ -384,44 +395,57 @@ async fn push_handler(
         }
         let stream = sync.stream(request.stream.as_str()).map_err(server_error)?;
         stream.authorize(ctx.clone()).await?;
-        // If the client is on an OLDER schema version than the server,
-        // run each mutation's payload through the source's
-        // `migrate_payload`. Mutations that can't be migrated (default
-        // impl returns Err(SchemaMigration)) get a typed rejection in
-        // `pre_rejected`; the survivors continue into `source.push`
-        // carrying their migrated payload via `ClientMutation::migrated_payload`
-        // so the source still sees the original wire payload for
-        // idempotency-log purposes.
-        //
-        // The comparison is `<` (not `!=`) deliberately: a NEWER client
-        // pushing to an OLDER server (mid-rolling-deploy) shouldn't try
-        // to "migrate down" — the source either accepts the newer
-        // shape as-is (often forward-compatible) or rejects with a
-        // typed deserialization error. Migrating backwards is an
-        // unwinnable game for the framework.
-        let mut pre_rejected: Vec<SyncRejectedMutation> = Vec::new();
         let server_schema_version = stream.source.schema_version();
+        // Reject `request.schema_version > server_schema_version` at
+        // the wire layer. A newer client pushing to an older server
+        // (rolling-deploy edge case) cannot safely fall through to
+        // `source.push`: serde's default behaviour DROPS unknown
+        // fields, so the older deserializer would silently accept a
+        // newer-shape payload with fields missing. The client must
+        // back off and retry; the durable queue stays intact thanks
+        // to the typed error.
+        if request.schema_version > server_schema_version {
+            tracing::info!(
+                target: "pocopine.log",
+                stream = stream.source.stream().as_str(),
+                request_schema_version = request.schema_version,
+                server_schema_version,
+                "sync push rejected: client schema_version newer than server (likely mid-deploy)"
+            );
+            return Err(server_error(SyncError::schema_migration(
+                stream.source.stream().as_str().to_string(),
+                request.schema_version,
+                server_schema_version,
+            )));
+        }
+        // When the client is on an OLDER schema version, attach a
+        // per-mutation `migration_outcome` to each mutation. The
+        // outcome is consumed by the source's `push`:
+        //
+        //   * `MigrationOutcome::Migrated(value)` — successful
+        //     migration; the source applies the migrated value.
+        //   * `MigrationOutcome::Failed { reason }` — the migrator
+        //     rejected; the source surfaces the reason ONLY if its
+        //     idempotency log doesn't already have this mutation_id+
+        //     payload as accepted. This preserves replay-safety
+        //     across migrator changes (e.g., a v1 mutation was
+        //     accepted via a now-removed migrator; a retry from the
+        //     same client hits the log and accepts despite the
+        //     migrator no longer being registered).
+        //
+        // No pre-rejection happens at this layer — the source has
+        // final say.
         if request.schema_version < server_schema_version {
             let from = request.schema_version;
             let to = server_schema_version;
-            let mut survivors: Vec<ClientMutation<Value>> =
-                Vec::with_capacity(request.mutations.len());
-            for mutation in request.mutations.drain(..) {
-                // Stream sources are responsible for catching panics
-                // inside their own migrator closures (CrudResource
-                // wraps user-supplied `migrate_with` fns in
-                // `catch_unwind` already). The framework just routes
-                // the typed `Err(SyncError::Backend("…panicked…"))`
-                // into a per-mutation rejection.
+            for mutation in request.mutations.iter_mut() {
                 match stream
                     .source
                     .migrate_payload(from, to, mutation.payload.clone())
                     .await
                 {
                     Ok(migrated) => {
-                        let mut next = mutation;
-                        next.migrated_payload = Some(migrated);
-                        survivors.push(next);
+                        mutation.migration_outcome = Some(MigrationOutcome::Migrated(migrated));
                     }
                     Err(err) => {
                         tracing::info!(
@@ -431,59 +455,26 @@ async fn push_handler(
                             to,
                             mutation_id = mutation.id.as_str(),
                             reason = %err,
-                            "sync push pre-rejected by migrate_payload"
+                            "sync push migrate_payload failed; deferring to source idempotency check"
                         );
-                        pre_rejected.push(SyncRejectedMutation {
-                            mutation_id: mutation.id,
-                            key: mutation.key,
+                        mutation.migration_outcome = Some(MigrationOutcome::Failed {
                             reason: err.to_string(),
                         });
                     }
                 }
             }
-            request.mutations = survivors;
             // NOTE: we deliberately leave `request.schema_version` as
             // the client's wire value. Custom `SyncStreamSource::push`
             // impls may consult it for logging/audit/version-aware
             // routing; rewriting it would silently lie about what the
-            // client claimed. The migrated payload travels inside each
-            // mutation via `ClientMutation::migrated_payload`.
+            // client claimed.
         }
-        // Build the response shell ahead of `source.push` so that even
-        // a transient `source.push` failure still surfaces the
-        // pre-migration rejections to the client. Without this the `?`
-        // propagation would drop `pre_rejected` on the floor and the
-        // client would replay the stale-schema mutations forever.
-        let stream_name = stream.source.stream().clone();
         let collection_name = stream.source.collection().clone();
-        let mut response = match stream.source.push(ctx, request).await {
-            Ok(response) => response,
-            Err(err) => {
-                if pre_rejected.is_empty() {
-                    return Err(server_error(err));
-                }
-                tracing::warn!(
-                    target: "pocopine.log",
-                    error = %err,
-                    stream = stream_name.as_str(),
-                    pre_rejected = pre_rejected.len(),
-                    "sync push source returned error; surfacing pre-migration rejections only"
-                );
-                SyncPushResponse {
-                    protocol: SYNC_PROTOCOL_V1.to_string(),
-                    stream: stream_name.clone(),
-                    collection: Some(collection_name.clone()),
-                    accepted: Vec::new(),
-                    rejected: Vec::new(),
-                    rows: Vec::new(),
-                    conflicts: Vec::new(),
-                    cursor: None,
-                }
-            }
-        };
-        if !pre_rejected.is_empty() {
-            response.rejected.extend(pre_rejected);
-        }
+        let mut response = stream
+            .source
+            .push(ctx, request)
+            .await
+            .map_err(server_error)?;
         if response.collection.is_none() {
             response.collection = Some(collection_name);
         }
@@ -603,7 +594,7 @@ mod tests {
                 op: SyncOp::Upsert,
                 base_version: None,
                 payload: "from push".to_string(),
-                migrated_payload: None,
+                migration_outcome: None,
             }],
         );
         let outer: ServerResult<SyncPushResponse<String>> =

--- a/crates/pocopine-sync/src/server.rs
+++ b/crates/pocopine-sync/src/server.rs
@@ -16,9 +16,9 @@ use serde::de::DeserializeOwned;
 use serde_json::Value;
 
 use crate::{
-    sync_stream_tag, SyncError, SyncOpenRequest, SyncOpenResponse, SyncOpenStream, SyncPullRequest,
-    SyncPullResponse, SyncPushRequest, SyncPushResponse, SyncResult, SYNC_OPEN_PATH,
-    SYNC_PULL_PATH, SYNC_PUSH_PATH,
+    sync_stream_tag, ClientMutation, SyncError, SyncOpenRequest, SyncOpenResponse, SyncOpenStream,
+    SyncPullRequest, SyncPullResponse, SyncPushRequest, SyncPushResponse, SyncRejectedMutation,
+    SyncResult, SYNC_OPEN_PATH, SYNC_PULL_PATH, SYNC_PUSH_PATH,
 };
 
 /// Future returned by a stream source.
@@ -110,6 +110,31 @@ pub trait SyncStreamSource: Send + Sync + 'static {
                 "push is not implemented for this stream",
             ))
         })
+    }
+
+    /// Migrate a client-side mutation payload encoded under `from` to
+    /// the source's currently-advertised schema version `to`.
+    ///
+    /// The framework's `push_handler` invokes this once per mutation
+    /// when the request's `schema_version` differs from
+    /// `self.schema_version()`. The default implementation returns
+    /// `SyncError::SchemaMigration` so any out-of-tree source that
+    /// hasn't opted in surfaces a clean per-mutation rejection rather
+    /// than silently mis-deserializing stale payloads into the new
+    /// shape. Apps that want to accept stale pushes (e.g. to preserve
+    /// side-effecting writes like payments across a schema bump)
+    /// override this method directly or use the
+    /// `#[resource(schema_version = N, migrate_with = path)]` macro
+    /// attribute which generates the impl.
+    ///
+    /// On `Ok`, the framework substitutes the migrated payload into
+    /// the mutation before delegating to `push`. On `Err`, the
+    /// mutation is added to the response's `rejected` array with the
+    /// error's `reason`; the rest of the batch continues.
+    fn migrate_payload<'a>(&'a self, from: u32, to: u32, value: Value) -> SyncBoxFuture<'a, Value> {
+        let _ = value;
+        let stream = self.stream().as_str().to_string();
+        Box::pin(async move { Err(SyncError::schema_migration(stream, from, to)) })
     }
 }
 
@@ -340,14 +365,55 @@ async fn push_handler(
     request: Request<Body>,
 ) -> Json<ServerResult<SyncPushResponse<Value>>> {
     let result = async {
-        let (ctx, request) = parse_json_request::<SyncPushRequest<Value>>(request).await?;
+        let (ctx, mut request) = parse_json_request::<SyncPushRequest<Value>>(request).await?;
         let stream = sync.stream(request.stream.as_str()).map_err(server_error)?;
         stream.authorize(ctx.clone()).await?;
+        // If the client and server disagree on the application-level
+        // schema version, run each mutation's payload through the
+        // source's `migrate_payload`. Mutations that can't be migrated
+        // (default impl returns Err(SchemaMigration)) get a typed
+        // rejection in `pre_rejected`; the survivors continue into
+        // `source.push` carrying their migrated payloads. The
+        // request's schema_version is then updated so the source
+        // sees a self-consistent batch.
+        let mut pre_rejected: Vec<SyncRejectedMutation> = Vec::new();
+        let server_schema_version = stream.source.schema_version();
+        if request.schema_version != server_schema_version {
+            let from = request.schema_version;
+            let to = server_schema_version;
+            let mut survivors: Vec<ClientMutation<Value>> =
+                Vec::with_capacity(request.mutations.len());
+            for mutation in request.mutations.drain(..) {
+                match stream
+                    .source
+                    .migrate_payload(from, to, mutation.payload.clone())
+                    .await
+                {
+                    Ok(migrated) => {
+                        let mut next = mutation;
+                        next.payload = migrated;
+                        survivors.push(next);
+                    }
+                    Err(err) => {
+                        pre_rejected.push(SyncRejectedMutation {
+                            mutation_id: mutation.id,
+                            key: mutation.key,
+                            reason: err.to_string(),
+                        });
+                    }
+                }
+            }
+            request.mutations = survivors;
+            request.schema_version = server_schema_version;
+        }
         let mut response = stream
             .source
             .push(ctx, request)
             .await
             .map_err(server_error)?;
+        if !pre_rejected.is_empty() {
+            response.rejected.extend(pre_rejected);
+        }
         if response.collection.is_none() {
             response.collection = Some(stream.source.collection().clone());
         }
@@ -545,6 +611,7 @@ mod tests {
         let request = SyncPushRequest::<String> {
             protocol: SYNC_PROTOCOL_V1.to_string(),
             stream: SyncStreamName::new("posts_for_tenant").unwrap(),
+            schema_version: crate::default_schema_version_one(),
             mutations: Vec::new(),
         };
 

--- a/crates/pocopine-sync/tests/client_browser.rs
+++ b/crates/pocopine-sync/tests/client_browser.rs
@@ -406,6 +406,8 @@ async fn open_replays_pending_mutations_before_pull() {
         op: SyncOp::Upsert,
         base_version: None,
         payload: serde_json::json!({"id": "post_2", "title": "Pending"}),
+
+        migrated_payload: None,
     };
     store.enqueue_mutation(&stream, pending).await.unwrap();
 
@@ -562,6 +564,8 @@ async fn open_keeps_hydrated_pending_overlay_when_replay_fails() {
                     "op": "create",
                     "payload": {"id": "post_2", "draft": {"title": "Envelope only"}}
                 }),
+
+                migrated_payload: None,
             })
             .with_optimistic_row(Some(
                 SyncRow::new(

--- a/crates/pocopine-sync/tests/client_browser.rs
+++ b/crates/pocopine-sync/tests/client_browser.rs
@@ -407,7 +407,7 @@ async fn open_replays_pending_mutations_before_pull() {
         base_version: None,
         payload: serde_json::json!({"id": "post_2", "title": "Pending"}),
 
-        migrated_payload: None,
+        migration_outcome: None,
     };
     store.enqueue_mutation(&stream, pending).await.unwrap();
 
@@ -565,7 +565,7 @@ async fn open_keeps_hydrated_pending_overlay_when_replay_fails() {
                     "payload": {"id": "post_2", "draft": {"title": "Envelope only"}}
                 }),
 
-                migrated_payload: None,
+                migration_outcome: None,
             })
             .with_optimistic_row(Some(
                 SyncRow::new(

--- a/docs/sync-local-first-gaps.md
+++ b/docs/sync-local-first-gaps.md
@@ -8,7 +8,11 @@
 
 ## Axis 1: Schema migrations (versioned payloads, queued-mutation drift)
 
-- **Status in pocopine:** Missing.
+- **Status in pocopine:** ✅ Done — three batches landed.
+  - **Batch 1** (#128): protocol surface — `SyncStreamSource::schema_version()` + `#[resource(schema_version = N)]` macro attribute + `SyncError::SchemaMigration` variant + `SyncOpenStream.schema_version` wire field with `#[serde(default)]` for backwards-compat.
+  - **Batch 2** (#130): local cache invalidation — `SyncLocalStore::clear_stream`, durable v3→v4 storage migration adding `app_schema_version` column, `CollectionState::reset_for_schema_invalidation`, post-/open mismatch detection + wipe in `start_open_then_pull`.
+  - **Batch 3** (this PR): author-facing migration adapter — `SyncStreamSource::migrate_payload` default-reject implementation, `SyncPushRequest.schema_version` wire field, push-handler routing, `CrudResourceBuilder::migrate_with(fn)`, `#[resource(..., migrate_with = path)]` macro attribute. Cookbook page at `docs/sync-schema-versioning.md`.
+- **Field evidence (resolved by the implementation):**
 - **Field evidence:**
   - Linear's reverse-engineering notes ([wzhudev/reverse-linear-sync-engine](https://github.com/wzhudev/reverse-linear-sync-engine)) explicitly call this out: "Migrations trigger via schema hash comparisons stored in metadata. When model definitions change, the hash updates, prompting `IndexedDB.open()` with an incremented version number."
   - CR-SQLite has a first-class API ([vlcn.io migrations](https://vlcn.io/docs/cr-sqlite/migrations)): "tables that have been upgraded to crrs need some extra handling … start that modification with a call to `crsql_begin_alter`, and complete with `crsql_commit_alter`. Bookkeeping metadata needs to be migrated as well."

--- a/docs/sync-local-first-roadmap.md
+++ b/docs/sync-local-first-roadmap.md
@@ -348,8 +348,12 @@ simple and hard to misuse.
    Done — `SyncLocalStore::clear_all_streams`,
    `SyncClient::sign_out` / `watch_sign_outs`, and the §7 deliverables
    above.
-6. Add broader browser CI around SQLite local-first flows.
-7. Only then consider database-specific changefeed adapters.
+6. ~~Schema versioning + migration adapter (Axis 1 of
+   `docs/sync-local-first-gaps.md`).~~ Done across PRs #128, #130, and
+   the schema-migrator PR. Cookbook page at
+   `docs/sync-schema-versioning.md`.
+7. Add broader browser CI around SQLite local-first flows.
+8. Only then consider database-specific changefeed adapters.
 
 This order uses the SQLite sync store we already have while preserving the
 database-agnostic engine boundary.

--- a/docs/sync-schema-versioning.md
+++ b/docs/sync-schema-versioning.md
@@ -1,0 +1,159 @@
+# Sync schema versioning
+
+When you change a synced row's shape — add a required field, rename a
+column, narrow a type — clients with **cached rows** or **queued
+mutations** encoded against the old shape will silently corrupt their
+views unless the server tells them their cache is stale.
+
+Pocopine's sync engine ships a three-piece versioning system. Two of
+the three are automatic; the third (migration) is opt-in for apps that
+must preserve queued local edits across a bump.
+
+## The contract
+
+Every CRUD resource declares an integer `schema_version`. The server
+advertises it on every `/open` response; the client compares against
+its locally-cached value and reacts on mismatch.
+
+```rust
+#[pocopine_sync_crud::resource(name = "customers", schema_version = 2)]
+#[pocopine_sync_crud::async_trait]
+impl CrudSource for Customers { … }
+```
+
+Defaults to `1` when omitted. Bump the number whenever the row, draft,
+or payload shape changes in a way that older cached data cannot
+deserialize into. Versions start at `1`; `0` is rejected at the macro
+level and at the wire level.
+
+## What happens on a mismatch
+
+### Default: drop the client's cache + queue
+
+When the server advertises `schema_version = N` and the client's
+cached value is `M ≠ N`:
+
+1. The client durably wipes the stream's rows + pending mutations via
+   `SyncLocalStore::clear_stream`.
+2. The in-memory `CollectionState` is reset (rows, pending overlay,
+   cursor all cleared) via `CollectionState::reset_for_schema_invalidation`.
+3. The advertised version is stamped onto the local store.
+4. The post-open pull rebuilds canonical state under the new shape.
+
+If `clear_stream` fails, the client surfaces the error via
+`apply_error` and stops rather than proceeding to the pull — this keeps
+the cached version at the OLD value so the next open retries.
+
+If `cached_schema_version == None` (fresh install or a stream the store
+has never observed), the advertised version is adopted silently — no
+wipe is needed.
+
+### Default for pushed mutations: per-mutation reject
+
+When a `/push` carries `request.schema_version < source.schema_version()`,
+the server invokes `SyncStreamSource::migrate_payload` on each
+mutation. The trait default returns
+`SyncError::SchemaMigration { stream, from, to }`. The framework adds
+the failing mutation to the response's `rejected` array with the
+error's `reason`; the rest of the batch continues. Clients see a
+typed `Rejected` outcome on those mutations.
+
+This matches Replicache and Linear: drop queued local edits when the
+schema bumps; the user's view is rebuilt from canonical.
+
+## Escape hatch: register a migrator
+
+For apps where dropping queued mutations is unacceptable (payments,
+inventory writes, anything with side effects), register a
+`migrate_with` function:
+
+```rust
+fn migrate_v1_to_v2(from: u32, to: u32, mut value: Value) -> SyncResult<Value> {
+    if from != 1 || to != 2 {
+        return Err(SyncError::schema_migration("customers", from, to));
+    }
+    // CrudMutationPayload's wire shape is
+    //   { "op": "create"|"save"|"remove",
+    //     "payload": { "id": …, "draft": <draft> } }
+    if let Some(payload) = value.get_mut("payload") {
+        if let Some(draft) = payload.get_mut("draft") {
+            if let Some(obj) = draft.as_object_mut() {
+                obj.entry("email".to_string())
+                    .or_insert_with(|| Value::String(String::new()));
+            }
+        }
+    }
+    Ok(value)
+}
+
+#[pocopine_sync_crud::resource(
+    name = "customers",
+    schema_version = 2,
+    migrate_with = migrate_v1_to_v2,
+)]
+#[pocopine_sync_crud::async_trait]
+impl CrudSource for Customers { … }
+```
+
+The framework calls your fn once per mutation when the request's
+`schema_version` differs from the resource's current version. On `Ok`,
+the migrated payload replaces the original and continues into
+`source.push`. On `Err`, the mutation lands in `rejected` with the
+error's `reason`.
+
+The wire payload your migrator receives is a `serde_json::Value`
+representing the entire `CrudMutationPayload<Id, Draft>` enum. The
+shape is documented above; mutate it in place and return.
+
+## When to choose which
+
+| Situation | Choice |
+|---|---|
+| Most apps; queued edits are best-effort | **Default drop** (no `migrate_with`) |
+| Payments, inventory, anything side-effecting | **`migrate_with`** with explicit field defaults |
+| Field rename only, no semantic change | **`migrate_with`** that just renames |
+| Backward-incompatible deletion of a field | **`migrate_with` that returns `Err`** for those drafts and use the drop-default for the rest. The errors lose the drafts; that's correct. |
+
+## Common pitfalls
+
+- **Forgetting to bump `schema_version`** after a row/draft change.
+  Older clients then push stale data and the server silently
+  mis-deserializes. The compiler doesn't help — bumping the macro
+  attribute is your responsibility.
+
+- **Migrator that loses required fields.** A migrator that drops a
+  field the v2 source needs (e.g. removes `version` from a save
+  payload) will succeed in `migrate_payload` and then fail in
+  `source.save`. The mutation ends up in `rejected` either way, but
+  the reason will read like a deserialization or backend error
+  instead of a migration error.
+
+- **Bumping without coordinating with the client app.** The server
+  rejects stale client pushes, but it does NOT prevent a stale client
+  from reading new-shape rows over `/pull`. If the row's `Deserialize`
+  fails, the row is dropped silently. Plan a transition window where
+  the server accepts both shapes (via `migrate_with`) until you're
+  confident every client deployment has updated.
+
+- **`0` is not a valid schema_version.** The macro, the builder, and
+  the wire-level validator all reject `schema_version = 0`. Start at
+  `1`.
+
+## Wire & error reference
+
+- `SyncOpenStream.schema_version: u32` — server advertises per stream.
+- `SyncPushRequest.schema_version: u32` — client tags every push.
+- `SyncStreamSource::schema_version(&self) -> u32` — server-side
+  declaration.
+- `SyncStreamSource::migrate_payload(from, to, value) -> Value` —
+  default impl returns `SchemaMigration`; override to opt in.
+- `SyncError::SchemaMigration { stream, from, to }` —
+  client-and-server-shared error variant; maps to
+  `ServerError::BadRequest` on the wire.
+- `CrudMigrateFn` — type alias for the migrator function signature.
+
+## End-to-end example
+
+See `crates/pocopine-sync-crud/tests/schema_migration.rs` for a
+complete test that exercises both the default-reject path and the
+`migrate_with` path against an axum-mounted resource.

--- a/docs/sync-schema-versioning.md
+++ b/docs/sync-schema-versioning.md
@@ -118,6 +118,53 @@ shape is documented above; mutate it in place and return.
 | Field rename only, no semantic change | **`migrate_with`** that just renames |
 | Backward-incompatible deletion of a field | **`migrate_with` that returns `Err`** for those drafts and use the drop-default for the rest. The errors lose the drafts; that's correct. |
 
+## Out-of-tree sources
+
+If you implement `SyncStreamSource` directly (not through
+`CrudResource`), you become responsible for two contract points:
+
+1. **Use the migration sidecar.** The framework's `push_handler`
+   attaches the migration result to each `ClientMutation` as
+   `migration_outcome: Option<MigrationOutcome<Value>>`. Call
+   `mutation.take_processing_payload()` to get the payload to apply
+   — it returns `Ok(value)` (migrated or original) or `Err(reason)`
+   for a migrator-rejected mutation. The mutation's `payload` field
+   stays the ORIGINAL wire value; use it for your idempotency log
+   key. NEVER read `mutation.payload` for the actual write — that
+   would silently bypass any registered migrator.
+
+2. **Check the idempotency log BEFORE consuming the migration
+   result.** A retry of a previously-accepted mutation should
+   succeed even when the current migrator now rejects (or panics)
+   on the same inputs. The accepted-log lookup uses
+   `mutation.payload` (original); only mutations not in the log
+   need their `take_processing_payload()` outcome inspected.
+
+The CRUD `push_mutations` (and its transactional sibling) implement
+both points; copy the pattern if you write a custom source.
+
+## Migration cannot change the envelope
+
+`migrate_payload` migrates the `serde_json::Value` payload only —
+it cannot change `ClientMutation.key`, `op`, or `base_version`.
+This matters when a schema bump renames row IDs (e.g. moving from
+`"42"` to `"tenant:42"`):
+
+* The migrator can update the embedded `id` inside the payload, but
+  the outer `key` (set by the client at queue-time) stays at the v1
+  form.
+* CRUD validates `payload.id().to_row_key() == mutation.key` and
+  rejects the mismatch with a typed `row key does not match payload
+  id` reason.
+
+The recommended approach for ID-shape changes: bump
+`schema_version` and rely on the **default drop-the-cache** path.
+Local rows are rebuilt from canonical via a fresh `/pull`; pending
+mutations queued under the old ID shape are dropped. If you must
+preserve queued mutations across an ID rename, you'd need a custom
+`SyncStreamSource::push` that re-derives the key from the migrated
+payload before delegating to your store.
+
 ## Migrator caveats
 
 A registered `migrate_with` function runs with these constraints:

--- a/docs/sync-schema-versioning.md
+++ b/docs/sync-schema-versioning.md
@@ -69,6 +69,10 @@ inventory writes, anything with side effects), register a
 
 ```rust
 fn migrate_v1_to_v2(from: u32, to: u32, mut value: Value) -> SyncResult<Value> {
+    // The framework only invokes this when `from < to`, so we only
+    // need to handle the strict-forward direction. Bail on any
+    // unexpected version pair so a future v3 doesn't silently
+    // double-migrate through this fn.
     if from != 1 || to != 2 {
         return Err(SyncError::schema_migration("customers", from, to));
     }
@@ -114,12 +118,45 @@ shape is documented above; mutate it in place and return.
 | Field rename only, no semantic change | **`migrate_with`** that just renames |
 | Backward-incompatible deletion of a field | **`migrate_with` that returns `Err`** for those drafts and use the drop-default for the rest. The errors lose the drafts; that's correct. |
 
+## Migrator caveats
+
+A registered `migrate_with` function runs with these constraints:
+
+* **Synchronous and blocking.** The closure executes on the tokio
+  runtime worker handling the push. Keep it fast — pure JSON
+  manipulation. Any I/O blocks every other concurrent task on that
+  worker thread until the migrator returns. A future iteration of
+  the API may accept an async migrator; today, it does not.
+
+* **Out-of-transaction (for `TransactionalCrudResource`).** The
+  framework calls `migrate_payload` BEFORE the per-mutation
+  transaction opens, so any side effects the migrator performs (e.g.
+  writing to an audit table on the same database) are NOT rolled
+  back if the subsequent transactional write fails. Keep migrators
+  side-effect-free.
+
+* **Panic-safe.** A panic inside your migrator is caught by
+  `std::panic::catch_unwind`; the framework converts it into a
+  per-mutation `SyncRejectedMutation` with a `migrate_with panicked`
+  reason. The push request itself is not crashed — adjacent
+  well-formed mutations continue through `source.push` normally.
+
+* **Forward-only.** The migrator only fires when the client's wire
+  `schema_version` is STRICTLY LESS than the server's
+  `schema_version()`. A newer client pushing to an older server (a
+  rolling-deploy edge case) is NOT routed through `migrate_payload`;
+  the source receives the newer-shape payload and either accepts it
+  (if forward-compatible) or rejects it with a typed deserialization
+  error.
+
 ## Common pitfalls
 
 - **Forgetting to bump `schema_version`** after a row/draft change.
   Older clients then push stale data and the server silently
-  mis-deserializes. The compiler doesn't help — bumping the macro
-  attribute is your responsibility.
+  mis-deserializes. The macro guards one related case for you: a
+  `migrate_with = ...` declaration without `schema_version >= 2`
+  fails to compile, because such a migrator would be dead code
+  (clients and servers both default to v1).
 
 - **Migrator that loses required fields.** A migrator that drops a
   field the v2 source needs (e.g. removes `version` from a save
@@ -135,9 +172,25 @@ shape is documented above; mutate it in place and return.
   the server accepts both shapes (via `migrate_with`) until you're
   confident every client deployment has updated.
 
-- **`0` is not a valid schema_version.** The macro, the builder, and
-  the wire-level validator all reject `schema_version = 0`. Start at
-  `1`.
+- **Non-deterministic migrators break idempotency.** If your migrator
+  injects server-side timestamps, UUIDs, or other non-deterministic
+  defaults, the same wire payload will migrate to different values on
+  retries. The framework stores the ORIGINAL wire payload (not the
+  migrated value) in its idempotency log to keep replays correct, but
+  if you also write your own bookkeeping keyed on the migrated
+  payload, you'll diverge.
+
+- **`0` is not a valid schema_version.** The macro, the
+  `SyncCollection::schema_version()` builder, the
+  `SyncPushRequest::with_schema_version()` builder (which silently
+  coerces `0` → `1`), AND the server's push handler (which rejects
+  inbound `schema_version: 0` with `BadRequest`) all enforce this.
+  Versions start at `1`.
+
+- **`rejected[]` ordering is not preserved.** Correlate rejections
+  with request mutations by `mutation_id`, not by index. The server
+  may interleave migration-time rejections with source-side
+  rejections in any order.
 
 ## Wire & error reference
 

--- a/examples/keep/src/sqlite_stream.rs
+++ b/examples/keep/src/sqlite_stream.rs
@@ -864,6 +864,8 @@ mod tests {
             op: SyncOp::Upsert,
             base_version: None,
             payload: serde_json::to_value(test_note("note_1", "First")).unwrap(),
+
+            migration_outcome: None,
         };
 
         stream

--- a/examples/keep/src/store/mutations.rs
+++ b/examples/keep/src/store/mutations.rs
@@ -172,6 +172,8 @@ impl KeepStore {
             op: pocopine_sync::SyncOp::Upsert,
             base_version,
             payload: note.clone(),
+
+            migration_outcome: None,
         };
         let optimistic = pocopine_sync::SyncRow::new(note.id.clone(), note)?;
 
@@ -204,6 +206,8 @@ impl KeepStore {
             op: pocopine_sync::SyncOp::Delete,
             base_version,
             payload: (),
+
+            migration_outcome: None,
         };
 
         client
@@ -235,6 +239,8 @@ impl KeepStore {
             op: pocopine_sync::SyncOp::Upsert,
             base_version: None,
             payload: tag.clone(),
+
+            migration_outcome: None,
         };
         let optimistic = pocopine_sync::SyncRow::new(tag.id.clone(), tag)?;
 

--- a/examples/keep/tests/keep_flow.rs
+++ b/examples/keep/tests/keep_flow.rs
@@ -148,6 +148,8 @@ async fn push_note(
             op: SyncOp::Upsert,
             base_version: None,
             payload: note,
+
+            migration_outcome: None,
         }],
     );
     let response = app
@@ -179,6 +181,8 @@ async fn push_tag(app: &pocopine_server::axum::Router, tag: KeepTag) -> SyncPush
             op: SyncOp::Upsert,
             base_version: None,
             payload: tag,
+
+            migration_outcome: None,
         }],
     );
     let response = app

--- a/examples/sync/tests/sync_flow.rs
+++ b/examples/sync/tests/sync_flow.rs
@@ -92,6 +92,8 @@ async fn push_post(app: &pocopine_server::axum::Router, post: Post) -> SyncPushR
             op: SyncOp::Upsert,
             base_version: None,
             payload: post,
+
+            migration_outcome: None,
         }],
     );
     let response = app


### PR DESCRIPTION
## Summary

Closes the schema-versioning gap from `docs/sync-local-first-gaps.md` Axis 1. Batch 1 (#128) shipped the protocol surface; Batch 2 (#130) shipped local cache invalidation; this batch ships the opt-in server-side migrator that lets apps preserve queued mutations across a schema bump.

- `SyncStreamSource::migrate_payload(from, to, value)` — default returns `SyncError::SchemaMigration` so non-opt-in sources surface a clean per-mutation rejection rather than mis-deserializing stale payloads.
- `SyncPushRequest.schema_version: u32` wire field (`#[serde(default)]` for backwards-compat) + `with_schema_version()` builder. Threaded through `SyncCollection` and every push helper.
- `push_handler` calls `migrate_payload` once per mutation when `request.schema_version != source.schema_version()`; failures land in `rejected[]` with the error reason, successes substitute the migrated payload before delegating to `source.push`.
- `CrudResourceBuilder::migrate_with(fn)` + `CrudMigrateFn` type alias; both `CrudResource` and `TransactionalCrudResource` impl `migrate_payload` to dispatch into the registered fn.
- `#[resource(schema_version = N, migrate_with = path::to::fn)]` macro attribute that chains `.map(|b| b.migrate_with(#path))` onto the `.schema_version(N)?` result.
- Cookbook page at `docs/sync-schema-versioning.md` covering the default drop-the-cache behaviour, the `migrate_with` escape hatch with a working example, when to choose which strategy, and common pitfalls. `docs/sync-local-first-gaps.md` Axis 1 marked done; `docs/sync-local-first-roadmap.md` step 6 added as done.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p pocopine-sync -p pocopine-sync-crud -p pocopine-sync-crud-macros -p pocopine-sync-sqlite -p pocopine-sync-indexdb -p pocopine-sync-sqlx --all-targets -- -D warnings`
- [x] `cargo clippy --target wasm32-unknown-unknown -p pocopine-sync -p pocopine-sync-crud -p pocopine-sync-crud-macros -p pocopine-sync-sqlite -p pocopine-sync-indexdb --all-targets -- -D warnings`
- [x] `cargo test -p pocopine-sync -p pocopine-sync-crud --lib --tests` — 119 + 56 + 1 (`resource_server`) + **3 new schema_migration** + 3 (`tenant_boundary`) all pass
- [x] `cargo test -p pocopine-sync-crud-macros --tests` — 13 trybuild UI cases pass (2 existing `.stderr` snapshots regenerated to mention `migrate_with = path`)
- [x] `cargo test -p pocopine-sync-sqlite -p pocopine-sync-indexdb -p pocopine-sync-sqlx --tests` — Batch 2's v3→v4 migration regression suite still green

Closes #126.