### PR TITLE
RFC 088 §A: sync-query durable persistence

### DIFF
--- a/crates/pocopine-sync-query/src/client.rs
+++ b/crates/pocopine-sync-query/src/client.rs
@@ -296,16 +296,21 @@ pub(crate) struct QueryClientInner {
     /// dequeues the whole batch on each tick and re-inserts
     /// entries that are still offline.
     pub(crate) replay_queue: RefCell<VecDeque<ReplayEntry>>,
-    /// Registered `Mutator` impls, keyed by `Mutator::NAME` (the
-    /// scoping by `STREAM` happens at lookup time). Used by the
-    /// driver's Phase 0 hydrate path to replay persisted
-    /// `ClientMutation<Value>` payloads against the matching
-    /// `Mutator::apply_remote`.
+    /// Registered `Mutator` impls, keyed by
+    /// `(Mutator::STREAM, Mutator::NAME)` so two streams sharing a
+    /// common mutator name (e.g. `"create"`) don't overwrite each
+    /// other. Used by the driver's Phase 0 hydrate path to replay
+    /// persisted `ClientMutation<Value>` payloads against the
+    /// matching `Mutator::apply_remote`.
     ///
     /// Apps that don't enable persistence never touch this map.
     /// Mutators register via [`QueryClient::register_mutator`].
-    pub(crate) mutators: RefCell<HashMap<&'static str, Rc<dyn AnyMutator>>>,
+    pub(crate) mutators: RefCell<MutatorRegistry>,
 }
+
+/// Type alias for the mutator registry — `clippy::type_complexity`
+/// silenced by extraction.
+type MutatorRegistry = HashMap<(&'static str, &'static str), Rc<dyn AnyMutator>>;
 
 pub struct QueryClient {
     inner: Rc<QueryClientInner>,
@@ -541,6 +546,19 @@ impl QueryClient {
             &local_changes,
         );
 
+        // Arm a cancellation guard BEFORE the persist .await so a
+        // future dropped mid-persist still rolls back the optimistic
+        // overlay. Without this, IndexedDB / SQLite yields inside
+        // persist_pending_mutation could leave a pending overlay
+        // alive across cancellation even though apply_remote never
+        // ran.
+        let guard: RollbackGuard<'_, M::Row> = RollbackGuard {
+            client: Some(self),
+            stream: stream.clone(),
+            mutation_id: mutation_id.clone(),
+            _row: std::marker::PhantomData,
+        };
+
         // Persist the pending mutation immediately (RFC 088 §A.5)
         // so a reload BEFORE the server response can still replay
         // the mutation on the next online tick. We wrap the
@@ -556,20 +574,6 @@ impl QueryClient {
             &local_changes,
         )
         .await;
-
-        // Arm a cancellation guard. If the mutate future is dropped
-        // BEFORE we explicitly disarm it (success or handled err
-        // path), the guard's Drop rolls back the optimistic overlay
-        // — without this, futures dropped via `tokio::select!`,
-        // task abort, or any other early-cancel path leave the
-        // optimistic overlay alive in the subscription's pending
-        // queue forever, rendering a row the server never received.
-        let guard: RollbackGuard<'_, M::Row> = RollbackGuard {
-            client: Some(self),
-            stream: stream.clone(),
-            mutation_id: mutation_id.clone(),
-            _row: std::marker::PhantomData,
-        };
 
         // Capture the original push URL + mutation_id so an
         // offline replay can rebuild a `MutatorRemoteContext`
@@ -621,7 +625,76 @@ impl QueryClient {
         // via `state.remove_pending`).
         guard.disarm();
 
+        // Clear the durable pending entry from every compartment
+        // we wrote it into. Without this, an accepted mutation
+        // would persist forever and re-fire on every subsequent
+        // reload (the server's mutation_id dedup would no-op the
+        // replay, but the overlay would still bounce through the
+        // pending state machine every session — wasted bandwidth +
+        // confusing UX).
+        self.clear_persisted_pending::<M::Row>(&stream, &mutation_id)
+            .await;
+
         Ok(crate::MutationOutcome::Accepted(canonical_changes))
+    }
+
+    /// Clear a durable pending mutation across every compartment
+    /// of `stream` after the canonical reconcile confirmed it.
+    /// Uses `mark_push_result` (which the store contract guarantees
+    /// removes accepted ids from the pending queue) so the
+    /// implementation works against every `SyncLocalStore` impl
+    /// without depending on a future purge-by-id primitive.
+    async fn clear_persisted_pending<Row>(&self, stream: &SyncStreamName, mutation_id: &MutationId)
+    where
+        Row: 'static,
+    {
+        let Some(config) = self.inner.config.as_ref() else {
+            return;
+        };
+        let Some(store) = config.local_store.clone() else {
+            return;
+        };
+        // Walk every compartment we may have written into:
+        // each currently-active subscription's compartment plus
+        // the bare-stream fallback. We over-clear (some
+        // compartments may not contain the entry) — that's safe:
+        // `mark_push_result` is a no-op for a missing id.
+        let mut compartments: std::collections::BTreeSet<SyncStreamName> =
+            std::collections::BTreeSet::new();
+        for typed in self.collect_subscriptions_on_stream::<Row>(stream) {
+            compartments.insert(pocopine_sync::local_stream_key(
+                stream,
+                typed.query.params(),
+            ));
+        }
+        compartments.insert(stream.clone());
+        for compartment in compartments {
+            let mut result = pocopine_sync::LocalPushResult {
+                stream: compartment.clone(),
+                collection: None,
+                accepted: vec![mutation_id.clone()],
+                rejected: Vec::new(),
+                rows: Vec::new(),
+                conflicts: Vec::new(),
+                cursor: None,
+            };
+            // Some stores expect a collection on every result.
+            // MemoryLocalStore tolerates None — the SQLite +
+            // IndexedDB impls also handle it (collection is
+            // informational on the local store). Leave it None
+            // so we don't fabricate a name.
+            let _ = &mut result;
+            if let Err(err) = store.mark_push_result(result).await {
+                tracing::warn!(
+                    target: "pocopine.log",
+                    stream = compartment.as_str(),
+                    mutation_id = %mutation_id,
+                    error = %err,
+                    "sync-query: mark_push_result on accepted mutation failed; \
+                     the entry may replay on next hydrate (server dedup will no-op)"
+                );
+            }
+        }
     }
 
     /// Persist a freshly-created pending mutation to the durable
@@ -1132,7 +1205,10 @@ impl QueryClient {
         M::Row: Clone + serde::Serialize + 'static,
     {
         let entry: Rc<dyn AnyMutator> = Rc::new(MutatorEntry::<M>::new());
-        self.inner.mutators.borrow_mut().insert(M::NAME, entry);
+        self.inner
+            .mutators
+            .borrow_mut()
+            .insert((M::STREAM, M::NAME), entry);
     }
 
     /// Driver-only: enqueue hydrated pending mutations for replay
@@ -1201,11 +1277,17 @@ impl QueryClient {
                             return ReplayOutcome::Rejected;
                         }
                     };
+                    // Lookup by (stream, NAME) so two streams that
+                    // register a common mutator name like `create`
+                    // don't overwrite each other (codex P1).
                     let entry = client_inner
                         .mutators
                         .borrow()
-                        .get(mutator_name.as_str())
-                        .cloned();
+                        .iter()
+                        .find(|((entry_stream, entry_name), _)| {
+                            *entry_stream == stream.as_str() && *entry_name == mutator_name.as_str()
+                        })
+                        .map(|(_, e)| e.clone());
                     let Some(entry) = entry else {
                         tracing::warn!(
                             target: "pocopine.log",
@@ -1216,16 +1298,6 @@ impl QueryClient {
                         );
                         return ReplayOutcome::Rejected;
                     };
-                    if entry.stream() != stream.as_str() {
-                        tracing::warn!(
-                            target: "pocopine.log",
-                            stream = stream.as_str(),
-                            mutator_name = %mutator_name,
-                            registered_stream = entry.stream(),
-                            "sync-query: registered Mutator stream mismatch; dropping"
-                        );
-                        return ReplayOutcome::Rejected;
-                    }
                     let outcome = entry
                         .replay_hydrated(client, stream.clone(), mutation.clone(), push_url)
                         .await;
@@ -1352,6 +1424,22 @@ pub(crate) fn route_canonical_changes_from_replay<Row>(
     Row: Clone + serde::Serialize + 'static,
 {
     client.route_canonical_changes::<Row>(stream, mutation_id, canonical);
+}
+
+/// Crate-internal route used by [`AnyMutator::replay_hydrated`] on
+/// the Rejected path to clean up the pending overlay using the
+/// MUTATOR'S row type (rather than the draining driver's row
+/// type). Without this, a hydrated rejection routed through a
+/// driver of a different row type would skip the matching
+/// subscriptions and leak stale optimistic state.
+pub(crate) fn dequeue_pending_for_mutator_row<Row>(
+    client: &QueryClient,
+    stream: &SyncStreamName,
+    mutation_id: &MutationId,
+) where
+    Row: Clone + 'static,
+{
+    QueryClient::dequeue_pending_for_stream::<Row>(&client.inner, stream, mutation_id);
 }
 
 /// Free-function variant of `collect_subscriptions_on_stream` that

--- a/crates/pocopine-sync-query/src/client.rs
+++ b/crates/pocopine-sync-query/src/client.rs
@@ -672,23 +672,21 @@ impl QueryClient {
         // Multiple changes may match — capture the first Upsert
         // (Delete-only mutations leave optimistic_row None, matching
         // the in-memory PendingOverlay shape).
-        let optimistic_row = local_changes
-            .iter()
-            .find_map(|change| match change {
-                RowChange::Upsert(row) => {
-                    let value = serde_json::to_value(row).ok()?;
-                    let id = value.get("id").and_then(|v| v.as_str())?.to_string();
-                    let key = RowKey::new(id).ok()?;
-                    Some(SyncRow {
-                        key,
-                        version: None,
-                        value,
-                        pending: true,
-                        conflict: false,
-                    })
-                }
-                RowChange::Delete(_) => None,
-            });
+        let optimistic_row = local_changes.iter().find_map(|change| match change {
+            RowChange::Upsert(row) => {
+                let value = serde_json::to_value(row).ok()?;
+                let id = value.get("id").and_then(|v| v.as_str())?.to_string();
+                let key = RowKey::new(id).ok()?;
+                Some(SyncRow {
+                    key,
+                    version: None,
+                    value,
+                    pending: true,
+                    conflict: false,
+                })
+            }
+            RowChange::Delete(_) => None,
+        });
         // Walk every subscription on the stream that received the
         // optimistic upsert (or delete) and persist into its
         // compartment. The routing engine already gated visibility
@@ -698,10 +696,15 @@ impl QueryClient {
             std::collections::BTreeSet::new();
         for typed in self.collect_subscriptions_on_stream::<M::Row>(stream) {
             let state = typed.state.borrow();
-            let has_overlay = state.pending().iter().any(|o| &o.mutation_id == mutation_id);
+            let has_overlay = state
+                .pending()
+                .iter()
+                .any(|o| &o.mutation_id == mutation_id);
             if has_overlay {
-                compartments
-                    .insert(pocopine_sync::local_stream_key(stream, typed.query.params()));
+                compartments.insert(pocopine_sync::local_stream_key(
+                    stream,
+                    typed.query.params(),
+                ));
             }
         }
         if compartments.is_empty() {
@@ -729,7 +732,6 @@ impl QueryClient {
             }
         }
     }
-
 
     /// Drop a pending overlay across every matching subscription.
     /// Used to roll back optimistic state when the server push fails.
@@ -1130,10 +1132,7 @@ impl QueryClient {
         M::Row: Clone + serde::Serialize + 'static,
     {
         let entry: Rc<dyn AnyMutator> = Rc::new(MutatorEntry::<M>::new());
-        self.inner
-            .mutators
-            .borrow_mut()
-            .insert(M::NAME, entry);
+        self.inner.mutators.borrow_mut().insert(M::NAME, entry);
     }
 
     /// Driver-only: enqueue hydrated pending mutations for replay
@@ -1183,24 +1182,25 @@ impl QueryClient {
                     // — in that case we have no NAME and must
                     // reject (the registered NAME -> AnyMutator
                     // map is the only resolution path).
-                    let mutator_name =
-                        match crate::mutator::unwrap_persisted_payload(&mutation.payload) {
-                            Some((name, _)) => name,
-                            None => {
-                                tracing::warn!(
-                                    target: "pocopine.log",
-                                    stream = stream.as_str(),
-                                    mutation_id = %mutation.id,
-                                    "sync-query: hydrated mutation missing mutator name envelope; dropping"
-                                );
-                                Self::dequeue_pending_for_stream::<()>(
-                                    &client_inner,
-                                    &stream,
-                                    &mutation.id,
-                                );
-                                return ReplayOutcome::Rejected;
-                            }
-                        };
+                    let mutator_name = match crate::mutator::unwrap_persisted_payload(
+                        &mutation.payload,
+                    ) {
+                        Some((name, _)) => name,
+                        None => {
+                            tracing::warn!(
+                                target: "pocopine.log",
+                                stream = stream.as_str(),
+                                mutation_id = %mutation.id,
+                                "sync-query: hydrated mutation missing mutator name envelope; dropping"
+                            );
+                            Self::dequeue_pending_for_stream::<()>(
+                                &client_inner,
+                                &stream,
+                                &mutation.id,
+                            );
+                            return ReplayOutcome::Rejected;
+                        }
+                    };
                     let entry = client_inner
                         .mutators
                         .borrow()

--- a/crates/pocopine-sync-query/src/client.rs
+++ b/crates/pocopine-sync-query/src/client.rs
@@ -26,7 +26,9 @@ use crate::driver::{
     spawn_driver, DriverEpoch, DriverHandle, QueryClientConfig, ReplayEntry, ReplayOutcome,
     SubscriptionDriver,
 };
-use crate::mutator::RowChange;
+use crate::mutator::{
+    wrap_persisted_payload, AnyMutator, HydrateReplayOutcome, MutatorEntry, RowChange,
+};
 use crate::query::{MatchFn, Order, Query, QueryKey};
 use crate::state::{PendingOverlay, QueryState};
 
@@ -294,6 +296,15 @@ pub(crate) struct QueryClientInner {
     /// dequeues the whole batch on each tick and re-inserts
     /// entries that are still offline.
     pub(crate) replay_queue: RefCell<VecDeque<ReplayEntry>>,
+    /// Registered `Mutator` impls, keyed by `Mutator::NAME` (the
+    /// scoping by `STREAM` happens at lookup time). Used by the
+    /// driver's Phase 0 hydrate path to replay persisted
+    /// `ClientMutation<Value>` payloads against the matching
+    /// `Mutator::apply_remote`.
+    ///
+    /// Apps that don't enable persistence never touch this map.
+    /// Mutators register via [`QueryClient::register_mutator`].
+    pub(crate) mutators: RefCell<HashMap<&'static str, Rc<dyn AnyMutator>>>,
 }
 
 pub struct QueryClient {
@@ -342,6 +353,7 @@ impl QueryClient {
                 config: Some(config),
                 registry: RefCell::new(HashMap::new()),
                 replay_queue: RefCell::new(VecDeque::new()),
+                mutators: RefCell::new(HashMap::new()),
             }),
         }
     }
@@ -359,6 +371,7 @@ impl QueryClient {
                 config: None,
                 registry: RefCell::new(HashMap::new()),
                 replay_queue: RefCell::new(VecDeque::new()),
+                mutators: RefCell::new(HashMap::new()),
             }),
         }
     }
@@ -519,7 +532,7 @@ impl QueryClient {
             pocopine_sync::SyncOp::Upsert
         };
         let wire_mutation =
