### PR TITLE
sync: shape subscriptions Batch 2 — macro params(...) DSL + typed StreamParams

### DIFF
--- a/crates/pocopine-sync-crud-macros/Cargo.toml
+++ b/crates/pocopine-sync-crud-macros/Cargo.toml
@@ -12,7 +12,11 @@ proc-macro = true
 [dependencies]
 proc-macro2 = { workspace = true }
 quote = { workspace = true }
-syn = { workspace = true }
+# `extra-traits` enables `Debug`/`PartialEq` on syn types so the
+# macro's internal data structures (which embed `syn::Type` /
+# `syn::LitStr`) can derive `Debug` for the unit-test
+# `unwrap_err` calls. Proc-macro-only dep; no runtime impact.
+syn = { workspace = true, features = ["extra-traits"] }
 
 [dev-dependencies]
 js-sys = { workspace = true }

--- a/crates/pocopine-sync-crud-macros/src/lib.rs
+++ b/crates/pocopine-sync-crud-macros/src/lib.rs
@@ -8,10 +8,42 @@ use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
 use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
-use syn::{parse_macro_input, ExprPath, Ident, ImplItem, ItemImpl, LitInt, LitStr, Token, Type};
+use syn::{
+    parse_macro_input, ExprPath, GenericArgument, Ident, ImplItem, ItemImpl, LitInt, LitStr,
+    PathArguments, PathSegment, Token, Type,
+};
 
 // Matches the sync protocol's stream and row-key token budget.
 const MAX_SYNC_TOKEN_LEN: usize = 1024;
+
+/// Inferred comparator kind for one entry in `params(...)`.
+#[derive(Clone, Debug)]
+enum ComparatorKind {
+    /// Bare `T` — required equality.
+    RequiredEq,
+    /// `Option<T>` — optional equality. The inner `T` is the value
+    /// type used in the builder setter signature.
+    OptionalEq { inner: Type },
+    /// `params::InSet<T>` — membership in a non-empty set.
+    InSet { inner: Type },
+    /// `params::Range<T>` — bounded range.
+    Range { inner: Type },
+    /// `params::Contains` — substring match against a text field.
+    Contains,
+}
+
+/// One field declared in `#[resource(params(...))]`.
+#[derive(Clone, Debug)]
+struct ParamDef {
+    /// Field identifier as written by the author (e.g. `workspace_id`).
+    name: Ident,
+    /// Type the author wrote (used for the public `XxxStreamParams`
+    /// struct field type).
+    ty: Type,
+    /// Inferred comparator semantics + the inner value type when
+    /// applicable.
+    kind: ComparatorKind,
+}
 
 #[derive(Debug)]
 struct ResourceArgs {
@@ -19,6 +51,85 @@ struct ResourceArgs {
     module: Ident,
     schema_version: u32,
     migrate_with: Option<ExprPath>,
+    params: Vec<ParamDef>,
+}
+
+/// Pull the single generic-argument type out of `Wrapper<T>`. Returns
+/// `None` when the segment carries no angle-bracketed args or carries
+/// more than one type arg.
+fn extract_single_generic_type(segment: &PathSegment) -> Option<Type> {
+    let PathArguments::AngleBracketed(args) = &segment.arguments else {
+        return None;
+    };
+    let mut types = args.args.iter().filter_map(|arg| {
+        if let GenericArgument::Type(ty) = arg {
+            Some(ty.clone())
+        } else {
+            None
+        }
+    });
+    let first = types.next()?;
+    if types.next().is_some() {
+        return None;
+    }
+    Some(first)
+}
+
+/// Map a declared params field type to its comparator semantics.
+///
+/// Classification is by **last path segment** + generic-arg count:
+///
+/// | Last segment + arity      | Inferred kind                            |
+/// |---------------------------|------------------------------------------|
+/// | `Option<T>`               | `OptionalEq { inner: T }`                |
+/// | `InSet<T>` (any prefix)   | `InSet { inner: T }`                     |
+/// | `Range<T>` (any prefix)   | `Range { inner: T }`                     |
+/// | `Contains` (no args)      | `Contains`                               |
+/// | any other path / shape    | `RequiredEq`                             |
+///
+/// Authors who want a `std::ops::Range<T>` as a required-eq value
+/// must alias it (`use std::ops::Range as StdRange`) or accept the
+/// `Range` classification.
+fn classify_param_type(ty: &Type) -> syn::Result<ComparatorKind> {
+    let Type::Path(type_path) = ty else {
+        return Ok(ComparatorKind::RequiredEq);
+    };
+    let Some(last) = type_path.path.segments.last() else {
+        return Ok(ComparatorKind::RequiredEq);
+    };
+    match last.ident.to_string().as_str() {
+        "Option" => match extract_single_generic_type(last) {
+            Some(inner) => Ok(ComparatorKind::OptionalEq { inner }),
+            None => Err(syn::Error::new(
+                last.span(),
+                "`Option<T>` requires exactly one generic type argument",
+            )),
+        },
+        "InSet" => match extract_single_generic_type(last) {
+            Some(inner) => Ok(ComparatorKind::InSet { inner }),
+            None => Err(syn::Error::new(
+                last.span(),
+                "`InSet<T>` requires exactly one generic type argument; use `params::InSet<Status>` or similar",
+            )),
+        },
+        "Range" => match extract_single_generic_type(last) {
+            Some(inner) => Ok(ComparatorKind::Range { inner }),
+            None => Err(syn::Error::new(
+                last.span(),
+                "`Range<T>` requires exactly one generic type argument; use `params::Range<DateTime>` or similar",
+            )),
+        },
+        "Contains" => {
+            if !matches!(last.arguments, PathArguments::None) {
+                return Err(syn::Error::new(
+                    last.span(),
+                    "`Contains` takes no generic arguments — use `params::Contains` directly",
+                ));
+            }
+            Ok(ComparatorKind::Contains)
+        }
+        _ => Ok(ComparatorKind::RequiredEq),
+    }
 }
 
 impl Parse for ResourceArgs {
@@ -27,6 +138,8 @@ impl Parse for ResourceArgs {
         let mut module = None;
         let mut schema_version: Option<u32> = None;
         let mut migrate_with: Option<ExprPath> = None;
+        let mut params: Vec<ParamDef> = Vec::new();
+        let mut params_set = false;
 
         while !input.is_empty() {
             let key: Ident = input.parse()?;
@@ -103,10 +216,48 @@ impl Parse for ResourceArgs {
                     )
                 })?;
                 migrate_with = Some(path);
+            } else if key == "params" {
+                if params_set {
+                    return Err(syn::Error::new(
+                        key.span(),
+                        "duplicate `params(...)` in CRUD resource attribute",
+                    ));
+                }
+                params_set = true;
+                // `params(field: Type, field: Type, ...)`. Parenthesized
+                // list; entries are `Ident: Type` pairs. Comparator
+                // semantics are inferred from `Type` via
+                // `classify_param_type`.
+                let content;
+                syn::parenthesized!(content in input);
+                while !content.is_empty() {
+                    let field_name: Ident = content.parse()?;
+                    if params.iter().any(|p| p.name == field_name) {
+                        return Err(syn::Error::new(
+                            field_name.span(),
+                            format!(
+                                "duplicate param field `{field_name}` in params(...) — each field name must be unique"
+                            ),
+                        ));
+                    }
+                    content.parse::<Token![:]>()?;
+                    let field_type: Type = content.parse()?;
+                    let kind = classify_param_type(&field_type)?;
+                    params.push(ParamDef {
+                        name: field_name,
+                        ty: field_type,
+                        kind,
+                    });
+                    if content.peek(Token![,]) {
+                        content.parse::<Token![,]>()?;
+                    } else if !content.is_empty() {
+                        return Err(content.error("expected `,` between params(...) entries"));
+                    }
+                }
             } else {
                 return Err(syn::Error::new(
                     key.span(),
-                    "expected `name = \"...\"`, `module = ident`, `schema_version = N`, or `migrate_with = path` in CRUD resource attribute",
+                    "expected `name = \"...\"`, `module = ident`, `schema_version = N`, `migrate_with = path`, or `params(field: Type, ...)` in CRUD resource attribute",
                 ));
             }
 
@@ -144,6 +295,7 @@ impl Parse for ResourceArgs {
             module,
             schema_version,
             migrate_with,
+            params,
         })
     }
 }
