### PR TITLE
RFC 087: sync-query driver lifecycle (open + pull + live wakeup + offline replay)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6157,6 +6157,7 @@ name = "pocopine-sync-query"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "futures",
  "http 1.4.0",
  "http-body-util",
  "js-sys",
@@ -6169,7 +6170,10 @@ dependencies = [
  "serde_json",
  "tokio",
  "tower",
+ "tracing",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6163,6 +6163,7 @@ dependencies = [
  "js-sys",
  "pocopine-auth",
  "pocopine-core",
+ "pocopine-live",
  "pocopine-server",
  "pocopine-sync",
  "pocopine-sync-query-macros",

--- a/crates/pocopine-sync-query-macros/tests/routing.rs
+++ b/crates/pocopine-sync-query-macros/tests/routing.rs
@@ -85,7 +85,7 @@ impl MutatorRemoteContext for StubContext {
 
 #[tokio::test]
 async fn matching_view_receives_mutation_canonically() {
-    let client = QueryClient::new();
+    let client = QueryClient::without_driver();
     let ctx = StubContext::new();
     let q = Issue::query()
         .eq(issues::field::workspace_id, "W1")
@@ -123,7 +123,7 @@ async fn matching_view_receives_mutation_canonically() {
 
 #[tokio::test]
 async fn non_matching_view_is_untouched() {
-    let client = QueryClient::new();
+    let client = QueryClient::without_driver();
     let ctx = StubContext::new();
 
     let q_w1 = Issue::query().eq(issues::field::workspace_id, "W1").build();
@@ -151,7 +151,7 @@ async fn non_matching_view_is_untouched() {
 
 #[tokio::test]
 async fn version_counter_bumps_on_state_changes() {
-    let client = QueryClient::new();
+    let client = QueryClient::without_driver();
     let ctx = StubContext::new();
     let view =
         client.observe::<Issue>(Issue::query().eq(issues::field::workspace_id, "W1").build());
@@ -190,7 +190,7 @@ async fn version_counter_bumps_on_state_changes() {
 
 #[tokio::test]
 async fn observe_dedupes_via_refcount() {
-    let client = QueryClient::new();
+    let client = QueryClient::without_driver();
     let q1 = Issue::query().eq(issues::field::workspace_id, "W1").build();
     let q2 = Issue::query().eq(issues::field::workspace_id, "W1").build();
 
@@ -211,7 +211,7 @@ async fn on_update_listener_fires_after_state_changes() {
     use std::cell::Cell;
     use std::rc::Rc;
 
-    let client = QueryClient::new();
+    let client = QueryClient::without_driver();
     let ctx = StubContext::new();
     let view =
         client.observe::<Issue>(Issue::query().eq(issues::field::workspace_id, "W1").build());
@@ -247,7 +247,7 @@ async fn on_update_listener_unregisters_on_token_drop() {
     use std::cell::Cell;
     use std::rc::Rc;
 
-    let client = QueryClient::new();
+    let client = QueryClient::without_driver();
     let ctx = StubContext::new();
     let view =
         client.observe::<Issue>(Issue::query().eq(issues::field::workspace_id, "W1").build());
@@ -319,7 +319,7 @@ impl Mutator for DeleteIssue {
 
 #[tokio::test]
 async fn delete_mutation_removes_canonical_row() {
-    let client = QueryClient::new();
+    let client = QueryClient::without_driver();
     let ctx = StubContext::new();
     let view =
         client.observe::<Issue>(Issue::query().eq(issues::field::workspace_id, "W1").build());
@@ -362,7 +362,7 @@ async fn delete_mutation_removes_canonical_row() {
 fn handle_outliving_client_is_safe() {
     let q = Issue::query().eq(issues::field::workspace_id, "W1").build();
     let h = {
-        let c = QueryClient::new();
+        let c = QueryClient::without_driver();
         c.subscribe::<Issue>(q)
     };
     // Client is gone; dropping the handle must not panic or UAF.
@@ -399,7 +399,7 @@ async fn rollback_notifies_observers() {
     use std::cell::Cell;
     use std::rc::Rc;
 
-    let client = QueryClient::new();
+    let client = QueryClient::without_driver();
     let ctx = StubContext::new();
     let view =
         client.observe::<Issue>(Issue::query().eq(issues::field::workspace_id, "W1").build());
@@ -447,7 +447,7 @@ fn builder_supports_order_and_limit() {
 
 #[tokio::test]
 async fn rows_applied_order_by_and_limit() {
-    let client = QueryClient::new();
+    let client = QueryClient::without_driver();
     let ctx = StubContext::new();
     let view = client.observe::<Issue>(
         Issue::query()
@@ -536,7 +536,7 @@ async fn delete_suppresses_prior_pending_upsert() {
         }
     }
 
-    let client = QueryClient::new();
+    let client = QueryClient::without_driver();
     let ctx = StubContext::new();
     let view =
         client.observe::<Issue>(Issue::query().eq(issues::field::workspace_id, "W1").build());
@@ -599,7 +599,7 @@ async fn rollback_does_not_clobber_concurrent_canonical() {
         }
     }
 
-    let client = QueryClient::new();
+    let client = QueryClient::without_driver();
     let ctx = StubContext::new();
     let view =
         client.observe::<Issue>(Issue::query().eq(issues::field::workspace_id, "W1").build());

--- a/crates/pocopine-sync-query/Cargo.toml
+++ b/crates/pocopine-sync-query/Cargo.toml
@@ -15,6 +15,11 @@ serde = { workspace = true }
 # matching the pattern from pocopine-sync-crud. Declared unconditionally so wasm
 # consumers don't need their own transitive serde_json dep.
 serde_json = { workspace = true }
+# RFC 087 driver — `futures::select!` + `FutureExt::fuse()` provide a
+# runtime-agnostic select-shape across wasm + tokio so the driver's
+# main loop source compiles unchanged on both targets.
+futures = "0.3"
+tracing = { workspace = true }
 
 [dev-dependencies]
 js-sys = { workspace = true }
@@ -23,10 +28,25 @@ wasm-bindgen = { workspace = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 async-trait = "0.1"
 pocopine-auth = { workspace = true }
+# RFC 087 driver — `tokio::task::spawn_local` requires the host
+# caller to have a `LocalSet` active (documented on `QueryClient`).
+# `sync` brings `Mutex`/`Notify`; `time` brings `sleep`. `rt` is
+# transitive but explicit for clarity.
+tokio = { version = "1", features = ["macros", "rt", "time", "sync"] }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+# RFC 087 driver — wasm spawn shim is `spawn_local` here, with the
+# task captured in a `JoinHandle`-like wrapper for the eventual
+# scope-lifetime hook.
+wasm-bindgen-futures = { workspace = true }
+# `setTimeout` bridge for the polling tick + `Promise::new` for the
+# resolve callback. Plus `wasm-bindgen` for `JsCast` / `closure`.
+wasm-bindgen = { workspace = true }
+js-sys = { workspace = true }
+web-sys = { version = "0.3", features = ["Window"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 http = { workspace = true }
 http-body-util = "0.1"
 pocopine-server = { workspace = true }
-tokio = { version = "1", features = ["macros", "rt"] }
 tower = { version = "0.5", features = ["util"] }

--- a/crates/pocopine-sync-query/Cargo.toml
+++ b/crates/pocopine-sync-query/Cargo.toml
@@ -44,6 +44,10 @@ wasm-bindgen-futures = { workspace = true }
 wasm-bindgen = { workspace = true }
 js-sys = { workspace = true }
 web-sys = { version = "0.3", features = ["Window"] }
+# RFC 087 §6 — live wakeup via the per-collection SSE topic. The
+# driver opens one `LiveClient` per subscription, filters incoming
+# events against the captured params, and triggers `/pull` on match.
+pocopine-live = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 http = { workspace = true }

--- a/crates/pocopine-sync-query/src/client.rs
+++ b/crates/pocopine-sync-query/src/client.rs
@@ -985,33 +985,47 @@ impl QueryClient {
         inner.replay_queue.borrow_mut().push_back(entry);
     }
 
-    /// Driver-only: roll back the optimistic overlay for one
-    /// `(subscription, mutation_id)` pair without scanning the
-    /// registry. Used by the replay path when the server rejects
-    /// a mutation after a network blip — the offline-queued
-    /// optimistic state was a "best guess" the server later
-    /// invalidated.
-    pub(crate) fn dequeue_pending_for_subscription<Row>(
-        _inner: &Rc<QueryClientInner>,
-        subscription: &QuerySubscription<Row>,
+    /// Driver-only: roll back the optimistic overlay for `mutation_id`
+    /// across EVERY matching subscription on `stream`. Same semantics
+    /// as the private `dequeue_pending` method on `QueryClient` — the
+    /// shape this is exposed for the offline-replay path which only
+    /// holds the inner `Rc`, not the outer `QueryClient`.
+    ///
+    /// This is the correct entry point for the rejected-replay
+    /// cleanup path because optimistic state for one mutation is
+    /// fan-out across every subscription whose predicate matched at
+    /// the original `apply_local` time. Cleaning only the driver's
+    /// own subscription leaves stale pending state behind on every
+    /// other view that received the same optimistic upsert.
+    pub(crate) fn dequeue_pending_for_stream<Row>(
+        inner: &Rc<QueryClientInner>,
+        stream: &SyncStreamName,
         mutation_id: &MutationId,
     ) where
         Row: Clone + 'static,
     {
-        let removed = {
-            let mut state = subscription.state.borrow_mut();
-            let overlays = state.remove_pending(mutation_id);
-            for overlay in &overlays {
-                if let Some(restored) = overlay.deleted_row.clone() {
-                    if !state.canonical_contains(&restored.key) {
-                        state.upsert_canonical(restored);
+        for typed in collect_subscriptions_on_stream_inner::<Row>(inner, stream) {
+            let removed = {
+                let mut state = typed.state.borrow_mut();
+                let overlays = state.remove_pending(mutation_id);
+                // Same conservative-restore rule as the in-flight
+                // mutate() rollback: only re-upsert when canonical
+                // doesn't already hold a (potentially newer) row
+                // for the key. Skipping the restore on collision
+                // lets the newer canonical stand; the next /pull
+                // will reconcile.
+                for overlay in &overlays {
+                    if let Some(restored) = overlay.deleted_row.clone() {
+                        if !state.canonical_contains(&restored.key) {
+                            state.upsert_canonical(restored);
+                        }
                     }
                 }
+                overlays
+            };
+            if !removed.is_empty() {
+                typed.notify_listeners();
             }
-            overlays
-        };
-        if !removed.is_empty() {
-            subscription.notify_listeners();
         }
     }
 

--- a/crates/pocopine-sync-query/src/client.rs
+++ b/crates/pocopine-sync-query/src/client.rs
@@ -14,12 +14,18 @@
 
 use std::any::{Any, TypeId};
 use std::cell::{Cell, RefCell};
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::rc::{Rc, Weak};
 
-use pocopine_sync::{ClientMutation, MutationId, SyncRow, SyncStreamName, SYNC_ENDPOINT_PREFIX};
+use pocopine_sync::{
+    ClientMutation, MutationId, RowKey, SyncRow, SyncStreamName, SYNC_ENDPOINT_PREFIX,
+};
 use serde_json::Value;
 
+use crate::driver::{
+    spawn_driver, DriverEpoch, DriverHandle, QueryClientConfig, ReplayEntry, ReplayOutcome,
+    SubscriptionDriver,
+};
 use crate::mutator::RowChange;
 use crate::query::{MatchFn, Order, Query, QueryKey};
 use crate::state::{PendingOverlay, QueryState};
@@ -38,11 +44,23 @@ type RegistryKey = (TypeId, QueryKey);
 /// `Rc::downcast` (replacing the prior `Rc::into_raw`/`from_raw`
 /// hack that relied on `RcBox<dyn>` / `RcBox<Concrete>` layout
 /// coincidence).
-trait AnyQuerySubscription: 'static {
+pub(crate) trait AnyQuerySubscription: 'static {
     fn stream(&self) -> &SyncStreamName;
     fn refcount(&self) -> usize;
     fn bump_refcount(&self) -> usize;
     fn decrement_refcount(&self) -> usize;
+    /// Snapshot of this subscription's driver epoch — bumped on
+    /// last-handle drop so the spawned driver exits at its next
+    /// `.await`.
+    fn driver_epoch(&self) -> DriverEpoch;
+    /// `true` once a driver task has been spawned for this
+    /// subscription. The flag is sticky for the lifetime of the
+    /// subscription; `observe` checks it to avoid double-spawn
+    /// when a second `subscribe` lands on the same entry.
+    fn driver_spawned(&self) -> bool;
+    /// Mark the driver as spawned. The framework calls this once
+    /// from `observe` immediately after `spawn_driver` returns.
+    fn set_driver_spawned(&self);
     /// Re-package self into `Rc<dyn Any>` for safe `Rc::downcast`.
     /// The default-method-style cannot work here because `Rc::downcast`
     /// requires the source to be `Rc<dyn Any>`, not `Rc<dyn OtherTrait>`.
@@ -85,10 +103,19 @@ pub struct QuerySubscription<Row: 'static> {
     /// Monotonic counter for listener ids. The token returned from
     /// [`QueryView::on_update`] holds the id so drop can unregister.
     next_listener_id: Cell<u64>,
-    // Background-task lifecycle is owned externally; the runtime hooks
-    // into the subscription via `state`. The Drop on `QueryHandle`
-    // signals "no more observers" by decrementing the refcount; the
-    // QueryClient gc'd entry triggers cleanup.
+    /// Generation counter that the spawned driver task watches.
+    /// Bumped from `release_inner` on the last-handle drop so the
+    /// driver exits at its next `.await` per RFC 087 §8.
+    epoch: DriverEpoch,
+    /// Whether a driver task has been spawned for this subscription.
+    /// Set once by `observe`; never cleared (a re-subscribe after
+    /// the entry is GC'd builds a new `QuerySubscription` and the
+    /// flag starts fresh).
+    driver_spawned: Cell<bool>,
+    /// Owned driver handle. Currently a marker (cancellation is
+    /// epoch-driven, not abort-driven) — present so the type-shape
+    /// can carry per-platform metadata in follow-ups.
+    _driver_handle: Cell<Option<DriverHandle>>,
 }
 
 impl<Row: 'static> QuerySubscription<Row> {
@@ -101,7 +128,18 @@ impl<Row: 'static> QuerySubscription<Row> {
             refcount: Cell::new(0),
             listeners: RefCell::new(Vec::new()),
             next_listener_id: Cell::new(0),
+            epoch: DriverEpoch::new(),
+            driver_spawned: Cell::new(false),
+            _driver_handle: Cell::new(None),
         }
+    }
+
+    /// Fire `notify_listeners` from a caller outside this module —
+    /// the driver path needs to notify after applying a `/open` or
+    /// `/pull` response but doesn't have access to the private
+    /// `notify_listeners` symbol.
+    pub(crate) fn notify_listeners_external(&self) {
+        self.notify_listeners();
     }
 
     /// Borrow the query this subscription serves.
@@ -209,6 +247,18 @@ impl<Row: 'static> AnyQuerySubscription for QuerySubscription<Row> {
         next
     }
 
+    fn driver_epoch(&self) -> DriverEpoch {
+        self.epoch.clone()
+    }
+
+    fn driver_spawned(&self) -> bool {
+        self.driver_spawned.get()
+    }
+
+    fn set_driver_spawned(&self) {
+        self.driver_spawned.set(true);
+    }
+
     fn as_rc_any(self: Rc<Self>) -> Rc<dyn Any> {
         self
     }
@@ -227,13 +277,23 @@ impl<Row: 'static> AnyQuerySubscription for QuerySubscription<Row> {
 /// handle that outlives the client sees `Weak::upgrade` → `None`
 /// and silently no-ops its refcount decrement instead of triggering
 /// a use-after-free.
-struct QueryClientInner {
+pub(crate) struct QueryClientInner {
     endpoint: String,
+    /// Driver configuration (poll interval, live-wakeup flag,
+    /// credentials). `None` means "no driver" — `observe` skips the
+    /// spawn step. Set by `QueryClient::without_driver`.
+    pub(crate) config: Option<QueryClientConfig>,
     /// Active subscriptions keyed by `(Row TypeId, QueryKey)`. Two
     /// queries with the same `(stream, params, order, limit)` but
     /// different `Row` types live in separate entries — no
     /// `Rc<dyn Any>` downcast can panic on a Row mismatch.
     registry: RefCell<HashMap<RegistryKey, Rc<dyn AnyQuerySubscription>>>,
+    /// Mutations that failed with a transport error and need to be
+    /// re-fired by the driver on the next successful tick. FIFO so
+    /// the original order is preserved on replay. The driver
+    /// dequeues the whole batch on each tick and re-inserts
+    /// entries that are still offline.
+    pub(crate) replay_queue: RefCell<VecDeque<ReplayEntry>>,
 }
 
 pub struct QueryClient {
@@ -241,21 +301,73 @@ pub struct QueryClient {
 }
 
 impl QueryClient {
-    /// Build a fresh client. The default endpoint is the framework's
-    /// `/__pocopine/sync/v1` prefix; tests can override.
+    /// Build a fresh client with default config (driver enabled,
+    /// 30s poll cadence, framework endpoint).
+    ///
+    /// **Native runtime requirement.** When this client's driver
+    /// runs (via the first [`observe`](Self::observe) call), it
+    /// spawns the per-subscription task with
+    /// `tokio::task::spawn_local`. The caller's tokio runtime
+    /// must therefore have an active
+    /// [`tokio::task::LocalSet`](https://docs.rs/tokio/latest/tokio/task/struct.LocalSet.html);
+    /// tests should wrap their body in
+    /// `LocalSet::new().run_until(async { ... }).await`. Wasm
+    /// builds use `wasm_bindgen_futures::spawn_local` and have no
+    /// equivalent constraint. If you only want the routing engine
+    /// — no spawned drivers — use [`without_driver`](Self::without_driver).
     pub fn new() -> Self {
-        Self::with_endpoint(SYNC_ENDPOINT_PREFIX.to_string())
+        Self::with_config(QueryClientConfig::default())
     }
 
     /// Build a client targeting a custom endpoint prefix. Useful for
-    /// tests against a router mounted at a different path.
+    /// tests against a router mounted at a different path. The
+    /// other config knobs stay at their defaults.
     pub fn with_endpoint(endpoint: String) -> Self {
+        let cfg = QueryClientConfig {
+            endpoint,
+            ..QueryClientConfig::default()
+        };
+        Self::with_config(cfg)
+    }
+
+    /// Build a client with a fully-specified [`QueryClientConfig`].
+    /// The driver is spawned on the first [`observe`](Self::observe)
+    /// for each subscription — see [`Self::new`] for the native
+    /// LocalSet requirement.
+    pub fn with_config(config: QueryClientConfig) -> Self {
+        let endpoint = config.endpoint.clone();
         Self {
             inner: Rc::new(QueryClientInner {
                 endpoint,
+                config: Some(config),
                 registry: RefCell::new(HashMap::new()),
+                replay_queue: RefCell::new(VecDeque::new()),
             }),
         }
+    }
+
+    /// Build a client with the driver disabled. Pure routing-engine
+    /// mode — `observe` returns a view whose `canonical_rows`
+    /// stays empty until the caller manually feeds it through
+    /// `mutate`. Used by tests that want to exercise the routing
+    /// engine without spawning background tasks.
+    pub fn without_driver() -> Self {
+        let endpoint = SYNC_ENDPOINT_PREFIX.to_string();
+        Self {
+            inner: Rc::new(QueryClientInner {
+                endpoint,
+                config: None,
+                registry: RefCell::new(HashMap::new()),
+                replay_queue: RefCell::new(VecDeque::new()),
+            }),
+        }
+    }
+
+    /// Re-wrap an existing [`QueryClientInner`] so the driver's
+    /// replay path can call `mutate` against the canonical
+    /// `QueryClient` shape. Crate-internal helper.
+    pub(crate) fn from_inner(inner: Rc<QueryClientInner>) -> Self {
+        Self { inner }
     }
 
     /// The endpoint prefix this client posts against.
@@ -323,13 +435,44 @@ impl QueryClient {
     /// holds the underlying [`QueryHandle`] and exposes a borrow-only
     /// surface (`rows()`, `pending()`, `version()`). Drop the view to
     /// decrement the subscription's refcount.
+    ///
+    /// When the underlying client has a [`QueryClientConfig`]
+    /// installed (the default; cleared by
+    /// [`without_driver`](Self::without_driver)), this is also the
+    /// moment a per-subscription driver task is spawned. The
+    /// driver issues `/open` + initial `/pull` immediately, then
+    /// loops on the configured poll interval — per RFC 087 §1.
+    ///
+    /// Spawn happens once per subscription identity; observing
+    /// the same `Query` twice doesn't re-spawn.
     pub fn observe<Row>(&self, query: Query<Row>) -> QueryView<Row>
     where
-        Row: Clone + 'static,
+        Row: Clone + serde::Serialize + serde::de::DeserializeOwned + 'static,
     {
-        QueryView {
-            handle: self.subscribe(query),
+        let handle = self.subscribe(query);
+        self.maybe_spawn_driver(&handle.subscription);
+        QueryView { handle }
+    }
+
+    /// Spawn the driver for `subscription` if (1) the client has a
+    /// config and (2) the subscription doesn't already have a
+    /// driver. Idempotent.
+    fn maybe_spawn_driver<Row>(&self, subscription: &Rc<QuerySubscription<Row>>)
+    where
+        Row: Clone + serde::Serialize + serde::de::DeserializeOwned + 'static,
+    {
+        let Some(config) = self.inner.config.as_ref() else {
+            return;
+        };
+        if subscription.driver_spawned() {
+            return;
         }
+        let epoch = subscription.epoch.clone();
+        let weak_sub = Rc::downgrade(subscription);
+        let weak_inner = Rc::downgrade(&self.inner);
+        let driver = SubscriptionDriver::<Row>::new(weak_sub, weak_inner, epoch, config);
+        subscription.set_driver_spawned();
+        spawn_driver(driver.run());
     }
 
     /// Run a mutator end-to-end: apply optimistic locally, push to the
@@ -399,14 +542,38 @@ impl QueryClient {
             _row: std::marker::PhantomData,
         };
 
+        // Capture the original push URL + mutation_id so an
+        // offline replay can rebuild a `MutatorRemoteContext`
+        // that surfaces the SAME identity on retry — preserving
+        // the server-side dedup contract (RFC 087 §7 / RFC 072).
+        let original_push_url = ctx.push_url().to_string();
+
         // 2. Wire push (caller-supplied context handles transport).
         let canonical_changes = match M::apply_remote(ctx, payload).await {
             Ok(c) => c,
             Err(err) => {
-                // Roll back the optimistic overlay on push failure
-                // via the guard's Drop — disarm not called, so when
-                // `guard` falls out of scope at function return its
-                // Drop runs `dequeue_pending` exactly once.
+                if err.is_transport() && self.inner.config.is_some() {
+                    // RFC 087 §7 offline path: keep the optimistic
+                    // overlay in pending + enqueue a replay for the
+                    // driver to fire on the next successful tick.
+                    guard.disarm();
+                    let entry = build_replay_entry::<M>(
+                        stream.clone(),
+                        mutation_id.clone(),
+                        original_push_url,
+                        wire_mutation.payload.clone(),
+                    );
+                    self.inner.replay_queue.borrow_mut().push_back(entry);
+                    tracing::info!(
+                        target: "pocopine.log",
+                        stream = stream.as_str(),
+                        mutation_id = %mutation_id.as_str(),
+                        "sync-query: apply_remote network error; queued for replay"
+                    );
+                    return Err(err);
+                }
+                // Non-transport error OR driver disabled — fall
+                // through to the guard's Drop, which rolls back.
                 drop(guard);
                 return Err(err);
             }
@@ -695,6 +862,155 @@ impl QueryClient {
         }
     }
 
+    /// Route a server-confirmed canonical pull into matching
+    /// subscriptions. Driver-only entry point — distinct from
+    /// [`route_canonical_changes`] because `/pull` results carry
+    /// no `mutation_id` (they're unsolicited canonical updates
+    /// from the server, not the canonical-side of a client
+    /// mutation).
+    ///
+    /// Semantics:
+    ///
+    /// * `Upsert(row)` — for each subscription on `stream`:
+    ///   * predicate matches AND row not in canonical → upsert.
+    ///   * predicate matches AND row already in canonical → upsert
+    ///     (refresh the cached value).
+    ///   * predicate doesn't match AND row in canonical → remove
+    ///     (server-confirmed predicate departure).
+    ///   * predicate doesn't match AND row not in canonical → no-op.
+    /// * `Delete(key)` — remove from every subscription's
+    ///   canonical that holds the key.
+    ///
+    /// Does NOT touch the pending overlay — overlays are the
+    /// mutation-driven path's responsibility; the driver is only
+    /// authoritative on canonical state. Pending overlays for a
+    /// matching key remain visible; the merge in `QueryView::rows`
+    /// makes the optimistic upsert win over the canonical until
+    /// the matching `mutate()` clears it.
+    pub(crate) fn route_canonical_pull<Row>(
+        inner: &Rc<QueryClientInner>,
+        stream: &SyncStreamName,
+        canonical: &[RowChange<Row>],
+    ) where
+        Row: Clone + serde::Serialize + 'static,
+    {
+        let subscriptions = collect_subscriptions_on_stream_inner::<Row>(inner, stream);
+        for typed in subscriptions {
+            let touched = {
+                let mut state = typed.state.borrow_mut();
+                let mut touched = false;
+                for change in canonical {
+                    match change {
+                        RowChange::Upsert(row) => {
+                            let Some(key) = row_key_of(row) else {
+                                continue;
+                            };
+                            if typed.matches(row) {
+                                state.upsert_canonical(SyncRow {
+                                    key,
+                                    version: None,
+                                    value: row.clone(),
+                                    pending: false,
+                                    conflict: false,
+                                });
+                                touched = true;
+                            } else if state.canonical_contains(&key) {
+                                state.remove_canonical(&key);
+                                touched = true;
+                            }
+                        }
+                        RowChange::Delete(key) => {
+                            if state.canonical_contains(key) {
+                                state.remove_canonical(key);
+                                touched = true;
+                            }
+                        }
+                    }
+                }
+                touched
+            };
+            if touched {
+                typed.notify_listeners();
+            }
+        }
+    }
+
+    /// Wipe canonical rows on every subscription on `stream` whose
+    /// `Row` type matches. Driver-only — invoked from the
+    /// `SyncPullMode::Snapshot` path so the next `route_canonical_pull`
+    /// builds the canonical set from scratch instead of accumulating
+    /// stale rows alongside the snapshot's fresh ones.
+    ///
+    /// Notifies listeners only when the canonical set was actually
+    /// non-empty — avoids gratuitous re-renders for a snapshot pull
+    /// that lands on a fresh subscription.
+    pub(crate) fn clear_canonical_on_stream<Row>(
+        inner: &Rc<QueryClientInner>,
+        stream: &SyncStreamName,
+    ) where
+        Row: Clone + 'static,
+    {
+        let subscriptions = collect_subscriptions_on_stream_inner::<Row>(inner, stream);
+        for typed in subscriptions {
+            let touched = {
+                let mut state = typed.state.borrow_mut();
+                let keys: Vec<RowKey> = state.canonical_rows().map(|r| r.key.clone()).collect();
+                let was_non_empty = !keys.is_empty();
+                for key in keys {
+                    state.remove_canonical(&key);
+                }
+                was_non_empty
+            };
+            if touched {
+                typed.notify_listeners();
+            }
+        }
+    }
+
+    /// Driver-only: drain the replay queue. The caller iterates the
+    /// returned `Vec` and pushes still-failing entries back via
+    /// [`reinsert_replay_entry`].
+    pub(crate) fn take_replay_entries(inner: &Rc<QueryClientInner>) -> Vec<ReplayEntry> {
+        let mut q = inner.replay_queue.borrow_mut();
+        q.drain(..).collect()
+    }
+
+    /// Driver-only: push a replay entry back on the queue (the
+    /// caller's replay attempt observed `StillOffline`).
+    pub(crate) fn reinsert_replay_entry(inner: &Rc<QueryClientInner>, entry: ReplayEntry) {
+        inner.replay_queue.borrow_mut().push_back(entry);
+    }
+
+    /// Driver-only: roll back the optimistic overlay for one
+    /// `(subscription, mutation_id)` pair without scanning the
+    /// registry. Used by the replay path when the server rejects
+    /// a mutation after a network blip — the offline-queued
+    /// optimistic state was a "best guess" the server later
+    /// invalidated.
+    pub(crate) fn dequeue_pending_for_subscription<Row>(
+        _inner: &Rc<QueryClientInner>,
+        subscription: &QuerySubscription<Row>,
+        mutation_id: &MutationId,
+    ) where
+        Row: Clone + 'static,
+    {
+        let removed = {
+            let mut state = subscription.state.borrow_mut();
+            let overlays = state.remove_pending(mutation_id);
+            for overlay in &overlays {
+                if let Some(restored) = overlay.deleted_row.clone() {
+                    if !state.canonical_contains(&restored.key) {
+                        state.upsert_canonical(restored);
+                    }
+                }
+            }
+            overlays
+        };
+        if !removed.is_empty() {
+            subscription.notify_listeners();
+        }
+    }
+
     /// Snapshot all subscriptions on a given stream whose Row type
     /// matches `Row`. The returned Vec holds `Rc` clones so callers
     /// can freely call back into the `QueryClient` from inside the
@@ -704,16 +1020,25 @@ impl QueryClient {
         &self,
         stream: &SyncStreamName,
     ) -> Vec<Rc<QuerySubscription<Row>>> {
-        let target = (TypeId::of::<Row>(), ());
-        let registry = self.inner.registry.borrow();
-        registry
-            .iter()
-            .filter(|((tid, _), sub)| *tid == target.0 && sub.stream() == stream)
-            .filter_map(|(_, sub)| {
-                Rc::downcast::<QuerySubscription<Row>>(sub.clone().as_rc_any()).ok()
-            })
-            .collect()
+        collect_subscriptions_on_stream_inner(&self.inner, stream)
     }
+}
+
+/// Free-function variant of `collect_subscriptions_on_stream` that
+/// takes `Rc<QueryClientInner>` directly. Used by the driver's
+/// canonical-pull / clear-canonical paths, which only hold the
+/// inner `Rc` (not the outer `QueryClient`).
+fn collect_subscriptions_on_stream_inner<Row: 'static>(
+    inner: &Rc<QueryClientInner>,
+    stream: &SyncStreamName,
+) -> Vec<Rc<QuerySubscription<Row>>> {
+    let target = TypeId::of::<Row>();
+    let registry = inner.registry.borrow();
+    registry
+        .iter()
+        .filter(|((tid, _), sub)| *tid == target && sub.stream() == stream)
+        .filter_map(|(_, sub)| Rc::downcast::<QuerySubscription<Row>>(sub.clone().as_rc_any()).ok())
+        .collect()
 }
 
 impl Default for QueryClient {
@@ -756,6 +1081,119 @@ impl<Row: Clone + 'static> Drop for RollbackGuard<'_, Row> {
             client.dequeue_pending::<Row>(&self.stream, &self.mutation_id);
         }
     }
+}
+
+/// Context handed to a replayed `Mutator::apply_remote`. Surfaces
+/// the ORIGINAL `mutation_id` (not a fresh one) so the server's
+/// idempotency log accepts the retry as the same logical write —
+/// per RFC 087 §7 and the wire dedup contract in RFC 072.
+struct ReplayContext {
+    mutation_id: MutationId,
+    push_url: String,
+}
+
+impl crate::mutator::MutatorRemoteContext for ReplayContext {
+    fn push_url(&self) -> &str {
+        &self.push_url
+    }
+
+    fn next_mutation_id(&self) -> pocopine_sync::SyncResult<MutationId> {
+        // The driver re-fires apply_remote with the same logical
+        // identity. Clone instead of regenerate so the server
+        // dedup path treats this as the same row.
+        Ok(self.mutation_id.clone())
+    }
+}
+
+/// Build the offline-replay closure for one mutator + captured
+/// payload. The returned [`ReplayEntry`] is stored on the
+/// `QueryClientInner::replay_queue` and re-fired by the driver on
+/// the next successful tick.
+///
+/// Boxed as `Fn(&QueryClient) -> LocalBoxFuture` so the queue can
+/// hold heterogeneous entries — different `Mutator` impls
+/// monomorphize to different concrete types, but the wire-side
+/// behavior collapses to the same trait-object shape.
+fn build_replay_entry<M>(
+    stream: SyncStreamName,
+    mutation_id: MutationId,
+    push_url: String,
+    payload_value: Value,
+) -> ReplayEntry
+where
+    M: crate::Mutator,
+    M::Row: Clone + serde::Serialize + 'static,
+{
+    let replay_stream = stream.clone();
+    let replay_mutation_id = mutation_id.clone();
+    let replay_push_url = push_url.clone();
+    let replay_payload = payload_value.clone();
+    let replay: crate::driver::ReplayFuture = Box::new(move |client: &QueryClient| {
+        let stream = replay_stream.clone();
+        let mutation_id = replay_mutation_id.clone();
+        let push_url = replay_push_url.clone();
+        let payload_value = replay_payload.clone();
+        let inner = client.inner.clone();
+        Box::pin(async move {
+            // Decode the captured wire payload back into the
+            // mutator's typed Payload. A decode failure means
+            // the user changed the payload shape between
+            // submitting the mutation and the replay tick — we
+            // treat that as Rejected (drop the pending; surface
+            // via state.error on the next observe tick).
+            let payload: M::Payload = match serde_json::from_value(payload_value) {
+                Ok(p) => p,
+                Err(err) => {
+                    tracing::warn!(
+                        target: "pocopine.log",
+                        stream = stream.as_str(),
+                        error = %err,
+                        "sync-query: replay payload could not be decoded; dropping mutation"
+                    );
+                    return ReplayOutcome::Rejected;
+                }
+            };
+            let ctx = ReplayContext {
+                mutation_id: mutation_id.clone(),
+                push_url,
+            };
+            match M::apply_remote(&ctx, payload).await {
+                Ok(canonical_changes) => {
+                    // Route into matching subscriptions; this also
+                    // clears the pending overlay via remove_pending.
+                    let client = QueryClient::from_inner(inner);
+                    client.route_canonical_changes::<M::Row>(
+                        &stream,
+                        &mutation_id,
+                        &canonical_changes,
+                    );
+                    ReplayOutcome::Accepted
+                }
+                Err(err) if err.is_transport() => ReplayOutcome::StillOffline,
+                Err(err) => {
+                    tracing::warn!(
+                        target: "pocopine.log",
+                        stream = stream.as_str(),
+                        error = %err,
+                        "sync-query: replay rejected by server; rolling back overlay"
+                    );
+                    ReplayOutcome::Rejected
+                }
+            }
+        })
+    });
+    ReplayEntry {
+        stream,
+        mutation_id,
+        replay,
+    }
+}
+
+/// Bump the driver epoch for a subscription that just lost its
+/// last `QueryHandle`. Crate-internal entry point so
+/// `release_inner` doesn't need to know the trait-object shape.
+fn maybe_bump_driver_epoch(sub: &Rc<dyn AnyQuerySubscription>) {
+    sub.driver_epoch().bump();
 }
 
 /// Best-effort row-key extractor.
@@ -1128,11 +1566,15 @@ fn release_inner(inner: &QueryClientInner, key: RegistryKey) {
     let Ok(mut registry) = inner.registry.try_borrow_mut() else {
         return;
     };
-    let should_remove = registry
-        .get(&key)
-        .map(|sub| sub.decrement_refcount() == 0)
-        .unwrap_or(false);
-    if should_remove {
+    let Some(sub) = registry.get(&key).cloned() else {
+        return;
+    };
+    if sub.decrement_refcount() == 0 {
+        // Bump the driver epoch BEFORE removing the registry
+        // entry — the spawned task may still hold a `Weak<inner>`
+        // and re-enter; the epoch check at the next .await is
+        // what guarantees it stops touching state.
+        maybe_bump_driver_epoch(&sub);
         registry.remove(&key);
     }
 }

--- a/crates/pocopine-sync-query/src/client.rs
+++ b/crates/pocopine-sync-query/src/client.rs
@@ -936,14 +936,18 @@ impl QueryClient {
     }
 
     /// Wipe canonical rows on every subscription on `stream` whose
-    /// `Row` type matches. Driver-only — invoked from the
-    /// `SyncPullMode::Snapshot` path so the next `route_canonical_pull`
-    /// builds the canonical set from scratch instead of accumulating
-    /// stale rows alongside the snapshot's fresh ones.
+    /// `Row` type matches. Retained for future stream-wide reset
+    /// scenarios (e.g., admin-initiated schema rollover across
+    /// every subscription on a stream). The driver's per-pull
+    /// snapshot path uses a per-subscription wipe inside
+    /// `apply_pull` instead — different subscriptions are
+    /// independent compartments and a stream-wide wipe would
+    /// clobber a subscription whose /pull hasn't run yet.
     ///
     /// Notifies listeners only when the canonical set was actually
     /// non-empty — avoids gratuitous re-renders for a snapshot pull
     /// that lands on a fresh subscription.
+    #[allow(dead_code)]
     pub(crate) fn clear_canonical_on_stream<Row>(
         inner: &Rc<QueryClientInner>,
         stream: &SyncStreamName,

--- a/crates/pocopine-sync-query/src/driver.rs
+++ b/crates/pocopine-sync-query/src/driver.rs
@@ -571,10 +571,18 @@ where
         }
     }
 
-    /// Apply a `/pull` response: route each row into the
-    /// canonical state of every matching subscription on the
-    /// stream. Snapshot mode replaces the canonical set; delta
-    /// mode applies the changes.
+    /// Apply a `/pull` response.
+    ///
+    /// `Snapshot` mode replaces THIS subscription's canonical set:
+    /// only the originating subscription's rows are wiped before
+    /// the routing engine re-upserts the snapshot's rows. Other
+    /// subscriptions on the same stream keep their independent
+    /// canonical state — they may be ahead or behind this
+    /// subscription's cursor because each driver issues its own
+    /// `/pull`.
+    ///
+    /// `Incremental` mode just routes the deltas through
+    /// `route_canonical_pull`; nothing is wiped first.
     fn apply_pull(&self, response: SyncPullResponse<Value>) {
         let Some(sub) = self.subscription.upgrade() else {
             return;
@@ -589,14 +597,22 @@ where
         // Decode failures are warned + skipped per RFC 086.
         let changes = decode_pull_changes::<Row>(&response);
 
-        match response.mode {
-            SyncPullMode::Snapshot => {
-                // For a snapshot, the canonical set is REPLACED.
-                // Wipe canonical_rows on every matching
-                // subscription, then upsert the new rows.
-                QueryClient::clear_canonical_on_stream::<Row>(&client_inner, &stream);
+        if matches!(response.mode, SyncPullMode::Snapshot) {
+            // Wipe only THIS subscription's canonical set; the
+            // routing engine's predicate evaluation below
+            // re-inserts the matching rows. Other subscriptions
+            // on the same stream are untouched — their cursors
+            // and snapshots are independent.
+            let keys: Vec<pocopine_sync::RowKey> = {
+                let state = sub.state().borrow();
+                state.canonical_rows().map(|r| r.key.clone()).collect()
+            };
+            if !keys.is_empty() {
+                let mut state = sub.state().borrow_mut();
+                for key in keys {
+                    state.remove_canonical(&key);
+                }
             }
-            SyncPullMode::Incremental => {}
         }
 
         QueryClient::route_canonical_pull::<Row>(&client_inner, &stream, &changes);

--- a/crates/pocopine-sync-query/src/driver.rs
+++ b/crates/pocopine-sync-query/src/driver.rs
@@ -1,0 +1,986 @@
+//! Per-subscription background driver — owns `/open`, `/pull`, live
+//! wakeup, and offline replay for one `QuerySubscription`.
+//!
+//! Spawned by [`QueryClient::observe`] the first time a query is
+//! subscribed; survives across additional subscribes (refcount > 1)
+//! and exits at its next `.await` point when the last
+//! [`QueryHandle`](crate::QueryHandle) drops via [`DriverEpoch::bump`].
+//!
+//! ## Why a per-subscription driver, not per-stream
+//!
+//! Two subscriptions to the same stream with different params have
+//! different `/pull` cursors and different canonical state
+//! compartments — a per-stream driver would still need a per-
+//! subscription state machine. See RFC 087 §"Alternatives B".
+//!
+//! ## Cancellation invariants
+//!
+//! 1. Every `.await` boundary in [`SubscriptionDriver::run`] is
+//!    followed by an `if !self.epoch.is_current() { return; }`
+//!    guard, OR an upgrade of the `Weak<QuerySubscription>` that
+//!    bails on `None`. There is no path where a stale task can
+//!    mutate state.
+//! 2. `Drop` on the last `QueryHandle` runs
+//!    `release_inner → maybe_bump_driver_epoch` which calls
+//!    [`DriverEpoch::bump`]. The task observes the bump at its
+//!    next yield via [`DriverEpoch::is_current`].
+//! 3. The driver carries a `Weak<QuerySubscription<Row>>`, not
+//!    `Rc`, so it doesn't keep the subscription alive past Drop.
+//!    If the subscription is reclaimed while the driver is between
+//!    awaits, the next `Weak::upgrade` returns `None` and the
+//!    task exits.
+//!
+//! ## Native runtime requirement
+//!
+//! On native targets the driver is spawned via
+//! `tokio::task::spawn_local` — it requires a `tokio::task::LocalSet`
+//! to be active on the calling thread. Host tests must wrap their
+//! body in `LocalSet::new().run_until(async { ... }).await`. Wasm
+//! uses `wasm_bindgen_futures::spawn_local` which is local by
+//! construction.
+
+use std::cell::Cell;
+use std::future::Future;
+use std::rc::{Rc, Weak};
+use std::time::Duration;
+
+use pocopine_sync::{
+    SyncCursor, SyncOpenRequest, SyncOpenResponse, SyncOpenStream, SyncPullMode, SyncPullRequest,
+    SyncPullResponse, SyncReason, SyncStreamName, SYNC_OPEN_PATH, SYNC_PULL_PATH,
+};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::client::{QueryClient, QueryClientInner, QuerySubscription};
+use crate::mutator::RowChange;
+use crate::wire::{build_open_request, build_pull_request};
+
+/// Default sync endpoint prefix. Re-exported from `pocopine-sync`
+/// at lib.rs.
+pub const DEFAULT_SYNC_ENDPOINT: &str = pocopine_sync::SYNC_ENDPOINT_PREFIX;
+
+/// Default driver polling cadence. Picked to match the
+/// observed Linear/Slack patterns documented in RFC 087 §"Open
+/// questions" — long enough that polling doesn't dominate the
+/// request log, short enough that a missed live wakeup recovers
+/// within human-noticeable latency.
+pub const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Tunable knobs for a [`QueryClient`]. See per-field docs for the
+/// individual defaults.
+#[derive(Clone, Debug)]
+pub struct QueryClientConfig {
+    /// Base endpoint for `/open`, `/pull`, `/push`. Defaults to
+    /// [`DEFAULT_SYNC_ENDPOINT`]. Override for tests against a
+    /// router mounted at a different path.
+    pub endpoint: String,
+    /// How often the driver tick polls `/pull` when no live wakeup
+    /// fires. Defaults to [`DEFAULT_POLL_INTERVAL`]. `None`
+    /// disables polling — the driver relies solely on live wakeup
+    /// + manual refresh (currently a v2 feature; not exposed).
+    pub poll_interval: Option<Duration>,
+    /// Disable live wakeup subscription. Defaults to `false`. Set
+    /// `true` for offline-only flows or tests that don't want SSE
+    /// traffic.
+    pub disable_live: bool,
+    /// Send cookies / credentials with `/open` + `/pull` + `/push`.
+    /// Defaults to `true`.
+    pub with_credentials: bool,
+}
+
+impl Default for QueryClientConfig {
+    fn default() -> Self {
+        Self {
+            endpoint: DEFAULT_SYNC_ENDPOINT.to_string(),
+            poll_interval: Some(DEFAULT_POLL_INTERVAL),
+            disable_live: false,
+            with_credentials: true,
+        }
+    }
+}
+
+/// Snapshot-style generation token for the driver. Mirrors the
+/// shape of `pocopine_sync::SyncEpoch` (private to that crate);
+/// the driver carries one per spawn so a stale task that resumes
+/// after `Drop` can detect the bump and bail.
+///
+/// Two values cooperate:
+///
+/// * `shared` — the live counter, held by every clone (the
+///   subscription's master copy AND every spawned driver's
+///   snapshot).
+/// * `started` — the counter value captured at snapshot time.
+///   `is_current` returns `true` while `shared.get() == started`.
+#[derive(Clone, Debug)]
+pub struct DriverEpoch {
+    shared: Rc<Cell<u64>>,
+    started: u64,
+}
+
+impl DriverEpoch {
+    /// Build a fresh epoch with both `shared` and `started` at 0.
+    pub fn new() -> Self {
+        Self {
+            shared: Rc::new(Cell::new(0)),
+            started: 0,
+        }
+    }
+
+    /// Snapshot the current generation for a new spawn. The
+    /// returned value shares the underlying counter with the
+    /// caller; both observe later [`bump`](Self::bump) calls.
+    pub fn snapshot(&self) -> Self {
+        Self {
+            shared: self.shared.clone(),
+            started: self.shared.get(),
+        }
+    }
+
+    /// `true` until the next `bump` invalidates this snapshot.
+    /// Re-checked after every `.await` boundary inside the driver.
+    pub fn is_current(&self) -> bool {
+        self.shared.get() == self.started
+    }
+
+    /// Advance the shared generation. Run from
+    /// `release_inner` on the last handle drop so any spawned
+    /// driver bails at its next yield.
+    pub fn bump(&self) {
+        self.shared.set(self.shared.get().wrapping_add(1));
+    }
+}
+
+impl Default for DriverEpoch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Handle to a spawned driver task, parked on the subscription so
+/// `Drop` semantics flow through the existing refcount path.
+///
+/// The handle is currently a marker only — its presence on a
+/// subscription tells `QueryClient::observe` "a driver is already
+/// running for this subscription, don't spawn a second one". The
+/// actual cancellation goes through [`DriverEpoch`], not through
+/// a `JoinHandle::abort`, because aborting a task mid-`/pull`
+/// would leave the subscription's `state.syncing = true` and
+/// confuse the next observer.
+#[derive(Debug)]
+pub struct DriverHandle {
+    /// Marker only; the field stops Rust from complaining the type
+    /// has no inhabitable shape on host (where we don't store a
+    /// concrete future handle).
+    _placeholder: (),
+}
+
+impl DriverHandle {
+    #[allow(dead_code)]
+    pub(crate) fn placeholder() -> Self {
+        Self { _placeholder: () }
+    }
+}
+
+/// Per-subscription driver. One spawn per `(TypeId, QueryKey)`.
+pub(crate) struct SubscriptionDriver<Row: 'static> {
+    /// Weak ref to the subscription. Upgraded on every tick;
+    /// failure → task exits.
+    subscription: Weak<QuerySubscription<Row>>,
+    /// Weak ref to the client so the driver can call the
+    /// canonical-pull ingest path without keeping the client
+    /// alive past its drop.
+    client: Weak<QueryClientInner>,
+    /// Snapshot of the subscription's driver epoch — captured
+    /// once at spawn time; checked after every `.await`.
+    epoch: DriverEpoch,
+    /// Sync endpoint prefix for this driver's HTTP calls.
+    endpoint: String,
+    /// Poll cadence. `None` disables the heartbeat — the driver
+    /// only pulls in response to live wakeup events.
+    poll_interval: Option<Duration>,
+    /// Whether to attempt a live-wakeup subscription. Per RFC 087
+    /// §6 this is wasm-only today; the host path always treats
+    /// `disable_live = false` as "no live wakeup available; rely
+    /// on polling".
+    disable_live: bool,
+}
+
+impl<Row> SubscriptionDriver<Row>
+where
+    Row: Clone + Serialize + DeserializeOwned + 'static,
+{
+    /// Build a driver. The caller threads this into [`spawn_driver`].
+    pub(crate) fn new(
+        subscription: Weak<QuerySubscription<Row>>,
+        client: Weak<QueryClientInner>,
+        epoch: DriverEpoch,
+        config: &QueryClientConfig,
+    ) -> Self {
+        Self {
+            subscription,
+            client,
+            epoch: epoch.snapshot(),
+            endpoint: config.endpoint.clone(),
+            poll_interval: config.poll_interval,
+            disable_live: config.disable_live,
+        }
+    }
+
+    /// Drive the subscription forever (or until cancelled).
+    pub(crate) async fn run(self) {
+        // ── Phase 1: /open ──────────────────────────────────────
+        //
+        // Sets `loading = true` synchronously BEFORE the await so a
+        // UI binding observes the loading state immediately on
+        // subscribe. If `/open` fails we still mark the error and
+        // continue to the polling loop (the loop retries on the
+        // next interval).
+        self.mark_loading();
+        let open_response = match self.send_open().await {
+            Ok(resp) => resp,
+            Err(err) => {
+                if !self.epoch.is_current() {
+                    return;
+                }
+                self.mark_error(err);
+                // Fall through to the loop so a subsequent retry can
+                // recover when the network comes back.
+                self.run_loop().await;
+                return;
+            }
+        };
+        if !self.epoch.is_current() {
+            return;
+        }
+        if let Err(()) = self.apply_open(open_response) {
+            // Schema-drift path bumped state.version; nothing more
+            // to do here, the next /pull rebuilds the rows.
+        }
+
+        // ── Phase 2: initial /pull ──────────────────────────────
+        let pull_response = match self.send_pull(None).await {
+            Ok(resp) => resp,
+            Err(err) => {
+                if !self.epoch.is_current() {
+                    return;
+                }
+                self.mark_error(err);
+                self.run_loop().await;
+                return;
+            }
+        };
+        if !self.epoch.is_current() {
+            return;
+        }
+        self.apply_pull(pull_response);
+        if !self.epoch.is_current() {
+            return;
+        }
+        self.clear_loading();
+
+        // ── Phase 3: main loop ──────────────────────────────────
+        self.run_loop().await;
+    }
+
+    /// Run the post-initial loop: heartbeat polling + live wakeup +
+    /// offline replay. The function returns when the epoch goes stale
+    /// or the subscription's Weak fails to upgrade.
+    async fn run_loop(&self) {
+        // The wasm path could `select!` on a live-wakeup stream
+        // here; this PR ships the polling cadence + offline replay
+        // hooks and leaves the live-wakeup stream wiring for the
+        // wasm-side hook in `tick_live_wakeup`. Host code paths
+        // run polling-only.
+        if self.disable_live {
+            tracing::debug!(
+                target: "pocopine.log",
+                "sync-query driver: live wakeup disabled; relying on polling"
+            );
+        }
+        loop {
+            // 1. Wait for the next tick.
+            if !self.wait_tick().await {
+                // Stale — caller already returned.
+                return;
+            }
+            if !self.epoch.is_current() {
+                return;
+            }
+            if self.subscription.upgrade().is_none() {
+                return;
+            }
+            // 2. Issue a pull.
+            self.tick_pull().await;
+            if !self.epoch.is_current() {
+                return;
+            }
+            // 3. Walk pending replay queue (offline-replay).
+            self.replay_pending().await;
+            if !self.epoch.is_current() {
+                return;
+            }
+        }
+    }
+
+    /// Wait for the next polling tick. Returns `false` when the
+    /// epoch went stale during the wait — caller should bail.
+    /// `None` poll interval parks indefinitely (until live wakeup
+    /// would arrive — placeholder until wasm wiring lands).
+    async fn wait_tick(&self) -> bool {
+        match self.poll_interval {
+            Some(interval) => {
+                sleep(interval).await;
+                self.epoch.is_current()
+            }
+            None => {
+                // Polling disabled. In a fully-wired wasm build
+                // this `select!`s on the live wakeup channel;
+                // here we exit since there's nothing else to wait
+                // on (host tests should always set a poll
+                // interval).
+                tracing::debug!(
+                    target: "pocopine.log",
+                    "sync-query driver polling disabled and no live wakeup available; exiting"
+                );
+                false
+            }
+        }
+    }
+
+    /// Issue a /pull and route results into canonical state.
+    /// Errors surface into `state.error`; the next tick retries.
+    async fn tick_pull(&self) {
+        let cursor = self.with_state_borrow(|s| s.cursor.clone()).flatten();
+        let response = match self.send_pull(cursor).await {
+            Ok(resp) => resp,
+            Err(err) => {
+                if !self.epoch.is_current() {
+                    return;
+                }
+                self.mark_error(err);
+                return;
+            }
+        };
+        if !self.epoch.is_current() {
+            return;
+        }
+        self.apply_pull(response);
+    }
+
+    /// Walk the pending-replay queue on the client and re-fire
+    /// `apply_remote` for each entry. Successful replays clear
+    /// the queue entry; persistent failures leave it for the next
+    /// tick.
+    ///
+    /// The replay set is keyed by `mutation_id`. Each entry holds
+    /// a boxed `Future`-builder so the driver doesn't need the
+    /// concrete `Mutator` type. The original payload is
+    /// preserved verbatim — the wire dedup contract (RFC 072) is
+    /// what keeps a replay-after-accept idempotent.
+    async fn replay_pending(&self) {
+        let Some(client_inner) = self.client.upgrade() else {
+            return;
+        };
+        let entries = QueryClient::take_replay_entries(&client_inner);
+        for entry in entries {
+            if !self.epoch.is_current() {
+                return;
+            }
+            // The replay future builds against a strong
+            // QueryClient handle — we materialize one for the
+            // duration of the call, then release it. This avoids
+            // pinning the client alive in a long-lived closure.
+            let client = QueryClient::from_inner(client_inner.clone());
+            let fut = (entry.replay)(&client);
+            let outcome = fut.await;
+            if !self.epoch.is_current() {
+                return;
+            }
+            match outcome {
+                ReplayOutcome::Accepted => {
+                    // Routing engine already cleared the pending
+                    // overlay via route_canonical_changes; nothing
+                    // more to do.
+                }
+                ReplayOutcome::StillOffline => {
+                    // Re-queue. The map entry was popped on take;
+                    // push it back so the next successful tick
+                    // retries.
+                    QueryClient::reinsert_replay_entry(&client_inner, entry);
+                }
+                ReplayOutcome::Rejected => {
+                    // Server explicitly rejected (4xx, app error).
+                    // Roll back the pending overlay. The wire
+                    // contract says retries of a rejected
+                    // mutation must NOT change the outcome — so
+                    // dropping the queue entry is correct.
+                    if let Some(sub) = self.subscription.upgrade() {
+                        QueryClient::dequeue_pending_for_subscription::<Row>(
+                            &client_inner,
+                            &sub,
+                            &entry.mutation_id,
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    /// Issue the `/open` HTTP call. Returns the deserialized
+    /// response or a typed error wrapped into a `String` for the
+    /// state.error sink.
+    async fn send_open(&self) -> Result<SyncOpenResponse, DriverError> {
+        let query = self.with_subscription(|sub| {
+            let q = sub.query();
+            build_open_request_for(q)
+        })?;
+        let url = build_url(&self.endpoint, SYNC_OPEN_PATH);
+        let res: Result<SyncOpenResponse, _> =
+            pocopine_core::fetch::call::<SyncOpenRequest, SyncOpenResponse>(&url, &query).await;
+        res.map_err(DriverError::from_server_error)
+    }
+
+    /// Issue the `/pull` HTTP call.
+    async fn send_pull(
+        &self,
+        cursor: Option<SyncCursor>,
+    ) -> Result<SyncPullResponse<Value>, DriverError> {
+        let request = self.with_subscription(|sub| build_pull_request(sub.query(), cursor))?;
+        let url = build_url(&self.endpoint, SYNC_PULL_PATH);
+        let res: Result<SyncPullResponse<Value>, _> =
+            pocopine_core::fetch::call::<SyncPullRequest, SyncPullResponse<Value>>(&url, &request)
+                .await;
+        res.map_err(DriverError::from_server_error)
+    }
+
+    /// Apply an `/open` response: validate the stream, detect
+    /// schema drift, install cursor.
+    ///
+    /// Returns `Err(())` when schema-drift triggered a state
+    /// reset — caller should NOT treat that as a hard error
+    /// (the next `/pull` rebuilds the canonical set).
+    fn apply_open(&self, response: SyncOpenResponse) -> Result<(), ()> {
+        let Some(sub) = self.subscription.upgrade() else {
+            return Ok(());
+        };
+        let stream_name = sub.query().stream().clone();
+        let Some(opened) = response
+            .streams
+            .iter()
+            .find(|s| s.stream == stream_name)
+            .cloned()
+        else {
+            // Server didn't accept this stream. Surface as an
+            // error; the next tick retries.
+            self.mark_error(DriverError::Client(format!(
+                "/open response missing stream {}",
+                stream_name.as_str()
+            )));
+            return Ok(());
+        };
+        let SyncOpenStream {
+            cursor,
+            schema_version,
+            ..
+        } = opened;
+        let mut state = sub.state().borrow_mut();
+        // Schema-drift gate.
+        let drift =
+            matches!(state.application_schema_version, Some(cached) if cached != schema_version);
+        if drift {
+            tracing::info!(
+                target: "pocopine.log",
+                stream = stream_name.as_str(),
+                from = state.application_schema_version,
+                to = schema_version,
+                "sync-query: schema drift detected; resetting state"
+            );
+            state.reset();
+        }
+        state.application_schema_version = Some(schema_version);
+        state.cursor = cursor;
+        state.error.clear();
+        state.last_reason = SyncReason::Initial;
+        drop(state);
+        sub.notify_listeners_external();
+        if drift {
+            Err(())
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Apply a `/pull` response: route each row into the
+    /// canonical state of every matching subscription on the
+    /// stream. Snapshot mode replaces the canonical set; delta
+    /// mode applies the changes.
+    fn apply_pull(&self, response: SyncPullResponse<Value>) {
+        let Some(sub) = self.subscription.upgrade() else {
+            return;
+        };
+        let Some(client_inner) = self.client.upgrade() else {
+            return;
+        };
+        let stream = response.stream.clone();
+        let new_cursor = response.cursor.clone();
+
+        // Build a Vec<RowChange<Row>> from the wire response.
+        // Decode failures are warned + skipped per RFC 086.
+        let changes = decode_pull_changes::<Row>(&response);
+
+        match response.mode {
+            SyncPullMode::Snapshot => {
+                // For a snapshot, the canonical set is REPLACED.
+                // Wipe canonical_rows on every matching
+                // subscription, then upsert the new rows.
+                QueryClient::clear_canonical_on_stream::<Row>(&client_inner, &stream);
+            }
+            SyncPullMode::Incremental => {}
+        }
+
+        QueryClient::route_canonical_pull::<Row>(&client_inner, &stream, &changes);
+
+        // Update cursor and reason on the originating
+        // subscription (not all subscriptions on the stream — a
+        // different subscription's cursor may be ahead or behind
+        // this one, since each subscription's /pull is
+        // independent).
+        let mut state = sub.state().borrow_mut();
+        state.cursor = new_cursor;
+        state.syncing = false;
+        state.loading = false;
+        state.last_reason = SyncReason::Manual;
+        state.error.clear();
+        drop(state);
+        sub.notify_listeners_external();
+    }
+
+    /// Set the subscription's loading flag without writing to
+    /// canonical state. Synchronous; runs before the first await.
+    fn mark_loading(&self) {
+        let Some(sub) = self.subscription.upgrade() else {
+            return;
+        };
+        let mut state = sub.state().borrow_mut();
+        state.loading = true;
+        state.last_reason = SyncReason::Initial;
+        drop(state);
+        sub.notify_listeners_external();
+    }
+
+    /// Clear loading after a successful initial pull.
+    fn clear_loading(&self) {
+        let Some(sub) = self.subscription.upgrade() else {
+            return;
+        };
+        let mut state = sub.state().borrow_mut();
+        state.loading = false;
+        state.syncing = false;
+        drop(state);
+        sub.notify_listeners_external();
+    }
+
+    /// Park an error message on the subscription's state.
+    /// Surfaces in the reactive view so UIs can show "syncing
+    /// failed" / "offline" banners. Does NOT clear the canonical
+    /// rows — the cache stays visible during a network blip.
+    fn mark_error(&self, err: DriverError) {
+        let Some(sub) = self.subscription.upgrade() else {
+            return;
+        };
+        let mut state = sub.state().borrow_mut();
+        state.error = err.to_string();
+        state.syncing = false;
+        state.loading = false;
+        state.last_reason = SyncReason::Error;
+        drop(state);
+        sub.notify_listeners_external();
+        tracing::warn!(
+            target: "pocopine.log",
+            error = %err,
+            "sync-query driver tick failed; will retry on next interval"
+        );
+    }
+
+    /// Borrow the subscription's state and run `f` against an
+    /// immutable view. Returns `None` if the subscription has
+    /// been reclaimed.
+    fn with_state_borrow<R, F: FnOnce(&crate::state::QueryState<Row>) -> R>(
+        &self,
+        f: F,
+    ) -> Option<R> {
+        let sub = self.subscription.upgrade()?;
+        let state = sub.state().borrow();
+        Some(f(&state))
+    }
+
+    /// Run `f` against the subscription. Returns
+    /// `Err(DriverError::Cancelled)` if the subscription has
+    /// already been reclaimed — caller treats it as a clean
+    /// stale-task exit.
+    fn with_subscription<R, F: FnOnce(&QuerySubscription<Row>) -> R>(
+        &self,
+        f: F,
+    ) -> Result<R, DriverError> {
+        match self.subscription.upgrade() {
+            Some(sub) => Ok(f(&sub)),
+            None => Err(DriverError::Cancelled),
+        }
+    }
+}
+
+/// Helper to build an open request that doesn't borrow the
+/// builder return for longer than the closure — keeps
+/// `with_subscription` polymorphic.
+fn build_open_request_for<Row>(query: &crate::query::Query<Row>) -> SyncOpenRequest {
+    build_open_request(query)
+}
+
+/// Decode a `/pull` response's rows / changes into typed
+/// `RowChange<Row>` values. Rows that fail to decode are
+/// `tracing::warn`'d and skipped per the RFC 086 wire-shape
+/// mismatch rule.
+fn decode_pull_changes<Row>(response: &SyncPullResponse<Value>) -> Vec<RowChange<Row>>
+where
+    Row: DeserializeOwned + 'static,
+{
+    let mut out: Vec<RowChange<Row>> = Vec::new();
+    match response.mode {
+        SyncPullMode::Snapshot => {
+            for row in &response.rows {
+                match serde_json::from_value::<Row>(row.value.clone()) {
+                    Ok(decoded) => out.push(RowChange::Upsert(decoded)),
+                    Err(err) => {
+                        tracing::warn!(
+                            target: "pocopine.log",
+                            stream = response.stream.as_str(),
+                            key = row.key.as_str(),
+                            error = %err,
+                            "sync-query: dropping /pull snapshot row that failed to decode"
+                        );
+                    }
+                }
+            }
+        }
+        SyncPullMode::Incremental => {
+            for change in &response.changes {
+                match (&change.op, &change.row, &change.key) {
+                    (pocopine_sync::SyncOp::Upsert, Some(row), _) => {
+                        match serde_json::from_value::<Row>(row.value.clone()) {
+                            Ok(decoded) => out.push(RowChange::Upsert(decoded)),
+                            Err(err) => {
+                                tracing::warn!(
+                                    target: "pocopine.log",
+                                    stream = response.stream.as_str(),
+                                    key = row.key.as_str(),
+                                    error = %err,
+                                    "sync-query: dropping /pull incremental upsert that failed to decode"
+                                );
+                            }
+                        }
+                    }
+                    (pocopine_sync::SyncOp::Delete, _, Some(key)) => {
+                        out.push(RowChange::Delete(key.clone()));
+                    }
+                    _ => {
+                        // Malformed change — skip per the wire-
+                        // shape mismatch rule.
+                        tracing::warn!(
+                            target: "pocopine.log",
+                            stream = response.stream.as_str(),
+                            "sync-query: skipping malformed /pull change (op/row/key shape mismatch)"
+                        );
+                    }
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Join two path components with at most one '/' between.
+fn build_url(endpoint: &str, path: &str) -> String {
+    let trimmed_prefix = endpoint.trim_end_matches('/');
+    // `path` already starts with the canonical "/__pocopine/..."
+    // when callers pass `SYNC_OPEN_PATH` (the absolute path
+    // constants). If the configured endpoint overrides the prefix,
+    // re-attach the suffix.
+    if path.starts_with(trimmed_prefix) || trimmed_prefix.is_empty() {
+        path.to_string()
+    } else if let Some(suffix) = path.strip_prefix(pocopine_sync::SYNC_ENDPOINT_PREFIX) {
+        format!("{trimmed_prefix}{suffix}")
+    } else {
+        path.to_string()
+    }
+}
+
+/// Typed driver error. Folds host-fetch failures and
+/// subscription-cancelled signals into one enum so the loop can
+/// pattern-match instead of carrying free-form strings.
+#[derive(Debug)]
+pub enum DriverError {
+    /// Network or HTTP failure surfaced by `pocopine::fetch`.
+    Network(String),
+    /// Server returned a typed 4xx/5xx — non-network, but the
+    /// driver should still retry on the next interval (the
+    /// server might be temporarily unhealthy).
+    Server(String),
+    /// Local client error (build URL failed, etc.).
+    Client(String),
+    /// Subscription has been reclaimed; caller should exit cleanly.
+    Cancelled,
+}
+
+impl DriverError {
+    /// Returns `true` for errors the driver treats as transient
+    /// — pending overlays stay in the replay queue for these.
+    pub fn is_transient(&self) -> bool {
+        matches!(self, Self::Network(_) | Self::Server(_))
+    }
+
+    /// Convert a `pocopine_core::server::ServerError` (the wire
+    /// error from `fetch::call`) into a driver-side category.
+    /// All `Network` variants stay `Network` so the offline
+    /// replay path triggers. Other variants are `Server`.
+    pub fn from_server_error(err: pocopine_core::server::ServerError) -> Self {
+        use pocopine_core::server::ServerError;
+        match err {
+            ServerError::Network(msg) => Self::Network(msg),
+            ServerError::App(msg)
+            | ServerError::Unauthorized(msg)
+            | ServerError::Forbidden(msg)
+            | ServerError::BadRequest(msg) => Self::Server(msg),
+        }
+    }
+}
+
+impl std::fmt::Display for DriverError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Network(msg) => write!(f, "network error: {msg}"),
+            Self::Server(msg) => write!(f, "server error: {msg}"),
+            Self::Client(msg) => write!(f, "client error: {msg}"),
+            Self::Cancelled => f.write_str("driver cancelled"),
+        }
+    }
+}
+
+impl std::error::Error for DriverError {}
+
+/// Outcome of one replay attempt. The driver feeds this back
+/// from the replay future into [`SubscriptionDriver::replay_pending`].
+#[derive(Debug)]
+pub enum ReplayOutcome {
+    /// Server accepted; canonical reconcile already ran; the
+    /// pending overlay was cleared by `route_canonical_changes`.
+    Accepted,
+    /// Still offline (network error). Re-queue.
+    StillOffline,
+    /// Server rejected (non-network error). Drop the pending
+    /// overlay; the user's UI should re-surface the failure via
+    /// `state.error`.
+    Rejected,
+}
+
+/// Boxed replay-future builder. Type-aliased so clippy doesn't
+/// flag the closure-shape as "very complex type" — the surface
+/// IS load-bearing here (heterogeneous across Mutator impls).
+pub(crate) type ReplayFuture =
+    Box<dyn for<'a> Fn(&'a QueryClient) -> futures::future::LocalBoxFuture<'a, ReplayOutcome>>;
+
+/// One queued mutation replay. The replay closure is built
+/// inside `QueryClient::mutate` and captures the original
+/// payload + Mutator type via a generic argument.
+pub(crate) struct ReplayEntry {
+    pub(crate) stream: SyncStreamName,
+    pub(crate) mutation_id: pocopine_sync::MutationId,
+    /// `Box<dyn Fn(...) -> Pin<Box<dyn Future>>>` instead of an
+    /// `async fn` so the entry can be heterogeneous across
+    /// `Mutator` types in the same client-side replay queue.
+    pub(crate) replay: ReplayFuture,
+}
+
+impl std::fmt::Debug for ReplayEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ReplayEntry")
+            .field("stream", &self.stream.as_str())
+            .field("mutation_id", &self.mutation_id)
+            .finish_non_exhaustive()
+    }
+}
+
+// ─── spawn shim ─────────────────────────────────────────────────────
+//
+// Per RFC 087 §2, the driver is spawned via a `#[cfg]`-split
+// helper instead of a public `Runtime` trait. Both forms park the
+// driver on the current task's executor:
+//
+// * wasm — `wasm_bindgen_futures::spawn_local` (single-threaded by
+//   construction).
+// * native — `tokio::task::spawn_local` (requires the caller to
+//   have an active `LocalSet`).
+//
+// The driver type itself holds `Rc<...>`/`Weak<...>` interior, so
+// the future is `!Send`. This is why the native path uses
+// `spawn_local`, not `tokio::spawn`.
+
+/// Spawn the driver on the runtime's local task set.
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn spawn_driver<F>(fut: F)
+where
+    F: Future<Output = ()> + 'static,
+{
+    wasm_bindgen_futures::spawn_local(fut);
+}
+
+/// Spawn the driver on the host's `tokio::task::LocalSet`. Panics
+/// if no LocalSet is active — host tests must wrap their body in
+/// `LocalSet::new().run_until(async { ... }).await`. This is
+/// documented on [`QueryClient::with_config`](crate::QueryClient::with_config)
+/// because the panic location otherwise points deep into tokio.
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) fn spawn_driver<F>(fut: F)
+where
+    F: Future<Output = ()> + 'static,
+{
+    // `spawn_local` returns a JoinHandle that we deliberately
+    // discard — cancellation flows through `DriverEpoch::bump`,
+    // not through aborting the future. The `drop` makes the
+    // discard explicit to the clippy `let_underscore_future`
+    // lint (which would otherwise flag `let _ = ...` as
+    // potentially-forgetting-an-await).
+    drop(tokio::task::spawn_local(fut));
+}
+
+/// Asynchronously sleep for `duration` on both wasm and native.
+/// On wasm we use `gloo-timers` equivalent via a small JS bridge;
+/// on native we use `tokio::time::sleep` directly.
+#[cfg(target_arch = "wasm32")]
+async fn sleep(duration: Duration) {
+    use wasm_bindgen::closure::Closure;
+    use wasm_bindgen::JsCast;
+    let ms = duration.as_millis() as i32;
+    let promise = js_sys::Promise::new(&mut |resolve, _reject| {
+        if let Some(win) = web_sys::window() {
+            let resolve_for_timeout = resolve.clone();
+            let closure = Closure::once_into_js(move || {
+                let _ = resolve_for_timeout.call0(&wasm_bindgen::JsValue::NULL);
+            });
+            let _ = win
+                .set_timeout_with_callback_and_timeout_and_arguments_0(closure.unchecked_ref(), ms);
+        } else {
+            let _ = resolve.call0(&wasm_bindgen::JsValue::NULL);
+        }
+    });
+    let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+async fn sleep(duration: Duration) {
+    tokio::time::sleep(duration).await;
+}
+
+/// Filter a live-wakeup event against the captured params.
+///
+/// Public for reuse from the wasm wiring; host code paths call it
+/// in tests to verify filtering logic without going through a real
+/// SSE source.
+///
+/// `affected_fields` carries the server's per-row field projection
+/// for the touched row; the filter is `true` (forward to /pull)
+/// when every captured param either matches or is absent from the
+/// server's projection. A missing field is treated as "server didn't
+/// report this field; conservatively allow" per RFC 087 §6.
+pub fn live_event_matches_params(
+    captured_params: &pocopine_sync::StreamParams,
+    affected_fields: &std::collections::BTreeMap<String, Value>,
+) -> bool {
+    for (key, want) in captured_params {
+        match affected_fields.get(key.as_str()) {
+            None => continue,
+            Some(value) if value == want => continue,
+            Some(_) => return false,
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn epoch_snapshot_observes_bump() {
+        let epoch = DriverEpoch::new();
+        let snap = epoch.snapshot();
+        assert!(snap.is_current());
+        epoch.bump();
+        assert!(!snap.is_current(), "post-bump, the snapshot is stale");
+    }
+
+    #[test]
+    fn epoch_multiple_snapshots_share_counter() {
+        let epoch = DriverEpoch::new();
+        let snap_a = epoch.snapshot();
+        let snap_b = epoch.snapshot();
+        epoch.bump();
+        assert!(!snap_a.is_current());
+        assert!(!snap_b.is_current());
+    }
+
+    #[test]
+    fn config_default_uses_canonical_endpoint() {
+        let cfg = QueryClientConfig::default();
+        assert_eq!(cfg.endpoint, DEFAULT_SYNC_ENDPOINT);
+        assert_eq!(cfg.poll_interval, Some(DEFAULT_POLL_INTERVAL));
+        assert!(!cfg.disable_live);
+        assert!(cfg.with_credentials);
+    }
+
+    #[test]
+    fn live_filter_drops_mismatched_params() {
+        let mut want = pocopine_sync::StreamParams::new();
+        want.insert("workspace_id".into(), serde_json::json!("W1"));
+
+        let mut got = std::collections::BTreeMap::new();
+        got.insert("workspace_id".to_string(), serde_json::json!("W2"));
+        assert!(!live_event_matches_params(&want, &got));
+
+        let mut got = std::collections::BTreeMap::new();
+        got.insert("workspace_id".to_string(), serde_json::json!("W1"));
+        assert!(live_event_matches_params(&want, &got));
+    }
+
+    #[test]
+    fn live_filter_allows_absent_fields() {
+        let mut want = pocopine_sync::StreamParams::new();
+        want.insert("workspace_id".into(), serde_json::json!("W1"));
+
+        // Server didn't include workspace_id in affected_fields —
+        // allow per RFC 087 §6.
+        let got = std::collections::BTreeMap::new();
+        assert!(live_event_matches_params(&want, &got));
+    }
+
+    #[test]
+    fn driver_error_is_transient_for_network_and_server() {
+        assert!(DriverError::Network("offline".into()).is_transient());
+        assert!(DriverError::Server("503".into()).is_transient());
+        assert!(!DriverError::Client("bad url".into()).is_transient());
+        assert!(!DriverError::Cancelled.is_transient());
+    }
+
+    #[test]
+    fn build_url_passthrough_when_path_matches_prefix() {
+        let url = build_url(DEFAULT_SYNC_ENDPOINT, SYNC_OPEN_PATH);
+        assert_eq!(url, SYNC_OPEN_PATH);
+    }
+
+    #[test]
+    fn build_url_rewrites_when_endpoint_overrides_prefix() {
+        let url = build_url("/custom/sync", SYNC_OPEN_PATH);
+        assert!(url.starts_with("/custom/sync/"));
+        assert!(url.ends_with("/open"));
+    }
+}

--- a/crates/pocopine-sync-query/src/driver.rs
+++ b/crates/pocopine-sync-query/src/driver.rs
@@ -287,22 +287,18 @@ where
     /// offline replay. The function returns when the epoch goes stale
     /// or the subscription's Weak fails to upgrade.
     async fn run_loop(&self) {
-        // The wasm path could `select!` on a live-wakeup stream
-        // here; this PR ships the polling cadence + offline replay
-        // hooks and leaves the live-wakeup stream wiring for the
-        // wasm-side hook in `tick_live_wakeup`. Host code paths
-        // run polling-only.
-        if self.disable_live {
-            tracing::debug!(
-                target: "pocopine.log",
-                "sync-query driver: live wakeup disabled; relying on polling"
-            );
-        }
+        // Open the live wakeup channel if enabled. The receiver
+        // participates in `wait_for_tick`'s select! alongside the
+        // polling timer. Host targets get a permanently-empty
+        // receiver because the LiveClient is wasm-only.
+        let mut live = self.open_live_wakeup();
         loop {
-            // 1. Wait for the next tick.
-            if !self.wait_tick().await {
-                // Stale — caller already returned.
-                return;
+            // 1. Wait for the next tick: either the poll timer or
+            //    a matching live event (whichever first).
+            let outcome = self.wait_for_tick(&mut live).await;
+            match outcome {
+                TickOutcome::Poll | TickOutcome::Live => {}
+                TickOutcome::Stale => return,
             }
             if !self.epoch.is_current() {
                 return;
@@ -323,27 +319,91 @@ where
         }
     }
 
-    /// Wait for the next polling tick. Returns `false` when the
-    /// epoch went stale during the wait — caller should bail.
-    /// `None` poll interval parks indefinitely (until live wakeup
-    /// would arrive — placeholder until wasm wiring lands).
-    async fn wait_tick(&self) -> bool {
+    /// Open the live-wakeup receiver. On wasm this calls into
+    /// `pocopine-live::LiveClient` to subscribe to the
+    /// per-collection topic and pipes events through an
+    /// unbounded mpsc into the driver's select!. On host (or with
+    /// `disable_live = true`) returns a stub that never fires.
+    fn open_live_wakeup(&self) -> LiveWakeup {
+        if self.disable_live {
+            tracing::debug!(
+                target: "pocopine.log",
+                "sync-query driver: live wakeup disabled by config"
+            );
+            return LiveWakeup::disabled();
+        }
+        #[cfg(target_arch = "wasm32")]
+        {
+            let Some(sub) = self.subscription.upgrade() else {
+                return LiveWakeup::disabled();
+            };
+            // We need a stable collection name to subscribe to;
+            // pocopine-sync's `local_stream_key(stream, params)`
+            // gives us the per-`(stream, params)` topic identity,
+            // but the live channel today only knows the
+            // collection (stream name). Use the stream as the
+            // collection topic per RFC 087 §6 — server filters by
+            // collection, client filters by params.
+            let stream_name = sub.query().stream().as_str().to_string();
+            let captured_params = sub.query().params().clone();
+            LiveWakeup::open_on_collection(stream_name, captured_params)
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            LiveWakeup::disabled()
+        }
+    }
+
+    /// Wait for the next driver tick. Returns the originating
+    /// signal so the loop can decide whether to pull. The select
+    /// on (sleep, live) is biased toward live wakeup so a coherent
+    /// burst of events doesn't get starved by the poll timer.
+    async fn wait_for_tick(&self, live: &mut LiveWakeup) -> TickOutcome {
+        use futures::future::{self, Either};
         match self.poll_interval {
             Some(interval) => {
-                sleep(interval).await;
-                self.epoch.is_current()
+                let timer = sleep(interval);
+                let live_fut = live.next_matching();
+                futures::pin_mut!(timer);
+                futures::pin_mut!(live_fut);
+                match future::select(timer, live_fut).await {
+                    Either::Left((_, _)) => {
+                        if !self.epoch.is_current() {
+                            return TickOutcome::Stale;
+                        }
+                        TickOutcome::Poll
+                    }
+                    Either::Right((event, _)) => {
+                        if !self.epoch.is_current() {
+                            return TickOutcome::Stale;
+                        }
+                        match event {
+                            LiveTickOutcome::Match => TickOutcome::Live,
+                            LiveTickOutcome::Closed => {
+                                // Live channel closed (subscription
+                                // dropped or server hung up); fall
+                                // back to polling — the next loop
+                                // iteration just sleeps again.
+                                TickOutcome::Poll
+                            }
+                        }
+                    }
+                }
             }
             None => {
-                // Polling disabled. In a fully-wired wasm build
-                // this `select!`s on the live wakeup channel;
-                // here we exit since there's nothing else to wait
-                // on (host tests should always set a poll
-                // interval).
-                tracing::debug!(
-                    target: "pocopine.log",
-                    "sync-query driver polling disabled and no live wakeup available; exiting"
-                );
-                false
+                // Polling disabled. Block on live; if that's also
+                // unavailable, exit cleanly.
+                if live.is_disabled() {
+                    tracing::debug!(
+                        target: "pocopine.log",
+                        "sync-query driver: polling disabled + no live wakeup; exiting"
+                    );
+                    return TickOutcome::Stale;
+                }
+                match live.next_matching().await {
+                    LiveTickOutcome::Match => TickOutcome::Live,
+                    LiveTickOutcome::Closed => TickOutcome::Stale,
+                }
             }
         }
     }
@@ -807,6 +867,172 @@ impl std::fmt::Debug for ReplayEntry {
             .field("stream", &self.stream.as_str())
             .field("mutation_id", &self.mutation_id)
             .finish_non_exhaustive()
+    }
+}
+
+/// Why the driver woke up. Returned from `wait_for_tick` so the
+/// loop can record telemetry (poll vs live) without re-checking
+/// the timer.
+#[derive(Debug)]
+enum TickOutcome {
+    /// Heartbeat poll timer fired.
+    Poll,
+    /// A matching live wakeup event arrived.
+    Live,
+    /// Epoch is stale OR neither source can produce another event;
+    /// caller exits.
+    Stale,
+}
+
+/// Outcome of one live-wakeup pump.
+#[derive(Debug)]
+enum LiveTickOutcome {
+    /// An incoming event matched the captured params (or carried
+    /// no field projection, which we conservatively treat as a
+    /// match per RFC 087 §6).
+    Match,
+    /// The underlying receiver was closed.
+    Closed,
+}
+
+/// Per-subscription live wakeup. Owns the `LiveSubscription` (so
+/// the underlying EventSource closes on drop) and the receiver
+/// end of the bridge mpsc.
+///
+/// On host targets this is a stub — the LiveClient is wasm-only;
+/// `next_matching()` returns `LiveTickOutcome::Closed` once.
+struct LiveWakeup {
+    /// `Some` when live wakeup is wired up; `None` for the
+    /// host-stub / disabled-by-config path.
+    receiver: Option<futures::channel::mpsc::UnboundedReceiver<LiveWakeupEvent>>,
+    /// Captured params used for client-side filtering on every
+    /// arriving event. Stored here (not just on the subscription)
+    /// so the filter can be exercised in unit tests without an
+    /// active LiveClient.
+    captured_params: pocopine_sync::StreamParams,
+    /// Owned EventSource handle. On host this is always `None`;
+    /// on wasm dropping it closes the SSE stream so the live
+    /// subscription's lifetime is tied to the driver's.
+    #[cfg(target_arch = "wasm32")]
+    _subscription: Option<pocopine_live::LiveSubscription>,
+}
+
+/// Payload pushed through the live-wakeup mpsc. Carries the
+/// affected_fields projection (when the server includes one) so
+/// the client-side filter can decide whether to trigger /pull.
+#[derive(Debug)]
+struct LiveWakeupEvent {
+    affected_fields: std::collections::BTreeMap<String, Value>,
+}
+
+impl LiveWakeup {
+    /// Build a no-op wakeup — used for host targets and the
+    /// `disable_live = true` config knob.
+    fn disabled() -> Self {
+        Self {
+            receiver: None,
+            captured_params: pocopine_sync::StreamParams::new(),
+            #[cfg(target_arch = "wasm32")]
+            _subscription: None,
+        }
+    }
+
+    /// Returns `true` when the wakeup channel will never deliver
+    /// — host stub or `disable_live`.
+    fn is_disabled(&self) -> bool {
+        self.receiver.is_none()
+    }
+
+    /// Pump one matching live event. Drops every non-matching
+    /// event until either a match arrives or the receiver closes.
+    /// The "no projection" case forwards to /pull per the
+    /// RFC 087 §6 conservative fallback.
+    async fn next_matching(&mut self) -> LiveTickOutcome {
+        use futures::stream::StreamExt;
+        let Some(rx) = self.receiver.as_mut() else {
+            // Never resolves — but the caller checks
+            // `is_disabled()` first and short-circuits.
+            futures::future::pending::<()>().await;
+            return LiveTickOutcome::Closed;
+        };
+        loop {
+            match rx.next().await {
+                Some(event) => {
+                    if live_event_matches_params(&self.captured_params, &event.affected_fields) {
+                        return LiveTickOutcome::Match;
+                    }
+                    // Mismatched — drop and wait for the next.
+                }
+                None => return LiveTickOutcome::Closed,
+            }
+        }
+    }
+
+    /// Open a live subscription against the per-collection topic.
+    /// wasm-only — host falls back to `disabled()` in the caller.
+    #[cfg(target_arch = "wasm32")]
+    fn open_on_collection(
+        collection: String,
+        captured_params: pocopine_sync::StreamParams,
+    ) -> Self {
+        let (tx, rx) = futures::channel::mpsc::unbounded::<LiveWakeupEvent>();
+        let connect_result = pocopine_live::LiveClient::new()
+            .collection(collection.clone())
+            .on_event({
+                let tx = tx.clone();
+                move |event| {
+                    let affected_fields = extract_affected_fields(&event);
+                    let _ = tx.unbounded_send(LiveWakeupEvent { affected_fields });
+                }
+            })
+            .open();
+        let _subscription = match connect_result {
+            Ok(sub) => Some(sub),
+            Err(err) => {
+                tracing::warn!(
+                    target: "pocopine.log",
+                    collection = collection.as_str(),
+                    error = ?err,
+                    "sync-query driver: live wakeup open failed; relying on polling"
+                );
+                None
+            }
+        };
+        Self {
+            receiver: Some(rx),
+            captured_params,
+            _subscription,
+        }
+    }
+}
+
+/// Best-effort extraction of `affected_fields` from a live event.
+/// The wire shape (RFC 071) carries this on the `payload`
+/// envelope; the typed `LiveEvent` doesn't expose it directly, so
+/// we rebuild from the event's `keys` (treated as a degenerate
+/// projection) until the live protocol grows a richer field
+/// projection in a follow-up RFC.
+#[cfg(target_arch = "wasm32")]
+fn extract_affected_fields(
+    event: &pocopine_live::LiveEvent,
+) -> std::collections::BTreeMap<String, Value> {
+    use pocopine_live::LiveEvent;
+    // Today's wire shape: server publishes the affected `keys`
+    // for the collection. Until RFC 071 grows a field-level
+    // projection we conservatively treat the projection as
+    // empty — every collection event triggers a pull, which the
+    // client-side filter then narrows on the SUBSEQUENT match
+    // attempt. (The filter logic returns `true` when the
+    // projection is missing-key, per RFC 087 §6.)
+    let _ = event;
+    match event {
+        LiveEvent::CollectionChanged { .. }
+        | LiveEvent::CollectionDeleted { .. }
+        | LiveEvent::QueryInvalidated { .. }
+        | LiveEvent::Ready { .. } => std::collections::BTreeMap::new(),
+        LiveEvent::Gap { .. } | LiveEvent::Error { .. } | LiveEvent::Custom { .. } => {
+            std::collections::BTreeMap::new()
+        }
     }
 }
 

--- a/crates/pocopine-sync-query/src/driver.rs
+++ b/crates/pocopine-sync-query/src/driver.rs
@@ -84,8 +84,17 @@ pub struct QueryClientConfig {
     /// `true` for offline-only flows or tests that don't want SSE
     /// traffic.
     pub disable_live: bool,
-    /// Send cookies / credentials with `/open` + `/pull` + `/push`.
-    /// Defaults to `true`.
+    /// Send cookies / credentials with credentialed live-channel
+    /// requests. Defaults to `true`.
+    ///
+    /// **Scope:** today this flag only controls the wasm
+    /// `LiveClient.with_credentials(...)` call. The HTTP path
+    /// (`/open` / `/pull` / `/push`) goes through
+    /// `pocopine_core::fetch::call`, which doesn't expose a
+    /// per-call credentials toggle — cross-origin credentialing
+    /// for those calls is configured globally via fetch
+    /// middleware (per RFC 078). A future RFC may unify the two,
+    /// at which point this flag would govern both.
     pub with_credentials: bool,
 }
 
@@ -204,6 +213,20 @@ pub(crate) struct SubscriptionDriver<Row: 'static> {
     /// `disable_live = false` as "no live wakeup available; rely
     /// on polling".
     disable_live: bool,
+    /// Mirrors `QueryClientConfig::with_credentials` — passed to the
+    /// wasm `LiveClient.with_credentials(...)` so cookie- or
+    /// session-backed live channels actually carry credentials.
+    ///
+    /// **Note on HTTP `/open` / `/pull` / `/push`:** the
+    /// `pocopine_core::fetch::call` path doesn't expose a
+    /// per-call credentials toggle; cross-origin credentialing
+    /// for those calls is configured globally via fetch
+    /// middleware. This flag therefore only affects the live
+    /// channel today. The doc on
+    /// [`QueryClientConfig::with_credentials`] records the same
+    /// limitation.
+    #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
+    with_credentials: bool,
 }
 
 impl<Row> SubscriptionDriver<Row>
@@ -224,6 +247,7 @@ where
             endpoint: config.endpoint.clone(),
             poll_interval: config.poll_interval,
             disable_live: config.disable_live,
+            with_credentials: config.with_credentials,
         }
     }
 
@@ -320,10 +344,16 @@ where
     }
 
     /// Open the live-wakeup receiver. On wasm this calls into
-    /// `pocopine-live::LiveClient` to subscribe to the
-    /// per-collection topic and pipes events through an
-    /// unbounded mpsc into the driver's select!. On host (or with
-    /// `disable_live = true`) returns a stub that never fires.
+    /// `pocopine-live::LiveClient` to subscribe to the per-stream
+    /// **query-tag** topic (`sync_stream_tag(stream)`) — the same
+    /// topic `SyncServer::invalidate_stream` publishes to and the
+    /// CRUD client's `LiveRefresh::scoped().query_tag(...)`
+    /// listener consumes. Earlier drafts subscribed to the
+    /// collection-name topic; that mismatched the server's publish
+    /// path and silently dropped every live invalidation, leaving
+    /// query views to refresh only on the poll fallback. On host
+    /// (or with `disable_live = true`) returns a stub that never
+    /// fires.
     fn open_live_wakeup(&self) -> LiveWakeup {
         if self.disable_live {
             tracing::debug!(
@@ -337,16 +367,9 @@ where
             let Some(sub) = self.subscription.upgrade() else {
                 return LiveWakeup::disabled();
             };
-            // We need a stable collection name to subscribe to;
-            // pocopine-sync's `local_stream_key(stream, params)`
-            // gives us the per-`(stream, params)` topic identity,
-            // but the live channel today only knows the
-            // collection (stream name). Use the stream as the
-            // collection topic per RFC 087 §6 — server filters by
-            // collection, client filters by params.
             let stream_name = sub.query().stream().as_str().to_string();
             let captured_params = sub.query().params().clone();
-            LiveWakeup::open_on_collection(stream_name, captured_params)
+            LiveWakeup::open_on_stream(stream_name, captured_params, self.with_credentials)
         }
         #[cfg(not(target_arch = "wasm32"))]
         {
@@ -471,17 +494,24 @@ where
                 }
                 ReplayOutcome::Rejected => {
                     // Server explicitly rejected (4xx, app error).
-                    // Roll back the pending overlay. The wire
-                    // contract says retries of a rejected
+                    // Roll back the pending overlay ACROSS EVERY
+                    // subscription on the stream — the original
+                    // optimistic apply fanned out to every view
+                    // whose predicate matched at apply_local time,
+                    // and the replay queue is also shared across
+                    // every driver on the stream (any driver may
+                    // dequeue this entry). Cleaning only the
+                    // driver-local subscription leaks stale
+                    // pending rows into every other view that
+                    // received the same optimistic upsert. The
+                    // wire contract says retries of a rejected
                     // mutation must NOT change the outcome — so
                     // dropping the queue entry is correct.
-                    if let Some(sub) = self.subscription.upgrade() {
-                        QueryClient::dequeue_pending_for_subscription::<Row>(
-                            &client_inner,
-                            &sub,
-                            &entry.mutation_id,
-                        );
-                    }
+                    QueryClient::dequeue_pending_for_stream::<Row>(
+                        &client_inner,
+                        &entry.stream,
+                        &entry.mutation_id,
+                    );
                 }
             }
         }
@@ -984,16 +1014,30 @@ impl LiveWakeup {
         }
     }
 
-    /// Open a live subscription against the per-collection topic.
-    /// wasm-only — host falls back to `disabled()` in the caller.
+    /// Open a live subscription against the per-stream query-tag
+    /// topic — same topic `pocopine_sync::SyncServer::invalidate_stream`
+    /// publishes to. wasm-only; host falls back to `disabled()` in
+    /// the caller.
+    ///
+    /// On open failure we drop the receiver and return
+    /// `Self { receiver: None, ... }`. That makes
+    /// [`Self::is_disabled`] true and [`Self::next_matching`]
+    /// block forever, so the driver's `select!` resolves cleanly
+    /// on the poll timer instead of busy-looping on a closed
+    /// receiver (which would treat every immediate-`Closed`
+    /// resolution as a poll trigger and hammer `/pull` without
+    /// honoring the configured poll interval).
     #[cfg(target_arch = "wasm32")]
-    fn open_on_collection(
-        collection: String,
+    fn open_on_stream(
+        stream_name: String,
         captured_params: pocopine_sync::StreamParams,
+        with_credentials: bool,
     ) -> Self {
         let (tx, rx) = futures::channel::mpsc::unbounded::<LiveWakeupEvent>();
+        let live_tag = pocopine_sync::sync_stream_tag(stream_name.as_str());
         let connect_result = pocopine_live::LiveClient::new()
-            .collection(collection.clone())
+            .query_tag(live_tag.clone())
+            .with_credentials(with_credentials)
             .on_event({
                 let tx = tx.clone();
                 move |event| {
@@ -1002,22 +1046,33 @@ impl LiveWakeup {
                 }
             })
             .open();
-        let _subscription = match connect_result {
-            Ok(sub) => Some(sub),
+        match connect_result {
+            Ok(subscription) => Self {
+                receiver: Some(rx),
+                captured_params,
+                _subscription: Some(subscription),
+            },
             Err(err) => {
                 tracing::warn!(
                     target: "pocopine.log",
-                    collection = collection.as_str(),
+                    stream = stream_name.as_str(),
+                    live_tag = live_tag.as_str(),
                     error = ?err,
                     "sync-query driver: live wakeup open failed; relying on polling"
                 );
-                None
+                // CRITICAL: drop the receiver. Keeping `Some(rx)`
+                // with closed senders makes `next_matching`
+                // resolve `Closed` immediately; the driver's
+                // select treats that as a poll trigger, then
+                // loops back to `next_matching` which resolves
+                // `Closed` again — a tight loop that hammers
+                // `/pull` ignoring the configured poll interval.
+                Self {
+                    receiver: None,
+                    captured_params,
+                    _subscription: None,
+                }
             }
-        };
-        Self {
-            receiver: Some(rx),
-            captured_params,
-            _subscription,
         }
     }
 }

--- a/crates/pocopine-sync-query/src/lib.rs
+++ b/crates/pocopine-sync-query/src/lib.rs
@@ -42,6 +42,7 @@
 //! [`pocopine-sync-crud`]: https://docs.rs/pocopine-sync-crud
 
 pub mod client;
+pub mod driver;
 pub mod mutator;
 pub mod params;
 pub mod plugin;
@@ -52,6 +53,10 @@ pub mod wire;
 
 // Re-exports of the curated public API.
 pub use client::{QueryClient, QueryHandle, QuerySubscription, QueryView, UpdateToken};
+pub use driver::{
+    live_event_matches_params, DriverEpoch, QueryClientConfig, DEFAULT_POLL_INTERVAL,
+    DEFAULT_SYNC_ENDPOINT,
+};
 pub use mutator::{MutationOutcome, Mutator, MutatorRemoteContext, MutatorRemoteFuture, RowChange};
 pub use plugin::{query_client_plugin, QueryClientPlugin};
 pub use predicate::{

--- a/crates/pocopine-sync-query/src/plugin.rs
+++ b/crates/pocopine-sync-query/src/plugin.rs
@@ -11,6 +11,7 @@ use std::rc::Rc;
 use pocopine_core::{App, AppPlugin};
 
 use crate::client::QueryClient;
+use crate::driver::QueryClientConfig;
 
 /// Build the query-client app plugin.
 ///
@@ -31,30 +32,31 @@ pub fn query_client_plugin() -> QueryClientPlugin {
 
 /// Builder for the query-client app plugin. Configure endpoint /
 /// transport options here before installing.
+#[derive(Default)]
 pub struct QueryClientPlugin {
-    endpoint: String,
+    config: QueryClientConfig,
 }
 
 impl QueryClientPlugin {
     /// Override the sync HTTP endpoint prefix this client posts to.
     /// Defaults to [`pocopine_sync::SYNC_ENDPOINT_PREFIX`].
     pub fn endpoint(mut self, endpoint: impl Into<String>) -> Self {
-        self.endpoint = endpoint.into();
+        self.config.endpoint = endpoint.into();
+        self
+    }
+
+    /// Replace the full driver configuration. Use this when the
+    /// app needs to tune the poll interval, disable live wakeup,
+    /// or strip credentials from sync requests.
+    pub fn config(mut self, config: QueryClientConfig) -> Self {
+        self.config = config;
         self
     }
 
     /// Build the runtime client without installing. Useful for tests
     /// and host-side bench harnesses that don't run a full `App`.
     pub fn into_client(self) -> QueryClient {
-        QueryClient::with_endpoint(self.endpoint)
-    }
-}
-
-impl Default for QueryClientPlugin {
-    fn default() -> Self {
-        Self {
-            endpoint: pocopine_sync::SYNC_ENDPOINT_PREFIX.to_string(),
-        }
+        QueryClient::with_config(self.config)
     }
 }
 
@@ -86,7 +88,7 @@ mod tests {
     #[test]
     fn builder_accepts_endpoint_override() {
         let plugin = query_client_plugin().endpoint("/custom/prefix");
-        assert_eq!(plugin.endpoint, "/custom/prefix");
+        assert_eq!(plugin.config.endpoint, "/custom/prefix");
         let client = plugin.into_client();
         assert_eq!(client.endpoint(), "/custom/prefix");
     }

--- a/crates/pocopine-sync-query/src/query.rs
+++ b/crates/pocopine-sync-query/src/query.rs
@@ -406,7 +406,7 @@ impl<Row> QueryBuilder<Row> {
     /// view. Sugar for `client.observe(self.build())`.
     pub fn observe(self, client: &crate::QueryClient) -> crate::QueryView<Row>
     where
-        Row: Clone + 'static,
+        Row: Clone + serde::Serialize + serde::de::DeserializeOwned + 'static,
     {
         client.observe(self.build())
     }

--- a/crates/pocopine-sync-query/tests/driver.rs
+++ b/crates/pocopine-sync-query/tests/driver.rs
@@ -1,0 +1,485 @@
+//! End-to-end tests for the per-subscription driver (RFC 087).
+//!
+//! Each test installs a `pocopine::fetch` middleware that mocks
+//! `/open` + `/pull` responses, then `observe`s a query inside a
+//! `tokio::task::LocalSet` so the driver task can spawn. The
+//! `LocalSet::run_until(async { ... })` shape mirrors what real
+//! native consumers do.
+//!
+//! Tests cover:
+//!
+//! * `/open` → `/pull` populates canonical rows.
+//! * Schema-version drift resets state + repopulates.
+//! * Live wakeup filter (drops mismatched events).
+//! * Offline replay re-fires `apply_remote` after `/pull` recovers.
+//! * Cancellation: drop the QueryHandle, verify the driver exits.
+//! * `QueryClient::without_driver` skips the spawn entirely.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::time::Duration;
+
+use pocopine_core::fetch::{
+    install_middleware, FetchNext, FetchRequest, FetchResponse, __reset_middleware_chain_for_test,
+};
+use pocopine_core::server::ServerError;
+use pocopine_sync::{
+    MutationId, SyncCollectionName, SyncCursor, SyncOpenResponse, SyncOpenStream, SyncPullResponse,
+    SyncResult, SyncRow, SyncStreamName, SYNC_OPEN_PATH, SYNC_PULL_PATH,
+};
+use pocopine_sync_query::{
+    Mutator, MutatorRemoteContext, MutatorRemoteFuture, QueryClient, QueryClientConfig, RowChange,
+};
+use pocopine_sync_query_macros::query_resource;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::task::LocalSet;
+
+/// Each test owns its own middleware-state Rc and resets the chain
+/// at the start, so tests don't bleed mocks into each other.
+fn reset_middleware() {
+    __reset_middleware_chain_for_test();
+}
+
+/// Stream + collection identifiers used across all tests.
+const STREAM: &str = "issues";
+const COLLECTION: &str = "issues";
+
+#[query_resource(name = "issues", schema_version = 1)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Issue {
+    pub id: String,
+    #[query_param(required)]
+    pub workspace_id: String,
+    pub title: String,
+}
+
+/// Mutator whose `apply_remote` reads a per-test mode (online /
+/// offline / online-after-replay) so the offline-replay test can
+/// flip transport behavior mid-flight.
+struct PendingControlled;
+
+thread_local! {
+    static PENDING_MODE: RefCell<PendingMode> = const { RefCell::new(PendingMode::Offline) };
+    static PENDING_REMOTE_HITS: RefCell<Vec<MutationId>> = const { RefCell::new(Vec::new()) };
+}
+
+#[derive(Clone, Copy, Debug)]
+enum PendingMode {
+    Offline,
+    Online,
+}
+
+impl Mutator for PendingControlled {
+    type Payload = Issue;
+    type Row = Issue;
+    const NAME: &'static str = "pending_controlled";
+    const STREAM: &'static str = "issues";
+    const SCHEMA_VERSION: u32 = 1;
+
+    fn apply_local(payload: &Self::Payload) -> Vec<RowChange<Self::Row>> {
+        vec![RowChange::Upsert(payload.clone())]
+    }
+
+    fn apply_remote(
+        ctx: &dyn MutatorRemoteContext,
+        payload: Self::Payload,
+    ) -> MutatorRemoteFuture<Self::Row> {
+        // Capture the context's `next_mutation_id` — on the
+        // original call, this is the framework-supplied
+        // `StubContext`, which mints fresh ids per call. On the
+        // replay, this is the framework's internal
+        // `ReplayContext`, which returns the SAME mutation id
+        // captured at queue time. The test asserts every
+        // ReplayContext call returns the same id (offsets that
+        // the original StubContext call is one-ahead — typical
+        // wrapper that mints the wire id outside of apply_remote).
+        let id = ctx.next_mutation_id();
+        Box::pin(async move {
+            let id = id?;
+            PENDING_REMOTE_HITS.with(|hits| hits.borrow_mut().push(id));
+            let mode = PENDING_MODE.with(|m| *m.borrow());
+            match mode {
+                PendingMode::Offline => Err(pocopine_sync::SyncError::network("simulated offline")),
+                PendingMode::Online => Ok(vec![RowChange::Upsert(payload)]),
+            }
+        })
+    }
+}
+
+/// Minimal `MutatorRemoteContext` that mints predictable mutation
+/// ids and uses the canonical push URL.
+struct StubContext {
+    next_id: std::cell::Cell<u64>,
+}
+
+impl StubContext {
+    fn new() -> Self {
+        Self {
+            next_id: std::cell::Cell::new(1),
+        }
+    }
+}
+
+impl MutatorRemoteContext for StubContext {
+    fn push_url(&self) -> &str {
+        "/__pocopine/sync/v1/push"
+    }
+
+    fn next_mutation_id(&self) -> SyncResult<MutationId> {
+        let n = self.next_id.get();
+        self.next_id.set(n + 1);
+        MutationId::new(format!("test:{n}"))
+    }
+}
+
+/// JSON body for a successful fetch response.
+fn json_response<T: serde::Serialize>(body: &T) -> FetchResponse {
+    FetchResponse {
+        status: 200,
+        body: format!(
+            "{{\"Ok\":{}}}",
+            serde_json::to_string(body).expect("test body serializable")
+        ),
+    }
+}
+
+/// Build a `SyncOpenResponse` for our test stream.
+fn open_response(schema_version: u32, cursor: Option<SyncCursor>) -> SyncOpenResponse {
+    SyncOpenResponse::new(vec![SyncOpenStream {
+        stream: SyncStreamName::new(STREAM).unwrap(),
+        collection: SyncCollectionName::new(COLLECTION).unwrap(),
+        cursor,
+        schema_version,
+        params: pocopine_sync::StreamParams::new(),
+    }])
+}
+
+/// Build a `SyncPullResponse` snapshot from typed `Issue`s.
+fn snapshot_response(rows: Vec<Issue>) -> SyncPullResponse<Value> {
+    let wire_rows: Vec<SyncRow<Value>> = rows
+        .into_iter()
+        .map(|r| SyncRow::new(r.id.clone(), serde_json::to_value(&r).unwrap()).unwrap())
+        .collect();
+    SyncPullResponse::snapshot(
+        SyncStreamName::new(STREAM).unwrap(),
+        SyncCollectionName::new(COLLECTION).unwrap(),
+        wire_rows,
+        Some(SyncCursor::new("c_1").unwrap()),
+    )
+}
+
+/// Drive the LocalSet forward by a few yields so spawned drivers
+/// observe their initial /open + /pull responses. We use a tiny
+/// poll interval so the test doesn't wait 30s for the second
+/// tick.
+async fn settle_ticks(ticks: usize) {
+    for _ in 0..ticks {
+        tokio::task::yield_now().await;
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+}
+
+/// Build a test-friendly `QueryClientConfig`: short poll interval,
+/// live wakeup disabled (host can't open an EventSource).
+fn test_config() -> QueryClientConfig {
+    QueryClientConfig {
+        poll_interval: Some(Duration::from_millis(30)),
+        disable_live: true,
+        ..QueryClientConfig::default()
+    }
+}
+
+#[tokio::test]
+async fn open_then_pull_populates_canonical_rows() {
+    let local = LocalSet::new();
+    local
+        .run_until(async {
+            reset_middleware();
+            install_middleware(|req: FetchRequest, _next: FetchNext| async move {
+                match req.url.as_str() {
+                    SYNC_OPEN_PATH => Ok(json_response(&open_response(1, None))),
+                    SYNC_PULL_PATH => Ok(json_response(&snapshot_response(vec![Issue {
+                        id: "issue_1".into(),
+                        workspace_id: "W1".into(),
+                        title: "first".into(),
+                    }]))),
+                    other => Err(ServerError::Network(format!("unexpected {other}"))),
+                }
+            });
+
+            let client = QueryClient::with_config(test_config());
+            let view = client.observe(Issue::query().eq(issues::field::workspace_id, "W1").build());
+            settle_ticks(3).await;
+
+            let rows = view.rows();
+            assert_eq!(rows.len(), 1, "canonical row populated by /pull");
+            assert_eq!(rows[0].id, "issue_1");
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn schema_drift_resets_state_and_repopulates() {
+    let local = LocalSet::new();
+    local
+        .run_until(async {
+            reset_middleware();
+            let open_calls = Rc::new(RefCell::new(0u32));
+            let pull_calls = Rc::new(RefCell::new(0u32));
+            let open_for_mw = open_calls.clone();
+            let pull_for_mw = pull_calls.clone();
+            install_middleware(move |req: FetchRequest, _next: FetchNext| {
+                let open_for_mw = open_for_mw.clone();
+                let pull_for_mw = pull_for_mw.clone();
+                async move {
+                    match req.url.as_str() {
+                        SYNC_OPEN_PATH => {
+                            let n = {
+                                let mut c = open_for_mw.borrow_mut();
+                                *c += 1;
+                                *c
+                            };
+                            // First open → v1; second open → v2 (drift).
+                            let sv = if n == 1 { 1 } else { 2 };
+                            Ok(json_response(&open_response(sv, None)))
+                        }
+                        SYNC_PULL_PATH => {
+                            let n = {
+                                let mut c = pull_for_mw.borrow_mut();
+                                *c += 1;
+                                *c
+                            };
+                            // First pull → 1 row; after drift → 2 rows.
+                            let rows = if n == 1 {
+                                vec![Issue {
+                                    id: "old".into(),
+                                    workspace_id: "W1".into(),
+                                    title: "stale".into(),
+                                }]
+                            } else {
+                                vec![
+                                    Issue {
+                                        id: "new_a".into(),
+                                        workspace_id: "W1".into(),
+                                        title: "fresh".into(),
+                                    },
+                                    Issue {
+                                        id: "new_b".into(),
+                                        workspace_id: "W1".into(),
+                                        title: "fresher".into(),
+                                    },
+                                ]
+                            };
+                            Ok(json_response(&snapshot_response(rows)))
+                        }
+                        other => Err(ServerError::Network(format!("unexpected {other}"))),
+                    }
+                }
+            });
+
+            let client = Rc::new(QueryClient::with_config(test_config()));
+            // First observe → loads v1.
+            let view = client.observe(Issue::query().eq(issues::field::workspace_id, "W1").build());
+            settle_ticks(3).await;
+            assert_eq!(view.rows().len(), 1, "initial /pull populated v1");
+
+            // Second observe of the SAME query reuses the
+            // subscription — to force a fresh /open we drop and
+            // re-observe. A real drift happens on reconnect; the
+            // test models it by issuing two drivers back to back.
+            drop(view);
+            settle_ticks(2).await;
+            let _view2 =
+                client.observe(Issue::query().eq(issues::field::workspace_id, "W1").build());
+            // The driver re-runs /open + /pull; the second /open
+            // returns schema_version = 2 → reset_state, then the
+            // second /pull returns the 2-row snapshot.
+            settle_ticks(5).await;
+
+            assert!(
+                *open_calls.borrow() >= 2,
+                "schema drift should have triggered at least 2 /open calls"
+            );
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn cancellation_via_handle_drop_exits_driver() {
+    let local = LocalSet::new();
+    local
+        .run_until(async {
+            reset_middleware();
+            let pull_calls = Rc::new(RefCell::new(0u32));
+            let pull_for_mw = pull_calls.clone();
+            install_middleware(move |req: FetchRequest, _next: FetchNext| {
+                let pull_for_mw = pull_for_mw.clone();
+                async move {
+                    match req.url.as_str() {
+                        SYNC_OPEN_PATH => Ok(json_response(&open_response(1, None))),
+                        SYNC_PULL_PATH => {
+                            *pull_for_mw.borrow_mut() += 1;
+                            Ok(json_response(&snapshot_response(vec![])))
+                        }
+                        other => Err(ServerError::Network(format!("unexpected {other}"))),
+                    }
+                }
+            });
+
+            let client = QueryClient::with_config(test_config());
+            let view = client.observe(Issue::query().eq(issues::field::workspace_id, "W1").build());
+            settle_ticks(3).await;
+            let initial_count = *pull_calls.borrow();
+            assert!(initial_count >= 1, "first /pull issued before drop");
+
+            drop(view);
+            // Give the driver several poll intervals to (try to)
+            // tick again — but since the handle was dropped, the
+            // epoch bumped, and the driver should NOT issue more
+            // /pulls.
+            for _ in 0..5 {
+                tokio::time::sleep(Duration::from_millis(40)).await;
+            }
+            let final_count = *pull_calls.borrow();
+            // Permit at most 1 additional /pull (the one already in
+            // flight when drop happened) — anything more proves the
+            // epoch cancellation didn't fire.
+            assert!(
+                final_count - initial_count <= 1,
+                "driver should have exited after handle drop; pulls before={initial_count}, after={final_count}"
+            );
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn offline_replay_redrives_apply_remote_with_same_mutation_id() {
+    let local = LocalSet::new();
+    local
+        .run_until(async {
+            reset_middleware();
+            install_middleware(|req: FetchRequest, _next: FetchNext| async move {
+                match req.url.as_str() {
+                    SYNC_OPEN_PATH => Ok(json_response(&open_response(1, None))),
+                    SYNC_PULL_PATH => Ok(json_response(&snapshot_response(vec![]))),
+                    other => Err(ServerError::Network(format!("unexpected {other}"))),
+                }
+            });
+
+            PENDING_MODE.with(|m| *m.borrow_mut() = PendingMode::Offline);
+            PENDING_REMOTE_HITS.with(|h| h.borrow_mut().clear());
+
+            let client = QueryClient::with_config(test_config());
+            let ctx = StubContext::new();
+            let view = client.observe(Issue::query().eq(issues::field::workspace_id, "W1").build());
+            settle_ticks(2).await;
+
+            // 1. Mutate; apply_remote returns Network → optimistic
+            //    stays pending + the entry is queued for replay.
+            let issue = Issue {
+                id: "pending_1".into(),
+                workspace_id: "W1".into(),
+                title: "offline".into(),
+            };
+            let err = client
+                .mutate::<PendingControlled>(issue.clone(), &ctx)
+                .await
+                .expect_err("offline mutate should return a network error");
+            assert!(err.is_transport(), "got non-transport error: {err}");
+
+            // Pending overlay still visible.
+            let pending_len = view.state().pending().len();
+            assert_eq!(pending_len, 1, "optimistic overlay should still be pending");
+            assert_eq!(
+                PENDING_REMOTE_HITS.with(|h| h.borrow().len()),
+                1,
+                "apply_remote fired once on the original mutate"
+            );
+            let original_id = PENDING_REMOTE_HITS.with(|h| h.borrow()[0].clone());
+
+            // 2. Flip the transport to online. The next driver tick
+            //    walks the replay queue and re-fires apply_remote.
+            PENDING_MODE.with(|m| *m.borrow_mut() = PendingMode::Online);
+            // Let the driver run several ticks so it observes the
+            // mode flip and successfully replays.
+            for _ in 0..10 {
+                tokio::time::sleep(Duration::from_millis(40)).await;
+            }
+
+            // The replay invoked apply_remote at least once more.
+            // Replay invocations all flow through the framework's
+            // `ReplayContext::next_mutation_id` which returns the
+            // SAME captured id — so every replay hit must be
+            // equal to itself (the dedup invariant).
+            let hits = PENDING_REMOTE_HITS.with(|h| h.borrow().clone());
+            assert!(
+                hits.len() >= 2,
+                "expected at least one replay; got {} apply_remote hits",
+                hits.len()
+            );
+            let replay_id = hits[1].clone();
+            for (i, h) in hits.iter().enumerate().skip(1) {
+                assert_eq!(
+                    h, &replay_id,
+                    "replay #{i} must reuse the same mutation_id (RFC 072 dedup)"
+                );
+            }
+            // Original wire mutation_id was `test:1`; the
+            // mutator's first call to ctx.next_mutation_id() got
+            // `test:2` (StubContext is one-ahead). The replay
+            // observes the framework-captured wire id `test:1`,
+            // which is distinct from `original_id` here BY
+            // DESIGN of the test mutator. The cross-check is that
+            // the replay-time call has stable identity across
+            // multiple retries — proven by the loop above.
+            assert_ne!(
+                replay_id, original_id,
+                "test mutator's first call sees StubContext id, replay sees framework-captured id; \
+                 these are distinct by construction in this test"
+            );
+
+            // Pending drained.
+            assert_eq!(
+                view.state().pending().len(),
+                0,
+                "successful replay should clear the pending overlay"
+            );
+        })
+        .await;
+}
+
+#[test]
+fn without_driver_skips_spawn_and_routing_still_works() {
+    // No LocalSet, no tokio runtime — the routing engine MUST
+    // still work because observe with `without_driver` doesn't
+    // spawn anything.
+    let client = QueryClient::without_driver();
+    let _view = client.observe(Issue::query().eq(issues::field::workspace_id, "W1").build());
+    // If a driver had been spawned this test would have panicked
+    // (`spawn_local` outside a LocalSet panics).
+    assert_eq!(client.active_subscription_count(), 1);
+}
+
+#[test]
+fn live_event_filter_drops_non_matching_params() {
+    let mut want = pocopine_sync::StreamParams::new();
+    want.insert("workspace_id".into(), serde_json::json!("W1"));
+
+    let mut got = std::collections::BTreeMap::new();
+    got.insert("workspace_id".to_string(), serde_json::json!("W2"));
+    assert!(!pocopine_sync_query::live_event_matches_params(&want, &got));
+
+    got.clear();
+    got.insert("workspace_id".to_string(), serde_json::json!("W1"));
+    assert!(pocopine_sync_query::live_event_matches_params(&want, &got));
+
+    // Server didn't include the field at all → conservative
+    // allow per RFC 087 §6.
+    let empty = std::collections::BTreeMap::new();
+    assert!(pocopine_sync_query::live_event_matches_params(
+        &want, &empty
+    ));
+}

--- a/crates/pocopine-sync/src/error.rs
+++ b/crates/pocopine-sync/src/error.rs
@@ -42,6 +42,19 @@ pub enum SyncError {
     /// schema. The variant is introduced here so downstream callers can
     /// already typecheck against it.
     SchemaMigration { stream: String, from: u32, to: u32 },
+    /// Transport-class failure: the HTTP request could not reach the
+    /// server, the response could not be parsed, or the browser
+    /// reported a network-level error.
+    ///
+    /// Distinct from [`Self::Client`] (which captures e.g. wasm
+    /// runtime integration bugs) so the sync-query driver can
+    /// classify a failed `Mutator::apply_remote` as "retry on
+    /// reconnect" without parsing the error message. Wrap a
+    /// `ServerError::Network(msg)` from
+    /// [`pocopine_core::fetch::call`] with this variant when
+    /// surfacing transport failures up to the sync-query mutate
+    /// path.
+    Network(String),
 }
 
 impl SyncError {
@@ -86,6 +99,21 @@ impl SyncError {
             to,
         }
     }
+
+    /// Build a transport/network failure (HTTP timeout, fetch refused,
+    /// SSE stream lost). Used by sync-query's `Mutator::apply_remote`
+    /// path so the driver can identify retry-on-reconnect errors
+    /// without parsing the message string.
+    pub fn network(msg: impl Into<String>) -> Self {
+        Self::Network(msg.into())
+    }
+
+    /// Returns `true` for errors the sync layer treats as transient
+    /// — the mutation should be re-queued for replay rather than
+    /// rolled back.
+    pub fn is_transport(&self) -> bool {
+        matches!(self, Self::Network(_))
+    }
 }
 
 impl fmt::Display for SyncError {
@@ -105,6 +133,7 @@ impl fmt::Display for SyncError {
                 f,
                 "sync schema migration required for stream {stream}: client at v{from}, server at v{to}"
             ),
+            Self::Network(msg) => write!(f, "sync network error: {msg}"),
         }
     }
 }

--- a/crates/pocopine-sync/src/server.rs
+++ b/crates/pocopine-sync/src/server.rs
@@ -623,6 +623,19 @@ fn server_error(error: SyncError) -> ServerError {
             tracing::error!(target: "pocopine.log", error = %msg, "sync backend error");
             ServerError::App("sync internal error".to_string())
         }
+        SyncError::Network(msg) => {
+            // Server-side handlers don't generate Network errors —
+            // that variant is for the sync-query driver classifying
+            // transport failures from a `Mutator::apply_remote`
+            // future. If we ever observe one here it's a bug; map
+            // to a generic 500 with the message in the log.
+            tracing::error!(
+                target: "pocopine.log",
+                error = %msg,
+                "unexpected SyncError::Network surfaced from a sync request handler"
+            );
+            ServerError::App("sync internal error".to_string())
+        }
     }
 }
 

--- a/rfcs/rfc-087-sync-query-driver.md
+++ b/rfcs/rfc-087-sync-query-driver.md
@@ -1,0 +1,327 @@
+# RFC 087 — `pocopine-sync-query` driver lifecycle
+
+* **Status:** Draft
+* **Author:** sync framework working group
+* **Tracking branch:** `wip/sync-query-driver`
+* **Supersedes:** the "background-task drivers" line item in `pocopine-sync-query` README's roadmap
+* **Related:** [RFC 086 (pocopine-sync-query)](./rfc-086-sync-query.md), [RFC 071 (event spine + live invalidation)](./rfc-071-event-spine.md), [RFC 072 (offline sync protocol)](./rfc-072-offline-sync.md)
+
+## Summary
+
+RFC 086 shipped `pocopine-sync-query` as a routing engine + macro DSL: queries are typed, subscriptions are refcounted, mutations are predicate-routed into matching views, and the wire envelopes are built. What's **missing** is the actual sync loop — nothing today issues `/open` + `/pull` against the server, nothing subscribes to the live-wakeup channel, and nothing replays queued mutations after a disconnect. `client.observe(q)` returns a `QueryView` with empty canonical state; the only way data flows in is via the caller manually pushing mutation results through `Mutator::apply_remote`.
+
+This RFC closes the gap with a **per-subscription background driver**. When a subscription is created, the `QueryClient` spawns a driver task that owns the `/open` handshake, the incremental `/pull` loop, live-wakeup invalidation routing, and offline mutation replay. When the last `QueryHandle` to a subscription drops, the driver's epoch is bumped and the task exits at its next yield point. The driver is a sync-query-native abstraction, not a retrofit of `pocopine-sync::SyncCollection<C, T>` — `SyncCollection` is CRUD-resource-centric and reusing it would re-create the architectural tension that drove the `pocopine-sync-crud` / `pocopine-sync-query` split in the first place.
+
+## Motivation
+
+Post-PR #146, the surface looks like a working framework but doesn't actually sync:
+
+| Capability                                | Today                                                 | This RFC                                               |
+| ----------------------------------------- | ----------------------------------------------------- | ------------------------------------------------------ |
+| Routing engine                            | ✅ predicate-routed; correct under cancellation       | unchanged                                              |
+| Macro DSL                                 | ✅ `#[query_resource]` + `#[query_param]`             | unchanged                                              |
+| Wire builders                             | ✅ `build_open_request` / `build_pull_request` etc.   | consumed by the driver                                 |
+| Initial population (`/open` + `/pull`)    | ❌ nothing calls them                                 | driver issues both on subscribe                        |
+| Incremental sync                          | ❌ no periodic `/pull`                                | driver loops on cursor + heartbeat                     |
+| Live invalidation                         | ❌ no listener attached                               | driver consumes `pocopine-live` events                 |
+| Offline replay                            | ❌ failed pushes just error out                       | driver queues + retries on reconnect                   |
+| Schema-version drift                      | ❌ stale state silently retained                      | driver resets state + re-opens on mismatch             |
+| Subscription cancellation                 | ✅ Drop bumps refcount                                | Drop also bumps `SyncEpoch`; task exits at next yield  |
+
+The user model post-RFC 087: declare a query, call `observe`, get a live view. No manual `apply_remote` glue for canonical data — only `Mutator::apply_remote` for client-initiated writes (which is the right place for that seam).
+
+## Goals
+
+* **Per-subscription driver task.** One sync-query-native lifecycle per `(TypeId, QueryKey)` — same identity as the registry.
+* **Reuse pocopine-sync's wire layer.** `SyncStreamSubscription`, `SyncPullRequest`, `SyncPushRequest`, `validate_params`, `local_stream_key` — all unchanged, all consumed by the driver.
+* **Reuse pocopine-live's invalidation channel.** Per-collection topic + client-side params filter is v1; per-`(name, params_hash)` topics is a v2 perf concern (not in scope).
+* **Cancellation safety.** Tasks observe the same `SyncEpoch` as the subscription; epoch bump on last `QueryHandle::drop` causes the task to exit at its next `.await`.
+* **`apply_remote` stays the push transport seam.** The driver does NOT take over `/push` — `Mutator::apply_remote` remains user-owned. The driver only owns `/open`, `/pull`, live wakeup, and offline replay (which re-invokes `apply_remote`).
+* **Runtime-agnostic spawn shim.** `#[cfg(target_arch = "wasm32")]` uses `wasm_bindgen_futures::spawn_local`; native uses `tokio::spawn`. No public `Runtime` trait — keeps the user API the same on both targets.
+* **Persistence-agnostic.** Driver works against in-memory `QueryState`; durable storage (IndexedDB, SQLite) is layered on later via the same `SyncLocalStore` interface used by `pocopine-sync`. Out of scope for this RFC.
+
+## Non-goals
+
+* **Persistent state across page reloads.** In-memory only this RFC. Persistence is a follow-up against a `SyncLocalStore`-shaped trait.
+* **Per-`(name, params_hash)` live topics.** Server pushes on the per-collection topic; clients filter by their captured params. v2 perf optimization.
+* **`#[query]` selector composition (Layer 2).** Composed views with read-tracking belong in a separate RFC. This RFC is just the single-query lifecycle.
+* **Optimistic conflict resolution.** Server is authoritative; conflicts surface as failed `apply_remote` and flow through the existing rollback path (RFC 086 §3).
+* **CRUD-Source → QuerySource adapter.** Filed as a follow-up; lets existing `CrudSource` impls be served by sync-query queries without rewriting.
+
+## Design
+
+### 1. Subscription lifecycle state machine
+
+A `QuerySubscription<Row>` (from RFC 086) gains a `driver: Cell<Option<DriverHandle>>` field. The driver's state machine:
+
+```
+                  observe()
+                     │
+                     ▼
+              ┌─────────────┐
+              │  Spawning   │  (driver_handle.spawn → returns DriverHandle)
+              └──────┬──────┘
+                     ▼
+              ┌─────────────┐
+              │   Opening   │  (POST /open → cursor, schema_version, collection)
+              └──────┬──────┘
+                     ▼
+              ┌─────────────┐
+              │   Pulling   │  (POST /pull → snapshot/delta into canonical_rows)
+              └──────┬──────┘
+                     ▼
+              ┌─────────────┐
+              │    Idle     │  ◄─── live wakeup OR poll-interval timeout
+              └──────┬──────┘
+                     ▼
+              ┌─────────────┐
+              │  Replaying  │  (walk pending; re-invoke apply_remote for queued)
+              └──────┬──────┘
+                     │
+                     └──── back to Idle
+              
+                 epoch.bump()
+                     │
+                     ▼
+              ┌─────────────┐
+              │  Cancelled  │  (any .await checks epoch.is_current; bails)
+              └─────────────┘
+```
+
+State transitions are reactive in the sense that the QueryState's `version()` ticks on every canonical mutation — observers (UI) re-render. Driver state transitions don't themselves bump version unless they change canonical/pending data.
+
+### 2. Runtime abstraction (cfg-split spawn shim)
+
+```rust
+// In crates/pocopine-sync-query/src/driver.rs:
+
+#[cfg(target_arch = "wasm32")]
+fn spawn_driver<F>(fut: F)
+where
+    F: std::future::Future<Output = ()> + 'static,
+{
+    wasm_bindgen_futures::spawn_local(fut);
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn spawn_driver<F>(fut: F)
+where
+    F: std::future::Future<Output = ()> + Send + 'static,
+{
+    // Use the tokio handle the host runtime already installed. Panics
+    // if there's no current tokio runtime — host tests + native apps
+    // start one explicitly; the panic surfaces a real misconfiguration.
+    tokio::spawn(fut);
+}
+```
+
+The `Send` bound on native differs from wasm (wasm is single-threaded, doesn't need Send). The driver type itself avoids `!Send` types (Rc, RefCell) on the await boundary by carrying a `Weak<QuerySubscription<Row>>` and upgrading inside each tick.
+
+Actually, **important detail**: `QuerySubscription` holds `Rc<RefCell<QueryState<Row>>>`. `Rc` is not `Send`. To make the future `Send` on native, the driver task runs on a `LocalSet` or holds the subscription via a sync-friendly handle. Two paths:
+
+1. **Native: require `tokio::task::LocalSet`** in the host runtime; spawn via `tokio::task::spawn_local`. Same single-threaded execution model as wasm. Cleaner alignment.
+2. **Add `Arc<Mutex<QueryState<Row>>>`** in the subscription. Bigger surgery, breaks the existing single-threaded RefCell pattern.
+
+This RFC picks **(1)** — `tokio::task::spawn_local` requires the caller to have a `LocalSet` available. Native test code (and `pocopine-server`) already runs in a LocalSet for the same reason CRUD's `SyncCollection` does. Wasm uses `wasm_bindgen_futures::spawn_local` which is already local.
+
+### 3. Driver loop
+
+```rust
+pub(crate) struct SubscriptionDriver<Row: Clone + 'static> {
+    /// Weak ref so the driver doesn't keep the subscription alive after
+    /// the last QueryHandle drops. Each tick re-upgrades; on failure the
+    /// task exits cleanly.
+    subscription: Weak<QuerySubscription<Row>>,
+    /// Generation token; epoch.bump() on subscription drop signals exit.
+    epoch: SyncEpoch,
+    /// Sync endpoint base (default "/__pocopine/sync/v1", overridable).
+    endpoint: String,
+    /// Configured poll interval for incremental pulls (when no live
+    /// wakeup is connected, or as a fallback heartbeat).
+    poll_interval: Duration,
+    /// Live wakeup channel; None if disabled by config.
+    live_wakeup: Option<LiveWakeup<Row>>,
+}
+
+impl<Row: Clone + Serialize + DeserializeOwned + 'static> SubscriptionDriver<Row> {
+    async fn run(self) {
+        // Phase 1: /open
+        let open_response = match self.open().await {
+            Ok(r) => r,
+            Err(_) => return self.mark_error_and_exit(),
+        };
+        self.apply_open(open_response);
+        if !self.epoch.is_current() { return; }
+
+        // Phase 2: initial /pull
+        let pull_response = match self.pull().await {
+            Ok(r) => r,
+            Err(_) => return self.mark_error_and_exit(),
+        };
+        self.apply_pull(pull_response);
+        if !self.epoch.is_current() { return; }
+
+        // Phase 3: hook live wakeup (item 2)
+        let mut live_rx = self.connect_live_wakeup();
+
+        // Phase 4: main loop
+        loop {
+            tokio::select! {
+                _ = self.poll_interval_timer() => {
+                    self.tick_pull().await;
+                }
+                Some(event) = live_rx.next() => {
+                    if self.live_event_matches_params(&event) {
+                        self.tick_pull().await;
+                    }
+                }
+            }
+            if !self.epoch.is_current() { return; }
+            // Phase 5: offline replay (item 3)
+            self.replay_pending_if_offline().await;
+        }
+    }
+}
+```
+
+The `tokio::select!` shape works for native; the wasm port uses `futures::select_biased!` or a small hand-rolled state machine because wasm doesn't have tokio. To keep the source unified, the driver uses `futures::select!` (provided by the `futures` crate, works on both targets).
+
+### 4. `/open` and `/pull`
+
+Both call the existing `wire::build_*_request` helpers from RFC 086, then issue the HTTP call via `pocopine::fetch`'s middleware chain (so tests can install a mock middleware). The response shape is the standard `SyncOpenResponse` / `SyncPullResponse<Value>` from `pocopine-sync` — already used by `SyncCollection` for the CRUD client.
+
+`/pull` results land in `QueryState` via the routing engine's `route_canonical_changes` (already exists from RFC 086). Each row in the response is decoded as `Row` via `serde_json::from_value`; decode failures are logged with `tracing::warn!` and the row is skipped (per RFC 086's wire-shape mismatch handling).
+
+### 5. Schema-version drift handling
+
+The driver remembers the `application_schema_version` from the most recent successful `/open`. On every subsequent `/open` (e.g., on reconnect), if the response's schema_version differs from the remembered one:
+
+1. Call `QueryState::reset()` — drops canonical_rows + pending + cursor.
+2. Bump `application_schema_version` to the new value.
+3. Bump the subscription's `version()` so observers re-render the empty state.
+4. Continue with a fresh `/pull`.
+
+This matches `SyncCollection`'s drift behavior and the RFC 086 §3.3 reset path.
+
+### 6. Live wakeup hookup
+
+Reuses the existing `pocopine-live::LiveClient`:
+
+```rust
+struct LiveWakeup<Row> {
+    rx: LiveSubscription,    // from pocopine-live, per-collection topic
+    captured_params: StreamParams,
+}
+
+fn live_event_matches_params(&self, event: &LiveEvent) -> bool {
+    // v1: server publishes affected_keys + affected_fields for the
+    // stream's collection. The driver compares the event's per-row
+    // field values against the subscription's params. Mismatch → drop;
+    // match → trigger /pull.
+    //
+    // The "minimal field set" the server publishes is the SAME field
+    // set the resource declares with #[query_param] — bounded
+    // vocabulary, predictable wire size.
+    for (key, want) in &self.captured_params {
+        match event.affected_fields.get(key) {
+            None => continue,                  // server didn't include this field; allow
+            Some(value) if value == want => continue,
+            Some(_) => return false,           // mismatch → drop event
+        }
+    }
+    true
+}
+```
+
+If `affected_fields` is empty (server doesn't track field-level deltas), every event triggers a `/pull` — bandwidth-suboptimal but correct. Documented as the v1 fallback. v2 adds per-`(name, params_hash)` topics + server-side filtering.
+
+### 7. Offline replay
+
+Trigger: `Mutator::apply_remote` returns a transport-error `SyncError::Network(...)`. The driver marks the subscription's state as `syncing=false, error="offline"` and leaves the optimistic overlay in `pending`. The optimistic state stays visible to the UI.
+
+On the next successful `/pull` (which fires when the network recovers + the next live-wakeup or poll interval), the driver walks `state.pending()` and re-invokes `apply_remote` for each overlay's captured `payload` (stored in `PendingOverlay::mutation.payload`). Successful replays clear the overlay via `dequeue_pending`; persistent failures stay queued.
+
+**Server-side dedup contract**: each mutation carries a durable `mutation_id`. Servers MUST treat duplicate `mutation_id`s as idempotent — return the prior result if already applied. This is consistent with the wire contract in RFC 072 (offline sync protocol). Documented in the cookbook (follow-up); not enforced by this RFC.
+
+Network detection: use `pocopine::fetch`'s `FetchError::Network` variant. `SyncError::Network` wraps it.
+
+### 8. Cancellation via SyncEpoch
+
+`QuerySubscription` already holds a `SyncEpoch`. The driver re-checks `epoch.is_current()` after every `.await` point. On stale: return immediately, no further state mutations. `Drop` on the last `QueryHandle` bumps the epoch; the task exits at its next yield.
+
+The `Weak<QuerySubscription<Row>>` upgrade in each tick catches the case where the subscription is dropped while the driver is between awaits — `upgrade().is_none()` → exit.
+
+### 9. Configuration
+
+A new `QueryClientConfig` with sensible defaults:
+
+```rust
+#[derive(Clone, Debug)]
+pub struct QueryClientConfig {
+    /// Base endpoint for /open, /pull, /push. Defaults to
+    /// "/__pocopine/sync/v1". Override for custom routing.
+    pub endpoint: String,
+    /// How often the driver tick polls for /pull when no live wakeup
+    /// fires. Defaults to 30s. Set to None to disable polling (rely
+    /// solely on live wakeup + manual refresh).
+    pub poll_interval: Option<Duration>,
+    /// Disable live wakeup subscription. Defaults to false.
+    pub disable_live: bool,
+    /// Send cookies / credentials with /open + /pull + /push. Defaults to true.
+    pub with_credentials: bool,
+}
+```
+
+`QueryClient::new()` uses defaults; `QueryClient::with_config(cfg)` overrides. Existing tests don't touch config (the defaults work).
+
+### 10. Tests
+
+* **Unit**: driver state machine transitions against a mock `pocopine::fetch::install_middleware`. Cover /open → /pull, schema drift, live wakeup match/mismatch, offline replay.
+* **Integration (host)**: spin up `pocopine-server` with a small `SyncStreamSource` impl, subscribe a `QueryClient`, mutate, verify canonical rows arrive.
+* **Integration (wasm)**: same shape via `wasm-bindgen-test`.
+* **Cancellation**: subscribe, mutate, drop handle, verify driver task exits within one tick.
+* **Offline**: install a mock middleware that returns `FetchError::Network`, verify pending overlay persists; flip middleware to success, verify replay drains pending.
+
+## Alternatives considered
+
+**A. Reuse `pocopine-sync::SyncCollection<C, T>`** instead of building a sync-query-native driver. SyncCollection has all the pieces (open/pull/push/live/replay) but is tightly coupled to the CRUD reactive model (`Handle<C>`, `CollectionSelector<C, T>`, single-state-per-resource). Retrofitting it for sync-query's predicate-routed multi-state model would recreate the architectural tension that drove the crate split. Rejected.
+
+**B. One driver task per stream, not per subscription.** Two subscriptions to the same stream with different params would share a task. Sounds efficient, but params differ → /pull cursors differ → state differs. The task would still need per-subscription cursors and state. Adds complexity for no real savings. Rejected.
+
+**C. Take over `/push` in the driver.** Replace `Mutator::apply_remote` with a built-in HTTP push the driver fires automatically. Simpler `Mutator` API but loses transport flexibility (custom auth headers, batching, alternative endpoints, RPC instead of HTTP). Rejected per the question to the user on the design call.
+
+**D. Public `Runtime` trait** instead of cfg-split spawn. Would let apps plug in actix's runtime, smol, embassy, etc. Adds API surface; existing pocopine crates uniformly use the cfg split. Rejected for consistency.
+
+**E. Per-`(name, params_hash)` live topics from day one.** More efficient bandwidth profile (no client-side filtering). Bigger server change (per-subscription topics in the broker), needs RFC 071 (event spine) updates. Deferred to a v2 follow-up.
+
+## Implementation status
+
+Single PR off `main` on branch `wip/sync-query-driver`:
+
+1. **driver.rs** — driver type, state machine, spawn shim, /open + /pull loop.
+2. **driver.rs (live)** — `LiveWakeup<Row>`, params filtering, `select!` on poll + live.
+3. **driver.rs (offline)** — pending replay on reconnect.
+4. **client.rs** — `QueryClient::observe` spawns driver on first-ref; `Drop` cancels via epoch.
+5. **plugin.rs** — `QueryClientConfig` + `QueryClient::with_config`.
+6. **Tests** — unit + integration.
+
+LOC estimate: ~1100 driver, ~600 tests, ~50 in client.rs/plugin.rs wiring. Total ~1750 LOC.
+
+## Migration / rollout
+
+Additive — no user code changes required. Existing `client.observe(q)` calls keep working; subscriptions now spawn a driver instead of staying inert. Existing tests that don't install a fetch mock middleware will see the driver attempt `/open` and get a network error — those tests need a mock middleware or a test-mode flag.
+
+A new `QueryClient::without_driver()` constructor lets tests opt out of the driver entirely (replaces `QueryClient::new()` for pure routing-engine tests that don't want network plumbing).
+
+## Open questions
+
+1. **Poll interval default.** 30s feels long; 5s feels noisy. Pick based on observed Linear/Slack/Replicache-app patterns; default 30s + document the knob.
+2. **Live wakeup topic naming.** Reuse `pocopine-live`'s existing per-collection topic (`sync:stream:{name}`)? Confirm there's no conflict with CRUD's existing subscriber.
+3. **Driver panic propagation.** If the driver task panics, the subscription stays in a broken state. Should we catch panics and surface them via `state.error = "driver panicked"`? Or let the panic propagate to the runtime?
+
+## Related RFCs
+
+* [RFC 086](./rfc-086-sync-query.md) — `pocopine-sync-query` crate (the routing engine this RFC drives).
+* [RFC 071](./rfc-071-event-spine.md) — live invalidation channel (consumed by item 2).
+* [RFC 072](./rfc-072-offline-sync.md) — offline sync protocol (server-side dedup contract).
+* [RFC 080](./rfc-080-deploy-contract.md) — deploy contract (sync endpoints).


### PR DESCRIPTION
Implements [RFC 087](rfcs/rfc-087-sync-query-driver.md) end-to-end. Closes the largest gap in `pocopine-sync-query` after #146: the routing engine + macro DSL + wire builders shipped, but nothing actually called `/open` or `/pull` — `client.observe(q)` returned a `QueryView` whose `canonical_rows` stayed empty unless the caller manually pushed data through `Mutator::apply_remote`.

This PR makes `observe` actually sync.

## What lands

**Per-subscription background driver** (`crates/pocopine-sync-query/src/driver.rs`, 1283 LOC).

- Lifecycle state machine: Spawning → Opening → Pulling → Idle (↔ Replaying) → Cancelled. Every `.await` boundary is guarded by `epoch.is_current()`.
- Spawn shim is `cfg`-split: `wasm_bindgen_futures::spawn_local` on wasm, `tokio::task::spawn_local` on native (requires a `LocalSet` to be active; documented loudly).
- `/open` handshake captures cursor + schema_version; schema-version drift triggers `state.reset()` + re-`/open`.
- `/pull` results fan out to canonical state via a new `QueryClient::route_canonical_pull` ingest point that doesn't go through the mutation_id dequeue path (driver pulls aren't tied to a client mutation).
- Cancellation: last `QueryHandle::drop` bumps `DriverEpoch`; driver exits at its next yield.

**Live wakeup** (RFC §6).

- Driver subscribes to the per-stream query-tag topic (`sync_stream_tag(stream)`) — same channel `SyncServer::invalidate_stream` publishes to.
- Filters incoming events client-side by the subscription's captured `StreamParams`; matches trigger `/pull`.
- v2 (per-`(name, params_hash)` topics) is a follow-up.

**Offline replay** (RFC §7).

- A `Mutator::apply_remote` that returns `SyncError::Network(...)` leaves the optimistic overlay in `pending`; new \`SyncError::Network\` variant + \`is_transport()\` helper on \`pocopine-sync\` for the network-class detection.
- On the next successful tick, the driver walks the per-stream replay queue and re-fires each entry. Rejected replays roll back across ALL subscriptions on the stream via the new `dequeue_pending_for_stream` (since one mutation fans out to every matching subscription).
- Server-side mutation_id dedup contract documented in the RFC + via tracing on the replay loop.

**Cancellation-safe `mutate`** unchanged from #146; the new driver work composes with the existing `RollbackGuard`.

**`QueryClientConfig`** — endpoint base, poll interval, live-wakeup toggle, credentials. `QueryClient::with_config(cfg)` constructor; existing `QueryClient::new()` uses defaults so existing tests don't touch config.

**Tests** (`crates/pocopine-sync-query/tests/driver.rs`, 485 LOC).

- `/open` → `/pull` populates canonical via a mock fetch middleware (host) inside a `tokio::task::LocalSet`.
- Schema-drift reset on subsequent `/open` with a different schema_version.
- Cancellation: drop handle, verify driver exits at next yield, no further state writes.
- `QueryClient::without_driver()` constructor for routing-only tests.
- Plus per-subsystem unit tests in `driver.rs` (epoch snapshot semantics, live-event filter logic).

## Codex review

Codex review surfaced four findings; all four were fixed in commit `a8f7e189` (the head of this branch):

- **[P1] Tight loop on wasm `LiveClient::open()` failure** — closed-receiver-still-Some made `select!` busy-loop on `/pull`, ignoring the configured poll interval. Now an open failure returns `receiver: None`, making `next_matching` block forever; the timer arm fires cleanly.
- **[P2] Wrong live-wakeup topic** — subscribed to a collection name; server publishes to the query-tag topic. Now uses `sync_stream_tag(stream)`.
- **[P2] Rejected-replay rollback was per-driver** — one mutation can be in multiple subscriptions' pending queues; only the driver-local one was cleaned. Now cleans across every matching subscription on the stream.
- **[P2] `with_credentials` knob was a no-op** — wired to `LiveClient.with_credentials(...)`; HTTP-path scoping documented in the field's doc comment.

## Files touched

| File | Δ |
| --- | --- |
| `rfcs/rfc-087-sync-query-driver.md` (new) | +327 |
| `crates/pocopine-sync-query/src/driver.rs` (new) | +1283 |
| `crates/pocopine-sync-query/tests/driver.rs` (new) | +485 |
| `crates/pocopine-sync-query/src/client.rs` | +526 / -19 |
| `crates/pocopine-sync-query/src/plugin.rs` | +26 / -1 |
| `crates/pocopine-sync-query/src/lib.rs` | +5 |
| `crates/pocopine-sync-query/Cargo.toml` | +26 / -1 |
| `crates/pocopine-sync-query-macros/tests/routing.rs` | +24 / -1 |
| `crates/pocopine-sync-query/src/query.rs` | +1 / -1 |
| `crates/pocopine-sync/src/error.rs` | +29 |
| `crates/pocopine-sync/src/server.rs` | +13 |
| `Cargo.lock` | +5 |

**Total: +2750 / -22 across 12 files.**

## Gates

- `cargo fmt --all -- --check` ✅
- 91 tests pass (`pocopine-sync-query` + `pocopine-sync-query-macros`)
- Host clippy `-D warnings` ✅
- wasm32 clippy `-D warnings` ✅

## What's NOT in this PR (per RFC §"Non-goals")

- Durable persistence across page reloads. In-memory only. Follow-up against the `SyncLocalStore` interface used by `pocopine-sync`.
- Per-`(name, params_hash)` live topics. Server publishes per-collection (per-stream-tag); client filters by params. v2 perf opt.
- `#[query]` selector composition (Layer 2). Separate RFC.
- CRUD-Source → QuerySource adapter. Filed as follow-up.

## Out-of-band

The agent that drafted the bulk of this PR also added a `SyncError::Network` variant + `is_transport()` helper to `pocopine-sync` so the driver can identify retry-on-reconnect errors without parsing message strings. Small additive change; no breaking impact on `pocopine-sync-crud` (which doesn't construct or match `SyncError::Network` today).