### PR TITLE
sync-query: `#[query]` selector layer (runtime + macro)

### DIFF
--- a/crates/pocopine-sync-query-macros/src/lib.rs
+++ b/crates/pocopine-sync-query-macros/src/lib.rs
@@ -1008,13 +1008,15 @@ fn expand_query(func: ItemFn) -> syn::Result<TokenStream2> {
                         ));
                     }
                 };
-                if matches!(&*pt.ty, Type::ImplTrait(_)) {
+                if contains_impl_trait(&pt.ty) {
                     return Err(syn::Error::new_spanned(
                         &pt.ty,
                         "`#[query]` selectors cannot use argument-position `impl Trait` — \
-                         the cache key only covers `(SelectorId, args_hash)`, so two \
-                         instantiations could alias each other's entries. Use a concrete \
-                         type instead.",
+                         not even nested (e.g. `Box<impl Trait>`, `Option<impl Trait>`). \
+                         Argument-position `impl Trait` makes the fn generic over the \
+                         call-site type, but the cache key only covers \
+                         `(SelectorId, args_hash)`, so two concrete instantiations could \
+                         alias each other's cached entries. Use a concrete type.",
                     ));
                 }
                 arg_idents.push(ident);
@@ -1098,11 +1100,17 @@ fn expand_query(func: ItemFn) -> syn::Result<TokenStream2> {
         .collect();
 
     Ok(quote! {
+        // User attrs go on the inner fn — that's where the body
+        // lives, so function-scoped lint attrs (e.g.
+        // `#[allow(unused_variables)]`, `#[expect(…)]`) emitted by
+        // the user have to follow the body to keep their effect.
+        // Doc comments end up on a `#[doc(hidden)]` private fn,
+        // which is harmless (they aren't surfaced in rustdoc).
+        #(#user_attrs)*
         #[doc(hidden)]
         #[allow(non_snake_case, clippy::too_many_arguments)]
         fn #inner_fn_ident( #( #inner_fn_params ),* ) -> #ret_type #block
 
-        #(#user_attrs)*
         #[allow(non_camel_case_types, non_snake_case, dead_code)]
         #mod_vis mod #fn_name {
             // Bring the parent module's items into scope so `observe`
@@ -1178,4 +1186,34 @@ fn is_query_client_type(ty: &Type) -> bool {
         .segments
         .last()
         .is_some_and(|seg| seg.ident == "QueryClient")
+}
+
+/// Walk `ty` recursively and return `true` if any embedded type is
+/// argument-position `impl Trait`. Catches `Box<impl T>`,
+/// `Option<impl T>`, `(impl T, …)`, `&impl T`, etc. Rust desugars
+/// these to anonymous generics; with the selector cache key only
+/// covering `(SelectorId, args_hash)`, two concrete instantiations
+/// of the same `observe()` could alias their cached entries — that's
+/// the unsoundness the recursive check guards against.
+fn contains_impl_trait(ty: &Type) -> bool {
+    match ty {
+        Type::ImplTrait(_) => true,
+        Type::Reference(r) => contains_impl_trait(&r.elem),
+        Type::Slice(s) => contains_impl_trait(&s.elem),
+        Type::Array(a) => contains_impl_trait(&a.elem),
+        Type::Ptr(p) => contains_impl_trait(&p.elem),
+        Type::Paren(p) => contains_impl_trait(&p.elem),
+        Type::Group(g) => contains_impl_trait(&g.elem),
+        Type::Tuple(t) => t.elems.iter().any(contains_impl_trait),
+        Type::Path(p) => p.path.segments.iter().any(|seg| {
+            if let PathArguments::AngleBracketed(args) = &seg.arguments {
+                args.args
+                    .iter()
+                    .any(|arg| matches!(arg, GenericArgument::Type(t) if contains_impl_trait(t)))
+            } else {
+                false
+            }
+        }),
+        _ => false,
+    }
 }

--- a/crates/pocopine-sync-query-macros/src/lib.rs
+++ b/crates/pocopine-sync-query-macros/src/lib.rs
@@ -1081,7 +1081,23 @@ fn expand_query(func: ItemFn) -> syn::Result<TokenStream2> {
     // Visibility for the generated module. Forward the user's
     // visibility so a `pub fn` selector becomes a `pub mod`.
     let mod_vis = &vis;
-    let user_attrs = &attrs;
+
+    // Split the user-written attrs by audience:
+    //
+    // * Lint / behavior attrs (`#[allow]`, `#[deny]`, `#[warn]`,
+    //   `#[forbid]`, `#[expect]`, `#[inline]`, `#[cold]`, `#[cfg]`,
+    //   `#[cfg_attr]`) follow the body to the lifted inner fn so
+    //   lints emitted inside the body see them.
+    // * Public-API attrs (`#[doc]` / `///`, `#[deprecated]`,
+    //   `#[must_use]`) go on the public module — they describe the
+    //   selector's outward surface. Putting `#[deprecated]` on the
+    //   inner fn would cause the macro's own `super::<inner>()`
+    //   call to trigger `deny(deprecated)`.
+    // * `#[cfg]` and `#[cfg_attr]` end up on BOTH so a cfg-disabled
+    //   selector compiles consistently (the module and the body
+    //   need to disappear together).
+    let (module_attrs, inner_attrs): (Vec<&Attribute>, Vec<&Attribute>) =
+        partition_selector_attrs(&attrs);
 
     // Mangled name for the carried-over user body. Lives at the
     // SAME module level as the original `#[query] fn` so any
@@ -1102,17 +1118,19 @@ fn expand_query(func: ItemFn) -> syn::Result<TokenStream2> {
         .collect();
 
     Ok(quote! {
-        // User attrs go on the inner fn — that's where the body
-        // lives, so function-scoped lint attrs (e.g.
-        // `#[allow(unused_variables)]`, `#[expect(…)]`) emitted by
-        // the user have to follow the body to keep their effect.
-        // Doc comments end up on a `#[doc(hidden)]` private fn,
-        // which is harmless (they aren't surfaced in rustdoc).
-        #(#user_attrs)*
+        // Inner-fn attrs: lint and behavior attrs that need to
+        // follow the body. `#[doc(hidden)]` keeps any user docs out
+        // of rustdoc (the public module already carries them).
+        #(#inner_attrs)*
         #[doc(hidden)]
         #[allow(non_snake_case, clippy::too_many_arguments)]
         fn #inner_fn_ident( #( #inner_fn_params ),* ) -> #ret_type #block
 
+        // Module attrs: doc comments, `#[deprecated]`,
+        // `#[must_use]` — they describe the selector's public API.
+        // `#[cfg(...)]` attrs are duplicated here so the module
+        // disappears in lockstep with the body.
+        #(#module_attrs)*
         #[allow(non_camel_case_types, non_snake_case, dead_code)]
         #mod_vis mod #fn_name {
             // Bring the parent module's items into scope so `observe`
@@ -1191,6 +1209,38 @@ fn expand_query(func: ItemFn) -> syn::Result<TokenStream2> {
     })
 }
 
+/// Split user-supplied attrs on a `#[query] fn` into two groups —
+/// `(module_attrs, inner_attrs)` — by audience. See the call site
+/// in `expand_query` for the rationale.
+///
+/// * `#[doc]` / `///`, `#[deprecated]`, `#[must_use]` → module
+///   (public API surface).
+/// * `#[allow]` / `#[deny]` / `#[warn]` / `#[forbid]` / `#[expect]`,
+///   `#[inline]` / `#[cold]` / `#[no_mangle]` → inner fn (body
+///   audience).
+/// * `#[cfg]` / `#[cfg_attr]` → both (module and body must compile
+///   or disappear together).
+/// * Unknown attrs default to the inner fn — they probably affect
+///   the body and `#[deprecated]`-style attrs on the inner fn don't
+///   fire warnings as long as the macro doesn't reference an
+///   unknown-named attr. Erring inward is conservative.
+fn partition_selector_attrs(attrs: &[Attribute]) -> (Vec<&Attribute>, Vec<&Attribute>) {
+    let mut module = Vec::new();
+    let mut inner = Vec::new();
+    for attr in attrs {
+        let ident = attr.path().segments.last().map(|s| s.ident.to_string());
+        match ident.as_deref() {
+            Some("doc" | "deprecated" | "must_use") => module.push(attr),
+            Some("cfg" | "cfg_attr") => {
+                module.push(attr);
+                inner.push(attr);
+            }
+            _ => inner.push(attr),
+        }
+    }
+    (module, inner)
+}
+
 /// Detect whether a type is `QueryClient` by last path segment.
 /// Matches `QueryClient`, `pocopine_sync_query::QueryClient`, etc;
 /// does NOT match `&QueryClient` or `Rc<QueryClient>` (the macro's
@@ -1221,15 +1271,49 @@ fn contains_impl_trait(ty: &Type) -> bool {
         Type::Paren(p) => contains_impl_trait(&p.elem),
         Type::Group(g) => contains_impl_trait(&g.elem),
         Type::Tuple(t) => t.elems.iter().any(contains_impl_trait),
-        Type::Path(p) => p.path.segments.iter().any(|seg| {
-            if let PathArguments::AngleBracketed(args) = &seg.arguments {
-                args.args
+        Type::Path(p) => p
+            .path
+            .segments
+            .iter()
+            .any(|seg| path_args_contain_impl_trait(&seg.arguments)),
+        // Walk `dyn Trait1 + Trait2<Item = impl X>` — the bound's
+        // path can carry assoc-type bindings that contain
+        // `impl Trait`.
+        Type::TraitObject(t) => t.bounds.iter().any(|b| {
+            if let syn::TypeParamBound::Trait(tb) = b {
+                tb.path
+                    .segments
                     .iter()
-                    .any(|arg| matches!(arg, GenericArgument::Type(t) if contains_impl_trait(t)))
+                    .any(|seg| path_args_contain_impl_trait(&seg.arguments))
             } else {
                 false
             }
         }),
         _ => false,
     }
+}
+
+fn path_args_contain_impl_trait(args: &PathArguments) -> bool {
+    let PathArguments::AngleBracketed(args) = args else {
+        return false;
+    };
+    args.args.iter().any(|arg| match arg {
+        GenericArgument::Type(t) => contains_impl_trait(t),
+        // `Trait<Item = impl X>` — the assoc-type's RHS can be
+        // `impl Trait`.
+        GenericArgument::AssocType(at) => contains_impl_trait(&at.ty),
+        // `Trait<Item: impl X>` — the constraint's bounds can carry
+        // trait paths whose segments embed `impl Trait`.
+        GenericArgument::Constraint(c) => c.bounds.iter().any(|b| {
+            if let syn::TypeParamBound::Trait(tb) = b {
+                tb.path
+                    .segments
+                    .iter()
+                    .any(|seg| path_args_contain_impl_trait(&seg.arguments))
+            } else {
+                false
+            }
+        }),
+        _ => false,
+    })
 }

--- a/crates/pocopine-sync-query-macros/src/lib.rs
+++ b/crates/pocopine-sync-query-macros/src/lib.rs
@@ -1218,10 +1218,16 @@ fn expand_query(func: ItemFn) -> syn::Result<TokenStream2> {
 /// the call site in `expand_query` for the rationale.
 ///
 /// * `#[doc]` / `///`, `#[deprecated]` → module (public API surface).
-/// * `#[must_use]`, `#[track_caller]` → `observe()` (Rust rejects
-///   `#[must_use]` on modules, and these attrs fire against the
-///   call site that consumes the selector — `observe()` is the
-///   user-visible call site, not the module).
+/// * `#[must_use]` → `observe()` (Rust rejects `#[must_use]` on
+///   modules; the lint fires against the callsite of `observe()`,
+///   which is what the user intended).
+/// * `#[track_caller]` → BOTH `observe()` and the inner fn.
+///   `observe()` carries it so `Location::caller()` resolves to the
+///   user's call site at the first synchronous compute. The inner
+///   fn also carries it so panics inside the body report a
+///   meaningful location (the chain still goes through an
+///   anonymous compute closure, which is a documented limitation —
+///   `Location::caller()` doesn't propagate through closures).
 /// * `#[allow]` / `#[deny]` / `#[warn]` / `#[forbid]` / `#[expect]`,
 ///   `#[inline]` / `#[cold]` / `#[no_mangle]` → inner fn (body
 ///   audience).
@@ -1239,7 +1245,11 @@ fn partition_selector_attrs(
         let ident = attr.path().segments.last().map(|s| s.ident.to_string());
         match ident.as_deref() {
             Some("doc" | "deprecated") => module.push(attr),
-            Some("must_use" | "track_caller") => observe.push(attr),
+            Some("must_use") => observe.push(attr),
+            Some("track_caller") => {
+                observe.push(attr);
+                inner.push(attr);
+            }
             Some("cfg" | "cfg_attr") => {
                 module.push(attr);
                 observe.push(attr);

--- a/crates/pocopine-sync-query-macros/src/lib.rs
+++ b/crates/pocopine-sync-query-macros/src/lib.rs
@@ -41,8 +41,8 @@ use quote::quote;
 use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
 use syn::{
-    parse_macro_input, Attribute, Fields, GenericArgument, Ident, ItemStruct, LitInt, LitStr, Meta,
-    PathArguments, PathSegment, Token, Type,
+    parse_macro_input, Attribute, Fields, FnArg, GenericArgument, Ident, ItemFn, ItemStruct,
+    LitInt, LitStr, Meta, Pat, PatIdent, PathArguments, PathSegment, ReturnType, Token, Type,
 };
 
 const MAX_SYNC_TOKEN_LEN: usize = 1024;
@@ -859,4 +859,286 @@ fn generate_matches_body(params: &[ParamDef]) -> TokenStream2 {
         let _ = params; // silence unused if no #[query_param] fields declared
         #(#checks)*
     }
+}
+
+// ---- #[query] selector macro --------------------------------------
+
+/// `#[query]` — declare a memoized selector function over
+/// `pocopine-sync-query` reactive state.
+///
+/// Wraps a Rust function so that its return value is cached by
+/// `(SelectorId, args_hash)`, its reads of `QueryView::rows()` are
+/// tracked, and the cached value is automatically refreshed when a
+/// tracked subscription changes. The user-facing return type
+/// MUST implement `PartialEq + Clone + 'static`; each argument MUST
+/// implement `Clone + std::hash::Hash + 'static`.
+///
+/// The macro replaces the annotated `fn name(args...) -> Ret { ... }`
+/// with a sibling module `name` containing:
+///
+/// * `pub const SELECTOR_ID: pocopine_sync_query::SelectorId` —
+///   `FNV-1a 64(concat!(module_path!(), "::", "name"))`.
+/// * `pub fn observe(client: &QueryClient, args...) -> SelectorView<Ret>`.
+/// * a private `__user_fn(args) -> Ret` carrying the original body.
+///
+/// `observe()` hashes the args via `std::hash::Hash`, looks up or
+/// creates the cached entry, and returns a fresh `SelectorView`. The
+/// compute closure clones the args and the client into a `'static`
+/// `Fn` so it can be invoked on every rerun.
+///
+/// See `docs/sync-query-selector-mechanism.md` for the runtime
+/// design and the four-moving-parts walk-through.
+#[proc_macro_attribute]
+pub fn query(attr: TokenStream, item: TokenStream) -> TokenStream {
+    // No selector attributes are accepted in v1. `#[query(no_diff)]`
+    // is deferred — keep the parser strict so misuse fails loud
+    // instead of silently being ignored.
+    if !attr.is_empty() {
+        let attr_ts: TokenStream2 = attr.into();
+        return syn::Error::new_spanned(
+            attr_ts,
+            "`#[query]` does not accept any arguments yet (the `no_diff` opt-out is \
+             deferred — track via RFC follow-up)",
+        )
+        .to_compile_error()
+        .into();
+    }
+
+    let func = parse_macro_input!(item as ItemFn);
+    match expand_query(func) {
+        Ok(ts) => ts.into(),
+        Err(e) => e.to_compile_error().into(),
+    }
+}
+
+fn expand_query(func: ItemFn) -> syn::Result<TokenStream2> {
+    let ItemFn {
+        attrs,
+        vis,
+        sig,
+        block,
+    } = func;
+
+    // Reject anything that doesn't fit the selector contract.
+    if let Some(asyncness) = sig.asyncness {
+        return Err(syn::Error::new(
+            asyncness.span,
+            "`#[query]` selectors must be synchronous — the compute closure runs inside the \
+             reactive-rerun path",
+        ));
+    }
+    if let Some(unsafety) = sig.unsafety {
+        return Err(syn::Error::new(
+            unsafety.span,
+            "`#[query]` selectors must not be `unsafe`",
+        ));
+    }
+    if !sig.generics.params.is_empty() {
+        return Err(syn::Error::new_spanned(
+            &sig.generics,
+            "`#[query]` selectors must not be generic — the cache key is keyed by the args' \
+             runtime hash, not by type parameters",
+        ));
+    }
+    if let Some(where_clause) = &sig.generics.where_clause {
+        return Err(syn::Error::new_spanned(
+            where_clause,
+            "`#[query]` selectors must not have a `where` clause",
+        ));
+    }
+    if let Some(variadic) = &sig.variadic {
+        return Err(syn::Error::new_spanned(
+            variadic,
+            "`#[query]` selectors must not be variadic",
+        ));
+    }
+    if sig.constness.is_some() {
+        return Err(syn::Error::new_spanned(
+            sig.constness,
+            "`#[query]` selectors cannot be `const fn`",
+        ));
+    }
+
+    let fn_name = sig.ident.clone();
+    let fn_name_str = fn_name.to_string();
+    let ret_type = match &sig.output {
+        ReturnType::Type(_, t) => (**t).clone(),
+        ReturnType::Default => {
+            return Err(syn::Error::new_spanned(
+                &sig.ident,
+                "`#[query]` selectors must declare an explicit return type — the default `()` \
+                 return is rarely useful and trips up `PartialEq + Clone` inference",
+            ));
+        }
+    };
+
+    // Extract typed args. Reject `self` receivers and patterns more
+    // complex than a simple ident (the compute closure needs to
+    // capture each by name).
+    let mut arg_idents: Vec<Ident> = Vec::with_capacity(sig.inputs.len());
+    let mut arg_types: Vec<Type> = Vec::with_capacity(sig.inputs.len());
+    for input in &sig.inputs {
+        match input {
+            FnArg::Receiver(rec) => {
+                return Err(syn::Error::new_spanned(
+                    rec,
+                    "`#[query]` selectors must be free functions — no `self` parameter",
+                ));
+            }
+            FnArg::Typed(pt) => {
+                let ident = match &*pt.pat {
+                    Pat::Ident(PatIdent {
+                        ident,
+                        subpat: None,
+                        ..
+                    }) => ident.clone(),
+                    other => {
+                        return Err(syn::Error::new_spanned(
+                            other,
+                            "`#[query]` selector args must use simple identifier patterns \
+                             (e.g. `ws_id: String`); destructuring is not supported",
+                        ));
+                    }
+                };
+                arg_idents.push(ident);
+                arg_types.push((*pt.ty).clone());
+            }
+        }
+    }
+
+    // Convention: if the user fn's first arg is typed `QueryClient`
+    // (any path ending in that segment), the macro treats it as the
+    // selector's client handle — NOT hashed, NOT replicated in the
+    // generated `observe()`'s arg list (which always takes
+    // `&QueryClient` as its first param). The user's body sees the
+    // client as that first param so it can call `client.observe(q)`
+    // ergonomically. If the user fn has no `QueryClient` arg, the
+    // body must reach a client some other way (thread_local, etc.).
+    let client_arg_present = arg_types.first().is_some_and(is_query_client_type);
+
+    // Hashable (user-visible) args: everything except the recognized
+    // client arg. These are what `observe()` exposes publicly and
+    // what `args_hash` covers.
+    let (user_arg_idents, user_arg_types): (Vec<Ident>, Vec<Type>) = if client_arg_present {
+        (arg_idents[1..].to_vec(), arg_types[1..].to_vec())
+    } else {
+        (arg_idents.clone(), arg_types.clone())
+    };
+    // Per-arg helper idents for the captured + per-rerun clones.
+    let captured_user_idents: Vec<Ident> = user_arg_idents
+        .iter()
+        .map(|i| Ident::new(&format!("__pq_arg_{i}"), i.span()))
+        .collect();
+
+    // `let __pq_client_for_compute = client.clone();` — emitted only
+    // when the user declared a client arg, so the closure has
+    // something to clone into each rerun's `__user_fn` call.
+    let client_capture_let: TokenStream2 = if client_arg_present {
+        quote! {
+            let __pq_client_for_compute =
+                ::core::clone::Clone::clone(__pq_client);
+        }
+    } else {
+        quote! {}
+    };
+
+    // Args passed into `__user_fn` per rerun. When the user
+    // declared a client param, the first arg is a cloned client;
+    // the rest are cloned hashed args.
+    let user_fn_call_args: Vec<TokenStream2> = {
+        let mut out: Vec<TokenStream2> = Vec::with_capacity(arg_idents.len());
+        if client_arg_present {
+            out.push(quote! { ::core::clone::Clone::clone(&__pq_client_for_compute) });
+        }
+        for captured in &captured_user_idents {
+            out.push(quote! { ::core::clone::Clone::clone(&#captured) });
+        }
+        out
+    };
+
+    // Visibility for the generated module. Forward the user's
+    // visibility so a `pub fn` selector becomes a `pub mod`.
+    let mod_vis = &vis;
+    let user_attrs = &attrs;
+
+    Ok(quote! {
+        #(#user_attrs)*
+        #[allow(non_camel_case_types, non_snake_case, dead_code)]
+        #mod_vis mod #fn_name {
+            // Bring the parent module's items into scope so the user
+            // body's references (sibling fns, types) resolve. We use
+            // a glob import so the macro doesn't have to enumerate.
+            use super::*;
+
+            /// Stable identity for this selector. FNV-1a 64 of
+            /// `concat!(module_path!(), "::", "<fn_name>")` evaluated
+            /// at the user-crate compile time. Uniqueness collapses
+            /// to "no two `#[query]` fns share the same module path
+            /// AND name" — a conflict rustc already rejects.
+            pub const SELECTOR_ID: ::pocopine_sync_query::SelectorId =
+                ::pocopine_sync_query::SelectorId::new(
+                    ::pocopine_sync_query::__private::fnv1a64(
+                        ::core::concat!(::core::module_path!(), "::", #fn_name_str).as_bytes()
+                    )
+                );
+
+            /// Observe this selector. Hashes the args, looks up or
+            /// creates the cached entry, returns a fresh
+            /// [`SelectorView`](::pocopine_sync_query::SelectorView).
+            ///
+            /// On a cache hit, `__user_fn` is NOT called — the cached
+            /// value is reused. On a cache miss, `__user_fn` runs
+            /// inside the selector's tracking frame so any
+            /// `QueryView::rows()` reads register as dependencies.
+            pub fn observe(
+                __pq_client: &::pocopine_sync_query::QueryClient,
+                #( #user_arg_idents : #user_arg_types ),*
+            ) -> ::pocopine_sync_query::SelectorView<#ret_type> {
+                // Hash hashable args (everything except the
+                // recognized client param). `DefaultHasher` is fine
+                // here — the hash is consumed only by an in-process
+                // HashMap lookup; it isn't exposed on the wire.
+                let mut __pq_hasher =
+                    ::std::collections::hash_map::DefaultHasher::new();
+                #(
+                    ::std::hash::Hash::hash(&#user_arg_idents, &mut __pq_hasher);
+                )*
+                let __pq_args_hash = ::std::hash::Hasher::finish(&__pq_hasher);
+
+                // Capture owned clones of args (and a clone of the
+                // client, if the user declared a client arg) into
+                // the `'static` `Fn` closure. Each rerun further
+                // clones them to pass into `__user_fn` (which takes
+                // args by value, matching the user-written
+                // signature).
+                #client_capture_let
+                #(
+                    let #captured_user_idents =
+                        ::core::clone::Clone::clone(&#user_arg_idents);
+                )*
+                let __pq_compute = move || -> #ret_type {
+                    __user_fn( #( #user_fn_call_args ),* )
+                };
+                __pq_client.observe_selector(SELECTOR_ID, __pq_args_hash, __pq_compute)
+            }
+
+            /// Original `#[query]` function body. Kept private — call
+            /// through [`observe`] so the cache + tracking machinery
+            /// runs.
+            fn __user_fn( #( #arg_idents : #arg_types ),* ) -> #ret_type #block
+        }
+    })
+}
+
+/// Detect whether a type is `QueryClient` by last path segment.
+/// Matches `QueryClient`, `pocopine_sync_query::QueryClient`, etc;
+/// does NOT match `&QueryClient` or `Rc<QueryClient>` (the macro's
+/// contract requires an owned client param, mirroring the
+/// generated compute closure's capture).
+fn is_query_client_type(ty: &Type) -> bool {
+    let Type::Path(p) = ty else { return false };
+    p.path
+        .segments
+        .last()
+        .is_some_and(|seg| seg.ident == "QueryClient")
 }

--- a/crates/pocopine-sync-query-macros/src/lib.rs
+++ b/crates/pocopine-sync-query-macros/src/lib.rs
@@ -974,8 +974,14 @@ fn expand_query(func: ItemFn) -> syn::Result<TokenStream2> {
 
     // Extract typed args. Reject `self` receivers and patterns more
     // complex than a simple ident (the compute closure needs to
-    // capture each by name).
+    // capture each by name). Also reject argument-position
+    // `impl Trait`: it makes the user fn generic over the type at
+    // the call site, but the cache key only carries
+    // `(SelectorId, args_hash)` — two instantiations with the same
+    // hash would alias each other's cached entry across different
+    // monomorphized return types.
     let mut arg_idents: Vec<Ident> = Vec::with_capacity(sig.inputs.len());
+    let mut arg_mutabilities: Vec<Option<Token![mut]>> = Vec::with_capacity(sig.inputs.len());
     let mut arg_types: Vec<Type> = Vec::with_capacity(sig.inputs.len());
     for input in &sig.inputs {
         match input {
@@ -986,21 +992,33 @@ fn expand_query(func: ItemFn) -> syn::Result<TokenStream2> {
                 ));
             }
             FnArg::Typed(pt) => {
-                let ident = match &*pt.pat {
+                let (ident, mutability) = match &*pt.pat {
                     Pat::Ident(PatIdent {
                         ident,
+                        mutability,
                         subpat: None,
+                        by_ref: None,
                         ..
-                    }) => ident.clone(),
+                    }) => (ident.clone(), *mutability),
                     other => {
                         return Err(syn::Error::new_spanned(
                             other,
                             "`#[query]` selector args must use simple identifier patterns \
-                             (e.g. `ws_id: String`); destructuring is not supported",
+                             (e.g. `ws_id: String`); destructuring and `ref` are not supported",
                         ));
                     }
                 };
+                if matches!(&*pt.ty, Type::ImplTrait(_)) {
+                    return Err(syn::Error::new_spanned(
+                        &pt.ty,
+                        "`#[query]` selectors cannot use argument-position `impl Trait` — \
+                         the cache key only covers `(SelectorId, args_hash)`, so two \
+                         instantiations could alias each other's entries. Use a concrete \
+                         type instead.",
+                    ));
+                }
                 arg_idents.push(ident);
+                arg_mutabilities.push(mutability);
                 arg_types.push((*pt.ty).clone());
             }
         }
@@ -1061,13 +1079,37 @@ fn expand_query(func: ItemFn) -> syn::Result<TokenStream2> {
     let mod_vis = &vis;
     let user_attrs = &attrs;
 
+    // Mangled name for the carried-over user body. Lives at the
+    // SAME module level as the original `#[query] fn` so any
+    // `super::*` references in the body keep their original
+    // resolution. The generated module's `observe()` calls it via
+    // `super::<this_ident>`.
+    let inner_fn_ident = Ident::new(&format!("__pq_user_fn__{fn_name_str}"), fn_name.span());
+
+    // Reconstruct each parameter for the inner fn, preserving any
+    // `mut` binding the user wrote.
+    let inner_fn_params: Vec<TokenStream2> = arg_idents
+        .iter()
+        .zip(arg_mutabilities.iter())
+        .zip(arg_types.iter())
+        .map(|((ident, mutability), ty)| {
+            quote! { #mutability #ident: #ty }
+        })
+        .collect();
+
     Ok(quote! {
+        #[doc(hidden)]
+        #[allow(non_snake_case, clippy::too_many_arguments)]
+        fn #inner_fn_ident( #( #inner_fn_params ),* ) -> #ret_type #block
+
         #(#user_attrs)*
         #[allow(non_camel_case_types, non_snake_case, dead_code)]
         #mod_vis mod #fn_name {
-            // Bring the parent module's items into scope so the user
-            // body's references (sibling fns, types) resolve. We use
-            // a glob import so the macro doesn't have to enumerate.
+            // Bring the parent module's items into scope so `observe`
+            // can resolve `QueryClient` / `SelectorId` if the parent
+            // already has them in scope. Doesn't pollute the user
+            // body's resolution, since the body lives in the parent
+            // module (see `super::#inner_fn_ident`).
             use super::*;
 
             /// Stable identity for this selector. FNV-1a 64 of
@@ -1086,9 +1128,9 @@ fn expand_query(func: ItemFn) -> syn::Result<TokenStream2> {
             /// creates the cached entry, returns a fresh
             /// [`SelectorView`](::pocopine_sync_query::SelectorView).
             ///
-            /// On a cache hit, `__user_fn` is NOT called — the cached
-            /// value is reused. On a cache miss, `__user_fn` runs
-            /// inside the selector's tracking frame so any
+            /// On a cache hit, the user body is NOT called — the
+            /// cached value is reused. On a cache miss, the body
+            /// runs inside the selector's tracking frame so any
             /// `QueryView::rows()` reads register as dependencies.
             pub fn observe(
                 __pq_client: &::pocopine_sync_query::QueryClient,
@@ -1108,8 +1150,8 @@ fn expand_query(func: ItemFn) -> syn::Result<TokenStream2> {
                 // Capture owned clones of args (and a clone of the
                 // client, if the user declared a client arg) into
                 // the `'static` `Fn` closure. Each rerun further
-                // clones them to pass into `__user_fn` (which takes
-                // args by value, matching the user-written
+                // clones them to pass into the user body (which
+                // takes args by value, matching the user-written
                 // signature).
                 #client_capture_let
                 #(
@@ -1117,15 +1159,10 @@ fn expand_query(func: ItemFn) -> syn::Result<TokenStream2> {
                         ::core::clone::Clone::clone(&#user_arg_idents);
                 )*
                 let __pq_compute = move || -> #ret_type {
-                    __user_fn( #( #user_fn_call_args ),* )
+                    super::#inner_fn_ident( #( #user_fn_call_args ),* )
                 };
                 __pq_client.observe_selector(SELECTOR_ID, __pq_args_hash, __pq_compute)
             }
-
-            /// Original `#[query]` function body. Kept private — call
-            /// through [`observe`] so the cache + tracking machinery
-            /// runs.
-            fn __user_fn( #( #arg_idents : #arg_types ),* ) -> #ret_type #block
         }
     })
 }

--- a/crates/pocopine-sync-query-macros/src/lib.rs
+++ b/crates/pocopine-sync-query-macros/src/lib.rs
@@ -1221,13 +1221,15 @@ fn expand_query(func: ItemFn) -> syn::Result<TokenStream2> {
 /// * `#[must_use]` → `observe()` (Rust rejects `#[must_use]` on
 ///   modules; the lint fires against the callsite of `observe()`,
 ///   which is what the user intended).
-/// * `#[track_caller]` → BOTH `observe()` and the inner fn.
-///   `observe()` carries it so `Location::caller()` resolves to the
-///   user's call site at the first synchronous compute. The inner
-///   fn also carries it so panics inside the body report a
-///   meaningful location (the chain still goes through an
-///   anonymous compute closure, which is a documented limitation —
-///   `Location::caller()` doesn't propagate through closures).
+/// * `#[track_caller]` → `observe()` only. The user body is invoked
+///   through an anonymous compute closure that breaks the
+///   `#[track_caller]` chain regardless of where the attr lives, so
+///   putting it on the lifted body would actually DEGRADE panic
+///   location quality: `panic!()` inside the body without the attr
+///   reports the body's panic line; with the attr it reports the
+///   (opaque) closure call site. Observe-only is the best we can
+///   do; `Location::caller()` reads inside the body are a
+///   documented unsupported case.
 /// * `#[allow]` / `#[deny]` / `#[warn]` / `#[forbid]` / `#[expect]`,
 ///   `#[inline]` / `#[cold]` / `#[no_mangle]` → inner fn (body
 ///   audience).
@@ -1245,11 +1247,7 @@ fn partition_selector_attrs(
         let ident = attr.path().segments.last().map(|s| s.ident.to_string());
         match ident.as_deref() {
             Some("doc" | "deprecated") => module.push(attr),
-            Some("must_use") => observe.push(attr),
-            Some("track_caller") => {
-                observe.push(attr);
-                inner.push(attr);
-            }
+            Some("must_use" | "track_caller") => observe.push(attr),
             Some("cfg" | "cfg_attr") => {
                 module.push(attr);
                 observe.push(attr);

--- a/crates/pocopine-sync-query-macros/src/lib.rs
+++ b/crates/pocopine-sync-query-macros/src/lib.rs
@@ -1045,9 +1045,11 @@ fn expand_query(func: ItemFn) -> syn::Result<TokenStream2> {
         (arg_idents.clone(), arg_types.clone())
     };
     // Per-arg helper idents for the captured + per-rerun clones.
-    let captured_user_idents: Vec<Ident> = user_arg_idents
-        .iter()
-        .map(|i| Ident::new(&format!("__pq_arg_{i}"), i.span()))
+    // Named by position (`__pq_arg_0`, `__pq_arg_1`, …) so a raw
+    // identifier user-arg (`r#type: String`) doesn't produce an
+    // invalid `__pq_arg_r#type` and panic during macro expansion.
+    let captured_user_idents: Vec<Ident> = (0..user_arg_idents.len())
+        .map(|i| Ident::new(&format!("__pq_arg_{i}"), proc_macro2::Span::call_site()))
         .collect();
 
     // `let __pq_client_for_compute = client.clone();` — emitted only
@@ -1144,16 +1146,25 @@ fn expand_query(func: ItemFn) -> syn::Result<TokenStream2> {
                 __pq_client: &::pocopine_sync_query::QueryClient,
                 #( #user_arg_idents : #user_arg_types ),*
             ) -> ::pocopine_sync_query::SelectorView<#ret_type> {
-                // Hash hashable args (everything except the
-                // recognized client param). `DefaultHasher` is fine
-                // here — the hash is consumed only by an in-process
-                // HashMap lookup; it isn't exposed on the wire.
+                // Hash hashable args. `DefaultHasher` is fine for
+                // bucketing speed; the actual cache equality check
+                // uses `AnyArgs::dyn_eq` on the boxed tuple below,
+                // so hash collisions cannot cause cross-args
+                // aliasing.
                 let mut __pq_hasher =
                     ::std::collections::hash_map::DefaultHasher::new();
                 #(
                     ::std::hash::Hash::hash(&#user_arg_idents, &mut __pq_hasher);
                 )*
                 let __pq_args_hash = ::std::hash::Hasher::finish(&__pq_hasher);
+
+                // Boxed args tuple — used by the runtime to
+                // disambiguate hash collisions via PartialEq.
+                let __pq_args_boxed: ::std::boxed::Box<
+                    dyn ::pocopine_sync_query::AnyArgs,
+                > = ::std::boxed::Box::new((
+                    #( ::core::clone::Clone::clone(&#user_arg_idents), )*
+                ));
 
                 // Capture owned clones of args (and a clone of the
                 // client, if the user declared a client arg) into
@@ -1169,7 +1180,12 @@ fn expand_query(func: ItemFn) -> syn::Result<TokenStream2> {
                 let __pq_compute = move || -> #ret_type {
                     super::#inner_fn_ident( #( #user_fn_call_args ),* )
                 };
-                __pq_client.observe_selector(SELECTOR_ID, __pq_args_hash, __pq_compute)
+                __pq_client.observe_selector(
+                    SELECTOR_ID,
+                    __pq_args_hash,
+                    __pq_args_boxed,
+                    __pq_compute,
+                )
             }
         }
     })

--- a/crates/pocopine-sync-query-macros/src/lib.rs
+++ b/crates/pocopine-sync-query-macros/src/lib.rs
@@ -1107,7 +1107,18 @@ fn expand_query(func: ItemFn) -> syn::Result<TokenStream2> {
     // `super::*` references in the body keep their original
     // resolution. The generated module's `observe()` calls it via
     // `super::<this_ident>`.
-    let inner_fn_ident = Ident::new(&format!("__pq_user_fn__{fn_name_str}"), fn_name.span());
+    //
+    // Strip any `r#` raw-ident prefix via `raw_ident_body`. Without
+    // this, `#[query] fn r#type(...)` would expand into
+    // `Ident::new("__pq_user_fn__r#type", …)`, which panics — `#`
+    // is not a valid identifier character. The raw form is unique
+    // among rustc-accepted fn names because keyword-collisioning
+    // names HAVE to be written `r#kw`, so `raw_ident_body("r#kw")`
+    // == "kw" is unambiguous in the surrounding mod scope.
+    let inner_fn_ident = Ident::new(
+        &format!("__pq_user_fn__{}", raw_ident_body(&fn_name)),
+        fn_name.span(),
+    );
 
     // Reconstruct each parameter for the inner fn, preserving any
     // `mut` binding the user wrote.

--- a/crates/pocopine-sync-query-macros/src/lib.rs
+++ b/crates/pocopine-sync-query-macros/src/lib.rs
@@ -1096,8 +1096,11 @@ fn expand_query(func: ItemFn) -> syn::Result<TokenStream2> {
     // * `#[cfg]` and `#[cfg_attr]` end up on BOTH so a cfg-disabled
     //   selector compiles consistently (the module and the body
     //   need to disappear together).
-    let (module_attrs, inner_attrs): (Vec<&Attribute>, Vec<&Attribute>) =
-        partition_selector_attrs(&attrs);
+    let (module_attrs, observe_attrs, inner_attrs): (
+        Vec<&Attribute>,
+        Vec<&Attribute>,
+        Vec<&Attribute>,
+    ) = partition_selector_attrs(&attrs);
 
     // Mangled name for the carried-over user body. Lives at the
     // SAME module level as the original `#[query] fn` so any
@@ -1160,6 +1163,7 @@ fn expand_query(func: ItemFn) -> syn::Result<TokenStream2> {
             /// cached value is reused. On a cache miss, the body
             /// runs inside the selector's tracking frame so any
             /// `QueryView::rows()` reads register as dependencies.
+            #(#observe_attrs)*
             pub fn observe(
                 __pq_client: &::pocopine_sync_query::QueryClient,
                 #( #user_arg_idents : #user_arg_types ),*
@@ -1209,36 +1213,42 @@ fn expand_query(func: ItemFn) -> syn::Result<TokenStream2> {
     })
 }
 
-/// Split user-supplied attrs on a `#[query] fn` into two groups —
-/// `(module_attrs, inner_attrs)` — by audience. See the call site
-/// in `expand_query` for the rationale.
+/// Split user-supplied attrs on a `#[query] fn` into three groups —
+/// `(module_attrs, observe_attrs, inner_attrs)` — by audience. See
+/// the call site in `expand_query` for the rationale.
 ///
-/// * `#[doc]` / `///`, `#[deprecated]`, `#[must_use]` → module
-///   (public API surface).
+/// * `#[doc]` / `///`, `#[deprecated]` → module (public API surface).
+/// * `#[must_use]`, `#[track_caller]` → `observe()` (Rust rejects
+///   `#[must_use]` on modules, and these attrs fire against the
+///   call site that consumes the selector — `observe()` is the
+///   user-visible call site, not the module).
 /// * `#[allow]` / `#[deny]` / `#[warn]` / `#[forbid]` / `#[expect]`,
 ///   `#[inline]` / `#[cold]` / `#[no_mangle]` → inner fn (body
 ///   audience).
-/// * `#[cfg]` / `#[cfg_attr]` → both (module and body must compile
-///   or disappear together).
-/// * Unknown attrs default to the inner fn — they probably affect
-///   the body and `#[deprecated]`-style attrs on the inner fn don't
-///   fire warnings as long as the macro doesn't reference an
-///   unknown-named attr. Erring inward is conservative.
-fn partition_selector_attrs(attrs: &[Attribute]) -> (Vec<&Attribute>, Vec<&Attribute>) {
+/// * `#[cfg]` / `#[cfg_attr]` → all three (module, observe, and
+///   body must compile or disappear together).
+/// * Unknown attrs default to the inner fn (it carries the body, so
+///   most behavior-y attrs belong there).
+fn partition_selector_attrs(
+    attrs: &[Attribute],
+) -> (Vec<&Attribute>, Vec<&Attribute>, Vec<&Attribute>) {
     let mut module = Vec::new();
+    let mut observe = Vec::new();
     let mut inner = Vec::new();
     for attr in attrs {
         let ident = attr.path().segments.last().map(|s| s.ident.to_string());
         match ident.as_deref() {
-            Some("doc" | "deprecated" | "must_use") => module.push(attr),
+            Some("doc" | "deprecated") => module.push(attr),
+            Some("must_use" | "track_caller") => observe.push(attr),
             Some("cfg" | "cfg_attr") => {
                 module.push(attr);
+                observe.push(attr);
                 inner.push(attr);
             }
             _ => inner.push(attr),
         }
     }
-    (module, inner)
+    (module, observe, inner)
 }
 
 /// Detect whether a type is `QueryClient` by last path segment.

--- a/crates/pocopine-sync-query-macros/tests/query_macro.rs
+++ b/crates/pocopine-sync-query-macros/tests/query_macro.rs
@@ -233,6 +233,31 @@ fn macro_routes_doc_to_module() {
     assert_eq!(view.value(), 42);
 }
 
+// ---- Regression: `#[must_use]` routes to observe(), not module ----
+//
+// `#[must_use]` on a module is a Rust warning (and `-D warnings`
+// would make it a build failure). The macro must route the attr to
+// `observe()` instead, where it actually fires the must-use lint
+// against callers that drop the returned `SelectorView`.
+
+#[query]
+#[must_use]
+fn must_use_selector(_client: QueryClient) -> u32 {
+    99
+}
+
+#[test]
+#[deny(unused_must_use)]
+fn macro_routes_must_use_to_observe() {
+    let client = QueryClient::without_driver();
+    // We USE the returned view, so `must_use` is satisfied. The
+    // value of this test is the build itself: if the macro had
+    // placed `#[must_use]` on the module, this file would fail
+    // under `-D warnings` even before reaching the assertion.
+    let view = must_use_selector::observe(&client);
+    assert_eq!(view.value(), 99);
+}
+
 // ---- Regression: raw-identifier args ------------------------------
 //
 // A user fn arg whose ident is a raw identifier (e.g. `r#type:

--- a/crates/pocopine-sync-query-macros/tests/query_macro.rs
+++ b/crates/pocopine-sync-query-macros/tests/query_macro.rs
@@ -169,6 +169,53 @@ async fn macro_observe_returns_cached_value_and_reacts_to_mutations() {
         .await;
 }
 
+// ---- Regression: super:: resolution -------------------------------
+//
+// If the macro nested the user body inside the generated module,
+// `super::*` references in the body would resolve through the wrong
+// scope. The macro keeps the body at the same module level as the
+// original `#[query] fn`, so `super::HELPER_CONST` here must continue
+// to refer to `crate::HELPER_CONST`.
+
+const HELPER_CONST: u32 = 1234;
+
+mod nested_scope {
+    use super::*;
+
+    #[query]
+    pub fn uses_parent_const(_client: QueryClient) -> u32 {
+        // Should resolve to crate::HELPER_CONST. Pre-fix this would
+        // have been `nested_scope::uses_parent_const::HELPER_CONST`
+        // which doesn't exist.
+        super::HELPER_CONST
+    }
+}
+
+#[test]
+fn macro_preserves_super_resolution_in_body() {
+    let client = QueryClient::without_driver();
+    let view = nested_scope::uses_parent_const::observe(&client);
+    assert_eq!(view.value(), HELPER_CONST);
+}
+
+// ---- Regression: mut binding preserved ----------------------------
+//
+// A user body that mutates a `mut`-bound arg must still compile —
+// the macro propagates `mut` to the inner fn's parameter list.
+
+#[query]
+fn doubled_via_mut(_client: QueryClient, mut n: u32) -> u32 {
+    n *= 2;
+    n
+}
+
+#[test]
+fn macro_preserves_mut_arg_binding() {
+    let client = QueryClient::without_driver();
+    let view = doubled_via_mut::observe(&client, 21);
+    assert_eq!(view.value(), 42);
+}
+
 #[tokio::test]
 async fn macro_selector_composes_inside_another_selector() {
     LocalSet::new()

--- a/crates/pocopine-sync-query-macros/tests/query_macro.rs
+++ b/crates/pocopine-sync-query-macros/tests/query_macro.rs
@@ -1,0 +1,199 @@
+//! Integration tests for the `#[query]` proc-macro.
+//!
+//! Verifies that the macro's expansion compiles, produces a stable
+//! `SELECTOR_ID`, hashes args correctly, and plugs into the runtime's
+//! caching + diff-suppression machinery end-to-end.
+//!
+//! The runtime itself is covered by
+//! `crates/pocopine-sync-query/tests/selector.rs`; these tests
+//! exercise the macro's args-hashing and code-generation surface.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::cell::Cell;
+use std::rc::Rc;
+
+use pocopine_sync::{MutationId, SyncResult};
+use pocopine_sync_query::{
+    Mutator, MutatorRemoteContext, MutatorRemoteFuture, QueryClient, RowChange,
+};
+use pocopine_sync_query_macros::{query, query_resource};
+use serde::{Deserialize, Serialize};
+use tokio::task::LocalSet;
+
+#[query_resource(name = "issues", schema_version = 1)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Issue {
+    pub id: String,
+    #[query_param(required)]
+    pub workspace_id: String,
+    pub title: String,
+}
+
+struct EchoMutator;
+
+impl Mutator for EchoMutator {
+    type Payload = Issue;
+    type Row = Issue;
+    const NAME: &'static str = "echo";
+    const STREAM: &'static str = "issues";
+    const SCHEMA_VERSION: u32 = 1;
+
+    fn apply_local(payload: &Self::Payload) -> Vec<RowChange<Self::Row>> {
+        vec![RowChange::Upsert(payload.clone())]
+    }
+
+    fn apply_remote(
+        _ctx: &dyn MutatorRemoteContext,
+        payload: Self::Payload,
+    ) -> MutatorRemoteFuture<Self::Row> {
+        Box::pin(async move { Ok(vec![RowChange::Upsert(payload)]) })
+    }
+}
+
+struct StubContext {
+    next_id: Cell<u64>,
+}
+
+impl StubContext {
+    fn new() -> Self {
+        Self {
+            next_id: Cell::new(1),
+        }
+    }
+}
+
+impl MutatorRemoteContext for StubContext {
+    fn push_url(&self) -> &str {
+        "/__pocopine/sync/v1/push"
+    }
+
+    fn next_mutation_id(&self) -> SyncResult<MutationId> {
+        let n = self.next_id.get();
+        self.next_id.set(n + 1);
+        MutationId::new(format!("test:{n}"))
+    }
+}
+
+fn make_issue(id: &str, ws: &str, title: &str) -> Issue {
+    Issue {
+        id: id.into(),
+        workspace_id: ws.into(),
+        title: title.into(),
+    }
+}
+
+// ---- Selectors under test -----------------------------------------
+
+thread_local! {
+    static OPEN_RUNS: Cell<u32> = const { Cell::new(0) };
+    static TITLES_RUNS: Cell<u32> = const { Cell::new(0) };
+}
+
+#[query]
+fn issue_count_in_workspace(client: QueryClient, ws: String) -> u32 {
+    OPEN_RUNS.with(|c| c.set(c.get() + 1));
+    let view = client.observe(
+        Issue::query()
+            .eq(issues::field::workspace_id, ws.clone())
+            .build(),
+    );
+    view.rows().len() as u32
+}
+
+#[query]
+fn issue_titles(client: QueryClient, ws: String) -> Vec<String> {
+    TITLES_RUNS.with(|c| c.set(c.get() + 1));
+    let view = client.observe(
+        Issue::query()
+            .eq(issues::field::workspace_id, ws.clone())
+            .build(),
+    );
+    view.rows().into_iter().map(|i| i.title).collect()
+}
+
+// ---- Tests --------------------------------------------------------
+
+#[test]
+fn selector_id_is_stable_and_distinct() {
+    let a = issue_count_in_workspace::SELECTOR_ID.as_u64();
+    let b = issue_titles::SELECTOR_ID.as_u64();
+    assert_ne!(a, b, "two #[query] fns must hash to distinct ids");
+    // Stability: same fn, same id across reads.
+    assert_eq!(a, issue_count_in_workspace::SELECTOR_ID.as_u64());
+}
+
+#[tokio::test]
+async fn macro_observe_returns_cached_value_and_reacts_to_mutations() {
+    LocalSet::new()
+        .run_until(async {
+            OPEN_RUNS.with(|c| c.set(0));
+            let client = QueryClient::without_driver();
+
+            let view = issue_count_in_workspace::observe(&client, "W1".to_string());
+            assert_eq!(view.value(), 0);
+            assert_eq!(OPEN_RUNS.with(|c| c.get()), 1);
+
+            // Second observe with SAME args — cache hit, compute NOT
+            // re-fired.
+            let view2 = issue_count_in_workspace::observe(&client, "W1".to_string());
+            assert_eq!(view2.value(), 0);
+            assert_eq!(
+                OPEN_RUNS.with(|c| c.get()),
+                1,
+                "cache hit must not rerun compute"
+            );
+
+            // Different args → new entry → compute fires.
+            let view_w2 = issue_count_in_workspace::observe(&client, "W2".to_string());
+            assert_eq!(view_w2.value(), 0);
+            assert_eq!(OPEN_RUNS.with(|c| c.get()), 2);
+
+            // Track listener fires after a mutation.
+            let fires = Rc::new(Cell::new(0u32));
+            let fires_c = fires.clone();
+            let _tok = view.on_update(move || {
+                fires_c.set(fires_c.get() + 1);
+            });
+
+            let ctx = StubContext::new();
+            client
+                .mutate::<EchoMutator>(make_issue("i1", "W1", "first"), &ctx)
+                .await
+                .expect("mutate ok");
+
+            assert_eq!(view.value(), 1, "selector observed the new row");
+            assert_eq!(view_w2.value(), 0, "W2 selector unaffected");
+            assert!(fires.get() >= 1);
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn macro_selector_composes_inside_another_selector() {
+    LocalSet::new()
+        .run_until(async {
+            OPEN_RUNS.with(|c| c.set(0));
+            TITLES_RUNS.with(|c| c.set(0));
+            let client = QueryClient::without_driver();
+
+            // Outer reads count + titles; both inner selectors track
+            // the same workspace subscription, so a W1 mutation
+            // reruns both via the diff-fire chain.
+            let count_view = issue_count_in_workspace::observe(&client, "W1".to_string());
+            let titles_view = issue_titles::observe(&client, "W1".to_string());
+
+            assert_eq!(count_view.value(), 0);
+            assert_eq!(titles_view.value(), Vec::<String>::new());
+
+            let ctx = StubContext::new();
+            client
+                .mutate::<EchoMutator>(make_issue("i1", "W1", "rate-limit auth"), &ctx)
+                .await
+                .expect("mutate ok");
+
+            assert_eq!(count_view.value(), 1);
+            assert_eq!(titles_view.value(), vec!["rate-limit auth".to_string()]);
+        })
+        .await;
+}

--- a/crates/pocopine-sync-query-macros/tests/query_macro.rs
+++ b/crates/pocopine-sync-query-macros/tests/query_macro.rs
@@ -198,6 +198,26 @@ fn macro_preserves_super_resolution_in_body() {
     assert_eq!(view.value(), HELPER_CONST);
 }
 
+// ---- Regression: raw-identifier args ------------------------------
+//
+// A user fn arg whose ident is a raw identifier (e.g. `r#type:
+// String` — `type` is a keyword) is valid Rust. The macro must not
+// panic at expansion time when it builds helper names. The fix names
+// helpers by position (`__pq_arg_0`, …) rather than splicing the
+// ident, so raw idents survive.
+
+#[query]
+fn with_raw_ident(_client: QueryClient, r#type: u32) -> u32 {
+    r#type + 1
+}
+
+#[test]
+fn macro_handles_raw_identifier_args() {
+    let client = QueryClient::without_driver();
+    let view = with_raw_ident::observe(&client, 41);
+    assert_eq!(view.value(), 42);
+}
+
 // ---- Regression: user attrs propagate to the lifted body ----------
 //
 // Lint attrs on the original `#[query] fn` must follow the body when

--- a/crates/pocopine-sync-query-macros/tests/query_macro.rs
+++ b/crates/pocopine-sync-query-macros/tests/query_macro.rs
@@ -305,6 +305,21 @@ fn macro_handles_raw_identifier_args() {
     assert_eq!(view.value(), 42);
 }
 
+// The fn NAME itself is also a raw identifier (the macro must
+// strip `r#` before constructing the mangled `__pq_user_fn__…`
+// inner ident, or Ident::new panics during expansion on `#`).
+#[query]
+fn r#type(_client: QueryClient) -> u32 {
+    7
+}
+
+#[test]
+fn macro_handles_raw_identifier_fn_name() {
+    let client = QueryClient::without_driver();
+    let view = r#type::observe(&client);
+    assert_eq!(view.value(), 7);
+}
+
 // ---- Regression: user attrs propagate to the lifted body ----------
 //
 // Lint attrs on the original `#[query] fn` must follow the body when

--- a/crates/pocopine-sync-query-macros/tests/query_macro.rs
+++ b/crates/pocopine-sync-query-macros/tests/query_macro.rs
@@ -198,6 +198,41 @@ fn macro_preserves_super_resolution_in_body() {
     assert_eq!(view.value(), HELPER_CONST);
 }
 
+// ---- Regression: public attrs survive on the generated module ----
+//
+// `#[doc]` and `#[deprecated]` on a `#[query] fn` must end up on
+// the GENERATED MODULE (the public surface), not on the hidden
+// lifted body. Otherwise `#![deny(missing_docs)]` rejects the
+// public module and `#[deprecated]` on the body trips
+// `deny(deprecated)` when the macro's own `super::__user_fn(...)`
+// call references it.
+//
+// We can't easily assert "doc string is present in rustdoc" from a
+// Rust test, but we CAN observe `#[deprecated]` via the lint:
+// the user-side `observe()` call on a deprecated selector should
+// fire `deprecated` ONCE (from the module-level attr), not twice.
+// We assert "compiles with -D deprecated" elsewhere; here we just
+// confirm `#[doc]` doesn't break compilation.
+
+/// This selector has a doc comment. The macro must route the doc
+/// to the public module, not to the hidden lifted fn (which is
+/// `#[doc(hidden)]` and would swallow it).
+#[query]
+fn documented_selector(_client: QueryClient) -> u32 {
+    42
+}
+
+#[test]
+fn macro_routes_doc_to_module() {
+    // The selector works; the doc comment didn't cause expansion to
+    // fail. Doc visibility is verified by rustdoc rendering, not by
+    // a runtime assert — this test just locks in that doc attrs
+    // pass through the macro without breaking the build.
+    let client = QueryClient::without_driver();
+    let view = documented_selector::observe(&client);
+    assert_eq!(view.value(), 42);
+}
+
 // ---- Regression: raw-identifier args ------------------------------
 //
 // A user fn arg whose ident is a raw identifier (e.g. `r#type:

--- a/crates/pocopine-sync-query-macros/tests/query_macro.rs
+++ b/crates/pocopine-sync-query-macros/tests/query_macro.rs
@@ -258,6 +258,35 @@ fn macro_routes_must_use_to_observe() {
     assert_eq!(view.value(), 99);
 }
 
+// ---- Regression: `#[track_caller]` lands on observe() AND body ----
+//
+// `#[track_caller]` on a `#[query] fn` must propagate to BOTH the
+// generated `observe()` and the lifted inner body, so panics
+// originating in the body (or in observe()'s own
+// `Location::caller()` reads) point at the user's call site instead
+// of the macro's generated chain. The chain through the anonymous
+// compute closure still breaks full propagation — that's a
+// documented limitation — but having the attr on both endpoints
+// keeps the easy cases working.
+
+#[query]
+#[track_caller]
+fn tc_selector(_client: QueryClient, n: u32) -> u32 {
+    n * 2
+}
+
+#[test]
+fn macro_routes_track_caller_to_both_surfaces() {
+    let client = QueryClient::without_driver();
+    // We mainly assert the build compiles + runs: a missing or
+    // wrongly-routed `#[track_caller]` doesn't cause runtime
+    // failures, but it WOULD silently break panic-location quality
+    // (verified offline by inspecting Location::caller() output —
+    // not portable to a runtime assert).
+    let view = tc_selector::observe(&client, 21);
+    assert_eq!(view.value(), 42);
+}
+
 // ---- Regression: raw-identifier args ------------------------------
 //
 // A user fn arg whose ident is a raw identifier (e.g. `r#type:

--- a/crates/pocopine-sync-query-macros/tests/query_macro.rs
+++ b/crates/pocopine-sync-query-macros/tests/query_macro.rs
@@ -258,16 +258,15 @@ fn macro_routes_must_use_to_observe() {
     assert_eq!(view.value(), 99);
 }
 
-// ---- Regression: `#[track_caller]` lands on observe() AND body ----
+// ---- Regression: `#[track_caller]` lands on observe() only -------
 //
-// `#[track_caller]` on a `#[query] fn` must propagate to BOTH the
-// generated `observe()` and the lifted inner body, so panics
-// originating in the body (or in observe()'s own
-// `Location::caller()` reads) point at the user's call site instead
-// of the macro's generated chain. The chain through the anonymous
-// compute closure still breaks full propagation — that's a
-// documented limitation — but having the attr on both endpoints
-// keeps the easy cases working.
+// `#[track_caller]` on a `#[query] fn` routes to the generated
+// `observe()` fn only — NOT the lifted body. Forwarding to the
+// body would actually degrade panic quality: `panic!()` inside a
+// `#[track_caller]` body reports the caller's line (the opaque
+// anonymous compute closure here), whereas the unannotated body
+// reports the natural panic-site line. Observe-only is the best
+// the macro can do given the closure hop.
 
 #[query]
 #[track_caller]
@@ -276,13 +275,12 @@ fn tc_selector(_client: QueryClient, n: u32) -> u32 {
 }
 
 #[test]
-fn macro_routes_track_caller_to_both_surfaces() {
+fn macro_accepts_track_caller_attr() {
     let client = QueryClient::without_driver();
-    // We mainly assert the build compiles + runs: a missing or
-    // wrongly-routed `#[track_caller]` doesn't cause runtime
-    // failures, but it WOULD silently break panic-location quality
-    // (verified offline by inspecting Location::caller() output —
-    // not portable to a runtime assert).
+    // Build-level assertion: `#[track_caller]` on a selector
+    // compiles and runs. The macro routes the attr to `observe()`
+    // (not the inner body) — a missing route would just fail to
+    // compile or warn under `-D warnings`.
     let view = tc_selector::observe(&client, 21);
     assert_eq!(view.value(), 42);
 }

--- a/crates/pocopine-sync-query-macros/tests/query_macro.rs
+++ b/crates/pocopine-sync-query-macros/tests/query_macro.rs
@@ -198,6 +198,29 @@ fn macro_preserves_super_resolution_in_body() {
     assert_eq!(view.value(), HELPER_CONST);
 }
 
+// ---- Regression: user attrs propagate to the lifted body ----------
+//
+// Lint attrs on the original `#[query] fn` must follow the body when
+// the macro lifts it to a sibling fn — otherwise lints emitted INSIDE
+// the body (where the user's `#[allow(...)]` would silence them) hit
+// the new fn without the silencer and break `#[deny(warnings)]` /
+// `-D warnings` builds. Here `#[allow(unused_variables)]` silences
+// the unused `extra` param; without forwarding, that would warn-as-
+// error in CI.
+
+#[query]
+#[allow(unused_variables)]
+fn allow_attr_followed_through(_client: QueryClient, n: u32, extra: u32) -> u32 {
+    n + 1
+}
+
+#[test]
+fn macro_forwards_user_attrs_to_lifted_body() {
+    let client = QueryClient::without_driver();
+    let view = allow_attr_followed_through::observe(&client, 41, 999);
+    assert_eq!(view.value(), 42);
+}
+
 // ---- Regression: mut binding preserved ----------------------------
 //
 // A user body that mutates a `mut`-bound arg must still compile —

--- a/crates/pocopine-sync-query-macros/tests/ui/query_async_fn.rs
+++ b/crates/pocopine-sync-query-macros/tests/ui/query_async_fn.rs
@@ -1,0 +1,12 @@
+//! `#[query]` selectors must be synchronous — compute runs on the
+//! reactive rerun path, which is not an async context.
+use pocopine_sync_query::QueryClient;
+use pocopine_sync_query_macros::query;
+
+#[query]
+async fn bad_async(_client: QueryClient, ws: String) -> u32 {
+    let _ = ws;
+    0
+}
+
+fn main() {}

--- a/crates/pocopine-sync-query-macros/tests/ui/query_async_fn.stderr
+++ b/crates/pocopine-sync-query-macros/tests/ui/query_async_fn.stderr
@@ -1,0 +1,13 @@
+error: `#[query]` selectors must be synchronous — the compute closure runs inside the reactive-rerun path
+ --> tests/ui/query_async_fn.rs:7:1
+  |
+7 | async fn bad_async(_client: QueryClient, ws: String) -> u32 {
+  | ^^^^^
+
+warning: unused import: `pocopine_sync_query::QueryClient`
+ --> tests/ui/query_async_fn.rs:3:5
+  |
+3 | use pocopine_sync_query::QueryClient;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

--- a/crates/pocopine-sync-query-macros/tests/ui/query_impl_trait_assoc.rs
+++ b/crates/pocopine-sync-query-macros/tests/ui/query_impl_trait_assoc.rs
@@ -1,0 +1,21 @@
+//! `#[query]` must reject `impl Trait` embedded in trait-object
+//! assoc-type bindings — e.g. `*const dyn Foo<Item = impl Bar>`.
+//! The argument is still anonymous-generic at the call site.
+use pocopine_sync_query::QueryClient;
+use pocopine_sync_query_macros::query;
+use std::fmt::Debug;
+
+trait Assoc {
+    type Item;
+}
+
+#[query]
+fn bad_assoc_impl(
+    _client: QueryClient,
+    x: *const dyn Assoc<Item = impl Debug + 'static>,
+) -> u32 {
+    let _ = x;
+    0
+}
+
+fn main() {}

--- a/crates/pocopine-sync-query-macros/tests/ui/query_impl_trait_assoc.stderr
+++ b/crates/pocopine-sync-query-macros/tests/ui/query_impl_trait_assoc.stderr
@@ -1,0 +1,19 @@
+error: `#[query]` selectors cannot use argument-position `impl Trait` — not even nested (e.g. `Box<impl Trait>`, `Option<impl Trait>`). Argument-position `impl Trait` makes the fn generic over the call-site type, but the cache key only covers `(SelectorId, args_hash)`, so two concrete instantiations could alias each other's cached entries. Use a concrete type.
+  --> tests/ui/query_impl_trait_assoc.rs:15:8
+   |
+15 |     x: *const dyn Assoc<Item = impl Debug + 'static>,
+   |        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused import: `pocopine_sync_query::QueryClient`
+ --> tests/ui/query_impl_trait_assoc.rs:4:5
+  |
+4 | use pocopine_sync_query::QueryClient;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+
+warning: unused import: `std::fmt::Debug`
+ --> tests/ui/query_impl_trait_assoc.rs:6:5
+  |
+6 | use std::fmt::Debug;
+  |     ^^^^^^^^^^^^^^^

--- a/crates/pocopine-sync-query-macros/tests/ui/query_impl_trait_nested.rs
+++ b/crates/pocopine-sync-query-macros/tests/ui/query_impl_trait_nested.rs
@@ -1,0 +1,16 @@
+//! `#[query]` must reject argument-position `impl Trait` even when
+//! nested inside another type — `Box<impl Hash>`, `Option<impl …>`,
+//! etc. Rust still desugars these to anonymous generics, which would
+//! let two concrete instantiations alias the same selector cache
+//! entry.
+use pocopine_sync_query::QueryClient;
+use pocopine_sync_query_macros::query;
+use std::hash::Hash;
+
+#[query]
+fn bad_nested(_client: QueryClient, b: Box<impl Hash + Clone + 'static>) -> u32 {
+    let _ = b;
+    0
+}
+
+fn main() {}

--- a/crates/pocopine-sync-query-macros/tests/ui/query_impl_trait_nested.stderr
+++ b/crates/pocopine-sync-query-macros/tests/ui/query_impl_trait_nested.stderr
@@ -1,0 +1,19 @@
+error: `#[query]` selectors cannot use argument-position `impl Trait` — not even nested (e.g. `Box<impl Trait>`, `Option<impl Trait>`). Argument-position `impl Trait` makes the fn generic over the call-site type, but the cache key only covers `(SelectorId, args_hash)`, so two concrete instantiations could alias each other's cached entries. Use a concrete type.
+  --> tests/ui/query_impl_trait_nested.rs:11:40
+   |
+11 | fn bad_nested(_client: QueryClient, b: Box<impl Hash + Clone + 'static>) -> u32 {
+   |                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused import: `pocopine_sync_query::QueryClient`
+ --> tests/ui/query_impl_trait_nested.rs:6:5
+  |
+6 | use pocopine_sync_query::QueryClient;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+
+warning: unused import: `std::hash::Hash`
+ --> tests/ui/query_impl_trait_nested.rs:8:5
+  |
+8 | use std::hash::Hash;
+  |     ^^^^^^^^^^^^^^^

--- a/crates/pocopine-sync-query-macros/tests/ui/query_impl_trait_top_level.rs
+++ b/crates/pocopine-sync-query-macros/tests/ui/query_impl_trait_top_level.rs
@@ -1,0 +1,12 @@
+//! `#[query]` must reject argument-position `impl Trait` (top-level).
+use pocopine_sync_query::QueryClient;
+use pocopine_sync_query_macros::query;
+use std::fmt::Debug;
+
+#[query]
+fn bad_top_level(_client: QueryClient, x: impl Debug + Clone + std::hash::Hash + 'static) -> u32 {
+    let _ = x;
+    0
+}
+
+fn main() {}

--- a/crates/pocopine-sync-query-macros/tests/ui/query_impl_trait_top_level.stderr
+++ b/crates/pocopine-sync-query-macros/tests/ui/query_impl_trait_top_level.stderr
@@ -1,0 +1,19 @@
+error: `#[query]` selectors cannot use argument-position `impl Trait` — not even nested (e.g. `Box<impl Trait>`, `Option<impl Trait>`). Argument-position `impl Trait` makes the fn generic over the call-site type, but the cache key only covers `(SelectorId, args_hash)`, so two concrete instantiations could alias each other's cached entries. Use a concrete type.
+ --> tests/ui/query_impl_trait_top_level.rs:7:43
+  |
+7 | fn bad_top_level(_client: QueryClient, x: impl Debug + Clone + std::hash::Hash + 'static) -> u32 {
+  |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused import: `pocopine_sync_query::QueryClient`
+ --> tests/ui/query_impl_trait_top_level.rs:2:5
+  |
+2 | use pocopine_sync_query::QueryClient;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default
+
+warning: unused import: `std::fmt::Debug`
+ --> tests/ui/query_impl_trait_top_level.rs:4:5
+  |
+4 | use std::fmt::Debug;
+  |     ^^^^^^^^^^^^^^^

--- a/crates/pocopine-sync-query-macros/tests/ui_query.rs
+++ b/crates/pocopine-sync-query-macros/tests/ui_query.rs
@@ -11,5 +11,6 @@ fn query_rejected_inputs_fail_to_compile() {
     let cases = trybuild::TestCases::new();
     cases.compile_fail("tests/ui/query_impl_trait_top_level.rs");
     cases.compile_fail("tests/ui/query_impl_trait_nested.rs");
+    cases.compile_fail("tests/ui/query_impl_trait_assoc.rs");
     cases.compile_fail("tests/ui/query_async_fn.rs");
 }

--- a/crates/pocopine-sync-query-macros/tests/ui_query.rs
+++ b/crates/pocopine-sync-query-macros/tests/ui_query.rs
@@ -1,0 +1,15 @@
+//! Compile-fail driver for the `#[query]` macro.
+//!
+//! Trybuild verifies that selector inputs the macro explicitly
+//! rejects DO fail to compile. We deliberately don't pin the exact
+//! `.stderr` output (rustc spans + clippy versions drift faster than
+//! the macro itself); the test asserts "this case must not compile",
+//! which is the contract that matters.
+
+#[test]
+fn query_rejected_inputs_fail_to_compile() {
+    let cases = trybuild::TestCases::new();
+    cases.compile_fail("tests/ui/query_impl_trait_top_level.rs");
+    cases.compile_fail("tests/ui/query_impl_trait_nested.rs");
+    cases.compile_fail("tests/ui/query_async_fn.rs");
+}

--- a/crates/pocopine-sync-query/README.md
+++ b/crates/pocopine-sync-query/README.md
@@ -38,7 +38,8 @@ Read [`docs/sync-query-design.md`](../../docs/sync-query-design.md) for the impl
 | `src/state.rs`                    | ✅      | `QueryState<Row>` (per-query reactive state)           |
 | `src/client.rs`                   | ✅      | `QueryClient` + refcounted `QuerySubscription` registry + routing engine |
 | `src/wire.rs`                     | ✅      | Build `SyncOpenRequest` / `SyncPullRequest` / `SyncPushRequest` from typed queries |
-| `pocopine-sync-query-macros`      | ✅      | `#[query_resource]` macro: builders, field markers, comparator trait impls, predicate evaluator |
+| `pocopine-sync-query-macros`      | ✅      | `#[query_resource]` + `#[query]` macros: query DSL builders, comparator-trait impls, predicate evaluator, selector memoization |
+| `src/selector.rs`                 | ✅      | `#[query]` runtime: tracking stack, `SelectorEntry`, `SelectorView`, `AnyTrackable`, `PartialEq` diff-suppression |
 | Background-task drivers (wasm)    | ⏳ next | spawn-aware `/open` + `/pull` flow; live wakeup; offline replay |
 | `examples/issue-tracker`          | ⏳ later| Linear-clone demo                                      |
 | `docs/sync-query-cookbook.md`     | ⏳ later| User-facing cookbook                                   |
@@ -149,6 +150,34 @@ qc.mutate::<CreateIssue>(payload, &remote_ctx).await?;
 ```
 
 The engine routes `apply_local`'s row changes through every observing query's predicate evaluator. W1's view sees a W1 mutation immediately; W2's view doesn't. No "active subscription" plumbing in user code.
+
+## Derived state with `#[query]` selectors
+
+For derived values over queries — counts, filtered projections, joins, dashboards — wrap the computation in a `#[query]` function. The framework caches the result by `(fn identity, args)`, tracks which subscriptions the body reads, reruns when any tracked subscription changes, and suppresses downstream notifications when the new output equals the cached one (`PartialEq`).
+
+```rust,ignore
+use pocopine_sync_query::{query, QueryClient};
+
+#[query]
+fn open_issue_count(client: QueryClient, ws: String) -> u32 {
+    let view = client.observe(
+        Issue::query()
+            .eq(issues::field::workspace_id, ws.clone())
+            .any_of(issues::field::status, [Status::Open])?
+            .build()
+    );
+    view.rows().len() as u32
+}
+
+// In a component:
+let view = open_issue_count::observe(&qc, "W1".to_string());
+view.value();                // current count
+let _tok = view.on_update(|| pocopine_core::scope::notify(scope, "open_count"));
+```
+
+The convention: if the first arg's type is `QueryClient`, it's the selector's client handle — not hashed, not in `observe()`'s public arg list (which always takes `&QueryClient` first). Every other arg must be `Hash + Clone + 'static`; the return type must be `PartialEq + Clone + 'static`.
+
+Selectors compose: `#[query] fn dashboard(...) { open_issue_count::observe(&client, ws).value() + … }`. An inner selector whose output is `PartialEq`-equal across reruns stops the cascade — the outer selector doesn't rerun. See [`docs/sync-query-selector-mechanism.md`](../docs/sync-query-selector-mechanism.md) for the full design.
 
 ## CRUD vs Query — which one?
 

--- a/crates/pocopine-sync-query/README.md
+++ b/crates/pocopine-sync-query/README.md
@@ -177,7 +177,7 @@ let _tok = view.on_update(|| pocopine_core::scope::notify(scope, "open_count"));
 
 The convention: if the first arg's type is `QueryClient`, it's the selector's client handle — not hashed, not in `observe()`'s public arg list (which always takes `&QueryClient` first). Every other arg must be `Hash + Clone + 'static`; the return type must be `PartialEq + Clone + 'static`.
 
-Selectors compose: `#[query] fn dashboard(...) { open_issue_count::observe(&client, ws).value() + … }`. An inner selector whose output is `PartialEq`-equal across reruns stops the cascade — the outer selector doesn't rerun. See [`docs/sync-query-selector-mechanism.md`](../docs/sync-query-selector-mechanism.md) for the full design.
+Selectors compose: `#[query] fn dashboard(...) { open_issue_count::observe(&client, ws).value() + … }`. An inner selector whose output is `PartialEq`-equal across reruns stops the cascade — the outer selector doesn't rerun. See [`docs/sync-query-selector-mechanism.md`](../../docs/sync-query-selector-mechanism.md) for the full design and [`docs/sync-query-selector-implementation.md`](../../docs/sync-query-selector-implementation.md) for the code map (layer diagram, data flows, file pointers).
 
 ## CRUD vs Query — which one?
 

--- a/crates/pocopine-sync-query/src/client.rs
+++ b/crates/pocopine-sync-query/src/client.rs
@@ -563,32 +563,31 @@ impl QueryClient {
         let key = (id, args_hash);
 
         // Cache hit path. Walk the bucket; for each live `Weak`,
-        // check args equality. Dead `Weak`s are tolerated here —
-        // they get cleaned up by the entry's `Drop`.
-        if let Some(hit) = {
+        // check args equality AND that the entry's concrete type
+        // downcasts to the caller's `T`. Either failed dyn_eq or
+        // failed downcast means "not our entry — keep looking" (no
+        // panic).
+        //
+        // The downcast filter is the principled escape from FNV-1a
+        // 64-bit `SelectorId` collisions: if two `#[query]` fns ever
+        // happen to hash to the same id and one is queried first,
+        // the wrong-T entry is in the bucket. Filtering by downcast
+        // lets the right-T entry be found, OR — if absent — falls
+        // through to the cache-miss path that builds a fresh entry.
+        // Dead `Weak`s are tolerated here too; they get cleaned up
+        // by the entry's `Drop`.
+        if let Some(typed) = {
             let map = self.inner.selectors.borrow();
             map.get(&key).and_then(|bucket| {
                 bucket.iter().find_map(|w| {
                     let alive = w.upgrade()?;
-                    if alive.args().dyn_eq(&*args) {
-                        Some(alive)
-                    } else {
-                        None
+                    if !alive.args().dyn_eq(&*args) {
+                        return None;
                     }
+                    Rc::downcast::<SelectorEntry<T>>(alive.as_rc_any()).ok()
                 })
             })
         } {
-            // Same `(SelectorId, args)` MUST mean the same `T` —
-            // SelectorId encodes the fn's crate-qualified identity,
-            // which uniquely determines the return type. A failed
-            // downcast would mean two `#[query]` fns hashed to the
-            // same id with different signatures — framework
-            // invariant violation, not a user-recoverable error.
-            let typed: Rc<SelectorEntry<T>> = Rc::downcast::<SelectorEntry<T>>(hit.as_rc_any())
-                .expect(
-                    "(SelectorId, args) match across selectors with different T \
-                     — framework invariant violated",
-                );
             return SelectorView::from_entry(typed);
         }
 
@@ -1924,6 +1923,7 @@ impl<Row: 'static> QueryView<Row> {
 
     /// Borrow the per-query state.
     pub fn state(&self) -> std::cell::Ref<'_, QueryState<Row>> {
+        self.track_for_selector();
         self.handle.state()
     }
 
@@ -2064,12 +2064,14 @@ impl<Row: 'static> QueryView<Row> {
     /// (canonical or optimistic) so a reactive observer can track
     /// changes by reading this single integer.
     pub fn version(&self) -> u64 {
+        self.track_for_selector();
         self.state().version()
     }
 
     /// Borrow the shared state for custom reactive integration.
     /// Same `Rc<RefCell<...>>` the routing engine writes through.
     pub fn shared_state(&self) -> Rc<RefCell<QueryState<Row>>> {
+        self.track_for_selector();
         self.handle.shared_state()
     }
 

--- a/crates/pocopine-sync-query/src/client.rs
+++ b/crates/pocopine-sync-query/src/client.rs
@@ -30,6 +30,7 @@ use crate::mutator::{
     wrap_persisted_payload, AnyMutator, HydrateReplayOutcome, MutatorEntry, RowChange,
 };
 use crate::query::{MatchFn, Order, Query, QueryKey};
+use crate::selector::{AnySelector, SelectorEntry, SelectorId, SelectorView};
 use crate::state::{PendingOverlay, QueryState};
 
 /// Composite registry key. Including the `TypeId` of the row type
@@ -185,9 +186,18 @@ impl<Row: 'static> QuerySubscription<Row> {
     where
         F: Fn() + 'static,
     {
+        self.register_listener_rc(Rc::new(callback))
+    }
+
+    /// Variant of `register_listener` that takes a pre-built
+    /// `Rc<dyn Fn()>`. Used by the selector layer's
+    /// `AnyTrackable` impl to avoid re-wrapping a closure that's
+    /// already shared (a selector's rerun callback is held by every
+    /// upstream).
+    pub(crate) fn register_listener_rc(&self, callback: Rc<dyn Fn()>) -> u64 {
         let id = self.next_listener_id.get();
         self.next_listener_id.set(id.wrapping_add(1));
-        self.listeners.borrow_mut().push((id, Rc::new(callback)));
+        self.listeners.borrow_mut().push((id, callback));
         id
     }
 
@@ -225,6 +235,17 @@ impl<Row: 'static> QuerySubscription<Row> {
         for cb in snapshot {
             cb();
         }
+    }
+}
+
+impl<Row: 'static> crate::selector::AnyTrackable for QuerySubscription<Row> {
+    fn register_listener(&self, callback: Rc<dyn Fn()>) -> u64 {
+        self.register_listener_rc(callback)
+    }
+
+    fn unregister_listener(&self, id: u64) {
+        // Disambiguate from the trait method we're inside via UFCS.
+        QuerySubscription::<Row>::unregister_listener(self, id);
     }
 }
 
@@ -306,6 +327,13 @@ pub(crate) struct QueryClientInner {
     /// Apps that don't enable persistence never touch this map.
     /// Mutators register via [`QueryClient::register_mutator`].
     pub(crate) mutators: RefCell<MutatorRegistry>,
+    /// Selector registry, keyed by `(SelectorId, args_hash)`. Holds
+    /// `Weak` so an entry whose last `SelectorView` and last parent-
+    /// selector tracker dropped is GC'd via the entry's `Drop` impl
+    /// (which clears the now-dangling Weak from this map). Strong
+    /// references live on `SelectorView`s and inside parent
+    /// selectors' captured-dep keepers.
+    pub(crate) selectors: RefCell<HashMap<(SelectorId, u64), Weak<dyn AnySelector>>>,
 }
 
 /// Type alias for the mutator registry — `clippy::type_complexity`
@@ -314,6 +342,18 @@ type MutatorRegistry = HashMap<(&'static str, &'static str), Rc<dyn AnyMutator>>
 
 pub struct QueryClient {
     inner: Rc<QueryClientInner>,
+}
+
+impl Clone for QueryClient {
+    /// Cheap — clones the inner `Rc`. Two clones share the same
+    /// subscription + selector registry, so a clone passed into a
+    /// `#[query]` selector's compute closure observes the same
+    /// reactive state as the outer caller.
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
 }
 
 impl QueryClient {
@@ -359,6 +399,7 @@ impl QueryClient {
                 registry: RefCell::new(HashMap::new()),
                 replay_queue: RefCell::new(VecDeque::new()),
                 mutators: RefCell::new(HashMap::new()),
+                selectors: RefCell::new(HashMap::new()),
             }),
         }
     }
@@ -377,6 +418,7 @@ impl QueryClient {
                 registry: RefCell::new(HashMap::new()),
                 replay_queue: RefCell::new(VecDeque::new()),
                 mutators: RefCell::new(HashMap::new()),
+                selectors: RefCell::new(HashMap::new()),
             }),
         }
     }
@@ -470,6 +512,77 @@ impl QueryClient {
         let handle = self.subscribe(query);
         self.maybe_spawn_driver(&handle.subscription);
         QueryView { handle }
+    }
+
+    /// Runtime entry point for the `#[query]` macro. Users normally
+    /// don't call this directly; the macro's generated
+    /// `<fn_name>::observe(client, args)` desugars to this call.
+    ///
+    /// * `id` — stable selector identity (from the macro).
+    /// * `args_hash` — caller-computed hash of the args tuple.
+    /// * `compute` — closure that runs the user fn body with the args
+    ///   captured. Called once per rerun.
+    ///
+    /// On a cache hit (entry with `(id, args_hash)` already lives in
+    /// the selector registry), returns a fresh
+    /// [`SelectorView`](crate::SelectorView) wrapping the existing
+    /// entry; `compute` is NOT invoked.
+    ///
+    /// On a cache miss, builds the entry, runs `compute` once inside
+    /// a tracking frame, captures the read deps + wires listeners,
+    /// caches the output, and returns the view. The entry stays in
+    /// the registry until its last strong reference (`SelectorView`
+    /// plus any parent selector's captured-dep keeper) drops.
+    pub fn observe_selector<T, F>(
+        &self,
+        id: SelectorId,
+        args_hash: u64,
+        compute: F,
+    ) -> SelectorView<T>
+    where
+        T: PartialEq + Clone + 'static,
+        F: Fn() -> T + 'static,
+    {
+        let key = (id, args_hash);
+
+        // Cache hit path. Drop the immutable borrow before any
+        // downcast / refcount work — a downstream `Rc::downcast`
+        // doesn't touch the map but keeping the borrow narrow
+        // mirrors the subscription registry's pattern.
+        if let Some(existing) = self
+            .inner
+            .selectors
+            .borrow()
+            .get(&key)
+            .and_then(|w| w.upgrade())
+        {
+            // Same (SelectorId, args_hash) MUST mean the same `T` —
+            // SelectorId encodes the fn's crate-qualified identity,
+            // which uniquely determines the return type. A failed
+            // downcast here would mean two `#[query]` fns hashed to
+            // the same id with different signatures — framework
+            // invariant violation, not a user-recoverable error.
+            let typed: Rc<SelectorEntry<T>> =
+                Rc::downcast::<SelectorEntry<T>>(existing.as_rc_any()).expect(
+                    "(SelectorId, args_hash) collision across selectors with different T \
+                     — framework invariant violated",
+                );
+            return SelectorView::from_entry(typed);
+        }
+
+        // Cache miss. Build, insert, run first rerun, return.
+        let entry = Rc::new(SelectorEntry::<T>::new(
+            id,
+            args_hash,
+            Box::new(compute),
+            Rc::downgrade(&self.inner),
+        ));
+        {
+            let mut map = self.inner.selectors.borrow_mut();
+            map.insert(key, Rc::downgrade(&entry) as Weak<dyn AnySelector>);
+        }
+        entry.rerun();
+        SelectorView::from_entry(entry)
     }
 
     /// Spawn the driver for `subscription` if (1) the client has a
@@ -1721,6 +1834,21 @@ pub struct QueryHandle<Row: 'static> {
     registry: RegistryWeakRef,
 }
 
+impl<Row: 'static> Clone for QueryHandle<Row> {
+    /// Bumps the subscription's refcount and clones the registry
+    /// weak-ref. The new handle's `Drop` decrements just like the
+    /// original. Used by [`QueryView::rows`] when running inside a
+    /// selector body, so the selector entry can keep the underlying
+    /// subscription alive between reruns via an erased keeper.
+    fn clone(&self) -> Self {
+        self.subscription.bump_refcount();
+        Self {
+            subscription: self.subscription.clone(),
+            registry: self.registry.clone(),
+        }
+    }
+}
+
 impl<Row: 'static> QueryHandle<Row> {
     /// Borrow the underlying query.
     pub fn query(&self) -> &Query<Row> {
@@ -1781,6 +1909,7 @@ impl<Row: 'static> QueryView<Row> {
     where
         Row: Clone + serde::Serialize,
     {
+        self.track_for_selector();
         let query = self.query();
         if query.order_by().is_none() && query.limit().is_none() {
             return self.rendered_key_count();
@@ -1794,12 +1923,32 @@ impl<Row: 'static> QueryView<Row> {
     where
         Row: Clone + serde::Serialize,
     {
+        self.track_for_selector();
         // Cheap path: don't materialize rows just to ask "anything
         // visible?". A `rendered_key_count` walk visits each
         // canonical row and overlay once; no row cloning or JSON
         // serialization. The pending-empty check matches the
         // documented "idle view" semantics.
         self.rendered_key_count() == 0 && self.state().pending().is_empty()
+    }
+
+    /// Record this view's subscription as a dependency on the current
+    /// selector's tracking frame, if one is active. No-op when no
+    /// selector is running (ordinary component reads aren't tracked).
+    ///
+    /// The keeper is a cloned `QueryHandle`, which bumps the
+    /// subscription's refcount and stays alive in the selector
+    /// entry's `keepers` list until the selector reruns and the dep
+    /// is no longer captured (or the selector itself is dropped).
+    /// This is what prevents the subscription from being GC'd while
+    /// a selector still observes it.
+    fn track_for_selector(&self) {
+        if !crate::selector::currently_tracking() {
+            return;
+        }
+        let trackable: Rc<dyn crate::selector::AnyTrackable> = self.handle.subscription.clone();
+        let keeper: Box<dyn std::any::Any> = Box::new(self.handle.clone());
+        crate::selector::record_read(trackable, keeper);
     }
 
     /// Number of distinct keys that survive the canonical + pending
@@ -1842,6 +1991,7 @@ impl<Row: 'static> QueryView<Row> {
     where
         Row: Clone + serde::Serialize,
     {
+        self.track_for_selector();
         use std::collections::BTreeMap;
         let state = self.state();
         let mut rendered: BTreeMap<pocopine_sync::RowKey, Row> = state
@@ -1959,6 +2109,19 @@ impl<Row: 'static> Drop for QueryHandle<Row> {
 struct RegistryWeakRef {
     client: Weak<QueryClientInner>,
     key: RegistryKey,
+}
+
+impl Clone for RegistryWeakRef {
+    /// Cheap — the `Weak` clone is one atomic ref bump and `key` is
+    /// `Copy`. Used by [`QueryHandle::clone`] so a selector can carry
+    /// its own handle into the entry's keepers without re-running
+    /// `subscribe()`.
+    fn clone(&self) -> Self {
+        Self {
+            client: self.client.clone(),
+            key: self.key,
+        }
+    }
 }
 
 impl RegistryWeakRef {

--- a/crates/pocopine-sync-query/src/client.rs
+++ b/crates/pocopine-sync-query/src/client.rs
@@ -30,7 +30,7 @@ use crate::mutator::{
     wrap_persisted_payload, AnyMutator, HydrateReplayOutcome, MutatorEntry, RowChange,
 };
 use crate::query::{MatchFn, Order, Query, QueryKey};
-use crate::selector::{AnySelector, SelectorEntry, SelectorId, SelectorView};
+use crate::selector::{AnyArgs, AnySelector, SelectorEntry, SelectorId, SelectorView};
 use crate::state::{PendingOverlay, QueryState};
 
 /// Composite registry key. Including the `TypeId` of the row type
@@ -38,6 +38,12 @@ use crate::state::{PendingOverlay, QueryState};
 /// but different `Row` types from colliding — a collision used to
 /// trigger `downcast_subscription.expect(...)` panics.
 type RegistryKey = (TypeId, QueryKey);
+
+/// One bucket in the selector registry. Each bucket holds the live
+/// `Weak`s for entries whose args happen to hash to the same
+/// `(SelectorId, args_hash)` slot — the bucket lookup disambiguates
+/// by `AnyArgs::dyn_eq` per [`QueryClient::observe_selector`].
+type SelectorBucket = Vec<Weak<dyn AnySelector>>;
 
 /// Untyped subscription trait — needed so the registry can hold
 /// subscriptions of any `Row` type behind one map.
@@ -327,13 +333,19 @@ pub(crate) struct QueryClientInner {
     /// Apps that don't enable persistence never touch this map.
     /// Mutators register via [`QueryClient::register_mutator`].
     pub(crate) mutators: RefCell<MutatorRegistry>,
-    /// Selector registry, keyed by `(SelectorId, args_hash)`. Holds
-    /// `Weak` so an entry whose last `SelectorView` and last parent-
-    /// selector tracker dropped is GC'd via the entry's `Drop` impl
-    /// (which clears the now-dangling Weak from this map). Strong
-    /// references live on `SelectorView`s and inside parent
+    /// Selector registry, keyed by `(SelectorId, args_hash)`. Each
+    /// slot is a small bucket so two distinct arg values whose
+    /// `Hash` outputs collide can coexist — the lookup
+    /// disambiguates with `AnyArgs::dyn_eq`. Without this, a hash
+    /// collision would return the wrong cached value to the second
+    /// caller.
+    ///
+    /// Holds `Weak` so an entry whose last `SelectorView` and last
+    /// parent-selector tracker dropped is GC'd via the entry's
+    /// `Drop` impl (which clears its own dead Weak from the bucket).
+    /// Strong references live on `SelectorView`s and inside parent
     /// selectors' captured-dep keepers.
-    pub(crate) selectors: RefCell<HashMap<(SelectorId, u64), Weak<dyn AnySelector>>>,
+    pub(crate) selectors: RefCell<HashMap<(SelectorId, u64), SelectorBucket>>,
 }
 
 /// Type alias for the mutator registry — `clippy::type_complexity`
@@ -520,13 +532,17 @@ impl QueryClient {
     ///
     /// * `id` — stable selector identity (from the macro).
     /// * `args_hash` — caller-computed hash of the args tuple.
+    /// * `args` — type-erased copy of the args. The lookup
+    ///   disambiguates hash collisions by equality on this value,
+    ///   so two distinct arg values whose hashes collide can't
+    ///   alias each other's cache entries.
     /// * `compute` — closure that runs the user fn body with the args
     ///   captured. Called once per rerun.
     ///
-    /// On a cache hit (entry with `(id, args_hash)` already lives in
-    /// the selector registry), returns a fresh
-    /// [`SelectorView`](crate::SelectorView) wrapping the existing
-    /// entry; `compute` is NOT invoked.
+    /// On a cache hit (entry with matching `(id, args_hash)` AND
+    /// `args.dyn_eq(...)` already lives in the selector registry),
+    /// returns a fresh [`SelectorView`](crate::SelectorView)
+    /// wrapping the existing entry; `compute` is NOT invoked.
     ///
     /// On a cache miss, builds the entry, runs `compute` once inside
     /// a tracking frame, captures the read deps + wires listeners,
@@ -537,6 +553,7 @@ impl QueryClient {
         &self,
         id: SelectorId,
         args_hash: u64,
+        args: Box<dyn AnyArgs>,
         compute: F,
     ) -> SelectorView<T>
     where
@@ -545,26 +562,31 @@ impl QueryClient {
     {
         let key = (id, args_hash);
 
-        // Cache hit path. Drop the immutable borrow before any
-        // downcast / refcount work — a downstream `Rc::downcast`
-        // doesn't touch the map but keeping the borrow narrow
-        // mirrors the subscription registry's pattern.
-        if let Some(existing) = self
-            .inner
-            .selectors
-            .borrow()
-            .get(&key)
-            .and_then(|w| w.upgrade())
-        {
-            // Same (SelectorId, args_hash) MUST mean the same `T` —
+        // Cache hit path. Walk the bucket; for each live `Weak`,
+        // check args equality. Dead `Weak`s are tolerated here —
+        // they get cleaned up by the entry's `Drop`.
+        if let Some(hit) = {
+            let map = self.inner.selectors.borrow();
+            map.get(&key).and_then(|bucket| {
+                bucket.iter().find_map(|w| {
+                    let alive = w.upgrade()?;
+                    if alive.args().dyn_eq(&*args) {
+                        Some(alive)
+                    } else {
+                        None
+                    }
+                })
+            })
+        } {
+            // Same `(SelectorId, args)` MUST mean the same `T` —
             // SelectorId encodes the fn's crate-qualified identity,
             // which uniquely determines the return type. A failed
-            // downcast here would mean two `#[query]` fns hashed to
-            // the same id with different signatures — framework
+            // downcast would mean two `#[query]` fns hashed to the
+            // same id with different signatures — framework
             // invariant violation, not a user-recoverable error.
-            let typed: Rc<SelectorEntry<T>> =
-                Rc::downcast::<SelectorEntry<T>>(existing.as_rc_any()).expect(
-                    "(SelectorId, args_hash) collision across selectors with different T \
+            let typed: Rc<SelectorEntry<T>> = Rc::downcast::<SelectorEntry<T>>(hit.as_rc_any())
+                .expect(
+                    "(SelectorId, args) match across selectors with different T \
                      — framework invariant violated",
                 );
             return SelectorView::from_entry(typed);
@@ -574,12 +596,17 @@ impl QueryClient {
         let entry = Rc::new(SelectorEntry::<T>::new(
             id,
             args_hash,
+            args,
             Box::new(compute),
             Rc::downgrade(&self.inner),
         ));
         {
             let mut map = self.inner.selectors.borrow_mut();
-            map.insert(key, Rc::downgrade(&entry) as Weak<dyn AnySelector>);
+            let bucket = map.entry(key).or_default();
+            // Opportunistic GC: prune any dead Weaks already in the
+            // bucket. Keeps bucket size bounded under churn.
+            bucket.retain(|w| w.strong_count() > 0);
+            bucket.push(Rc::downgrade(&entry) as Weak<dyn AnySelector>);
         }
         entry.rerun();
         SelectorView::from_entry(entry)

--- a/crates/pocopine-sync-query/src/lib.rs
+++ b/crates/pocopine-sync-query/src/lib.rs
@@ -67,7 +67,7 @@ pub use predicate::{
     contains_matches, range_contains, FieldContains, FieldEq, FieldInSet, FieldRange,
 };
 pub use query::{MatchFn, Order, OrderBy, Query, QueryBuilder, QueryKey};
-pub use selector::{AnyTrackable, SelectorId, SelectorView, TrackToken};
+pub use selector::{AnyArgs, AnyTrackable, SelectorId, SelectorView, TrackToken};
 pub use state::QueryState;
 
 // The macro lives in its own crate (proc-macros must), but downstream

--- a/crates/pocopine-sync-query/src/lib.rs
+++ b/crates/pocopine-sync-query/src/lib.rs
@@ -73,7 +73,7 @@ pub use state::QueryState;
 // The macro lives in its own crate (proc-macros must), but downstream
 // code follows the same one-stop-shop import path as
 // `pocopine-sync-crud`: `use pocopine_sync_query::query_resource;`.
-pub use pocopine_sync_query_macros::query_resource;
+pub use pocopine_sync_query_macros::{query, query_resource};
 
 // Re-export wire-level types from pocopine-sync that the macro emissions
 // and runtime touch directly. Users mostly don't see these.
@@ -94,4 +94,22 @@ pub mod __private {
     // dep — the macro should compile inside a workspace whose only
     // serde access is transitive through `pocopine-sync-query`).
     pub use serde;
+
+    /// FNV-1a 64-bit hash. `const fn` so the `#[query]` macro's
+    /// generated `const SELECTOR_ID` initializer evaluates it at the
+    /// downstream crate's compile time, producing a stable identity
+    /// derived from `module_path!() + "::" + fn_name`. Collisions
+    /// would require two `#[query]` fns sharing both the same module
+    /// path AND the same name — a user-level conflict that rustc
+    /// already catches.
+    pub const fn fnv1a64(bytes: &[u8]) -> u64 {
+        let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+        let mut i = 0;
+        while i < bytes.len() {
+            hash ^= bytes[i] as u64;
+            hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+            i += 1;
+        }
+        hash
+    }
 }

--- a/crates/pocopine-sync-query/src/lib.rs
+++ b/crates/pocopine-sync-query/src/lib.rs
@@ -48,6 +48,7 @@ pub mod params;
 pub mod plugin;
 pub mod predicate;
 pub mod query;
+pub mod selector;
 pub mod state;
 pub mod wire;
 
@@ -66,6 +67,7 @@ pub use predicate::{
     contains_matches, range_contains, FieldContains, FieldEq, FieldInSet, FieldRange,
 };
 pub use query::{MatchFn, Order, OrderBy, Query, QueryBuilder, QueryKey};
+pub use selector::{AnyTrackable, SelectorId, SelectorView, TrackToken};
 pub use state::QueryState;
 
 // The macro lives in its own crate (proc-macros must), but downstream

--- a/crates/pocopine-sync-query/src/selector.rs
+++ b/crates/pocopine-sync-query/src/selector.rs
@@ -55,6 +55,35 @@ pub trait AnyTrackable: 'static {
     fn unregister_listener(&self, id: u64);
 }
 
+/// Type-erased selector arguments. The `#[query]` macro boxes the
+/// args tuple at every `observe()` call so the cache can do an
+/// equality check on lookup — NOT just a hash compare. Without this,
+/// two distinct arg values whose `Hash` outputs happen to collide
+/// would share one cached entry and the second caller would receive
+/// the first call's cached value.
+///
+/// Implemented automatically for any `T: PartialEq + 'static` via a
+/// blanket impl, so user code never names this trait directly.
+pub trait AnyArgs: std::any::Any + 'static {
+    /// `self == other` after a successful concrete-type downcast.
+    /// Different concrete types compare `false`.
+    fn dyn_eq(&self, other: &dyn AnyArgs) -> bool;
+    /// Upcast to `&dyn Any` for safe downcasting in [`Self::dyn_eq`].
+    fn as_any(&self) -> &dyn std::any::Any;
+}
+
+impl<T: PartialEq + 'static> AnyArgs for T {
+    fn dyn_eq(&self, other: &dyn AnyArgs) -> bool {
+        other
+            .as_any()
+            .downcast_ref::<T>()
+            .is_some_and(|o| self == o)
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+}
+
 /// RAII handle returned by selector tracking. Drop unregisters the
 /// listener from the upstream trackable; holds a `Weak` so a token
 /// outliving its source silently no-ops.
@@ -156,6 +185,9 @@ fn pop_frame() -> TrackingFrame {
 /// the safe-stdlib path to `Rc::downcast`.
 pub(crate) trait AnySelector: AnyTrackable {
     fn as_rc_any(self: Rc<Self>) -> Rc<dyn Any>;
+    /// The args this selector was built with. Used by `observe_selector`
+    /// to disambiguate hash collisions in the cache bucket.
+    fn args(&self) -> &dyn AnyArgs;
 }
 
 /// `(id, callback)` entry in a selector's listener list. The id is
@@ -171,6 +203,9 @@ type Listener = (u64, Rc<dyn Fn()>);
 pub(crate) struct SelectorEntry<T: PartialEq + Clone + 'static> {
     id: SelectorId,
     args_hash: u64,
+    /// Owned args (boxed, type-erased) for equality-disambiguation
+    /// when multiple entries land in the same hash bucket.
+    args: Box<dyn AnyArgs>,
     cached_output: RefCell<Option<T>>,
     /// Erased keepers (cloned `QueryHandle`s for subscriptions,
     /// nested `Rc<SelectorEntry<_>>`s for sub-selectors) holding each
@@ -199,12 +234,14 @@ impl<T: PartialEq + Clone + 'static> SelectorEntry<T> {
     pub(crate) fn new(
         id: SelectorId,
         args_hash: u64,
+        args: Box<dyn AnyArgs>,
         compute: Box<dyn Fn() -> T>,
         client: Weak<QueryClientInner>,
     ) -> Self {
         Self {
             id,
             args_hash,
+            args,
             cached_output: RefCell::new(None),
             keepers: RefCell::new(Vec::new()),
             listener_tokens: RefCell::new(Vec::new()),
@@ -312,14 +349,18 @@ impl<T: PartialEq + Clone + 'static> AnySelector for SelectorEntry<T> {
     fn as_rc_any(self: Rc<Self>) -> Rc<dyn Any> {
         self
     }
+    fn args(&self) -> &dyn AnyArgs {
+        &*self.args
+    }
 }
 
 impl<T: PartialEq + Clone + 'static> Drop for SelectorEntry<T> {
     fn drop(&mut self) {
-        // Self-remove from the client's selector registry. Only
-        // touch the slot if its Weak still points at THIS entry —
-        // a replacement entry inserted between the strong-count
-        // hitting zero and this Drop running must not be clobbered.
+        // Self-remove from the client's selector registry. Walk the
+        // bucket at `(id, args_hash)`, prune any dead Weaks. When the
+        // bucket empties, drop the slot entirely. Other live entries
+        // in the bucket (distinct args that happened to collide on
+        // hash) are left alone.
         let Some(inner) = self.client.upgrade() else {
             return;
         };
@@ -327,12 +368,11 @@ impl<T: PartialEq + Clone + 'static> Drop for SelectorEntry<T> {
             return;
         };
         let key = (self.id, self.args_hash);
-        let still_ours = selectors
-            .get(&key)
-            .map(|w| w.strong_count() == 0)
-            .unwrap_or(false);
-        if still_ours {
-            selectors.remove(&key);
+        if let Some(bucket) = selectors.get_mut(&key) {
+            bucket.retain(|w| w.strong_count() > 0);
+            if bucket.is_empty() {
+                selectors.remove(&key);
+            }
         }
     }
 }

--- a/crates/pocopine-sync-query/src/selector.rs
+++ b/crates/pocopine-sync-query/src/selector.rs
@@ -1,0 +1,377 @@
+//! Selector layer for `pocopine-sync-query`.
+//!
+//! Implements the runtime behind `#[query]`-decorated functions: a
+//! thread-local read-tracking stack, `(SelectorId, ArgsHash)`-keyed
+//! memoization, invalidation that rides on the existing
+//! `QuerySubscription::notify_listeners` plumbing, and `PartialEq`-diff
+//! suppression of downstream notifications.
+//!
+//! See [`docs/sync-query-selector-mechanism.md`](../../docs/sync-query-selector-mechanism.md)
+//! for the design explainer.
+
+use std::any::Any;
+use std::cell::{Cell, RefCell};
+use std::rc::{Rc, Weak};
+
+use crate::client::QueryClientInner;
+
+/// Stable identity for a `#[query]`-decorated function.
+///
+/// Computed by the proc-macro at expansion time via FNV-1a 64 of a
+/// crate-qualified identifier string. The macro is the only intended
+/// producer of values; the `const` constructor exists for it (and for
+/// unit tests that wire up a selector by hand).
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub struct SelectorId(u64);
+
+impl SelectorId {
+    /// Build a `SelectorId` from a precomputed 64-bit hash. Used by
+    /// the `#[query]` macro's expansion.
+    pub const fn new(hash: u64) -> Self {
+        Self(hash)
+    }
+
+    /// Raw 64-bit identity. Tests and tracing consumers only.
+    pub fn as_u64(&self) -> u64 {
+        self.0
+    }
+}
+
+/// Common interface every selector dependency implements. Both
+/// `QuerySubscription<Row>` and [`SelectorEntry<T>`] impl it so the
+/// tracking stack can hold them behind one `Rc<dyn AnyTrackable>`.
+///
+/// Object-safe — only `&self` methods, no associated types. The
+/// trait is exposed publicly so that downstream crates implementing
+/// custom reactive sources could plug into the selector tracker if
+/// ever needed, but the in-tree impls are the canonical consumers.
+pub trait AnyTrackable: 'static {
+    /// Register a listener that fires after every state-mutating op
+    /// on this trackable. Returns an id used by
+    /// [`Self::unregister_listener`].
+    fn register_listener(&self, callback: Rc<dyn Fn()>) -> u64;
+
+    /// Drop a previously-registered listener.
+    fn unregister_listener(&self, id: u64);
+}
+
+/// RAII handle returned by selector tracking. Drop unregisters the
+/// listener from the upstream trackable; holds a `Weak` so a token
+/// outliving its source silently no-ops.
+pub struct TrackToken {
+    trackable: Weak<dyn AnyTrackable>,
+    id: u64,
+}
+
+impl TrackToken {
+    pub(crate) fn new(trackable: &Rc<dyn AnyTrackable>, id: u64) -> Self {
+        Self {
+            trackable: Rc::downgrade(trackable),
+            id,
+        }
+    }
+}
+
+impl Drop for TrackToken {
+    fn drop(&mut self) {
+        if let Some(t) = self.trackable.upgrade() {
+            t.unregister_listener(self.id);
+        }
+    }
+}
+
+// ---- Thread-local tracking stack ----------------------------------
+
+thread_local! {
+    /// Stack of in-progress selector reruns. `record_read` pushes
+    /// into the top frame; ordinary component reads (no frame active)
+    /// no-op.
+    static SELECTOR_STACK: RefCell<Vec<TrackingFrame>> = const { RefCell::new(Vec::new()) };
+}
+
+/// `(listener target, anything-to-keep-alive)` pair captured by the
+/// tracking frame. The trackable is what listeners register against;
+/// the keeper (a cloned `QueryHandle` or a nested
+/// `Rc<SelectorEntry<T>>`) holds the upstream alive between reruns.
+type TrackedDep = (Rc<dyn AnyTrackable>, Box<dyn Any>);
+
+/// One frame on the tracking stack.
+struct TrackingFrame {
+    deps: Vec<TrackedDep>,
+}
+
+/// Record a dependency read against the current selector's tracking
+/// frame. No-op when the stack is empty (the common case for
+/// ordinary component reads outside any selector).
+///
+/// `keeper` is the value the selector entry stores to keep the
+/// upstream alive across reruns — typically a cloned `QueryHandle`
+/// for a subscription dep, or the upstream selector entry's `Rc` for
+/// a nested-selector dep. Dedupe within a frame is by `Rc` pointer
+/// identity, so multiple reads against the same view are folded into
+/// one tracked dep.
+pub(crate) fn record_read(trackable: Rc<dyn AnyTrackable>, keeper: Box<dyn Any>) {
+    SELECTOR_STACK.with(|stack| {
+        let mut stack = stack.borrow_mut();
+        let Some(frame) = stack.last_mut() else {
+            return;
+        };
+        let ptr = Rc::as_ptr(&trackable) as *const ();
+        let already_tracked = frame
+            .deps
+            .iter()
+            .any(|(t, _)| Rc::as_ptr(t) as *const () == ptr);
+        if !already_tracked {
+            frame.deps.push((trackable, keeper));
+        }
+    });
+}
+
+/// Is a selector currently mid-`compute()`? Read sites use this to
+/// skip the work of building a keeper (cloning `QueryHandle`, etc.)
+/// when no tracking frame is active — the common case for ordinary
+/// component reads.
+pub(crate) fn currently_tracking() -> bool {
+    SELECTOR_STACK.with(|stack| !stack.borrow().is_empty())
+}
+
+fn push_frame() {
+    SELECTOR_STACK.with(|stack| {
+        stack.borrow_mut().push(TrackingFrame { deps: Vec::new() });
+    });
+}
+
+fn pop_frame() -> TrackingFrame {
+    SELECTOR_STACK
+        .with(|stack| stack.borrow_mut().pop())
+        .expect("pop_frame called without matching push_frame")
+}
+
+// ---- Selector entry -----------------------------------------------
+
+/// Object-safe shape over a typed `SelectorEntry<T>`. Lets
+/// `QueryClientInner.selectors` hold heterogeneous entries behind one
+/// `Weak<dyn AnySelector>`. The `as_rc_any` upcast mirrors the
+/// `AnyQuerySubscription::as_rc_any` pattern in `client.rs` and is
+/// the safe-stdlib path to `Rc::downcast`.
+pub(crate) trait AnySelector: AnyTrackable {
+    fn as_rc_any(self: Rc<Self>) -> Rc<dyn Any>;
+}
+
+/// `(id, callback)` entry in a selector's listener list. The id is
+/// what the returned [`TrackToken`] keeps so drop can unregister.
+type Listener = (u64, Rc<dyn Fn()>);
+
+/// One memoized selector instance. Keyed in the client by
+/// `(SelectorId, args_hash)`.
+///
+/// Owns the compute closure, the cached output, the set of upstream
+/// dependencies it captured on its last run, the listener tokens it
+/// holds on each upstream, and its own listener registry.
+pub(crate) struct SelectorEntry<T: PartialEq + Clone + 'static> {
+    id: SelectorId,
+    args_hash: u64,
+    cached_output: RefCell<Option<T>>,
+    /// Erased keepers (cloned `QueryHandle`s for subscriptions,
+    /// nested `Rc<SelectorEntry<_>>`s for sub-selectors) holding each
+    /// tracked dep alive between reruns.
+    keepers: RefCell<Vec<Box<dyn Any>>>,
+    /// Listener tokens on each upstream. Drop unregisters.
+    listener_tokens: RefCell<Vec<TrackToken>>,
+    /// Selector's own listener registry. Fires on diffed output
+    /// change after each rerun.
+    listeners: RefCell<Vec<Listener>>,
+    next_listener_id: Cell<u64>,
+    /// Re-entrancy guard. If a rerun's compute() somehow triggers a
+    /// notify on a tracked dep that re-enters this selector's
+    /// listener callback, the nested rerun is skipped; the outer
+    /// rerun's continued execution will observe the updated upstream
+    /// state on its next read.
+    running: Cell<bool>,
+    compute: Box<dyn Fn() -> T>,
+    /// Weak back-ref for `Drop` self-removal from the client's
+    /// selector registry. Mirrors the `RegistryWeakRef` pattern used
+    /// for subscriptions.
+    client: Weak<QueryClientInner>,
+}
+
+impl<T: PartialEq + Clone + 'static> SelectorEntry<T> {
+    pub(crate) fn new(
+        id: SelectorId,
+        args_hash: u64,
+        compute: Box<dyn Fn() -> T>,
+        client: Weak<QueryClientInner>,
+    ) -> Self {
+        Self {
+            id,
+            args_hash,
+            cached_output: RefCell::new(None),
+            keepers: RefCell::new(Vec::new()),
+            listener_tokens: RefCell::new(Vec::new()),
+            listeners: RefCell::new(Vec::new()),
+            next_listener_id: Cell::new(0),
+            running: Cell::new(false),
+            compute,
+            client,
+        }
+    }
+
+    /// Execute `compute`, capture the tracked deps, diff the output
+    /// against the cache, and fire selector listeners on change.
+    ///
+    /// Steps mirror the explainer's algorithm (see the doc):
+    ///   1. Push a tracking frame.
+    ///   2. Run `compute()`.
+    ///   3. Pop the frame.
+    ///   4. Drop old listener tokens; install new keepers + tokens.
+    ///   5. If output differs from cache: update cache, fire
+    ///      selector's own listeners.
+    pub(crate) fn rerun(self: &Rc<Self>) {
+        if self.running.get() {
+            return;
+        }
+        self.running.set(true);
+
+        push_frame();
+        let new_output = (self.compute)();
+        let frame = pop_frame();
+
+        // Re-wire listeners. Drop old tokens FIRST so a same-upstream
+        // listener is unregistered before its replacement registers
+        // — keeps listener-vec growth bounded across reruns.
+        self.listener_tokens.borrow_mut().clear();
+
+        let weak_self: Weak<Self> = Rc::downgrade(self);
+        let mut new_keepers: Vec<Box<dyn Any>> = Vec::with_capacity(frame.deps.len());
+        let mut new_tokens: Vec<TrackToken> = Vec::with_capacity(frame.deps.len());
+        for (trackable, keeper) in frame.deps {
+            let w = weak_self.clone();
+            let cb: Rc<dyn Fn()> = Rc::new(move || {
+                if let Some(this) = w.upgrade() {
+                    this.rerun();
+                }
+            });
+            let id = trackable.register_listener(cb);
+            new_tokens.push(TrackToken::new(&trackable, id));
+            new_keepers.push(keeper);
+        }
+        *self.keepers.borrow_mut() = new_keepers;
+        *self.listener_tokens.borrow_mut() = new_tokens;
+
+        self.running.set(false);
+
+        let changed = {
+            let cache = self.cached_output.borrow();
+            cache.as_ref() != Some(&new_output)
+        };
+        if !changed {
+            return;
+        }
+        *self.cached_output.borrow_mut() = Some(new_output);
+
+        // Snapshot listeners before invoking so a callback that
+        // registers / drops listeners on this same selector doesn't
+        // re-enter the `listeners` RefCell mid-iteration. Mirrors the
+        // pattern in `QuerySubscription::notify_listeners`.
+        let snapshot: Vec<Rc<dyn Fn()>> = {
+            let listeners = self.listeners.borrow();
+            listeners.iter().map(|(_, cb)| cb.clone()).collect()
+        };
+        for cb in snapshot {
+            cb();
+        }
+    }
+
+    /// Clone of the cached output. Callers must ensure the initial
+    /// `rerun` has completed before calling (the
+    /// `QueryClient::observe_selector` entry point guarantees this).
+    pub(crate) fn cached(&self) -> T {
+        self.cached_output
+            .borrow()
+            .clone()
+            .expect("selector cache populated by initial rerun before observe returns")
+    }
+}
+
+impl<T: PartialEq + Clone + 'static> AnyTrackable for SelectorEntry<T> {
+    fn register_listener(&self, callback: Rc<dyn Fn()>) -> u64 {
+        let id = self.next_listener_id.get();
+        self.next_listener_id.set(id.wrapping_add(1));
+        self.listeners.borrow_mut().push((id, callback));
+        id
+    }
+
+    fn unregister_listener(&self, id: u64) {
+        if let Ok(mut listeners) = self.listeners.try_borrow_mut() {
+            listeners.retain(|(lid, _)| *lid != id);
+        }
+    }
+}
+
+impl<T: PartialEq + Clone + 'static> AnySelector for SelectorEntry<T> {
+    fn as_rc_any(self: Rc<Self>) -> Rc<dyn Any> {
+        self
+    }
+}
+
+impl<T: PartialEq + Clone + 'static> Drop for SelectorEntry<T> {
+    fn drop(&mut self) {
+        // Self-remove from the client's selector registry. Only
+        // touch the slot if its Weak still points at THIS entry —
+        // a replacement entry inserted between the strong-count
+        // hitting zero and this Drop running must not be clobbered.
+        let Some(inner) = self.client.upgrade() else {
+            return;
+        };
+        let Ok(mut selectors) = inner.selectors.try_borrow_mut() else {
+            return;
+        };
+        let key = (self.id, self.args_hash);
+        let still_ours = selectors
+            .get(&key)
+            .map(|w| w.strong_count() == 0)
+            .unwrap_or(false);
+        if still_ours {
+            selectors.remove(&key);
+        }
+    }
+}
+
+// ---- User-facing view ---------------------------------------------
+
+/// User-facing handle to a cached selector. Returned by the
+/// `#[query]` macro's generated `observe()` and by
+/// [`QueryClient::observe_selector`](crate::QueryClient::observe_selector).
+///
+/// Reading [`Self::value`] inside another selector's body records the
+/// inner selector as a dependency, so selectors compose recursively.
+/// Drop the view to release the selector — entries with no remaining
+/// `SelectorView` and no parent selector tracking them are GC'd.
+pub struct SelectorView<T: PartialEq + Clone + 'static> {
+    entry: Rc<SelectorEntry<T>>,
+}
+
+impl<T: PartialEq + Clone + 'static> SelectorView<T> {
+    pub(crate) fn from_entry(entry: Rc<SelectorEntry<T>>) -> Self {
+        Self { entry }
+    }
+
+    /// Current memoized value. Calling this inside another selector's
+    /// body records this selector as a dep of the caller — that's
+    /// how nested selectors compose. Outside any selector, the call
+    /// is a plain cache read.
+    pub fn value(&self) -> T {
+        let trackable: Rc<dyn AnyTrackable> = self.entry.clone();
+        record_read(trackable, Box::new(self.entry.clone()));
+        self.entry.cached()
+    }
+
+    /// Register a callback to fire whenever the selector's diffed
+    /// output changes. Returned token unregisters on drop.
+    pub fn on_update<F: Fn() + 'static>(&self, callback: F) -> TrackToken {
+        let cb: Rc<dyn Fn()> = Rc::new(callback);
+        let trackable: Rc<dyn AnyTrackable> = self.entry.clone();
+        let id = trackable.register_listener(cb);
+        TrackToken::new(&trackable, id)
+    }
+}

--- a/crates/pocopine-sync-query/src/selector.rs
+++ b/crates/pocopine-sync-query/src/selector.rs
@@ -269,9 +269,41 @@ impl<T: PartialEq + Clone + 'static> SelectorEntry<T> {
         }
         self.running.set(true);
 
+        // RAII guard: pops the tracking frame and clears `running`
+        // even if `compute` panics. Without this, a panic in user
+        // code would leak the frame onto SELECTOR_STACK forever
+        // (poisoning every later selector on this thread) and pin
+        // `running = true` (every future rerun would silently no-op
+        // at the line above's guard). The guard runs whether
+        // `compute` returns normally or unwinds.
+        struct RerunGuard<'a> {
+            running: &'a Cell<bool>,
+            frame_popped: bool,
+        }
+        impl Drop for RerunGuard<'_> {
+            fn drop(&mut self) {
+                if !self.frame_popped {
+                    // pop_frame panics on missing frame; use the
+                    // lower-level peek to avoid double-panic during
+                    // unwind. Pop iff a frame is actually on top.
+                    SELECTOR_STACK.with(|stack| {
+                        if let Ok(mut s) = stack.try_borrow_mut() {
+                            s.pop();
+                        }
+                    });
+                }
+                self.running.set(false);
+            }
+        }
+        let mut guard = RerunGuard {
+            running: &self.running,
+            frame_popped: false,
+        };
+
         push_frame();
         let new_output = (self.compute)();
         let frame = pop_frame();
+        guard.frame_popped = true;
 
         // Re-wire listeners. Drop old tokens FIRST so a same-upstream
         // listener is unregistered before its replacement registers
@@ -295,8 +327,13 @@ impl<T: PartialEq + Clone + 'static> SelectorEntry<T> {
         *self.keepers.borrow_mut() = new_keepers;
         *self.listener_tokens.borrow_mut() = new_tokens;
 
-        self.running.set(false);
-
+        // NB: `running` stays `true` through the listener-fire block
+        // below; the RerunGuard at the top of the fn resets it on
+        // exit (whether by return or unwind). Keeping it set during
+        // fire blocks re-entrant rerun() calls triggered by our own
+        // listeners — they hit the guard at the top of rerun and
+        // return cleanly. Other selectors' reruns are unaffected
+        // (they have their own `running` cells).
         let changed = {
             let cache = self.cached_output.borrow();
             cache.as_ref() != Some(&new_output)
@@ -321,12 +358,36 @@ impl<T: PartialEq + Clone + 'static> SelectorEntry<T> {
 
     /// Clone of the cached output. Callers must ensure the initial
     /// `rerun` has completed before calling (the
-    /// `QueryClient::observe_selector` entry point guarantees this).
+    /// `QueryClient::observe_selector` entry point guarantees this
+    /// in the common case).
+    ///
+    /// Panics if the cache is `None`. The only realistic trigger is
+    /// recursive self-observation: a selector's compute body calls
+    /// `observe_selector` with the same `(id, args)` before its
+    /// initial rerun completes, gets a `SelectorView` over the
+    /// just-inserted (but not-yet-populated) entry, and reads
+    /// `.value()`. The panic message names the condition so the
+    /// caller can break the cycle rather than chase a 'cache invariant
+    /// violated' error.
     pub(crate) fn cached(&self) -> T {
-        self.cached_output
-            .borrow()
-            .clone()
-            .expect("selector cache populated by initial rerun before observe returns")
+        if let Some(v) = self.cached_output.borrow().clone() {
+            return v;
+        }
+        if self.running.get() {
+            panic!(
+                "recursive self-observation of selector ({:#x}/{:#x}): cannot read \
+                 SelectorView::value() while the selector's initial rerun is still \
+                 in progress. A `#[query]` body must not call `observe()` for itself.",
+                self.id.as_u64(),
+                self.args_hash,
+            );
+        }
+        panic!(
+            "selector ({:#x}/{:#x}) cache was unexpectedly empty after initial \
+             rerun — framework invariant violated",
+            self.id.as_u64(),
+            self.args_hash,
+        );
     }
 }
 
@@ -401,8 +462,14 @@ impl<T: PartialEq + Clone + 'static> SelectorView<T> {
     /// how nested selectors compose. Outside any selector, the call
     /// is a plain cache read.
     pub fn value(&self) -> T {
-        let trackable: Rc<dyn AnyTrackable> = self.entry.clone();
-        record_read(trackable, Box::new(self.entry.clone()));
+        // Skip the keeper construction (Box alloc + Rc clones) when
+        // no tracking frame is active — the common case for ordinary
+        // component reads. Mirrors `QueryView::track_for_selector`'s
+        // fast path.
+        if currently_tracking() {
+            let trackable: Rc<dyn AnyTrackable> = self.entry.clone();
+            record_read(trackable, Box::new(self.entry.clone()));
+        }
         self.entry.cached()
     }
 

--- a/crates/pocopine-sync-query/tests/selector.rs
+++ b/crates/pocopine-sync-query/tests/selector.rs
@@ -1,0 +1,355 @@
+//! Integration tests for the `#[query]` selector runtime.
+//!
+//! Exercises the four moving parts from
+//! `docs/sync-query-selector-mechanism.md`:
+//!
+//! * Thread-local read tracking — `QueryView::rows()` inside a
+//!   selector's compute registers the subscription as a dep.
+//! * `(SelectorId, args_hash)` caching — repeat `observe_selector`
+//!   calls return the same entry.
+//! * Invalidation via the existing `notify_listeners` plumbing —
+//!   mutating through `QueryClient::mutate` reruns the selector.
+//! * `PartialEq` diff suppression — selectors whose output didn't
+//!   change do NOT fire their own listeners.
+//!
+//! Tests drive a no-network `EchoMutator` whose `apply_remote`
+//! returns the payload synchronously, so the routing engine's
+//! optimistic + canonical paths both fire without a real fetch.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::cell::Cell;
+use std::rc::Rc;
+
+use pocopine_sync::{MutationId, SyncResult};
+use pocopine_sync_query::{
+    selector::SelectorId, Mutator, MutatorRemoteContext, MutatorRemoteFuture, QueryClient,
+    RowChange,
+};
+use pocopine_sync_query_macros::query_resource;
+use serde::{Deserialize, Serialize};
+use tokio::task::LocalSet;
+
+#[query_resource(name = "issues", schema_version = 1)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Issue {
+    pub id: String,
+    #[query_param(required)]
+    pub workspace_id: String,
+    pub title: String,
+}
+
+/// No-network mutator. `apply_local` and `apply_remote` both echo the
+/// payload as a single Upsert so the routing engine fires both
+/// optimistic and canonical paths.
+struct EchoMutator;
+
+impl Mutator for EchoMutator {
+    type Payload = Issue;
+    type Row = Issue;
+    const NAME: &'static str = "echo";
+    const STREAM: &'static str = "issues";
+    const SCHEMA_VERSION: u32 = 1;
+
+    fn apply_local(payload: &Self::Payload) -> Vec<RowChange<Self::Row>> {
+        vec![RowChange::Upsert(payload.clone())]
+    }
+
+    fn apply_remote(
+        _ctx: &dyn MutatorRemoteContext,
+        payload: Self::Payload,
+    ) -> MutatorRemoteFuture<Self::Row> {
+        Box::pin(async move { Ok(vec![RowChange::Upsert(payload)]) })
+    }
+}
+
+struct StubContext {
+    next_id: Cell<u64>,
+}
+
+impl StubContext {
+    fn new() -> Self {
+        Self {
+            next_id: Cell::new(1),
+        }
+    }
+}
+
+impl MutatorRemoteContext for StubContext {
+    fn push_url(&self) -> &str {
+        "/__pocopine/sync/v1/push"
+    }
+
+    fn next_mutation_id(&self) -> SyncResult<MutationId> {
+        let n = self.next_id.get();
+        self.next_id.set(n + 1);
+        MutationId::new(format!("test:{n}"))
+    }
+}
+
+/// Helper: build a workspace-scoped issues query.
+fn workspace_query(ws: &str) -> pocopine_sync_query::Query<Issue> {
+    Issue::query()
+        .eq(issues::field::workspace_id, ws.to_string())
+        .build()
+}
+
+fn issue(id: &str, ws: &str, title: &str) -> Issue {
+    Issue {
+        id: id.into(),
+        workspace_id: ws.into(),
+        title: title.into(),
+    }
+}
+
+// ---- 1. Caching by (id, args_hash) --------------------------------
+
+#[tokio::test]
+async fn observe_selector_caches_by_id_and_args_hash() {
+    LocalSet::new()
+        .run_until(async {
+            let client = QueryClient::without_driver();
+            let id = SelectorId::new(0x01);
+
+            let call_count = Rc::new(Cell::new(0u32));
+            let client_for_compute = client.clone();
+            let counter = call_count.clone();
+            let compute = move || {
+                counter.set(counter.get() + 1);
+                let view = client_for_compute.observe(workspace_query("W1"));
+                view.len() as u32
+            };
+
+            // First observe — compute fires once, caches.
+            let v1 = client.observe_selector(id, 0xAA, compute.clone());
+            assert_eq!(v1.value(), 0);
+            assert_eq!(call_count.get(), 1);
+
+            // Second observe with SAME (id, args_hash) — cache hit,
+            // compute does NOT fire.
+            let v2 = client.observe_selector(id, 0xAA, compute.clone());
+            assert_eq!(v2.value(), 0);
+            assert_eq!(call_count.get(), 1, "compute reused cached entry");
+
+            // Same id, different args_hash — distinct entry, compute fires.
+            let v3 = client.observe_selector(id, 0xBB, compute.clone());
+            assert_eq!(v3.value(), 0);
+            assert_eq!(call_count.get(), 2);
+        })
+        .await;
+}
+
+// ---- 2. Invalidation on subscription change -----------------------
+
+#[tokio::test]
+async fn selector_reruns_when_tracked_subscription_changes() {
+    LocalSet::new()
+        .run_until(async {
+            let client = QueryClient::without_driver();
+            let id = SelectorId::new(0x02);
+
+            let runs = Rc::new(Cell::new(0u32));
+            let client_for_compute = client.clone();
+            let runs_for_compute = runs.clone();
+            let view = client.observe_selector(id, 0, move || {
+                runs_for_compute.set(runs_for_compute.get() + 1);
+                let qv = client_for_compute.observe(workspace_query("W1"));
+                qv.rows().len() as u32
+            });
+
+            assert_eq!(view.value(), 0);
+            assert_eq!(runs.get(), 1);
+
+            // Wire a listener so we can see rerun-with-diff fire.
+            let fires = Rc::new(Cell::new(0u32));
+            let fires_for_cb = fires.clone();
+            let _tok = view.on_update(move || {
+                fires_for_cb.set(fires_for_cb.get() + 1);
+            });
+
+            let ctx = StubContext::new();
+            client
+                .mutate::<EchoMutator>(issue("i1", "W1", "first"), &ctx)
+                .await
+                .expect("mutate ok");
+
+            assert_eq!(view.value(), 1, "selector picked up the new row");
+            assert!(runs.get() >= 2, "selector reran at least once");
+            assert!(fires.get() >= 1, "diff-fire fired at least once");
+        })
+        .await;
+}
+
+// ---- 3. Diff suppression ------------------------------------------
+
+#[tokio::test]
+async fn diff_suppression_blocks_listener_when_output_unchanged() {
+    LocalSet::new()
+        .run_until(async {
+            let client = QueryClient::without_driver();
+            let id = SelectorId::new(0x03);
+
+            // Selector returns a CONSTANT — output never changes
+            // even though the tracked subscription does.
+            let runs = Rc::new(Cell::new(0u32));
+            let client_for_compute = client.clone();
+            let runs_for_compute = runs.clone();
+            let view = client.observe_selector(id, 0, move || {
+                runs_for_compute.set(runs_for_compute.get() + 1);
+                let qv = client_for_compute.observe(workspace_query("W1"));
+                let _force_read = qv.rows();
+                42u32 // constant
+            });
+
+            assert_eq!(view.value(), 42);
+            assert_eq!(runs.get(), 1);
+
+            let fires = Rc::new(Cell::new(0u32));
+            let fires_for_cb = fires.clone();
+            let _tok = view.on_update(move || {
+                fires_for_cb.set(fires_for_cb.get() + 1);
+            });
+
+            let ctx = StubContext::new();
+            client
+                .mutate::<EchoMutator>(issue("i1", "W1", "first"), &ctx)
+                .await
+                .expect("mutate ok");
+
+            assert!(runs.get() >= 2, "selector reran (was woken)");
+            assert_eq!(
+                fires.get(),
+                0,
+                "diff suppression prevented the listener from firing"
+            );
+            assert_eq!(view.value(), 42);
+        })
+        .await;
+}
+
+// ---- 4. Nested selector composition -------------------------------
+
+#[tokio::test]
+async fn nested_selector_propagates_through_outer() {
+    LocalSet::new()
+        .run_until(async {
+            let client = QueryClient::without_driver();
+            let inner_id = SelectorId::new(0x10);
+            let outer_id = SelectorId::new(0x11);
+
+            // Inner: count of rows in W1.
+            let client_for_inner = client.clone();
+            let inner_runs = Rc::new(Cell::new(0u32));
+            let inner_runs_c = inner_runs.clone();
+            let inner_compute = move || {
+                inner_runs_c.set(inner_runs_c.get() + 1);
+                let qv = client_for_inner.observe(workspace_query("W1"));
+                qv.rows().len() as u32
+            };
+            let _inner = client.observe_selector(inner_id, 0, inner_compute.clone());
+
+            // Outer: wraps inner, multiplies by 2.
+            let client_for_outer = client.clone();
+            let outer_runs = Rc::new(Cell::new(0u32));
+            let outer_runs_c = outer_runs.clone();
+            let outer = client.observe_selector(outer_id, 0, move || {
+                outer_runs_c.set(outer_runs_c.get() + 1);
+                let inner_view =
+                    client_for_outer.observe_selector(inner_id, 0, inner_compute.clone());
+                inner_view.value() * 2
+            });
+
+            assert_eq!(outer.value(), 0);
+            assert_eq!(inner_runs.get(), 1);
+            assert_eq!(outer_runs.get(), 1);
+
+            let ctx = StubContext::new();
+            client
+                .mutate::<EchoMutator>(issue("i1", "W1", "x"), &ctx)
+                .await
+                .expect("mutate ok");
+
+            // Inner reruns (output 0 → 1), outer reruns because its
+            // tracked inner-selector entry's diff-fire propagated.
+            assert_eq!(outer.value(), 2);
+            assert!(inner_runs.get() >= 2);
+            assert!(outer_runs.get() >= 2);
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn nested_diff_suppression_stops_cascade() {
+    LocalSet::new()
+        .run_until(async {
+            let client = QueryClient::without_driver();
+            let inner_id = SelectorId::new(0x20);
+            let outer_id = SelectorId::new(0x21);
+
+            // Inner returns a constant — its output never changes.
+            let client_for_inner = client.clone();
+            let inner_compute = move || {
+                let qv = client_for_inner.observe(workspace_query("W1"));
+                let _r = qv.rows();
+                7u32 // constant
+            };
+
+            let outer_runs = Rc::new(Cell::new(0u32));
+            let outer_runs_c = outer_runs.clone();
+            let client_for_outer = client.clone();
+            let outer = client.observe_selector(outer_id, 0, move || {
+                outer_runs_c.set(outer_runs_c.get() + 1);
+                let iv = client_for_outer.observe_selector(inner_id, 0, inner_compute.clone());
+                iv.value()
+            });
+
+            assert_eq!(outer.value(), 7);
+            let initial_outer_runs = outer_runs.get();
+
+            let ctx = StubContext::new();
+            client
+                .mutate::<EchoMutator>(issue("i1", "W1", "x"), &ctx)
+                .await
+                .expect("mutate ok");
+
+            // Outer must NOT have reran: inner's diff-suppression
+            // prevented it from notifying outer.
+            assert_eq!(
+                outer_runs.get(),
+                initial_outer_runs,
+                "inner's diff suppression must stop the cascade"
+            );
+        })
+        .await;
+}
+
+// ---- 5. Lifecycle / GC --------------------------------------------
+
+#[tokio::test]
+async fn drop_view_removes_entry_from_registry() {
+    LocalSet::new()
+        .run_until(async {
+            let client = QueryClient::without_driver();
+            let id = SelectorId::new(0x30);
+
+            let client_for_compute = client.clone();
+            let compute = move || {
+                let qv = client_for_compute.observe(workspace_query("W1"));
+                qv.rows().len() as u32
+            };
+
+            {
+                let _view = client.observe_selector(id, 0, compute);
+                // Underlying subscription is alive while the view holds.
+                assert!(client.refcount_of(&workspace_query("W1")).is_some());
+            }
+            // After view drops, the selector entry should be gone,
+            // and so should the subscription it was holding.
+            assert_eq!(
+                client.refcount_of(&workspace_query("W1")),
+                None,
+                "subscription GC'd after selector dropped"
+            );
+        })
+        .await;
+}

--- a/crates/pocopine-sync-query/tests/selector.rs
+++ b/crates/pocopine-sync-query/tests/selector.rs
@@ -102,6 +102,34 @@ fn issue(id: &str, ws: &str, title: &str) -> Issue {
     }
 }
 
+// ---- 0. Hash-collision disambiguation -----------------------------
+//
+// Regression for the codex finding that `Hash` is not collision-free.
+// Two `observe_selector` calls with the SAME `(id, args_hash)` but
+// distinct `AnyArgs` values must land in distinct entries — the
+// second call must NOT receive the first's cached value.
+
+#[tokio::test]
+async fn hash_collision_does_not_alias_distinct_args() {
+    LocalSet::new()
+        .run_until(async {
+            let client = QueryClient::without_driver();
+            let id = SelectorId::new(0xC0);
+
+            // Same args_hash, different boxed args. (In practice the
+            // macro hashes args, but a colliding hash is rare for
+            // String — we force it here to exercise the bucket.)
+            let v_a =
+                client.observe_selector::<u32, _>(id, 0xCAFE, Box::new("A".to_string()), || 1u32);
+            let v_b =
+                client.observe_selector::<u32, _>(id, 0xCAFE, Box::new("B".to_string()), || 2u32);
+
+            assert_eq!(v_a.value(), 1, "first entry preserved");
+            assert_eq!(v_b.value(), 2, "second entry NOT aliased to first");
+        })
+        .await;
+}
+
 // ---- 1. Caching by (id, args_hash) --------------------------------
 
 #[tokio::test]
@@ -121,18 +149,18 @@ async fn observe_selector_caches_by_id_and_args_hash() {
             };
 
             // First observe — compute fires once, caches.
-            let v1 = client.observe_selector(id, 0xAA, compute.clone());
+            let v1 = client.observe_selector(id, 0xAA, Box::new(0xAAu64), compute.clone());
             assert_eq!(v1.value(), 0);
             assert_eq!(call_count.get(), 1);
 
             // Second observe with SAME (id, args_hash) — cache hit,
             // compute does NOT fire.
-            let v2 = client.observe_selector(id, 0xAA, compute.clone());
+            let v2 = client.observe_selector(id, 0xAA, Box::new(0xAAu64), compute.clone());
             assert_eq!(v2.value(), 0);
             assert_eq!(call_count.get(), 1, "compute reused cached entry");
 
             // Same id, different args_hash — distinct entry, compute fires.
-            let v3 = client.observe_selector(id, 0xBB, compute.clone());
+            let v3 = client.observe_selector(id, 0xBB, Box::new(0xBBu64), compute.clone());
             assert_eq!(v3.value(), 0);
             assert_eq!(call_count.get(), 2);
         })
@@ -151,7 +179,7 @@ async fn selector_reruns_when_tracked_subscription_changes() {
             let runs = Rc::new(Cell::new(0u32));
             let client_for_compute = client.clone();
             let runs_for_compute = runs.clone();
-            let view = client.observe_selector(id, 0, move || {
+            let view = client.observe_selector(id, 0, Box::new(()), move || {
                 runs_for_compute.set(runs_for_compute.get() + 1);
                 let qv = client_for_compute.observe(workspace_query("W1"));
                 qv.rows().len() as u32
@@ -194,7 +222,7 @@ async fn diff_suppression_blocks_listener_when_output_unchanged() {
             let runs = Rc::new(Cell::new(0u32));
             let client_for_compute = client.clone();
             let runs_for_compute = runs.clone();
-            let view = client.observe_selector(id, 0, move || {
+            let view = client.observe_selector(id, 0, Box::new(()), move || {
                 runs_for_compute.set(runs_for_compute.get() + 1);
                 let qv = client_for_compute.observe(workspace_query("W1"));
                 let _force_read = qv.rows();
@@ -246,16 +274,20 @@ async fn nested_selector_propagates_through_outer() {
                 let qv = client_for_inner.observe(workspace_query("W1"));
                 qv.rows().len() as u32
             };
-            let _inner = client.observe_selector(inner_id, 0, inner_compute.clone());
+            let _inner = client.observe_selector(inner_id, 0, Box::new(()), inner_compute.clone());
 
             // Outer: wraps inner, multiplies by 2.
             let client_for_outer = client.clone();
             let outer_runs = Rc::new(Cell::new(0u32));
             let outer_runs_c = outer_runs.clone();
-            let outer = client.observe_selector(outer_id, 0, move || {
+            let outer = client.observe_selector(outer_id, 0, Box::new(()), move || {
                 outer_runs_c.set(outer_runs_c.get() + 1);
-                let inner_view =
-                    client_for_outer.observe_selector(inner_id, 0, inner_compute.clone());
+                let inner_view = client_for_outer.observe_selector(
+                    inner_id,
+                    0,
+                    Box::new(()),
+                    inner_compute.clone(),
+                );
                 inner_view.value() * 2
             });
 
@@ -297,9 +329,14 @@ async fn nested_diff_suppression_stops_cascade() {
             let outer_runs = Rc::new(Cell::new(0u32));
             let outer_runs_c = outer_runs.clone();
             let client_for_outer = client.clone();
-            let outer = client.observe_selector(outer_id, 0, move || {
+            let outer = client.observe_selector(outer_id, 0, Box::new(()), move || {
                 outer_runs_c.set(outer_runs_c.get() + 1);
-                let iv = client_for_outer.observe_selector(inner_id, 0, inner_compute.clone());
+                let iv = client_for_outer.observe_selector(
+                    inner_id,
+                    0,
+                    Box::new(()),
+                    inner_compute.clone(),
+                );
                 iv.value()
             });
 
@@ -339,7 +376,7 @@ async fn drop_view_removes_entry_from_registry() {
             };
 
             {
-                let _view = client.observe_selector(id, 0, compute);
+                let _view = client.observe_selector(id, 0, Box::new(()), compute);
                 // Underlying subscription is alive while the view holds.
                 assert!(client.refcount_of(&workspace_query("W1")).is_some());
             }

--- a/crates/pocopine-sync-query/tests/selector.rs
+++ b/crates/pocopine-sync-query/tests/selector.rs
@@ -102,6 +102,93 @@ fn issue(id: &str, ws: &str, title: &str) -> Issue {
     }
 }
 
+// ---- Regression: compute() panic doesn't poison the selector -----
+//
+// If a selector's compute body panics, the RAII RerunGuard inside
+// rerun() must still: (1) pop the tracking frame so subsequent
+// reads on this thread don't accumulate in a stale frame, and (2)
+// reset `running` so future reruns aren't permanently no-op'd at
+// the running-guard check. Catch the panic via
+// std::panic::catch_unwind and verify a fresh selector on the same
+// thread observes normal mutation semantics.
+
+#[tokio::test]
+async fn compute_panic_does_not_poison_thread() {
+    LocalSet::new()
+        .run_until(async {
+            let client = QueryClient::without_driver();
+
+            // Selector A: compute panics on first run.
+            let panic_id = SelectorId::new(0xBADC0FFEE);
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                let _ = client.observe_selector::<u32, _>(panic_id, 0, Box::new(()), || {
+                    panic!("intentional panic for the test")
+                });
+            }));
+            assert!(result.is_err(), "compute panic should propagate");
+
+            // Selector B: a normal selector on the same thread must
+            // work — if the guard didn't clean up, this would either
+            // panic from a poisoned frame or capture the wrong deps.
+            let normal_id = SelectorId::new(0xC0FFEE);
+            let client_for = client.clone();
+            let view = client.observe_selector(normal_id, 0, Box::new(()), move || {
+                let qv = client_for.observe(workspace_query("W1"));
+                qv.rows().len() as u32
+            });
+            assert_eq!(view.value(), 0);
+
+            // Mutate and verify the rerun fires — proves `running`
+            // was reset (otherwise B's listener-triggered rerun
+            // would no-op at the guard).
+            let ctx = StubContext::new();
+            client
+                .mutate::<EchoMutator>(issue("i1", "W1", "after panic"), &ctx)
+                .await
+                .expect("mutate ok");
+            assert_eq!(view.value(), 1, "selector reran after the unrelated panic");
+        })
+        .await;
+}
+
+// ---- Regression: selector tracks via QueryView::version() --------
+//
+// A selector body that reads `view.version()` (the documented
+// reactive integer-changes signal) must register the underlying
+// subscription as a dep. Same for `state()` / `shared_state()`.
+// Pre-fix, these methods bypassed track_for_selector, leaving the
+// selector with zero deps and never rerunning.
+
+#[tokio::test]
+async fn selector_tracks_through_version_call() {
+    LocalSet::new()
+        .run_until(async {
+            let client = QueryClient::without_driver();
+            let id = SelectorId::new(0xCEED);
+
+            let client_for = client.clone();
+            let view = client.observe_selector(id, 0, Box::new(()), move || {
+                let qv = client_for.observe(workspace_query("W1"));
+                qv.version() // version() must trigger track_for_selector
+            });
+
+            let initial = view.value();
+
+            let ctx = StubContext::new();
+            client
+                .mutate::<EchoMutator>(issue("i1", "W1", "x"), &ctx)
+                .await
+                .expect("mutate ok");
+
+            assert_ne!(
+                view.value(),
+                initial,
+                "selector picked up the version bump via version()"
+            );
+        })
+        .await;
+}
+
 // ---- 0. Hash-collision disambiguation -----------------------------
 //
 // Regression for the codex finding that `Hash` is not collision-free.

--- a/docs/sync-query-selector-implementation.md
+++ b/docs/sync-query-selector-implementation.md
@@ -1,0 +1,291 @@
+# `#[query]` selector — implementation map
+
+Where each piece lives, how data flows through the layers, and what to scrutinize when reviewing or modifying the selector code. Companion to [`sync-query-selector-mechanism.md`](sync-query-selector-mechanism.md), which explains the *design*; this doc explains the *code*.
+
+Line numbers are best-effort references — they drift; symbols and file paths are the durable handles.
+
+## Layer overview
+
+```text
+┌──────────────────────────────────────────────────────────────────┐
+│  USER CODE (downstream crate)                                    │
+│                                                                  │
+│  #[query] fn foo(client: QueryClient, ws: String) -> u32 { … }   │
+│                                                                  │
+│  foo::observe(&client, "W1".into())     ◄── proc-macro expansion │
+└────────────────────┬─────────────────────────────────────────────┘
+                     │
+                     ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  GENERATED MODULE  (pocopine-sync-query-macros)                  │
+│                                                                  │
+│  pub mod foo {                                                   │
+│    const SELECTOR_ID = FNV-1a(module_path!() + "::foo");         │
+│    pub fn observe(client: &QueryClient, ws: String)              │
+│        -> SelectorView<u32> { …box args, build closure… }        │
+│  }                                                               │
+│  fn __pq_user_fn__foo(client: QueryClient, ws: String) -> u32 ───┼─┐
+│  // ^ lifted SIBLING of the module so super:: still resolves     │ │
+└────────────────────┬─────────────────────────────────────────────┘ │
+                     │                                               │
+                     ▼                                               │
+┌──────────────────────────────────────────────────────────────────┐ │
+│  RUNTIME  (pocopine-sync-query crate)                            │ │
+│                                                                  │ │
+│   QueryClient::observe_selector(id, hash, args, compute) ────────┼─┘
+│                            │                                     │
+│                            ▼                                     │
+│   selectors: HashMap<(SelectorId, u64), Vec<Weak<…>>>            │
+│             ◄── bucketed; dyn_eq disambiguates hash collisions   │
+│                            │                                     │
+│                            ▼                                     │
+│   SelectorEntry<T> { compute, cached, args, keepers, listeners } │
+│                            │                                     │
+│                            │  rerun:                              │
+│                            │   1. push frame                      │
+│                            │   2. (self.compute)()  ────────────►│ user_fn body
+│                            │   3. pop frame                       │  calls view.rows()
+│                            │   4. wire listeners on tracked deps  │  → record_read
+│                            │   5. PartialEq diff; fire on change  │
+└────────────────────┬─────────────────────────────────────────────┘
+                     │
+                     ▼
+┌──────────────────────────────────────────────────────────────────┐
+│  EXISTING SUBSCRIPTION ENGINE  (unchanged)                       │
+│                                                                  │
+│   QuerySubscription<Row>.notify_listeners() fires after:         │
+│     route_optimistic_changes / route_canonical_changes /         │
+│     route_canonical_pull / dequeue_pending                       │
+│                                                                  │
+│   ◄── one of the listeners is the selector's rerun callback     │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+## Where each piece lives
+
+### `src/selector.rs` (new module)
+
+| Symbol | Notes |
+|---|---|
+| `SelectorId(u64)` | FNV-1a 64 of `module_path!() + "::" + fn_name`, computed at the user crate's compile time |
+| `AnyTrackable` trait | Object-safe; `register_listener` + `unregister_listener`. Implemented by `QuerySubscription<Row>` (bridges existing plumbing) and `SelectorEntry<T>` (so selectors compose recursively) |
+| `AnyArgs` trait + blanket impl | `dyn_eq` over any `T: PartialEq + 'static`. The blanket impl is what lets the macro box arbitrary tuples |
+| `TrackToken` | RAII; holds `Weak<dyn AnyTrackable>` so a token outliving its source silently no-ops on drop |
+| `SELECTOR_STACK` (thread_local) | Stack of `TrackingFrame { deps: Vec<(Rc<dyn AnyTrackable>, Box<dyn Any>)> }` |
+| `record_read` / `currently_tracking` | The only hook into the runtime; no-op outside any selector |
+| `AnySelector` trait | Object-safe; `as_rc_any` + `args()` |
+| `SelectorEntry<T>` | The heart — compute closure, cached output, captured deps (keepers + listener tokens), own listener registry, re-entrancy guard, weak ref back to `QueryClientInner` |
+| `SelectorEntry::rerun` | The 5-step algorithm in one place |
+| `Drop for SelectorEntry` | Bucket-aware self-removal from the client's selectors map |
+| `SelectorView<T>` | Thin user-facing wrapper; `value()` does `record_read` on its own entry so nested selectors compose |
+
+### `src/client.rs` (modifications)
+
+| What | Notes |
+|---|---|
+| `SelectorBucket` type alias | `Vec<Weak<dyn AnySelector>>` — separate chaining for the selectors hash map; satisfies clippy `type_complexity` |
+| `register_listener_rc` | Takes a pre-built `Rc<dyn Fn()>`, avoids double-wrapping the selector's rerun callback (one closure is held by every upstream) |
+| `AnyTrackable for QuerySubscription<Row>` | Two-line impl that bridges the existing listener plumbing into the trait-object interface |
+| `QueryClientInner.selectors` | `HashMap<(SelectorId, u64), SelectorBucket>` — keys are weak; entries self-remove on Drop |
+| `QueryClient::observe_selector` | The runtime entry point the macro targets |
+| `QueryView::track_for_selector` | Called from `rows`/`len`/`is_empty`; bumps the subscription's refcount via a cloned `QueryHandle` keeper |
+| `impl Clone for QueryHandle` | Bumps subscription refcount; needed for the keeper pattern so a selector's `tracked` list keeps the subscription alive between reruns |
+| `impl Clone for QueryClient` | Selector compute closures must own a client (`Fn() + 'static` can't borrow) |
+
+### `pocopine-sync-query-macros/src/lib.rs` (additions)
+
+| Symbol | Notes |
+|---|---|
+| `#[proc_macro_attribute] query` | Rejects macro args (no `no_diff` opt-out yet) |
+| `expand_query` | Main expansion; validates the fn shape — rejects `async`/`unsafe`/`const`/generic/`where`/variadic/`self`/destructuring/`ref` patterns |
+| `partition_selector_attrs` | Routes user attrs to module / observe() / inner-fn by audience |
+| `is_query_client_type` | First-arg-is-`QueryClient` heuristic — that arg is *not* hashed and *not* in `observe()`'s public arg list |
+| `contains_impl_trait` | Recursive walker; rejects argument-position `impl Trait` anywhere in the type — top-level, nested in containers, assoc-type bindings, trait-object bounds |
+| `path_args_contain_impl_trait` | Helper; walks `GenericArgument::Type` / `AssocType` / `Constraint` |
+
+## Critical data flows
+
+### A. First `observe()` — cache miss
+
+```text
+foo::observe(&client, "W1")
+  │
+  ├─ DefaultHasher::hash(ws) → args_hash
+  ├─ Box::new((ws.clone(),)) as Box<dyn AnyArgs>  // for dyn_eq
+  ├─ compute = move || __pq_user_fn__foo(client.clone(), ws.clone())
+  │
+  ▼
+client.observe_selector(SELECTOR_ID, hash, args, compute)
+  │
+  ├─ Walk selectors.get(&(id, hash)) bucket → no live entry with dyn_eq match
+  │
+  ├─ Rc::new(SelectorEntry::new(...))
+  ├─ selectors.entry(key).or_default().push(Weak::from(&entry))
+  │  ◄── opportunistic GC of dead Weaks in the bucket
+  │
+  ▼
+entry.rerun()
+  │
+  ├─ push_frame()
+  ├─ (compute)() ── runs __pq_user_fn__foo
+  │   └─ client.observe(query).rows()
+  │       └─ track_for_selector()
+  │           └─ record_read(subscription.clone() as Rc<dyn AnyTrackable>,
+  │                          Box::new(handle.clone()))
+  │                                  ▲          ▲
+  │                                  │          └─ keeper: bumps sub.refcount
+  │                                  └─ trackable: for listener register
+  │
+  ├─ pop_frame() → captured deps
+  ├─ Drop old listener_tokens (none on first run)
+  ├─ For each (trackable, keeper):
+  │   ├─ cb = move || weak_self.upgrade().map(|s| s.rerun())
+  │   ├─ id = trackable.register_listener(cb)  ── via AnyTrackable
+  │   └─ store TrackToken + keeper
+  │
+  └─ Diff: cached was None → write Some(output); listeners empty → no fire
+```
+
+### B. Mutation reaches a tracked subscription
+
+```text
+client.mutate::<EchoMutator>(payload).await
+  │
+  ├─ route_optimistic_changes(...)
+  │   └─ for matching sub: state.push_pending(); sub.notify_listeners()
+  │                                                       │
+  │                                                       ▼
+  │                                          (snapshots listeners, fires each)
+  │                                                       │
+  │                                          ┌────────────┴──────────┐
+  │                                          ▼                       ▼
+  │                                 (other listeners)        selector's rerun cb
+  │                                                                  │
+  │                                                                  ▼
+  │                                                        weak_entry.upgrade()
+  │                                                                  │
+  │                                                                  ▼
+  │                                                        SelectorEntry::rerun()
+  │                                                                  │
+  │                                                                  ├─ recompute
+  │                                                                  ├─ new ≠ cached?
+  │                                                                  │   yes → fire selector's
+  │                                                                  │         own listeners
+  │                                                                  │   no  → STOP (diff
+  │                                                                  │         suppression)
+  │
+  ├─ apply_remote(...).await → canonical changes
+  ├─ route_canonical_changes(...)  → notify_listeners again (same chain)
+  │
+  └─ guard.disarm()
+```
+
+### C. Drop cascade
+
+```text
+drop(view: SelectorView<T>)
+  │ entry.strong_count drops
+  ▼
+SelectorEntry::Drop
+  ├─ inner.upgrade()? .selectors.try_borrow_mut()?
+  ├─ bucket.retain(|w| w.strong_count() > 0)   // prune dead Weaks
+  ├─ if bucket.is_empty() → selectors.remove(&key)
+  │
+  ▼ then drop the entry's fields (declaration order):
+    ├─ keepers Vec drops
+    │   └─ Each Box<dyn Any> drops → cloned QueryHandle drops
+    │       └─ release_inner → subscription refcount--
+    │           └─ if 0 → driver epoch bumped + registry removed
+    └─ listener_tokens drops
+        └─ Each TrackToken: Weak.upgrade()?.unregister_listener(id)
+           ◄── safe if subscription already gone (Weak fails upgrade)
+```
+
+## Macro expansion shape
+
+User writes:
+
+```rust,ignore
+#[query]
+#[must_use]
+pub fn issue_count(client: QueryClient, ws: String) -> u32 {
+    client.observe(Issue::query().eq(field::workspace_id, ws).build())
+          .rows().len() as u32
+}
+```
+
+Becomes (approximately — see `expand_query` for the full shape):
+
+```rust,ignore
+// inner-fn attrs ⊕ #[doc(hidden)]; lives at PARENT scope so super:: still works
+#[doc(hidden)]
+fn __pq_user_fn__issue_count(client: QueryClient, ws: String) -> u32 {
+    client.observe(Issue::query().eq(field::workspace_id, ws).build())
+          .rows().len() as u32
+}
+
+// module-attrs (none in this example); module vis = user's vis
+pub mod issue_count {
+    use super::*;
+
+    pub const SELECTOR_ID: SelectorId = SelectorId::new(
+        __private::fnv1a64(concat!(module_path!(), "::issue_count").as_bytes())
+    );
+
+    // observe-attrs go here (e.g. #[must_use])
+    #[must_use]
+    pub fn observe(__pq_client: &QueryClient, ws: String) -> SelectorView<u32> {
+        let mut h = DefaultHasher::new();
+        Hash::hash(&ws, &mut h);
+        let args_hash = h.finish();
+
+        let __pq_args_boxed: Box<dyn AnyArgs> = Box::new((ws.clone(),));
+
+        let __pq_client_for_compute = __pq_client.clone();   // emitted only if user has a `QueryClient` arg
+        let __pq_arg_0 = ws.clone();                          // positional helper names (raw-ident-safe)
+
+        let __pq_compute = move || {
+            super::__pq_user_fn__issue_count(
+                __pq_client_for_compute.clone(),
+                __pq_arg_0.clone(),
+            )
+        };
+
+        __pq_client.observe_selector(SELECTOR_ID, args_hash, __pq_args_boxed, __pq_compute)
+    }
+}
+```
+
+## Areas worth scrutiny
+
+| Where | Concern | Why it's load-bearing |
+|---|---|---|
+| `SelectorEntry::rerun` | Re-entrancy + RefCell borrow safety | Snapshots listeners before firing; `running: Cell<bool>` guards re-entry; old tokens dropped BEFORE new ones registered |
+| `Drop for SelectorEntry` | Bucket pruning + GC | `try_borrow_mut` is intentional (silent no-op on contention); fields drop in declaration order — `keepers` BEFORE `listener_tokens` |
+| `QueryClient::observe_selector` | `Rc::downcast` safety | `SelectorId` encodes `(crate, module_path, fn_name)` → unique `T`. A failed downcast means a framework-invariant violation |
+| `QueryView::track_for_selector` | Refcount hygiene | `QueryHandle::clone` is what keeps the underlying subscription alive across reruns. Without the keeper, the subscription could be GC'd while a selector's Weak listener still points at it |
+| `expand_query` validation | Soundness of the cache key | The cache key is `(SelectorId, AnyArgs)`. Anything that makes the user fn generic over the call-site type (explicit generics, `impl Trait` anywhere in arg types) is rejected — otherwise two concrete instantiations could alias the same cached value |
+| `partition_selector_attrs` | Attr routing correctness | doc/deprecated → module; must_use/track_caller → observe; lint → inner; cfg → all three |
+
+## Test coverage map
+
+| Concern | Test |
+|---|---|
+| Caching by `(id, args_hash)` | `tests/selector.rs::observe_selector_caches_by_id_and_args_hash` |
+| Hash-collision soundness | `tests/selector.rs::hash_collision_does_not_alias_distinct_args` |
+| Invalidation via real mutation | `tests/selector.rs::selector_reruns_when_tracked_subscription_changes` |
+| Diff suppression | `tests/selector.rs::diff_suppression_blocks_listener_when_output_unchanged` |
+| Nested composition | `tests/selector.rs::nested_selector_propagates_through_outer` |
+| Cascade stop on inner diff-equal | `tests/selector.rs::nested_diff_suppression_stops_cascade` |
+| Cascade drop + sub GC | `tests/selector.rs::drop_view_removes_entry_from_registry` |
+| `SELECTOR_ID` stability | `tests/query_macro.rs::selector_id_is_stable_and_distinct` |
+| End-to-end macro + mutation | `tests/query_macro.rs::macro_observe_returns_cached_value_and_reacts_to_mutations` |
+| Sibling selector composition | `tests/query_macro.rs::macro_selector_composes_inside_another_selector` |
+| `super::` resolution preserved | `tests/query_macro.rs::macro_preserves_super_resolution_in_body` |
+| `mut`-arg preserved | `tests/query_macro.rs::macro_preserves_mut_arg_binding` |
+| User attrs follow body | `tests/query_macro.rs::macro_forwards_user_attrs_to_lifted_body` |
+| Doc on module (rustdoc surface) | `tests/query_macro.rs::macro_routes_doc_to_module` |
+| `#[must_use]` on observe() | `tests/query_macro.rs::macro_routes_must_use_to_observe` |
+| `#[track_caller]` accepted | `tests/query_macro.rs::macro_accepts_track_caller_attr` |
+| Raw-ident args | `tests/query_macro.rs::macro_handles_raw_identifier_args` |
+| `impl Trait` rejection (4 forms) | `tests/ui/query_impl_trait_{top_level,nested,assoc}.rs`, `tests/ui/query_async_fn.rs` |

--- a/docs/sync-query-selector-mechanism.md
+++ b/docs/sync-query-selector-mechanism.md
@@ -453,6 +453,7 @@ If profiling shows these are real bottlenecks, row-key tracking can layer on top
 
 ## Related
 
+* [`sync-query-selector-implementation.md`](sync-query-selector-implementation.md) — implementation map: where each piece lives, data flows, areas to scrutinize when reviewing or modifying the code.
 * [RFC 086 — `pocopine-sync-query`](../rfcs/rfc-086-sync-query.md) — the routing engine + DSL.
 * [RFC 087 — driver lifecycle](../rfcs/rfc-087-sync-query-driver.md) — what `notify_listeners` fires on.
 * [RFC 088 — production parity (§B)](../rfcs/rfc-088-sync-query-production-parity.md) — the formal spec for `#[query]`.

--- a/docs/sync-query-selector-mechanism.md
+++ b/docs/sync-query-selector-mechanism.md
@@ -1,0 +1,458 @@
+# `#[query]` selector mechanism
+
+How the read-tracking, invalidation, and re-run machinery for `#[query]`-decorated functions actually works in `pocopine-sync-query`. Companion to [RFC 088 §B](../rfcs/rfc-088-sync-query-production-parity.md).
+
+This is an explainer, not a spec. The RFC is the contract.
+
+## TL;DR
+
+A `#[query]` function is just Rust code. The framework instruments its **reads** — every `QueryView::rows()` call inside its body records the underlying `QuerySubscription` as tracked. When ANY tracked subscription's state changes, the framework re-runs the function. The new output is diffed against the cached one via `PartialEq`; the selector's own observers fire only when the output actually differs.
+
+There is no virtual-DOM-style document tree. There is no per-row dependency graph. The tracking unit is the **subscription handle** — one per `Resource::query()` you call inside the function body.
+
+## The four moving parts
+
+### 1. Read tracking via a thread-local stack
+
+```rust
+thread_local! {
+    static SELECTOR_STACK: RefCell<Vec<TrackingFrame>> = RefCell::new(Vec::new());
+}
+
+struct TrackingFrame {
+    selector_id: SelectorId,
+    tracked: Vec<Rc<dyn AnyTrackable>>,   // subscriptions OR other selectors
+}
+
+// QueryView::rows() (modified) calls this:
+pub(crate) fn record_read(trackable: Rc<dyn AnyTrackable>) {
+    SELECTOR_STACK.with(|stack| {
+        if let Some(frame) = stack.borrow_mut().last_mut() {
+            frame.tracked.push(trackable);
+        }
+    });
+}
+```
+
+When no selector is running (the stack is empty), `record_read` is a no-op — ordinary component reads aren't tracked here. When a selector IS running, every `view.rows()` call inside its body pushes the corresponding subscription's `Rc` into the top frame.
+
+### 2. Caching by `(SelectorId, ArgsHash)`
+
+```rust
+struct SelectorEntry<T> {
+    selector_id: SelectorId,                                // FNV-1a(module_path + fn_name)
+    args_hash: u64,
+    cached_output: RefCell<Option<T>>,
+    tracked: RefCell<Vec<Rc<dyn AnyTrackable>>>,
+    listener_tokens: RefCell<Vec<UpdateToken>>,             // tokens we hold on each upstream
+    listeners: RefCell<Vec<(u64, Rc<dyn Fn()>)>>,           // selector's own observers
+    refcount: Cell<usize>,
+}
+
+struct QueryClientInner {
+    // … existing subscription registry
+    selectors: RefCell<HashMap<(SelectorId, u64), Rc<dyn AnySelector>>>,
+}
+```
+
+**Cache hit:** `observe(client, args)` hashes args, looks up the entry, bumps refcount, returns a fresh `SelectorView<T>` wrapping the same entry. The output is reused; upstreams stay alive through the entry's `Rc`s.
+
+**Cache miss:** install a tracking frame, run the function, capture the tracked set, wire listeners, store the entry.
+
+### 3. Invalidation rides on `notify_listeners`
+
+`QuerySubscription::notify_listeners` (existing today, see PR #146/#148) fires after every state mutation:
+
+* `route_optimistic_changes` — after pushing a pending overlay.
+* `route_canonical_changes` — after a server `/pull` reconciles canonical state.
+* `route_canonical_pull` — driver-initiated canonical reconcile (PR #148).
+* `dequeue_pending` — after a rollback removes overlays.
+
+The selector's tracked-read callback is just another registered listener. When ANY tracked subscription notifies, the selector re-runs.
+
+```text
+              ┌──────────────────────────────────────────────┐
+              │  upstream Project::query() subscription      │
+              │  state mutated (canonical upsert, optimistic │
+              │  push, /pull reconcile, rollback, …)         │
+              └────────────────────┬─────────────────────────┘
+                                   │
+                       calls notify_listeners()
+                                   │
+                                   ▼
+              ┌──────────────────────────────────────────────┐
+              │  for each (id, callback) in listeners:       │
+              │      callback()                              │
+              └────────────────────┬─────────────────────────┘
+                                   │
+                       ──── one of the callbacks is ────
+                                   │
+                                   ▼
+              ┌──────────────────────────────────────────────┐
+              │  selector's tracked-read callback:           │
+              │      let weak = Rc::downgrade(&entry);       │
+              │      move || {                               │
+              │          if let Some(e) = weak.upgrade() {   │
+              │              e.rerun();                      │
+              │          }                                   │
+              │      }                                       │
+              └────────────────────┬─────────────────────────┘
+                                   │
+                                   ▼
+              ┌──────────────────────────────────────────────┐
+              │  SelectorEntry::rerun:                       │
+              │                                              │
+              │  1. Drop old listener_tokens                 │
+              │  2. Push frame; user_fn(args); pop frame.    │
+              │  3. Compute set-diff: new ∩ old, new − old,  │
+              │     old − new.                               │
+              │  4. Drop tracked Rcs in (old − new);         │
+              │     re-subscribe + push tokens for           │
+              │     (new − old); keep (new ∩ old) intact.    │
+              │  5. cached_output != new ? update + fire     │
+              │     selector's own listeners.                │
+              └──────────────────────────────────────────────┘
+```
+
+The whole mechanism is a wrapper around the existing `notify_listeners` plumbing. No new event bus, no new state machine, no new wire protocol.
+
+### 4. Diff suppression on the function's return value
+
+```rust
+fn rerun(self: &Rc<Self>) {
+    // Steps 1-4 from the diagram …
+    let new = user_fn_callable(args);
+
+    let mut cache = self.cached_output.borrow_mut();
+    if cache.as_ref() == Some(&new) {
+        // Same output. Cache stays; selector observers NOT fired.
+        return;
+    }
+    *cache = Some(new.clone());
+    drop(cache);
+
+    let listeners = self.listeners.borrow().iter().cloned().collect::<Vec<_>>();
+    for (_, callback) in listeners {
+        callback();
+    }
+}
+```
+
+The framework never introspects the output's structure. It compares the whole `T` via `PartialEq`. If structurally equal → no user-facing notification. If different → cache update + listeners fire.
+
+`T: PartialEq + Clone` is the trait-bound requirement. Opt out with `#[query(no_diff)]` for outputs that can't be `PartialEq` (closures, sockets, etc.) — every re-run then fires.
+
+## Why subscription handles and not a document tree
+
+The alternative model — track every row the function read, build a key-set dependency graph, re-run only when affected keys change — is roughly **Replicache/Zero's key-set tracking**:
+
+```js
+rep.subscribe(async (tx) => {
+    const projects = await tx.scan({prefix: "project/"}).toArray();
+    return projects.filter(p => p.workspace_id === w1);
+}, render);
+```
+
+Their framework instruments `tx.scan` / `tx.get` to record the exact keys (`project/123`, `project/456`, …) the function touched. On mutation: did the change affect a tracked key? If no, skip the rerun entirely.
+
+Trade-offs vs subscription-level tracking:
+
+| | Subscription-level (ours) | Row-key-level (Replicache) |
+|---|---|---|
+| Re-run when an unrelated row in the same subscription changes | YES (then diff suppresses) | NO |
+| Implementation complexity | Low — one `Rc` per query | High — set of keys per query + key-change tracking |
+| Function model | `fn(args) -> T` | `fn(tx) -> T` (every access via tx) |
+| Composition with other Rust crates | Trivial — it's just Rust | Awkward — tx threads everywhere |
+| User code style | Direct `Resource::query()` calls | `tx.scan(...)` / `tx.get(...)` ceremony |
+| Best for | Constrained query DSL (ours) | KV store with arbitrary access patterns |
+
+Why we picked subscription-level:
+
+1. **Our DSL already constrains access.** Users can't randomly `tx.get("project/123")`; they go through `Project::query().eq(...).rows()`. The query IS the dependency. Tracking the query is sufficient.
+2. **The diff layer covers most of the precision gap.** A selector that reads 1000 rows and renders 5: an unrelated row change → rerun → same output → diff suppresses → user-facing observers don't fire. We pay CPU on the rerun, not UI re-render.
+3. **Composition stays Rust-native.** No `tx` parameter threading through every helper. Selectors can call into ordinary Rust crates that use `QueryView`s normally.
+
+The cost: selectors with cheap diffs and expensive function bodies will re-run more than strictly necessary. If profiling shows that's real, row-key tracking can layer on top in a future RFC — the user-facing API doesn't change.
+
+## Concrete trace through the example function
+
+```rust
+#[query]
+fn projects_with_open_issues(ws_id: String) -> Vec<(Project, Vec<Issue>)> {
+    Project::query()
+        .eq(field::workspace_id, &ws_id).rows()
+        .into_iter()
+        .map(|p| {
+            let issues = Issue::query()
+                .eq(field::project_id, &p.id)
+                .any_of(field::status, [Status::Open]).rows();
+            (p, issues)
+        })
+        .collect()
+}
+
+// First call:
+let view = projects_with_open_issues::observe(&client, "W1".to_string());
+```
+
+Inside that first `observe`:
+
+```text
+1. Push TrackingFrame { selector_id=PWOI, tracked=[] } onto SELECTOR_STACK.
+
+2. user_fn("W1") runs:
+   - Project::query().eq(workspace_id="W1").rows() called:
+       client.observe(query) returns Rc<Subscription_ProjectsInW1>.
+       rows() calls record_read(Subscription_ProjectsInW1).
+       SELECTOR_STACK.top().tracked.push(Rc<Subscription_ProjectsInW1>).
+       Returns Vec<Project> with, say, 4 projects.
+
+   - .into_iter().map(|p| { ... }) iterates 4 projects:
+       Project p1: Issue::query().eq(project_id="p1").any_of(status=[Open]).rows():
+           → record_read(Rc<Subscription_IssuesInP1Open>) once.
+       Project p2: Issue::query().eq(project_id="p2").any_of(status=[Open]).rows():
+           → record_read(Rc<Subscription_IssuesInP2Open>) once.
+       Project p3, p4: same pattern.
+
+   - .collect() produces Vec<(Project, Vec<Issue>)>.
+
+3. Pop the TrackingFrame, capture tracked = [
+     Rc<Subscription_ProjectsInW1>,
+     Rc<Subscription_IssuesInP1Open>,
+     Rc<Subscription_IssuesInP2Open>,
+     Rc<Subscription_IssuesInP3Open>,
+     Rc<Subscription_IssuesInP4Open>,
+   ].
+
+4. Cache the output. Wire on_update on each of the 5 subscriptions to a
+   callback that calls selector.rerun().
+
+5. Return SelectorView<Vec<(Project, Vec<Issue>)>> with refcount=1.
+```
+
+## Adding a row: three scenarios
+
+The interesting question: when you add a row, how does the selector pick it up? It depends on whether the new row lands in an already-tracked subscription.
+
+### Case 1 — New row matches a tracked subscription
+
+```rust
+client.mutate::<CreateIssue>(Issue {
+    id: "i77",
+    project_id: "p1",                  // ← p1 was in the iterated set
+    status: Status::Open,
+    title: "rate-limit auth",
+    workspace_id: "W1",
+});
+```
+
+What happens:
+
+```text
+mutate() ─► apply_local() returns [RowChange::Upsert(new_issue)]
+              │
+              ▼
+        route_optimistic_changes::<Issue>("issues", mutation_id, &change)
+              │
+              │  walks every Subscription on the "issues" stream:
+              │  ├─ Subscription_IssuesInP1Open: predicate (project_id=p1 AND status=Open)
+              │  │     evaluates against new_issue → MATCHES
+              │  │     push PendingOverlay { optimistic_row: Some(new_issue), … }
+              │  │     touched = true
+              │  ├─ Subscription_IssuesInP2Open: project_id=p2 ≠ p1 → SKIP
+              │  ├─ Subscription_IssuesInP3Open: same, SKIP
+              │  └─ Subscription_IssuesInP4Open: same, SKIP
+              │
+              ▼
+        Subscription_IssuesInP1Open.notify_listeners()
+              │
+              │  one of its listeners is the selector's rerun callback
+              ▼
+        selector.rerun()
+              │
+              ├─ drop old listener_tokens
+              ├─ push TrackingFrame
+              ├─ run user_fn("W1"):
+              │     Project::query()...rows()       returns [p1, p2, p3, p4]
+              │                                     records Subscription_ProjectsInW1
+              │     for p1: Issue::query()...rows()
+              │        ↑ returns canonical (4 prior issues) + pending overlay (the new one)
+              │          = 5 issues total       records Subscription_IssuesInP1Open
+              │     for p2: ... records Subscription_IssuesInP2Open (same as before)
+              │     for p3, p4: same
+              │
+              ├─ pop frame, compare tracked set: identical to before, no churn
+              │
+              ├─ new output =
+              │       [(p1, [4 old + 1 new]), (p2, [...]), (p3, [...]), (p4, [...])]
+              │
+              ├─ cached output =
+              │       [(p1, [4 old]),         (p2, [...]), (p3, [...]), (p4, [...])]
+              │
+              ├─ PartialEq: differ at projects[0].issues.len()
+              │
+              ▼
+        update cache, fire selector's own listeners ─► UI re-renders
+```
+
+Two details from this trace:
+
+* **The merged read happens inside `view.rows()`.** When the selector re-reads `Issue::query()...rows()`, the `rows()` impl merges canonical rows with pending overlays (PR #146's BTreeMap merge), so the optimistic Upsert overlay shows up in the result. No special "pending vs canonical" logic in the selector body — it just reads `.rows()` and gets the current view.
+* **Cross-subscription mutations don't reach the selector.** If the new issue had `project_id: "p99"` and no matching subscription existed, `route_optimistic_changes` would walk all 4 tracked Issue subscriptions, none would match, and no `notify_listeners` would fire. The selector stays silent. That's the routing engine's predicate gate eliminating cross-tenant / cross-shape noise BEFORE it reaches the listener chain.
+
+### Case 2 — New row lands in a NOT-yet-tracked subscription
+
+Suppose Project `p5` exists in W1 but the selector hasn't iterated it (race: `p5` was created moments ago, between selector observations). The selector's tracked set: only `Subscription_IssuesIn{P1,P2,P3,P4}Open`.
+
+You call `mutate::<CreateIssue>(Issue { project_id: "p5", … })`:
+
+```text
+route_optimistic_changes::<Issue>("issues", …):
+    walks subscriptions on "issues" stream:
+    ├─ IssuesInP1Open  (predicate p1) → SKIP
+    ├─ IssuesInP2Open  (predicate p2) → SKIP
+    ├─ IssuesInP3Open  (predicate p3) → SKIP
+    └─ IssuesInP4Open  (predicate p4) → SKIP
+
+  NO subscription matches. notify_listeners does NOT fire on any "issues"
+  subscription. The selector does NOT rerun.
+```
+
+Is that a bug? No — because the lifecycle goes through the Projects subscription first:
+
+```text
+Step A: someone (or you, or a /pull) creates Project p5.
+        Subscription_ProjectsInW1 matches predicate (workspace_id="W1").
+        PendingOverlay pushed for p5. notify_listeners fires.
+
+Step B: selector.rerun() — Subscription_ProjectsInW1 woke us up.
+        user_fn now iterates [p1, p2, p3, p4, p5] (the merged view includes p5).
+        For p5: Issue::query().eq(project_id, "p5").any_of(status, [Open])
+                ↑ client.observe() creates a NEW Subscription_IssuesInP5Open
+                  (didn't exist before; refcount=1; driver task spawned).
+                .rows() returns empty initially (driver's /pull hasn't completed).
+        Selector tracks the new subscription. Output:
+        [(p1, [...]), (p2, [...]), (p3, [...]), (p4, [...]), (p5, [])]
+        Differs from cache → fire selector observers.
+
+Step C: driver for Subscription_IssuesInP5Open completes /open + /pull.
+        Returns the existing p5 issues including the one you created.
+        route_canonical_pull upserts them; notify_listeners fires.
+
+Step D: selector.rerun() — IssuesInP5Open woke us up.
+        user_fn iterates [p1..p5] again. For p5, .rows() now returns the issue.
+        Output: [..., (p5, [the issue])]
+        Diff differs → fire observers.
+```
+
+Between Step A and Step D there's a brief window where `p5` appears with `issues: []`. That's normal loading behavior — same as observing any new query for the first time. The user sees the project appear immediately; the issues populate when the driver's `/pull` completes.
+
+The order matters: Projects has to update FIRST so the selector discovers the new Issue subscription. The routing engine guarantees this because Issue subscriptions can only be discovered THROUGH a Project iteration; the selector body's control flow enforces the order.
+
+### Case 3 — Removing rows works the same way
+
+For completeness:
+
+```rust
+client.mutate::<DeleteIssue>("i77".into());
+// triggers RowChange::Delete(key="i77")
+```
+
+Same routing logic:
+
+* `route_optimistic_changes` walks subscriptions; the row's key matches `Subscription_IssuesInP1Open`'s canonical or pending → push a Delete-shaped overlay (with `evicted_key`) → `notify_listeners`.
+* Selector reruns; `Issue::query()...rows()` now excludes the deleted row (because `view.rows()` honors `evicted_key`, per PR #148 fix #2/#3).
+* Output diff differs → observers fire.
+
+Same flow for **predicate-departure** (an issue moving from `Open` to `Closed` while the selector only wants `Open`): the routing engine pushes a Delete-shaped overlay onto `Subscription_IssuesInP1Open` and the selector reruns to an output without that issue.
+
+## Summary table
+
+| New row scenario | Trigger path | Selector reruns? |
+|---|---|---|
+| Matches an already-tracked subscription | `notify_listeners` on that subscription | YES, once |
+| Matches a NOT-yet-tracked subscription | Indirect: parent subscription updates → selector reruns + discovers new subscription → driver fetches → new subscription's notify fires the next rerun | YES, two reruns (intermediate empty state) |
+| Doesn't match any tracked subscription | Routing engine drops it | NO (correctly) |
+| Optimistic apply | Overlay pushed during `route_optimistic_changes`, same chain | YES |
+| Server `/pull` reconcile | Overlay applied during `route_canonical_pull`, same chain | YES |
+| Rollback (server rejects an optimistic mutation) | `dequeue_pending` calls `notify_listeners` after rolling back | YES |
+
+## Composition: nested selectors
+
+The `record_read` arg is `Rc<dyn AnyTrackable>` — a unified trait that BOTH `QuerySubscription` AND `SelectorEntry` implement. So selectors compose:
+
+```rust
+#[query]
+fn dashboard(ws_id: String) -> DashboardView {
+    let projects = projects_with_open_issues::observe(&CLIENT, ws_id.clone()).value();
+    let comments = recent_comments::observe(&CLIENT, ws_id).value();
+    DashboardView { projects, comments }
+}
+```
+
+When `dashboard` runs:
+
+1. Both inner selectors' `.value()` calls register THEIR entries with `dashboard`'s tracking frame.
+2. When `projects_with_open_issues` reruns and its output differs, IT fires its own listeners. One of those listeners is `dashboard`'s rerun callback.
+3. Same mechanism, one level up.
+
+A diff-suppressed inner selector stops the cascade — `projects_with_open_issues` reruns but its output equals cached → it does NOT fire its listeners → `dashboard` does NOT rerun.
+
+The composition is fully recursive. Selectors and subscriptions are interchangeable from the tracker's point of view.
+
+## Lifecycle (refcount chain)
+
+```text
+let view = dashboard::observe(&client, "W1");
+└─ dashboard entry: refcount = 1
+   ├─ tracked Rcs (from dashboard's first run):
+   │  ├─ projects_with_open_issues entry: refcount = 1
+   │  │  └─ tracked Rcs:
+   │  │     ├─ Subscription_ProjectsInW1: refcount = 1
+   │  │     ├─ Subscription_IssuesInP1Open: refcount = 1
+   │  │     └─ Subscription_IssuesInP2Open: refcount = 1
+   │  └─ recent_comments entry: refcount = 1
+   │     └─ Subscription_CommentsInW1: refcount = 1
+   └─ listeners: [] (no observers attached yet)
+
+drop(view);
+└─ dashboard entry: refcount = 0 → removed from registry
+   ├─ listener_tokens dropped → upstream selectors unsubscribed
+   └─ tracked Rcs dropped:
+      ├─ projects_with_open_issues entry: refcount = 0 → removed
+      │  └─ its tracked Rcs dropped:
+      │     ├─ Subscription_ProjectsInW1: refcount = 0 → driver epoch bumped, task exits
+      │     ├─ Subscription_IssuesInP1Open: refcount = 0 → driver exits
+      │     └─ Subscription_IssuesInP2Open: refcount = 0 → driver exits
+      └─ recent_comments entry: refcount = 0 → removed
+         └─ Subscription_CommentsInW1: refcount = 0 → driver exits
+```
+
+Drop is fully recursive via Rust's ownership. No explicit cleanup. The `Drop` impl on `SelectorEntry` (decrements its own refcount + removes from the registry on zero) is the only custom Drop logic — everything downstream cascades naturally.
+
+## When the document-tree model would help
+
+Two scenarios where our subscription-level model re-runs more than strictly necessary:
+
+1. **Wide subscription, narrow output.** Selector reads `Project::query().eq(workspace_id, W1).rows()` (returns 1000 projects), then filters in-Rust to 5 visible ones. ANY project update in W1 fires a rerun. Replicache-style key tracking would only fire when one of those 5 specific projects changes.
+
+   *Workaround today*: decompose into nested selectors — each row-level computation becomes its own selector, and the diff layer suppresses propagation through the chain.
+
+2. **Mutation that touches many rows.** A bulk operation that updates 100 rows in one subscription triggers 1 `notify_listeners` call per batch (one per `route_*` invocation per subscription), so 1 rerun. But for 100 separate batches (rare), that'd be 100 reruns.
+
+   *Workaround today*: batch the source mutations, or accept the rerun cost (cheap if the function is cheap; diff layer suppresses spurious renders).
+
+If profiling shows these are real bottlenecks, row-key tracking can layer on top of the subscription tracking without changing the user-facing API. The selector function body stays identical; only `record_read` becomes richer.
+
+## Open questions (settled before PR-B implementation)
+
+* **Batched re-run coalescing — ship as v1 or accept-then-optimize?** Recommendation: accept-then-optimize. Document the property; add microtask coalescing in a follow-up if needed.
+* **`refetch()` API surface — `client.refetch(&query)` only, or also `view.refetch_all()`?** Recommendation: `client.refetch(&query)` only. Selector-level refetch has cascade complexity.
+* **Strict `PartialEq` vs hash-based shallow equality?** Recommendation: `PartialEq` for v1 (simple, correct); add `#[query(hash_eq)]` opt-in later if profiling shows comparison cost.
+* **`Result<T, E>` selectors?** Recommendation: supported transparently — just require `Result<T, E>: PartialEq`. The macro doesn't special-case it.
+
+## Related
+
+* [RFC 086 — `pocopine-sync-query`](../rfcs/rfc-086-sync-query.md) — the routing engine + DSL.
+* [RFC 087 — driver lifecycle](../rfcs/rfc-087-sync-query-driver.md) — what `notify_listeners` fires on.
+* [RFC 088 — production parity (§B)](../rfcs/rfc-088-sync-query-production-parity.md) — the formal spec for `#[query]`.


### PR DESCRIPTION
## Summary

Implements the `#[query]` selector layer over `pocopine-sync-query`, the user-facing memoization primitive for derived state — counts, projections, joins, dashboards — over the reactive query subscription engine. Companion to the explainer doc at `docs/sync-query-selector-mechanism.md` (also included in this PR).

Four moving parts, exactly as the explainer specifies:
1. **Thread-local read tracking.** `QueryView::{rows, len, is_empty}` push their underlying subscription as a dep on the current selector's frame.
2. **`(SelectorId, AnyArgs)` memoization.** Bucketed registry on `QueryClientInner` keyed by `(SelectorId, args_hash)`, equality-disambiguated by `AnyArgs::dyn_eq` so hash collisions can't alias.
3. **Invalidation via existing `notify_listeners`.** Selector listeners ride the same plumbing that fires on canonical / optimistic / `/pull` / rollback. No new event bus.
4. **`PartialEq` diff suppression.** Selectors whose output is unchanged across reruns don't fire their own listeners — the cascade stops.

User-facing API:

```rust
#[query]
fn open_issue_count(client: QueryClient, ws: String) -> u32 {
    let view = client.observe(
        Issue::query().eq(issues::field::workspace_id, ws).build()
    );
    view.rows().len() as u32
}

let view = open_issue_count::observe(&client, "W1".to_string());
view.value();                  // current count
let _tok = view.on_update(|| ...);  // fires only on diffed change
```

Out of scope (deferred to follow-ups):
- `#[query(no_diff)]` opt-out
- `client.refetch(&query)`
- Row-key-level tracking
- RFC 088 §B document (explainer is the contract)

## Test plan

- [x] `cargo test -p pocopine-sync-query -p pocopine-sync-query-macros` — 109 tests pass (runtime: caching, invalidation, diff suppression, nested composition, lifecycle, hash-collision disambiguation; macro: SELECTOR_ID stability, args hashing, sibling composition, mut/raw-ident/doc/must_use/track_caller/super-resolution regression tests; 4 trybuild compile_fail cases for `impl Trait` / nested `impl Trait` / `dyn Trait<Item = impl …>` / `async fn`)
- [x] `cargo clippy --all-targets -- -D warnings` clean (host)
- [x] `cargo clippy --target wasm32-unknown-unknown -- -D warnings` clean (wasm)
- [x] `cargo fmt --all -- --check` clean
- [x] Six rounds of Codex review applied — each surfaced 1–2 P2 correctness findings that landed as follow-up commits (see commit log for the chain: `super::` resolution, top-level + nested + assoc-type `impl Trait`, `mut` binding preservation, user-attr split across module/observe/inner-fn, hash-collision soundness via `AnyArgs::dyn_eq`, raw-ident args, `#[must_use]` / `#[track_caller]` routing)