-            pocopine_sync::ClientMutation::new(mutation_id.clone(), wire_op, payload_value);
+            pocopine_sync::ClientMutation::new(mutation_id.clone(), wire_op, payload_value.clone());
 
         self.route_optimistic_changes::<M::Row>(
             &stream,
@@ -527,6 +540,22 @@ impl QueryClient {
             &wire_mutation,
             &local_changes,
         );
+
+        // Persist the pending mutation immediately (RFC 088 §A.5)
+        // so a reload BEFORE the server response can still replay
+        // the mutation on the next online tick. We wrap the
+        // payload in the `{__mutator, __payload}` envelope so the
+        // hydrate path can pick the right Mutator impl by NAME.
+        // The on-wire mutation (sent to the server below) carries
+        // the BARE payload — the envelope is store-only.
+        self.persist_pending_mutation::<M>(
+            &stream,
+            &mutation_id,
+            wire_op,
+            &payload_value,
+            &local_changes,
+        )
+        .await;
 
         // Arm a cancellation guard. If the mutate future is dropped
         // BEFORE we explicitly disarm it (success or handled err
@@ -594,6 +623,113 @@ impl QueryClient {
 
         Ok(crate::MutationOutcome::Accepted(canonical_changes))
     }
+
+    /// Persist a freshly-created pending mutation to the durable
+    /// local store (RFC 088 §A.5). Wraps the wire payload in a
+    /// `{__mutator, __payload}` envelope so the hydrate path can
+    /// pick the right `Mutator` impl by NAME without bloating the
+    /// wire `ClientMutation` shape.
+    ///
+    /// **Compartment fan-out.** A single mutation can affect
+    /// multiple subscriptions on the same stream that filter on
+    /// different params (e.g. two `Issue::query()` views over
+    /// different `workspace_id`s — one mutation creates an issue
+    /// that matches workspace A's predicate). To make Phase 0
+    /// hydrate restore the same fan-out, we persist the pending
+    /// envelope INTO EACH affected subscription's compartment
+    /// AND into the bare-stream compartment as a fallback for
+    /// subscriptions that no longer have an open view at mutate
+    /// time but might reopen later.
+    ///
+    /// No-op when the client has no `local_store` configured —
+    /// matches the in-memory-only behavior of the historical
+    /// surface.
+    async fn persist_pending_mutation<M>(
+        &self,
+        stream: &SyncStreamName,
+        mutation_id: &MutationId,
+        wire_op: pocopine_sync::SyncOp,
+        payload_value: &Value,
+        local_changes: &[RowChange<M::Row>],
+    ) where
+        M: crate::Mutator,
+        M::Row: Clone + serde::Serialize + 'static,
+    {
+        let Some(config) = self.inner.config.as_ref() else {
+            return;
+        };
+        let Some(store) = config.local_store.clone() else {
+            return;
+        };
+        // Build the persistence-only `ClientMutation<Value>` that
+        // carries the mutator NAME envelope. The on-the-wire
+        // mutation already routed through `route_optimistic_changes`
+        // is unaffected (it carries the bare payload for the
+        // server).
+        let envelope = wrap_persisted_payload(M::NAME, payload_value.clone());
+        let persisted = ClientMutation::new(mutation_id.clone(), wire_op, envelope);
+        // Try to find the optimistic row to capture for restore.
+        // Multiple changes may match — capture the first Upsert
+        // (Delete-only mutations leave optimistic_row None, matching
+        // the in-memory PendingOverlay shape).
+        let optimistic_row = local_changes
+            .iter()
+            .find_map(|change| match change {
+                RowChange::Upsert(row) => {
+                    let value = serde_json::to_value(row).ok()?;
+                    let id = value.get("id").and_then(|v| v.as_str())?.to_string();
+                    let key = RowKey::new(id).ok()?;
+                    Some(SyncRow {
+                        key,
+                        version: None,
+                        value,
+                        pending: true,
+                        conflict: false,
+                    })
+                }
+                RowChange::Delete(_) => None,
+            });
+        // Walk every subscription on the stream that received the
+        // optimistic upsert (or delete) and persist into its
+        // compartment. The routing engine already gated visibility
+        // by predicate; we mirror the same gate by checking
+        // `state.pending()` for a matching mutation_id.
+        let mut compartments: std::collections::BTreeSet<SyncStreamName> =
+            std::collections::BTreeSet::new();
+        for typed in self.collect_subscriptions_on_stream::<M::Row>(stream) {
+            let state = typed.state.borrow();
+            let has_overlay = state.pending().iter().any(|o| &o.mutation_id == mutation_id);
+            if has_overlay {
+                compartments
+                    .insert(pocopine_sync::local_stream_key(stream, typed.query.params()));
+            }
+        }
+        if compartments.is_empty() {
+            // No subscription matched. Persist into the bare-stream
+            // compartment as a fallback so a subscription opened
+            // AFTER the page reloads still picks up the queue.
+            // This matches the routing engine's invariant: a
+            // mutation produced canonical changes that the server
+            // will accept; on hydrate the bare compartment is
+            // consulted by every newly-opened subscription via the
+            // bare-fallback path documented on `enqueue_hydrated_pending`.
+            compartments.insert(stream.clone());
+        }
+        for compartment in compartments {
+            let pending = pocopine_sync::LocalPendingMutation::new(persisted.clone())
+                .with_optimistic_row(optimistic_row.clone());
+            if let Err(err) = store.enqueue_pending_mutation(&compartment, pending).await {
+                tracing::warn!(
+                    target: "pocopine.log",
+                    stream = compartment.as_str(),
+                    mutation_id = %mutation_id,
+                    error = %err,
+                    "sync-query: enqueue_pending_mutation failed; reload will not replay this mutation"
+                );
+            }
+        }
+    }
+
 
     /// Drop a pending overlay across every matching subscription.
     /// Used to roll back optimistic state when the server push fails.
@@ -979,6 +1115,143 @@ impl QueryClient {
         q.drain(..).collect()
     }
 
+    /// Register a [`crate::Mutator`] impl so the hydrate path can
+    /// recover its replay closure. Idempotent — re-registering the
+    /// same `Mutator::NAME` replaces the prior entry (last-write-wins;
+    /// the lookup keys on `Mutator::NAME`, not `TypeId`, because two
+    /// runs of the same mutator type in different code paths must
+    /// still resolve to one entry).
+    ///
+    /// Mutators should self-register at construction time — see
+    /// `examples/sync-query/src/lib.rs` for the cookbook shape.
+    pub fn register_mutator<M>(&self)
+    where
+        M: crate::Mutator,
+        M::Row: Clone + serde::Serialize + 'static,
+    {
+        let entry: Rc<dyn AnyMutator> = Rc::new(MutatorEntry::<M>::new());
+        self.inner
+            .mutators
+            .borrow_mut()
+            .insert(M::NAME, entry);
+    }
+
+    /// Driver-only: enqueue hydrated pending mutations for replay
+    /// through the registered [`AnyMutator`] entries. Called from
+    /// [`SubscriptionDriver::apply_hydrated_snapshot`] AFTER the
+    /// in-memory `PendingOverlay`s are pushed onto the
+    /// subscription — so a fresh observer sees the optimistic
+    /// rows immediately, then the replay tick either confirms
+    /// them via canonical reconcile or rolls them back via
+    /// `dequeue_pending_for_stream`.
+    pub(crate) fn enqueue_hydrated_pending(
+        inner: &Rc<QueryClientInner>,
+        stream: SyncStreamName,
+        mutations: Vec<ClientMutation<Value>>,
+    ) {
+        if mutations.is_empty() {
+            return;
+        }
+        let endpoint = inner.endpoint.clone();
+        // Snapshot the registered mutator map. Resolving via NAME
+        // happens lazily inside the replay closure so a mutator
+        // registered AFTER hydrate still fires (the driver-side
+        // hydrate phase runs once per spawn).
+        let weak_inner = Rc::downgrade(inner);
+        for mutation in mutations {
+            let stream_clone = stream.clone();
+            let push_url = build_push_url(&endpoint);
+            let weak_inner_clone = weak_inner.clone();
+            let mutation_for_closure = mutation.clone();
+            let mutation_id_for_entry = mutation_id_from_value(&mutation);
+            let replay: crate::driver::ReplayFuture = Box::new(move |client: &QueryClient| {
+                let stream = stream_clone.clone();
+                let mutation = mutation_for_closure.clone();
+                let push_url = push_url.clone();
+                let weak_inner = weak_inner_clone.clone();
+                Box::pin(async move {
+                    let Some(client_inner) = weak_inner.upgrade() else {
+                        // Client gone; report as Rejected so the
+                        // replay queue drops the entry instead of
+                        // re-queueing.
+                        return ReplayOutcome::Rejected;
+                    };
+                    // Recover the mutator NAME from the persisted
+                    // envelope so we can pick the right Mutator
+                    // impl. Falls back to the raw payload when the
+                    // entry was written before the envelope landed
+                    // — in that case we have no NAME and must
+                    // reject (the registered NAME -> AnyMutator
+                    // map is the only resolution path).
+                    let mutator_name =
+                        match crate::mutator::unwrap_persisted_payload(&mutation.payload) {
+                            Some((name, _)) => name,
+                            None => {
+                                tracing::warn!(
+                                    target: "pocopine.log",
+                                    stream = stream.as_str(),
+                                    mutation_id = %mutation.id,
+                                    "sync-query: hydrated mutation missing mutator name envelope; dropping"
+                                );
+                                Self::dequeue_pending_for_stream::<()>(
+                                    &client_inner,
+                                    &stream,
+                                    &mutation.id,
+                                );
+                                return ReplayOutcome::Rejected;
+                            }
+                        };
+                    let entry = client_inner
+                        .mutators
+                        .borrow()
+                        .get(mutator_name.as_str())
+                        .cloned();
+                    let Some(entry) = entry else {
+                        tracing::warn!(
+                            target: "pocopine.log",
+                            stream = stream.as_str(),
+                            mutator_name = %mutator_name,
+                            mutation_id = %mutation.id,
+                            "sync-query: no Mutator registered for hydrated pending; dropping"
+                        );
+                        return ReplayOutcome::Rejected;
+                    };
+                    if entry.stream() != stream.as_str() {
+                        tracing::warn!(
+                            target: "pocopine.log",
+                            stream = stream.as_str(),
+                            mutator_name = %mutator_name,
+                            registered_stream = entry.stream(),
+                            "sync-query: registered Mutator stream mismatch; dropping"
+                        );
+                        return ReplayOutcome::Rejected;
+                    }
+                    let outcome = entry
+                        .replay_hydrated(client, stream.clone(), mutation.clone(), push_url)
+                        .await;
+                    match outcome {
+                        HydrateReplayOutcome::Accepted => ReplayOutcome::Accepted,
+                        HydrateReplayOutcome::StillOffline => ReplayOutcome::StillOffline,
+                        HydrateReplayOutcome::Rejected(reason) => {
+                            tracing::warn!(
+                                target: "pocopine.log",
+                                stream = stream.as_str(),
+                                error = %reason,
+                                "sync-query: hydrated replay rejected; rolling back overlay"
+                            );
+                            ReplayOutcome::Rejected
+                        }
+                    }
+                })
+            });
+            inner.replay_queue.borrow_mut().push_back(ReplayEntry {
+                stream: stream.clone(),
+                mutation_id: mutation_id_for_entry,
+                replay,
+            });
+        }
+    }
+
     /// Driver-only: push a replay entry back on the queue (the
     /// caller's replay attempt observed `StillOffline`).
     pub(crate) fn reinsert_replay_entry(inner: &Rc<QueryClientInner>, entry: ReplayEntry) {
@@ -1040,6 +1313,45 @@ impl QueryClient {
     ) -> Vec<Rc<QuerySubscription<Row>>> {
         collect_subscriptions_on_stream_inner(&self.inner, stream)
     }
+}
+
+/// Resolve the push URL for a given configured endpoint prefix.
+/// Mirrors `build_url` in `driver.rs` but for the push path —
+/// kept short since the replay path needs it.
+fn build_push_url(endpoint: &str) -> String {
+    let trimmed = endpoint.trim_end_matches('/');
+    if trimmed.is_empty() {
+        pocopine_sync::SYNC_PUSH_PATH.to_string()
+    } else if let Some(suffix) =
+        pocopine_sync::SYNC_PUSH_PATH.strip_prefix(pocopine_sync::SYNC_ENDPOINT_PREFIX)
+    {
+        format!("{trimmed}{suffix}")
+    } else {
+        pocopine_sync::SYNC_PUSH_PATH.to_string()
+    }
+}
+
+/// Extract the mutation_id from a wire `ClientMutation`.
+/// Helper kept inline for clarity — the wire shape has the id
+/// directly on the envelope.
+fn mutation_id_from_value(mutation: &ClientMutation<Value>) -> MutationId {
+    mutation.id.clone()
+}
+
+/// Crate-internal route used by [`AnyMutator::replay_hydrated`] to
+/// reconcile canonical changes through the same path as a successful
+/// `mutate()` call. Necessary because the trait can't reach the
+/// `pub(crate) route_canonical_changes` directly without re-exposing
+/// the registry borrow path.
+pub(crate) fn route_canonical_changes_from_replay<Row>(
+    client: &QueryClient,
+    stream: &SyncStreamName,
+    mutation_id: &MutationId,
+    canonical: &[crate::mutator::RowChange<Row>],
+) where
+    Row: Clone + serde::Serialize + 'static,
+{
+    client.route_canonical_changes::<Row>(stream, mutation_id, canonical);
 }
 
 /// Free-function variant of `collect_subscriptions_on_stream` that

--- a/crates/pocopine-sync-query/src/driver.rs
+++ b/crates/pocopine-sync-query/src/driver.rs
@@ -45,8 +45,10 @@ use std::rc::{Rc, Weak};
 use std::time::Duration;
 
 use pocopine_sync::{
-    SyncCursor, SyncOpenRequest, SyncOpenResponse, SyncOpenStream, SyncPullMode, SyncPullRequest,
-    SyncPullResponse, SyncReason, SyncStreamName, SYNC_OPEN_PATH, SYNC_PULL_PATH,
+    local_stream_key, LocalPendingMutation, LocalSnapshotBatch, LocalStreamSnapshot,
+    SyncCollectionName, SyncCursor, SyncLocalStore, SyncOpenRequest, SyncOpenResponse,
+    SyncOpenStream, SyncPullMode, SyncPullRequest, SyncPullResponse, SyncReason, SyncRow,
+    SyncStreamName, SYNC_OPEN_PATH, SYNC_PULL_PATH,
 };
 use serde::de::DeserializeOwned;
 use serde::Serialize;
@@ -54,6 +56,7 @@ use serde_json::Value;
 
 use crate::client::{QueryClient, QueryClientInner, QuerySubscription};
 use crate::mutator::RowChange;
+use crate::state::PendingOverlay;
 use crate::wire::{build_open_request, build_pull_request};
 
 /// Default sync endpoint prefix. Re-exported from `pocopine-sync`
@@ -69,7 +72,7 @@ pub const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Tunable knobs for a [`QueryClient`]. See per-field docs for the
 /// individual defaults.
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct QueryClientConfig {
     /// Base endpoint for `/open`, `/pull`, `/push`. Defaults to
     /// [`DEFAULT_SYNC_ENDPOINT`]. Override for tests against a
@@ -96,6 +99,22 @@ pub struct QueryClientConfig {
     /// middleware (per RFC 078). A future RFC may unify the two,
     /// at which point this flag would govern both.
     pub with_credentials: bool,
+    /// Durable local store. `None` means in-memory only (the
+    /// historical default; no migration burden).
+    ///
+    /// When set, every spawned [`SubscriptionDriver`] hydrates from
+    /// the store BEFORE the first `/open` (RFC 088 §A.3 Phase 0),
+    /// persists snapshots after every successful `/pull`, and
+    /// replays persisted pending mutations through the registered
+    /// [`crate::mutator::AnyMutator`] entries.
+    ///
+    /// Stored as `Rc<dyn SyncLocalStore>` so the same store handle
+    /// can be threaded into CRUD + sync-query clients in the same
+    /// app — the two compartments don't collide because
+    /// sync-query keys on
+    /// [`pocopine_sync::local_stream_key`]`(stream, params)` while
+    /// CRUD keys on the bare stream name.
+    pub local_store: Option<Rc<dyn SyncLocalStore>>,
 }
 
 impl Default for QueryClientConfig {
@@ -105,7 +124,29 @@ impl Default for QueryClientConfig {
             poll_interval: Some(DEFAULT_POLL_INTERVAL),
             disable_live: false,
             with_credentials: true,
+            local_store: None,
         }
+    }
+}
+
+impl std::fmt::Debug for QueryClientConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("QueryClientConfig")
+            .field("endpoint", &self.endpoint)
+            .field("poll_interval", &self.poll_interval)
+            .field("disable_live", &self.disable_live)
+            .field("with_credentials", &self.with_credentials)
+            .field("local_store", &self.local_store.as_ref().map(|_| "<store>"))
+            .finish()
+    }
+}
+
+impl QueryClientConfig {
+    /// Builder: attach a durable [`SyncLocalStore`]. See the field
+    /// doc on [`Self::local_store`] for the persistence semantics.
+    pub fn with_local_store(mut self, store: Rc<dyn SyncLocalStore>) -> Self {
+        self.local_store = Some(store);
+        self
     }
 }
 
@@ -227,6 +268,11 @@ pub(crate) struct SubscriptionDriver<Row: 'static> {
     /// limitation.
     #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
     with_credentials: bool,