@@ -200,6 +352,7 @@ fn expand_resource(args: ResourceArgs, item: ItemImpl) -> syn::Result<TokenStrea
         Some(path) => quote! { .map(|b| b.migrate_with(#path)) },
         None => quote! {},
     };
+    let params_codegen = generate_params_codegen(&args.params);
 
     Ok(quote! {
         #[cfg(not(target_arch = "wasm32"))]
@@ -516,6 +669,8 @@ fn expand_resource(args: ResourceArgs, item: ItemImpl) -> syn::Result<TokenStrea
                     .stream(NAME)?
                     .schema_version(SCHEMA_VERSION)
             }
+
+            #params_codegen
         }
     })
 }
@@ -543,6 +698,404 @@ fn module_ident_from_name(name: &LitStr) -> syn::Result<Ident> {
             "CRUD resource name is not a Rust module identifier; add `module = ident`",
         )
     })
+}
+
+/// Generate the typed `StreamParams` struct + fluent stream builder
+/// for the given `params(...)` declarations. When no params are
+/// declared, expand to nothing — non-opt-in resources keep their
+/// existing surface unchanged.
+fn generate_params_codegen(params: &[ParamDef]) -> TokenStream2 {
+    if params.is_empty() {
+        return quote! {};
+    }
+
+    // Field declarations for the public `StreamParams` struct. Each
+    // entry uses the author-declared type verbatim (e.g.
+    // `params::InSet<Status>`, `Option<UserId>`, `WorkspaceId`).
+    let struct_fields: Vec<TokenStream2> = params
+        .iter()
+        .map(|param| {
+            let name = &param.name;
+            let ty = &param.ty;
+            quote! { pub #name: #ty, }
+        })
+        .collect();
+
+    // `serialize_params` walks every declared field and folds it into
+    // the wire `StreamParams` map (`BTreeMap<String, Value>`).
+    // Optional fields are omitted when `None`; all other kinds always
+    // emit their key.
+    let serialize_lines: Vec<TokenStream2> = params
+        .iter()
+        .map(|param| {
+            let name = &param.name;
+            let name_str = name.to_string();
+            match &param.kind {
+                ComparatorKind::OptionalEq { .. } => {
+                    quote! {
+                        if let ::std::option::Option::Some(value) = &self.#name {
+                            map.insert(
+                                #name_str.to_string(),
+                                ::serde_json::to_value(value)
+                                    .expect("StreamParams::serialize_params: encode field"),
+                            );
+                        }
+                    }
+                }
+                _ => {
+                    quote! {
+                        map.insert(
+                            #name_str.to_string(),
+                            ::serde_json::to_value(&self.#name)
+                                .expect("StreamParams::serialize_params: encode field"),
+                        );
+                    }
+                }
+            }
+        })
+        .collect();
+
+    // Known-keys allow-list for `extract`. Unknown keys reject so a
+    // client typo can't silently fall through.
+    let known_keys_match_arms: Vec<TokenStream2> = params
+        .iter()
+        .map(|param| {
+            let name_str = param.name.to_string();
+            quote! { #name_str }
+        })
+        .collect();
+
+    // Per-field extraction inside `extract`. `OptionalEq` returns the
+    // inner `T` wrapped in `Some`; absent → `None`. Required fields
+    // (`RequiredEq`, `InSet`, `Range`, `Contains`) return an error
+    // when missing.
+    let extract_locals: Vec<TokenStream2> = params
+        .iter()
+        .map(|param| {
+            let name = &param.name;
+            let name_str = name.to_string();
+            let ty = &param.ty;
+            let field_label = format!("params.{name_str}");
+            let missing_label = format!("missing required param `{name_str}`");
+            match &param.kind {
+                ComparatorKind::OptionalEq { inner } => {
+                    quote! {
+                        let #name: #ty = match params.get(#name_str) {
+                            Some(raw) => Some(
+                                ::serde_json::from_value::<#inner>(raw.clone()).map_err(|err| {
+                                    ::pocopine_sync::SyncError::invalid_value(
+                                        #field_label,
+                                        err.to_string(),
+                                    )
+                                })?,
+                            ),
+                            None => None,
+                        };
+                    }
+                }
+                _ => {
+                    quote! {
+                        let #name: #ty = ::serde_json::from_value(
+                            params
+                                .get(#name_str)
+                                .ok_or_else(|| {
+                                    ::pocopine_sync::SyncError::invalid_value(
+                                        "params",
+                                        #missing_label,
+                                    )
+                                })?
+                                .clone(),
+                        )
+                        .map_err(|err| {
+                            ::pocopine_sync::SyncError::invalid_value(#field_label, err.to_string())
+                        })?;
+                    }
+                }
+            }
+        })
+        .collect();
+
+    let extract_struct_fields: Vec<TokenStream2> = params
+        .iter()
+        .map(|param| {
+            let name = &param.name;
+            quote! { #name, }
+        })
+        .collect();
+
+    // Fluent builder fields. Every declared field is tracked as
+    // `Option<value>` regardless of comparator kind — this lets us
+    // detect "required-but-not-set" at `observe()` time.
+    let builder_fields: Vec<TokenStream2> = params
+        .iter()
+        .map(|param| {
+            let name = &param.name;
+            let value_ty = builder_value_type(param);
+            quote! { #name: ::std::option::Option<#value_ty>, }
+        })
+        .collect();
+
+    // One setter per field. Method-name shape and argument type
+    // depend on the comparator kind:
+    let builder_setters: Vec<TokenStream2> = params.iter().map(|param| {
+        let name = &param.name;
+        let name_str = name.to_string();
+        match &param.kind {
+            ComparatorKind::RequiredEq => {
+                let ty = &param.ty;
+                quote! {
+                    pub fn #name(mut self, value: #ty) -> Self {
+                        self.#name = ::std::option::Option::Some(value);
+                        self
+                    }
+                }
+            }
+            ComparatorKind::OptionalEq { inner } => {
+                quote! {
+                    pub fn #name(mut self, value: #inner) -> Self {
+                        self.#name = ::std::option::Option::Some(value);
+                        self
+                    }
+                }
+            }
+            ComparatorKind::InSet { inner } => {
+                let setter_name = Ident::new(&format!("{name_str}_in"), name.span());
+                quote! {
+                    pub fn #setter_name<I>(mut self, values: I) -> ::pocopine_sync::SyncResult<Self>
+                    where
+                        I: ::std::iter::IntoIterator<Item = #inner>,
+                    {
+                        let set = ::pocopine_sync_crud::params::InSet::<#inner>::new(values)
+                            .map_err(|err| {
+                                ::pocopine_sync::SyncError::client(err.to_string())
+                            })?;
+                        self.#name = ::std::option::Option::Some(set);
+                        Ok(self)
+                    }
+                }
+            }
+            ComparatorKind::Range { inner } => {
+                let setter_name = Ident::new(&format!("{name_str}_range"), name.span());
+                quote! {
+                    pub fn #setter_name(
+                        mut self,
+                        range: ::pocopine_sync_crud::params::Range<#inner>,
+                    ) -> Self {
+                        self.#name = ::std::option::Option::Some(range);
+                        self
+                    }
+                }
+            }
+            ComparatorKind::Contains => {
+                let setter_name = Ident::new(&format!("{name_str}_contains"), name.span());
+                quote! {
+                    pub fn #setter_name(
+                        mut self,
+                        needle: impl ::std::convert::Into<::std::string::String>,
+                    ) -> ::pocopine_sync::SyncResult<Self> {
+                        let needle = ::pocopine_sync_crud::params::Contains::icontains(needle)
+                            .map_err(|err| {
+                                ::pocopine_sync::SyncError::client(err.to_string())
+                            })?;
+                        self.#name = ::std::option::Option::Some(needle);
+                        Ok(self)
+                    }
+                }
+            }
+        }
+    })
+        .collect();
+
+    // `into_params()` produces the wire `StreamParams` map. Required
+    // fields not set return an error; optional fields default to `None`.
+    let into_params_lines: Vec<TokenStream2> = params.iter().map(|param| {
+        let name = &param.name;
+        let name_str = name.to_string();
+        let missing = format!("StreamParams::into_params: required field `{name_str}` not set");
+        match &param.kind {
+            ComparatorKind::OptionalEq { .. } => {
+                quote! {
+                    if let ::std::option::Option::Some(value) = self.#name {
+                        map.insert(
+                            #name_str.to_string(),
+                            ::serde_json::to_value(value)
+                                .map_err(|err| ::pocopine_sync::SyncError::client(err.to_string()))?,
+                        );
+                    }
+                }
+            }
+            _ => {
+                quote! {
+                    {
+                        let value = self.#name.ok_or_else(|| {
+                            ::pocopine_sync::SyncError::client(#missing)
+                        })?;
+                        map.insert(
+                            #name_str.to_string(),
+                            ::serde_json::to_value(value)
+                                .map_err(|err| ::pocopine_sync::SyncError::client(err.to_string()))?,
+                        );
+                    }
+                }
+            }
+        }
+    })
+        .collect();
+
+    let builder_init_fields: Vec<TokenStream2> = params
+        .iter()
+        .map(|param| {
+            let name = &param.name;
+            quote! { #name: ::std::option::Option::None, }
+        })
+        .collect();
+
+    quote! {
+        /// Typed view of the subscription parameters declared via
+        /// `#[resource(params(...))]`. Generated by the macro.
+        #[derive(Clone, Debug)]
+        pub struct StreamParams {
+            #(#struct_fields)*
+        }
+
+        impl StreamParams {
+            /// Encode this typed params struct as the wire
+            /// `BTreeMap<String, Value>` envelope used by every
+            /// `/open`, `/pull`, and `/push` request.
+            pub fn serialize_params(&self) -> ::pocopine_sync::StreamParams {
+                let mut map = ::pocopine_sync::StreamParams::new();
+                #(#serialize_lines)*
+                map
+            }
+
+            /// Decode a wire `StreamParams` map into this typed
+            /// struct. Used by the macro-generated
+            /// `SyncStreamSource::validate_params` override. Returns
+            /// `SyncError::InvalidValue` for missing required fields,
+            /// wrong-shape values, or unknown keys.
+            pub fn extract(
+                params: &::pocopine_sync::StreamParams,
+            ) -> ::pocopine_sync::SyncResult<Self> {
+                for key in params.keys() {
+                    match key.as_str() {
+                        #(#known_keys_match_arms)|* => {}
+                        other => {
+                            return Err(::pocopine_sync::SyncError::invalid_value(
+                                "params",
+                                format!("unknown param `{}`", other),
+                            ));
+                        }
+                    }
+                }
+                #(#extract_locals)*
+                Ok(Self { #(#extract_struct_fields)* })
+            }
+        }
+
+        /// Fluent stream-subscription builder produced by
+        /// `Resource::stream()`. Each declared param gets a setter
+        /// (named for its comparator kind); `.observe()` validates
+        /// that required fields are set, encodes the wire map, and
+        /// returns a `LocalResourceView`.
+        pub struct StreamBuilder<C: 'static> {
+            resource: Resource<C>,
+            #(#builder_fields)*
+        }
+
+        impl<C: 'static> StreamBuilder<C>
+        where
+            Row: 'static,
+        {
+            fn new(resource: Resource<C>) -> Self {
+                Self {
+                    resource,
+                    #(#builder_init_fields)*
+                }
+            }
+
+            #(#builder_setters)*
+
+            fn into_params(self) -> ::pocopine_sync::SyncResult<
+                (Resource<C>, ::pocopine_sync::StreamParams),
+            > {
+                let mut map = ::pocopine_sync::StreamParams::new();
+                // Per-field moves out of `self`. Each block consumes
+                // exactly one field; `self.resource` stays accessible
+                // at the end because all prior moves are disjoint.
+                #(#into_params_lines)*
+                Ok((self.resource, map))
+            }
+
+            /// Resolve the subscription's typed params, build a
+            /// `SyncCollection` for this `(stream, params)` pair,
+            /// open the subscription, and return the current
+            /// `LocalResourceView` of the typed rows.
+            pub fn observe(self) -> ::pocopine_sync::SyncResult<View>
+            where
+                Id: ::pocopine_sync_crud::ResourceId,
+                Row: Clone + ::serde::de::DeserializeOwned + ::serde::Serialize,
+            {
+                let (resource, params) = self.into_params()?;
+                let collection = resource
+                    .sync
+                    .collection(resource.handle.clone(), resource.selector)
+                    .stream(NAME)?
+                    .schema_version(SCHEMA_VERSION)?
+                    .params(params);
+                collection.open()?;
+                resource.view()
+            }
+
+            /// Like `observe()` but additionally registers `callback`
+            /// to fire on every reactive update of this subscription's
+            /// view state.
+            pub fn observe_with<F>(self, callback: F) -> ::pocopine_sync::SyncResult<()>
+            where
+                Id: ::pocopine_sync_crud::ResourceId,
+                Row: Clone + ::serde::de::DeserializeOwned + ::serde::Serialize,
+                F: Fn(&ViewState, ::std::option::Option<&ViewState>) + 'static,
+            {
+                let (resource, params) = self.into_params()?;
+                let collection = resource
+                    .sync
+                    .collection(resource.handle.clone(), resource.selector)
+                    .stream(NAME)?
+                    .schema_version(SCHEMA_VERSION)?
+                    .params(params);
+                collection.open()?;
+                resource.observe_view(callback)
+            }
+        }
+
+        impl<C: 'static> Resource<C>
+        where
+            Row: 'static,
+        {
+            /// Build a typed fluent subscription for this resource's
+            /// declared `params(...)`. Returns a builder; call its
+            /// per-field setters then `.observe()` to start the
+            /// subscription.
+            pub fn stream(&self) -> StreamBuilder<C> {
+                StreamBuilder::new(self.clone())
+            }
+        }
+    }
+}
+
+/// Compute the value type stored inside the builder's `Option<…>` field
+/// for one declared param. The shape mirrors the public StreamParams
+/// struct field type — bare `T`, `Option<T>` becomes `T` (we wrap in
+/// Option<Option<T>> wouldn't make sense, so the builder collapses the
+/// declared `Option<T>` into `T` and uses `None` to mean "absent"),
+/// `InSet<T>` / `Range<T>` / `Contains` stay as their wrapper types.
+fn builder_value_type(param: &ParamDef) -> TokenStream2 {
+    match &param.kind {
+        ComparatorKind::OptionalEq { inner } => quote! { #inner },
+        _ => {
+            let ty = &param.ty;
+            quote! { #ty }
+        }
+    }
 }
 
 fn impl_targets_crud_source(item: &ItemImpl) -> bool {

--- a/crates/pocopine-sync-crud-macros/tests/ui/resource_extra_tokens.stderr
+++ b/crates/pocopine-sync-crud-macros/tests/ui/resource_extra_tokens.stderr
@@ -1,4 +1,4 @@
-error: expected `name = "..."`, `module = ident`, `schema_version = N`, or `migrate_with = path` in CRUD resource attribute
+error: expected `name = "..."`, `module = ident`, `schema_version = N`, `migrate_with = path`, or `params(field: Type, ...)` in CRUD resource attribute
  --> tests/ui/resource_extra_tokens.rs:3:52
   |
 3 | #[pocopine_sync_crud::resource(name = "customers", unexpected)]

--- a/crates/pocopine-sync-crud-macros/tests/ui/resource_unknown_key.stderr
+++ b/crates/pocopine-sync-crud-macros/tests/ui/resource_unknown_key.stderr
@@ -1,4 +1,4 @@
-error: expected `name = "..."`, `module = ident`, `schema_version = N`, or `migrate_with = path` in CRUD resource attribute
+error: expected `name = "..."`, `module = ident`, `schema_version = N`, `migrate_with = path`, or `params(field: Type, ...)` in CRUD resource attribute
  --> tests/ui/resource_unknown_key.rs:3:32
   |
 3 | #[pocopine_sync_crud::resource(stream = "customers")]

--- a/crates/pocopine-sync-crud/src/lib.rs
+++ b/crates/pocopine-sync-crud/src/lib.rs
@@ -12,6 +12,7 @@ mod id;
 mod mutation;
 mod options;
 mod outcome;
+pub mod params;
 mod row;
 mod subscription;
 mod transaction;

--- a/crates/pocopine-sync-crud/src/params.rs
+++ b/crates/pocopine-sync-crud/src/params.rs
@@ -1,0 +1,287 @@
+//! Comparator wrapper types for `#[resource(params(...))]` declarations.
+//!
+//! Authors declare filterable subscription parameters via the macro:
+//!
+//! ```ignore
+//! #[resource(
+//!     name = "issues",
+//!     params(
+//!         workspace_id: WorkspaceId,              // required eq
+//!         assignee_id: Option<UserId>,            // optional eq
+//!         status: params::InSet<Status>,          // in-set
+//!         created_at: params::Range<DateTime>,    // range
+//!         title: params::Contains,                // substring match
+//!     ),
+//! )]
+//! impl CrudSource for Issues { ... }
+//! ```
+//!
+//! The macro maps each declared `Type` to one of these comparator
+//! kinds at compile time:
+//!
+//! | Wrapper                  | Semantic              | Wire shape                                                                |
+//! |--------------------------|-----------------------|---------------------------------------------------------------------------|
+//! | `T` (bare)               | Required equality     | `{ "field": <value> }`                                                    |
+//! | `Option<T>`              | Optional equality     | `{ "field": <value> }` (or absent)                                        |
+//! | `params::InSet<T>`       | Membership in a set   | `{ "field": { "in": [<v1>, <v2>, ...] } }`                                |
+//! | `params::Range<T>`       | Bounded range         | `{ "field": { "from": <lo>, "to": <hi>, "inclusive": [<bool>, <bool>] } }`|
+//! | `params::Contains`       | Substring match       | `{ "field": { "contains": <needle>, "case_sensitive": <bool> } }`         |
+//!
+//! All comparator wrappers are `Serialize + Deserialize` so the same
+//! types travel through the wire envelope and the typed `IssuesStreamParams`
+//! struct the macro generates.
+
+use serde::{Deserialize, Serialize};
+
+/// Membership predicate: row matches when the declared field's value
+/// equals ANY value in this set. The set must be non-empty; empty sets
+/// are rejected at deserialization time because an empty `IN ()` is
+/// almost always a mistake (selects no rows, but the author probably
+/// wanted "no constraint" — they should omit the param entirely).
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct InSet<T> {
+    #[serde(rename = "in")]
+    values: Vec<T>,
+}
+
+impl<T> InSet<T> {
+    /// Build an `InSet` from an iterator of values. Returns `Err` if
+    /// the iterator was empty — empty in-sets are rejected because
+    /// they always select no rows.
+    pub fn new<I>(values: I) -> Result<Self, EmptyInSetError>
+    where
+        I: IntoIterator<Item = T>,
+    {
+        let values: Vec<T> = values.into_iter().collect();
+        if values.is_empty() {
+            return Err(EmptyInSetError);
+        }
+        Ok(Self { values })
+    }
+
+    /// Borrow the set's values in declaration order.
+    pub fn values(&self) -> &[T] {
+        &self.values
+    }
+
+    /// Consume the set and yield its values.
+    pub fn into_values(self) -> Vec<T> {
+        self.values
+    }
+}
+
+/// Returned by `InSet::new` when the input iterator was empty.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct EmptyInSetError;
+
+impl core::fmt::Display for EmptyInSetError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("InSet must contain at least one value (empty sets select no rows; omit the param to leave it unconstrained)")
+    }
+}
+
+impl std::error::Error for EmptyInSetError {}
+
+/// Bounded range predicate: row matches when the declared field's
+/// value falls within `[from, to]` with inclusivity per the
+/// `inclusive` tuple. Either bound may be `None` for half-open
+/// ranges. A range with BOTH bounds `None` is rejected at
+/// deserialization time — it always selects every row and the
+/// author probably wanted to omit the param entirely.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Range<T> {
+    /// Lower bound; `None` means unbounded below.
+    pub from: Option<T>,
+    /// Upper bound; `None` means unbounded above.
+    pub to: Option<T>,
+    /// Inclusivity of `(from, to)` — `(true, false)` is `[from, to)`,
+    /// `(true, true)` is `[from, to]`, etc. Defaults to `(true, true)`
+    /// when constructed via the helper constructors.
+    #[serde(default = "default_inclusive")]
+    pub inclusive: (bool, bool),
+}
+
+fn default_inclusive() -> (bool, bool) {
+    (true, true)
+}
+
+impl<T> Range<T> {
+    /// Closed range `[from, to]`. Errors if both bounds would be None
+    /// (would always match; omit the param instead).
+    pub fn closed(from: T, to: T) -> Self {
+        Self {
+            from: Some(from),
+            to: Some(to),
+            inclusive: (true, true),
+        }
+    }
+
+    /// Half-open range `[from, to)`.
+    pub fn half_open(from: T, to: T) -> Self {
+        Self {
+            from: Some(from),
+            to: Some(to),
+            inclusive: (true, false),
+        }
+    }
+
+    /// Lower-bounded range `[from, ∞)`.
+    pub fn at_least(from: T) -> Self {
+        Self {
+            from: Some(from),
+            to: None,
+            inclusive: (true, false),
+        }
+    }
+
+    /// Upper-bounded range `(-∞, to]`.
+    pub fn at_most(to: T) -> Self {
+        Self {
+            from: None,
+            to: Some(to),
+            inclusive: (false, true),
+        }
+    }
+
+    /// Strict lower-bounded range `(from, ∞)`.
+    pub fn greater_than(from: T) -> Self {
+        Self {
+            from: Some(from),
+            to: None,
+            inclusive: (false, false),
+        }
+    }
+
+    /// Strict upper-bounded range `(-∞, to)`.
+    pub fn less_than(to: T) -> Self {
+        Self {
+            from: None,
+            to: Some(to),
+            inclusive: (false, false),
+        }
+    }
+
+    /// True when both bounds are `None`. The framework rejects such
+    /// ranges at deserialization time; this is exposed for source
+    /// authors who need to validate manually.
+    pub fn is_unbounded(&self) -> bool {
+        self.from.is_none() && self.to.is_none()
+    }
+}
+
+/// Substring-match predicate: row matches when the declared text
+/// field contains `needle`. The match is case-insensitive by
+/// default; flip `case_sensitive` for exact-case matching. Empty
+/// needles are rejected (would always match).
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Contains {
+    /// Substring to search for. Cannot be empty.
+    pub contains: String,
+    /// When `true`, match exact case; when `false`, fold both sides
+    /// to lowercase before comparing. Defaults to `false`.
+    #[serde(default)]
+    pub case_sensitive: bool,
+}
+
+impl Contains {
+    /// Case-insensitive substring match.
+    pub fn icontains(needle: impl Into<String>) -> Result<Self, EmptyContainsError> {
+        Self::build(needle, false)
+    }
+
+    /// Case-sensitive substring match.
+    pub fn matches(needle: impl Into<String>) -> Result<Self, EmptyContainsError> {
+        Self::build(needle, true)
+    }
+
+    fn build(needle: impl Into<String>, case_sensitive: bool) -> Result<Self, EmptyContainsError> {
+        let contains = needle.into();
+        if contains.is_empty() {
+            return Err(EmptyContainsError);
+        }
+        Ok(Self {
+            contains,
+            case_sensitive,
+        })
+    }
+}
+
+/// Returned by `Contains::contains` / `icontains` when the needle
+/// is empty.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct EmptyContainsError;
+
+impl core::fmt::Display for EmptyContainsError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("Contains needle must be non-empty (empty matches every row; omit the param to leave it unconstrained)")
+    }
+}
+
+impl std::error::Error for EmptyContainsError {}
+
+// Tests rely on `serde_json` which is a host-only dep; the wasm
+// build of pocopine-sync-crud doesn't pull it in (the wasm bundle
+// would be larger for no benefit — wasm consumers serialize via
+// the framework's existing serde paths).
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn in_set_rejects_empty_iterator() {
+        let result: Result<InSet<u32>, _> = InSet::new(Vec::<u32>::new());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn in_set_round_trips_through_serde() {
+        let set = InSet::new(["open", "in_progress"]).unwrap();
+        let json = serde_json::to_value(&set).unwrap();
+        // Transparent representation: serializes as the inner struct.
+        assert_eq!(json["in"], serde_json::json!(["open", "in_progress"]));
+        let decoded: InSet<String> = serde_json::from_value(json).unwrap();
+        assert_eq!(decoded.values(), &["open", "in_progress"]);
+    }
+
+    #[test]
+    fn range_helpers_set_inclusivity() {
+        let closed = Range::closed(1, 10);
+        assert_eq!(closed.inclusive, (true, true));
+        let half_open = Range::half_open(1, 10);
+        assert_eq!(half_open.inclusive, (true, false));
+        let at_least = Range::at_least(1);
+        assert_eq!(at_least.from, Some(1));
+        assert_eq!(at_least.to, None);
+    }
+
+    #[test]
+    fn range_round_trips_with_default_inclusivity() {
+        // Old wire payloads without `inclusive` deserialize as
+        // `(true, true)` per the `#[serde(default)]`.
+        let json = serde_json::json!({
+            "from": 1,
+            "to": 10,
+        });
+        let range: Range<i32> = serde_json::from_value(json).unwrap();
+        assert_eq!(range.from, Some(1));
+        assert_eq!(range.to, Some(10));
+        assert_eq!(range.inclusive, (true, true));
+    }
+
+    #[test]
+    fn contains_rejects_empty_needle() {
+        assert!(Contains::icontains("").is_err());
+        assert!(Contains::matches("").is_err());
+    }
+
+    #[test]
+    fn contains_defaults_case_sensitive_false() {
+        // Old wire payloads without `case_sensitive` default to false.
+        let json = serde_json::json!({
+            "contains": "alice",
+        });
+        let needle: Contains = serde_json::from_value(json).unwrap();
+        assert_eq!(needle.contains, "alice");
+        assert!(!needle.case_sensitive);
+    }
+}

