### PR TITLE
sync-query: RFC 088 §C — per-(stream, params_hash) live topics

### DIFF
--- a/crates/pocopine-events/src/lib.rs
+++ b/crates/pocopine-events/src/lib.rs
@@ -683,9 +683,24 @@ mod host {
 
     /// Process-local event backend with bounded replay.
     ///
-    /// This backend is suitable for tests, development, and explicit
-    /// single-process deployments. It is not shared across processes and
-    /// does not survive restarts.
+    /// Suitable for tests, development, and explicit single-process
+    /// deployments. **Not** shared across processes and does not
+    /// survive restarts.
+    ///
+    /// # ⚠ NOT for multi-node production
+    ///
+    /// Events published on one process do NOT reach subscribers on
+    /// another process — each [`MemoryEventBackend`] is a private
+    /// per-process broadcast channel. If you run more than one
+    /// server process (Kubernetes replicas, auto-scaling, blue/green,
+    /// load-balanced fleets), use [`RedisEventBackend`] (or another
+    /// shared broker) instead. Symptom of the wrong choice: live
+    /// invalidations work in dev but mysteriously drop in production
+    /// the moment traffic crosses node boundaries.
+    ///
+    /// See `docs/live.md §8 "Production Backends"` for the broker
+    /// comparison and `pocopine_events::build_event_backend` for the
+    /// one-line config switch.
     #[derive(Clone, Debug)]
     pub struct MemoryEventBackend {
         config: MemoryEventConfig,

--- a/crates/pocopine-live/src/lib.rs
+++ b/crates/pocopine-live/src/lib.rs
@@ -680,18 +680,31 @@ fn validate_collection(collection: &str) -> Result<String, LiveClientError> {
     Ok(value)
 }
 
-/// Returns `true` iff `suffix` is exactly `:` followed by 16
-/// lowercase-hex digits — the format produced by
+/// Length of the per-params hash hex suffix produced by
 /// `pocopine_sync::sync_stream_params_tag`'s `{:016x}` formatter
-/// (RFC 088 §C). Used by `LiveHub::allow_topic_prefixes` (host-only)
-/// to disambiguate a per-params extension from a sibling stream
-/// name that happens to start with the same byte prefix + `:`.
-/// `#[allow(dead_code)]` because the host module is `cfg`-gated to
-/// non-wasm targets; this fn is reachable only from there.
+/// (RFC 088 §C). Mirrors `pocopine_sync::PARAMS_HASH_HEX_LEN`
+/// verbatim — they cannot share a single const because
+/// `pocopine_sync` depends on `pocopine_live` (we can't reverse the
+/// arrow without restructuring the workspace). A coupling test in
+/// `pocopine_sync` (`params_hash_hex_len_matches_live`) asserts the
+/// two constants agree, so a future widening of the hash trips that
+/// test if either side is updated in isolation.
+#[allow(dead_code)]
+const PARAMS_HASH_HEX_LEN: usize = 16;
+
+/// Returns `true` iff `suffix` is exactly `:` followed by
+/// [`PARAMS_HASH_HEX_LEN`] lowercase-hex digits — the format
+/// produced by `pocopine_sync::sync_stream_params_tag`'s `{:016x}`
+/// formatter (RFC 088 §C). Used by `LiveHub::allow_topic_prefixes`
+/// (host-only) to disambiguate a per-params extension from a
+/// sibling stream name that happens to start with the same byte
+/// prefix + `:`. `#[allow(dead_code)]` because the host module is
+/// `cfg`-gated to non-wasm targets; this fn is reachable only from
+/// there.
 #[allow(dead_code)]
 fn is_params_hash_suffix(suffix: &str) -> bool {
     let bytes = suffix.as_bytes();
-    if bytes.len() != 17 || bytes[0] != b':' {
+    if bytes.len() != PARAMS_HASH_HEX_LEN + 1 || bytes[0] != b':' {
         return false;
     }
     bytes[1..]

--- a/crates/pocopine-live/src/lib.rs
+++ b/crates/pocopine-live/src/lib.rs
@@ -1646,21 +1646,35 @@ mod host {
             self.with_topic_policy(move |_, topic| allowed.iter().any(|allowed| allowed == topic))
         }
 
-        /// Allow any topic whose name starts with one of the listed
-        /// prefixes. Designed for RFC 088 §C-style routing schemes
-        /// where one logical stream produces a family of topics:
-        /// `sync:stream:issues` (bare), `sync:stream:issues:abc…`,
-        /// `sync:stream:issues:def…`, … all share a prefix.
+        /// Allow any topic that EITHER equals one of the listed
+        /// prefixes exactly OR extends it with a `:` delimiter.
+        /// Designed for RFC 088 §C-style routing schemes where one
+        /// logical stream produces a family of topics:
+        /// `query:sync:stream:issues` (bare),
+        /// `query:sync:stream:issues:abc…`,
+        /// `query:sync:stream:issues:def…`, … all share a prefix.
         ///
-        /// Match is byte-prefix on the topic's string form (no
-        /// glob, no regex). For the sync server: call with
-        /// `sync.live_topic_prefixes()` (which returns the
-        /// `query:sync:stream:{name}` prefix per registered stream).
+        /// The `:` delimiter requirement is what makes this safe to
+        /// generate from a stream name. Without it, the prefix
+        /// `query:sync:stream:issues` would also authorize a
+        /// neighboring topic like `query:sync:stream:issues_private`
+        /// or `query:sync:stream:issues2` — a public stream
+        /// allowlist could leak access to a private stream whose
+        /// name happens to share a byte prefix.
+        ///
+        /// For the sync server: call with
+        /// `sync.live_topic_prefixes()`, which returns the
+        /// `query:sync:stream:{name}` prefix per registered stream.
         pub fn allow_topic_prefixes(self, prefixes: impl IntoIterator<Item = String>) -> Self {
             let allowed = Arc::new(prefixes.into_iter().collect::<Vec<_>>());
             self.with_topic_policy(move |_, topic| {
                 let topic_str = topic.as_str();
-                allowed.iter().any(|p| topic_str.starts_with(p.as_str()))
+                allowed.iter().any(|p| {
+                    let prefix = p.as_str();
+                    topic_str == prefix
+                        || (topic_str.starts_with(prefix)
+                            && topic_str.as_bytes().get(prefix.len()) == Some(&b':'))
+                })
             })
         }
 
@@ -2005,6 +2019,38 @@ mod host {
             let topics = hub.allowed_topics(&ctx, &query).unwrap();
 
             assert_eq!(topics, vec![posts]);
+        }
+
+        #[test]
+        fn allow_topic_prefixes_accepts_exact_and_delimited_extensions() {
+            // RFC 088 §C: the prefix `query:sync:stream:issues` must
+            // authorize the bare topic AND every per-params variant
+            // `query:sync:stream:issues:<hash>` — they're delimited
+            // by `:`. The prefix must NOT authorize a neighboring
+            // topic like `query:sync:stream:issues_private` (codex
+            // P2 finding).
+            let backend = MemoryEventBackend::new();
+            let hub = LiveHub::new(backend)
+                .allow_topic_prefixes(["query:sync:stream:issues".to_string()]);
+            let ctx = RequestContext::new(Method::GET, Uri::from_static("/"), HeaderMap::new());
+
+            // Exact match: bare topic.
+            let bare = crate::query_tag_topic("sync:stream:issues").unwrap();
+            assert!((hub.policy)(&ctx, &bare));
+
+            // Delimited extension: per-params topic.
+            let with_hash = crate::query_tag_topic("sync:stream:issues:abcd1234abcd1234").unwrap();
+            assert!((hub.policy)(&ctx, &with_hash));
+
+            // Underscore extension — same byte-prefix but a
+            // DIFFERENT stream name. MUST be rejected.
+            let neighbor = crate::query_tag_topic("sync:stream:issues_private").unwrap();
+            assert!(!(hub.policy)(&ctx, &neighbor));
+
+            // Numeric extension — same byte-prefix, different
+            // stream. MUST be rejected.
+            let neighbor2 = crate::query_tag_topic("sync:stream:issues2").unwrap();
+            assert!(!(hub.policy)(&ctx, &neighbor2));
         }
 
         #[test]

--- a/crates/pocopine-live/src/lib.rs
+++ b/crates/pocopine-live/src/lib.rs
@@ -680,6 +680,25 @@ fn validate_collection(collection: &str) -> Result<String, LiveClientError> {
     Ok(value)
 }
 
+/// Returns `true` iff `suffix` is exactly `:` followed by 16
+/// lowercase-hex digits — the format produced by
+/// `pocopine_sync::sync_stream_params_tag`'s `{:016x}` formatter
+/// (RFC 088 §C). Used by `LiveHub::allow_topic_prefixes` (host-only)
+/// to disambiguate a per-params extension from a sibling stream
+/// name that happens to start with the same byte prefix + `:`.
+/// `#[allow(dead_code)]` because the host module is `cfg`-gated to
+/// non-wasm targets; this fn is reachable only from there.
+#[allow(dead_code)]
+fn is_params_hash_suffix(suffix: &str) -> bool {
+    let bytes = suffix.as_bytes();
+    if bytes.len() != 17 || bytes[0] != b':' {
+        return false;
+    }
+    bytes[1..]
+        .iter()
+        .all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+}
+
 fn validate_topic(topic: &str) -> Result<String, LiveClientError> {
     let value = validate_csv_value("topic", topic)?;
     Topic::new(value.clone()).map_err(LiveClientError::Event)?;
@@ -1671,9 +1690,24 @@ mod host {
                 let topic_str = topic.as_str();
                 allowed.iter().any(|p| {
                     let prefix = p.as_str();
-                    topic_str == prefix
-                        || (topic_str.starts_with(prefix)
-                            && topic_str.as_bytes().get(prefix.len()) == Some(&b':'))
+                    if topic_str == prefix {
+                        return true;
+                    }
+                    if !topic_str.starts_with(prefix) {
+                        return false;
+                    }
+                    // The only legal extension of a sync-stream
+                    // prefix is `:<16-char lowercase-hex>` — the
+                    // `{:016x}` form produced by
+                    // `pocopine_sync::sync_stream_params_tag`.
+                    // Anything else (including `:private` for a
+                    // sibling stream named `issues:private`, which
+                    // `SyncStreamName::new` currently accepts) MUST
+                    // be rejected so a public prefix doesn't leak
+                    // access to a private sibling. Future
+                    // changes that broaden the wire format must
+                    // bump `LIVE_PROTOCOL_V1` and update this gate.
+                    crate::is_params_hash_suffix(&topic_str[prefix.len()..])
                 })
             })
         }
@@ -2051,6 +2085,28 @@ mod host {
             // stream. MUST be rejected.
             let neighbor2 = crate::query_tag_topic("sync:stream:issues2").unwrap();
             assert!(!(hub.policy)(&ctx, &neighbor2));
+
+            // Codex second-pass P2: a sibling stream named
+            // `issues:private` produces the topic
+            // `query:sync:stream:issues:private`, which shares the
+            // prefix `query:sync:stream:issues:` with legitimate
+            // per-params topics. The `is_params_hash_suffix` gate
+            // must reject it because `:private` is not 16
+            // lowercase-hex chars.
+            let sibling = crate::query_tag_topic("sync:stream:issues:private").unwrap();
+            assert!(
+                !(hub.policy)(&ctx, &sibling),
+                "sibling stream `issues:private` must NOT be authorized"
+            );
+
+            // Uppercase hex is rejected — the wire format is
+            // strictly lowercase per `{:016x}`.
+            let uppercase = crate::query_tag_topic("sync:stream:issues:ABCD1234ABCD1234").unwrap();
+            assert!(!(hub.policy)(&ctx, &uppercase));
+
+            // Too-short hex suffix.
+            let short = crate::query_tag_topic("sync:stream:issues:abc").unwrap();
+            assert!(!(hub.policy)(&ctx, &short));
         }
 
         #[test]

--- a/crates/pocopine-live/src/lib.rs
+++ b/crates/pocopine-live/src/lib.rs
@@ -806,6 +806,23 @@ mod browser {
             self
         }
 
+        /// Subscribe to the per-`(tag, params_hash)` framework topic
+        /// for RFC 088 §C precise live-wakeup routing.
+        ///
+        /// Wire shape: `query:{tag}:{params_hash:016x}`.
+        ///
+        /// Clients that want precise routing call BOTH
+        /// [`Self::query_tag`] (bare) AND this method (per-params) —
+        /// during the rollout window servers publish to both topics
+        /// and old clients only listen on the bare one. Once servers
+        /// drop the bare publish (RFC 088 §C.6 phase 2), this becomes
+        /// the only live-wakeup path for parameterized subscriptions.
+        pub fn query_tag_with_params(mut self, tag: impl Into<String>, params_hash: u64) -> Self {
+            self.topics
+                .push(format!("query:{}:{:016x}", tag.into(), params_hash));
+            self
+        }
+
         /// Resume from an opaque stream cursor.
         pub fn last_event_id(mut self, cursor: impl Into<String>) -> Self {
             self.last_event_id = Some(cursor.into());

--- a/crates/pocopine-live/src/lib.rs
+++ b/crates/pocopine-live/src/lib.rs
@@ -1646,6 +1646,24 @@ mod host {
             self.with_topic_policy(move |_, topic| allowed.iter().any(|allowed| allowed == topic))
         }
 
+        /// Allow any topic whose name starts with one of the listed
+        /// prefixes. Designed for RFC 088 §C-style routing schemes
+        /// where one logical stream produces a family of topics:
+        /// `sync:stream:issues` (bare), `sync:stream:issues:abc…`,
+        /// `sync:stream:issues:def…`, … all share a prefix.
+        ///
+        /// Match is byte-prefix on the topic's string form (no
+        /// glob, no regex). For the sync server: call with
+        /// `sync.live_topic_prefixes()` (which returns the
+        /// `query:sync:stream:{name}` prefix per registered stream).
+        pub fn allow_topic_prefixes(self, prefixes: impl IntoIterator<Item = String>) -> Self {
+            let allowed = Arc::new(prefixes.into_iter().collect::<Vec<_>>());
+            self.with_topic_policy(move |_, topic| {
+                let topic_str = topic.as_str();
+                allowed.iter().any(|p| topic_str.starts_with(p.as_str()))
+            })
+        }
+
         /// Allow every requested topic. Apps should only use this for
         /// already-public topic sets.
         pub fn allow_all_topics(self) -> Self {

--- a/crates/pocopine-sync-query-macros/src/lib.rs
+++ b/crates/pocopine-sync-query-macros/src/lib.rs
@@ -1065,39 +1065,57 @@ fn generate_partition_for_topic_body(params: &[ParamDef]) -> TokenStream2 {
         .map(|param| {
             let name = &param.name;
             let name_str = ident_wire_key(name);
+
+            // Per-field comparator-key set. ONLY include the keys
+            // for comparators this field can actually emit:
+            //   * InSet (`{"in": [...]}`) — universal (every
+            //     `#[query_param]` field gets FieldInSet).
+            //   * Contains (`{"contains", "case_sensitive"}`) —
+            //     only if `caps.contains` is set (auto for non-
+            //     Option `String`/`Cow`/`str`, or explicit
+            //     `#[query_param(contains)]`).
+            //   * Range (`{"from", "to", "inclusive"}`) — only if
+            //     `caps.range` is set (auto for orderable types, or
+            //     explicit `#[query_param(range)]`).
+            //
+            // Gating by capability is what avoids false positives
+            // on user types whose plain equality value happens to
+            // serialize as an object with `from`/`to` keys — e.g.
+            // `#[query_param(required)] window: TimeWindow` where
+            // `TimeWindow` serializes as `{"from": ..., "to": ...}`
+            // and the user filters with `.eq(field::window, w)`.
+            // Without this gate, we'd reject the plain equality
+            // value as a comparator and the client would miss
+            // scoped invalidations the server publishes.
+            let mut comparator_keys: Vec<&'static str> = vec!["in"];
+            if param.caps.contains {
+                comparator_keys.push("contains");
+                comparator_keys.push("case_sensitive");
+            }
+            if param.caps.range {
+                comparator_keys.push("from");
+                comparator_keys.push("to");
+                comparator_keys.push("inclusive");
+            }
+            let key_arms: Vec<TokenStream2> = comparator_keys
+                .iter()
+                .map(|k| {
+                    let lit = syn::LitStr::new(k, proc_macro2::Span::call_site());
+                    quote! { #lit }
+                })
+                .collect();
+
             quote! {
                 {
                     // Required field absent → no partition; `?` on
                     // Option<&Value> yields None from the outer fn.
                     let value = captured.get(#name_str)?;
-                    // Reject comparator-wrapped values — InSet
-                    // (`{"in": [...]}`), Contains
-                    // (`{"contains": "...", "case_sensitive": bool}`),
-                    // and Range (`{"from": ..., "to": ..., "inclusive": [_, _]}`).
-                    // These don't map to a single topic key — fall
-                    // back to bare-topic subscription.
-                    //
-                    // We detect via the wire-shape's distinctive
-                    // keys. The set is closed (these are the only
-                    // comparators `pocopine_sync_query::params`
-                    // emits); a future comparator would need to be
-                    // added here, or the macro could opt for a
-                    // strict allowlist of plain JSON value kinds
-                    // instead.
+                    // Reject comparator-wrapped values for the
+                    // comparators THIS field can emit. See the
+                    // per-field key set above.
                     if let ::pocopine_sync_query::__private::serde_json::Value::Object(obj) = value {
                         let is_comparator = obj.keys().any(|k| {
-                            matches!(
-                                k.as_str(),
-                                // InSet
-                                "in"
-                                // Contains
-                                | "contains"
-                                | "case_sensitive"
-                                // Range
-                                | "from"
-                                | "to"
-                                | "inclusive",
-                            )
+                            matches!(k.as_str(), #(#key_arms)|*)
                         });
                         if is_comparator {
                             return ::std::option::Option::None;

--- a/crates/pocopine-sync-query-macros/src/lib.rs
+++ b/crates/pocopine-sync-query-macros/src/lib.rs
@@ -548,6 +548,7 @@ fn expand_query_resource(
     let field_markers = generate_field_markers(&params);
     let matches_body = generate_matches_body(&params);
     let row_to_params_body = generate_row_to_params_body(&params);
+    let partition_for_topic_body = generate_partition_for_topic_body(&params);
 
     Ok(quote! {
         #item
@@ -566,6 +567,7 @@ fn expand_query_resource(
                     .expect("query_resource name passed validation");
                 ::pocopine_sync_query::Query::<Self>::builder(stream)
                     .with_matches(#module_ident::matches)
+                    .with_partition_hash(#module_ident::partition_for_topic)
             }
         }
 
@@ -659,6 +661,35 @@ fn expand_query_resource(
                     ::pocopine_sync_query::__private::pocopine_sync::StreamParams::new();
                 #row_to_params_body
                 ::std::result::Result::Ok(params)
+            }
+
+            /// Project the caller's captured query params into a hash
+            /// of the SAME canonical projection that `row_to_params`
+            /// projects on the server. Used by the client driver to
+            /// subscribe to the per-`(stream, params_hash)` live
+            /// topic — must agree byte-for-byte with the server's
+            /// hash for routing to work (RFC 088 §C).
+            ///
+            /// Returns `None` if the captured params can't be
+            /// projected unambiguously:
+            ///   * a required field is missing (no tenant gate → no
+            ///     partition possible)
+            ///   * a required field's value is a comparator wrapper
+            ///     (`any_of` / `range` / `contains` — partition isn't
+            ///     well-defined for a single topic)
+            /// In either case the client should fall back to the
+            /// bare topic subscription only.
+            pub fn partition_for_topic(
+                captured: &::pocopine_sync_query::__private::pocopine_sync::StreamParams,
+            ) -> ::std::option::Option<u64> {
+                let mut canonical =
+                    ::pocopine_sync_query::__private::pocopine_sync::StreamParams::new();
+                #partition_for_topic_body
+                ::std::option::Option::Some(
+                    ::pocopine_sync_query::__private::pocopine_sync::stream_params_hash(
+                        NAME, &canonical,
+                    ),
+                )
             }
         }
     })
@@ -984,24 +1015,82 @@ fn generate_row_to_params_body(params: &[ParamDef]) -> TokenStream2 {
 /// Decide whether a `#[query_param]` field contributes to the
 /// per-(stream, params_hash) topic key (RFC 088 §C).
 ///
-/// Skip when the field is a fuzzy-text candidate: `caps.contains`
-/// is set (auto-emitted on `String` / `Cow` / `str` types, or
-/// explicitly via `#[query_param(contains)]`) AND no other signal
-/// promotes it. A `required` flag overrides skip — required fields
-/// are tenant gates and MUST partition the topic (otherwise
-/// cross-tenant rows would publish to the same topic).
+/// **Only `required`-flagged fields partition the topic.** This
+/// keeps the server-side `row_to_params` and the client-side
+/// `partition_for_topic` projections aligned: a client subscription
+/// like `Issue::query().eq(workspace_id, "W1")` (just the tenant
+/// gate) hashes to the same value as `row_to_params` extracts from a
+/// row in that workspace, regardless of what other filters the
+/// query carries (status, assignee, title, etc.).
 ///
-/// Examples:
-///   - `#[query_param(required)] pub workspace_id: String`
-///     → contains=true (heuristic), required=true → INCLUDE.
-///   - `#[query_param] pub title: String`
-///     → contains=true, required=false → SKIP.
-///   - `#[query_param] pub status: Status`
-///     → contains=false → INCLUDE.
-///   - `#[query_param] pub priority: u32`
-///     → contains=false, range=true → INCLUDE.
+/// Optional / non-required fields are NOT in the topic key because:
+///   1. Different queries on the same stream filter on different
+///      subsets — including all optional fields in the row's hash
+///      would produce a hash that no subset-filtering subscriber
+///      ever computes on its side. (Codex finding.)
+///   2. Free-text (`contains`) fields naturally explode topic
+///      cardinality.
+///   3. Range / any_of comparator wrappers can't be hashed as plain
+///      values; they don't fit the "exact-match hash" contract.
+///
+/// Users who want finer routing (e.g. per-(workspace, status)) mark
+/// `status` as `required` too. The routing engine's existing
+/// matches predicate then handles the cross-tenant gate AND the
+/// status filter on the client side.
 fn include_in_row_params(caps: &FieldCapabilities) -> bool {
-    !caps.contains || caps.required
+    caps.required
+}
+
+/// Generate the body of `partition_for_topic` — the client-side
+/// projection that mirrors `row_to_params` for the topic hash.
+/// Reads each REQUIRED `#[query_param]` field from the caller's
+/// captured `StreamParams` and inserts it (verbatim) into the
+/// canonical map. Returns `None` from the surrounding function if
+/// any required field is missing or is a comparator wrapper.
+fn generate_partition_for_topic_body(params: &[ParamDef]) -> TokenStream2 {
+    let extracts: Vec<TokenStream2> = params
+        .iter()
+        .filter(|p| include_in_row_params(&p.caps))
+        .map(|param| {
+            let name = &param.name;
+            let name_str = ident_wire_key(name);
+            quote! {
+                {
+                    // Required field absent → no partition; `?` on
+                    // Option<&Value> yields None from the outer fn.
+                    let value = captured.get(#name_str)?;
+                    // Reject comparator-wrapped values
+                    // (`{"in": [...]}` / `{"range": ...}` /
+                    // `{"contains": ...}` etc.). These don't map to a
+                    // single topic key — fall back to bare-topic
+                    // subscription.
+                    if let ::pocopine_sync_query::__private::serde_json::Value::Object(obj) = value {
+                        let is_comparator = obj.keys().any(|k| {
+                            matches!(
+                                k.as_str(),
+                                "in" | "range"
+                                    | "any_of"
+                                    | "contains"
+                                    | "at_least"
+                                    | "at_most"
+                                    | "less_than"
+                                    | "greater_than",
+                            )
+                        });
+                        if is_comparator {
+                            return ::std::option::Option::None;
+                        }
+                    }
+                    canonical.insert(#name_str.to_string(), value.clone());
+                }
+            }
+        })
+        .collect();
+
+    quote! {
+        let _ = captured; // silence unused if no required fields declared
+        #(#extracts)*
+    }
 }
 
 // ---- #[query] selector macro --------------------------------------

--- a/crates/pocopine-sync-query-macros/src/lib.rs
+++ b/crates/pocopine-sync-query-macros/src/lib.rs
@@ -190,6 +190,34 @@ enum CapabilityKeyword {
 /// range; `String` / `str` / `Cow` → contains). Anything the heuristic
 /// misses can be opted in explicitly.
 fn extract_field_params(item: &ItemStruct) -> syn::Result<Vec<ParamDef>> {
+    // Struct-level `#[serde(rename_all = "...")]` silently changes
+    // every field's wire key. The macro keys row_to_params and
+    // partition_for_topic on the Rust ident, so a struct-level
+    // rename_all would produce a server-side hash on the renamed
+    // keys (because `from_value` deserializes from them) but the
+    // macro's `params.insert(<rust_ident>, ...)` writes the Rust
+    // names — net effect: client and server both use Rust idents
+    // (an accidentally-correct outcome), but third-party clients
+    // following the wire spec would use the renamed keys and miss
+    // every wakeup. Reject up front.
+    for serde_attr in item.attrs.iter().filter(|a| a.path().is_ident("serde")) {
+        let meta_tokens = match &serde_attr.meta {
+            Meta::List(list) => list.tokens.to_string(),
+            _ => continue,
+        };
+        if meta_tokens.contains("rename") {
+            return Err(syn::Error::new(
+                serde_attr.span(),
+                "`#[serde(rename...)]` on a `#[query_resource]` struct is not supported. The \
+                 macro keys both the predicate evaluator and the RFC 088 §C topic-hash projection \
+                 on the Rust field names (with `r#` stripped), so a serde rename would diverge \
+                 from the wire spec — third-party clients implementing the spec would hash \
+                 different bytes and miss every per-params wakeup. Remove the rename, or open an \
+                 issue if you need serde-rename-aware projection.",
+            ));
+        }
+    }
+
     let fields = match &item.fields {
         Fields::Named(named) => named,
         Fields::Unit => return Ok(Vec::new()),
@@ -223,6 +251,45 @@ fn extract_field_params(item: &ItemStruct) -> syn::Result<Vec<ParamDef>> {
         let Some(attr) = query_param_attrs.first() else {
             continue;
         };
+
+        // RFC 088 §C: reject `#[serde(rename)]` / `#[serde(rename_all)]`
+        // shaped attrs on `#[query_param]` fields. The macro
+        // currently keys both the predicate evaluator (`matches()`)
+        // and the topic-hash projection (`row_to_params` /
+        // `partition_for_topic`) on the raw Rust ident (with the
+        // `r#` prefix stripped), NOT on the serde wire key. A field
+        // with a serde rename would silently produce a different
+        // wire-shape than the projector expects — third-party
+        // language clients implementing the golden-fixture spec
+        // would hash a different value and miss every per-params
+        // wakeup. Rejecting at compile time turns a silent runtime
+        // routing-precision bug into a clear error.
+        //
+        // Detection is structural: any `#[serde(rename ...)]` or
+        // `#[serde(rename_all ...)]` on the same field is fatal.
+        // We don't try to parse serde's full attribute grammar —
+        // just look for the keyword in the meta list's tokens. A
+        // future enhancement could thread the rename through the
+        // macro's wire-key derivation; until then, reject.
+        for serde_attr in field.attrs.iter().filter(|a| a.path().is_ident("serde")) {
+            let meta_tokens = match &serde_attr.meta {
+                Meta::List(list) => list.tokens.to_string(),
+                _ => continue,
+            };
+            if meta_tokens.contains("rename") {
+                return Err(syn::Error::new(
+                    serde_attr.span(),
+                    format!(
+                        "field `{field_name}`: `#[serde(rename...)]` on a `#[query_param]` field \
+                         is not supported. The `#[query_resource]` macro keys both the predicate \
+                         evaluator and the RFC 088 §C topic-hash projection on the Rust field \
+                         name (with `r#` stripped), NOT the serde-renamed wire key — a third-party \
+                         client implementing the wire spec would hash a different value and miss \
+                         every per-params wakeup. Remove the rename or omit the `#[query_param]`."
+                    ),
+                ));
+            }
+        }
 
         let extras = parse_query_param_extras(attr)?;
         let (inner_ty, is_option) = unwrap_option_type(&field.ty);
@@ -449,6 +516,20 @@ fn validate_resource_name(name: &LitStr) -> syn::Result<()> {
             "invalid query_resource name: must be a non-empty sync token without leading/trailing whitespace or control chars (max 1024 bytes)",
         ));
     }
+    // RFC 088 §C: `:` is the live-wakeup wire delimiter. A resource
+    // name containing `:` would produce a topic that collides with
+    // the per-`(stream, params_hash)` format. `SyncStreamName::new`
+    // also rejects this at runtime, but catching it at compile time
+    // turns the `.expect("query_resource name passed validation")`
+    // panic in the generated `Resource::query()` into a clear
+    // proc-macro error.
+    if value.contains(':') {
+        return Err(syn::Error::new(
+            name.span(),
+            "invalid query_resource name: must not contain `:` — the live-wakeup wire \
+             protocol uses `:` as a structural delimiter (RFC 088 §C)",
+        ));
+    }
     Ok(())
 }
 
@@ -550,6 +631,57 @@ fn expand_query_resource(
     let row_to_params_body = generate_row_to_params_body(&params);
     let partition_for_topic_body = generate_partition_for_topic_body(&params);
 
+    // RFC 088 §C / code-review fix #10: per-(stream, params_hash)
+    // live wakeups depend on at least one `#[query_param(required)]`
+    // field to partition the topic space. A `#[query_resource]` with
+    // zero required fields generates a `partition_for_topic` that
+    // ALWAYS returns `None`, silently downgrading every live
+    // subscription to the bare stream tag — which means every routed
+    // change on the stream wakes every subscriber regardless of
+    // tenant. That's correct (the matches() predicate still gates
+    // delivery), but loses §C's fanout-reduction benefit.
+    //
+    // Surface the trade-off via:
+    //   1. A public const `HAS_PER_PARAMS_LIVE_ROUTING: bool` users
+    //      can introspect or assert against in their own builds.
+    //   2. When the count is zero, a one-shot `tracing::warn!` from
+    //      `partition_for_topic` the first time it returns `None`
+    //      due to the missing-required-field cause. Uses
+    //      `std::sync::Once` so production logs see one line per
+    //      process, not one per call. We chose the runtime channel
+    //      over a compile-time `#[deprecated]` because the macro-
+    //      generated lint surfaces in the user's crate's
+    //      `#[query_resource(...)]` site and CAN'T be suppressed
+    //      from outside the macro (lint attrs don't reach into
+    //      attr-macro-emitted sibling items in stable Rust).
+    let required_count = params.iter().filter(|p| p.caps.required).count();
+    let has_per_params_live_routing = required_count > 0;
+    let zero_required_runtime_warning = if required_count == 0 {
+        let name_for_warning = name_lit.clone();
+        quote! {
+            // One-shot warning the first time partition_for_topic
+            // returns `None` because no #[query_param(required)]
+            // field was declared. Cf. RFC 088 §C / code-review
+            // finding #10.
+            static __PER_PARAMS_ROUTING_DISABLED_WARNING: ::std::sync::Once =
+                ::std::sync::Once::new();
+            __PER_PARAMS_ROUTING_DISABLED_WARNING.call_once(|| {
+                ::pocopine_sync_query::__private::tracing::warn!(
+                    target: "pocopine.log",
+                    resource = #name_for_warning,
+                    "RFC 088 §C live routing disabled: `#[query_resource]` `{}` declares no \
+                     `#[query_param(required)]` field, so partition_for_topic always returns \
+                     None. Every routed change on this stream will wake every subscriber. \
+                     Annotate the tenant-gate field (e.g. workspace_id) with \
+                     `#[query_param(required)]` to enable precise live wakeups.",
+                    #name_for_warning,
+                );
+            });
+        }
+    } else {
+        quote! {}
+    };
+
     Ok(quote! {
         #item
 
@@ -583,6 +715,15 @@ fn expand_query_resource(
 
             pub const NAME: &str = #name_lit;
             pub const SCHEMA_VERSION: u32 = #schema_version;
+            /// `true` iff this resource declares at least one
+            /// `#[query_param(required)]` field — the gate that
+            /// enables RFC 088 §C per-(stream, params_hash) live
+            /// wakeups. When `false`, `partition_for_topic` always
+            /// returns `None` and live subscriptions fall back to
+            /// the bare stream tag (fanout-reduction disabled). The
+            /// macro also emits a `#[deprecated]` build warning
+            /// when this is `false`.
+            pub const HAS_PER_PARAMS_LIVE_ROUTING: bool = #has_per_params_live_routing;
             pub type Row = super::#row_ident;
 
             /// Field markers for the type-safe query DSL. One marker
@@ -651,12 +792,18 @@ fn expand_query_resource(
             ) -> ::pocopine_sync_query::__private::pocopine_sync::SyncResult<
                 ::pocopine_sync_query::__private::pocopine_sync::StreamParams,
             > {
-                let typed: Row = ::pocopine_sync_query::__private::serde_json::from_value(
-                    row.clone(),
-                )
-                .map_err(|e| ::pocopine_sync_query::__private::pocopine_sync::SyncError::client(
-                    format!("row_to_params: {} row didn't deserialize: {}", NAME, e),
-                ))?;
+                // RFC 088 §C / code-review fix #12: project required
+                // fields directly from the JSON `row` rather than
+                // round-tripping through `serde_json::from_value::<Row>`.
+                // The typed-roundtrip path forced the full row payload
+                // through serde even when the partition projection only
+                // cares about the (typically 1–2) `required`-flagged
+                // fields, and failed the whole publish if any unrelated
+                // field on `Row` was non-deserializable. Direct
+                // projection only touches the keys we actually need and
+                // never fails — a missing/null required field yields an
+                // empty `StreamParams` and the caller treats that as
+                // "skip per-params publish".
                 let mut params =
                     ::pocopine_sync_query::__private::pocopine_sync::StreamParams::new();
                 #row_to_params_body
@@ -694,6 +841,7 @@ fn expand_query_resource(
                 // allowlists (`allow_topics(sync.live_topics())`)
                 // would reject.
                 if canonical.is_empty() {
+                    #zero_required_runtime_warning
                     return ::std::option::Option::None;
                 }
                 ::std::option::Option::Some(
@@ -985,34 +1133,20 @@ fn generate_row_to_params_body(params: &[ParamDef]) -> TokenStream2 {
         .map(|param| {
             let name = &param.name;
             let name_str = ident_wire_key(name);
-            let field_access: TokenStream2 = quote! { typed.#name };
-            if param.caps.optional {
-                quote! {
-                    if let ::std::option::Option::Some(inner) = &#field_access {
-                        let v = ::pocopine_sync_query::__private::serde_json::to_value(inner)
-                            .map_err(|e|
-                                ::pocopine_sync_query::__private::pocopine_sync::SyncError::client(
-                                    format!(
-                                        "row_to_params: field `{}` failed to serialize: {}",
-                                        #name_str, e,
-                                    ),
-                                )
-                            )?;
-                        params.insert(#name_str.to_string(), v);
+            // Direct JSON projection (code-review fix #12). For both
+            // required and Option-wrapped required fields the semantics
+            // are the same: insert only if the JSON has the key and
+            // it's non-null. A missing or null required field
+            // short-circuits the partition (the surrounding caller
+            // treats an empty `StreamParams` as "skip per-params
+            // publish"), which matches what the typed-roundtrip path
+            // produced via the `Option::None` skip and serde's
+            // `default` handling.
+            quote! {
+                if let ::std::option::Option::Some(v) = row.get(#name_str) {
+                    if !v.is_null() {
+                        params.insert(#name_str.to_string(), v.clone());
                     }
-                }
-            } else {
-                quote! {
-                    let v = ::pocopine_sync_query::__private::serde_json::to_value(&#field_access)
-                        .map_err(|e|
-                            ::pocopine_sync_query::__private::pocopine_sync::SyncError::client(
-                                format!(
-                                    "row_to_params: field `{}` failed to serialize: {}",
-                                    #name_str, e,
-                                ),
-                            )
-                        )?;
-                    params.insert(#name_str.to_string(), v);
                 }
             }
         })
@@ -1066,60 +1200,63 @@ fn generate_partition_for_topic_body(params: &[ParamDef]) -> TokenStream2 {
             let name = &param.name;
             let name_str = ident_wire_key(name);
 
-            // Per-field comparator-key set. ONLY include the keys
-            // for comparators this field can actually emit:
-            //   * InSet (`{"in": [...]}`) — universal (every
-            //     `#[query_param]` field gets FieldInSet).
-            //   * Contains (`{"contains", "case_sensitive"}`) —
-            //     only if `caps.contains` is set (auto for non-
-            //     Option `String`/`Cow`/`str`, or explicit
-            //     `#[query_param(contains)]`).
-            //   * Range (`{"from", "to", "inclusive"}`) — only if
-            //     `caps.range` is set (auto for orderable types, or
-            //     explicit `#[query_param(range)]`).
+            // Detect comparator-wrapped values by FULL-shape match,
+            // not key-overlap. The three comparator wire shapes
+            // (defined in `pocopine_sync_query::params`) all use
+            // `deny_unknown_fields`, so a user type that happens to
+            // contain a `"contains"` or `"in"` or `"from"` key
+            // AMONG OTHER KEYS isn't a comparator and must be
+            // hashed as a plain partition value.
             //
-            // Gating by capability is what avoids false positives
-            // on user types whose plain equality value happens to
-            // serialize as an object with `from`/`to` keys — e.g.
-            // `#[query_param(required)] window: TimeWindow` where
-            // `TimeWindow` serializes as `{"from": ..., "to": ...}`
-            // and the user filters with `.eq(field::window, w)`.
-            // Without this gate, we'd reject the plain equality
-            // value as a comparator and the client would miss
-            // scoped invalidations the server publishes.
-            let mut comparator_keys: Vec<&'static str> = vec!["in"];
+            //   * InSet wire shape: keys == {"in"}
+            //   * Contains wire shape (if caps.contains):
+            //       keys ⊆ {"contains","case_sensitive"} AND "contains"∈keys
+            //   * Range wire shape (if caps.range):
+            //       keys ⊆ {"from","to","inclusive"} AND (from|to)∈keys
+            //
+            // Capability gating ensures a `(range)`-only-on-paper
+            // field (e.g. a `Range`-impl'd numeric) doesn't reject
+            // a TimeWindow-shaped equality value if the field
+            // wasn't marked range-capable. Plus the FULL-shape
+            // match means even marking the field `(range)` doesn't
+            // false-positive on a user struct like `{from, to,
+            // label, status}` — the extra keys disqualify the
+            // match.
+            let mut shape_checks: Vec<TokenStream2> = Vec::new();
+            // InSet always — every `#[query_param]` field gets `FieldInSet`.
+            shape_checks.push(quote! {
+                if obj.len() == 1 && obj.contains_key("in") {
+                    return ::std::option::Option::None;
+                }
+            });
             if param.caps.contains {
-                comparator_keys.push("contains");
-                comparator_keys.push("case_sensitive");
+                shape_checks.push(quote! {
+                    if obj.contains_key("contains")
+                        && obj.keys().all(|k| matches!(k.as_str(), "contains" | "case_sensitive"))
+                    {
+                        return ::std::option::Option::None;
+                    }
+                });
             }
             if param.caps.range {
-                comparator_keys.push("from");
-                comparator_keys.push("to");
-                comparator_keys.push("inclusive");
+                shape_checks.push(quote! {
+                    if (obj.contains_key("from") || obj.contains_key("to"))
+                        && obj.keys().all(|k| matches!(k.as_str(), "from" | "to" | "inclusive"))
+                    {
+                        return ::std::option::Option::None;
+                    }
+                });
             }
-            let key_arms: Vec<TokenStream2> = comparator_keys
-                .iter()
-                .map(|k| {
-                    let lit = syn::LitStr::new(k, proc_macro2::Span::call_site());
-                    quote! { #lit }
-                })
-                .collect();
 
             quote! {
                 {
                     // Required field absent → no partition; `?` on
                     // Option<&Value> yields None from the outer fn.
                     let value = captured.get(#name_str)?;
-                    // Reject comparator-wrapped values for the
-                    // comparators THIS field can emit. See the
-                    // per-field key set above.
+                    // Reject comparator-wrapped values. See the
+                    // FULL-shape rationale above.
                     if let ::pocopine_sync_query::__private::serde_json::Value::Object(obj) = value {
-                        let is_comparator = obj.keys().any(|k| {
-                            matches!(k.as_str(), #(#key_arms)|*)
-                        });
-                        if is_comparator {
-                            return ::std::option::Option::None;
-                        }
+                        #(#shape_checks)*
                     }
                     canonical.insert(#name_str.to_string(), value.clone());
                 }

--- a/crates/pocopine-sync-query-macros/src/lib.rs
+++ b/crates/pocopine-sync-query-macros/src/lib.rs
@@ -685,6 +685,17 @@ fn expand_query_resource(
                 let mut canonical =
                     ::pocopine_sync_query::__private::pocopine_sync::StreamParams::new();
                 #partition_for_topic_body
+                // Symmetric to the server: an empty canonical
+                // projection means there's no per-`(stream, params)`
+                // topic to subscribe to (the server's
+                // `invalidate_stream_with_row` short-circuits on
+                // empty params). Falling back to bare-topic only
+                // also avoids requesting a topic that exact-match
+                // allowlists (`allow_topics(sync.live_topics())`)
+                // would reject.
+                if canonical.is_empty() {
+                    return ::std::option::Option::None;
+                }
                 ::std::option::Option::Some(
                     ::pocopine_sync_query::__private::pocopine_sync::stream_params_hash(
                         NAME, &canonical,
@@ -1059,22 +1070,33 @@ fn generate_partition_for_topic_body(params: &[ParamDef]) -> TokenStream2 {
                     // Required field absent → no partition; `?` on
                     // Option<&Value> yields None from the outer fn.
                     let value = captured.get(#name_str)?;
-                    // Reject comparator-wrapped values
-                    // (`{"in": [...]}` / `{"range": ...}` /
-                    // `{"contains": ...}` etc.). These don't map to a
-                    // single topic key — fall back to bare-topic
-                    // subscription.
+                    // Reject comparator-wrapped values — InSet
+                    // (`{"in": [...]}`), Contains
+                    // (`{"contains": "...", "case_sensitive": bool}`),
+                    // and Range (`{"from": ..., "to": ..., "inclusive": [_, _]}`).
+                    // These don't map to a single topic key — fall
+                    // back to bare-topic subscription.
+                    //
+                    // We detect via the wire-shape's distinctive
+                    // keys. The set is closed (these are the only
+                    // comparators `pocopine_sync_query::params`
+                    // emits); a future comparator would need to be
+                    // added here, or the macro could opt for a
+                    // strict allowlist of plain JSON value kinds
+                    // instead.
                     if let ::pocopine_sync_query::__private::serde_json::Value::Object(obj) = value {
                         let is_comparator = obj.keys().any(|k| {
                             matches!(
                                 k.as_str(),
-                                "in" | "range"
-                                    | "any_of"
-                                    | "contains"
-                                    | "at_least"
-                                    | "at_most"
-                                    | "less_than"
-                                    | "greater_than",
+                                // InSet
+                                "in"
+                                // Contains
+                                | "contains"
+                                | "case_sensitive"
+                                // Range
+                                | "from"
+                                | "to"
+                                | "inclusive",
                             )
                         });
                         if is_comparator {

--- a/crates/pocopine-sync-query-macros/src/lib.rs
+++ b/crates/pocopine-sync-query-macros/src/lib.rs
@@ -547,6 +547,7 @@ fn expand_query_resource(
 
     let field_markers = generate_field_markers(&params);
     let matches_body = generate_matches_body(&params);
+    let row_to_params_body = generate_row_to_params_body(&params);
 
     Ok(quote! {
         #item
@@ -609,6 +610,55 @@ fn expand_query_resource(
                 let params = query.params();
                 #matches_body
                 true
+            }
+
+            /// Project a canonical row into the `StreamParams` that
+            /// identify which (RFC 088 §C) per-`(stream, params_hash)`
+            /// live topic should be invalidated when this row changes.
+            ///
+            /// Plug this into your `SyncStreamSource::row_to_params`
+            /// impl so the server can route precise wakeups to
+            /// matching subscribers:
+            ///
+            /// ```ignore
+            /// impl SyncStreamSource for MyIssuesSource {
+            ///     fn row_to_params(&self, row: &serde_json::Value)
+            ///         -> SyncResult<StreamParams>
+            ///     {
+            ///         issues::row_to_params(row)
+            ///     }
+            ///     // ... other methods ...
+            /// }
+            /// ```
+            ///
+            /// Field selection: includes every `#[query_param]` field
+            /// EXCEPT those whose only emitted comparator is
+            /// `FieldContains` (substring search). Substring filters
+            /// can't partition a topic space — a partial-text match
+            /// doesn't tell the server which audience cares. Required-
+            /// flagged fields are ALWAYS included; explicit
+            /// `#[query_param(range)]` / equality-shaped types are
+            /// included automatically.
+            ///
+            /// `None` values from `Option<T>` fields are omitted from
+            /// the returned map (a null in the topic key would
+            /// fragment unnecessarily; the client's params filter
+            /// already handles null match semantics).
+            pub fn row_to_params(
+                row: &::pocopine_sync_query::__private::serde_json::Value,
+            ) -> ::pocopine_sync_query::__private::pocopine_sync::SyncResult<
+                ::pocopine_sync_query::__private::pocopine_sync::StreamParams,
+            > {
+                let typed: Row = ::pocopine_sync_query::__private::serde_json::from_value(
+                    row.clone(),
+                )
+                .map_err(|e| ::pocopine_sync_query::__private::pocopine_sync::SyncError::client(
+                    format!("row_to_params: {} row didn't deserialize: {}", NAME, e),
+                ))?;
+                let mut params =
+                    ::pocopine_sync_query::__private::pocopine_sync::StreamParams::new();
+                #row_to_params_body
+                ::std::result::Result::Ok(params)
             }
         }
     })
@@ -859,6 +909,99 @@ fn generate_matches_body(params: &[ParamDef]) -> TokenStream2 {
         let _ = params; // silence unused if no #[query_param] fields declared
         #(#checks)*
     }
+}
+
+/// Generate the body of the `row_to_params(row: &Value) ->
+/// SyncResult<StreamParams>` function inside the generated module
+/// (see RFC 088 §C). Iterates the same `#[query_param]` fields the
+/// matches() body iterates, but:
+///
+/// 1. **Skips contains-only fields.** A field whose only emitted
+///    comparator is `FieldContains` (substring search) can't
+///    partition the topic space — a `.contains(field::title,
+///    "auth")?` filter matches an unbounded set of row values, so
+///    including the row's title in the params map would generate a
+///    distinct topic per row and defeat the fanout-reduction goal.
+///    Fields that ALSO carry `range`/`required`/or-are-non-String
+///    stay in the map.
+///
+/// 2. **Drops `None` from `Option<T>` fields.** Inserting a JSON
+///    null into params would partition `Option::None` rows into a
+///    distinct topic — almost always not what the user wants. The
+///    routing engine's predicate evaluator (matches() body) already
+///    handles `None` symmetry.
+///
+/// 3. **Uses each field's wire-key** (raw-ident-stripped) so the
+///    emitted topic keys match `serde_json::to_value(row)`'s field
+///    names. If the user later adds `#[serde(rename = "…")]`, the
+///    macro doesn't currently follow it — same limitation as the
+///    existing matches() body and the existing macro tests.
+fn generate_row_to_params_body(params: &[ParamDef]) -> TokenStream2 {
+    let inserts: Vec<TokenStream2> = params
+        .iter()
+        .filter(|p| include_in_row_params(&p.caps))
+        .map(|param| {
+            let name = &param.name;
+            let name_str = ident_wire_key(name);
+            let field_access: TokenStream2 = quote! { typed.#name };
+            if param.caps.optional {
+                quote! {
+                    if let ::std::option::Option::Some(inner) = &#field_access {
+                        let v = ::pocopine_sync_query::__private::serde_json::to_value(inner)
+                            .map_err(|e|
+                                ::pocopine_sync_query::__private::pocopine_sync::SyncError::client(
+                                    format!(
+                                        "row_to_params: field `{}` failed to serialize: {}",
+                                        #name_str, e,
+                                    ),
+                                )
+                            )?;
+                        params.insert(#name_str.to_string(), v);
+                    }
+                }
+            } else {
+                quote! {
+                    let v = ::pocopine_sync_query::__private::serde_json::to_value(&#field_access)
+                        .map_err(|e|
+                            ::pocopine_sync_query::__private::pocopine_sync::SyncError::client(
+                                format!(
+                                    "row_to_params: field `{}` failed to serialize: {}",
+                                    #name_str, e,
+                                ),
+                            )
+                        )?;
+                    params.insert(#name_str.to_string(), v);
+                }
+            }
+        })
+        .collect();
+
+    quote! {
+        #(#inserts)*
+    }
+}
+
+/// Decide whether a `#[query_param]` field contributes to the
+/// per-(stream, params_hash) topic key (RFC 088 §C).
+///
+/// Skip when the field is a fuzzy-text candidate: `caps.contains`
+/// is set (auto-emitted on `String` / `Cow` / `str` types, or
+/// explicitly via `#[query_param(contains)]`) AND no other signal
+/// promotes it. A `required` flag overrides skip — required fields
+/// are tenant gates and MUST partition the topic (otherwise
+/// cross-tenant rows would publish to the same topic).
+///
+/// Examples:
+///   - `#[query_param(required)] pub workspace_id: String`
+///     → contains=true (heuristic), required=true → INCLUDE.
+///   - `#[query_param] pub title: String`
+///     → contains=true, required=false → SKIP.
+///   - `#[query_param] pub status: Status`
+///     → contains=false → INCLUDE.
+///   - `#[query_param] pub priority: u32`
+///     → contains=false, range=true → INCLUDE.
+fn include_in_row_params(caps: &FieldCapabilities) -> bool {
+    !caps.contains || caps.required
 }
 
 // ---- #[query] selector macro --------------------------------------

--- a/crates/pocopine-sync-query-macros/tests/query_resource.rs
+++ b/crates/pocopine-sync-query-macros/tests/query_resource.rs
@@ -203,3 +203,71 @@ fn field_markers_typecheck_against_comparator_traits() {
     fn _contains_title<F: FieldContains>(_: F) {}
     _contains_title(issues::field::title);
 }
+
+// ---- RFC 088 §C: row_to_params codegen tests ---------------------
+
+use pocopine_sync::StreamParams;
+use serde_json::json;
+
+#[test]
+fn row_to_params_includes_required_and_categorical_fields() {
+    // Per the include-rule:
+    //   - workspace_id: required=true → INCLUDE
+    //   - assignee_id: contains=true (String), required=false → SKIP
+    //   - assignee_id: Option<String> → contains=false (auto-detect
+    //     only flags non-Option strings) → INCLUDE. This matches the
+    //     usual intent: Option<String> is typically a categorical FK
+    //     (assignee id), partition-friendly.
+    //   - title: String, required=false → SKIP (free-text contains)
+    //   - status: contains=false (enum) → INCLUDE
+    //   - priority: contains=false (numeric) → INCLUDE
+    let row = json!({
+        "id": "i1",
+        "workspace_id": "W1",
+        "assignee_id": "alice",
+        "title": "Auth bug",
+        "status": "open",
+        "priority": 5,
+    });
+    let params = issues::row_to_params(&row).expect("row deserializes");
+    let expected: StreamParams = [
+        ("workspace_id".to_string(), json!("W1")),
+        ("assignee_id".to_string(), json!("alice")),
+        ("status".to_string(), json!("open")),
+        ("priority".to_string(), json!(5u32)),
+    ]
+    .into_iter()
+    .collect();
+    assert_eq!(params, expected);
+    // `title` is SKIPPED because it's the prototypical contains-only
+    // (free-text) field: substring filters don't partition a topic
+    // space.
+    assert!(!params.contains_key("title"));
+}
+
+#[test]
+fn row_to_params_skips_none_options() {
+    // assignee_id: Option<String> with None → must be omitted from
+    // the returned map even though the field is INCLUDED in
+    // principle.
+    let row = json!({
+        "id": "i1",
+        "workspace_id": "W1",
+        "assignee_id": null,
+        "title": "",
+        "status": "open",
+        "priority": 0,
+    });
+    let params = issues::row_to_params(&row).expect("row deserializes");
+    assert!(!params.contains_key("assignee_id"));
+}
+
+#[test]
+fn row_to_params_propagates_deserialize_error() {
+    // A malformed row (missing required field) bubbles up as
+    // SyncError::client, NOT a panic — the server logs + falls back
+    // to bare-topic publish.
+    let bad_row = json!({"id": "i1"}); // missing workspace_id, etc.
+    let result = issues::row_to_params(&bad_row);
+    assert!(result.is_err());
+}

--- a/crates/pocopine-sync-query-macros/tests/query_resource.rs
+++ b/crates/pocopine-sync-query-macros/tests/query_resource.rs
@@ -210,17 +210,14 @@ use pocopine_sync::StreamParams;
 use serde_json::json;
 
 #[test]
-fn row_to_params_includes_required_and_categorical_fields() {
-    // Per the include-rule:
+fn row_to_params_includes_only_required_fields() {
+    // Post-codex-review (P2.1): only `required`-flagged fields
+    // partition the topic. Anything else would produce a hash on
+    // the server that no subset-filtering client subscription
+    // computes on its side (Codex finding).
+    //
     //   - workspace_id: required=true → INCLUDE
-    //   - assignee_id: contains=true (String), required=false → SKIP
-    //   - assignee_id: Option<String> → contains=false (auto-detect
-    //     only flags non-Option strings) → INCLUDE. This matches the
-    //     usual intent: Option<String> is typically a categorical FK
-    //     (assignee id), partition-friendly.
-    //   - title: String, required=false → SKIP (free-text contains)
-    //   - status: contains=false (enum) → INCLUDE
-    //   - priority: contains=false (numeric) → INCLUDE
+    //   - everything else → SKIP
     let row = json!({
         "id": "i1",
         "workspace_id": "W1",
@@ -230,19 +227,62 @@ fn row_to_params_includes_required_and_categorical_fields() {
         "priority": 5,
     });
     let params = issues::row_to_params(&row).expect("row deserializes");
-    let expected: StreamParams = [
-        ("workspace_id".to_string(), json!("W1")),
-        ("assignee_id".to_string(), json!("alice")),
-        ("status".to_string(), json!("open")),
-        ("priority".to_string(), json!(5u32)),
-    ]
-    .into_iter()
-    .collect();
+    let expected: StreamParams = [("workspace_id".to_string(), json!("W1"))]
+        .into_iter()
+        .collect();
     assert_eq!(params, expected);
-    // `title` is SKIPPED because it's the prototypical contains-only
-    // (free-text) field: substring filters don't partition a topic
-    // space.
-    assert!(!params.contains_key("title"));
+}
+
+#[test]
+fn partition_for_topic_matches_row_to_params_hash() {
+    // The whole point of the projection: server-side
+    // row_to_params and client-side partition_for_topic MUST hash
+    // identically when both project the same canonical fields.
+    use pocopine_sync::stream_params_hash;
+
+    let row = json!({
+        "id": "i1",
+        "workspace_id": "W1",
+        "assignee_id": "alice",
+        "title": "Auth bug",
+        "status": "open",
+        "priority": 5,
+    });
+    let server_params = issues::row_to_params(&row).unwrap();
+    let server_hash = stream_params_hash("issues", &server_params);
+
+    // Client subscription: just the tenant gate.
+    use issues::field;
+    let query = Issue::query().eq(field::workspace_id, "W1").build();
+    let client_hash = query.partition_hash().expect("partition_hash computes");
+
+    assert_eq!(client_hash, server_hash);
+}
+
+#[test]
+fn partition_for_topic_returns_none_for_missing_required_field() {
+    // A query that doesn't filter by the required field can't
+    // partition — falls back to bare-topic subscription.
+    let query: pocopine_sync_query::Query<Issue> = pocopine_sync_query::Query::builder(
+        pocopine_sync_query::SyncStreamName::new("issues").unwrap(),
+    )
+    .with_partition_hash(issues::partition_for_topic)
+    .build();
+    assert!(query.partition_hash().is_none());
+}
+
+#[test]
+fn partition_for_topic_returns_none_for_any_of_wrapper() {
+    // Comparator-wrapped values (any_of / range / contains) don't
+    // map to a single topic — fall back to bare. Here the user
+    // does `.any_of(workspace_id, [...])` so the partition is
+    // ambiguous.
+    use issues::field;
+    let query = Issue::query()
+        .any_of(field::workspace_id, ["W1", "W2"])
+        .unwrap()
+        .build();
+    assert!(query.partition_hash().is_none());
 }
 
 #[test]

--- a/crates/pocopine-sync-query-macros/tests/query_resource.rs
+++ b/crates/pocopine-sync-query-macros/tests/query_resource.rs
@@ -335,6 +335,49 @@ fn partition_for_topic_returns_none_when_no_required_fields_declared() {
     assert!(query.partition_hash().is_none());
 }
 
+// Regression for codex second-pass P2: the comparator-key
+// detection MUST be gated by the field's actual capabilities. A
+// required field with non-numeric, non-string type — that the
+// user filters with `.eq()` to a struct value whose JSON
+// serialization happens to share keys with the Range wire shape
+// (`from`, `to`) — must NOT be misclassified as a comparator
+// wrapper.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+pub struct TimeWindow {
+    pub from: u32,
+    pub to: u32,
+}
+
+#[query_resource(name = "windowed", schema_version = 1)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Windowed {
+    pub id: String,
+    // TimeWindow isn't in is_ordered_type, so caps.range stays
+    // false. The macro should NOT check `from`/`to`/`inclusive`
+    // keys for this field's captured value.
+    #[query_param(required)]
+    pub window: TimeWindow,
+}
+
+#[test]
+fn partition_for_topic_accepts_plain_struct_value_with_range_like_keys() {
+    use windowed::field;
+    let w = TimeWindow { from: 1, to: 10 };
+    let query = Windowed::query().eq(field::window, w.clone()).build();
+    let hash = query
+        .partition_hash()
+        .expect("plain equality value (not a Range comparator) partitions");
+    // Sanity: server-side projection of the same canonical row
+    // should hash identically.
+    let row = json!({
+        "id": "i1",
+        "window": {"from": 1, "to": 10},
+    });
+    let server_params = windowed::row_to_params(&row).unwrap();
+    let server_hash = pocopine_sync::stream_params_hash("windowed", &server_params);
+    assert_eq!(hash, server_hash);
+}
+
 #[test]
 fn row_to_params_skips_none_options() {
     // assignee_id: Option<String> with None → must be omitted from

--- a/crates/pocopine-sync-query-macros/tests/query_resource.rs
+++ b/crates/pocopine-sync-query-macros/tests/query_resource.rs
@@ -285,6 +285,56 @@ fn partition_for_topic_returns_none_for_any_of_wrapper() {
     assert!(query.partition_hash().is_none());
 }
 
+// Regression for the codex finding (P2): the macro's comparator
+// detection MUST also recognize the `Range<T>` wire shape
+// (`{"from": ..., "to": ..., "inclusive": [_, _]}`). Without this,
+// a range-filtered required field would hash the wrapper object as
+// if it were a plain partition value, subscribing to a topic the
+// server never publishes.
+#[query_resource(name = "priced", schema_version = 1)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Priced {
+    pub id: String,
+    #[query_param(required)]
+    pub price: u32,
+}
+
+#[test]
+fn partition_for_topic_returns_none_for_range_wrapper() {
+    use priced::field;
+    let query = Priced::query().range(field::price, 10u32..100).build();
+    // Range filters can't partition the topic — the server's
+    // row_to_params projects a plain price value, but here the
+    // client's params have a range wrapper. Returning None lets the
+    // driver fall back to bare-topic only.
+    assert!(query.partition_hash().is_none());
+}
+
+// Regression for the codex finding (P2): a resource with NO
+// `required` fields must NOT subscribe to per-params topics — the
+// server's `invalidate_stream_with_row` short-circuits on empty
+// row_to_params, so any per-params subscription is dead.
+#[query_resource(name = "no_required", schema_version = 1)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct NoRequiredResource {
+    pub id: String,
+    #[query_param]
+    pub flavor: String,
+}
+
+#[test]
+fn partition_for_topic_returns_none_when_no_required_fields_declared() {
+    let query: pocopine_sync_query::Query<NoRequiredResource> =
+        pocopine_sync_query::Query::builder(
+            pocopine_sync_query::SyncStreamName::new("no_required").unwrap(),
+        )
+        .with_partition_hash(no_required::partition_for_topic)
+        .build();
+    // Empty canonical projection → no per-params topic to subscribe
+    // to. Driver falls back to bare-topic only.
+    assert!(query.partition_hash().is_none());
+}
+
 #[test]
 fn row_to_params_skips_none_options() {
     // assignee_id: Option<String> with None → must be omitted from

--- a/crates/pocopine-sync-query-macros/tests/query_resource.rs
+++ b/crates/pocopine-sync-query-macros/tests/query_resource.rs
@@ -396,11 +396,43 @@ fn row_to_params_skips_none_options() {
 }
 
 #[test]
-fn row_to_params_propagates_deserialize_error() {
-    // A malformed row (missing required field) bubbles up as
-    // SyncError::client, NOT a panic — the server logs + falls back
-    // to bare-topic publish.
+fn row_to_params_missing_required_field_yields_empty_params() {
+    // Direct JSON projection (code-review fix #12). A malformed row
+    // — missing a required field — no longer errors. It silently
+    // yields an empty `StreamParams`, which the caller
+    // (`invalidate_stream_with_rows`) treats as "skip per-params
+    // publish" and falls back to bare-topic invalidation only.
+    // That's the right semantic: a row we can't project shouldn't
+    // be wrongly attributed to any partition.
     let bad_row = json!({"id": "i1"}); // missing workspace_id, etc.
-    let result = issues::row_to_params(&bad_row);
-    assert!(result.is_err());
+    let params = issues::row_to_params(&bad_row).expect("direct projection never fails");
+    assert!(
+        params.is_empty(),
+        "missing required field must yield empty params, got {params:?}"
+    );
+}
+
+#[test]
+fn row_to_params_skips_unrelated_fields_that_dont_deserialize() {
+    // A row whose IRRELEVANT fields (not in the partition
+    // projection) are malformed must still project the required
+    // fields correctly. The old typed-roundtrip path would have
+    // failed the whole row; the direct JSON projection only touches
+    // the keys we actually need.
+    let row = json!({
+        "id": "i1",
+        "workspace_id": "W1",
+        // `priority` is declared as a number in the test fixture
+        // but here we pass a string to force `serde_json::from_value`
+        // to fail. Direct projection ignores it.
+        "priority": "not a number",
+        "assignee_id": null,
+        "title": "Auth bug",
+        "status": "open",
+    });
+    let params = issues::row_to_params(&row).expect("direct projection never fails");
+    assert_eq!(
+        params.get("workspace_id").map(|v| v.as_str()),
+        Some(Some("W1"))
+    );
 }

--- a/crates/pocopine-sync-query/README.md
+++ b/crates/pocopine-sync-query/README.md
@@ -187,11 +187,9 @@ Live wakeups for `#[query]` selectors (and any `#[query_resource]`-backed view) 
 
 ```rust,ignore
 let backend = pocopine_events::build_event_backend(
-    pocopine_events::EventBackendConfig::Redis(pocopine_events::RedisEventConfig {
-        url: "redis://prod-redis:6379".into(),
-        app: "myapp".into(),
-        ..Default::default()
-    })
+    pocopine_events::EventBackendConfig::Redis(
+        pocopine_events::RedisEventConfig::new("redis://prod-redis:6379", "myapp")?,
+    ),
 )?;
 let hub = pocopine_live::LiveHub::new(backend)
     .allow_topic_prefixes(sync.live_topic_prefixes()); // RFC 088 §C

--- a/crates/pocopine-sync-query/README.md
+++ b/crates/pocopine-sync-query/README.md
@@ -179,6 +179,28 @@ The convention: if the first arg's type is `QueryClient`, it's the selector's cl
 
 Selectors compose: `#[query] fn dashboard(...) { open_issue_count::observe(&client, ws).value() + … }`. An inner selector whose output is `PartialEq`-equal across reruns stops the cascade — the outer selector doesn't rerun. See [`docs/sync-query-selector-mechanism.md`](../../docs/sync-query-selector-mechanism.md) for the full design and [`docs/sync-query-selector-implementation.md`](../../docs/sync-query-selector-implementation.md) for the code map (layer diagram, data flows, file pointers).
 
+## Live invalidation and multi-node deployments
+
+Live wakeups for `#[query]` selectors (and any `#[query_resource]`-backed view) flow through the `pocopine-events` event spine. If you deploy more than one server process — Kubernetes replicas, Render auto-scaling, blue/green, anything horizontally scaled — the in-process `MemoryEventBackend` will silently drop cross-node invalidations: a mutation on Node 2 never wakes a subscriber on Node 1.
+
+**Production needs a shared backend.** Swap to `RedisEventBackend` (already in tree, behind the `redis` feature) — one line at app boot, no code changes downstream:
+
+```rust,ignore
+let backend = pocopine_events::build_event_backend(
+    pocopine_events::EventBackendConfig::Redis(pocopine_events::RedisEventConfig {
+        url: "redis://prod-redis:6379".into(),
+        app: "myapp".into(),
+        ..Default::default()
+    })
+)?;
+let hub = pocopine_live::LiveHub::new(backend)
+    .allow_topic_prefixes(sync.live_topic_prefixes()); // RFC 088 §C
+```
+
+RFC 088 §C (per-`(stream, params_hash)` topics) is also broker-agnostic — it changes the *topic naming* scheme, not the broker contract. For ~1M users single-node Redis is fine; if you cross ~10M distinct partition hashes, shard with Redis Cluster or move to NATS / Kafka.
+
+Full picture, broker comparison, and topic-cardinality scaling notes in [`docs/live.md` §8 "Production Backends"](../../docs/live.md#8-production-backends).
+
 ## CRUD vs Query — which one?
 
 | You want to                                  | Use                  |

--- a/crates/pocopine-sync-query/src/driver.rs
+++ b/crates/pocopine-sync-query/src/driver.rs
@@ -441,7 +441,13 @@ where
             };
             let stream_name = sub.query().stream().as_str().to_string();
             let captured_params = sub.query().params().clone();
-            LiveWakeup::open_on_stream(stream_name, captured_params, self.with_credentials)
+            let partition_hash = sub.query().partition_hash();
+            LiveWakeup::open_on_stream(
+                stream_name,
+                captured_params,
+                partition_hash,
+                self.with_credentials,
+            )
         }
         #[cfg(not(target_arch = "wasm32"))]
         {
@@ -1472,6 +1478,7 @@ impl LiveWakeup {
     fn open_on_stream(
         stream_name: String,
         captured_params: pocopine_sync::StreamParams,
+        partition_hash: Option<u64>,
         with_credentials: bool,
     ) -> Self {
         let (tx, rx) = futures::channel::mpsc::unbounded::<LiveWakeupEvent>();
@@ -1493,10 +1500,15 @@ impl LiveWakeup {
         //     new rows. See RFC 088 §C.4 for the dedup-by-mutation_
         //     id follow-up.
         let mut live_builder = pocopine_live::LiveClient::new().query_tag(live_tag.clone());
-        if !captured_params.is_empty() {
-            let params_hash =
-                pocopine_sync::stream_params_hash(stream_name.as_str(), &captured_params);
-            live_builder = live_builder.query_tag_with_params(live_tag.clone(), params_hash);
+        // RFC 088 §C per-(stream, params_hash) subscription. The hash
+        // is supplied by the macro-generated `partition_for_topic`
+        // (via `Query::partition_hash`), which projects the captured
+        // params onto the canonical required-field projection that
+        // matches the server's `row_to_params`. None means: required
+        // field absent OR a comparator wrapper (any_of/range/contains)
+        // — fall back to bare-topic only.
+        if let Some(hash) = partition_hash {
+            live_builder = live_builder.query_tag_with_params(live_tag.clone(), hash);
         }
         let connect_result = live_builder
             .with_credentials(with_credentials)

--- a/crates/pocopine-sync-query/src/driver.rs
+++ b/crates/pocopine-sync-query/src/driver.rs
@@ -1476,8 +1476,29 @@ impl LiveWakeup {
     ) -> Self {
         let (tx, rx) = futures::channel::mpsc::unbounded::<LiveWakeupEvent>();
         let live_tag = pocopine_sync::sync_stream_tag(stream_name.as_str());
-        let connect_result = pocopine_live::LiveClient::new()
-            .query_tag(live_tag.clone())
+        // RFC 088 §C: subscribe to BOTH topics during the rollout
+        // window —
+        //   * bare topic: matches every mutation on this stream
+        //     (back-compat with servers that don't override
+        //     row_to_params, and with rows whose row_to_params
+        //     returns empty).
+        //   * per-(stream, params_hash) topic: matches only the
+        //     audience whose params project to the same hash as
+        //     this subscription's params. When the server publishes
+        //     to the per-params topic, it ALSO publishes bare for
+        //     back-compat — so a single mutation lands in this
+        //     driver's queue TWICE. That's tolerated because /pull
+        //     is idempotent against the cursor: the second pull is
+        //     a no-op-on-cursor and the routing engine sees zero
+        //     new rows. See RFC 088 §C.4 for the dedup-by-mutation_
+        //     id follow-up.
+        let mut live_builder = pocopine_live::LiveClient::new().query_tag(live_tag.clone());
+        if !captured_params.is_empty() {
+            let params_hash =
+                pocopine_sync::stream_params_hash(stream_name.as_str(), &captured_params);
+            live_builder = live_builder.query_tag_with_params(live_tag.clone(), params_hash);
+        }
+        let connect_result = live_builder
             .with_credentials(with_credentials)
             .on_event({
                 let tx = tx.clone();

--- a/crates/pocopine-sync-query/src/lib.rs
+++ b/crates/pocopine-sync-query/src/lib.rs
@@ -100,6 +100,12 @@ pub mod __private {
     // one stable path — the user's crate only needs
     // `pocopine-sync-query` as a direct dep.
     pub use pocopine_sync;
+    // Re-export so the `#[query_resource]` macro's emitted
+    // `partition_for_topic` (code-review fix #10) can reach
+    // `tracing::warn!` through one stable path. The macro emits a
+    // one-shot warning when the resource declares no `required`
+    // field and §C live routing is therefore disabled.
+    pub use tracing;
 
     /// FNV-1a 64-bit hash. `const fn` so the `#[query]` macro's
     /// generated `const SELECTOR_ID` initializer evaluates it at the

--- a/crates/pocopine-sync-query/src/lib.rs
+++ b/crates/pocopine-sync-query/src/lib.rs
@@ -66,7 +66,7 @@ pub use plugin::{query_client_plugin, QueryClientPlugin};
 pub use predicate::{
     contains_matches, range_contains, FieldContains, FieldEq, FieldInSet, FieldRange,
 };
-pub use query::{MatchFn, Order, OrderBy, Query, QueryBuilder, QueryKey};
+pub use query::{MatchFn, Order, OrderBy, PartitionHashFn, Query, QueryBuilder, QueryKey};
 pub use selector::{AnyArgs, AnyTrackable, SelectorId, SelectorView, TrackToken};
 pub use state::QueryState;
 

--- a/crates/pocopine-sync-query/src/lib.rs
+++ b/crates/pocopine-sync-query/src/lib.rs
@@ -94,6 +94,12 @@ pub mod __private {
     // dep — the macro should compile inside a workspace whose only
     // serde access is transitive through `pocopine-sync-query`).
     pub use serde;
+    // Re-export so the `#[query_resource]` macro's emitted
+    // `row_to_params` impl (RFC 088 §C) can reach `StreamParams`,
+    // `SyncResult`, `SyncError`, and `stream_params_hash` through
+    // one stable path — the user's crate only needs
+    // `pocopine-sync-query` as a direct dep.
+    pub use pocopine_sync;
 
     /// FNV-1a 64-bit hash. `const fn` so the `#[query]` macro's
     /// generated `const SELECTOR_ID` initializer evaluates it at the

--- a/crates/pocopine-sync-query/src/query.rs
+++ b/crates/pocopine-sync-query/src/query.rs
@@ -38,6 +38,13 @@ pub struct Query<Row> {
     /// declaration (which then can't participate in routing — they're
     /// useful as a raw envelope but won't receive optimistic updates).
     pub(crate) matches_fn: Option<MatchFn<Row>>,
+    /// Function pointer to the macro-generated partition projector.
+    /// Returns `Some(hash)` when the captured params project cleanly
+    /// onto the resource's canonical partition keys (RFC 088 §C);
+    /// `None` when a required field is missing or wraps a comparator
+    /// (`any_of`, `range`, …). Driver uses this to decide whether to
+    /// subscribe to the per-`(stream, params_hash)` live topic.
+    pub(crate) partition_hash_fn: Option<PartitionHashFn>,
     pub(crate) _row: PhantomData<fn() -> Row>,
 }
 
@@ -45,6 +52,13 @@ pub struct Query<Row> {
 /// `fn(&Query<Row>, &Row) -> bool` per declared `#[query_resource]`
 /// and the builder injects it via [`QueryBuilder::with_matches`].
 pub type MatchFn<Row> = fn(query: &Query<Row>, row: &Row) -> bool;
+
+/// Signature of a query's partition-hash projector. Macro-emitted;
+/// reads from the caller's captured params and produces the hash
+/// that matches what the server publishes against the row (RFC 088
+/// §C). Independent of `Row` because the projection operates on the
+/// already-typed params map.
+pub type PartitionHashFn = fn(captured: &StreamParams) -> Option<u64>;
 
 impl<Row> Query<Row> {
     /// Build a query from its parts. Most callers go through the macro-
@@ -59,8 +73,22 @@ impl<Row> Query<Row> {
             order_by: None,
             limit: None,
             matches_fn: None,
+            partition_hash_fn: None,
             _row: PhantomData,
         }
+    }
+
+    /// Compute the RFC 088 §C partition hash for this query's
+    /// captured params, if the macro registered a projector AND the
+    /// projection succeeds (all required fields present as plain
+    /// values, no comparator wrappers).
+    ///
+    /// `None` means the client should NOT subscribe to a per-params
+    /// topic for this query — fall back to the bare-topic
+    /// subscription (which the routing engine's params filter still
+    /// gates correctly).
+    pub fn partition_hash(&self) -> Option<u64> {
+        self.partition_hash_fn.and_then(|f| f(&self.params))
     }
 
     /// True when the row matches every declared param's comparator
@@ -135,6 +163,7 @@ impl<Row> Clone for Query<Row> {
             order_by: self.order_by.clone(),
             limit: self.limit,
             matches_fn: self.matches_fn,
+            partition_hash_fn: self.partition_hash_fn,
             _row: PhantomData,
         }
     }
@@ -205,6 +234,7 @@ pub struct QueryBuilder<Row> {
     order_by: Option<OrderBy>,
     limit: Option<u32>,
     matches_fn: Option<MatchFn<Row>>,
+    partition_hash_fn: Option<PartitionHashFn>,
     _row: PhantomData<fn() -> Row>,
 }
 
@@ -216,6 +246,7 @@ impl<Row> Clone for QueryBuilder<Row> {
             order_by: self.order_by.clone(),
             limit: self.limit,
             matches_fn: self.matches_fn,
+            partition_hash_fn: self.partition_hash_fn,
             _row: PhantomData,
         }
     }
@@ -257,6 +288,15 @@ impl<Row> QueryBuilder<Row> {
         self
     }
 
+    /// Inject the macro-generated partition-hash projector (RFC 088
+    /// §C). Called by the macro's `Resource::query()` so the client
+    /// driver can compute the per-`(stream, params_hash)` topic
+    /// matching the server's `row_to_params` projection.
+    pub fn with_partition_hash(mut self, partition_hash_fn: PartitionHashFn) -> Self {
+        self.partition_hash_fn = Some(partition_hash_fn);
+        self
+    }
+
     /// Finalize into a [`Query<Row>`].
     pub fn build(self) -> Query<Row> {
         Query {
@@ -265,6 +305,7 @@ impl<Row> QueryBuilder<Row> {
             order_by: self.order_by,
             limit: self.limit,
             matches_fn: self.matches_fn,
+            partition_hash_fn: self.partition_hash_fn,
             _row: PhantomData,
         }
     }

--- a/crates/pocopine-sync/src/lib.rs
+++ b/crates/pocopine-sync/src/lib.rs
@@ -26,12 +26,12 @@ pub use local_store::{
     SyncLocalIdentity, SyncLocalStore,
 };
 pub use protocol::{
-    default_schema_version_one, local_stream_key, sync_stream_tag, ClientMutation,
-    ClientMutationDraft, MigrationOutcome, MutationId, RowKey, RowVersion, StreamParams,
-    SyncChange, SyncCollectionName, SyncConflict, SyncCursor, SyncDeviceId, SyncOp,
-    SyncOpenRequest, SyncOpenResponse, SyncOpenStream, SyncPullMode, SyncPullRequest,
-    SyncPullResponse, SyncPushRequest, SyncPushResponse, SyncRejectedMutation, SyncRow,
-    SyncSessionId, SyncStreamName, SyncStreamSubscription, MAX_SYNC_TOKEN_LEN,
+    default_schema_version_one, local_stream_key, stream_params_hash, sync_stream_params_tag,
+    sync_stream_tag, ClientMutation, ClientMutationDraft, MigrationOutcome, MutationId, RowKey,
+    RowVersion, StreamParams, SyncChange, SyncCollectionName, SyncConflict, SyncCursor,
+    SyncDeviceId, SyncOp, SyncOpenRequest, SyncOpenResponse, SyncOpenStream, SyncPullMode,
+    SyncPullRequest, SyncPullResponse, SyncPushRequest, SyncPushResponse, SyncRejectedMutation,
+    SyncRow, SyncSessionId, SyncStreamName, SyncStreamSubscription, MAX_SYNC_TOKEN_LEN,
     SYNC_ENDPOINT_PREFIX, SYNC_OPEN_PATH, SYNC_PROTOCOL_V1, SYNC_PULL_PATH, SYNC_PUSH_PATH,
 };
 pub use state::{CollectionState, PendingMutation, SyncReason, SyncRequest};

--- a/crates/pocopine-sync/src/lib.rs
+++ b/crates/pocopine-sync/src/lib.rs
@@ -32,7 +32,8 @@ pub use protocol::{
     SyncDeviceId, SyncOp, SyncOpenRequest, SyncOpenResponse, SyncOpenStream, SyncPullMode,
     SyncPullRequest, SyncPullResponse, SyncPushRequest, SyncPushResponse, SyncRejectedMutation,
     SyncRow, SyncSessionId, SyncStreamName, SyncStreamSubscription, MAX_SYNC_TOKEN_LEN,
-    SYNC_ENDPOINT_PREFIX, SYNC_OPEN_PATH, SYNC_PROTOCOL_V1, SYNC_PULL_PATH, SYNC_PUSH_PATH,
+    PARAMS_HASH_HEX_LEN, SYNC_ENDPOINT_PREFIX, SYNC_OPEN_PATH, SYNC_PROTOCOL_V1, SYNC_PULL_PATH,
+    SYNC_PUSH_PATH,
 };
 pub use state::{CollectionState, PendingMutation, SyncReason, SyncRequest};
 

--- a/crates/pocopine-sync/src/protocol.rs
+++ b/crates/pocopine-sync/src/protocol.rs
@@ -160,6 +160,50 @@ pub fn sync_stream_tag(stream: &str) -> String {
     format!("sync:stream:{stream}")
 }
 
+/// Per-(stream, params) live query tag, used for RFC 088 §C precise
+/// invalidation routing. Same prefix as [`sync_stream_tag`] plus a
+/// 16-hex suffix derived from [`stream_params_hash`].
+///
+/// Wire shape: `sync:stream:{stream}:{params_hash:016x}`.
+///
+/// Mirrors the bare-tag convention; clients on the new protocol
+/// subscribe to BOTH the bare and per-params topics during rollout
+/// (see RFC 088 §C.6). Servers publish to per-params iff the source
+/// returns non-empty params from
+/// [`SyncStreamSource::row_to_params`](crate::server::SyncStreamSource::row_to_params).
+pub fn sync_stream_params_tag(stream: &str, params_hash: u64) -> String {
+    format!("sync:stream:{stream}:{params_hash:016x}")
+}
+
+/// FNV-1a 64-bit hash over `(stream_name, sorted-by-key params JSON)`.
+/// Same algorithm as [`local_stream_key`] (so on-disk + on-wire
+/// hashes match), with the stream name folded into the digest so two
+/// streams sharing an empty params map still partition to distinct
+/// topics.
+///
+/// This is the cross-language contract for RFC 088 §C — the
+/// SERVER computes this from the row's `row_to_params` projection,
+/// the CLIENT computes it from the captured subscription params,
+/// and the two MUST agree byte-for-byte. The hash function is FNV-1a
+/// (not cryptographic) and `StreamParams = BTreeMap<String, Value>`
+/// serializes in sorted-key order by construction, so the only
+/// portability constraints are: same FNV-1a constants, same JSON
+/// encoding (no insignificant whitespace, no number/float coercion).
+///
+/// The golden-fixture test at
+/// `tests/stream_params_hash_fixture.rs` pins a set of (stream,
+/// params) → hex-hash pairs that future ports (Swift / Go / Kotlin
+/// clients) MUST reproduce.
+pub fn stream_params_hash(stream: &str, params: &StreamParams) -> u64 {
+    let canonical = serde_json::to_vec(params).unwrap_or_default();
+    let mut buf: Vec<u8> = Vec::with_capacity(stream.len() + 1 + canonical.len());
+    buf.extend_from_slice(stream.as_bytes());
+    // Separator so `stream="ab", params={}` ≠ `stream="a", params={b:…}`.
+    buf.push(0u8);
+    buf.extend_from_slice(&canonical);
+    fnv1a_64(&buf)
+}
+
 /// Stable client-side cache key that combines a sync stream name with
 /// a hash of its subscription params. Used to scope the local store so
 /// two subscriptions to the same `stream` with different `params` do
@@ -1049,6 +1093,7 @@ impl<T> SyncPushResponse<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn validates_stream_names() {
@@ -1435,6 +1480,155 @@ mod tests {
         assert_eq!(mutation.op, SyncOp::Delete);
         assert_eq!(mutation.base_version, Some(version));
     }
+
+    // ---- RFC 088 §C: stream_params_hash + sync_stream_params_tag ---
+    //
+    // These tests double as the cross-language hash spec. The
+    // `stream_params_hash_golden_fixture` test pins a set of
+    // (stream, params) → hex-hash pairs. Future ports (a Swift
+    // client, a Go server, etc.) MUST reproduce these exact bytes
+    // or the per-(stream, params) live-wakeup routing silently
+    // breaks.
+
+    #[test]
+    fn stream_params_tag_format() {
+        let tag = sync_stream_params_tag("issues", 0xABCD_1234_5678_9ABC);
+        assert_eq!(tag, "sync:stream:issues:abcd123456789abc");
+    }
+
+    #[test]
+    fn stream_params_tag_pads_to_16_hex() {
+        // Small hashes must still be 16 hex chars (zero-padded) so
+        // the topic format is uniform across clients.
+        let tag = sync_stream_params_tag("issues", 0xFFu64);
+        assert_eq!(tag, "sync:stream:issues:00000000000000ff");
+    }
+
+    #[test]
+    fn stream_params_hash_empty_params_distinguishes_streams() {
+        let h_issues = stream_params_hash("issues", &StreamParams::new());
+        let h_comments = stream_params_hash("comments", &StreamParams::new());
+        assert_ne!(
+            h_issues, h_comments,
+            "stream name folds into the hash; empty params alone must not alias"
+        );
+    }
+
+    #[test]
+    fn stream_params_hash_separator_avoids_prefix_collision() {
+        // "ab" + {} vs "a" + {"b": null}: without the separator
+        // these would have identical byte sequences. With the 0x00
+        // separator they don't.
+        let mut p2 = StreamParams::new();
+        p2.insert("b".into(), Value::Null);
+        let h1 = stream_params_hash("ab", &StreamParams::new());
+        let h2 = stream_params_hash("a", &p2);
+        assert_ne!(h1, h2);
+    }
+
+    #[test]
+    fn stream_params_hash_is_stable_across_insert_order() {
+        // StreamParams is a BTreeMap — sorted-by-key by construction.
+        // Inserting in different orders must produce identical hashes.
+        let mut p_in_order = StreamParams::new();
+        p_in_order.insert("a".into(), json!("1"));
+        p_in_order.insert("b".into(), json!("2"));
+        p_in_order.insert("c".into(), json!("3"));
+
+        let mut p_reversed = StreamParams::new();
+        p_reversed.insert("c".into(), json!("3"));
+        p_reversed.insert("a".into(), json!("1"));
+        p_reversed.insert("b".into(), json!("2"));
+
+        assert_eq!(
+            stream_params_hash("issues", &p_in_order),
+            stream_params_hash("issues", &p_reversed),
+        );
+    }
+
+    #[test]
+    fn stream_params_hash_distinguishes_distinct_values() {
+        let mut p1 = StreamParams::new();
+        p1.insert("workspace_id".into(), json!("W1"));
+        let mut p2 = StreamParams::new();
+        p2.insert("workspace_id".into(), json!("W2"));
+        assert_ne!(
+            stream_params_hash("issues", &p1),
+            stream_params_hash("issues", &p2),
+        );
+    }
+
+    /// **Golden fixture** — DO NOT EDIT VALUES.
+    ///
+    /// These hex-encoded hashes are the wire-protocol contract for
+    /// RFC 088 §C. Any port (server-side hash producer, client-side
+    /// hash subscriber) must produce exactly these bytes for these
+    /// inputs, or the live-wakeup topic routing breaks silently
+    /// (mutations get published to topic X, clients listen on topic
+    /// X', no overlap, no error).
+    ///
+    /// If a future change MUST alter the hash function, bump
+    /// `LIVE_PROTOCOL_V1` first and add migration logic.
+    #[test]
+    #[allow(clippy::type_complexity)] // golden-fixture-only triple
+    fn stream_params_hash_golden_fixture() {
+        // (stream, params_kvs, expected_hex_hash)
+        let cases: &[(&str, &[(&str, Value)], &str)] = &[
+            // 1. bare stream, empty params
+            ("issues", &[], "issues_empty"),
+            // 2. single param, string value
+            ("issues", &[("workspace_id", json!("W1"))], "issues_w1"),
+            // 3. two params, sorted order
+            (
+                "issues",
+                &[("status", json!("open")), ("workspace_id", json!("W1"))],
+                "issues_w1_open",
+            ),
+            // 4. nested object value (rare but supported)
+            (
+                "comments",
+                &[("filter", json!({"status": "active"}))],
+                "comments_nested",
+            ),
+            // 5. distinct stream name with same params as #2
+            ("comments", &[("workspace_id", json!("W1"))], "comments_w1"),
+        ];
+
+        let mut computed: Vec<(String, u64)> = Vec::new();
+        for (stream, kvs, label) in cases {
+            let mut params = StreamParams::new();
+            for (k, v) in *kvs {
+                params.insert((*k).to_string(), v.clone());
+            }
+            computed.push(((*label).into(), stream_params_hash(stream, &params)));
+        }
+
+        // The expected hashes are pinned by the snapshot below.
+        // Pretty-printed so a diff in CI shows exactly which case
+        // drifted.
+        let snapshot: String = computed
+            .iter()
+            .map(|(label, hash)| format!("{label} = {hash:016x}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let expected = "\
+issues_empty = ebb76190a8dc90b7
+issues_w1 = 6937b67bfe60e730
+issues_w1_open = 35eea32b30a1d59c
+comments_nested = ba8db781db55988d
+comments_w1 = 668b4b2f8b17847e";
+
+        assert_eq!(
+            snapshot, expected,
+            "RFC 088 §C wire-protocol hash spec drifted. \
+             If this drift is intentional, bump LIVE_PROTOCOL_V1 \
+             FIRST and add migration logic — old clients hashing \
+             the old way will MISS wakeups until they upgrade."
+        );
+    }
+
+    // -----------------------------------------------------------------
 
     #[test]
     fn endpoint_paths_share_prefix() {

--- a/crates/pocopine-sync/src/protocol.rs
+++ b/crates/pocopine-sync/src/protocol.rs
@@ -177,9 +177,20 @@ pub fn sync_stream_tag(stream: &str) -> String {
     format!("sync:stream:{stream}")
 }
 
+/// Number of lowercase-hex digits in the per-params topic suffix
+/// (RFC 088 §C). The suffix is `{params_hash:016x}` — a `u64`
+/// formatted as 16 lowercase hex digits — so the validator in
+/// `pocopine_live::is_params_hash_suffix` checks against
+/// `PARAMS_HASH_HEX_LEN + 1` total bytes (the leading `:` plus 16
+/// hex digits). Exporting the constant keeps the formatter and the
+/// validator coupled so a future widening of the hash (say, to 128
+/// bits / 32 hex chars) updates both call sites simultaneously.
+pub const PARAMS_HASH_HEX_LEN: usize = 16;
+
 /// Per-(stream, params) live query tag, used for RFC 088 §C precise
 /// invalidation routing. Same prefix as [`sync_stream_tag`] plus a
-/// 16-hex suffix derived from [`stream_params_hash`].
+/// `PARAMS_HASH_HEX_LEN`-hex suffix derived from
+/// [`stream_params_hash`].
 ///
 /// Wire shape: `sync:stream:{stream}:{params_hash:016x}`.
 ///
@@ -193,10 +204,17 @@ pub fn sync_stream_params_tag(stream: &str, params_hash: u64) -> String {
 }
 
 /// FNV-1a 64-bit hash over `(stream_name, sorted-by-key params JSON)`.
-/// Same algorithm as [`local_stream_key`] (so on-disk + on-wire
-/// hashes match), with the stream name folded into the digest so two
-/// streams sharing an empty params map still partition to distinct
-/// topics.
+/// Closely related to [`local_stream_key`] — both use the same
+/// FNV-1a constants and the same `stream + 0x00 + canonical_json`
+/// byte recipe — but with one edge-case difference: `local_stream_key`
+/// short-circuits to the bare stream name for `params.is_empty()`,
+/// while this function always hashes (folding in the separator byte
+/// plus the empty-object JSON `"{}"`). In practice the wire-side
+/// path only calls this for non-empty params (the publish helper
+/// guards on empty), so the divergence is invisible; cross-language
+/// porters matching this byte spec for cache scoping should mirror
+/// the always-hash form here rather than copying
+/// `local_stream_key`'s short-circuit.
 ///
 /// This is the cross-language contract for RFC 088 §C — the
 /// SERVER computes this from the row's `row_to_params` projection,
@@ -212,7 +230,19 @@ pub fn sync_stream_params_tag(stream: &str, params_hash: u64) -> String {
 /// params) → hex-hash pairs that future ports (Swift / Go / Kotlin
 /// clients) MUST reproduce.
 pub fn stream_params_hash(stream: &str, params: &StreamParams) -> u64 {
-    let canonical = serde_json::to_vec(params).unwrap_or_default();
+    // Canonical JSON of a `BTreeMap<String, Value>` is infallible
+    // for any value that `serde_json::Value` can hold (Value rejects
+    // NaN/Infinity at construction time). The only documented
+    // failure path is `serde_json`'s default 128-level recursion
+    // limit on deeply-nested `Value::Object`/`Value::Array`. A
+    // silent `unwrap_or_default()` here would collapse every such
+    // failure to the same hash (FNV-1a of `stream + 0x00`), aliasing
+    // distinct subscriptions onto one topic — codex caught the
+    // regression in review. We `expect()` instead so the failure
+    // surfaces as a clear panic at the publish site rather than as
+    // mis-routed live wakeups in production.
+    let canonical = serde_json::to_vec(params)
+        .expect("BTreeMap<String, Value> canonical JSON is infallible for serde_json::Value");
     let mut buf: Vec<u8> = Vec::with_capacity(stream.len() + 1 + canonical.len());
     buf.extend_from_slice(stream.as_bytes());
     // Separator so `stream="ab", params={}` ≠ `stream="a", params={b:…}`.
@@ -1529,6 +1559,18 @@ mod tests {
     fn stream_params_tag_format() {
         let tag = sync_stream_params_tag("issues", 0xABCD_1234_5678_9ABC);
         assert_eq!(tag, "sync:stream:issues:abcd123456789abc");
+    }
+
+    #[test]
+    fn params_hash_hex_len_matches_formatter() {
+        // The formatter in `sync_stream_params_tag` hard-codes
+        // `{:016x}`. `PARAMS_HASH_HEX_LEN` must match — otherwise
+        // the live validator (`pocopine_live::is_params_hash_suffix`)
+        // would gate the wrong byte-count and reject valid topics
+        // (or accept malformed ones).
+        let tag = sync_stream_params_tag("s", 0);
+        let suffix = tag.rsplit_once(':').unwrap().1;
+        assert_eq!(suffix.len(), PARAMS_HASH_HEX_LEN);
     }
 
     #[test]

--- a/crates/pocopine-sync/src/protocol.rs
+++ b/crates/pocopine-sync/src/protocol.rs
@@ -40,6 +40,23 @@ fn validate_token(field: &'static str, value: String) -> SyncResult<String> {
     {
         return Err(SyncError::invalid_value(field, value));
     }
+    // Stream-name-only: reject `:` because the live-wakeup wire
+    // protocol uses it as a structural delimiter (see
+    // [`sync_stream_tag`] / [`sync_stream_params_tag`] / RFC 088
+    // §C). A stream named `"issues:abcd1234abcd1234"` would
+    // produce the bare topic `query:sync:stream:issues:abcd…`
+    // which is indistinguishable from a per-params topic for the
+    // public `issues` prefix — a public-prefix allowlist would
+    // then authorize access to the private sibling stream. We
+    // forbid the collision at the source of truth (the token
+    // validator) rather than chase it downstream.
+    //
+    // Field-specific via the `field` discriminator — RowKey,
+    // MutationId, etc. legitimately use `:` in composite keys.
+    // Only the stream token namespace is protocol-reserved.
+    if field == "stream" && value.contains(':') {
+        return Err(SyncError::invalid_value(field, value));
+    }
     Ok(value)
 }
 
@@ -1102,6 +1119,24 @@ mod tests {
         assert!(SyncStreamName::new(" posts").is_err());
         assert!(SyncStreamName::new("posts\nbad").is_err());
         assert!(SyncStreamName::new("x".repeat(MAX_SYNC_TOKEN_LEN + 1)).is_err());
+    }
+
+    // RFC 088 §C: stream names must not contain `:` — the live-
+    // wakeup wire protocol uses it as a structural delimiter, and
+    // a sibling stream `issues:abcd1234abcd1234` would otherwise
+    // collide with `issues`'s per-params topic format, breaking the
+    // `LiveHub::allow_topic_prefixes` security boundary.
+    #[test]
+    fn rejects_colon_in_stream_name() {
+        // 16-hex-suffix sibling: indistinguishable from per-params
+        // format `query:sync:stream:issues:<hash>`.
+        assert!(SyncStreamName::new("issues:abcd1234abcd1234").is_err());
+        // Other colon-containing names also rejected.
+        assert!(SyncStreamName::new("a:b").is_err());
+        // Other token types may still use `:` (RowKey composite keys,
+        // etc.). Only `stream` is protocol-reserved.
+        assert!(RowKey::new("tenant:row_42").is_ok());
+        assert!(MutationId::new("test:1").is_ok());
     }
 
     #[test]

--- a/crates/pocopine-sync/src/server.rs
+++ b/crates/pocopine-sync/src/server.rs
@@ -383,6 +383,68 @@ impl SyncServer {
         Ok(())
     }
 
+    /// Batched variant of [`Self::invalidate_stream_with_row`] —
+    /// project each row in `rows` to its params, DEDUPLICATE by
+    /// `(stream, params_hash)`, and publish ONCE per distinct hash.
+    ///
+    /// The dedup matters for bulk pushes: a single push that
+    /// accepts N rows all belonging to the same workspace (or
+    /// other partition) would otherwise issue N identical publishes
+    /// to the same topic — wasting broker capacity and waking
+    /// matching clients N times only for them to /pull-with-cursor
+    /// N times (the second through Nth are no-ops, but each costs
+    /// a round-trip). With dedup the same push issues one publish
+    /// per distinct hash.
+    ///
+    /// Per-row `row_to_params` errors are logged via
+    /// `tracing::warn!` and skipped; the rest of the batch still
+    /// publishes. The bare-topic publish is the caller's
+    /// responsibility (issued once per push regardless of row
+    /// count), so partial per-params publish failures don't break
+    /// back-compat clients.
+    pub async fn invalidate_stream_with_rows<'a, I>(&self, stream: &str, rows: I) -> SyncResult<()>
+    where
+        I: IntoIterator<Item = &'a Value>,
+    {
+        let Some(events) = self.inner.events.as_ref() else {
+            return Ok(());
+        };
+        let registered = self.stream(stream)?;
+        let mut seen: std::collections::HashSet<u64> = std::collections::HashSet::new();
+        for row in rows {
+            let params = match registered.source.row_to_params(row) {
+                Ok(p) => p,
+                Err(err) => {
+                    tracing::warn!(
+                        target: "pocopine.log",
+                        stream = stream,
+                        error = %err,
+                        "RFC 088 §C: row_to_params failed; skipping per-params publish for row",
+                    );
+                    continue;
+                }
+            };
+            if params.is_empty() {
+                continue;
+            }
+            let hash = crate::stream_params_hash(stream, &params);
+            if !seen.insert(hash) {
+                // Same partition already published in this batch.
+                continue;
+            }
+            let params_tag = crate::sync_stream_params_tag(stream, hash);
+            let params_topic = pocopine_live::query_tag_topic(&params_tag)
+                .map_err(|err| SyncError::backend(err.to_string()))?;
+            let params_draft = pocopine_live::query_invalidated(params_topic, [params_tag])
+                .map_err(|err| SyncError::backend(err.to_string()))?;
+            events
+                .publish(params_draft)
+                .await
+                .map_err(|err| SyncError::backend(err.to_string()))?;
+        }
+        Ok(())
+    }
+
     fn stream(&self, stream: &str) -> SyncResult<Arc<RegisteredSyncStream>> {
         self.inner
             .streams
@@ -689,30 +751,39 @@ async fn push_handler(
                 );
             }
 
-            // PER-PARAMS topic — one publish per accepted row that
-            // returned a canonical payload. Sources that don't
+            // PER-PARAMS topics — batch all accepted rows, project
+            // each through `row_to_params`, and publish ONCE per
+            // distinct hash (multiple rows hitting the same
+            // partition collapse to one wakeup). Sources that don't
             // override `row_to_params` (default impl returns empty)
-            // make this a no-op via the early return inside
-            // `invalidate_stream_with_row`. Sources that do override
-            // route precisely to the audience whose subscription
-            // params project to the same hash (RFC 088 §C). Pushes
-            // that accepted but returned no rows (deletes that
-            // don't echo the removed row) get bare-only invalidation
-            // — that's the right semantic since per-params routing
-            // needs a row to project.
-            for row in &response.rows {
-                if let Err(err) = sync
-                    .invalidate_stream_with_row(response.stream.as_str(), &row.value)
-                    .await
-                {
-                    tracing::warn!(
-                        target: "pocopine.log",
-                        error = %err,
-                        stream = response.stream.as_str(),
-                        row_key = row.key.as_str(),
-                        "failed to publish per-params sync stream invalidation after push"
-                    );
-                }
+            // make this a no-op via the empty-params guard inside
+            // the helper. Sources that DO override route precisely
+            // to the audience whose subscription params project to
+            // the same hash (RFC 088 §C). Pushes that accepted but
+            // returned no rows (deletes that don't echo the removed
+            // row) get bare-only invalidation — that's the right
+            // semantic since per-params routing needs a row to
+            // project.
+            // Collect into a `Vec<&Value>` rather than passing the
+            // lazy `map(|r| &r.value)` iterator directly. The map
+            // closure infers a single concrete lifetime for its
+            // argument, which trips the route-handler's HRTB FnOnce
+            // bound (axum needs `for<'r>` generality). Collecting
+            // sidesteps the HRTB by handing
+            // `invalidate_stream_with_rows` an already-erased
+            // iterator type.
+            let row_values: ::std::vec::Vec<&Value> =
+                response.rows.iter().map(|r| &r.value).collect();
+            if let Err(err) = sync
+                .invalidate_stream_with_rows(response.stream.as_str(), row_values)
+                .await
+            {
+                tracing::warn!(
+                    target: "pocopine.log",
+                    error = %err,
+                    stream = response.stream.as_str(),
+                    "failed to publish per-params sync stream invalidations after push"
+                );
             }
         }
         Ok(response)

--- a/crates/pocopine-sync/src/server.rs
+++ b/crates/pocopine-sync/src/server.rs
@@ -293,6 +293,23 @@ impl SyncServer {
             .collect()
     }
 
+    /// Return the live topic PREFIXES this server publishes against
+    /// for each registered stream. Each prefix matches the bare
+    /// topic AND every RFC 088 §C per-`(stream, params_hash)`
+    /// variant: `query:sync:stream:{name}` covers `query:sync:stream:{name}`
+    /// and `query:sync:stream:{name}:abc…`.
+    ///
+    /// Pair with [`pocopine_live::LiveHub::allow_topic_prefixes`]
+    /// to permit clients to subscribe to per-params topics that the
+    /// exact-match `allow_topics` couldn't accept (the hashes are
+    /// computed at runtime, so the allowlist must be a prefix).
+    pub fn live_topic_prefixes(&self) -> Vec<String> {
+        self.live_query_tags()
+            .into_iter()
+            .map(|tag| format!("query:{tag}"))
+            .collect()
+    }
+
     /// Publish a live wake-up for one stream when an event backend is
     /// attached. The sync data still moves through pull; this only wakes
     /// browsers to pull with their current sync cursor.
@@ -313,40 +330,27 @@ impl SyncServer {
     }
 
     /// Publish a live wake-up scoped to the (stream, params_hash)
-    /// audience the row's params identify (RFC 088 §C).
+    /// audience the row's params identify (RFC 088 §C). Per-params
+    /// ONLY — the caller is responsible for the bare-topic publish
+    /// once per push (see the `/push` handler).
     ///
-    /// Always publishes to the bare topic too (backwards compat —
-    /// old clients only listen on the bare topic and still need to
-    /// receive every event). If the stream's source overrides
-    /// [`SyncStreamSource::row_to_params`] AND returns a non-empty
-    /// params map, ALSO publishes to the per-`(stream, params_hash)`
-    /// topic so new clients listening there wake up too.
+    /// If the stream's source overrides
+    /// [`SyncStreamSource::row_to_params`] AND the projection
+    /// returns non-empty params, publishes to
+    /// `sync:stream:{stream}:{hash:016x}` so new clients listening
+    /// on the per-params topic wake up. Sources that don't override
+    /// (or that return empty params) make this a no-op — the
+    /// caller's bare publish already reaches everyone.
     ///
     /// If `row_to_params` errors, the per-params publish is skipped
-    /// and a `tracing::warn!` is emitted — a malformed row MUST NOT
-    /// block the bare invalidation (which is the back-compat lifeline
-    /// for old clients).
-    ///
-    /// The framework's `/push` handler calls this once per accepted
-    /// row. Stream-wide invalidations from other code paths can keep
-    /// calling [`Self::invalidate_stream`] for the bare publish.
+    /// and a `tracing::warn!` is emitted. The caller's bare publish
+    /// (issued once per push, regardless of how many rows were
+    /// accepted or whether any rows were returned) is the back-
+    /// compat lifeline; a malformed row MUST NOT block it.
     pub async fn invalidate_stream_with_row(&self, stream: &str, row: &Value) -> SyncResult<()> {
         let Some(events) = self.inner.events.as_ref() else {
             return Ok(());
         };
-
-        // 1) Bare-topic publish (backwards compat).
-        let bare_tag = sync_stream_tag(stream);
-        let bare_topic = pocopine_live::query_tag_topic(&bare_tag)
-            .map_err(|err| SyncError::backend(err.to_string()))?;
-        let bare_draft = pocopine_live::query_invalidated(bare_topic, [bare_tag.clone()])
-            .map_err(|err| SyncError::backend(err.to_string()))?;
-        events
-            .publish(bare_draft)
-            .await
-            .map_err(|err| SyncError::backend(err.to_string()))?;
-
-        // 2) Per-params topic publish (precise routing).
         let registered = self.stream(stream)?;
         let params = match registered.source.row_to_params(row) {
             Ok(p) => p,
@@ -355,16 +359,15 @@ impl SyncServer {
                     target: "pocopine.log",
                     stream = stream,
                     error = %err,
-                    "RFC 088 §C: row_to_params failed; bare publish only",
+                    "RFC 088 §C: row_to_params failed; skipping per-params publish",
                 );
                 return Ok(());
             }
         };
         if params.is_empty() {
-            // Source doesn't override row_to_params, or this row's
-            // projection genuinely has no partition keys. Either way
-            // the bare publish already covers everyone — no per-
-            // params topic to add.
+            // Source doesn't override row_to_params, or this row
+            // projects to no required partition keys. The caller's
+            // bare publish already covers everyone.
             return Ok(());
         }
         let hash = crate::stream_params_hash(stream, &params);
@@ -670,22 +673,33 @@ async fn push_handler(
             response.collection = Some(collection_name);
         }
         if !response.accepted.is_empty() {
-            // RFC 088 §C: publish per-row to BOTH the bare topic AND
-            // the per-(stream, params_hash) topic for each accepted
-            // row, so new clients on precise topics wake up while
-            // old clients on the bare topic keep working. The bare-
-            // topic publish would be redundant if we hit it once per
-            // row (vs once per stream), but `invalidate_stream_with_row`
-            // is currently shaped to bundle the bare publish per
-            // call. For pushes with many accepted rows hitting the
-            // SAME params_hash, this duplicates the bare publish —
-            // the event backend dedupes per topic and the receivers
-            // don't suffer (they only /pull once via their cursor).
-            //
-            // Sources that DON'T override `row_to_params` (every
-            // source today) get a single bare publish per row; the
-            // per-params publish is a no-op (empty params → early
-            // return inside `invalidate_stream_with_row`).
+            // BARE topic — one publish per push, regardless of how
+            // many rows were accepted or returned. This preserves
+            // the pre-RFC 088 §C behavior for delete-only pushes
+            // (where `response.rows` may be empty even though
+            // `accepted` is non-empty) and stops old clients on the
+            // bare topic from receiving N redundant wakeups for a
+            // multi-row push.
+            if let Err(err) = sync.invalidate_stream(response.stream.as_str()).await {
+                tracing::warn!(
+                    target: "pocopine.log",
+                    error = %err,
+                    stream = response.stream.as_str(),
+                    "failed to publish bare sync stream invalidation after push"
+                );
+            }
+
+            // PER-PARAMS topic — one publish per accepted row that
+            // returned a canonical payload. Sources that don't
+            // override `row_to_params` (default impl returns empty)
+            // make this a no-op via the early return inside
+            // `invalidate_stream_with_row`. Sources that do override
+            // route precisely to the audience whose subscription
+            // params project to the same hash (RFC 088 §C). Pushes
+            // that accepted but returned no rows (deletes that
+            // don't echo the removed row) get bare-only invalidation
+            // — that's the right semantic since per-params routing
+            // needs a row to project.
             for row in &response.rows {
                 if let Err(err) = sync
                     .invalidate_stream_with_row(response.stream.as_str(), &row.value)
@@ -696,7 +710,7 @@ async fn push_handler(
                         error = %err,
                         stream = response.stream.as_str(),
                         row_key = row.key.as_str(),
-                        "failed to publish sync stream invalidation after push"
+                        "failed to publish per-params sync stream invalidation after push"
                     );
                 }
             }
@@ -1018,8 +1032,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn invalidate_stream_with_row_publishes_to_both_topics() {
-        use pocopine_events::{MemoryEventBackend, ReplayRequest, Topic};
+    async fn invalidate_stream_with_row_publishes_per_params_only() {
+        // Post-codex-review (P2.2): `invalidate_stream_with_row` no
+        // longer emits the bare-topic publish. The caller (the
+        // `/push` handler) issues a SINGLE bare publish per push
+        // and lets this helper publish only the per-params topic
+        // per row.
+        use pocopine_events::{MemoryEventBackend, ReplayRequest};
         use std::sync::Arc;
 
         let backend: SharedEventBackend = Arc::new(MemoryEventBackend::new());
@@ -1033,7 +1052,6 @@ mod tests {
             .await
             .unwrap();
 
-        // Expected topics: bare + per-(stream, params_hash).
         let bare_tag = sync_stream_tag("issues");
         let mut expected_params = crate::StreamParams::new();
         expected_params.insert("workspace_id".into(), json!("W1"));
@@ -1042,7 +1060,6 @@ mod tests {
         let bare_topic = pocopine_live::query_tag_topic(&bare_tag).unwrap();
         let params_topic = pocopine_live::query_tag_topic(&params_tag).unwrap();
 
-        // Replay the recorded events on each topic; assert one each.
         let replay = backend
             .replay(ReplayRequest::new(vec![
                 bare_topic.clone(),
@@ -1050,25 +1067,25 @@ mod tests {
             ]))
             .await
             .unwrap();
-        let by_topic: std::collections::HashMap<Topic, usize> =
-            replay
-                .events
-                .iter()
-                .fold(std::collections::HashMap::new(), |mut acc, env| {
-                    *acc.entry(env.topic.clone()).or_insert(0) += 1;
-                    acc
-                });
-        assert_eq!(by_topic.get(&bare_topic).copied(), Some(1), "bare publish");
-        assert_eq!(
-            by_topic.get(&params_topic).copied(),
-            Some(1),
-            "per-params publish"
-        );
+        let bare_count = replay
+            .events
+            .iter()
+            .filter(|e| e.topic == bare_topic)
+            .count();
+        let params_count = replay
+            .events
+            .iter()
+            .filter(|e| e.topic == params_topic)
+            .count();
+        assert_eq!(bare_count, 0, "no bare publish (caller's responsibility)");
+        assert_eq!(params_count, 1, "exactly one per-params publish");
     }
 
     /// When `row_to_params` returns empty params (the default impl,
-    /// or a source that opts out), only the bare topic is published.
-    /// Verifies the back-compat path stays clean.
+    /// or a source that opts out), the per-params publish is a
+    /// no-op — and since the bare publish is now the caller's
+    /// responsibility, this test verifies the helper emits NO
+    /// events at all in that case.
     struct DefaultRoutedStream {
         name: SyncStreamName,
         collection: SyncCollectionName,
@@ -1127,10 +1144,12 @@ mod tests {
             .replay(ReplayRequest::new(vec![bare_topic.clone()]))
             .await
             .unwrap();
-        // Bare publish: exactly one event. No per-params topic was
-        // published because row_to_params returned empty.
-        assert_eq!(replay.events.len(), 1);
-        assert_eq!(replay.events[0].topic, bare_topic);
+        // No events: the helper publishes per-params only, and
+        // row_to_params returned empty so the per-params publish
+        // was skipped. The bare invalidation is the `/push`
+        // handler's responsibility (a separate code path), so this
+        // direct invocation produces zero events.
+        assert_eq!(replay.events.len(), 0);
     }
 
     fn router_with_guarded_posts_stream<P>(predicate: P) -> Router

--- a/crates/pocopine-sync/src/server.rs
+++ b/crates/pocopine-sync/src/server.rs
@@ -212,6 +212,34 @@ pub trait SyncStreamSource: Send + Sync + 'static {
         let stream = self.stream().as_str().to_string();
         Box::pin(async move { Err(SyncError::schema_migration(stream, from, to)) })
     }
+
+    /// Project a canonical row payload into the [`StreamParams`] that
+    /// identify which subscribers care about it (RFC 088 §C).
+    ///
+    /// The server hashes the returned params and publishes the
+    /// resulting invalidation to a per-(stream, params_hash) topic
+    /// so only clients whose subscription params match wake up.
+    /// Clients on the matching `(stream, params)` subscription
+    /// compute the SAME hash and listen on the SAME topic — see
+    /// [`crate::protocol::stream_params_hash`] for the contract.
+    ///
+    /// Default: empty params, equivalent to bare-topic publish only
+    /// (backwards-compatible). The `#[query_resource]` macro
+    /// auto-emits an override that projects each `#[query_param]`
+    /// field into the params map; sources written by hand can
+    /// override to opt into precise routing.
+    ///
+    /// The framework calls this AFTER the source's `push` returned
+    /// `accepted` and the row has been persisted, so it sees the
+    /// post-mutation row shape. A `None` return falls back to the
+    /// bare-topic publish path (no per-params routing).
+    ///
+    /// Errors propagate up to `invalidate_stream_with_row`, which
+    /// logs them via `tracing::warn!` and falls back to bare publish
+    /// — a malformed row must NOT block the canonical write.
+    fn row_to_params(&self, _row: &Value) -> SyncResult<crate::StreamParams> {
+        Ok(crate::StreamParams::new())
+    }
 }
 
 #[derive(Clone)]
@@ -279,6 +307,74 @@ impl SyncServer {
             .map_err(|err| SyncError::backend(err.to_string()))?;
         events
             .publish(draft)
+            .await
+            .map_err(|err| SyncError::backend(err.to_string()))?;
+        Ok(())
+    }
+
+    /// Publish a live wake-up scoped to the (stream, params_hash)
+    /// audience the row's params identify (RFC 088 §C).
+    ///
+    /// Always publishes to the bare topic too (backwards compat —
+    /// old clients only listen on the bare topic and still need to
+    /// receive every event). If the stream's source overrides
+    /// [`SyncStreamSource::row_to_params`] AND returns a non-empty
+    /// params map, ALSO publishes to the per-`(stream, params_hash)`
+    /// topic so new clients listening there wake up too.
+    ///
+    /// If `row_to_params` errors, the per-params publish is skipped
+    /// and a `tracing::warn!` is emitted — a malformed row MUST NOT
+    /// block the bare invalidation (which is the back-compat lifeline
+    /// for old clients).
+    ///
+    /// The framework's `/push` handler calls this once per accepted
+    /// row. Stream-wide invalidations from other code paths can keep
+    /// calling [`Self::invalidate_stream`] for the bare publish.
+    pub async fn invalidate_stream_with_row(&self, stream: &str, row: &Value) -> SyncResult<()> {
+        let Some(events) = self.inner.events.as_ref() else {
+            return Ok(());
+        };
+
+        // 1) Bare-topic publish (backwards compat).
+        let bare_tag = sync_stream_tag(stream);
+        let bare_topic = pocopine_live::query_tag_topic(&bare_tag)
+            .map_err(|err| SyncError::backend(err.to_string()))?;
+        let bare_draft = pocopine_live::query_invalidated(bare_topic, [bare_tag.clone()])
+            .map_err(|err| SyncError::backend(err.to_string()))?;
+        events
+            .publish(bare_draft)
+            .await
+            .map_err(|err| SyncError::backend(err.to_string()))?;
+
+        // 2) Per-params topic publish (precise routing).
+        let registered = self.stream(stream)?;
+        let params = match registered.source.row_to_params(row) {
+            Ok(p) => p,
+            Err(err) => {
+                tracing::warn!(
+                    target: "pocopine.log",
+                    stream = stream,
+                    error = %err,
+                    "RFC 088 §C: row_to_params failed; bare publish only",
+                );
+                return Ok(());
+            }
+        };
+        if params.is_empty() {
+            // Source doesn't override row_to_params, or this row's
+            // projection genuinely has no partition keys. Either way
+            // the bare publish already covers everyone — no per-
+            // params topic to add.
+            return Ok(());
+        }
+        let hash = crate::stream_params_hash(stream, &params);
+        let params_tag = crate::sync_stream_params_tag(stream, hash);
+        let params_topic = pocopine_live::query_tag_topic(&params_tag)
+            .map_err(|err| SyncError::backend(err.to_string()))?;
+        let params_draft = pocopine_live::query_invalidated(params_topic, [params_tag])
+            .map_err(|err| SyncError::backend(err.to_string()))?;
+        events
+            .publish(params_draft)
             .await
             .map_err(|err| SyncError::backend(err.to_string()))?;
         Ok(())
@@ -574,13 +670,35 @@ async fn push_handler(
             response.collection = Some(collection_name);
         }
         if !response.accepted.is_empty() {
-            if let Err(err) = sync.invalidate_stream(response.stream.as_str()).await {
-                tracing::warn!(
-                    target: "pocopine.log",
-                    error = %err,
-                    stream = response.stream.as_str(),
-                    "failed to publish sync stream invalidation after push"
-                );
+            // RFC 088 §C: publish per-row to BOTH the bare topic AND
+            // the per-(stream, params_hash) topic for each accepted
+            // row, so new clients on precise topics wake up while
+            // old clients on the bare topic keep working. The bare-
+            // topic publish would be redundant if we hit it once per
+            // row (vs once per stream), but `invalidate_stream_with_row`
+            // is currently shaped to bundle the bare publish per
+            // call. For pushes with many accepted rows hitting the
+            // SAME params_hash, this duplicates the bare publish —
+            // the event backend dedupes per topic and the receivers
+            // don't suffer (they only /pull once via their cursor).
+            //
+            // Sources that DON'T override `row_to_params` (every
+            // source today) get a single bare publish per row; the
+            // per-params publish is a no-op (empty params → early
+            // return inside `invalidate_stream_with_row`).
+            for row in &response.rows {
+                if let Err(err) = sync
+                    .invalidate_stream_with_row(response.stream.as_str(), &row.value)
+                    .await
+                {
+                    tracing::warn!(
+                        target: "pocopine.log",
+                        error = %err,
+                        stream = response.stream.as_str(),
+                        row_key = row.key.as_str(),
+                        "failed to publish sync stream invalidation after push"
+                    );
+                }
             }
         }
         Ok(response)
@@ -850,6 +968,169 @@ mod tests {
         posts.upsert("post_1", "hello".to_string()).unwrap();
         let sync = SyncServer::builder().public_stream(posts).build();
         finalize(sync)
+    }
+
+    // ---- RFC 088 §C: invalidate_stream_with_row dual publish -------
+
+    /// Test source: overrides `row_to_params` to project
+    /// `workspace_id` into the params map so we can assert the
+    /// per-params topic is published.
+    struct ParamsRoutedStream {
+        name: SyncStreamName,
+        collection: SyncCollectionName,
+    }
+    impl ParamsRoutedStream {
+        fn new() -> Self {
+            Self {
+                name: SyncStreamName::new("issues").unwrap(),
+                collection: SyncCollectionName::new("issues").unwrap(),
+            }
+        }
+    }
+    impl SyncStreamSource for ParamsRoutedStream {
+        fn stream(&self) -> &SyncStreamName {
+            &self.name
+        }
+        fn collection(&self) -> &SyncCollectionName {
+            &self.collection
+        }
+        fn pull(
+            &self,
+            _ctx: RequestContext,
+            _request: SyncPullRequest,
+        ) -> SyncBoxFuture<'_, SyncPullResponse<Value>> {
+            Box::pin(async move { Err(SyncError::Unsupported("test stream".into())) })
+        }
+        fn push(
+            &self,
+            _ctx: RequestContext,
+            _request: SyncPushRequest<Value>,
+        ) -> SyncBoxFuture<'_, SyncPushResponse<Value>> {
+            Box::pin(async move { Err(SyncError::Unsupported("test stream".into())) })
+        }
+        fn row_to_params(&self, row: &Value) -> SyncResult<crate::StreamParams> {
+            let mut params = crate::StreamParams::new();
+            if let Some(ws) = row.get("workspace_id") {
+                params.insert("workspace_id".into(), ws.clone());
+            }
+            Ok(params)
+        }
+    }
+
+    #[tokio::test]
+    async fn invalidate_stream_with_row_publishes_to_both_topics() {
+        use pocopine_events::{MemoryEventBackend, ReplayRequest, Topic};
+        use std::sync::Arc;
+
+        let backend: SharedEventBackend = Arc::new(MemoryEventBackend::new());
+        let sync = SyncServer::builder()
+            .public_stream(ParamsRoutedStream::new())
+            .events(backend.clone())
+            .build();
+
+        let row = json!({"id": "i1", "workspace_id": "W1"});
+        sync.invalidate_stream_with_row("issues", &row)
+            .await
+            .unwrap();
+
+        // Expected topics: bare + per-(stream, params_hash).
+        let bare_tag = sync_stream_tag("issues");
+        let mut expected_params = crate::StreamParams::new();
+        expected_params.insert("workspace_id".into(), json!("W1"));
+        let hash = crate::stream_params_hash("issues", &expected_params);
+        let params_tag = crate::sync_stream_params_tag("issues", hash);
+        let bare_topic = pocopine_live::query_tag_topic(&bare_tag).unwrap();
+        let params_topic = pocopine_live::query_tag_topic(&params_tag).unwrap();
+
+        // Replay the recorded events on each topic; assert one each.
+        let replay = backend
+            .replay(ReplayRequest::new(vec![
+                bare_topic.clone(),
+                params_topic.clone(),
+            ]))
+            .await
+            .unwrap();
+        let by_topic: std::collections::HashMap<Topic, usize> =
+            replay
+                .events
+                .iter()
+                .fold(std::collections::HashMap::new(), |mut acc, env| {
+                    *acc.entry(env.topic.clone()).or_insert(0) += 1;
+                    acc
+                });
+        assert_eq!(by_topic.get(&bare_topic).copied(), Some(1), "bare publish");
+        assert_eq!(
+            by_topic.get(&params_topic).copied(),
+            Some(1),
+            "per-params publish"
+        );
+    }
+
+    /// When `row_to_params` returns empty params (the default impl,
+    /// or a source that opts out), only the bare topic is published.
+    /// Verifies the back-compat path stays clean.
+    struct DefaultRoutedStream {
+        name: SyncStreamName,
+        collection: SyncCollectionName,
+    }
+    impl DefaultRoutedStream {
+        fn new() -> Self {
+            Self {
+                name: SyncStreamName::new("comments").unwrap(),
+                collection: SyncCollectionName::new("comments").unwrap(),
+            }
+        }
+    }
+    impl SyncStreamSource for DefaultRoutedStream {
+        fn stream(&self) -> &SyncStreamName {
+            &self.name
+        }
+        fn collection(&self) -> &SyncCollectionName {
+            &self.collection
+        }
+        fn pull(
+            &self,
+            _ctx: RequestContext,
+            _request: SyncPullRequest,
+        ) -> SyncBoxFuture<'_, SyncPullResponse<Value>> {
+            Box::pin(async move { Err(SyncError::Unsupported("test stream".into())) })
+        }
+        fn push(
+            &self,
+            _ctx: RequestContext,
+            _request: SyncPushRequest<Value>,
+        ) -> SyncBoxFuture<'_, SyncPushResponse<Value>> {
+            Box::pin(async move { Err(SyncError::Unsupported("test stream".into())) })
+        }
+        // No override of row_to_params → trait default → empty params.
+    }
+
+    #[tokio::test]
+    async fn invalidate_stream_with_row_skips_per_params_when_empty() {
+        use pocopine_events::{MemoryEventBackend, ReplayRequest};
+        use std::sync::Arc;
+
+        let backend: SharedEventBackend = Arc::new(MemoryEventBackend::new());
+        let sync = SyncServer::builder()
+            .public_stream(DefaultRoutedStream::new())
+            .events(backend.clone())
+            .build();
+
+        let row = json!({"id": "c1"});
+        sync.invalidate_stream_with_row("comments", &row)
+            .await
+            .unwrap();
+
+        let bare_tag = sync_stream_tag("comments");
+        let bare_topic = pocopine_live::query_tag_topic(&bare_tag).unwrap();
+        let replay = backend
+            .replay(ReplayRequest::new(vec![bare_topic.clone()]))
+            .await
+            .unwrap();
+        // Bare publish: exactly one event. No per-params topic was
+        // published because row_to_params returned empty.
+        assert_eq!(replay.events.len(), 1);
+        assert_eq!(replay.events[0].topic, bare_topic);
     }
 
     fn router_with_guarded_posts_stream<P>(predicate: P) -> Router

--- a/docs/live.md
+++ b/docs/live.md
@@ -417,16 +417,13 @@ locally but mysteriously drop in production"; the fix is one line.
 use pocopine_events::{build_event_backend, EventBackendConfig, RedisEventConfig};
 use pocopine_live::LiveHub;
 
-let backend = build_event_backend(EventBackendConfig::Redis(RedisEventConfig {
-    url: "redis://prod-redis:6379".to_string(),
-    app:  "myapp".to_string(),
-    ..Default::default()
-}))?;
+let backend = build_event_backend(EventBackendConfig::Redis(
+    RedisEventConfig::new("redis://prod-redis:6379", "myapp")?,
+))?;
 
 let hub = LiveHub::new(backend)
-    .allow_topic_prefixes(sync.live_topic_prefixes())  // RFC 088 §C; or
-    // .allow_topics(sync.live_topics())               // pre-§C bare-only.
-    .default_topics(default_topics);
+    .allow_topic_prefixes(sync.live_topic_prefixes());  // RFC 088 §C; or
+    // .allow_topics(sync.live_topics())                // pre-§C bare-only.
 ```
 
 No `LiveHub` / `SyncServer` / `LiveClient` / browser code changes. The

--- a/docs/live.md
+++ b/docs/live.md
@@ -349,11 +349,134 @@ That test opens the real SSE route for `query:posts:list`, calls
 
 ## 8. Production Backends
 
-Use `MemoryEventBackend` only when all publishers and subscribers live in
-one process. For multi-process servers, deploy a shared backend such as
-Redis and build the hub from that backend instead. The browser stream
-URL, component subscriptions, collection names, and query tags do not
-change.
+Pocopine ships two event backends; the one you pick is the single most
+important deployment decision for live invalidation.
+
+| Backend | Crate path | Use when |
+|---|---|---|
+| `MemoryEventBackend` | `pocopine_events::MemoryEventBackend` | Tests, dev, single-process deployments only |
+| `RedisEventBackend` | `pocopine_events::RedisEventBackend` (`redis` feature) | Multi-process / horizontally-scaled servers |
+
+### Why `MemoryEventBackend` is not enough for production
+
+`MemoryEventBackend` is a per-process `tokio::sync::broadcast`. Events
+published on one process **never reach a subscriber on another process** —
+they live and die inside one node's memory.
+
+```text
+   Single node (MemoryEventBackend works):
+
+     ┌─────────── Node 1 ──────────────┐
+     │                                  │
+     │  /push  ──► MemoryEventBackend   │
+     │              │                    │
+     │              ▼                    │
+     │  ◄── SSE to all clients on Node 1 │
+     └──────────────────────────────────┘
+
+
+   Multi-node with MemoryEventBackend (BROKEN):
+
+     Client A ──SSE──► Node 1                     Node 2 ◄──/push── Client B
+                       │                            │
+                       │  Memory backend            │  Memory backend
+                       │  (Node 1, in-proc)         │  (Node 2, in-proc)
+                       │                            │
+                       ▼                            ▼
+                Sees only events Node 1     Sees only events Node 2
+                publishes locally           publishes locally
+
+                ❌ Client A never receives Client B's mutation.
+                   The publish stayed in Node 2's memory.
+
+
+   Multi-node with shared broker (works):
+
+     Client A ──SSE──► Node 1                     Node 2 ◄──/push── Client B
+                       │                            │
+                       ▼                            ▼
+                  RedisEventBackend  ◄────►  RedisEventBackend
+                       │                            ▲
+                       │      ┌── Redis ──┐         │
+                       └──────┤  PUB/SUB  ├─────────┘
+                              │  + Streams│
+                              └───────────┘
+
+                ✓ Node 1 receives Client B's invalidation via Redis,
+                  forwards to Client A's SSE.
+```
+
+If you run more than one server process — `kubectl` replica count > 1,
+Render auto-scaling, blue/green deploy, anything — you need a shared
+backend. The symptom of a missing shared backend is "live updates work
+locally but mysteriously drop in production"; the fix is one line.
+
+### Switching to `RedisEventBackend`
+
+```rust,ignore
+use pocopine_events::{build_event_backend, EventBackendConfig, RedisEventConfig};
+use pocopine_live::LiveHub;
+
+let backend = build_event_backend(EventBackendConfig::Redis(RedisEventConfig {
+    url: "redis://prod-redis:6379".to_string(),
+    app:  "myapp".to_string(),
+    ..Default::default()
+}))?;
+
+let hub = LiveHub::new(backend)
+    .allow_topic_prefixes(sync.live_topic_prefixes())  // RFC 088 §C; or
+    // .allow_topics(sync.live_topics())               // pre-§C bare-only.
+    .default_topics(default_topics);
+```
+
+No `LiveHub` / `SyncServer` / `LiveClient` / browser code changes. The
+backend is plug-and-play.
+
+### Choosing a broker at scale
+
+For most apps, `RedisEventBackend` is the right answer; it's batteries-
+included and handles ~1M topics on a single node comfortably. The table
+below covers the alternatives if your scale or platform constraints
+make Redis a poor fit.
+
+| Broker | Scale | When to pick |
+|---|---|---|
+| **Redis Pub/Sub + Streams** (built-in) | ~1M topics single-node, multi-million across Redis Cluster | Default. Already a dep. Streams give replay; fall back to /pull works. |
+| **NATS JetStream** (custom backend) | 10M+ subjects across cluster | Subject-based routing maps naturally to RFC 088 §C's `(stream, params_hash)` topic shape. Best for fanout-heavy workloads. |
+| **Kafka** (custom backend) | High-throughput sequential workloads | Use if you already run Kafka. Topic cardinality stresses Kafka — prefer one topic + header filtering over one-topic-per-(stream, hash). |
+| **Postgres LISTEN/NOTIFY** (custom backend) | <10k concurrent subscribers per node | Smallest-scale option; no extra infra if you already run Postgres. |
+
+`pocopine-events` ships Memory + Redis; NATS / Kafka / Postgres
+backends are user-implementable via the `LiveEventBackend` trait.
+
+### Topic cardinality with RFC 088 §C
+
+RFC 088 §C (`sync-query` selector-level live routing) publishes to
+per-`(stream, params_hash)` topics. With 1M users observing N streams ×
+M workspaces (or other partition keys), the active topic count is
+typically `N × M` — for 10 streams × 5k workspaces, that's 50k topics.
+Redis single-node handles this without breaking a sweat.
+
+If your topic count crosses ~10M (e.g. millions of distinct partition
+hashes), shard with Redis Cluster (topic name is the shard key) or
+move to NATS / Kafka. The `LiveHub::allow_topic_prefixes` policy is
+broker-agnostic; only your config + backend change.
+
+### What §C changes (and doesn't)
+
+- **Subscribers per topic** drops dramatically (the whole point — from
+  O(all clients) to O(matching clients)).
+- **Topic count** rises (more topics, each with fewer subscribers).
+- **Events per mutation** stays approximately the same (one bare publish
+  + one per-params publish per row, vs the pre-§C single bare publish).
+- **Broker CPU** is roughly a wash; broker memory rises slightly with
+  topic metadata.
+
+You only see the bandwidth win once the matching-subscriber count is
+much smaller than the all-subscriber count — i.e. for filtered
+multi-tenant workloads. For single-tenant or low-traffic apps, the
+plain bare topic is enough; `MemoryEventBackend` + `allow_topics` is
+fine.
 
 ## Failure Model
 

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -227,7 +227,9 @@ async fn invalidate_posts() {
 ## 4. Mount Routes
 
 Mount sync routes with the host server plugin. If live wake-up is
-enabled, allow the topics reported by `sync.live_topics()`.
+enabled, allow the topic PREFIXES reported by
+`sync.live_topic_prefixes()` so RFC 088 §C per-`(stream, params_hash)`
+topics are authorized too.
 
 ```rust
 #[cfg(pocopine_host)]
@@ -240,10 +242,11 @@ async fn main() -> std::io::Result<()> {
     pocopine_logging::init_default().map_err(std::io::Error::other)?;
 
     let sync = sync_server();
-    let sync_topics = sync.live_topics().map_err(std::io::Error::other)?;
+    let sync_topic_prefixes = sync.live_topic_prefixes();
+    let default_topics = sync.live_topics().map_err(std::io::Error::other)?;
     let live_hub = LiveHub::new(live_backend())
-        .allow_topics(sync_topics.clone())
-        .default_topics(sync_topics);
+        .allow_topic_prefixes(sync_topic_prefixes)
+        .default_topics(default_topics);
 
     let router = Router::new()
         .merge(routes(live_hub))
@@ -258,8 +261,14 @@ async fn main() -> std::io::Result<()> {
 }
 ```
 
-The default live topic policy is deny-all. `sync.live_topics()` returns
-only the wake-up topics for registered streams.
+The default live topic policy is deny-all. `sync.live_topic_prefixes()`
+returns one prefix per registered stream (`query:sync:stream:{name}`);
+`LiveHub::allow_topic_prefixes` authorizes both the bare topic AND any
+per-`(stream, params_hash)` extension (`{prefix}:<16-hex>`). Apps that
+don't use RFC 088 §C per-params routing can still pair the older
+`allow_topics(sync.live_topics())` (exact-match) — but adopting
+`#[query_resource]` with overridden `row_to_params` requires the
+prefix variant or per-params subscriptions get silently denied.
 
 `/open` is not a session token. It validates discovery and gives the
 client metadata before the first pull, but `/pull` and `/push` still run

--- a/examples/keep/src/bin/server.rs
+++ b/examples/keep/src/bin/server.rs
@@ -10,10 +10,15 @@ async fn main() -> std::io::Result<()> {
     init_default().map_err(std::io::Error::other)?;
 
     let sync = sync_server();
-    let sync_topics = sync.live_topics().map_err(std::io::Error::other)?;
+    // RFC 088 §C: use `allow_topic_prefixes` so per-`(stream, params_hash)`
+    // topics are authorized too. `allow_topics` alone would silently
+    // deny per-params subscriptions the moment any source overrides
+    // `SyncStreamSource::row_to_params`.
+    let sync_topic_prefixes = sync.live_topic_prefixes();
+    let default_topics = sync.live_topics().map_err(std::io::Error::other)?;
     let live_hub = LiveHub::new(live_backend())
-        .allow_topics(sync_topics.clone())
-        .default_topics(sync_topics);
+        .allow_topic_prefixes(sync_topic_prefixes)
+        .default_topics(default_topics);
 
     // $POCOPINE_DIST is set by the deploy container (RFC 080 §4.2);
     // unset under `pocopine dev`, so fall back to the source tree.

--- a/examples/keep/tests/keep_flow.rs
+++ b/examples/keep/tests/keep_flow.rs
@@ -28,11 +28,12 @@ async fn keep_push_and_live_wakeup_share_the_stream_topic() {
     std::env::set_var("POCOPINE_KEEP_TAGS_DB_PATH", &test_tags_path);
 
     let sync = sync_server();
-    let sync_topics = sync.live_topics().unwrap();
+    let sync_topic_prefixes = sync.live_topic_prefixes();
+    let default_topics = sync.live_topics().unwrap();
     let app = Server::new(routes(
         LiveHub::new(live_backend())
-            .allow_topics(sync_topics.clone())
-            .default_topics(sync_topics),
+            .allow_topic_prefixes(sync_topic_prefixes)
+            .default_topics(default_topics),
     ))
     .plugin(sync_server_plugin(sync))
     .try_finalize()

--- a/examples/sync/src/bin/server.rs
+++ b/examples/sync/src/bin/server.rs
@@ -10,10 +10,14 @@ async fn main() -> std::io::Result<()> {
     init_default().map_err(std::io::Error::other)?;
 
     let sync = sync_server();
-    let sync_topics = sync.live_topics().map_err(std::io::Error::other)?;
+    // RFC 088 §C: prefix-based allowlist authorizes both the bare
+    // `query:sync:stream:{name}` topic AND per-`(stream, params_hash)`
+    // variants `query:sync:stream:{name}:<16-hex>`.
+    let sync_topic_prefixes = sync.live_topic_prefixes();
+    let default_topics = sync.live_topics().map_err(std::io::Error::other)?;
     let live_hub = LiveHub::new(live_backend())
-        .allow_topics(sync_topics.clone())
-        .default_topics(sync_topics);
+        .allow_topic_prefixes(sync_topic_prefixes)
+        .default_topics(default_topics);
 
     let manifest_dir = env!("CARGO_MANIFEST_DIR");
     let router = Router::new()

--- a/examples/sync/tests/sync_flow.rs
+++ b/examples/sync/tests/sync_flow.rs
@@ -17,11 +17,12 @@ use tower::ServiceExt;
 async fn sync_pull_and_live_wakeup_share_the_stream_topic() {
     pocopine_server::__reset_for_test();
     let sync = sync_server();
-    let sync_topics = sync.live_topics().unwrap();
+    let sync_topic_prefixes = sync.live_topic_prefixes();
+    let default_topics = sync.live_topics().unwrap();
     let app = Server::new(routes(
         LiveHub::new(live_backend())
-            .allow_topics(sync_topics.clone())
-            .default_topics(sync_topics),
+            .allow_topic_prefixes(sync_topic_prefixes)
+            .default_topics(default_topics),
     ))
     .plugin(sync_server_plugin(sync))
     .try_finalize()


### PR DESCRIPTION
## Summary

Implements RFC 088 §C — per-`(stream, params_hash)` live topic routing
for `sync-query`. Subscribers no longer wake on every mutation to a
shared stream; the server publishes precise invalidations scoped to the
audience whose captured params project to the same partition hash. The
contract is wire-portable (FNV-1a 64 over canonical sorted JSON) so
future Swift / Go / Kotlin clients can reproduce the same hash.

* **Server side.** `SyncStreamSource::row_to_params` projects a row to
  its `StreamParams`; the push handler batches per-row projections,
  dedupes by `(stream, params_hash)`, and publishes ONCE per distinct
  partition. The bare stream topic is still invalidated unconditionally
  for back-compat.
* **Client side.** `#[query_resource]` now emits a `partition_for_topic`
  alongside the predicate evaluator. The driver subscribes to the bare
  stream topic AND the per-params topic, with `LiveHub::allow_topic_prefixes`
  gating which `(prefix + 16-hex)` combinations are allowed.
* **Macro.** `#[query_param(required)]` declares the topic-partitioning
  fields; only required fields appear in `row_to_params` / the partition
  projection. Comparator-wrapped values are detected by full-shape match
  (not key-overlap) so user types with `from` / `to` / `in` keys aren't
  misclassified.
* **Code review pass.** Final commit addresses 15 findings from an
  xhigh-effort recall-prioritized review: silent-collapse on hash
  encode, batched dedup, comparator detection, `:` rejection in stream
  names, `#[serde(rename...)]` rejection, direct JSON projection,
  exported `PARAMS_HASH_HEX_LEN`, runtime warning when a resource has
  zero `required` fields.
* **Docs.** `docs/live.md` and `docs/sync.md` document the multi-node
  Redis requirement (memory backend is single-process only); the README
  shows the `RedisEventConfig::new(url, app)?` setup path.

## Test plan

- [x] `cargo test -p pocopine-sync-query-macros` (44 tests)
- [x] `cargo test -p pocopine-sync-query`
- [x] `cargo test -p pocopine-sync` (golden fixture for cross-language hash)
- [x] `cargo test -p pocopine-live`
- [x] `cargo test -p sync-example -p keep-example` (push → live wakeup → incremental pull)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --tests -- -D warnings` (host)
- [x] `cargo clippy -p pocopine-sync-query{,-macros} -p pocopine-sync -p pocopine-live --target wasm32-unknown-unknown -- -D warnings`
- [ ] Workspace-wide `cargo clippy --target wasm32-unknown-unknown` — fails in unrelated `mio` (pre-existing CI breakage on `main`, out of scope for this PR)