### PR TITLE
Add Azure Blob storage backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,7 @@ jobs:
           --exclude pocopine-jobs
           --exclude pocopine-launcher
           --exclude pocopine-server
+          --exclude pocopine-storage-azure
           --exclude pocopine-storage-gcs
           --exclude pocopine-storage-s3
           --exclude pocopine-sync

--- a/.github/workflows/storage-stress.yml
+++ b/.github/workflows/storage-stress.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - 'crates/pocopine-storage/**'
+      - 'crates/pocopine-storage-azure/**'
       - 'crates/pocopine-storage-s3/**'
       - 'crates/pocopine-storage-gcs/**'
       - 'Cargo.toml'
@@ -15,6 +16,7 @@ on:
     branches: [main]
     paths:
       - 'crates/pocopine-storage/**'
+      - 'crates/pocopine-storage-azure/**'
       - 'crates/pocopine-storage-s3/**'
       - 'crates/pocopine-storage-gcs/**'
       - 'Cargo.toml'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "async-lock"
 version = "3.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -275,6 +287,28 @@ name = "async-once-cell"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288f83726785267c6f2ef073a3d83dc3f9b81464e9f99898240cced85fce35a"
+
+[[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "async-trait"
@@ -790,6 +824,58 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "azure_core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe6a26a7d374b440015cbbcbf2d9d8be5a133aa940599f5e5dc569504baa262e"
+dependencies = [
+ "async-lock",
+ "async-trait",
+ "azure_core_macros",
+ "bytes",
+ "futures",
+ "pin-project",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "typespec",
+ "typespec_client_core",
+]
+
+[[package]]
+name = "azure_core_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9b52dba6a345f3ad2d42ff8d0d63df9d0994cfa29657bf18ffdbf149f78a4f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "tracing",
+]
+
+[[package]]
+name = "azure_storage_blob"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1756febbcca86c862ef718b983b505d08bd65a9bc984a915b0a16af4a4c3fe5b"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "azure_core",
+ "bytes",
+ "futures",
+ "percent-encoding",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "time",
+ "tokio",
 ]
 
 [[package]]