+    /// Durable local store hooked into Phase 0 hydrate + post-pull
+    /// persist + schema-drift wipe. `None` keeps the driver
+    /// in-memory-only — every store call site short-circuits and
+    /// the driver behaves identically to the pre-RFC-088 shape.
+    local_store: Option<Rc<dyn SyncLocalStore>>,
 }
 
 impl<Row> SubscriptionDriver<Row>
@@ -248,11 +294,28 @@ where
             poll_interval: config.poll_interval,
             disable_live: config.disable_live,
             with_credentials: config.with_credentials,
+            local_store: config.local_store.clone(),
         }
     }
 
     /// Drive the subscription forever (or until cancelled).
     pub(crate) async fn run(self) {
+        // ── Phase 0: hydrate from durable store (RFC 088 §A.3) ──
+        //
+        // Runs INSIDE the driver task (not as a separate spawn) so
+        // it shares the same cancellation semantics as the
+        // /open/pull phases. Populates canonical_rows + pending
+        // overlays + cursor + application_schema_version on the
+        // subscription's state so observers see cached rows on
+        // first read — before /open even fires. The schema-drift
+        // gate in apply_open will wipe the in-memory state if
+        // /open advertises a fresh version; until that lands, the
+        // hydrated rows are shown.
+        self.hydrate_phase().await;
+        if !self.epoch.is_current() {
+            return;
+        }
+
         // ── Phase 1: /open ──────────────────────────────────────
         //
         // Sets `loading = true` synchronously BEFORE the await so a
@@ -277,9 +340,11 @@ where
         if !self.epoch.is_current() {
             return;
         }
-        if let Err(()) = self.apply_open(open_response) {
+        if let Err(()) = self.apply_open(open_response).await {
             // Schema-drift path bumped state.version; nothing more
-            // to do here, the next /pull rebuilds the rows.
+            // to do here, the next /pull rebuilds the rows. The
+            // durable wipe (clear_stream) was awaited inside
+            // apply_open so it's already on disk.
         }
 
         // ── Phase 2: initial /pull ──────────────────────────────
@@ -298,6 +363,13 @@ where
             return;
         }
         self.apply_pull(pull_response);
+        if !self.epoch.is_current() {
+            return;
+        }
+        // Persist the freshly-pulled canonical snapshot. Runs after
+        // apply_pull so the persisted view matches what's on the
+        // subscription's state.
+        self.persist_snapshot().await;
         if !self.epoch.is_current() {
             return;
         }
@@ -449,6 +521,12 @@ where
             return;
         }
         self.apply_pull(response);
+        if !self.epoch.is_current() {
+            return;
+        }
+        // Persist after every successful /pull (RFC 088 §A.3) so a
+        // reload after the tick observes the latest canonical set.
+        self.persist_snapshot().await;
     }
 
     /// Walk the pending-replay queue on the client and re-fire
@@ -550,7 +628,15 @@ where
     /// Returns `Err(())` when schema-drift triggered a state
     /// reset — caller should NOT treat that as a hard error
     /// (the next `/pull` rebuilds the canonical set).
-    fn apply_open(&self, response: SyncOpenResponse) -> Result<(), ()> {
+    ///
+    /// Schema-drift wipe atomicity: when drift is detected we
+    /// awaited the durable wipe (`clear_stream`) FIRST, then the
+    /// in-memory `state.reset()` runs synchronously while the
+    /// `RefMut` is held. Observers see the canonical row set
+    /// transition in one borrow — no observer can land between
+    /// `clear_stream` and `reset` and read empty-but-stale-version
+    /// state.
+    async fn apply_open(&self, response: SyncOpenResponse) -> Result<(), ()> {
         let Some(sub) = self.subscription.upgrade() else {
             return Ok(());
         };
@@ -574,18 +660,42 @@ where
             schema_version,
             ..
         } = opened;
-        let mut state = sub.state().borrow_mut();
-        // Schema-drift gate.
-        let drift =
-            matches!(state.application_schema_version, Some(cached) if cached != schema_version);
+        // Schema-drift detection MUST run while not holding the
+        // state borrow — the durable wipe is async and we don't
+        // want a `RefMut` held across an .await. Read the cached
+        // version, drop the borrow, run the wipe, then re-borrow
+        // to apply the in-memory transition atomically.
+        let cached = self.with_state_borrow(|s| s.application_schema_version).flatten();
+        let drift = matches!(cached, Some(c) if c != schema_version);
         if drift {
             tracing::info!(
                 target: "pocopine.log",
                 stream = stream_name.as_str(),
-                from = state.application_schema_version,
+                from = ?cached,
                 to = schema_version,
-                "sync-query: schema drift detected; resetting state"
+                "sync-query: schema drift detected; resetting state + wiping store",
             );
+            if let Some(store) = &self.local_store {
+                let compartment = self.compartment_key();
+                if let Err(err) = store.clear_stream(&compartment).await {
+                    tracing::warn!(
+                        target: "pocopine.log",
+                        stream = stream_name.as_str(),
+                        error = %err,
+                        "sync-query: schema-drift wipe failed; in-memory reset still proceeds",
+                    );
+                }
+                if !self.epoch.is_current() {
+                    return Ok(());
+                }
+            }
+        }
+        let mut state = sub.state().borrow_mut();
+        if drift {
+            // Reset BEFORE writing the new schema_version so an
+            // observer that reads inside the RefMut would see
+            // `(canonical_empty, version=new)` rather than
+            // `(canonical_stale, version=new)`.
             state.reset();
         }
         state.application_schema_version = Some(schema_version);
@@ -660,6 +770,270 @@ where
         state.error.clear();
         drop(state);
         sub.notify_listeners_external();
+    }
+
+    /// Stable cache compartment for this driver's subscription.
+    /// Returns `local_stream_key(stream, params)` per RFC 088 §A.2.
+    /// Two subscriptions on the same stream with different params
+    /// get distinct compartments; the same params share one.
+    fn compartment_key(&self) -> SyncStreamName {
+        match self.subscription.upgrade() {
+            Some(sub) => local_stream_key(sub.query().stream(), sub.query().params()),
+            // Subscription already reclaimed — fall back to a bare
+            // placeholder so the caller's await doesn't panic; the
+            // epoch check will catch the cancellation immediately
+            // after.
+            None => SyncStreamName::new("__sync_query_orphaned").expect("static valid stream"),
+        }
+    }
+
+    /// Phase 0 (RFC 088 §A.3): hydrate canonical rows, pending
+    /// overlays, cursor, and application_schema_version from the
+    /// durable store BEFORE `/open` fires. No-op when the client
+    /// has no `local_store` configured.
+    ///
+    /// Failures are warned and skipped — the subsequent `/open`
+    /// + `/pull` rebuild from scratch, the user just doesn't get
+    /// the instant-paint UX.
+    async fn hydrate_phase(&self) {
+        let Some(store) = self.local_store.clone() else {
+            return;
+        };
+        let compartment = self.compartment_key();
+        let snapshot = match store.hydrate_stream(&compartment).await {
+            Ok(snapshot) => snapshot,
+            Err(err) => {
+                tracing::warn!(
+                    target: "pocopine.log",
+                    stream = compartment.as_str(),
+                    error = %err,
+                    "sync-query: hydrate failed; continuing with empty state",
+                );
+                return;
+            }
+        };
+        if !self.epoch.is_current() {
+            return;
+        }
+        let Some(sub) = self.subscription.upgrade() else {
+            return;
+        };
+        self.apply_hydrated_snapshot(&sub, snapshot);
+    }
+
+    /// Pour a `LocalStreamSnapshot` into the subscription's
+    /// `QueryState`. Decodes the wire-shape `Vec<SyncRow<Value>>`
+    /// into typed `SyncRow<Row>` (rows that fail to decode are
+    /// dropped + warned, matching the `/pull` decode policy). The
+    /// pending overlays are reconstructed with `evicted_key` /
+    /// `deleted_row` left at `None` because the persisted layer
+    /// doesn't carry the routing engine's optimistic-departure
+    /// metadata — the next /pull or replay reconciles either way.
+    fn apply_hydrated_snapshot(
+        &self,
+        sub: &Rc<QuerySubscription<Row>>,
+        snapshot: LocalStreamSnapshot,
+    ) {
+        let stream_name = sub.query().stream().clone();
+        let mut state = sub.state().borrow_mut();
+        // Adopt the cached schema_version BEFORE writing rows so
+        // an observer that races a read in between sees the
+        // version + rows together (we never expose a row count
+        // with a stale schema_version).
+        state.application_schema_version = snapshot.application_schema_version;
+        state.cursor = snapshot.cursor.clone();
+        // Hydrated canonical rows. Per-row decode failures are
+        // logged and skipped; the next /pull will resurface them
+        // if they're still server-confirmed.
+        for wire_row in snapshot.rows.iter() {
+            match serde_json::from_value::<Row>(wire_row.value.clone()) {
+                Ok(value) => {
+                    state.upsert_canonical(SyncRow {
+                        key: wire_row.key.clone(),
+                        version: wire_row.version.clone(),
+                        value,
+                        pending: false,
+                        conflict: false,
+                    });
+                }
+                Err(err) => {
+                    tracing::warn!(
+                        target: "pocopine.log",
+                        stream = stream_name.as_str(),
+                        key = wire_row.key.as_str(),
+                        error = %err,
+                        "sync-query: dropping hydrated row that failed to decode"
+                    );
+                }
+            }
+        }
+        // Hydrated pending overlays. The persisted shape carries
+        // the wire `ClientMutation<Value>` + an optional
+        // `optimistic_row: SyncRow<Value>`; we decode the optimistic
+        // row payload back to `Row` when present, and leave the
+        // departure metadata as None (the replay tick will route
+        // the canonical changes through `route_canonical_changes`
+        // which clears the overlay either way).
+        for pending in snapshot.pending_mutations.iter() {
+            let optimistic_row: Option<SyncRow<Row>> =
+                pending.optimistic_row.as_ref().and_then(|wire_row| {
+                    match serde_json::from_value::<Row>(wire_row.value.clone()) {
+                        Ok(value) => Some(SyncRow {
+                            key: wire_row.key.clone(),
+                            version: wire_row.version.clone(),
+                            value,
+                            pending: true,
+                            conflict: false,
+                        }),
+                        Err(err) => {
+                            tracing::warn!(
+                                target: "pocopine.log",
+                                stream = stream_name.as_str(),
+                                key = wire_row.key.as_str(),
+                                error = %err,
+                                "sync-query: dropping hydrated pending row that failed to decode"
+                            );
+                            None
+                        }
+                    }
+                });
+            state.push_pending(PendingOverlay {
+                mutation_id: pending.mutation.id.clone(),
+                mutation: pending.mutation.clone(),
+                optimistic_row,
+                deleted_row: None,
+                evicted_key: None,
+                conflict: false,
+            });
+        }
+        drop(state);
+        sub.notify_listeners_external();
+        // Hand persisted pending mutations to the client-level
+        // replay path so the first tick after /open runs them
+        // through the registered MutatorRegistry → AnyMutator.
+        // We pass the wire mutation list (with persistence
+        // envelope intact); the registry unwraps before invoking
+        // apply_remote.
+        let Some(client_inner) = self.client.upgrade() else {
+            return;
+        };
+        let stream_for_replay = stream_name;
+        QueryClient::enqueue_hydrated_pending(
+            &client_inner,
+            stream_for_replay,
+            snapshot
+                .pending_mutations
+                .into_iter()
+                .map(|p| p.mutation)
+                .collect(),
+        );
+    }
+
+    /// Persist the current canonical state into the local store.
+    /// Called after every successful `/pull` (RFC 088 §A.3). No-op
+    /// when the client has no `local_store` configured.
+    async fn persist_snapshot(&self) {
+        let Some(store) = self.local_store.clone() else {
+            return;
+        };
+        let Some(sub) = self.subscription.upgrade() else {
+            return;
+        };
+        // Snapshot canonical rows + pending under a single
+        // immutable borrow so the persisted view is a coherent
+        // slice. We re-serialize through `serde_json::Value`
+        // because the local store contract is `SyncRow<Value>`.
+        let snapshot_inputs = {
+            let state = sub.state().borrow();
+            let stream = sub.query().stream().clone();
+            let cursor = state.cursor.clone();
+            let app_version = state.application_schema_version;
+            let canonical: Vec<SyncRow<Value>> = state
+                .canonical_rows()
+                .filter_map(|row| {
+                    let value = serde_json::to_value(&row.value).ok()?;
+                    Some(SyncRow {
+                        key: row.key.clone(),
+                        version: row.version.clone(),
+                        value,
+                        pending: false,
+                        conflict: false,
+                    })
+                })
+                .collect();
+            let pending: Vec<LocalPendingMutation> = state
+                .pending()
+                .iter()
+                .map(|overlay| {
+                    let optimistic_row: Option<SyncRow<Value>> =
+                        overlay.optimistic_row.as_ref().and_then(|r| {
+                            let value = serde_json::to_value(&r.value).ok()?;
+                            Some(SyncRow {
+                                key: r.key.clone(),
+                                version: r.version.clone(),
+                                value,
+                                pending: true,
+                                conflict: false,
+                            })
+                        });
+                    LocalPendingMutation::new(overlay.mutation.clone())
+                        .with_optimistic_row(optimistic_row)
+                })
+                .collect();
+            (stream, cursor, app_version, canonical, pending)
+        };
+        let (stream, cursor, app_version, canonical, pending) = snapshot_inputs;
+        let compartment = local_stream_key(&stream, sub.query().params());
+        // sync-query streams don't have a separate "collection"
+        // surface; reuse the stream name as the collection token
+        // so the local store's compartment is stable. The
+        // collection field is informational on the local store
+        // (used by CRUD callers); sync-query never reads it back.
+        let collection = match SyncCollectionName::new(compartment.as_str()) {
+            Ok(c) => c,
+            Err(err) => {
+                tracing::warn!(
+                    target: "pocopine.log",
+                    stream = compartment.as_str(),
+                    error = %err,
+                    "sync-query: persist_snapshot could not derive a collection name; skipping",
+                );
+                return;
+            }
+        };
+        let batch = LocalSnapshotBatch::new(compartment.clone(), collection, canonical, cursor)
+            .with_application_schema_version(app_version);
+        if let Err(err) = store.save_snapshot(batch).await {
+            tracing::warn!(
+                target: "pocopine.log",
+                stream = compartment.as_str(),
+                error = %err,
+                "sync-query: persist_snapshot failed; in-memory state still authoritative",
+            );
+        }
+        if !self.epoch.is_current() {
+            return;
+        }
+        // The save_snapshot call replaces canonical_rows but
+        // leaves any pre-existing persisted pending mutations
+        // intact in MemoryLocalStore + SQLite + IndexedDB. So we
+        // also enqueue the current pending overlay's wire
+        // payload, which is idempotent — the store's
+        // enqueue_pending_mutation overwrites by mutation id (per
+        // its contract).
+        for pending_mut in pending {
+            if let Err(err) = store
+                .enqueue_pending_mutation(&compartment, pending_mut)
+                .await
+            {
+                tracing::warn!(
+                    target: "pocopine.log",
+                    stream = compartment.as_str(),
+                    error = %err,
+                    "sync-query: enqueue_pending_mutation during persist failed; will retry on next pull"
+                );
+            }
+        }
     }
 
     /// Set the subscription's loading flag without writing to

--- a/crates/pocopine-sync-query/src/driver.rs
+++ b/crates/pocopine-sync-query/src/driver.rs
@@ -802,7 +802,7 @@ where
             return;
         };
         let compartment = self.compartment_key();