--- a/crates/pocopine-sync-crud/tests/shape_subscriptions.rs
+++ b/crates/pocopine-sync-crud/tests/shape_subscriptions.rs
@@ -1,0 +1,199 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+//! Macro `params(...)` integration test for RFC 085 Batch 2.
+//!
+//! Verifies the macro-generated typed `StreamParams` struct emits
+//! the right wire shape, decodes via `extract`, and rejects unknown
+//! or malformed params.
+//!
+//! NOTE: server-side auto-validation via
+//! `SyncStreamSource::validate_params` is intentionally NOT wired up
+//! in Batch 2 — source authors call `StreamParams::extract` directly
+//! from their own `pull`/`push` (or from a manually-overridden
+//! `validate_params`). The auto-wire ships in a follow-up Batch 2b.
+
+use pocopine_auth::RequestContext;
+use pocopine_sync::{RowVersion, SyncResult};
+use pocopine_sync_crud::{
+    async_trait, params, resource, CrudRemoveResult, CrudSource, CrudWriteResult,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[serde(rename_all = "snake_case")]
+enum Status {
+    Open,
+    InProgress,
+    Closed,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+struct Issue {
+    id: String,
+    workspace_id: String,
+    title: String,
+    status: Status,
+    version: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+struct IssueDraft {
+    workspace_id: String,
+    title: String,
+    status: Status,
+}
+
+#[derive(Clone, Default)]
+struct Issues;
+
+#[resource(
+    name = "issues",
+    schema_version = 1,
+    params(
+        workspace_id: String,
+        assignee_id: Option<String>,
+        status: params::InSet<Status>,
+        title: params::Contains,
+    ),
+)]
+#[async_trait]
+impl CrudSource for Issues {
+    type Id = String;
+    type Row = Issue;
+    type Draft = IssueDraft;
+
+    async fn list(&self, _ctx: RequestContext, _limit: usize) -> SyncResult<Vec<Self::Row>> {
+        Ok(Vec::new())
+    }
+
+    async fn get(&self, _ctx: RequestContext, _id: Self::Id) -> SyncResult<Option<Self::Row>> {
+        Ok(None)
+    }
+
+    async fn create(
+        &self,
+        _ctx: RequestContext,
+        _id: Self::Id,
+        _draft: Self::Draft,
+    ) -> SyncResult<Self::Row> {
+        Err(pocopine_sync::SyncError::unsupported("test stub"))
+    }
+
+    async fn save(
+        &self,
+        _ctx: RequestContext,
+        _id: Self::Id,
+        _draft: Self::Draft,
+        _base_version: Option<RowVersion>,
+    ) -> SyncResult<CrudWriteResult<Self::Row>> {
+        Err(pocopine_sync::SyncError::unsupported("test stub"))
+    }
+
+    async fn remove(
+        &self,
+        _ctx: RequestContext,
+        _id: Self::Id,
+        _base_version: Option<RowVersion>,
+    ) -> SyncResult<CrudRemoveResult<Self::Row>> {
+        Err(pocopine_sync::SyncError::unsupported("test stub"))
+    }
+}
+
+#[test]
+fn typed_stream_params_round_trips_through_wire() {
+    let typed = issues::StreamParams {
+        workspace_id: "W".to_string(),
+        assignee_id: Some("alice".to_string()),
+        status: params::InSet::new([Status::Open, Status::InProgress]).unwrap(),
+        title: params::Contains::icontains("auth").unwrap(),
+    };
+    let wire = typed.serialize_params();
+
+    // All non-None fields appear on the wire.
+    assert!(wire.contains_key("workspace_id"));
+    assert!(wire.contains_key("assignee_id"));
+    assert!(wire.contains_key("status"));
+    assert!(wire.contains_key("title"));
+
+    let decoded = issues::StreamParams::extract(&wire).expect("decode");
+    assert_eq!(decoded.workspace_id, "W");
+    assert_eq!(decoded.assignee_id.as_deref(), Some("alice"));
+    assert_eq!(decoded.status.values(), &[Status::Open, Status::InProgress]);
+    assert_eq!(decoded.title.contains, "auth");
+    assert!(!decoded.title.case_sensitive);
+}
+
+#[test]
+fn typed_stream_params_omits_none_optional_field() {
+    let typed = issues::StreamParams {
+        workspace_id: "W".to_string(),
+        assignee_id: None,
+        status: params::InSet::new([Status::Open]).unwrap(),
+        title: params::Contains::icontains("auth").unwrap(),
+    };
+    let wire = typed.serialize_params();
+
+    // None-valued optionals are omitted from the wire shape.
+    assert!(!wire.contains_key("assignee_id"));
+
+    let decoded = issues::StreamParams::extract(&wire).expect("decode");
+    assert!(decoded.assignee_id.is_none());
+}
+
+#[test]
+fn extract_rejects_missing_required() {
+    let empty = pocopine_sync::StreamParams::new();
+    let err = issues::StreamParams::extract(&empty).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("missing required param") && msg.contains("workspace_id"),
+        "unexpected: {msg}"
+    );
+}
+
+#[test]
+fn extract_rejects_unknown_param_key() {
+    let mut wire = pocopine_sync::StreamParams::new();
+    wire.insert(
+        "workspace_id".to_string(),
+        serde_json::Value::String("W".to_string()),
+    );
+    wire.insert("status".to_string(), serde_json::json!({ "in": ["open"] }));
+    wire.insert(
+        "title".to_string(),
+        serde_json::json!({ "contains": "auth", "case_sensitive": false }),
+    );
+    wire.insert(
+        "typo_key".to_string(),
+        serde_json::Value::String("ignored".to_string()),
+    );
+
+    let err = issues::StreamParams::extract(&wire).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("unknown param") && msg.contains("typo_key"),
+        "unexpected: {msg}"
+    );
+}
+
+#[test]
+fn extract_rejects_wrong_shape_for_inset() {
+    let mut wire = pocopine_sync::StreamParams::new();
+    wire.insert(
+        "workspace_id".to_string(),
+        serde_json::Value::String("W".to_string()),
+    );
+    // status is declared as InSet<Status>, expects { "in": [...] }
+    // but here we send a bare string — must reject.
+    wire.insert(
+        "status".to_string(),
+        serde_json::Value::String("not-an-inset".to_string()),
+    );
+    wire.insert(
+        "title".to_string(),
+        serde_json::json!({ "contains": "auth", "case_sensitive": false }),
+    );
+
+    let err = issues::StreamParams::extract(&wire).unwrap_err();
+    assert!(err.to_string().contains("params.status"));
+}