@@ -1328,6 +1414,23 @@ dependencies = [
  "ryu",
  "static_assertions",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "compression-core",
+ "flate2",
+ "memchr",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -5912,6 +6015,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pocopine-storage-azure"
+version = "0.1.0"
+dependencies = [
+ "azure_core",
+ "azure_storage_blob",
+ "base64",
+ "bytes",
+ "futures-util",
+ "hmac 0.12.1",
+ "percent-encoding",
+ "pocopine-storage",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "testcontainers",
+ "time",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "pocopine-storage-gcs"
 version = "0.1.0"
 dependencies = [
@@ -6320,6 +6446,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50793def1b900256624a709439404384204a5dc3a6ec580281bfaac35e882e90"
 dependencies = [
  "pulldown-cmark",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -8671,6 +8807,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags 2.11.1",
  "bytes",
  "futures-core",
@@ -8852,6 +8989,58 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "typespec"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21666a31293beab8f41d38c2849ddbc342cd9c7cb4d71a9818868287a8934e53"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures",
+ "quick-xml",
+ "serde",
+ "serde_json",
+ "url",
+]
+
+[[package]]
+name = "typespec_client_core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924f0c734e0ac3b881ab99d032bd28fcc969d2bb73ef1b8dd4772fd8e518a382"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "dyn-clone",
+ "futures",
+ "pin-project",
+ "rand 0.10.1",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "time",
+ "tokio",
+ "tracing",
+ "typespec",
+ "typespec_macros",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "typespec_macros"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c608f4427943f8adb211abc95c87672b1b98847152783507d54e3246e502f60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "unicase"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
     "crates/pocopine-observe",
     "crates/pocopine-server",
     "crates/pocopine-storage",
+    "crates/pocopine-storage-azure",
     "crates/pocopine-storage-gcs",
     "crates/pocopine-storage-s3",
     "crates/pocopine-sync",
@@ -99,6 +100,7 @@ pocopine-macros = { path = "crates/pocopine-macros", version = "0.1.0" }
 pocopine-observe = { path = "crates/pocopine-observe", version = "0.1.0" }
 pocopine-server = { path = "crates/pocopine-server", version = "0.1.0" }
 pocopine-storage = { path = "crates/pocopine-storage", version = "0.1.0" }
+pocopine-storage-azure = { path = "crates/pocopine-storage-azure", version = "0.1.0" }
 pocopine-storage-gcs = { path = "crates/pocopine-storage-gcs", version = "0.1.0" }
 pocopine-storage-s3 = { path = "crates/pocopine-storage-s3", version = "0.1.0" }
 pocopine-sync = { path = "crates/pocopine-sync", version = "0.1.0" }

--- a/crates/pocopine-storage-azure/Cargo.toml
+++ b/crates/pocopine-storage-azure/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "pocopine-storage-azure"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Azure Blob Storage backend adapter for pocopine-storage."
+
+[dependencies]
+azure_core = "1"
+azure_storage_blob = "1"
+bytes = "1"
+futures-util = "0.3"
+pocopine-storage = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+time = { version = "0.3", features = ["serde"] }
+tokio = { version = "1", default-features = false, features = ["sync"] }
+tracing = { workspace = true }
+uuid = { version = "1", features = ["v4"] }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+base64 = "0.22"
+hmac = "0.12"
+percent-encoding = "2"
+reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
+sha2 = "0.10"
+testcontainers = { version = "0.23", features = ["http_wait"] }
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/crates/pocopine-storage-azure/src/layout.rs
+++ b/crates/pocopine-storage-azure/src/layout.rs
@@ -1,0 +1,233 @@
+use azure_core::http::Url;
+use pocopine_storage::{SafeObjectKey, StorageError, StorageResult, UploadSessionId};
+
+pub(crate) const DEFAULT_INTERNAL_PREFIX: &str = "__pocopine/storage/sessions";
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(crate) struct AzureKeyLayout {
+    pub(crate) container_name: String,
+    pub(crate) container_url: String,
+    pub(crate) object_prefix: Option<String>,
+    internal_prefix_base: String,
+    pub(crate) internal_prefix: String,
+}
+
+impl AzureKeyLayout {
+    pub(crate) fn new(
+        container_url: &Url,
+        object_prefix: Option<String>,
+        internal_prefix: String,
+    ) -> StorageResult<Self> {
+        let container_name = container_name_from_url(container_url)?;
+        let object_prefix = match object_prefix {
+            Some(prefix) => normalize_object_prefix(prefix)?,
+            None => None,
+        };
+        let internal_prefix_base = normalize_internal_prefix(internal_prefix).ok_or_else(|| {
+            StorageError::policy_rejected("Azure internal prefix must not be empty")
+        })?;
+        let internal_prefix =
+            join_optional_prefix(object_prefix.as_deref(), internal_prefix_base.as_str());
+        Ok(Self {
+            container_name,
+            container_url: container_url.to_string(),
+            object_prefix,
+            internal_prefix_base,
+            internal_prefix,
+        })
+    }
+
+    pub(crate) fn with_prefix(&self, prefix: String) -> StorageResult<Self> {
+        Self::new(
+            &Url::parse(&self.container_url).map_err(|err| {
+                StorageError::backend(format!("parse Azure container URL: {err}"))
+            })?,
+            Some(prefix),
+            self.internal_prefix_base.clone(),
+        )
+    }
+
+    pub(crate) fn with_internal_prefix(&self, prefix: String) -> StorageResult<Self> {
+        Self::new(
+            &Url::parse(&self.container_url).map_err(|err| {
+                StorageError::backend(format!("parse Azure container URL: {err}"))
+            })?,
+            self.object_prefix.clone(),
+            prefix,
+        )
+    }
+
+    pub(crate) fn object_key(&self, key: &str) -> String {
+        join_optional_prefix(self.object_prefix.as_deref(), key)
+    }
+
+    pub(crate) fn session_meta_key(&self, session: &UploadSessionId) -> String {
+        format!("{}/{}/session.json", self.internal_prefix, session.as_str())
+    }
+
+    pub(crate) fn session_bytes_key(&self, session: &UploadSessionId) -> String {
+        format!("{}/{}/bytes.tmp", self.internal_prefix, session.as_str())
+    }
+}
+
+fn container_name_from_url(url: &Url) -> StorageResult<String> {
+    let segments: Vec<_> = url
+        .path_segments()
+        .map(|segments| {
+            segments
+                .filter(|segment| !segment.is_empty())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let container = match segments.as_slice() {
+        [container] => (*container).to_string(),
+        [_account, container] if is_local_azurite_url(url) => (*container).to_string(),
+        [] => {
+            return Err(StorageError::policy_rejected(
+                "Azure container URL must include a container name",
+            ));
+        }
+        _ => {
+            return Err(StorageError::policy_rejected(
+                "Azure container URL must point directly to one container",
+            ));
+        }
+    };
+    if container.trim().is_empty() {
+        return Err(StorageError::policy_rejected(
+            "Azure container name must not be empty",
+        ));
+    }
+    Ok(container)
+}
+
+fn is_local_azurite_url(url: &Url) -> bool {
+    url.host_str()
+        .map(|host| matches!(host, "127.0.0.1" | "localhost" | "::1"))
+        .unwrap_or(false)
+}
+
+fn normalize_object_prefix(prefix: String) -> StorageResult<Option<String>> {
+    let prefix = prefix.trim().trim_matches('/');
+    if prefix.is_empty() {
+        return Ok(None);
+    }
+    SafeObjectKey::parse(prefix)?;
+    Ok(Some(prefix.to_string()))
+}
+
+fn normalize_internal_prefix(prefix: String) -> Option<String> {
+    let prefix = prefix.trim().trim_matches('/');
+    if prefix.is_empty() {
+        None
+    } else {
+        Some(prefix.to_string())
+    }
+}
+
+fn join_optional_prefix(prefix: Option<&str>, key: &str) -> String {
+    match prefix {
+        Some(prefix) => format!("{prefix}/{}", key.trim_start_matches('/')),
+        None => key.trim_start_matches('/').to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use azure_core::http::Url;
+
+    use super::*;
+
+    fn container_url() -> Url {
+        Url::parse("http://127.0.0.1:10000/devstoreaccount1/pocopine").unwrap()
+    }
+
+    #[test]
+    fn prefix_layout_keeps_internal_objects_out_of_app_keyspace() {
+        let layout = AzureKeyLayout::new(
+            &container_url(),
+            Some("tenant-a/".to_string()),
+            DEFAULT_INTERNAL_PREFIX.to_string(),
+        )
+        .unwrap();
+        let session = UploadSessionId::new("session-1").unwrap();
+
+        assert_eq!(
+            layout.object_key("files/avatar.png"),
+            "tenant-a/files/avatar.png"
+        );
+        assert_eq!(
+            layout.session_meta_key(&session),
+            "tenant-a/__pocopine/storage/sessions/session-1/session.json"
+        );
+        assert_eq!(
+            layout.session_bytes_key(&session),
+            "tenant-a/__pocopine/storage/sessions/session-1/bytes.tmp"
+        );
+        assert_eq!(layout.container_name, "pocopine");
+    }
+
+    #[test]
+    fn prefix_and_internal_prefix_are_order_independent() {
+        let first =
+            AzureKeyLayout::new(&container_url(), None, DEFAULT_INTERNAL_PREFIX.to_string())
+                .unwrap()
+                .with_internal_prefix("custom/sessions".to_string())
+                .unwrap()
+                .with_prefix("tenant-a".to_string())
+                .unwrap();
+        let second =
+            AzureKeyLayout::new(&container_url(), None, DEFAULT_INTERNAL_PREFIX.to_string())
+                .unwrap()
+                .with_prefix("tenant-a".to_string())
+                .unwrap()
+                .with_internal_prefix("custom/sessions".to_string())
+                .unwrap();
+
+        assert_eq!(first.internal_prefix, "tenant-a/custom/sessions");
+        assert_eq!(second.internal_prefix, first.internal_prefix);
+    }
+
+    #[test]
+    fn empty_container_is_rejected() {
+        let url = Url::parse("https://account.blob.core.windows.net/").unwrap();
+        assert!(AzureKeyLayout::new(&url, None, DEFAULT_INTERNAL_PREFIX.to_string()).is_err());
+    }
+
+    #[test]
+    fn multi_segment_non_azurite_container_url_is_rejected() {
+        let url = Url::parse("https://account.blob.core.windows.net/pocopine/audit/").unwrap();
+        assert!(AzureKeyLayout::new(&url, None, DEFAULT_INTERNAL_PREFIX.to_string()).is_err());
+    }
+
+    #[test]
+    fn reserved_object_prefix_is_rejected() {
+        let rejected = AzureKeyLayout::new(
+            &container_url(),
+            Some("__pocopine".to_string()),
+            DEFAULT_INTERNAL_PREFIX.to_string(),
+        );
+        assert!(matches!(
+            rejected,
+            Err(StorageError::InvalidValue { field, .. }) if field == "object key"
+        ));
+    }
+
+    #[test]
+    fn path_traversal_object_prefix_is_rejected() {
+        let rejected = AzureKeyLayout::new(
+            &container_url(),
+            Some("tenant/../files".to_string()),
+            DEFAULT_INTERNAL_PREFIX.to_string(),
+        );
+        assert!(matches!(
+            rejected,
+            Err(StorageError::InvalidValue { field, .. }) if field == "object key"
+        ));
+    }
+
+    #[test]
+    fn empty_internal_prefix_is_rejected() {
+        assert!(AzureKeyLayout::new(&container_url(), None, " / ".to_string()).is_err());
+    }
+}

--- a/crates/pocopine-storage-azure/src/layout.rs
+++ b/crates/pocopine-storage-azure/src/layout.rs
@@ -57,6 +57,10 @@ impl AzureKeyLayout {
         )
     }
 
+    pub(crate) fn redacted_container_url(&self) -> String {
+        redacted_url(&self.container_url)
+    }
+
     pub(crate) fn object_key(&self, key: &str) -> String {
         join_optional_prefix(self.object_prefix.as_deref(), key)
     }
@@ -81,7 +85,7 @@ fn container_name_from_url(url: &Url) -> StorageResult<String> {
         .unwrap_or_default();
     let container = match segments.as_slice() {
         [container] => (*container).to_string(),
-        [_account, container] if is_local_azurite_url(url) => (*container).to_string(),
+        [_account, container] if !is_official_azure_blob_host(url) => (*container).to_string(),
         [] => {
             return Err(StorageError::policy_rejected(
                 "Azure container URL must include a container name",
@@ -101,10 +105,26 @@ fn container_name_from_url(url: &Url) -> StorageResult<String> {
     Ok(container)
 }
 
-fn is_local_azurite_url(url: &Url) -> bool {
+fn is_official_azure_blob_host(url: &Url) -> bool {
     url.host_str()
-        .map(|host| matches!(host, "127.0.0.1" | "localhost" | "::1"))
+        .map(|host| {
+            host.ends_with(".blob.core.windows.net")
+                || host.ends_with(".blob.core.usgovcloudapi.net")
+                || host.ends_with(".blob.core.chinacloudapi.cn")
+                || host.ends_with(".blob.core.cloudapi.de")
+        })
         .unwrap_or(false)
+}
+
+fn redacted_url(value: &str) -> String {
+    let Ok(mut url) = Url::parse(value) else {
+        return "<invalid Azure container URL>".to_string();
+    };
+    url.set_query(None);
+    url.set_fragment(None);
+    let _ = url.set_username("");
+    let _ = url.set_password(None);
+    url.to_string()
 }
 
 fn normalize_object_prefix(prefix: String) -> StorageResult<Option<String>> {
@@ -198,6 +218,29 @@ mod tests {
     fn multi_segment_non_azurite_container_url_is_rejected() {
         let url = Url::parse("https://account.blob.core.windows.net/pocopine/audit/").unwrap();
         assert!(AzureKeyLayout::new(&url, None, DEFAULT_INTERNAL_PREFIX.to_string()).is_err());
+    }
+
+    #[test]
+    fn non_local_path_style_container_url_is_accepted() {
+        let url = Url::parse("http://azurite:10000/devstoreaccount1/pocopine").unwrap();
+        let layout = AzureKeyLayout::new(&url, None, DEFAULT_INTERNAL_PREFIX.to_string()).unwrap();
+
+        assert_eq!(layout.container_name, "pocopine");
+    }
+
+    #[test]
+    fn redacted_container_url_removes_query_fragment_and_userinfo() {
+        let url = Url::parse(
+            "https://user:password@account.blob.core.windows.net/pocopine?sig=secret#frag",
+        )
+        .unwrap();
+        let layout = AzureKeyLayout::new(&url, None, DEFAULT_INTERNAL_PREFIX.to_string()).unwrap();
+        let redacted = layout.redacted_container_url();
+
+        assert_eq!(redacted, "https://account.blob.core.windows.net/pocopine");
+        assert!(!redacted.contains("sig="));
+        assert!(!redacted.contains("secret"));
+        assert!(!redacted.contains("password"));
     }
 
     #[test]

--- a/crates/pocopine-storage-azure/src/lib.rs
+++ b/crates/pocopine-storage-azure/src/lib.rs
@@ -1,0 +1,18 @@
+//! Azure Blob Storage backend adapter for `pocopine-storage`.
+//!
+//! This crate implements Pocopine's current bounded sequential proxy upload
+//! contract using the official `azure_storage_blob` client surface. Completed
+//! objects are written by `SafeObjectKey`, while upload-session metadata and
+//! staging bytes live under an internal prefix in the same Azure container.
+//!
+//! The adapter rewrites the staged blob on each append and keeps only
+//! in-process per-session locks, so route a given upload session to one server
+//! replica or wait for a future provider-side block-blob backend before using
+//! it for large or horizontally written uploads.
+
+mod layout;
+mod state;
+mod storage;
+mod util;
+
+pub use storage::AzureBlobStorageBackend;

--- a/crates/pocopine-storage-azure/src/state.rs
+++ b/crates/pocopine-storage-azure/src/state.rs
@@ -1,0 +1,133 @@
+use std::collections::BTreeMap;
+
+use pocopine_storage::backend_common::refresh_expired;
+use pocopine_storage::{
+    ChecksumPolicy, ObjectRef, ObjectVisibility, StorageActor, StorageKey, UploadSession,
+};
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub(crate) struct StoredUploadSession {
+    pub(crate) public: UploadSession,
+    pub(crate) owner: StorageActor,
+    pub(crate) storage_key: StorageKey,
+    pub(crate) visibility: ObjectVisibility,
+    pub(crate) max_bytes: u64,
+    pub(crate) checksum_policy: ChecksumPolicy,
+    pub(crate) request_metadata: BTreeMap<String, String>,
+    pub(crate) object: Option<ObjectRef>,
+    #[serde(default)]
+    pub(crate) completion_object_key: Option<String>,
+    #[serde(default)]
+    pub(crate) cleanup_pending: bool,
+    #[serde(skip)]
+    pub(crate) meta_etag: Option<String>,
+}
+
+pub(crate) struct AzureObjectBytes {
+    pub(crate) bytes: Vec<u8>,
+    pub(crate) etag: Option<String>,
+    pub(crate) version_id: Option<String>,
+    pub(crate) truncated: bool,
+}
+
+impl AzureObjectBytes {
+    pub(crate) fn empty() -> Self {
+        Self {
+            bytes: Vec::new(),
+            etag: None,
+            version_id: None,
+            truncated: false,
+        }
+    }
+}
+
+pub(crate) struct AzureObjectMetadata {
+    pub(crate) size: Option<u64>,
+    pub(crate) etag: Option<String>,
+    pub(crate) version_id: Option<String>,
+}
+
+pub(crate) struct AzureObjectWrite {
+    pub(crate) etag: Option<String>,
+    pub(crate) version_id: Option<String>,
+}
+
+pub(crate) enum AbortSessionRead {
+    Known(Box<StoredUploadSession>),
+    Missing,
+    Corrupt,
+}
+
+pub(crate) fn decode_session_object(
+    object: AzureObjectBytes,
+) -> Result<StoredUploadSession, serde_json::Error> {
+    let meta_etag = object.etag;
+    let mut stored: StoredUploadSession = serde_json::from_slice(&object.bytes)?;
+    stored.meta_etag = meta_etag;
+    refresh_expired(&mut stored.public);
+    Ok(stored)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use pocopine_storage::{
+        ChecksumPolicy, ObjectVisibility, SafeObjectKey, StorageActor, StorageKey, TransferPlan,
+        UploadSession, UploadSessionId, UploadSessionStatus, UploadStrategy,
+    };
+    use time::OffsetDateTime;
+
+    use super::*;
+
+    #[test]
+    fn metadata_decode_refreshes_expiration_and_carries_etag_state() {
+        let session = UploadSession {
+            id: UploadSessionId::new("expired-session").unwrap(),
+            scope: "files".to_string(),
+            file_name: "hello.txt".to_string(),
+            size: Some(5),
+            content_type: Some("text/plain".to_string()),
+            metadata: BTreeMap::new(),
+            strategy: UploadStrategy::Sequential,
+            status: UploadSessionStatus::Open,
+            next_offset: Some(0),
+            part_size: Some(5),
+            plan: TransferPlan {
+                min_part_size: None,
+                preferred_part_size: Some(5),
+                max_part_size: None,
+                max_parts: None,
+                max_concurrent_parts: 1,
+                resumable: true,
+            },
+            uploaded_parts: Vec::new(),
+            expires_at: OffsetDateTime::UNIX_EPOCH,
+        };
+        let stored = StoredUploadSession {
+            public: session,
+            owner: StorageActor::System("owner".to_string()),
+            storage_key: StorageKey::new(SafeObjectKey::parse("files/hello.txt").unwrap()),
+            visibility: ObjectVisibility::Private,
+            max_bytes: 1024,
+            checksum_policy: ChecksumPolicy::None,
+            request_metadata: BTreeMap::new(),
+            object: None,
+            completion_object_key: None,
+            cleanup_pending: false,
+            meta_etag: None,
+        };
+        let bytes = serde_json::to_vec(&stored).unwrap();
+
+        let decoded = decode_session_object(AzureObjectBytes {
+            bytes,
+            etag: Some("\"etag-1\"".to_string()),
+            version_id: Some("version-1".to_string()),
+            truncated: false,
+        })
+        .unwrap();
+
+        assert_eq!(decoded.public.status, UploadSessionStatus::Expired);
+        assert_eq!(decoded.meta_etag.as_deref(), Some("\"etag-1\""));
+    }
+}

--- a/crates/pocopine-storage-azure/src/storage.rs
+++ b/crates/pocopine-storage-azure/src/storage.rs
@@ -60,7 +60,7 @@ impl std::fmt::Debug for AzureBlobStorageBackend {
         f.debug_struct("AzureBlobStorageBackend")
             .field("name", &self.name)
             .field("container", &self.layout.container_name)
-            .field("container_url", &self.layout.container_url)
+            .field("container_url", &self.layout.redacted_container_url())
             .field("object_prefix", &self.layout.object_prefix)
             .field("internal_prefix", &self.layout.internal_prefix)
             .field("max_proxy_upload_bytes", &self.max_proxy_upload_bytes)
@@ -993,5 +993,31 @@ impl StorageBackend for AzureBlobStorageBackend {
             meta_deleted?;
             Ok(())
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use azure_core::http::Url;
+    use azure_storage_blob::BlobContainerClient;
+
+    use super::*;
+
+    #[test]
+    fn debug_redacts_container_sas_query() {
+        let url =
+            Url::parse("https://account.blob.core.windows.net/pocopine?sv=2024-01-01&sig=secret")
+                .unwrap();
+        let container =
+            BlobContainerClient::new(url, None, None).expect("build Azure container client");
+        let backend = AzureBlobStorageBackend::new(container).unwrap();
+
+        let debug = format!("{backend:?}");
+
+        assert!(debug.contains("AzureBlobStorageBackend"));
+        assert!(debug.contains("https://account.blob.core.windows.net/pocopine"));
+        assert!(!debug.contains("sig="));
+        assert!(!debug.contains("secret"));
+        assert!(!debug.contains("?sv="));
     }
 }

--- a/crates/pocopine-storage-azure/src/storage.rs
+++ b/crates/pocopine-storage-azure/src/storage.rs
@@ -1,0 +1,997 @@
+use std::sync::Arc;
+
+use azure_core::http::{Etag, NoFormat, RequestContent};
+use azure_storage_blob::models::{
+    BlobClientDeleteOptions, BlobClientDownloadOptions, BlobClientGetPropertiesResultHeaders,
+    BlobClientUploadOptions, DeleteSnapshotsOptionType, HttpRange,
+};
+use azure_storage_blob::{BlobContainerClient, BlobServiceClient};
+use bytes::Bytes;
+use futures_util::StreamExt;
+use pocopine_storage::backend_common::{
+    checked_new_offset, ensure_open, ensure_owner, ensure_size_limit,
+    ensure_upload_length_can_be_set, expires_at, selected_strategy, UploadSessionLockCleanup,
+    UploadSessionLockRegistry,
+};
+use pocopine_storage::checksum::{ensure_supported_checksum_policy, validate_complete_checksum};
+use pocopine_storage::{
+    CompleteUpload, InitiateUpload, ObjectChecksum, ObjectRef, StorageActor, StorageBackend,
+    StorageBoxFuture, StorageContext, StorageError, StorageResult, TransferPlan, UploadSession,
+    UploadSessionId, UploadSessionStatus, UploadStrategy,
+};
+use uuid::Uuid;
+
+use crate::layout::{AzureKeyLayout, DEFAULT_INTERNAL_PREFIX};
+use crate::state::{
+    decode_session_object, AbortSessionRead, AzureObjectBytes, AzureObjectMetadata,
+    AzureObjectWrite, StoredUploadSession,
+};
+use crate::util::{
+    azure_error, bytes_match_at, ensure_completable, is_azure_already_exists, is_azure_not_found,
+    is_azure_precondition_failed, map_session_write_error, usize_from_u64,
+};
+
+const DEFAULT_BACKEND_NAME: &str = "azure";
+const DEFAULT_MAX_PROXY_UPLOAD_BYTES: u64 = 64 * 1024 * 1024;
+const MAX_SESSION_METADATA_BYTES: u64 = 256 * 1024;
+
+#[derive(Clone, Debug)]
+enum BlobWritePrecondition {
+    IfNotExists,
+    IfMatch(String),
+}
+
+/// Storage backend backed by Azure Blob Storage.
+///
+/// Pass a pre-built [`BlobContainerClient`] so applications can configure
+/// authentication, SAS URLs, emulators, custom transports, retry policy, and
+/// tracing through the official Azure SDK.
+#[derive(Clone)]
+pub struct AzureBlobStorageBackend {
+    name: &'static str,
+    container: Arc<BlobContainerClient>,
+    layout: AzureKeyLayout,
+    max_proxy_upload_bytes: u64,
+    session_locks: UploadSessionLockRegistry,
+}
+
+impl std::fmt::Debug for AzureBlobStorageBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AzureBlobStorageBackend")
+            .field("name", &self.name)
+            .field("container", &self.layout.container_name)
+            .field("container_url", &self.layout.container_url)
+            .field("object_prefix", &self.layout.object_prefix)
+            .field("internal_prefix", &self.layout.internal_prefix)
+            .field("max_proxy_upload_bytes", &self.max_proxy_upload_bytes)
+            .finish_non_exhaustive()
+    }
+}
+
+impl AzureBlobStorageBackend {
+    /// Build a backend named `azure` for the given container.
+    pub fn new(container: BlobContainerClient) -> StorageResult<Self> {
+        Self::named(DEFAULT_BACKEND_NAME, container)
+    }
+
+    /// Build a backend named `azure` by deriving a container client from an
+    /// Azure Blob service client.
+    pub fn from_service(
+        service: BlobServiceClient,
+        container_name: impl AsRef<str>,
+    ) -> StorageResult<Self> {
+        if container_name.as_ref().trim().is_empty() {
+            return Err(StorageError::policy_rejected(
+                "Azure container name must not be empty",
+            ));
+        }
+        Self::new(service.blob_container_client(container_name.as_ref()))
+    }
+
+    /// Build a backend with an explicit registry name.
+    pub fn named(name: &'static str, container: BlobContainerClient) -> StorageResult<Self> {
+        let layout =
+            AzureKeyLayout::new(container.url(), None, DEFAULT_INTERNAL_PREFIX.to_string())?;
+        Ok(Self {
+            name,
+            container: Arc::new(container),
+            layout,
+            max_proxy_upload_bytes: DEFAULT_MAX_PROXY_UPLOAD_BYTES,
+            session_locks: UploadSessionLockRegistry::new(),
+        })
+    }
+
+    /// Store completed blobs below a container prefix.
+    ///
+    /// The internal session prefix is also nested under this prefix to keep all
+    /// Pocopine-owned blobs together.
+    pub fn with_prefix(mut self, prefix: impl Into<String>) -> StorageResult<Self> {
+        self.layout = self.layout.with_prefix(prefix.into())?;
+        Ok(self)
+    }
+
+    /// Override the internal upload-session prefix.
+    pub fn with_internal_prefix(mut self, prefix: impl Into<String>) -> StorageResult<Self> {
+        self.layout = self.layout.with_internal_prefix(prefix.into())?;
+        Ok(self)
+    }
+
+    /// Override the maximum size accepted by this sequential proxy backend.
+    ///
+    /// The default is 64 MiB because each append rewrites the staged blob and
+    /// completion loads the staged bytes before the final Azure write.
+    pub fn with_max_proxy_upload_bytes(mut self, max_bytes: u64) -> StorageResult<Self> {
+        if max_bytes == 0 {
+            return Err(StorageError::policy_rejected(
+                "Azure max proxy upload bytes must be greater than zero",
+            ));
+        }
+        self.max_proxy_upload_bytes = max_bytes;
+        Ok(self)
+    }
+
+    pub fn container(&self) -> &str {
+        &self.layout.container_name
+    }
+
+    pub fn container_url(&self) -> &str {
+        &self.layout.container_url
+    }
+
+    pub fn object_prefix(&self) -> Option<&str> {
+        self.layout.object_prefix.as_deref()
+    }
+
+    pub fn internal_prefix(&self) -> &str {
+        &self.layout.internal_prefix
+    }
+
+    pub fn max_proxy_upload_bytes(&self) -> u64 {
+        self.max_proxy_upload_bytes
+    }
+
+    async fn read_session(&self, session: &UploadSessionId) -> StorageResult<StoredUploadSession> {
+        match self.read_session_object(session).await {
+            Ok(object) => {
+                let stored = decode_session_object(object).map_err(|err| {
+                    StorageError::backend(format!("read Azure upload metadata: {err}"))
+                })?;
+                if stored.meta_etag.is_none() {
+                    return Err(StorageError::backend(
+                        "Azure upload metadata ETag is unavailable",
+                    ));
+                }
+                Ok(stored)
+            }
+            Err(StorageError::UnknownUploadSession { .. }) => {
+                Err(StorageError::unknown_upload_session(session.to_string()))
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    async fn read_session_for_abort(
+        &self,
+        session: &UploadSessionId,
+    ) -> StorageResult<AbortSessionRead> {
+        match self.read_session_object(session).await {
+            Ok(object) => match decode_session_object(object) {
+                Ok(stored) => Ok(AbortSessionRead::Known(Box::new(stored))),
+                Err(err) => {
+                    tracing::warn!(
+                        target: "pocopine.log",
+                        event_name = "pocopine.storage.azure_corrupt_upload_metadata",
+                        session = %session,
+                        error = %err,
+                    );
+                    Ok(AbortSessionRead::Corrupt)
+                }
+            },
+            Err(StorageError::UnknownUploadSession { .. }) => Ok(AbortSessionRead::Missing),
+            Err(err) => Err(err),
+        }
+    }
+
+    async fn read_session_object(
+        &self,
+        session: &UploadSessionId,
+    ) -> StorageResult<AzureObjectBytes> {
+        let key = self.layout.session_meta_key(session);
+        self.get_object_bytes_with_limit(&key, MAX_SESSION_METADATA_BYTES)
+            .await
+    }
+
+    async fn create_session(
+        &self,
+        session: &UploadSessionId,
+        stored: &mut StoredUploadSession,
+    ) -> StorageResult<()> {
+        self.write_session_with_precondition(session, stored, BlobWritePrecondition::IfNotExists)
+            .await
+    }
+
+    async fn write_session(
+        &self,
+        session: &UploadSessionId,
+        stored: &mut StoredUploadSession,
+    ) -> StorageResult<()> {
+        let etag = stored
+            .meta_etag
+            .clone()
+            .ok_or_else(|| StorageError::backend("Azure upload metadata ETag is unavailable"))?;
+        self.write_session_with_precondition(session, stored, BlobWritePrecondition::IfMatch(etag))
+            .await
+    }
+
+    async fn write_session_with_precondition(
+        &self,
+        session: &UploadSessionId,
+        stored: &mut StoredUploadSession,
+        precondition: BlobWritePrecondition,
+    ) -> StorageResult<()> {
+        let key = self.layout.session_meta_key(session);
+        let bytes = serde_json::to_vec_pretty(stored)
+            .map_err(|err| StorageError::backend(format!("encode Azure upload metadata: {err}")))?;
+        let written = self
+            .put_object_bytes(
+                &key,
+                Bytes::from(bytes),
+                Some("application/json"),
+                Some(precondition),
+            )
+            .await
+            .map_err(map_session_write_error)?;
+        stored.meta_etag = written.etag;
+        Ok(())
+    }
+
+    async fn get_staged_bytes(
+        &self,
+        session: &UploadSessionId,
+        read_limit: u64,
+    ) -> StorageResult<AzureObjectBytes> {
+        let key = self.layout.session_bytes_key(session);
+        match self.get_object_bytes_with_limit(&key, read_limit).await {
+            Ok(bytes) => Ok(bytes),
+            Err(StorageError::UnknownUploadSession { .. }) => Ok(AzureObjectBytes::empty()),
+            Err(err) => Err(err),
+        }
+    }
+
+    async fn reconcile_staged_bytes(
+        &self,
+        session: &UploadSessionId,
+        trusted_len: u64,
+    ) -> StorageResult<Vec<u8>> {
+        let read_limit = trusted_len
+            .checked_add(1)
+            .ok_or_else(|| StorageError::policy_rejected("upload byte offset overflowed"))?;
+        let mut staged = self.get_staged_bytes(session, read_limit).await?;
+        let actual = staged.bytes.len() as u64;
+        if actual > trusted_len {
+            tracing::warn!(
+                target: "pocopine.log",
+                event_name = "pocopine.storage.azure_staged_bytes_truncated",
+                session = %session,
+                actual,
+                trusted = trusted_len,
+            );
+            staged.bytes.truncate(usize_from_u64(trusted_len)?);
+            self.put_staged_bytes(
+                session,
+                Bytes::from(staged.bytes.clone()),
+                staged.etag.map(BlobWritePrecondition::IfMatch),
+            )
+            .await?;
+            return Ok(staged.bytes);
+        }
+        if actual == trusted_len {
+            return Ok(staged.bytes);
+        }
+        Err(StorageError::backend(format!(
+            "Azure staged upload blob is shorter than committed metadata: expected {trusted_len} bytes, got {actual}"
+        )))
+    }
+
+    async fn ensure_staged_not_shorter_than_metadata(
+        &self,
+        session: &UploadSessionId,
+        trusted_len: u64,
+    ) -> StorageResult<()> {
+        let read_limit = trusted_len
+            .checked_add(1)
+            .ok_or_else(|| StorageError::policy_rejected("upload byte offset overflowed"))?;
+        let staged = self.get_staged_bytes(session, read_limit).await?;
+        let actual = staged.bytes.len() as u64;
+        if actual < trusted_len {
+            return Err(StorageError::backend(format!(
+                "Azure staged upload blob is shorter than committed metadata: expected {trusted_len} bytes, got {actual}"
+            )));
+        }
+        Ok(())
+    }
+
+    async fn put_staged_bytes(
+        &self,
+        session: &UploadSessionId,
+        bytes: Bytes,
+        precondition: Option<BlobWritePrecondition>,
+    ) -> StorageResult<AzureObjectWrite> {
+        let key = self.layout.session_bytes_key(session);
+        self.put_object_bytes(&key, bytes, Some("application/octet-stream"), precondition)
+            .await
+            .map_err(map_session_write_error)
+    }
+
+    async fn get_object_bytes_with_limit(
+        &self,
+        key: &str,
+        max_bytes: u64,
+    ) -> StorageResult<AzureObjectBytes> {
+        let metadata = self.get_object_metadata(key).await?;
+        self.download_object_bytes_with_limit(key, max_bytes, metadata)
+            .await
+    }
+
+    async fn download_object_bytes_with_limit(
+        &self,
+        key: &str,
+        max_bytes: u64,
+        metadata: AzureObjectMetadata,
+    ) -> StorageResult<AzureObjectBytes> {
+        if metadata.size == Some(0) {
+            return Ok(AzureObjectBytes {
+                bytes: Vec::new(),
+                etag: metadata.etag,
+                version_id: metadata.version_id,
+                truncated: false,
+            });
+        }
+        let probe_limit = max_bytes
+            .checked_add(1)
+            .ok_or_else(|| StorageError::policy_rejected("blob read limit overflowed"))?;
+        let read_len = metadata
+            .size
+            .map_or(probe_limit, |size| size.min(probe_limit));
+        let mut options = BlobClientDownloadOptions {
+            range: Some(HttpRange::new(0, read_len)),
+            ..Default::default()
+        };
+        if let Some(etag) = &metadata.etag {
+            options.if_match = Some(Etag::from(etag.clone()));
+        }
+        let response = self
+            .container
+            .blob_client(key)
+            .download(Some(options))
+            .await
+            .map_err(|err| {
+                if is_azure_not_found(&err) {
+                    StorageError::unknown_upload_session(key.to_string())
+                } else if is_azure_precondition_failed(&err) {
+                    StorageError::conflict("Azure blob changed while reading")
+                } else {
+                    azure_error("download blob", err)
+                }
+            })?;
+        let collect_limit = usize_from_u64(probe_limit)?;
+        let mut body = response.body;
+        let mut bytes = Vec::with_capacity(usize_from_u64(read_len.min(probe_limit))?);
+        let mut body_exceeded_limit = false;
+        while let Some(chunk) = body.next().await {
+            let chunk = chunk.map_err(|err| azure_error("read blob body", err))?;
+            let remaining = collect_limit.saturating_sub(bytes.len());
+            if chunk.len() > remaining {
+                bytes.extend_from_slice(&chunk[..remaining]);
+                body_exceeded_limit = true;
+                break;
+            }
+            bytes.extend_from_slice(&chunk);
+            if bytes.len() == collect_limit {
+                body_exceeded_limit = true;
+                break;
+            }
+        }
+        let truncated =
+            metadata.size.map(|size| size > max_bytes).unwrap_or(false) || body_exceeded_limit;
+        if bytes.len() > usize_from_u64(max_bytes)? {
+            bytes.truncate(usize_from_u64(max_bytes)?);
+        }
+        Ok(AzureObjectBytes {
+            bytes,
+            etag: response
+                .properties
+                .etag
+                .map(|etag| etag.to_string())
+                .or(metadata.etag),
+            version_id: response.properties.version_id.or(metadata.version_id),
+            truncated,
+        })
+    }
+
+    async fn get_object_metadata(&self, key: &str) -> StorageResult<AzureObjectMetadata> {
+        let response = self
+            .container
+            .blob_client(key)
+            .get_properties(None)
+            .await
+            .map_err(|err| {
+                if is_azure_not_found(&err) {
+                    StorageError::unknown_upload_session(key.to_string())
+                } else {
+                    azure_error("read blob metadata", err)
+                }
+            })?;
+        let size = response
+            .content_length()
+            .map_err(|err| azure_error("read blob content length", err))?;
+        let etag = response
+            .etag()
+            .map_err(|err| azure_error("read blob etag", err))?
+            .map(|etag| etag.to_string());
+        let version_id = response
+            .version_id()
+            .map_err(|err| azure_error("read blob version id", err))?;
+        Ok(AzureObjectMetadata {
+            size,
+            etag,
+            version_id,
+        })
+    }
+
+    async fn put_object_bytes(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        content_type: Option<&str>,
+        precondition: Option<BlobWritePrecondition>,
+    ) -> StorageResult<AzureObjectWrite> {
+        let mut options = BlobClientUploadOptions::default();
+        if let Some(content_type) = content_type {
+            options.blob_content_type = Some(content_type.to_string());
+        }
+        if let Some(precondition) = precondition {
+            match precondition {
+                BlobWritePrecondition::IfNotExists => {
+                    options.if_none_match = Some(Etag::from("*"));
+                }
+                BlobWritePrecondition::IfMatch(etag) => {
+                    options.if_match = Some(Etag::from(etag));
+                }
+            }
+        }
+        let content: RequestContent<Bytes, NoFormat> = bytes.into();
+        let response = self
+            .container
+            .blob_client(key)
+            .upload(content, Some(options))
+            .await
+            .map_err(|err| {
+                if is_azure_precondition_failed(&err) || is_azure_already_exists(&err) {
+                    StorageError::conflict("Azure blob write precondition failed")
+                } else {
+                    azure_error("write blob", err)
+                }
+            })?;
+        Ok(AzureObjectWrite {
+            etag: response.etag.map(|etag| etag.to_string()),
+            version_id: response.version_id,
+        })
+    }
+
+    async fn put_completed_object(
+        &self,
+        key: &str,
+        bytes: Bytes,
+        content_type: Option<&str>,
+    ) -> StorageResult<AzureObjectWrite> {
+        match self.compare_existing_completed_object(key, &bytes).await {
+            Ok(Some(existing)) => return Ok(existing),
+            Ok(None) => {
+                return Err(StorageError::policy_rejected(format!(
+                    "Azure blob key already exists with different bytes: {key}"
+                )));
+            }
+            Err(StorageError::UnknownUploadSession { .. }) => {}
+            Err(err) => return Err(err),
+        }
+        match self
+            .put_object_bytes(
+                key,
+                bytes.clone(),
+                content_type,
+                Some(BlobWritePrecondition::IfNotExists),
+            )
+            .await
+        {
+            Ok(written) => Ok(written),
+            Err(StorageError::Conflict { .. }) => {
+                match self.compare_existing_completed_object(key, &bytes).await {
+                    Ok(Some(existing)) => Ok(existing),
+                    Ok(None) | Err(StorageError::UnknownUploadSession { .. }) => {
+                        Err(StorageError::policy_rejected(format!(
+                            "Azure blob key already exists: {key}"
+                        )))
+                    }
+                    Err(err) => Err(err),
+                }
+            }
+            Err(err) => Err(err),
+        }
+    }
+
+    async fn compare_existing_completed_object(
+        &self,
+        key: &str,
+        bytes: &Bytes,
+    ) -> StorageResult<Option<AzureObjectWrite>> {
+        let metadata = self.get_object_metadata(key).await?;
+        if let Some(size) = metadata.size {
+            if size != bytes.len() as u64 {
+                return Ok(None);
+            }
+        }
+        let metadata_etag = metadata.etag.clone();
+        let metadata_version_id = metadata.version_id.clone();
+        let existing = self
+            .download_object_bytes_with_limit(key, bytes.len() as u64, metadata)
+            .await?;
+        if existing.truncated || existing.bytes.as_slice() != bytes.as_ref() {
+            return Ok(None);
+        }
+        Ok(Some(AzureObjectWrite {
+            etag: existing.etag.or(metadata_etag),
+            version_id: existing.version_id.or(metadata_version_id),
+        }))
+    }
+
+    async fn delete_object(&self, key: &str) -> StorageResult<()> {
+        let options = BlobClientDeleteOptions {
+            delete_snapshots: Some(DeleteSnapshotsOptionType::Include),
+            ..Default::default()
+        };
+        self.container
+            .blob_client(key)
+            .delete(Some(options))
+            .await
+            .map_err(|err| {
+                if is_azure_not_found(&err) {
+                    StorageError::unknown_upload_session(key.to_string())
+                } else {
+                    azure_error("delete blob", err)
+                }
+            })?;
+        Ok(())
+    }
+
+    async fn delete_object_if_exists(&self, key: &str) -> StorageResult<()> {
+        match self.delete_object(key).await {
+            Ok(()) | Err(StorageError::UnknownUploadSession { .. }) => Ok(()),
+            Err(err) => Err(err),
+        }
+    }
+
+    async fn persist_expired_if_needed(
+        &self,
+        session: &UploadSessionId,
+        stored: &mut StoredUploadSession,
+    ) -> StorageResult<()> {
+        if stored.public.status == UploadSessionStatus::Expired {
+            self.write_session(session, stored).await?;
+        }
+        Ok(())
+    }
+
+    async fn cleanup_staged_bytes(
+        &self,
+        session: &UploadSessionId,
+        stored: &mut StoredUploadSession,
+    ) -> StorageResult<()> {
+        if !stored.cleanup_pending {
+            return Ok(());
+        }
+        self.delete_object_if_exists(&self.layout.session_bytes_key(session))
+            .await?;
+        stored.cleanup_pending = false;
+        self.write_session(session, stored).await
+    }
+
+    async fn cleanup_staged_bytes_best_effort(
+        &self,
+        session: &UploadSessionId,
+        stored: &mut StoredUploadSession,
+    ) {
+        if let Err(err) = self.cleanup_staged_bytes(session, stored).await {
+            tracing::warn!(
+                target: "pocopine.log",
+                event_name = "pocopine.storage.azure_cleanup_pending",
+                session = %session,
+                error = %err,
+            );
+        }
+    }
+
+    async fn rollback_completion_after_error(
+        &self,
+        session: &UploadSessionId,
+        stored: &mut StoredUploadSession,
+        error: StorageError,
+    ) -> StorageError {
+        stored.public.status = UploadSessionStatus::Open;
+        stored.completion_object_key = None;
+        match self.write_session(session, stored).await {
+            Ok(()) => error,
+            Err(rollback_error) => {
+                tracing::error!(
+                    target: "pocopine.log",
+                    event_name = "pocopine.storage.azure_completion_rollback_failed",
+                    session = %session,
+                    original_error = %error,
+                    rollback_error = %rollback_error,
+                );
+                StorageError::backend(format!(
+                    "Azure complete upload failed ({error}); rollback failed ({rollback_error})"
+                ))
+            }
+        }
+    }
+
+    fn ensure_requested_size_is_supported(&self, size: Option<u64>) -> StorageResult<()> {
+        if let Some(size) = size {
+            if size > self.max_proxy_upload_bytes {
+                return Err(StorageError::payload_too_large(self.max_proxy_upload_bytes));
+            }
+        }
+        Ok(())
+    }
+
+    fn ensure_policy_is_supported(&self, max_bytes: u64) -> StorageResult<()> {
+        if max_bytes > self.max_proxy_upload_bytes {
+            return Err(StorageError::payload_too_large(self.max_proxy_upload_bytes));
+        }
+        Ok(())
+    }
+
+    fn object_ref(
+        &self,
+        stored: &StoredUploadSession,
+        size: u64,
+        written: AzureObjectWrite,
+        checksum: Option<ObjectChecksum>,
+    ) -> ObjectRef {
+        let mut metadata = stored.storage_key.metadata.0.clone();
+        metadata.extend(stored.request_metadata.clone());
+        ObjectRef {
+            backend: self.name.to_string(),
+            scope: stored.public.scope.clone(),
+            key: stored.storage_key.key.to_string(),
+            version: written.version_id,
+            etag: written.etag,
+            checksum,
+            content_type: stored.public.content_type.clone(),
+            size,
+            visibility: stored.visibility,
+            metadata,
+        }
+    }
+}
+
+impl StorageBackend for AzureBlobStorageBackend {
+    fn name(&self) -> &'static str {
+        self.name
+    }
+
+    fn initiate_upload<'a>(
+        &'a self,
+        ctx: &'a StorageContext,
+        request: InitiateUpload,
+    ) -> StorageBoxFuture<'a, UploadSession> {
+        Box::pin(async move {
+            let strategy = selected_strategy(request.requested_strategy)?;
+            ensure_supported_checksum_policy(&request.policy.checksum)?;
+            self.ensure_policy_is_supported(request.policy.max_bytes)?;
+            self.ensure_requested_size_is_supported(request.size)?;
+            let id = UploadSessionId::new(Uuid::new_v4().to_string())?;
+            let session = UploadSession {
+                id: id.clone(),
+                scope: request.scope.clone(),
+                file_name: request.file_name.clone(),
+                size: request.size,
+                content_type: request.content_type.clone(),
+                metadata: request.metadata.clone(),
+                strategy,
+                status: UploadSessionStatus::Open,
+                next_offset: Some(0),
+                part_size: request.policy.preferred_chunk_size,
+                plan: TransferPlan {
+                    min_part_size: request.policy.min_part_size,
+                    preferred_part_size: request.policy.preferred_chunk_size,
+                    max_part_size: request.policy.max_part_size,
+                    max_parts: request.policy.max_parts,
+                    max_concurrent_parts: 1,
+                    resumable: true,
+                },
+                uploaded_parts: Vec::new(),
+                expires_at: expires_at(request.policy.expires_after),
+            };
+            let mut stored = StoredUploadSession {
+                public: session.clone(),
+                owner: ctx.actor.clone(),
+                storage_key: request.storage_key,
+                visibility: request.policy.visibility,
+                max_bytes: request.policy.max_bytes.min(self.max_proxy_upload_bytes),
+                checksum_policy: request.policy.checksum,
+                request_metadata: request.metadata,
+                object: None,
+                completion_object_key: None,
+                cleanup_pending: false,
+                meta_etag: None,
+            };
+            self.create_session(&id, &mut stored).await?;
+            if let Err(err) = self
+                .put_staged_bytes(&id, Bytes::new(), Some(BlobWritePrecondition::IfNotExists))
+                .await
+            {
+                let _ = self
+                    .delete_object_if_exists(&self.layout.session_meta_key(&id))
+                    .await;
+                return Err(err);
+            }
+            Ok(session)
+        })
+    }
+
+    fn inspect_upload<'a>(
+        &'a self,
+        ctx: &'a StorageContext,
+        session: UploadSessionId,
+    ) -> StorageBoxFuture<'a, UploadSession> {
+        Box::pin(async move {
+            let lock = self.session_locks.lock(&session);
+            let _cleanup = UploadSessionLockCleanup::new(&self.session_locks, &session);
+            let _guard = lock.lock().await;
+            let stored = self.read_session(&session).await?;
+            ensure_owner(&ctx.actor, &stored.owner)?;
+            if stored.public.status == UploadSessionStatus::Open {
+                self.ensure_staged_not_shorter_than_metadata(
+                    &session,
+                    stored.public.next_offset.unwrap_or(0),
+                )
+                .await?;
+            }
+            Ok(stored.public)
+        })
+    }
+
+    fn set_upload_length<'a>(
+        &'a self,
+        ctx: &'a StorageContext,
+        session: UploadSessionId,
+        size: u64,
+    ) -> StorageBoxFuture<'a, UploadSession> {
+        Box::pin(async move {
+            let lock = self.session_locks.lock(&session);
+            let _cleanup = UploadSessionLockCleanup::new(&self.session_locks, &session);
+            let _guard = lock.lock().await;
+            self.ensure_requested_size_is_supported(Some(size))?;
+            let mut stored = self.read_session(&session).await?;
+            ensure_owner(&ctx.actor, &stored.owner)?;
+            self.persist_expired_if_needed(&session, &mut stored)
+                .await?;
+            let committed_offset = stored.public.next_offset.unwrap_or(0);
+            self.ensure_staged_not_shorter_than_metadata(&session, committed_offset)
+                .await?;
+            ensure_upload_length_can_be_set(
+                stored.max_bytes,
+                &stored.public,
+                committed_offset,
+                size,
+            )?;
+            stored.public.size = Some(size);
+            self.write_session(&session, &mut stored).await?;
+            Ok(stored.public)
+        })
+    }
+
+    fn append_upload_bytes<'a>(
+        &'a self,
+        ctx: &'a StorageContext,
+        session: UploadSessionId,
+        offset: u64,
+        bytes: Bytes,
+    ) -> StorageBoxFuture<'a, UploadSession> {
+        Box::pin(async move {
+            let lock = self.session_locks.lock(&session);
+            let _cleanup = UploadSessionLockCleanup::new(&self.session_locks, &session);
+            let _guard = lock.lock().await;
+            let mut stored = self.read_session(&session).await?;
+            ensure_owner(&ctx.actor, &stored.owner)?;
+            self.persist_expired_if_needed(&session, &mut stored)
+                .await?;
+            ensure_open(&stored.public)?;
+            if stored.public.strategy != UploadStrategy::Sequential {
+                return Err(StorageError::unsupported(
+                    "Azure backend currently supports sequential proxy uploads only",
+                ));
+            }
+            let expected = stored.public.next_offset.unwrap_or(0);
+            let new_offset = checked_new_offset(offset, bytes.len())?;
+            let read_limit = expected
+                .max(new_offset)
+                .checked_add(1)
+                .ok_or_else(|| StorageError::policy_rejected("upload byte offset overflowed"))?;
+            let mut staged_object = self.get_staged_bytes(&session, read_limit).await?;
+            let staged_len = staged_object.bytes.len() as u64;
+            if expected != offset {
+                if new_offset == expected
+                    && bytes_match_at(&staged_object.bytes, offset, bytes.as_ref())?
+                {
+                    return Ok(stored.public);
+                }
+                tracing::debug!(
+                    target: "pocopine.log",
+                    event_name = "pocopine.storage.offset_mismatch",
+                    session = %session,
+                    expected,
+                    provided = offset,
+                );
+                return Err(StorageError::offset_mismatch(expected, offset));
+            }
+            if staged_len > expected {
+                if staged_len == new_offset
+                    && bytes_match_at(&staged_object.bytes, expected, bytes.as_ref())?
+                {
+                    stored.public.next_offset = Some(new_offset);
+                    self.write_session(&session, &mut stored).await?;
+                    return Ok(stored.public);
+                }
+                tracing::warn!(
+                    target: "pocopine.log",
+                    event_name = "pocopine.storage.azure_staged_bytes_truncated",
+                    session = %session,
+                    actual = staged_len,
+                    trusted = expected,
+                );
+                staged_object.bytes.truncate(usize_from_u64(expected)?);
+                let written = self
+                    .put_staged_bytes(
+                        &session,
+                        Bytes::from(staged_object.bytes.clone()),
+                        staged_object
+                            .etag
+                            .clone()
+                            .map(BlobWritePrecondition::IfMatch),
+                    )
+                    .await?;
+                staged_object.etag = written.etag;
+            } else if staged_len < expected {
+                return Err(StorageError::backend(format!(
+                    "Azure staged upload blob is shorter than committed metadata: expected {expected} bytes, got {staged_len}"
+                )));
+            }
+            ensure_size_limit(stored.max_bytes, stored.public.size, new_offset)?;
+            staged_object.bytes.extend_from_slice(&bytes);
+            self.put_staged_bytes(
+                &session,
+                Bytes::from(staged_object.bytes),
+                staged_object.etag.map(BlobWritePrecondition::IfMatch),
+            )
+            .await?;
+            stored.public.next_offset = Some(new_offset);
+            self.write_session(&session, &mut stored).await?;
+            Ok(stored.public)
+        })
+    }
+
+    fn complete_upload<'a>(
+        &'a self,
+        ctx: &'a StorageContext,
+        request: CompleteUpload,
+    ) -> StorageBoxFuture<'a, ObjectRef> {
+        Box::pin(async move {
+            let lock = self.session_locks.lock(&request.session);
+            let _cleanup = UploadSessionLockCleanup::new(&self.session_locks, &request.session);
+            let _guard = lock.lock().await;
+            let mut stored = self.read_session(&request.session).await?;
+            ensure_owner(&ctx.actor, &stored.owner)?;
+            if let Some(object) = &stored.object {
+                let object = object.clone();
+                self.cleanup_staged_bytes_best_effort(&request.session, &mut stored)
+                    .await;
+                return Ok(object);
+            }
+            self.persist_expired_if_needed(&request.session, &mut stored)
+                .await?;
+            ensure_completable(&stored.public)?;
+            let trusted = stored.public.next_offset.unwrap_or(0);
+            let staged = self
+                .reconcile_staged_bytes(&request.session, trusted)
+                .await?;
+            let actual = staged.len() as u64;
+            if let Some(expected) = stored.public.size {
+                if actual != expected {
+                    return Err(StorageError::policy_rejected(format!(
+                        "upload is incomplete: expected {expected} bytes, got {actual}"
+                    )));
+                }
+            }
+            ensure_size_limit(stored.max_bytes, stored.public.size, actual)?;
+            let checksum =
+                validate_complete_checksum(&stored.checksum_policy, &staged, request.checksum)?;
+            let object_key = self.layout.object_key(stored.storage_key.key.as_str());
+            if stored.public.status == UploadSessionStatus::Open
+                || stored.public.next_offset != Some(actual)
+                || stored.completion_object_key.as_deref() != Some(object_key.as_str())
+            {
+                stored.public.status = UploadSessionStatus::Completing;
+                stored.public.next_offset = Some(actual);
+                stored.completion_object_key = Some(object_key.clone());
+                self.write_session(&request.session, &mut stored).await?;
+            }
+            let staged = Bytes::from(staged);
+            let written = match self
+                .put_completed_object(&object_key, staged, stored.public.content_type.as_deref())
+                .await
+            {
+                Ok(written) => written,
+                Err(err) => {
+                    return Err(self
+                        .rollback_completion_after_error(&request.session, &mut stored, err)
+                        .await);
+                }
+            };
+            let object = self.object_ref(&stored, actual, written, checksum);
+            stored.public.status = UploadSessionStatus::Complete;
+            stored.public.next_offset = Some(actual);
+            stored.object = Some(object.clone());
+            stored.cleanup_pending = true;
+            self.write_session(&request.session, &mut stored).await?;
+            self.cleanup_staged_bytes(&request.session, &mut stored)
+                .await?;
+            Ok(object)
+        })
+    }
+
+    fn abort_upload<'a>(
+        &'a self,
+        ctx: &'a StorageContext,
+        session: UploadSessionId,
+    ) -> StorageBoxFuture<'a, ()> {
+        Box::pin(async move {
+            let lock = self.session_locks.lock(&session);
+            let _cleanup = UploadSessionLockCleanup::new(&self.session_locks, &session);
+            let _guard = lock.lock().await;
+            let read_session = self.read_session_for_abort(&session).await?;
+            match &read_session {
+                AbortSessionRead::Known(stored) => {
+                    ensure_owner(&ctx.actor, &stored.owner)?;
+                    if stored.public.status == UploadSessionStatus::Completing {
+                        return Err(StorageError::UploadClosed {
+                            session: session.to_string(),
+                        });
+                    }
+                }
+                AbortSessionRead::Missing => {}
+                AbortSessionRead::Corrupt => {
+                    if !matches!(&ctx.actor, StorageActor::System(_)) {
+                        return Err(StorageError::forbidden(
+                            "corrupt Azure upload metadata can only be aborted by a system actor",
+                        ));
+                    }
+                }
+            }
+            let meta_key = self.layout.session_meta_key(&session);
+            let bytes_key = self.layout.session_bytes_key(&session);
+            let bytes_deleted = self.delete_object_if_exists(&bytes_key).await;
+            let meta_deleted = match read_session {
+                AbortSessionRead::Known(_) | AbortSessionRead::Corrupt => {
+                    self.delete_object_if_exists(&meta_key).await
+                }
+                AbortSessionRead::Missing => Ok(()),
+            };
+            bytes_deleted?;
+            meta_deleted?;
+            Ok(())
+        })
+    }
+}

--- a/crates/pocopine-storage-azure/src/util.rs
+++ b/crates/pocopine-storage-azure/src/util.rs
@@ -1,0 +1,128 @@
+use azure_core::error::ErrorKind;
+use azure_core::http::StatusCode;
+use azure_storage_blob::models::StorageErrorCode;
+use pocopine_storage::backend_common::ensure_open;
+use pocopine_storage::{StorageError, StorageResult, UploadSession, UploadSessionStatus};
+
+pub(crate) fn ensure_completable(session: &UploadSession) -> StorageResult<()> {
+    if session.status == UploadSessionStatus::Completing {
+        Ok(())
+    } else {
+        ensure_open(session)
+    }
+}
+
+pub(crate) fn usize_from_u64(value: u64) -> StorageResult<usize> {
+    usize::try_from(value)
+        .map_err(|_| StorageError::policy_rejected("upload byte count exceeds host capacity"))
+}
+
+pub(crate) fn bytes_match_at(staged: &[u8], offset: u64, bytes: &[u8]) -> StorageResult<bool> {
+    let start = usize_from_u64(offset)?;
+    let end = start
+        .checked_add(bytes.len())
+        .ok_or_else(|| StorageError::policy_rejected("upload byte offset overflowed"))?;
+    Ok(staged
+        .get(start..end)
+        .is_some_and(|existing| existing == bytes))
+}
+
+pub(crate) fn map_session_write_error(error: StorageError) -> StorageError {
+    match error {
+        StorageError::Conflict { .. } | StorageError::PolicyRejected { .. } => {
+            StorageError::conflict("Azure upload session changed concurrently")
+        }
+        other => other,
+    }
+}
+
+pub(crate) fn is_azure_not_found(err: &azure_core::Error) -> bool {
+    err.http_status() == Some(StatusCode::NotFound)
+        || matches!(
+            azure_error_code(err),
+            Some(code)
+                if code == StorageErrorCode::BlobNotFound.as_ref()
+                    || code == StorageErrorCode::ContainerNotFound.as_ref()
+                    || code == StorageErrorCode::ResourceNotFound.as_ref()
+        )
+}
+
+pub(crate) fn is_azure_already_exists(err: &azure_core::Error) -> bool {
+    err.http_status() == Some(StatusCode::Conflict)
+        && matches!(
+            azure_error_code(err),
+            Some(code)
+                if code == StorageErrorCode::BlobAlreadyExists.as_ref()
+                    || code == StorageErrorCode::ContainerAlreadyExists.as_ref()
+                    || code == StorageErrorCode::ResourceAlreadyExists.as_ref()
+        )
+}
+
+pub(crate) fn is_azure_precondition_failed(err: &azure_core::Error) -> bool {
+    err.http_status() == Some(StatusCode::PreconditionFailed)
+        || matches!(
+            azure_error_code(err),
+            Some(code)
+                if code == StorageErrorCode::ConditionNotMet.as_ref()
+                    || code == StorageErrorCode::TargetConditionNotMet.as_ref()
+                    || code == StorageErrorCode::SourceConditionNotMet.as_ref()
+        )
+}
+
+pub(crate) fn azure_error(operation: &'static str, err: impl std::fmt::Display) -> StorageError {
+    tracing::error!(
+        target: "pocopine.log",
+        event_name = "pocopine.storage.azure_error",
+        operation,
+        error = %err,
+    );
+    StorageError::backend(format!("Azure Blob Storage {operation}: {err}"))
+}
+
+fn azure_error_code(err: &azure_core::Error) -> Option<&str> {
+    match err.kind() {
+        ErrorKind::HttpResponse {
+            error_code: Some(error_code),
+            ..
+        } => Some(error_code.as_str()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use azure_core::error::ErrorKind;
+    use azure_core::http::StatusCode;
+
+    use super::*;
+
+    fn azure_http_error(status: StatusCode, error_code: Option<&str>) -> azure_core::Error {
+        ErrorKind::HttpResponse {
+            status,
+            error_code: error_code.map(str::to_string),
+            raw_response: None,
+        }
+        .into_error()
+    }
+
+    #[test]
+    fn classifies_not_found_errors() {
+        let missing = azure_http_error(StatusCode::NotFound, Some("BlobNotFound"));
+        assert!(is_azure_not_found(&missing));
+        assert!(!is_azure_precondition_failed(&missing));
+    }
+
+    #[test]
+    fn classifies_already_exists_errors() {
+        let exists = azure_http_error(StatusCode::Conflict, Some("BlobAlreadyExists"));
+        assert!(is_azure_already_exists(&exists));
+        assert!(!is_azure_not_found(&exists));
+    }
+
+    #[test]
+    fn classifies_precondition_errors() {
+        let failed = azure_http_error(StatusCode::PreconditionFailed, Some("ConditionNotMet"));
+        assert!(is_azure_precondition_failed(&failed));
+        assert!(!is_azure_already_exists(&failed));
+    }
+}

--- a/crates/pocopine-storage-azure/tests/azurite.rs
+++ b/crates/pocopine-storage-azure/tests/azurite.rs
@@ -1,0 +1,589 @@
+// Azurite-backed integration tests for `pocopine-storage-azure`.
+//
+// Requires a working Docker daemon. Local contributors without Docker can skip
+// these with `cargo test -p pocopine-storage-azure --lib`.
+//
+// Host-only.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+
+use azure_core::http::{NoFormat, RequestContent, Url};
+use azure_storage_blob::BlobContainerClient;
+use base64::Engine;
+use bytes::Bytes;
+use hmac::{Hmac, Mac};
+use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
+use pocopine_storage::{
+    CompleteUpload, InitiateUpload, PrincipalRef, SafeObjectKey, StorageActor, StorageBackend,
+    StorageContext, StorageError, StorageKey, StorageResult, UploadPolicy, UploadSession,
+    UploadSessionStatus, UploadStrategy,
+};
+use pocopine_storage_azure::AzureBlobStorageBackend;
+use sha2::Sha256;
+use testcontainers::core::{wait::HttpWaitStrategy, ContainerPort, WaitFor};
+use testcontainers::runners::AsyncRunner;
+use testcontainers::{ContainerAsync, GenericImage, ImageExt};
+use tokio::sync::OnceCell;
+
+const AZURITE_IMAGE: &str = "mcr.microsoft.com/azure-storage/azurite";
+const AZURITE_TAG: &str = "3.35.0";
+const AZURITE_BLOB_PORT: u16 = 10000;
+const AZURITE_ACCOUNT: &str = "devstoreaccount1";
+const AZURITE_KEY: &str =
+    "Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==";
+
+static AZURITE: OnceCell<ContainerAsync<GenericImage>> = OnceCell::const_new();
+static CONTAINER_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+#[derive(Clone)]
+struct AzuriteContainer {
+    url: Url,
+}
+
+impl AzuriteContainer {
+    fn client(&self) -> BlobContainerClient {
+        BlobContainerClient::new(self.url.clone(), None, None)
+            .expect("build Azurite container client")
+    }
+}
+
+async fn azurite_endpoint() -> String {
+    let container = AZURITE
+        .get_or_init(|| async {
+            GenericImage::new(AZURITE_IMAGE, AZURITE_TAG)
+                .with_exposed_port(ContainerPort::Tcp(AZURITE_BLOB_PORT))
+                .with_wait_for(WaitFor::http(
+                    HttpWaitStrategy::new("/")
+                        .with_port(ContainerPort::Tcp(AZURITE_BLOB_PORT))
+                        .with_response_matcher(|response| response.status().as_u16() < 500),
+                ))
+                .with_cmd([
+                    "azurite-blob",
+                    "--blobHost",
+                    "0.0.0.0",
+                    "--blobPort",
+                    "10000",
+                    "--loose",
+                    "--skipApiVersionCheck",
+                ])
+                .start()
+                .await
+                .expect("start Azurite testcontainer")
+        })
+        .await;
+    let port = container
+        .get_host_port_ipv4(AZURITE_BLOB_PORT)
+        .await
+        .expect("Azurite container port");
+    format!("http://127.0.0.1:{port}/{AZURITE_ACCOUNT}")
+}
+
+async fn create_container(prefix: &str) -> AzuriteContainer {
+    let endpoint = azurite_endpoint().await;
+    let container = unique_container(prefix);
+    create_container_with_shared_key(&endpoint, &container).await;
+    let url = format!("{endpoint}/{container}?{}", service_sas_query(&container));
+    AzuriteContainer {
+        url: Url::parse(&url).expect("valid Azurite URL"),
+    }
+}
+
+async fn create_container_with_shared_key(endpoint: &str, container: &str) {
+    let date = "Tue, 26 May 2026 00:00:00 GMT";
+    let version = "2020-12-06";
+    let canonicalized_headers = format!("x-ms-date:{date}\nx-ms-version:{version}\n");
+    let canonicalized_resource =
+        format!("/{AZURITE_ACCOUNT}/{AZURITE_ACCOUNT}/{container}\nrestype:container");
+    let string_to_sign =
+        format!("PUT\n\n\n\n\n\n\n\n\n\n\n\n{canonicalized_headers}{canonicalized_resource}");
+    let signature = hmac_sha256_base64(&string_to_sign);
+    let response = reqwest::Client::new()
+        .put(format!("{endpoint}/{container}?restype=container"))
+        .header("x-ms-date", date)
+        .header("x-ms-version", version)
+        .header(
+            "Authorization",
+            format!("SharedKey {AZURITE_ACCOUNT}:{signature}"),
+        )
+        .send()
+        .await
+        .expect("create Azurite container request");
+    let status = response.status();
+    let body = response.text().await.expect("read create container body");
+    assert!(
+        status.is_success() || status.as_u16() == 409,
+        "create Azurite container failed: {status} {body}"
+    );
+}
+
+fn unique_container(prefix: &str) -> String {
+    format!(
+        "poco-{prefix}-{}-{}",
+        std::process::id(),
+        CONTAINER_COUNTER.fetch_add(1, Ordering::SeqCst)
+    )
+}
+
+fn service_sas_query(container: &str) -> String {
+    let permissions = "racwdl";
+    let start = "2024-01-01T00:00:00Z";
+    let expiry = "2030-01-01T00:00:00Z";
+    let protocol = "http";
+    let version = "2020-12-06";
+    let resource = "c";
+    let canonicalized_resource = format!("/blob/{AZURITE_ACCOUNT}/{container}");
+    let string_to_sign = [
+        permissions,
+        start,
+        expiry,
+        canonicalized_resource.as_str(),
+        "",
+        "",
+        protocol,
+        version,
+        resource,
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+        "",
+    ]
+    .join("\n");
+    let signature = hmac_sha256_base64(&string_to_sign);
+    format!(
+        "sv={}&st={}&se={}&sr={resource}&sp={permissions}&spr={protocol}&sig={}",
+        encode_query_value(version),
+        encode_query_value(start),
+        encode_query_value(expiry),
+        encode_query_value(&signature)
+    )
+}
+
+fn encode_query_value(value: &str) -> String {
+    utf8_percent_encode(value, NON_ALPHANUMERIC).to_string()
+}
+
+fn hmac_sha256_base64(string_to_sign: &str) -> String {
+    let key = base64::engine::general_purpose::STANDARD
+        .decode(AZURITE_KEY)
+        .expect("decode Azurite account key");
+    let mut mac = Hmac::<Sha256>::new_from_slice(&key).expect("create HMAC");
+    mac.update(string_to_sign.as_bytes());
+    base64::engine::general_purpose::STANDARD.encode(mac.finalize().into_bytes())
+}
+
+fn session_object_key(
+    backend: &AzureBlobStorageBackend,
+    session: &UploadSession,
+    name: &str,
+) -> String {
+    format!(
+        "{}/{}/{}",
+        backend.internal_prefix(),
+        session.id.as_str(),
+        name
+    )
+}
+
+fn ctx() -> StorageContext {
+    StorageContext::system("azure-azurite-it")
+}
+
+fn principal_ctx(subject: &str) -> StorageContext {
+    StorageContext {
+        actor: StorageActor::Principal(PrincipalRef {
+            subject: subject.to_string(),
+            attributes: BTreeMap::new(),
+        }),
+        request: None,
+    }
+}
+
+fn policy() -> StorageResult<UploadPolicy> {
+    let mut policy = UploadPolicy::new("azure")?
+        .max_bytes(1024 * 1024)
+        .preferred_chunk_size(4);
+    policy.expires_after = Duration::from_secs(60 * 60);
+    Ok(policy)
+}
+
+async fn initiate(
+    backend: &AzureBlobStorageBackend,
+    size: Option<u64>,
+) -> StorageResult<UploadSession> {
+    backend
+        .initiate_upload(
+            &ctx(),
+            InitiateUpload {
+                scope: "files".to_string(),
+                storage_key: StorageKey::new(SafeObjectKey::parse("files/hello.txt")?),
+                file_name: "hello.txt".to_string(),
+                size,
+                content_type: Some("text/plain".to_string()),
+                metadata: BTreeMap::from([("purpose".to_string(), "integration".to_string())]),
+                requested_strategy: UploadStrategy::Auto,
+                policy: policy()?,
+            },
+        )
+        .await
+}
+
+async fn object_bytes(container: &AzuriteContainer, key: &str) -> Vec<u8> {
+    container
+        .client()
+        .blob_client(key)
+        .download(None)
+        .await
+        .expect("download blob")
+        .body
+        .collect()
+        .await
+        .expect("read blob body")
+        .to_vec()
+}
+
+async fn put_object(container: &AzuriteContainer, key: impl AsRef<str>, bytes: &'static [u8]) {
+    let content: RequestContent<Bytes, NoFormat> = Bytes::from_static(bytes).into();
+    container
+        .client()
+        .blob_client(key.as_ref())
+        .upload(content, None)
+        .await
+        .expect("put blob");
+}
+
+async fn blob_exists(container: &AzuriteContainer, key: &str) -> bool {
+    container
+        .client()
+        .blob_client(key)
+        .exists()
+        .await
+        .expect("check blob exists")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sequential_upload_resumes_and_completes_against_azurite() -> StorageResult<()> {
+    let container = create_container("resume").await;
+    let backend = AzureBlobStorageBackend::new(container.client())?.with_prefix("tenant-a")?;
+    let session = initiate(&backend, Some(11)).await?;
+
+    let updated = backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, Bytes::from_static(b"hello "))
+        .await?;
+    assert_eq!(updated.next_offset, Some(6));
+
+    let reloaded = AzureBlobStorageBackend::new(container.client())?.with_prefix("tenant-a")?;
+    let inspected = reloaded.inspect_upload(&ctx(), session.id.clone()).await?;
+    assert_eq!(inspected.next_offset, Some(6));
+
+    let updated = reloaded
+        .append_upload_bytes(&ctx(), session.id.clone(), 6, Bytes::from_static(b"world"))
+        .await?;
+    assert_eq!(updated.next_offset, Some(11));
+
+    let object = reloaded
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id.clone(),
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(object.backend, "azure");
+    assert_eq!(object.scope, "files");
+    assert_eq!(object.key, "files/hello.txt");
+    assert_eq!(object.content_type.as_deref(), Some("text/plain"));
+    assert_eq!(object.size, 11);
+    assert_eq!(
+        object.metadata.get("purpose").map(String::as_str),
+        Some("integration")
+    );
+    assert_eq!(
+        object_bytes(&container, "tenant-a/files/hello.txt").await,
+        b"hello world"
+    );
+
+    let repeated = reloaded
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id.clone(),
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(repeated, object);
+    assert!(
+        !blob_exists(
+            &container,
+            &session_object_key(&reloaded, &session, "bytes.tmp")
+        )
+        .await
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn wrong_offset_returns_typed_mismatch_against_azurite() -> StorageResult<()> {
+    let container = create_container("offset").await;
+    let backend = AzureBlobStorageBackend::new(container.client())?;
+    let session = initiate(&backend, Some(5)).await?;
+
+    backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, Bytes::from_static(b"hel"))
+        .await?;
+
+    let rejected = backend
+        .append_upload_bytes(&ctx(), session.id, 1, Bytes::from_static(b"lo"))
+        .await;
+    assert!(matches!(
+        rejected,
+        Err(StorageError::OffsetMismatch {
+            expected: 3,
+            provided: 1
+        })
+    ));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unknown_session_and_repeated_abort_are_typed_against_azurite() -> StorageResult<()> {
+    let container = create_container("unknown").await;
+    let backend = AzureBlobStorageBackend::new(container.client())?;
+    let missing = pocopine_storage::UploadSessionId::new("missing-session")?;
+
+    let inspected = backend.inspect_upload(&ctx(), missing.clone()).await;
+    assert!(matches!(
+        inspected,
+        Err(StorageError::UnknownUploadSession { .. })
+    ));
+
+    backend.abort_upload(&ctx(), missing.clone()).await?;
+    backend.abort_upload(&ctx(), missing).await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn changing_upload_length_uses_shared_invalid_value_error() -> StorageResult<()> {
+    let container = create_container("length").await;
+    let backend = AzureBlobStorageBackend::new(container.client())?;
+    let session = initiate(&backend, None).await?;
+
+    backend
+        .set_upload_length(&ctx(), session.id.clone(), 5)
+        .await?;
+    let rejected = backend.set_upload_length(&ctx(), session.id, 6).await;
+    assert!(matches!(
+        rejected,
+        Err(StorageError::InvalidValue { field, .. }) if field == "Upload-Length"
+    ));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn complete_does_not_overwrite_existing_object_key() -> StorageResult<()> {
+    let container = create_container("collision").await;
+    put_object(&container, "files/hello.txt", b"existing").await;
+
+    let backend = AzureBlobStorageBackend::new(container.client())?;
+    let session = initiate(&backend, Some(5)).await?;
+    backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, Bytes::from_static(b"hello"))
+        .await?;
+
+    let rejected = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id.clone(),
+                checksum: None,
+            },
+        )
+        .await;
+    assert!(matches!(rejected, Err(StorageError::PolicyRejected { .. })));
+    let inspected = backend.inspect_upload(&ctx(), session.id.clone()).await?;
+    assert_eq!(inspected.status, UploadSessionStatus::Open);
+
+    let repeated = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await;
+    assert!(matches!(repeated, Err(StorageError::PolicyRejected { .. })));
+    assert_eq!(
+        object_bytes(&container, "files/hello.txt").await,
+        b"existing"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn duplicate_append_retry_after_staged_write_advances_metadata() -> StorageResult<()> {
+    let container = create_container("retry").await;
+    let backend = AzureBlobStorageBackend::new(container.client())?;
+    let session = initiate(&backend, Some(5)).await?;
+    let bytes_key = session_object_key(&backend, &session, "bytes.tmp");
+    put_object(&container, bytes_key, b"hello").await;
+
+    let updated = backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, Bytes::from_static(b"hello"))
+        .await?;
+    assert_eq!(updated.next_offset, Some(5));
+    let inspected = backend.inspect_upload(&ctx(), session.id).await?;
+    assert_eq!(inspected.next_offset, Some(5));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn append_refreshes_staged_etag_after_truncating_rogue_bytes() -> StorageResult<()> {
+    let container = create_container("truncate-append").await;
+    let backend = AzureBlobStorageBackend::new(container.client())?;
+    let session = initiate(&backend, Some(6)).await?;
+    let bytes_key = session_object_key(&backend, &session, "bytes.tmp");
+
+    backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, Bytes::from_static(b"abc"))
+        .await?;
+    put_object(&container, bytes_key.clone(), b"abcjunk").await;
+
+    let updated = backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 3, Bytes::from_static(b"def"))
+        .await?;
+    assert_eq!(updated.next_offset, Some(6));
+    assert_eq!(object_bytes(&container, &bytes_key).await, b"abcdef");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn inspect_does_not_truncate_rogue_staged_bytes() -> StorageResult<()> {
+    let container = create_container("truncate").await;
+    let backend = AzureBlobStorageBackend::new(container.client())?;
+    let session = initiate(&backend, Some(5)).await?;
+    let bytes_key = session_object_key(&backend, &session, "bytes.tmp");
+    put_object(&container, bytes_key.clone(), b"hello").await;
+
+    let inspected = backend.inspect_upload(&ctx(), session.id).await?;
+    assert_eq!(inspected.next_offset, Some(0));
+    assert_eq!(object_bytes(&container, &bytes_key).await, b"hello");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn set_upload_length_does_not_promote_staged_bytes() -> StorageResult<()> {
+    let container = create_container("set-length").await;
+    let backend = AzureBlobStorageBackend::new(container.client())?;
+    let session = initiate(&backend, None).await?;
+    let bytes_key = session_object_key(&backend, &session, "bytes.tmp");
+    put_object(&container, bytes_key.clone(), b"hello").await;
+
+    let updated = backend
+        .set_upload_length(&ctx(), session.id.clone(), 5)
+        .await?;
+    assert_eq!(updated.size, Some(5));
+    assert_eq!(updated.next_offset, Some(0));
+    let inspected = backend.inspect_upload(&ctx(), session.id).await?;
+    assert_eq!(inspected.next_offset, Some(0));
+    assert_eq!(object_bytes(&container, &bytes_key).await, b"hello");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn non_system_actor_cannot_abort_corrupt_upload_metadata() -> StorageResult<()> {
+    let container = create_container("corrupt-owner").await;
+    let backend = AzureBlobStorageBackend::new(container.client())?;
+    let session = initiate(&backend, Some(5)).await?;
+    let meta_key = session_object_key(&backend, &session, "session.json");
+    let bytes_key = session_object_key(&backend, &session, "bytes.tmp");
+    put_object(&container, meta_key.clone(), b"{not-json").await;
+
+    let rejected = backend
+        .abort_upload(&principal_ctx("tenant-b"), session.id.clone())
+        .await;
+    assert!(matches!(rejected, Err(StorageError::Forbidden { .. })));
+    assert!(blob_exists(&container, &meta_key).await);
+    assert!(blob_exists(&container, &bytes_key).await);
+
+    backend.abort_upload(&ctx(), session.id).await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn abort_removes_corrupt_upload_metadata_against_azurite() -> StorageResult<()> {
+    let container = create_container("corrupt").await;
+    let backend = AzureBlobStorageBackend::new(container.client())?;
+    let session = initiate(&backend, Some(5)).await?;
+    let meta_key = session_object_key(&backend, &session, "session.json");
+    put_object(&container, meta_key, b"{not-json").await;
+
+    backend.abort_upload(&ctx(), session.id.clone()).await?;
+    let inspected = backend.inspect_upload(&ctx(), session.id).await;
+    assert!(matches!(
+        inspected,
+        Err(StorageError::UnknownUploadSession { .. })
+    ));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn abort_refuses_in_flight_completion_against_azurite() -> StorageResult<()> {
+    let container = create_container("completing").await;
+    let backend = AzureBlobStorageBackend::new(container.client())?;
+    let session = initiate(&backend, Some(5)).await?;
+    let meta_key = session_object_key(&backend, &session, "session.json");
+    let mut session_json: serde_json::Value =
+        serde_json::from_slice(&object_bytes(&container, &meta_key).await)
+            .expect("decode session json");
+    session_json["public"]["status"] = serde_json::json!("completing");
+    session_json["completion_object_key"] = serde_json::json!("files/hello.txt");
+    let bytes = serde_json::to_vec(&session_json).expect("encode completing session json");
+    container
+        .client()
+        .blob_client(&meta_key)
+        .upload(RequestContent::<Bytes, NoFormat>::from(bytes), None)
+        .await
+        .expect("write completing session metadata");
+
+    let rejected = backend.abort_upload(&ctx(), session.id).await;
+    assert!(matches!(rejected, Err(StorageError::UploadClosed { .. })));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn initiate_rejects_policy_above_proxy_cap_for_streaming_upload() -> StorageResult<()> {
+    let container = create_container("policy-cap").await;
+    let backend =
+        AzureBlobStorageBackend::new(container.client())?.with_max_proxy_upload_bytes(8)?;
+    let mut policy = policy()?.max_bytes(9);
+    policy.preferred_chunk_size = Some(4);
+
+    let rejected = backend
+        .initiate_upload(
+            &ctx(),
+            InitiateUpload {
+                scope: "files".to_string(),
+                storage_key: StorageKey::new(SafeObjectKey::parse("files/hello.txt")?),
+                file_name: "hello.txt".to_string(),
+                size: None,
+                content_type: Some("text/plain".to_string()),
+                metadata: BTreeMap::new(),
+                requested_strategy: UploadStrategy::Auto,
+                policy,
+            },
+        )
+        .await;
+    assert!(matches!(
+        rejected,
+        Err(StorageError::PayloadTooLarge { limit: 8 })
+    ));
+    Ok(())
+}

--- a/crates/pocopine-storage-gcs/src/layout.rs
+++ b/crates/pocopine-storage-gcs/src/layout.rs
@@ -1,4 +1,4 @@
-use pocopine_storage::{StorageError, StorageResult, UploadSessionId};
+use pocopine_storage::{SafeObjectKey, StorageError, StorageResult, UploadSessionId};
 
 pub(crate) const DEFAULT_INTERNAL_PREFIX: &str = "__pocopine/storage/sessions";
 
@@ -33,8 +33,11 @@ impl GcsKeyLayout {
             ));
         }
         let bucket_resource = format!("projects/_/buckets/{bucket}");
-        let object_prefix = object_prefix.and_then(normalize_prefix);
-        let internal_prefix_base = normalize_prefix(internal_prefix).ok_or_else(|| {
+        let object_prefix = match object_prefix {
+            Some(prefix) => normalize_object_prefix(prefix)?,
+            None => None,
+        };
+        let internal_prefix_base = normalize_internal_prefix(internal_prefix).ok_or_else(|| {
             StorageError::policy_rejected("GCS internal prefix must not be empty")
         })?;
         let internal_prefix =
@@ -49,20 +52,15 @@ impl GcsKeyLayout {
     }
 
     pub(crate) fn with_prefix(&self, prefix: String) -> StorageResult<Self> {
-        let object_prefix = normalize_prefix(prefix);
         Self::new(
             self.bucket.clone(),
-            object_prefix,
+            Some(prefix),
             self.internal_prefix_base.clone(),
         )
     }
 
     pub(crate) fn with_internal_prefix(&self, prefix: String) -> StorageResult<Self> {
-        Self::new(
-            self.bucket.clone(),
-            self.object_prefix.clone(),
-            prefix.trim_matches('/').to_string(),
-        )
+        Self::new(self.bucket.clone(), self.object_prefix.clone(), prefix)
     }
 
     pub(crate) fn bucket_resource(&self) -> &str {
@@ -86,7 +84,16 @@ impl GcsKeyLayout {
     }
 }
 
-fn normalize_prefix(prefix: String) -> Option<String> {
+fn normalize_object_prefix(prefix: String) -> StorageResult<Option<String>> {
+    let prefix = prefix.trim().trim_matches('/');
+    if prefix.is_empty() {
+        return Ok(None);
+    }
+    SafeObjectKey::parse(prefix)?;
+    Ok(Some(prefix.to_string()))
+}
+
+fn normalize_internal_prefix(prefix: String) -> Option<String> {
     let prefix = prefix.trim().trim_matches('/');
     if prefix.is_empty() {
         None
@@ -175,5 +182,31 @@ mod tests {
         assert!(
             GcsKeyLayout::new("  ".to_string(), None, DEFAULT_INTERNAL_PREFIX.to_string()).is_err()
         );
+    }
+
+    #[test]
+    fn reserved_object_prefix_is_rejected() {
+        let rejected = GcsKeyLayout::new(
+            "bucket".to_string(),
+            Some("__pocopine".to_string()),
+            DEFAULT_INTERNAL_PREFIX.to_string(),
+        );
+        assert!(matches!(
+            rejected,
+            Err(StorageError::InvalidValue { field, .. }) if field == "object key"
+        ));
+    }
+
+    #[test]
+    fn path_traversal_object_prefix_is_rejected() {
+        let rejected = GcsKeyLayout::new(
+            "bucket".to_string(),
+            Some("tenant/../files".to_string()),
+            DEFAULT_INTERNAL_PREFIX.to_string(),
+        );
+        assert!(matches!(
+            rejected,
+            Err(StorageError::InvalidValue { field, .. }) if field == "object key"
+        ));
     }
 }

--- a/crates/pocopine-storage-gcs/src/storage.rs
+++ b/crates/pocopine-storage-gcs/src/storage.rs
@@ -7,9 +7,9 @@ use pocopine_storage::backend_common::{
 };
 use pocopine_storage::checksum::{ensure_supported_checksum_policy, validate_complete_checksum};
 use pocopine_storage::{
-    CompleteUpload, InitiateUpload, ObjectChecksum, ObjectRef, StorageBackend, StorageBoxFuture,
-    StorageContext, StorageError, StorageResult, TransferPlan, UploadSession, UploadSessionId,
-    UploadSessionStatus, UploadStrategy,
+    CompleteUpload, InitiateUpload, ObjectChecksum, ObjectRef, StorageActor, StorageBackend,
+    StorageBoxFuture, StorageContext, StorageError, StorageResult, TransferPlan, UploadSession,
+    UploadSessionId, UploadSessionStatus, UploadStrategy,
 };
 use uuid::Uuid;
 
@@ -869,7 +869,14 @@ impl StorageBackend for GcsStorageBackend {
                         });
                     }
                 }
-                AbortSessionRead::Missing | AbortSessionRead::Corrupt => {}
+                AbortSessionRead::Missing => {}
+                AbortSessionRead::Corrupt => {
+                    if !matches!(&ctx.actor, StorageActor::System(_)) {
+                        return Err(StorageError::forbidden(
+                            "corrupt GCS upload metadata can only be aborted by a system actor",
+                        ));
+                    }
+                }
             }
             let meta_key = self.layout.session_meta_key(&session);
             let bytes_key = self.layout.session_bytes_key(&session);

--- a/crates/pocopine-storage-gcs/tests/fake_gcs.rs
+++ b/crates/pocopine-storage-gcs/tests/fake_gcs.rs
@@ -14,8 +14,9 @@ use bytes::Bytes;
 use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
 use google_cloud_storage::client::Storage;
 use pocopine_storage::{
-    CompleteUpload, InitiateUpload, SafeObjectKey, StorageBackend, StorageContext, StorageError,
-    StorageKey, StorageResult, UploadPolicy, UploadSession, UploadSessionStatus, UploadStrategy,
+    CompleteUpload, InitiateUpload, PrincipalRef, SafeObjectKey, StorageActor, StorageBackend,
+    StorageContext, StorageError, StorageKey, StorageResult, UploadPolicy, UploadSession,
+    UploadSessionStatus, UploadStrategy,
 };
 use pocopine_storage_gcs::GcsStorageBackend;
 use testcontainers::core::{wait::HttpWaitStrategy, ContainerPort, WaitFor};
@@ -117,6 +118,16 @@ fn session_object_key(backend: &GcsStorageBackend, session: &UploadSession, name
 
 fn ctx() -> StorageContext {
     StorageContext::system("gcs-fake-it")
+}
+
+fn principal_ctx(subject: &str) -> StorageContext {
+    StorageContext {
+        actor: StorageActor::Principal(PrincipalRef {
+            subject: subject.to_string(),
+            attributes: BTreeMap::new(),
+        }),
+        request: None,
+    }
 }
 
 fn policy() -> StorageResult<UploadPolicy> {
@@ -501,6 +512,39 @@ async fn set_upload_length_does_not_promote_staged_bytes() -> StorageResult<()> 
     assert_eq!(updated.next_offset, Some(0));
     let inspected = backend.inspect_upload(&ctx(), session.id).await?;
     assert_eq!(inspected.next_offset, Some(0));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn non_system_actor_cannot_abort_corrupt_upload_metadata_against_fake_gcs(
+) -> StorageResult<()> {
+    let clients = gcs_clients().await;
+    let bucket = create_bucket(&clients, "corrupt-owner").await;
+    let backend =
+        GcsStorageBackend::emulator(clients.storage.clone(), clients.endpoint.clone(), bucket)?;
+    let session = initiate(&backend, Some(5)).await?;
+    let meta_key = session_object_key(&backend, &session, "session.json");
+    clients
+        .storage
+        .write_object(
+            backend.bucket_resource(),
+            meta_key.clone(),
+            Bytes::from_static(b"{not-json"),
+        )
+        .send_unbuffered()
+        .await
+        .expect("corrupt session metadata");
+
+    let rejected = backend
+        .abort_upload(&principal_ctx("tenant-b"), session.id.clone())
+        .await;
+    assert!(matches!(rejected, Err(StorageError::Forbidden { .. })));
+    assert_eq!(
+        object_bytes(&clients.storage, backend.bucket(), &meta_key).await,
+        b"{not-json"
+    );
+
+    backend.abort_upload(&ctx(), session.id).await?;
     Ok(())
 }
 

--- a/crates/pocopine-storage-s3/src/layout.rs
+++ b/crates/pocopine-storage-s3/src/layout.rs
@@ -1,4 +1,4 @@
-use pocopine_storage::{StorageError, StorageResult, UploadSessionId};
+use pocopine_storage::{SafeObjectKey, StorageError, StorageResult, UploadSessionId};
 
 pub(crate) const DEFAULT_INTERNAL_PREFIX: &str = "__pocopine/storage/sessions";
 
@@ -22,8 +22,11 @@ impl S3KeyLayout {
                 "S3 bucket name must not be empty",
             ));
         }
-        let object_prefix = object_prefix.and_then(normalize_prefix);
-        let internal_prefix_base = normalize_prefix(internal_prefix)
+        let object_prefix = match object_prefix {
+            Some(prefix) => normalize_object_prefix(prefix)?,
+            None => None,
+        };
+        let internal_prefix_base = normalize_internal_prefix(internal_prefix)
             .ok_or_else(|| StorageError::policy_rejected("S3 internal prefix must not be empty"))?;
         let internal_prefix =
             join_optional_prefix(object_prefix.as_deref(), internal_prefix_base.as_str());
@@ -36,20 +39,15 @@ impl S3KeyLayout {
     }
 
     pub(crate) fn with_prefix(&self, prefix: String) -> StorageResult<Self> {
-        let object_prefix = normalize_prefix(prefix);
         Self::new(
             self.bucket.clone(),
-            object_prefix,
+            Some(prefix),
             self.internal_prefix_base.clone(),
         )
     }
 
     pub(crate) fn with_internal_prefix(&self, prefix: String) -> StorageResult<Self> {
-        Self::new(
-            self.bucket.clone(),
-            self.object_prefix.clone(),
-            prefix.trim_matches('/').to_string(),
-        )
+        Self::new(self.bucket.clone(), self.object_prefix.clone(), prefix)
     }
 
     pub(crate) fn object_key(&self, key: &str) -> String {
@@ -65,7 +63,16 @@ impl S3KeyLayout {
     }
 }
 
-fn normalize_prefix(prefix: String) -> Option<String> {
+fn normalize_object_prefix(prefix: String) -> StorageResult<Option<String>> {
+    let prefix = prefix.trim().trim_matches('/');
+    if prefix.is_empty() {
+        return Ok(None);
+    }
+    SafeObjectKey::parse(prefix)?;
+    Ok(Some(prefix.to_string()))
+}
+
+fn normalize_internal_prefix(prefix: String) -> Option<String> {
     let prefix = prefix.trim().trim_matches('/');
     if prefix.is_empty() {
         None
@@ -141,5 +148,31 @@ mod tests {
         assert!(
             S3KeyLayout::new("  ".to_string(), None, DEFAULT_INTERNAL_PREFIX.to_string()).is_err()
         );
+    }
+
+    #[test]
+    fn reserved_object_prefix_is_rejected() {
+        let rejected = S3KeyLayout::new(
+            "bucket".to_string(),
+            Some("__pocopine".to_string()),
+            DEFAULT_INTERNAL_PREFIX.to_string(),
+        );
+        assert!(matches!(
+            rejected,
+            Err(StorageError::InvalidValue { field, .. }) if field == "object key"
+        ));
+    }
+
+    #[test]
+    fn path_traversal_object_prefix_is_rejected() {
+        let rejected = S3KeyLayout::new(
+            "bucket".to_string(),
+            Some("tenant/../files".to_string()),
+            DEFAULT_INTERNAL_PREFIX.to_string(),
+        );
+        assert!(matches!(
+            rejected,
+            Err(StorageError::InvalidValue { field, .. }) if field == "object key"
+        ));
     }
 }

--- a/crates/pocopine-storage/src/client.rs
+++ b/crates/pocopine-storage/src/client.rs
@@ -594,7 +594,9 @@ mod wasm {
                             self.emit(UploadPhase::Uploading, offset);
                             break;
                         }
-                        Err(StorageError::OffsetMismatch { .. }) => {
+                        Err(
+                            StorageError::OffsetMismatch { .. } | StorageError::Conflict { .. },
+                        ) => {
                             session = self.inspect_session(&session).await?;
                             self.store_resume_session(&session);
                             offset = session.next_offset.unwrap_or(0);

--- a/crates/pocopine-storage/src/local_fs.rs
+++ b/crates/pocopine-storage/src/local_fs.rs
@@ -43,13 +43,22 @@ struct StoredUploadSession {
 /// per-session async mutex, and the underlying `std::fs` I/O runs on
 /// `spawn_blocking` workers so the tokio runtime stays responsive even when
 /// the disk is slow.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct LocalFsStorageBackend {
     name: &'static str,
     root: PathBuf,
     // Per-session async locks. Cloned cheaply via Arc; the inner StdMutex
     // protects only the map and is held briefly.
     session_locks: Arc<StdMutex<HashMap<String, Arc<TokioMutex<()>>>>>,
+}
+
+impl std::fmt::Debug for LocalFsStorageBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LocalFsStorageBackend")
+            .field("name", &self.name)
+            .field("root", &"<redacted>")
+            .finish_non_exhaustive()
+    }
 }
 
 impl LocalFsStorageBackend {
@@ -621,4 +630,21 @@ fn local_io_error(operation: &'static str, err: std::io::Error) -> StorageError 
         .map(|code| format!(" (os error {code})"))
         .unwrap_or_default();
     StorageError::backend(format!("{operation}: {kind:?}{raw}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_does_not_expose_root_or_session_locks() {
+        let backend = LocalFsStorageBackend::new("/tmp/pocopine-secret-storage-root");
+
+        let debug = format!("{backend:?}");
+
+        assert!(debug.contains("LocalFsStorageBackend"));
+        assert!(debug.contains("<redacted>"));
+        assert!(!debug.contains("/tmp/pocopine-secret-storage-root"));
+        assert!(!debug.contains("session_locks"));
+    }
 }

--- a/crates/pocopine-storage/src/memory.rs
+++ b/crates/pocopine-storage/src/memory.rs
@@ -39,10 +39,18 @@ struct Inner {
 ///
 /// It mirrors the local filesystem backend's sequential session semantics but
 /// does not persist across process restarts.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct MemoryStorageBackend {
     name: &'static str,
     inner: Arc<Mutex<Inner>>,
+}
+
+impl std::fmt::Debug for MemoryStorageBackend {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MemoryStorageBackend")
+            .field("name", &self.name)
+            .finish_non_exhaustive()
+    }
 }
 
 impl Default for MemoryStorageBackend {
@@ -304,5 +312,28 @@ impl StorageBackend for MemoryStorageBackend {
 fn refresh_expired_public(stored: &mut StoredUpload) {
     if refresh_expired(&mut stored.public) {
         stored.public.next_offset = Some(stored.bytes.len() as u64);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn debug_does_not_dump_in_memory_objects() {
+        let backend = MemoryStorageBackend::new();
+        backend
+            .inner
+            .lock()
+            .unwrap()
+            .objects
+            .insert("secret-key".to_string(), b"secret-bytes".to_vec());
+
+        let debug = format!("{backend:?}");
+
+        assert!(debug.contains("MemoryStorageBackend"));
+        assert!(!debug.contains("secret-key"));
+        assert!(!debug.contains("secret-bytes"));
+        assert!(!debug.contains("objects"));
     }
 }


### PR DESCRIPTION
## Summary
- add `pocopine-storage-azure` using the official `azure_storage_blob` SDK
- wire the crate into the workspace, CI wasm exclusions, and storage stress path filters
- add Azurite-backed integration coverage and harden Azure completion, cleanup, ETag, prefix, Debug redaction, and retry behavior
- retry browser resume on backend `Conflict` responses by inspecting the session
- security-audit existing storage backends: validate S3/GCS prefixes, harden GCS corrupt-metadata abort ownership, and redact local/memory backend Debug output

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p pocopine-storage-azure --lib`
- `sg docker -c 'cargo test -p pocopine-storage-azure --tests -- --test-threads=1'`
- `cargo test -p pocopine-storage-gcs --lib`
- `sg docker -c 'cargo test -p pocopine-storage-gcs --tests -- --test-threads=1'`
- `cargo test -p pocopine-storage-s3 --lib`
- `cargo test -p pocopine-storage`
- `cargo clippy -p pocopine-storage --all-targets -- -D warnings`
- `cargo clippy -p pocopine-storage-azure --all-targets -- -D warnings`
- `cargo clippy -p pocopine-storage-gcs --all-targets -- -D warnings`
- `cargo clippy -p pocopine-storage-s3 --all-targets -- -D warnings`
- `git diff --check origin/main...HEAD`