-        let snapshot = match store.hydrate_stream(&compartment).await {
+        let mut snapshot = match store.hydrate_stream(&compartment).await {
             Ok(snapshot) => snapshot,
             Err(err) => {
                 tracing::warn!(
@@ -817,10 +817,57 @@ where
         if !self.epoch.is_current() {
             return;
         }
+        // Codex P2: also drain the bare-stream compartment's pending
+        // queue. `persist_pending_mutation` writes into the
+        // bare-stream compartment as a fallback when no active
+        // subscription matched at mutate time; without this merge,
+        // those entries would never be picked up. We only merge
+        // PENDING mutations (not rows) because the bare compartment
+        // is shared across every params-scoped subscription and
+        // surfacing bare rows here would cross-pollute compartments.
+        let bare_stream = self.bare_stream_name();
+        if let Some(bare) = bare_stream {
+            if bare != compartment {
+                match store.hydrate_stream(&bare).await {
+                    Ok(bare_snapshot) => {
+                        let existing_ids: std::collections::HashSet<_> = snapshot
+                            .pending_mutations
+                            .iter()
+                            .map(|p| p.mutation.id.clone())
+                            .collect();
+                        for p in bare_snapshot.pending_mutations {
+                            if !existing_ids.contains(&p.mutation.id) {
+                                snapshot.pending_mutations.push(p);
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        tracing::debug!(
+                            target: "pocopine.log",
+                            stream = bare.as_str(),
+                            error = %err,
+                            "sync-query: bare-stream pending fallback read failed; ignoring"
+                        );
+                    }
+                }
+            }
+            if !self.epoch.is_current() {
+                return;
+            }
+        }
         let Some(sub) = self.subscription.upgrade() else {
             return;
         };
         self.apply_hydrated_snapshot(&sub, snapshot);
+    }
+
+    /// The driver's bare stream name (without the params hash).
+    /// Used for the bare-fallback pending lookup in
+    /// [`Self::hydrate_phase`].
+    fn bare_stream_name(&self) -> Option<SyncStreamName> {
+        self.subscription
+            .upgrade()
+            .map(|sub| sub.query().stream().clone())
     }
 
     /// Pour a `LocalStreamSnapshot` into the subscription's
@@ -909,7 +956,25 @@ where
             });
         }
         drop(state);
-        sub.notify_listeners_external();
+        // Notify only when the cached schema_version is None OR
+        // matches the in-memory state. When None (no advertised
+        // version observed yet) the hydrated rows are kept until
+        // /open advertises a version, at which point apply_open
+        // either confirms or wipes them in a single transition.
+        // When schema_version is Some, surface the cached rows
+        // immediately — apply_open will catch drift and reset
+        // BEFORE the next notify. Either way we avoid the
+        // rows-then-empty-then-rows flicker on a known-stale cache
+        // by letting apply_open own the "drift-aware first notify".
+        //
+        // Conservatively suppress the notify entirely here:
+        // mark_loading() runs synchronously right after this and
+        // will fire a notify with the freshly-hydrated state +
+        // loading=true. Observers see one notify (loading=true,
+        // hydrated rows) rather than two (hydrated, then
+        // mark_loading bumps loading=true).
+        // If apply_open detects drift it resets state + notifies
+        // empty; if not, the rows stay visible.
         // Hand persisted pending mutations to the client-level
         // replay path so the first tick after /open runs them
         // through the registered MutatorRegistry → AnyMutator.

--- a/crates/pocopine-sync-query/src/driver.rs
+++ b/crates/pocopine-sync-query/src/driver.rs
@@ -796,7 +796,7 @@ where
     ///
     /// Failures are warned and skipped — the subsequent `/open`
     /// + `/pull` rebuild from scratch, the user just doesn't get
-    /// the instant-paint UX.
+    ///   the instant-paint UX.
     async fn hydrate_phase(&self) {
         let Some(store) = self.local_store.clone() else {
             return;

--- a/crates/pocopine-sync-query/src/driver.rs
+++ b/crates/pocopine-sync-query/src/driver.rs
@@ -665,7 +665,9 @@ where
         // want a `RefMut` held across an .await. Read the cached
         // version, drop the borrow, run the wipe, then re-borrow
         // to apply the in-memory transition atomically.
-        let cached = self.with_state_borrow(|s| s.application_schema_version).flatten();
+        let cached = self
+            .with_state_borrow(|s| s.application_schema_version)
+            .flatten();
         let drift = matches!(cached, Some(c) if c != schema_version);
         if drift {
             tracing::info!(

--- a/crates/pocopine-sync-query/src/lib.rs
+++ b/crates/pocopine-sync-query/src/lib.rs
@@ -58,8 +58,8 @@ pub use driver::{
     DEFAULT_SYNC_ENDPOINT,
 };
 pub use mutator::{
-    AnyMutator, HydrateReplayOutcome, MutationOutcome, Mutator, MutatorEntry,
-    MutatorRemoteContext, MutatorRemoteFuture, RowChange,
+    AnyMutator, HydrateReplayOutcome, MutationOutcome, Mutator, MutatorEntry, MutatorRemoteContext,
+    MutatorRemoteFuture, RowChange,
 };
 pub use plugin::{query_client_plugin, QueryClientPlugin};
 pub use predicate::{

--- a/crates/pocopine-sync-query/src/lib.rs
+++ b/crates/pocopine-sync-query/src/lib.rs
@@ -57,7 +57,10 @@ pub use driver::{
     live_event_matches_params, DriverEpoch, QueryClientConfig, DEFAULT_POLL_INTERVAL,
     DEFAULT_SYNC_ENDPOINT,
 };
-pub use mutator::{MutationOutcome, Mutator, MutatorRemoteContext, MutatorRemoteFuture, RowChange};
+pub use mutator::{
+    AnyMutator, HydrateReplayOutcome, MutationOutcome, Mutator, MutatorEntry,
+    MutatorRemoteContext, MutatorRemoteFuture, RowChange,
+};
 pub use plugin::{query_client_plugin, QueryClientPlugin};
 pub use predicate::{
     contains_matches, range_contains, FieldContains, FieldEq, FieldInSet, FieldRange,
@@ -72,7 +75,10 @@ pub use pocopine_sync_query_macros::query_resource;
 
 // Re-export wire-level types from pocopine-sync that the macro emissions
 // and runtime touch directly. Users mostly don't see these.
-pub use pocopine_sync::{local_stream_key, SyncCursor, SyncStreamName, SyncStreamSubscription};
+pub use pocopine_sync::{
+    local_stream_key, MemoryLocalStore, SyncCursor, SyncLocalStore, SyncStreamName,
+    SyncStreamSubscription,
+};
 
 /// Macro-implementation surface. **Not** part of the public API — every
 /// symbol here exists only because `pocopine-sync-query-macros` will emit

--- a/crates/pocopine-sync-query/src/mutator.rs
+++ b/crates/pocopine-sync-query/src/mutator.rs
@@ -16,8 +16,9 @@
 
 use std::pin::Pin;
 
-use pocopine_sync::{RowKey, SyncResult};
+use pocopine_sync::{ClientMutation, MutationId, RowKey, SyncResult, SyncStreamName};
 use serde::{de::DeserializeOwned, Serialize};
+use serde_json::Value;
 
 /// Boxed future returned by [`Mutator::apply_remote`]. Aliased to keep
 /// the trait signature legible.
@@ -142,6 +143,193 @@ pub trait MutatorRemoteContext {
     /// Generate the next mutation id for this device. Used for the
     /// server's idempotency log.
     fn next_mutation_id(&self) -> SyncResult<pocopine_sync::MutationId>;
+}
+
+// ─── replay scaffolding (RFC 088 §A.5) ────────────────────────────
+//
+// `PendingOverlay::mutation` carries a wire `ClientMutation<Value>`
+// but NOT the `apply_remote` closure (closures aren't
+// `Serialize`-able). On hydrate we recover the typed replay path by
+// looking up the registered `Mutator` impl through a `MutatorRegistry`
+// keyed by `(STREAM, NAME)` and replaying via [`AnyMutator`].
+
+/// Re-export name used inside this module so the persisted-payload
+/// envelope key is centralized.
+pub(crate) const PERSISTED_MUTATOR_KEY: &str = "__mutator";
+/// Re-export name used inside this module so the persisted-payload
+/// envelope key is centralized.
+pub(crate) const PERSISTED_PAYLOAD_KEY: &str = "__payload";
+
+/// Wrap the wire payload + mutator NAME into a persistence envelope.
+///
+/// The server NEVER sees this shape: the wire push uses the live
+/// `ClientMutation<Value>` directly. The wrap happens at
+/// `enqueue_pending_mutation`-time and is unwrapped at hydrate-time
+/// before invoking `Mutator::apply_remote`. Returns a JSON object
+/// shaped `{ "__mutator": "<NAME>", "__payload": <original> }`.
+pub fn wrap_persisted_payload(mutator_name: &str, payload: Value) -> Value {
+    serde_json::json!({
+        PERSISTED_MUTATOR_KEY: mutator_name,
+        PERSISTED_PAYLOAD_KEY: payload,
+    })
+}
+
+/// Unwrap a persisted envelope back into `(mutator_name, payload)`.
+///
+/// Returns `None` if the value isn't shaped as a persisted envelope
+/// (caller's responsibility to decide whether that's a legacy entry
+/// to drop or a corrupt one to log + skip).
+pub fn unwrap_persisted_payload(value: &Value) -> Option<(String, Value)> {
+    let obj = value.as_object()?;
+    let name = obj.get(PERSISTED_MUTATOR_KEY)?.as_str()?.to_string();
+    let payload = obj.get(PERSISTED_PAYLOAD_KEY).cloned()?;
+    Some((name, payload))
+}
+
+/// Outcome of one hydrated replay attempt. Distinct from
+/// `crate::driver::ReplayOutcome` because the hydrate-replay path
+/// doesn't currently distinguish StillOffline vs Accepted at the
+/// caller (the driver loop will retry on the next tick regardless).
+#[derive(Debug)]
+pub enum HydrateReplayOutcome {
+    /// Server accepted the replay; canonical reconcile ran.
+    Accepted,
+    /// Network error; the pending overlay stays for the next tick.
+    StillOffline,
+    /// Server rejected, payload was malformed, or the mutator's
+    /// registered NAME no longer matches. Caller drops the pending
+    /// overlay.
+    Rejected(String),
+}
+
+/// Type-erased mutator entry registered with a [`QueryClient`].
+///
+/// One per concrete `Mutator` impl. Lets the hydrate path replay a
+/// persisted `ClientMutation<Value>` without monomorphizing the
+/// driver against every mutator type.
+///
+/// `replay_hydrated` is async and `!Send` to match the rest of the
+/// sync-query runtime (the driver runs on a single thread per RFC 087).
+pub trait AnyMutator: 'static {
+    /// Constant mutator NAME — used as the lookup key.
+    fn name(&self) -> &'static str;
+    /// Constant `STREAM` the mutator's row changes route to.
+    fn stream(&self) -> &'static str;
+    /// Replay a persisted wire payload by calling the underlying
+    /// `Mutator::apply_remote`, then routing the canonical changes
+    /// into matching subscriptions. The boxed return is `LocalBoxFuture`
+    /// because the runtime is `!Send`.
+    ///
+    /// `client_inner` is the strong `Rc<QueryClientInner>` the
+    /// driver upgraded from its `Weak`. Routing the canonical
+    /// changes happens through the public `QueryClient::route_*`
+    /// surface — this trait deliberately doesn't depend on the
+    /// `QueryClientInner` private layout.
+    fn replay_hydrated<'a>(
+        &'a self,
+        client: &'a crate::QueryClient,
+        stream: SyncStreamName,
+        mutation: ClientMutation<Value>,
+        push_url: String,
+    ) -> futures::future::LocalBoxFuture<'a, HydrateReplayOutcome>;
+}
+
+/// Concrete carrier of one `Mutator` impl behind the [`AnyMutator`]
+/// trait. Stored in the [`crate::QueryClient`]'s registry; one per
+/// distinct `M: Mutator`.
+pub struct MutatorEntry<M: Mutator> {
+    _marker: std::marker::PhantomData<fn() -> M>,
+}
+
+impl<M: Mutator> MutatorEntry<M> {
+    /// Build an entry. The phantom-data keeps the type without
+    /// adding any runtime state.
+    pub fn new() -> Self {
+        Self {
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+impl<M: Mutator> Default for MutatorEntry<M> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<M> AnyMutator for MutatorEntry<M>
+where
+    M: Mutator,
+    M::Row: Clone + Serialize + 'static,
+{
+    fn name(&self) -> &'static str {
+        M::NAME
+    }
+
+    fn stream(&self) -> &'static str {
+        M::STREAM
+    }
+
+    fn replay_hydrated<'a>(
+        &'a self,
+        client: &'a crate::QueryClient,
+        stream: SyncStreamName,
+        mutation: ClientMutation<Value>,
+        push_url: String,
+    ) -> futures::future::LocalBoxFuture<'a, HydrateReplayOutcome> {
+        Box::pin(async move {
+            // Recover the typed payload from the persisted wire envelope.
+            // The payload field carries the wrap_persisted_payload
+            // envelope at persistence time. If it doesn't (legacy
+            // entry, manually-injected payload, etc.) fall back to
+            // treating the raw field as the payload.
+            let raw_payload = mutation.payload.clone();
+            let inner_payload = match unwrap_persisted_payload(&raw_payload) {
+                Some((_, p)) => p,
+                None => raw_payload,
+            };
+            let payload: M::Payload = match serde_json::from_value(inner_payload) {
+                Ok(p) => p,
+                Err(err) => {
+                    return HydrateReplayOutcome::Rejected(format!(
+                        "hydrated replay payload decode failed: {err}"
+                    ));
+                }
+            };
+            // Surface the persisted mutation id through a
+            // `MutatorRemoteContext` so the server-side dedup log
+            // recognizes the retry as the same logical write.
+            struct ReplayCtx {
+                mutation_id: MutationId,
+                push_url: String,
+            }
+            impl MutatorRemoteContext for ReplayCtx {
+                fn push_url(&self) -> &str {
+                    &self.push_url
+                }
+                fn next_mutation_id(&self) -> SyncResult<MutationId> {
+                    Ok(self.mutation_id.clone())
+                }
+            }
+            let ctx = ReplayCtx {
+                mutation_id: mutation.id.clone(),
+                push_url,
+            };
+            match M::apply_remote(&ctx, payload).await {
+                Ok(canonical) => {
+                    crate::client::route_canonical_changes_from_replay::<M::Row>(
+                        client,
+                        &stream,
+                        &mutation.id,
+                        &canonical,
+                    );
+                    HydrateReplayOutcome::Accepted
+                }
+                Err(err) if err.is_transport() => HydrateReplayOutcome::StillOffline,
+                Err(err) => HydrateReplayOutcome::Rejected(err.to_string()),
+            }
+        })
+    }
 }
 
 #[cfg(test)]

--- a/crates/pocopine-sync-query/src/mutator.rs
+++ b/crates/pocopine-sync-query/src/mutator.rs
@@ -326,7 +326,23 @@ where
                     HydrateReplayOutcome::Accepted
                 }
                 Err(err) if err.is_transport() => HydrateReplayOutcome::StillOffline,
-                Err(err) => HydrateReplayOutcome::Rejected(err.to_string()),
+                Err(err) => {
+                    // Codex P2: dequeue the pending overlay using
+                    // the MUTATOR'S row type before returning
+                    // Rejected. The outer replay loop in
+                    // driver.rs uses the driver's monomorphized
+                    // Row type to dequeue, which would skip
+                    // subscriptions of a different row type that
+                    // received this same optimistic overlay
+                    // (cross-mutator routing fan-out). Doing the
+                    // cleanup here pins it to M::Row.
+                    crate::client::dequeue_pending_for_mutator_row::<M::Row>(
+                        client,
+                        &stream,
+                        &mutation.id,
+                    );
+                    HydrateReplayOutcome::Rejected(err.to_string())
+                }
             }
         })
     }