--- a/crates/pocopine-sync/src/error.rs
+++ b/crates/pocopine-sync/src/error.rs
@@ -45,7 +45,12 @@ pub enum SyncError {
 }
 
 impl SyncError {
-    pub(crate) fn invalid_value(field: &'static str, value: impl Into<String>) -> Self {
+    /// Build a typed `InvalidValue` error. Surfaces as
+    /// `ServerError::BadRequest` over the wire via `server_error`.
+    /// Macro-generated `validate_params` impls use this for unknown
+    /// param keys, missing required params, and wrong-shape values
+    /// — anything the client could have sent better.
+    pub fn invalid_value(field: &'static str, value: impl Into<String>) -> Self {
         Self::InvalidValue {
             field,
             value: value.into(),


### PR DESCRIPTION
Second of 4 batches implementing [RFC 085 — Shape subscriptions](https://github.com/mambisi/pocopine/pull/136). Closes #138 (Batch 2 scope minus the SyncClient subscription registry; that's deferred to a follow-up Batch 2b). Stacks on Batch 1 ([#141](https://github.com/mambisi/pocopine/pull/141)).

## Summary

Adds the macro-side surface that lets resource authors declare typed subscription parameters and get the wire encoding + extraction for free.

\`\`\`rust
#[resource(
    name = \"issues\",
    schema_version = 1,
    params(
        workspace_id: String,                     // required eq
        assignee_id: Option<String>,              // optional eq
        status: params::InSet<Status>,            // in
        title: params::Contains,                  // contains
    ),
)]
impl CrudSource for Issues { /* ... */ }

// Generated:
let typed = issues::StreamParams { workspace_id: \"W\".into(), … };
let wire: BTreeMap<String, Value> = typed.serialize_params();
let decoded = issues::StreamParams::extract(&wire)?;

// Fluent builder (will route through subscription registry in Batch 2b):
let view = resource.stream()
    .workspace_id(\"W\")
    .status_in([Status::Open, Status::InProgress])?
    .title_contains(\"auth\")?
    .observe()?;
\`\`\`

## What's in this PR

- \`crates/pocopine-sync-crud/src/params.rs\` (new): \`InSet<T>\`, \`Range<T>\`, \`Contains\` comparator wrappers with validation (non-empty InSet, non-empty Contains needle).
- \`crates/pocopine-sync-crud-macros/src/lib.rs\`: 
  - \`params(field: Type, ...)\` clause parsing
  - \`classify_param_type\` — last-segment + arity inference (\`Option<T>\` / \`InSet<T>\` / \`Range<T>\` / \`Contains\` / bare \`T\`)
  - \`generate_params_codegen\` emits typed \`StreamParams\` struct, \`serialize_params\`, \`extract\`, fluent \`StreamBuilder\`, and \`Resource::stream()\` entry point per declared resource
- \`SyncError::invalid_value\` promoted from \`pub(crate)\` to \`pub\` (macro-generated code constructs typed \`BadRequest\` errors)
- \`pocopine-sync-crud-macros\` gains \`syn/extra-traits\` feature for proc-macro-internal Debug derives

## Tests

- 6 unit tests for \`InSet\` / \`Range\` / \`Contains\` (host-only via cfg, since they exercise serde_json which isn't in pocopine-sync-crud's wasm dep tree)
- 5 integration tests in \`tests/shape_subscriptions.rs\` exercising the macro-generated \`StreamParams\` struct: wire round-trip, optional-field-omitted, missing-required rejection, unknown-key rejection, wrong-shape rejection
- All 19 existing macro unit tests still pass; trybuild snapshots regenerated for the expanded \"expected attribute\" error message

## Deferred to Batch 2b

Two pieces from the original Batch 2 scope split out for focused review:

1. **\`SyncClient\` subscription registry** — \`(name, params_hash)\` dedup, refcount, grace-window cleanup. ~300 LOC on its own; will file as a new issue.
2. **Macro-generated \`validate_params\` override on the source impl** — today source authors call \`StreamParams::extract\` directly from their \`pull\` / \`push\` / \`validate_params\` overrides. The auto-wire is a follow-up.

These deferrals don't break the contract — they're additive convenience.

## CI

- [x] \`cargo fmt --all -- --check\`
- [x] Host + wasm32 clippy with \`-D warnings\`
- [x] Full sync/sync-crud/macros test matrix green