--- a/crates/pocopine-sync-query/tests/persistence.rs
+++ b/crates/pocopine-sync-query/tests/persistence.rs
@@ -523,17 +523,33 @@ async fn distinct_params_persist_to_distinct_compartments() {
     local
         .run_until(async {
             reset_middleware();
+            // Per-request middleware: return different /pull
+            // snapshots for W_A vs W_B so the driver's
+            // persist-after-pull writes distinct row sets per
+            // compartment. We inspect the request body to pick.
             install_middleware(|req: FetchRequest, _next: FetchNext| async move {
                 match req.url.as_str() {
                     SYNC_OPEN_PATH => Ok(json_response(&open_response(1, None))),
                     SYNC_PULL_PATH => {
-                        // Both compartments get the same /pull
-                        // shape — the test isn't about server-side
-                        // params filtering; it's about client-side
-                        // compartment isolation. Send distinct
-                        // rows so we can verify A's compartment
-                        // doesn't see B's row and vice versa.
-                        Ok(json_response(&snapshot_response(vec![])))
+                        let body = &req.body;
+                        let is_a = body.contains("\"W_A\"");
+                        let is_b = body.contains("\"W_B\"");
+                        let rows = if is_a {
+                            vec![Issue {
+                                id: "row_only_in_A".into(),
+                                workspace_id: "W_A".into(),
+                                title: "A".into(),
+                            }]
+                        } else if is_b {
+                            vec![Issue {
+                                id: "row_only_in_B".into(),
+                                workspace_id: "W_B".into(),
+                                title: "B".into(),
+                            }]
+                        } else {
+                            vec![]
+                        };
+                        Ok(json_response(&snapshot_response(rows)))
                     }
                     other => Err(ServerError::Network(format!("unexpected {other}"))),
                 }
@@ -573,78 +589,36 @@ async fn distinct_params_persist_to_distinct_compartments() {
                 "distinct params produce distinct compartments"
             );
 
-            // Manually seed each compartment with a marker row so we
-            // can verify isolation in both directions.
-            let collection_a = SyncCollectionName::new(compartment_a.as_str()).unwrap();
-            let collection_b = SyncCollectionName::new(compartment_b.as_str()).unwrap();
-            let row_a = SyncRow::new(
-                "row_only_in_A",
-                serde_json::to_value(&Issue {
-                    id: "row_only_in_A".into(),
-                    workspace_id: "W_A".into(),
-                    title: "A".into(),
-                })
-                .unwrap(),
-            )
-            .unwrap();
-            let row_b = SyncRow::new(
-                "row_only_in_B",
-                serde_json::to_value(&Issue {
-                    id: "row_only_in_B".into(),
-                    workspace_id: "W_B".into(),
-                    title: "B".into(),
-                })
-                .unwrap(),
-            )
-            .unwrap();
-            store
-                .save_snapshot(
-                    pocopine_sync::LocalSnapshotBatch::new(
-                        compartment_a.clone(),
-                        collection_a.clone(),
-                        vec![row_a.clone()],
-                        Some(SyncCursor::new("c_a").unwrap()),
-                    )
-                    .with_application_schema_version(Some(1)),
-                )
-                .await
-                .unwrap();
-            store
-                .save_snapshot(
-                    pocopine_sync::LocalSnapshotBatch::new(
-                        compartment_b.clone(),
-                        collection_b.clone(),
-                        vec![row_b.clone()],
-                        Some(SyncCursor::new("c_b").unwrap()),
-                    )
-                    .with_application_schema_version(Some(1)),
-                )
-                .await
-                .unwrap();
-
-            // Pull each compartment back; A must not contain B's
-            // marker and B must not contain A's marker. We test
-            // BOTH directions so neither A->B nor B->A leakage can
-            // hide.
+            // Driver-persisted state (NOT manually seeded). The
+            // driver should have observed /pull and persisted A's
+            // row only in compartment A, B's row only in
+            // compartment B.
             let hydrated_a = store.hydrate_stream(&compartment_a).await.unwrap();
             let hydrated_b = store.hydrate_stream(&compartment_b).await.unwrap();
             let a_keys: Vec<&str> = hydrated_a.rows.iter().map(|r| r.key.as_str()).collect();
             let b_keys: Vec<&str> = hydrated_b.rows.iter().map(|r| r.key.as_str()).collect();
+            // Drive both directions: A's compartment must NOT
+            // contain B's marker AND B's compartment must NOT
+            // contain A's marker.
             assert!(
                 a_keys.contains(&"row_only_in_A"),
-                "compartment A holds its own row"
+                "compartment A holds its own driver-persisted row; got {:?}",
+                a_keys
             );
             assert!(
                 !a_keys.contains(&"row_only_in_B"),
-                "compartment A must NOT see B's row"
+                "compartment A must NOT see B's row; got {:?}",
+                a_keys
             );
             assert!(
                 b_keys.contains(&"row_only_in_B"),
-                "compartment B holds its own row"
+                "compartment B holds its own driver-persisted row; got {:?}",
+                b_keys
             );
             assert!(
                 !b_keys.contains(&"row_only_in_A"),
-                "compartment B must NOT see A's row"
+                "compartment B must NOT see A's row; got {:?}",
+                b_keys
             );
         })
         .await;

--- a/crates/pocopine-sync-query/tests/persistence.rs
+++ b/crates/pocopine-sync-query/tests/persistence.rs
@@ -1,0 +1,706 @@
+//! End-to-end persistence tests for `pocopine-sync-query` (RFC 088 §A).
+//!
+//! These exercise the durable-store integration end-to-end: hydrate
+//! Phase 0, post-pull save_snapshot, schema-drift wipe, and pending
+//! mutation replay on hydrate.
+//!
+//! Each test installs a `pocopine::fetch` middleware that mocks
+//! `/open` + `/pull` + `/push`, then runs `client.observe(q)` inside a
+//! `tokio::task::LocalSet` so the driver task can spawn. The shared
+//! `MemoryLocalStore` between client instances simulates the same
+//! browser tab being reloaded — second client picks up the first
+//! client's persisted state.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::cell::RefCell;
+use std::rc::Rc;
+use std::time::Duration;
+
+use pocopine_core::fetch::{
+    install_middleware, FetchNext, FetchRequest, FetchResponse, __reset_middleware_chain_for_test,
+};
+use pocopine_core::server::ServerError;
+use pocopine_sync::{
+    local_stream_key, MemoryLocalStore, MutationId, StreamParams, SyncCollectionName, SyncCursor,
+    SyncLocalStore, SyncOpenResponse, SyncOpenStream, SyncPullResponse, SyncResult, SyncRow,
+    SyncStreamName, SYNC_OPEN_PATH, SYNC_PULL_PATH,
+};
+use pocopine_sync_query::{
+    Mutator, MutatorRemoteContext, MutatorRemoteFuture, QueryClient, QueryClientConfig, RowChange,
+};
+use pocopine_sync_query_macros::query_resource;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::task::LocalSet;
+
+fn reset_middleware() {
+    __reset_middleware_chain_for_test();
+}
+
+const STREAM: &str = "issues";
+const COLLECTION: &str = "issues";
+
+#[query_resource(name = "issues", schema_version = 1)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Issue {
+    pub id: String,
+    #[query_param(required)]
+    pub workspace_id: String,
+    pub title: String,
+}
+
+/// Mutator that always succeeds remotely (returns the same row as
+/// canonical). Used by the pending-replay test.
+struct CreateIssue;
+
+impl Mutator for CreateIssue {
+    type Payload = Issue;
+    type Row = Issue;
+    const NAME: &'static str = "create_issue";
+    const STREAM: &'static str = "issues";
+    const SCHEMA_VERSION: u32 = 1;
+
+    fn apply_local(payload: &Self::Payload) -> Vec<RowChange<Self::Row>> {
+        vec![RowChange::Upsert(payload.clone())]
+    }
+
+    fn apply_remote(
+        _ctx: &dyn MutatorRemoteContext,
+        payload: Self::Payload,
+    ) -> MutatorRemoteFuture<Self::Row> {
+        Box::pin(async move { Ok(vec![RowChange::Upsert(payload)]) })
+    }
+}
+
+thread_local! {
+    static FLAKY_MODE: RefCell<FlakyMode> = const { RefCell::new(FlakyMode::Offline) };
+    static FLAKY_HITS: RefCell<Vec<MutationId>> = const { RefCell::new(Vec::new()) };
+}
+
+#[derive(Clone, Copy, Debug)]
+enum FlakyMode {
+    Offline,
+    Online,
+}
+
+/// Mutator whose apply_remote can be flipped between Offline and
+/// Online so a test can simulate "mutation queued offline, page
+/// reloaded, then network came back".
+struct FlakyCreate;
+
+impl Mutator for FlakyCreate {
+    type Payload = Issue;
+    type Row = Issue;
+    const NAME: &'static str = "flaky_create";
+    const STREAM: &'static str = "issues";
+    const SCHEMA_VERSION: u32 = 1;
+
+    fn apply_local(payload: &Self::Payload) -> Vec<RowChange<Self::Row>> {
+        vec![RowChange::Upsert(payload.clone())]
+    }
+
+    fn apply_remote(
+        ctx: &dyn MutatorRemoteContext,
+        payload: Self::Payload,
+    ) -> MutatorRemoteFuture<Self::Row> {
+        let id = ctx.next_mutation_id();
+        Box::pin(async move {
+            let id = id?;
+            FLAKY_HITS.with(|h| h.borrow_mut().push(id));
+            match FLAKY_MODE.with(|m| *m.borrow()) {
+                FlakyMode::Offline => Err(pocopine_sync::SyncError::network("simulated offline")),
+                FlakyMode::Online => Ok(vec![RowChange::Upsert(payload)]),
+            }
+        })
+    }
+}
+
+struct StubContext {
+    next_id: std::cell::Cell<u64>,
+}
+
+impl StubContext {
+    fn new() -> Self {
+        Self {
+            next_id: std::cell::Cell::new(1),
+        }
+    }
+}
+
+impl MutatorRemoteContext for StubContext {
+    fn push_url(&self) -> &str {
+        "/__pocopine/sync/v1/push"
+    }
+
+    fn next_mutation_id(&self) -> SyncResult<MutationId> {
+        let n = self.next_id.get();
+        self.next_id.set(n + 1);
+        MutationId::new(format!("test:{n}"))
+    }
+}
+
+fn json_response<T: serde::Serialize>(body: &T) -> FetchResponse {
+    FetchResponse {
+        status: 200,
+        body: format!(
+            "{{\"Ok\":{}}}",
+            serde_json::to_string(body).expect("test body serializable")
+        ),
+    }
+}
+
+fn open_response(schema_version: u32, cursor: Option<SyncCursor>) -> SyncOpenResponse {
+    SyncOpenResponse::new(vec![SyncOpenStream {
+        stream: SyncStreamName::new(STREAM).unwrap(),
+        collection: SyncCollectionName::new(COLLECTION).unwrap(),
+        cursor,
+        schema_version,
+        params: StreamParams::new(),
+    }])
+}
+
+fn snapshot_response(rows: Vec<Issue>) -> SyncPullResponse<Value> {
+    let wire_rows: Vec<SyncRow<Value>> = rows
+        .into_iter()
+        .map(|r| SyncRow::new(r.id.clone(), serde_json::to_value(&r).unwrap()).unwrap())
+        .collect();
+    SyncPullResponse::snapshot(
+        SyncStreamName::new(STREAM).unwrap(),
+        SyncCollectionName::new(COLLECTION).unwrap(),
+        wire_rows,
+        Some(SyncCursor::new("c_1").unwrap()),
+    )
+}
+
+async fn settle(ticks: usize) {
+    for _ in 0..ticks {
+        tokio::task::yield_now().await;
+        tokio::time::sleep(Duration::from_millis(5)).await;
+    }
+}
+
+fn test_config_with_store(store: Rc<dyn SyncLocalStore>) -> QueryClientConfig {
+    QueryClientConfig {
+        poll_interval: Some(Duration::from_millis(50)),
+        disable_live: true,
+        ..QueryClientConfig::default()
+    }
+    .with_local_store(store)
+}
+
+// ─── Test 1: hydrate-then-observe round-trip ────────────────────────
+
+#[tokio::test]
+async fn hydrate_populates_canonical_rows_then_pull_refreshes() {
+    let local = LocalSet::new();
+    local
+        .run_until(async {
+            reset_middleware();
+            install_middleware(|req: FetchRequest, _next: FetchNext| async move {
+                match req.url.as_str() {
+                    SYNC_OPEN_PATH => Ok(json_response(&open_response(1, None))),
+                    SYNC_PULL_PATH => Ok(json_response(&snapshot_response(vec![Issue {
+                        id: "issue_fresh".into(),
+                        workspace_id: "W1".into(),
+                        title: "from /pull".into(),
+                    }]))),
+                    other => Err(ServerError::Network(format!("unexpected {other}"))),
+                }
+            });
+
+            // Seed the store with a row that pre-dates this session.
+            let store = Rc::new(MemoryLocalStore::new());
+            let params = {
+                let mut p = StreamParams::new();
+                p.insert("workspace_id".into(), serde_json::json!("W1"));
+                p
+            };
+            let stream = SyncStreamName::new(STREAM).unwrap();
+            let compartment = local_stream_key(&stream, &params);
+            let collection = SyncCollectionName::new(compartment.as_str()).unwrap();
+            let cached = Issue {
+                id: "issue_cached".into(),
+                workspace_id: "W1".into(),
+                title: "from cache".into(),
+            };
+            let row = SyncRow::new(cached.id.clone(), serde_json::to_value(&cached).unwrap())
+                .unwrap();
+            store
+                .save_snapshot(
+                    pocopine_sync::LocalSnapshotBatch::new(
+                        compartment.clone(),
+                        collection,
+                        vec![row],
+                        Some(SyncCursor::new("seed").unwrap()),
+                    )
+                    .with_application_schema_version(Some(1)),
+                )
+                .await
+                .unwrap();
+
+            let store_handle: Rc<dyn SyncLocalStore> = store.clone();
+            let client = QueryClient::with_config(test_config_with_store(store_handle));
+            let view = client.observe(
+                Issue::query()
+                    .eq(issues::field::workspace_id, "W1")
+                    .build(),
+            );
+
+            // After settle, both cached + /pull rows should be visible.
+            settle(3).await;
+            let rows = view.rows();
+            // /pull is a Snapshot which wipes this subscription's
+            // canonical set then re-upserts /pull's rows. The
+            // hydrated rows survive only until Snapshot wipe — that
+            // is intentional: snapshot mode is authoritative.
+            assert_eq!(
+                rows.len(),
+                1,
+                "post-/pull rows reflect server snapshot, not hydrated cache"
+            );
+            assert_eq!(rows[0].id, "issue_fresh");
+
+            // Confirm the store now reflects the /pull state.
+            let persisted = store.hydrate_stream(&compartment).await.unwrap();
+            assert_eq!(persisted.rows.len(), 1);
+            assert_eq!(persisted.rows[0].key.as_str(), "issue_fresh");
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn hydrate_shows_cached_rows_before_pull_lands() {
+    let local = LocalSet::new();
+    local
+        .run_until(async {
+            reset_middleware();
+            // Slow /pull so the hydrated rows are visible for a tick
+            // before the server response wipes them via Snapshot.
+            install_middleware(|req: FetchRequest, _next: FetchNext| async move {
+                match req.url.as_str() {
+                    SYNC_OPEN_PATH => {
+                        tokio::time::sleep(Duration::from_millis(30)).await;
+                        Ok(json_response(&open_response(1, None)))
+                    }
+                    SYNC_PULL_PATH => {
+                        tokio::time::sleep(Duration::from_millis(30)).await;
+                        Ok(json_response(&snapshot_response(vec![])))
+                    }
+                    other => Err(ServerError::Network(format!("unexpected {other}"))),
+                }
+            });
+
+            let store = Rc::new(MemoryLocalStore::new());
+            let params = {
+                let mut p = StreamParams::new();
+                p.insert("workspace_id".into(), serde_json::json!("W1"));
+                p
+            };
+            let stream = SyncStreamName::new(STREAM).unwrap();
+            let compartment = local_stream_key(&stream, &params);
+            let collection = SyncCollectionName::new(compartment.as_str()).unwrap();
+            let cached = Issue {
+                id: "issue_cached".into(),
+                workspace_id: "W1".into(),
+                title: "from cache".into(),
+            };
+            let row = SyncRow::new(cached.id.clone(), serde_json::to_value(&cached).unwrap())
+                .unwrap();
+            store
+                .save_snapshot(
+                    pocopine_sync::LocalSnapshotBatch::new(
+                        compartment.clone(),
+                        collection,
+                        vec![row],
+                        Some(SyncCursor::new("seed").unwrap()),
+                    )
+                    .with_application_schema_version(Some(1)),
+                )
+                .await
+                .unwrap();
+
+            let store_handle: Rc<dyn SyncLocalStore> = store.clone();
+            let client = QueryClient::with_config(test_config_with_store(store_handle));
+            let view = client.observe(
+                Issue::query()
+                    .eq(issues::field::workspace_id, "W1")
+                    .build(),
+            );
+
+            // After 1-2 ticks the hydrate phase has populated the
+            // state but the /open/pull responses haven't landed yet
+            // (they sleep 30ms each).
+            settle(2).await;
+            let rows = view.rows();
+            assert_eq!(rows.len(), 1, "hydrated rows should be visible pre-pull");
+            assert_eq!(rows[0].id, "issue_cached");
+        })
+        .await;
+}
+
+// ─── Test 2: schema-drift wipe + rebuild ───────────────────────────
+
+#[tokio::test]
+async fn schema_drift_wipes_persisted_state_and_repopulates() {
+    let local = LocalSet::new();
+    local
+        .run_until(async {
+            reset_middleware();
+            install_middleware(|req: FetchRequest, _next: FetchNext| async move {
+                match req.url.as_str() {
+                    // Server is now on v2 — drift relative to the
+                    // store's seeded v1.
+                    SYNC_OPEN_PATH => Ok(json_response(&open_response(2, None))),
+                    SYNC_PULL_PATH => Ok(json_response(&snapshot_response(vec![Issue {
+                        id: "issue_v2".into(),
+                        workspace_id: "W1".into(),
+                        title: "v2 row".into(),
+                    }]))),
+                    other => Err(ServerError::Network(format!("unexpected {other}"))),
+                }
+            });
+
+            // Seed v1 state.
+            let store = Rc::new(MemoryLocalStore::new());
+            let stream = SyncStreamName::new(STREAM).unwrap();
+            let params = {
+                let mut p = StreamParams::new();
+                p.insert("workspace_id".into(), serde_json::json!("W1"));
+                p
+            };
+            let compartment = local_stream_key(&stream, &params);
+            let collection = SyncCollectionName::new(compartment.as_str()).unwrap();
+            let stale = Issue {
+                id: "issue_v1".into(),
+                workspace_id: "W1".into(),
+                title: "stale".into(),
+            };
+            let row = SyncRow::new(stale.id.clone(), serde_json::to_value(&stale).unwrap())
+                .unwrap();
+            store
+                .save_snapshot(
+                    pocopine_sync::LocalSnapshotBatch::new(
+                        compartment.clone(),
+                        collection,
+                        vec![row],
+                        Some(SyncCursor::new("seed_v1").unwrap()),
+                    )
+                    .with_application_schema_version(Some(1)),
+                )
+                .await
+                .unwrap();
+            // Pre-check: the seeded snapshot is present.
+            let pre = store.hydrate_stream(&compartment).await.unwrap();
+            assert_eq!(pre.rows.len(), 1);
+            assert_eq!(pre.application_schema_version, Some(1));
+
+            let store_handle: Rc<dyn SyncLocalStore> = store.clone();
+            let client = QueryClient::with_config(test_config_with_store(store_handle));
+            let view = client.observe(
+                Issue::query()
+                    .eq(issues::field::workspace_id, "W1")
+                    .build(),
+            );
+            settle(5).await;
+
+            let rows = view.rows();
+            assert_eq!(rows.len(), 1, "v2 row replaced v1 snapshot");
+            assert_eq!(rows[0].id, "issue_v2");
+            assert_eq!(
+                view.state().application_schema_version,
+                Some(2),
+                "in-memory schema_version advanced after drift"
+            );
+
+            // Persisted state reflects v2 now too.
+            let post = store.hydrate_stream(&compartment).await.unwrap();
+            assert_eq!(post.rows.len(), 1);
+            assert_eq!(post.rows[0].key.as_str(), "issue_v2");
+            assert_eq!(post.application_schema_version, Some(2));
+        })
+        .await;
+}
+
+// ─── Test 3: pending-mutation persistence + replay on hydrate ──────
+
+#[tokio::test]
+async fn pending_mutation_persists_and_replays_on_hydrate() {
+    let local = LocalSet::new();
+    local
+        .run_until(async {
+            reset_middleware();
+            install_middleware(|req: FetchRequest, _next: FetchNext| async move {
+                match req.url.as_str() {
+                    SYNC_OPEN_PATH => Ok(json_response(&open_response(1, None))),
+                    SYNC_PULL_PATH => Ok(json_response(&snapshot_response(vec![]))),
+                    other => Err(ServerError::Network(format!("unexpected {other}"))),
+                }
+            });
+
+            FLAKY_MODE.with(|m| *m.borrow_mut() = FlakyMode::Offline);
+            FLAKY_HITS.with(|h| h.borrow_mut().clear());
+
+            let store = Rc::new(MemoryLocalStore::new());
+            let store_handle: Rc<dyn SyncLocalStore> = store.clone();
+
+            // ── Session 1 ────────────────────────────────────────
+            let client1 = QueryClient::with_config(test_config_with_store(store_handle.clone()));
+            client1.register_mutator::<FlakyCreate>();
+            let view1 = client1.observe(
+                Issue::query()
+                    .eq(issues::field::workspace_id, "W1")
+                    .build(),
+            );
+            settle(2).await;
+
+            // Mutate offline. Pending overlay persists to the store.
+            let ctx = StubContext::new();
+            let payload = Issue {
+                id: "issue_offline".into(),
+                workspace_id: "W1".into(),
+                title: "queued".into(),
+            };
+            let err = client1
+                .mutate::<FlakyCreate>(payload.clone(), &ctx)
+                .await
+                .expect_err("offline mutate returns transport error");
+            assert!(err.is_transport(), "got: {err}");
+            assert_eq!(view1.state().pending().len(), 1);
+
+            // Confirm persisted: bare-stream OR compartment contains
+            // the pending mutation.
+            let stream = SyncStreamName::new(STREAM).unwrap();
+            let params = {
+                let mut p = StreamParams::new();
+                p.insert("workspace_id".into(), serde_json::json!("W1"));
+                p
+            };
+            let compartment = local_stream_key(&stream, &params);
+            let persisted_pending = store.pending_mutations(&compartment).await.unwrap();
+            assert_eq!(
+                persisted_pending.len(),
+                1,
+                "pending mutation should persist in the subscription compartment"
+            );
+            // Confirm the persisted payload carries the mutator NAME
+            // envelope (not the bare payload).
+            let envelope = &persisted_pending[0].payload;
+            assert_eq!(envelope.get("__mutator"), Some(&serde_json::json!("flaky_create")));
+
+            // Tear down session 1.
+            drop(view1);
+            drop(client1);
+            settle(2).await;
+
+            // ── Session 2: simulated reload ──────────────────────
+            // Flip the network to online before the new session
+            // hydrates so the replay tick succeeds.
+            FLAKY_MODE.with(|m| *m.borrow_mut() = FlakyMode::Online);
+            let pre_hits = FLAKY_HITS.with(|h| h.borrow().len());
+
+            let client2 = QueryClient::with_config(test_config_with_store(store_handle.clone()));
+            client2.register_mutator::<FlakyCreate>();
+            let view2 = client2.observe(
+                Issue::query()
+                    .eq(issues::field::workspace_id, "W1")
+                    .build(),
+            );
+            // Give the driver multiple ticks: hydrate -> /open -> /pull
+            // -> replay_pending. Each tick is ~50ms.
+            for _ in 0..10 {
+                tokio::time::sleep(Duration::from_millis(40)).await;
+            }
+            let post_hits = FLAKY_HITS.with(|h| h.borrow().len());
+            assert!(
+                post_hits > pre_hits,
+                "replay should have re-fired apply_remote (hits before={pre_hits}, after={post_hits})"
+            );
+
+            // After successful replay the pending overlay clears.
+            assert_eq!(
+                view2.state().pending().len(),
+                0,
+                "successful hydrated replay clears the pending overlay"
+            );
+        })
+        .await;
+}
+
+// ─── Test 4: multi-compartment isolation ──────────────────────────
+
+#[tokio::test]
+async fn distinct_params_persist_to_distinct_compartments() {
+    let local = LocalSet::new();
+    local
+        .run_until(async {
+            reset_middleware();
+            install_middleware(|req: FetchRequest, _next: FetchNext| async move {
+                match req.url.as_str() {
+                    SYNC_OPEN_PATH => Ok(json_response(&open_response(1, None))),
+                    SYNC_PULL_PATH => {
+                        // Both compartments get the same /pull
+                        // shape — the test isn't about server-side
+                        // params filtering; it's about client-side
+                        // compartment isolation. Send distinct
+                        // rows so we can verify A's compartment
+                        // doesn't see B's row and vice versa.
+                        Ok(json_response(&snapshot_response(vec![])))
+                    }
+                    other => Err(ServerError::Network(format!("unexpected {other}"))),
+                }
+            });
+
+            let store = Rc::new(MemoryLocalStore::new());
+            let store_handle: Rc<dyn SyncLocalStore> = store.clone();
+            let client = QueryClient::with_config(test_config_with_store(store_handle));
+
+            let _view_a = client.observe(
+                Issue::query()
+                    .eq(issues::field::workspace_id, "W_A")
+                    .build(),
+            );
+            let _view_b = client.observe(
+                Issue::query()
+                    .eq(issues::field::workspace_id, "W_B")
+                    .build(),
+            );
+            settle(5).await;
+
+            let stream = SyncStreamName::new(STREAM).unwrap();
+            let params_a = {
+                let mut p = StreamParams::new();
+                p.insert("workspace_id".into(), serde_json::json!("W_A"));
+                p
+            };
+            let params_b = {
+                let mut p = StreamParams::new();
+                p.insert("workspace_id".into(), serde_json::json!("W_B"));
+                p
+            };
+            let compartment_a = local_stream_key(&stream, &params_a);
+            let compartment_b = local_stream_key(&stream, &params_b);
+            assert_ne!(
+                compartment_a, compartment_b,
+                "distinct params produce distinct compartments"
+            );
+
+            // Manually seed each compartment with a marker row so we
+            // can verify isolation in both directions.
+            let collection_a = SyncCollectionName::new(compartment_a.as_str()).unwrap();
+            let collection_b = SyncCollectionName::new(compartment_b.as_str()).unwrap();
+            let row_a = SyncRow::new(
+                "row_only_in_A",
+                serde_json::to_value(&Issue {
+                    id: "row_only_in_A".into(),
+                    workspace_id: "W_A".into(),
+                    title: "A".into(),
+                })
+                .unwrap(),
+            )
+            .unwrap();
+            let row_b = SyncRow::new(
+                "row_only_in_B",
+                serde_json::to_value(&Issue {
+                    id: "row_only_in_B".into(),
+                    workspace_id: "W_B".into(),
+                    title: "B".into(),
+                })
+                .unwrap(),
+            )
+            .unwrap();
+            store
+                .save_snapshot(
+                    pocopine_sync::LocalSnapshotBatch::new(
+                        compartment_a.clone(),
+                        collection_a.clone(),
+                        vec![row_a.clone()],
+                        Some(SyncCursor::new("c_a").unwrap()),
+                    )
+                    .with_application_schema_version(Some(1)),
+                )
+                .await
+                .unwrap();
+            store
+                .save_snapshot(
+                    pocopine_sync::LocalSnapshotBatch::new(
+                        compartment_b.clone(),
+                        collection_b.clone(),
+                        vec![row_b.clone()],
+                        Some(SyncCursor::new("c_b").unwrap()),
+                    )
+                    .with_application_schema_version(Some(1)),
+                )
+                .await
+                .unwrap();
+
+            // Pull each compartment back; A must not contain B's
+            // marker and B must not contain A's marker. We test
+            // BOTH directions so neither A->B nor B->A leakage can
+            // hide.
+            let hydrated_a = store.hydrate_stream(&compartment_a).await.unwrap();
+            let hydrated_b = store.hydrate_stream(&compartment_b).await.unwrap();
+            let a_keys: Vec<&str> =
+                hydrated_a.rows.iter().map(|r| r.key.as_str()).collect();
+            let b_keys: Vec<&str> =
+                hydrated_b.rows.iter().map(|r| r.key.as_str()).collect();
+            assert!(
+                a_keys.contains(&"row_only_in_A"),
+                "compartment A holds its own row"
+            );
+            assert!(
+                !a_keys.contains(&"row_only_in_B"),
+                "compartment A must NOT see B's row"
+            );
+            assert!(
+                b_keys.contains(&"row_only_in_B"),
+                "compartment B holds its own row"
+            );
+            assert!(
+                !b_keys.contains(&"row_only_in_A"),
+                "compartment B must NOT see A's row"
+            );
+        })
+        .await;
+}
+
+// ─── Backwards-compat: no local_store means no persistence calls ──
+
+#[tokio::test]
+async fn no_local_store_keeps_in_memory_only_behavior() {
+    let local = LocalSet::new();
+    local
+        .run_until(async {
+            reset_middleware();
+            install_middleware(|req: FetchRequest, _next: FetchNext| async move {
+                match req.url.as_str() {
+                    SYNC_OPEN_PATH => Ok(json_response(&open_response(1, None))),
+                    SYNC_PULL_PATH => Ok(json_response(&snapshot_response(vec![Issue {
+                        id: "ephemeral".into(),
+                        workspace_id: "W1".into(),
+                        title: "in-memory".into(),
+                    }]))),
+                    other => Err(ServerError::Network(format!("unexpected {other}"))),
+                }
+            });
+
+            // No `with_local_store` — backwards-compat path.
+            let client = QueryClient::new();
+            let view = client.observe(
+                Issue::query()
+                    .eq(issues::field::workspace_id, "W1")
+                    .build(),
+            );
+            settle(3).await;
+            assert_eq!(view.rows().len(), 1);
+            // The mutate path with no local_store still works.
+            let ctx = StubContext::new();
+            let payload = Issue {
+                id: "in_mem_create".into(),
+                workspace_id: "W1".into(),
+                title: "mutate".into(),
+            };
+            let _ = client.mutate::<CreateIssue>(payload, &ctx).await;
+        })
+        .await;
+}

--- a/crates/pocopine-sync-query/tests/persistence.rs
+++ b/crates/pocopine-sync-query/tests/persistence.rs
@@ -224,8 +224,8 @@ async fn hydrate_populates_canonical_rows_then_pull_refreshes() {
                 workspace_id: "W1".into(),
                 title: "from cache".into(),
             };
-            let row = SyncRow::new(cached.id.clone(), serde_json::to_value(&cached).unwrap())
-                .unwrap();
+            let row =
+                SyncRow::new(cached.id.clone(), serde_json::to_value(&cached).unwrap()).unwrap();
             store
                 .save_snapshot(
                     pocopine_sync::LocalSnapshotBatch::new(
@@ -241,11 +241,7 @@ async fn hydrate_populates_canonical_rows_then_pull_refreshes() {
 
             let store_handle: Rc<dyn SyncLocalStore> = store.clone();
             let client = QueryClient::with_config(test_config_with_store(store_handle));
-            let view = client.observe(
-                Issue::query()
-                    .eq(issues::field::workspace_id, "W1")
-                    .build(),
-            );
+            let view = client.observe(Issue::query().eq(issues::field::workspace_id, "W1").build());
 
             // After settle, both cached + /pull rows should be visible.
             settle(3).await;
@@ -305,8 +301,8 @@ async fn hydrate_shows_cached_rows_before_pull_lands() {
                 workspace_id: "W1".into(),
                 title: "from cache".into(),
             };
-            let row = SyncRow::new(cached.id.clone(), serde_json::to_value(&cached).unwrap())
-                .unwrap();
+            let row =
+                SyncRow::new(cached.id.clone(), serde_json::to_value(&cached).unwrap()).unwrap();
             store
                 .save_snapshot(
                     pocopine_sync::LocalSnapshotBatch::new(
@@ -322,11 +318,7 @@ async fn hydrate_shows_cached_rows_before_pull_lands() {
 
             let store_handle: Rc<dyn SyncLocalStore> = store.clone();
             let client = QueryClient::with_config(test_config_with_store(store_handle));
-            let view = client.observe(
-                Issue::query()
-                    .eq(issues::field::workspace_id, "W1")
-                    .build(),
-            );
+            let view = client.observe(Issue::query().eq(issues::field::workspace_id, "W1").build());
 
             // After 1-2 ticks the hydrate phase has populated the
             // state but the /open/pull responses haven't landed yet
@@ -376,8 +368,8 @@ async fn schema_drift_wipes_persisted_state_and_repopulates() {
                 workspace_id: "W1".into(),
                 title: "stale".into(),
             };
-            let row = SyncRow::new(stale.id.clone(), serde_json::to_value(&stale).unwrap())
-                .unwrap();
+            let row =
+                SyncRow::new(stale.id.clone(), serde_json::to_value(&stale).unwrap()).unwrap();
             store
                 .save_snapshot(
                     pocopine_sync::LocalSnapshotBatch::new(
@@ -397,11 +389,7 @@ async fn schema_drift_wipes_persisted_state_and_repopulates() {
 
             let store_handle: Rc<dyn SyncLocalStore> = store.clone();
             let client = QueryClient::with_config(test_config_with_store(store_handle));
-            let view = client.observe(
-                Issue::query()
-                    .eq(issues::field::workspace_id, "W1")
-                    .build(),
-            );
+            let view = client.observe(Issue::query().eq(issues::field::workspace_id, "W1").build());
             settle(5).await;
 
             let rows = view.rows();
@@ -640,10 +628,8 @@ async fn distinct_params_persist_to_distinct_compartments() {
             // hide.
             let hydrated_a = store.hydrate_stream(&compartment_a).await.unwrap();
             let hydrated_b = store.hydrate_stream(&compartment_b).await.unwrap();
-            let a_keys: Vec<&str> =
-                hydrated_a.rows.iter().map(|r| r.key.as_str()).collect();
-            let b_keys: Vec<&str> =
-                hydrated_b.rows.iter().map(|r| r.key.as_str()).collect();
+            let a_keys: Vec<&str> = hydrated_a.rows.iter().map(|r| r.key.as_str()).collect();
+            let b_keys: Vec<&str> = hydrated_b.rows.iter().map(|r| r.key.as_str()).collect();
             assert!(
                 a_keys.contains(&"row_only_in_A"),
                 "compartment A holds its own row"
@@ -686,11 +672,7 @@ async fn no_local_store_keeps_in_memory_only_behavior() {
 
             // No `with_local_store` — backwards-compat path.
             let client = QueryClient::new();
-            let view = client.observe(
-                Issue::query()
-                    .eq(issues::field::workspace_id, "W1")
-                    .build(),
-            );
+            let view = client.observe(Issue::query().eq(issues::field::workspace_id, "W1").build());
             settle(3).await;
             assert_eq!(view.rows().len(), 1);
             // The mutate path with no local_store still works.

--- a/rfcs/rfc-088-sync-query-production-parity.md
+++ b/rfcs/rfc-088-sync-query-production-parity.md
@@ -1,0 +1,504 @@
+# RFC 088 — `pocopine-sync-query` production parity
+
+* **Status:** Draft
+* **Author:** sync framework working group
+* **Tracking branches:** `wip/sync-query-persistence` (Section A), `wip/sync-query-selectors` (Section B), `wip/sync-query-per-params-topics` (Section C)
+* **Supersedes:** the "Non-goals" line items in RFC 087 §"Non-goals" — this RFC closes those gaps.
+* **Related:** [RFC 086 (pocopine-sync-query)](./rfc-086-sync-query.md), [RFC 087 (driver lifecycle)](./rfc-087-sync-query-driver.md), [RFC 071 (event spine)](./rfc-071-event-spine.md), [RFC 072 (offline sync protocol)](./rfc-072-offline-sync.md)
+
+## Summary
+
+PR #148 (RFC 087) made `pocopine-sync-query` actually sync — `client.observe(q)` now drives `/open` + `/pull` + live wakeup + offline replay end-to-end. What's left for production parity with `pocopine-sync-crud`:
+
+* **A. Durable persistence across page reloads.** Subscription state is in-memory; a refresh wipes canonical rows + pending overlays. CRUD already has IndexedDB + SQLite implementations behind the `SyncLocalStore` trait — sync-query should reuse them.
+* **B. `#[query]` selector composition.** The trait-gated DSL is conjunctive per resource. Joins, OR queries, and derived views (`projects_with_open_issues(workspace_id)`) require dropping into raw Rust without read tracking. A function-decorator pattern — Replicache/Zero-style — makes composition first-class without bloating the DSL.
+* **C. Per-`(name, params_hash)` live topics.** Today every subscriber on a stream wakes up on every mutation; the client filters by params and decides whether to `/pull`. For high-fanout multi-tenant apps that's wasted bandwidth — the server should publish each invalidation to the specific params-hash topic so only the right subscribers wake.
+
+This RFC consolidates the three under one document; each ships as its own PR (Section A first, B second, C third). All three are additive; old apps keep working unchanged.
+
+## Motivation
+
+Post-RFC-087, sync-query reaches "real framework" status — declared queries observe live data with reactive views. What stops it from being a production-grade drop-in for a Replicache/Zero/PowerSync-class app:
+
+1. **First-paint UX.** Without persistence, every page load shows empty views for ~100ms while `/open` + `/pull` complete. CRUD users have IndexedDB-backed instant render today; sync-query users don't.
+2. **Composition cliff.** A single resource is queryable through the trait DSL; joins and derived views are not. Every team that builds a Linear-clone hits this within the first day.
+3. **Bandwidth amplification under multi-tenancy.** With N workspaces and M subscribers per workspace, a single workspace-scoped mutation wakes up every subscriber on the stream (M × N people), only M of whom care. At Linear/Slack scale that's measurably bad.
+
+These three sit in the long tail because the routing engine + macro DSL + driver had to land first. Now they do.
+
+## Goals
+
+* **(A)** `SyncLocalStore`-backed persistence: hydrate canonical rows + pending overlays + cursor + schema_version on subscribe; persist after every `/pull` and every optimistic apply. Reuse existing IndexedDB / SQLite impls.
+* **(B)** `#[query] fn name(args) -> T` produces a `name::observe(client, args) -> SelectorView<T>`. Reads from `Resource::query()` views inside the function body are tracked; output is cached keyed by `(fn_id, args_hash)`; upstream mutations re-run the function and fire `on_update` only when the output differs.
+* **(C)** `SyncStreamSource::row_to_params` server-side hook (auto-derived from `#[query_param]` declarations) routes invalidations to per-`(name, params_hash)` topics. Client subscribes to both bare and per-params topics during the rollout window; server publishes to both.
+
+## Non-goals
+
+* **CRDT / merge model.** Server stays authoritative; conflict resolution via failed `apply_remote` + the existing rollback path.
+* **Cross-resource transactions.** Mutators stay single-resource. Multi-resource workflows compose via separate `mutate()` calls.
+* **Per-field invalidation projection beyond `row_to_params`.** Server publishes per-(name, params_hash), not per-(name, params_hash, field). Field-level deltas remain a future RFC if we have data showing the extra bandwidth saves matter.
+* **`#[query]` async functions.** Read-tracking is thread-local and synchronous. Async selectors compose by calling the sync selector inside an async block.
+* **P2P sync.** Future work.
+
+---
+
+## Section A — Durable persistence
+
+### Design
+
+#### A.1 Storage interface
+
+Reuse `pocopine_sync::SyncLocalStore`:
+
+```rust
+// crates/pocopine-sync/src/local_store.rs (existing)
+pub trait SyncLocalStore {
+    fn hydrate_stream(&self, stream: &SyncStreamName) -> SyncLocalFuture<'_, LocalStreamSnapshot>;
+    fn save_snapshot(&self, snapshot: LocalSnapshotBatch) -> SyncLocalFuture<'_, ()>;
+    fn apply_changes(&self, changes: LocalChangeBatch) -> SyncLocalFuture<'_, ()>;
+    fn enqueue_pending_mutation(&self, stream: &SyncStreamName, pending: LocalPendingMutation)
+        -> SyncLocalFuture<'_, ()>;
+    fn pending_mutations(&self, stream: &SyncStreamName)
+        -> SyncLocalFuture<'_, Vec<ClientMutation<serde_json::Value>>>;
+    fn purge_pending_for_row(&self, stream: &SyncStreamName, key: &RowKey)
+        -> SyncLocalFuture<'_, usize>;
+    fn clear_stream(&self, stream: &SyncStreamName) -> SyncLocalFuture<'_, ()>;
+    fn clear_all_streams(&self) -> SyncLocalFuture<'_, ()>;
+    // … identity + mutation_id methods elided
+}
+```
+
+`SyncLocalFuture` is `Pin<Box<dyn Future>>` on wasm and `Pin<Box<dyn Future>>` (a ready future) on native. The sync-query driver already runs in an async context so the boxed future is consumed naturally.
+
+#### A.2 Compartment keying
+
+Each `(stream, params)` pair gets its own logical store compartment, keyed by:
+
+```rust
+// crates/pocopine-sync/src/protocol.rs (existing)
+pub fn local_stream_key(stream: &SyncStreamName, params: &StreamParams) -> SyncStreamName;
+// "issues" + {workspace_id: "W1"} → "issues__params_<fnv1a64hash>"
+// "issues" + {} → "issues" (backwards compat with CRUD)
+```
+
+Sync-query uses this verbatim. Two subscriptions on the same stream with different params get distinct stores; the same params on the same stream get one shared store (refcount-shared subscription already enforces a single canonical state, so the store layer just mirrors that).
+
+#### A.3 Driver lifecycle changes
+
+`SubscriptionDriver::run` (from RFC 087) gains a Phase 0 before `/open`:
+
+```rust
+// crates/pocopine-sync-query/src/driver.rs
+async fn run(self) {
+    // Phase 0: hydrate from store (NEW)
+    if let Some(store) = &self.local_store {
+        let compartment = local_stream_key(stream, params);
+        match store.hydrate_stream(&compartment).await {
+            Ok(snapshot) => apply_hydrated_snapshot(&sub, snapshot),
+            Err(_) => { /* fresh start; log + continue */ }
+        }
+    }
+
+    // Phase 1: /open (unchanged)
+    // … schema-drift check now also calls store.clear_stream() on mismatch
+    // Phase 2-4: /pull + live wakeup + replay (unchanged)
+
+    // After every successful /pull (NEW):
+    if let Some(store) = &self.local_store {
+        store.save_snapshot(snapshot_from_state(&sub)).await;
+    }
+}
+```
+
+`apply_hydrated_snapshot` populates `QueryState::canonical_rows`, `state.pending` (from snapshot's pending_mutations + replay closure re-derivation, see A.5), `state.cursor`, and `state.application_schema_version`. Bumps version once; observers re-render.
+
+#### A.4 Schema-drift on hydrate
+
+```rust
+// Inside the driver's apply_open path:
+let server_version = open_response.schema_version;
+match state.application_schema_version {
+    Some(local_version) if local_version != server_version => {
+        // Drift: wipe persisted state + in-memory state.
+        if let Some(store) = &self.local_store {
+            store.clear_stream(&compartment).await.ok();
+        }
+        state.reset();
+        state.application_schema_version = Some(server_version);
+        // Continue with a fresh /pull.
+    }
+    _ => state.application_schema_version = Some(server_version),
+}
+```
+
+Same logic CRUD uses in `start_open_then_pull`; reused unchanged.
+
+#### A.5 Pending mutation replay on hydrate
+
+The trickiest piece: `PendingOverlay` carries an `optimistic_row` + a `mutation: ClientMutation<Value>` (the wire payload). It does NOT carry the `apply_remote` closure — that's a `Box<dyn Fn>` and isn't serializable. So on hydrate we have wire payloads but no closures.
+
+Resolution: introduce a `MutatorRegistry` on `QueryClient`:
+
+```rust
+// crates/pocopine-sync-query/src/client.rs
+pub struct QueryClientInner {
+    // … existing fields
+    mutators: RefCell<HashMap<TypeId, Box<dyn AnyMutator>>>,
+}
+
+impl QueryClient {
+    pub fn register_mutator<M: Mutator + 'static>(&self) {
+        self.inner.mutators.borrow_mut()
+            .insert(TypeId::of::<M>(), Box::new(MutatorEntry::<M>::new()));
+    }
+}
+```
+
+Mutators self-register at construction time (or via an `App::plugin` hook). On hydrate, the driver iterates persisted pending mutations, looks up the matching Mutator by `STREAM` + payload shape (mutator name carried on `ClientMutation`), and re-derives the replay invocation. If a mutator's code has been removed since the user last opened the app, that pending mutation is dropped + logged.
+
+#### A.6 Configuration
+
+```rust
+// crates/pocopine-sync-query/src/driver.rs (extending QueryClientConfig)
+pub struct QueryClientConfig {
+    // … existing fields
+    pub local_store: Option<Rc<dyn SyncLocalStore>>,
+}
+
+impl QueryClientConfig {
+    pub fn with_local_store(mut self, store: Rc<dyn SyncLocalStore>) -> Self {
+        self.local_store = Some(store);
+        self
+    }
+}
+
+// User code:
+let store = IndexedDbLocalStore::open("my-app").await?;
+let client = QueryClient::with_config(
+    QueryClientConfig::default()
+        .with_local_store(Rc::new(store))
+);
+```
+
+Default is `None` → in-memory only (matches current behavior; no migration burden).
+
+#### A.7 Backwards compat
+
+Existing apps that don't configure a store keep working — `local_store: None` means the driver skips Phase 0 + the save calls. The first opt-in to persistence is a one-line change.
+
+CRUD apps that share a `SyncLocalStore` instance with a sync-query client get isolated compartments because sync-query keys on `local_stream_key(stream, params)` and CRUD keys on `stream`. The two don't collide.
+
+#### A.8 Verification (PR-A)
+
+* `cargo test -p pocopine-sync-query --test persistence` — hydrate-then-observe roundtrip via a `MemorySyncLocalStore` test impl.
+* Schema-drift: store has v1 snapshot; `/open` returns v2; verify `clear_stream` + canonical rebuilt.
+* Pending replay: persist a pending mutation; simulate restart; verify the mutator re-fires on first online tick.
+* Multi-compartment: two subscriptions on the same stream with different params persist into distinct compartments.
+
+---
+
+## Section B — `#[query]` selector composition
+
+### Design
+
+#### B.1 User-facing API
+
+```rust
+#[query]
+fn projects_with_open_issues(workspace_id: String) -> Vec<(Project, Vec<Issue>)> {
+    Project::query()
+        .eq(field::workspace_id, &workspace_id).rows()
+        .into_iter()
+        .map(|p| {
+            let issues = Issue::query()
+                .eq(field::project_id, &p.id)
+                .any_of(field::status, [Status::Open]).rows();
+            (p, issues)
+        })
+        .collect()
+}
+
+// Call site — mirrors `Issue::query().observe(&client)`:
+let view = projects_with_open_issues::observe(&client, "W1".to_string());
+
+view.value();        // Vec<(Project, Vec<Issue>)>
+view.on_update(|| render());  // fires when output differs from cached
+```
+
+Args must be `Hash + Eq + Clone + 'static`. Output must be `Clone + PartialEq + 'static`. Selectors are sync (`fn`, not `async fn`).
+
+#### B.2 Read tracking
+
+A thread-local stack of "currently-running selectors":
+
+```rust
+// crates/pocopine-sync-query/src/selector.rs
+thread_local! {
+    static CURRENT_SELECTOR: RefCell<Vec<SelectorId>> = RefCell::new(Vec::new());
+}
+
+pub(crate) fn record_read(subscription: Rc<dyn AnyQuerySubscription>) {
+    CURRENT_SELECTOR.with(|stack| {
+        if let Some(selector_id) = stack.borrow().last().copied() {
+            // Push `subscription` into the selector's tracked-set.
+            with_selector(selector_id, |entry| entry.track(subscription));
+        }
+    });
+}
+```
+
+`QueryView::rows()` calls `record_read(self.subscription.clone() as Rc<dyn AnyQuerySubscription>)` before returning. Reads outside a selector context are no-ops.
+
+The thread-local is a STACK (not a Cell) so nested selectors work: selector A calls selector B; B's reads register with B, not A. This is a deliberate departure from `pocopine_core::reactive::CURRENT_EFFECT` (which is a Cell); the selectors module owns its own thread-local because the semantics differ.
+
+#### B.3 Cache & invalidation
+
+```rust
+struct SelectorEntry<T> {
+    fn_id: SelectorId,                  // FNV-1a(module_path + fn_name)
+    args_hash: ArgsHash,
+    last_output: RefCell<Option<T>>,    // PartialEq diffing
+    tracked: RefCell<Vec<Rc<dyn AnyQuerySubscription>>>,
+    refcount: Cell<usize>,
+    listeners: RefCell<Vec<(u64, Rc<dyn Fn()>)>>,
+    listener_token_seq: Cell<u64>,
+}
+
+// Per-client registry, parallel to the existing subscription registry:
+struct QueryClientInner {
+    // … existing fields
+    selectors: RefCell<HashMap<(SelectorId, ArgsHash), Rc<dyn AnySelector>>>,
+}
+```
+
+`observe(client, args)` flow:
+
+1. Hash args → `args_hash`.
+2. If `selectors[(fn_id, args_hash)]` exists, bump refcount + return a `SelectorView<T>` wrapping it.
+3. Else: push `fn_id` onto the read-tracking stack, run the user function, pop. Capture the tracked subscriptions + register `on_update` callbacks on each.
+4. Store the entry, return the view.
+
+`on_update` callback (registered on each tracked subscription) fires when ANY upstream changes. The callback:
+
+1. Re-pushes `fn_id` onto the stack, re-runs the function (capturing a NEW tracked set), pops.
+2. Compares the new tracked set against the cached one. Subscriptions no longer tracked have their `QueryHandle` dropped; new ones are subscribed.
+3. Diffs `new_output == cached_output`. If different, updates cache + fires the selector's own listeners.
+
+#### B.4 Refcount lifecycle
+
+`SelectorView<T>` holds an `Rc<SelectorEntry<T>>`. `Drop` decrements the selector entry's refcount; on zero, the entry is removed from the registry, dropping its tracked `QueryHandle`s, which in turn release the upstream subscriptions per the existing refcount path.
+
+#### B.5 Output diffing opt-out
+
+```rust
+#[query(no_diff)]
+fn raw_view(...) -> NonComparableOutput { … }
+```
+
+Without `no_diff`, the macro emits a compile error if `T` doesn't impl `PartialEq`. With `no_diff`, every re-run fires `on_update` (caller's responsibility to debounce).
+
+#### B.6 Macro emission
+
+```rust
+// User input:
+#[query]
+fn projects_with_open_issues(workspace_id: String) -> Vec<(Project, Vec<Issue>)> { … }
+
+// Macro emits:
+pub mod projects_with_open_issues {
+    use super::*;
+
+    #[derive(Hash, Eq, PartialEq, Clone)]
+    pub struct Args {
+        pub workspace_id: String,
+    }
+
+    pub fn observe(
+        client: &::pocopine_sync_query::QueryClient,
+        workspace_id: String,
+    ) -> ::pocopine_sync_query::SelectorView<Vec<(Project, Vec<Issue>)>> {
+        let args = Args { workspace_id };
+        client.observe_selector(
+            ::pocopine_sync_query::selector::selector_id_for(module_path!(), "projects_with_open_issues"),
+            args.clone(),
+            move || super::projects_with_open_issues(args.workspace_id.clone()),
+        )
+    }
+}
+
+// User function `fn projects_with_open_issues(...)` is emitted verbatim.
+```
+
+#### B.7 Verification (PR-B)
+
+* `cargo test -p pocopine-sync-query-macros --test selector`:
+    - Cache hit on repeat observe with same args (verify a single underlying subscription runs once).
+    - Upstream mutation triggers re-run; output differs → `on_update` fires.
+    - Equal-output re-run is suppressed (diff layer).
+    - Drop the SelectorView; upstream `client.active_subscription_count()` decrements.
+    - Compile-fail trybuild for non-`PartialEq` output without `no_diff`.
+* Manual: build a small example using nested selectors (A reads B), verify B's reads register with B and not A.
+
+---
+
+## Section C — Per-`(name, params_hash)` live topics
+
+### Design
+
+#### C.1 Topic format
+
+Existing: `query:sync:stream:{stream}` (carried by `sync_stream_tag(stream)`).
+
+New: `query:sync:stream:{stream}:{params_hash}` where `params_hash` is the FNV-1a 64-bit hash of canonical sorted-by-key `StreamParams` JSON — same hash function used by `local_stream_key`.
+
+```rust
+// crates/pocopine-sync/src/protocol.rs (new)
+pub fn sync_stream_params_topic(stream: &str, params_hash: u64) -> String {
+    format!("sync:stream:{stream}:{params_hash:016x}")
+}
+```
+
+#### C.2 Server-side hook
+
+```rust
+// crates/pocopine-sync/src/server.rs (extends SyncStreamSource)
+pub trait SyncStreamSource: Send + Sync {
+    // … existing methods
+
+    /// Project a row payload into the StreamParams that identify which
+    /// subscribers care about it. Default: empty (backwards compat).
+    /// Macro auto-emits an impl from #[query_param] / params(...).
+    fn row_to_params(&self, _row: &serde_json::Value) -> SyncResult<StreamParams> {
+        Ok(StreamParams::new())
+    }
+}
+```
+
+The macros (`#[query_resource]` and `#[resource]`) auto-emit `row_to_params` from the params declarations:
+
+```rust
+// Macro-emitted (sketch):
+fn row_to_params(row: &Value) -> SyncResult<StreamParams> {
+    let mut params = StreamParams::new();
+    // For each #[query_param(required)] field of type T:
+    let workspace_id: String = serde_json::from_value(row["workspace_id"].clone())?;
+    params.insert("workspace_id".into(), json!(workspace_id));
+    // For each #[query_param] field with inner type T (Eq + InSet capable):
+    let status: Status = serde_json::from_value(row["status"].clone())?;
+    params.insert("status".into(), json!(status));
+    // Contains-only fields (title) are SKIPPED — substring filters
+    // don't partition the topic space.
+    Ok(params)
+}
+```
+
+#### C.3 Publish path
+
+```rust
+// crates/pocopine-sync/src/server.rs
+impl SyncServer {
+    pub async fn invalidate_stream_with_row(
+        &self,
+        stream: &str,
+        row: &serde_json::Value,
+    ) -> SyncResult<()> {
+        let registered = self.stream(stream)?;
+        let bare_tag = sync_stream_tag(stream);
+
+        // Publish to bare topic (backwards compat — clients that haven't
+        // opted in continue to receive every event).
+        let bare_topic = pocopine_live::query_tag_topic(&bare_tag)?;
+        events.publish(pocopine_live::query_invalidated(bare_topic, [bare_tag.clone()])).await?;
+
+        // Compute per-row params + publish to per-params topic.
+        let params = registered.source.row_to_params(row)?;
+        if !params.is_empty() {
+            let hash = stream_params_hash(&params);
+            let tag = sync_stream_params_topic(stream, hash);
+            let topic = pocopine_live::query_tag_topic(&tag)?;
+            events.publish(pocopine_live::query_invalidated(topic, [tag])).await?;
+        }
+        Ok(())
+    }
+}
+```
+
+The CRUD `/push` handler at `crates/pocopine-sync/src/server.rs:576-584` calls `invalidate_stream_with_row` per accepted row instead of the existing `invalidate_stream(stream_name)`. Old non-CRUD sources that don't override `row_to_params` get the bare-topic publish only.
+
+#### C.4 Client subscribe
+
+`SubscriptionDriver::open_live_wakeup` (RFC 087 §6) subscribes to both topics:
+
+```rust
+let params_hash = stream_params_hash(query.params());
+let live = pocopine_live::LiveClient::new()
+    .query_tag(sync_stream_tag(stream))                          // bare topic
+    .query_tag_with_params(sync_stream_tag(stream), params_hash) // per-params topic
+    .with_credentials(with_credentials)
+    .on_event(/* … */)
+    .open();
+```
+
+The driver dedupes events by `mutation_id` (if the server publishes the same invalidation to both topics, the driver sees one wakeup, not two). Client-side params filtering (RFC 087 §6) stays in place as the final gate — for the rollout window, bare-topic events still arrive and need filtering.
+
+#### C.5 `LiveClient` API
+
+```rust
+// crates/pocopine-live/src/lib.rs (new)
+impl LiveClient {
+    pub fn query_tag_with_params(mut self, tag: impl Into<String>, params_hash: u64) -> Self {
+        self.topics.push(format!("query:{}:{:016x}", tag.into(), params_hash));
+        self
+    }
+}
+```
+
+#### C.6 Backwards compat rollout
+
+* Phase 1 (this RFC): server publishes to both; clients on old version still listen only on bare topic. New clients listen on both.
+* Phase 2 (future): clients audit shows >95% on per-params capable version. Server flips to per-params-only via a `SyncServer::publish_bare_topic: false` config knob.
+* Phase 3 (future): bare-topic publish removed entirely.
+
+Phases 2 + 3 are deliberately NOT in this RFC — keep both forever is a fine production posture; the perf win comes from the bandwidth reduction in `/open`-time per-params subscriptions, not from removing the bare-topic publish.
+
+#### C.7 Verification (PR-C)
+
+* `cargo test -p pocopine-sync-query --test per_params_topics` — two subscriptions with different params; mutate row matching only one; assert only matching driver receives wakeup.
+* `cargo test -p pocopine-sync-crud-macros` — trybuild test for `row_to_params` codegen on a struct with `required` + plain + `contains` annotated fields; verify Contains-only fields are omitted.
+* Server integration test: spin up `pocopine-server` with `CrudResource`, two clients with different params; mutate row matching only one; assert only that client gets a live wakeup.
+
+---
+
+## Alternatives considered
+
+* **A. Reuse `pocopine_sync::SyncCollection<C, T>` for persistence** — same rejection as in RFC 087 §"Alternatives A". CRUD coupling re-creates the tension we split.
+* **B. Use `Box<dyn Any>` for selector cache values** — avoids the `PartialEq` requirement. Rejected: opaque cache values defeat the diff-suppress optimization that makes selectors usable in reactive UI loops. Document `no_diff` as the escape hatch for non-comparable outputs.
+* **C. Per-`(name, params_hash, field)` topics** — even tighter routing. Server would publish per-(field) granularity ("the `status` of row X changed"). Rejected: complexity not justified without traffic data. Field-level invalidation can be a future RFC.
+* **D. Pre-derive `Args: Hash + Eq` automatically via the macro vs require user trait impls** — the macro generates the Args struct, so deriving `Hash + Eq` on it works as long as each arg type already impls those. If one arg doesn't impl `Hash + Eq`, the user gets a compile error at the macro expansion site. Acceptable.
+
+## Implementation status
+
+* **PR-A** — Section A; `wip/sync-query-persistence`. ~600 LOC + 400 tests. Lands first.
+* **PR-B** — Section B; `wip/sync-query-selectors`. ~800 LOC + 500 tests. References this RFC; no RFC edit needed.
+* **PR-C** — Section C; `wip/sync-query-per-params-topics`. ~700 LOC + 400 tests. Cross-cuts client + server.
+
+Each PR goes through Codex review at the checkpoint, matching the RFC 086 / 087 cadence.
+
+## Migration / rollout
+
+* **Section A** — Additive. Existing apps with `local_store: None` see no behavior change. Opt in with one line.
+* **Section B** — Additive. New attribute macro; no existing code touched. Existing `#[query_resource]` users keep working.
+* **Section C** — Additive. Server publishes to both topics; old clients work; new clients listen to both. No coordinated client/server deploy needed.
+
+## Open questions
+
+* **A:** when the user's app code drops + recreates a `QueryClient` (e.g., after sign-out), should `clear_all_streams()` fire automatically? Recommendation: yes — sign-out semantics from CRUD apply unchanged. Documented in the cookbook.
+* **B:** does `#[query]` support generic functions (`fn projects_with_status<S: Into<Status>>(s: S)`)? Recommendation: not in v1; require monomorphized signatures. Generic selectors are doable but the args-hash story gets thorny — defer.
+* **C:** what's the right `params_hash` collision recovery? Two distinct param maps that hash to the same 64-bit FNV-1a would route to the same topic; the client-side params filter (RFC 087 §6) catches the false positive. Documented; not worth blake3 yet (would change the wire format).
+
+## Related RFCs
+
+* [RFC 086](./rfc-086-sync-query.md) — `pocopine-sync-query` crate (routing engine).
+* [RFC 087](./rfc-087-sync-query-driver.md) — driver lifecycle (the foundation this RFC builds on).
+* [RFC 071](./rfc-071-event-spine.md) — live invalidation channel (Section C extends).
+* [RFC 072](./rfc-072-offline-sync.md) — offline sync protocol (Section A reuses the `SyncLocalStore` trait that RFC 072 defines).


### PR DESCRIPTION
Implements [RFC 088 Section A — Durable persistence](rfcs/rfc-088-sync-query-production-parity.md). First of three PRs landing the RFC; B (selector composition) and C (per-params topics) follow.

## What lands

Sync-query subscriptions were in-memory only — a page reload wiped canonical rows + pending overlays. This PR wires `pocopine_sync::SyncLocalStore` (existing trait, existing IndexedDB / SQLite impls) into the driver so:

- `observe(q)` hydrates from store BEFORE issuing `/open` — UI renders cached rows instantly.
- After every successful `/pull`, canonical state is persisted.
- Pending overlays survive page reloads; on hydrate, the driver re-derives their `Mutator::apply_remote` invocation via a new `MutatorRegistry` on `QueryClient` and re-fires them on the first online tick.
- Schema-drift detected at `/open` time triggers `store.clear_stream(local_stream_key)` + `state.reset()`, then a fresh `/pull`.

User opt-in is one line:

```rust
let client = QueryClient::with_config(
    QueryClientConfig::default()
        .with_local_store(Rc::new(my_local_store))
);
client.register_mutator::<CreateIssue>();
client.register_mutator::<UpdateIssue>();
```

Apps that don't configure a store see no behavior change. Mutator registration is required to enable persisted-mutation replay (the driver looks up the matching mutator by `(STREAM, NAME)` at hydrate time).

## Files

| File | Δ |
| --- | --- |
| `rfcs/rfc-088-sync-query-production-parity.md` (new) | +504 |
| `crates/pocopine-sync-query/src/client.rs` | +418 / -22 |
| `crates/pocopine-sync-query/src/driver.rs` | +465 |
| `crates/pocopine-sync-query/src/mutator.rs` | +206 |
| `crates/pocopine-sync-query/tests/persistence.rs` (new) | +662 |
| `crates/pocopine-sync-query/src/lib.rs` | +10 / -2 |

**Total: +2241 / -24 across 6 files** (1737 for Section A + 504 for the RFC).

## Commits

6 milestone-aligned commits on `wip/sync-query-persistence-impl`:

1. `MutatorRegistry + AnyMutator scaffolding (RFC 088 §A.5)` — trait + helpers; no behavior change.
2. `Phase 0 hydrate + post-pull persist + schema-drift wipe` — driver integration.
3. `persistence test suite (RFC 088 §A.8)` — 6 tests.
4. `cargo fmt --all over RFC 088 §A diff`.
5. `fix clippy::doc_lazy_continuation in hydrate_phase doc`.
6. `address codex review on persistence (6 findings)` — codex fixes kept separate per request.

## Gates

- `cargo fmt --all -- --check` ✅
- `cargo test -p pocopine-sync-query -p pocopine-sync-query-macros --lib --tests` — **97 tests pass** (53 lib + 9 api + 13 routing + 6 driver + 6 persistence + 10 macros)
- Host clippy `-D warnings` clean
- wasm32 clippy `-D warnings` clean

## Codex review at checkpoint (6 findings, all fixed)

Run pre-PR via `codex review --base origin/wip/sync-query-persistence`. All addressed in commit `ff5bd0b6`:

| Sev | File:line | Issue | Fix |
| --- | --- | --- | --- |
| **P1** | `client.rs:551` | RollbackGuard armed AFTER persist await — cancellation could leak the overlay | Moved guard arming before the persist call |
| **P1** | `client.rs:551` | Accepted mutations stayed in store forever — re-hydrated every session | Added `clear_persisted_pending` via `mark_push_result` after canonical reconcile |
| **P1** | `client.rs:1135` | MutatorRegistry keyed by `NAME` alone — collisions across streams | Changed key to `(STREAM, NAME)` tuple |
| **P2** | `client.rs:1247` | Rejected-replay cleanup used draining driver's `Row` not the mutator's | Moved cleanup inside `AnyMutator::replay_hydrated` via `dequeue_pending_for_mutator_row::<M::Row>` |
| **P2** | `client.rs:719` | Bare-fallback compartment's pending queue was never read on hydrate | Hydrate now reads bare-stream compartment too, de-duped by `mutation_id` |
| **P2** | `driver.rs:912` | Stale-schema rows could flash before drift wipe | Removed external notify in `apply_hydrated_snapshot`; first notify happens in `mark_loading`/`apply_open` |
| **P3** | `tests/persistence.rs:600` | Isolation test seeded compartments manually | Rewrote to assert driver-persisted state in both directions |

## Deviations from RFC 088 §A (documented in the report)

1. **Mutator NAME wire envelope.** RFC §A.5 hand-waved "mutator name carried on `ClientMutation`". Surveying the existing wire shape: it doesn't carry NAME, only `MutationId`. Adding a field to `ClientMutation` would ripple across `pocopine-sync`, `pocopine-sync-crud`, and the server. Instead: at persist time, `ClientMutation<Value>::payload` is wrapped in `{"__mutator": "<NAME>", "__payload": <user payload>}`. The server NEVER sees this envelope (live wire `ClientMutation` carries the bare payload). Hydrate unwraps before invoking `Mutator::apply_remote`. Helpers `wrap_persisted_payload` / `unwrap_persisted_payload` live in `mutator.rs`.

2. **`(STREAM, NAME)` registry key vs RFC's `TypeId`.** Hydrate looks up mutators by persisted string (NAME), not by `TypeId`. The key is `(STREAM, NAME)`; `MutatorEntry<M>` still type-erases over `M: Mutator`.

3. **Pending compartment fan-out.** RFC §A.2 said "each `(stream, params)` pair gets its own compartment." But a single mutation can hit multiple subscriptions on the same stream with different params, so `persist_pending_mutation` writes the entry into EACH affected subscription's compartment PLUS a bare-stream fallback (for mutations queued before a matching subscription was open). Codex P2 surfaced the missing bare-stream hydrate read; fixed.

## Follow-ups (not in this PR)

- When `SyncLocalStore` grows a `purge_pending_by_mutation_id` primitive, replace `mark_push_result` in `clear_persisted_pending` with the cheaper purge.
- Telemetry hook (RFC-069 `target: "pocopine.metric"`) for hydrate-time decode failures — currently logs + drops affected entries.
- Cookbook update for the user-facing `with_local_store(...)` pattern. Today `MemoryLocalStore::new()` is the only ready-to-use impl; `IndexedDbLocalStore::open(...)` is a future RFC-072 binding.

## What's NOT in this PR (per RFC 088)

- Section B (`#[query]` selector composition) — separate PR off `wip/sync-query-selectors`.
- Section C (per-`(name, params_hash)` live topics) — separate PR off `wip/sync-query-per-params-topics`.