### PR TITLE
sync-crud + sync-query: .params_of bridges writes to §C reads

### DIFF
--- a/crates/pocopine-sync-crud/Cargo.toml
+++ b/crates/pocopine-sync-crud/Cargo.toml
@@ -25,6 +25,9 @@ serde_json = { workspace = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 http-body-util = "0.1"
 http = { workspace = true }
+pocopine-events = { workspace = true }
+pocopine-live = { workspace = true }
 pocopine-server = { workspace = true }
+pocopine-sync-query = { workspace = true }
 tokio = { version = "1", features = ["macros", "rt"] }
 tower = { version = "0.5", features = ["util"] }

--- a/crates/pocopine-sync-crud/src/resource.rs
+++ b/crates/pocopine-sync-crud/src/resource.rs
@@ -3,9 +3,10 @@ use std::sync::{Arc, Mutex};
 
 use pocopine_auth::RequestContext;
 use pocopine_sync::{
-    default_schema_version_one, MutationId, RowKey, RowVersion, SyncBoxFuture, SyncCollectionName,
-    SyncConflict, SyncError, SyncOp, SyncPullRequest, SyncPullResponse, SyncPushRequest,
-    SyncPushResponse, SyncRejectedMutation, SyncResult, SyncRow, SyncStreamName, SyncStreamSource,
+    default_schema_version_one, MutationId, RowKey, RowVersion, StreamParams, SyncBoxFuture,
+    SyncCollectionName, SyncConflict, SyncError, SyncOp, SyncPullRequest, SyncPullResponse,
+    SyncPushRequest, SyncPushResponse, SyncRejectedMutation, SyncResult, SyncRow, SyncStreamName,
+    SyncStreamSource,
 };
 use serde::Serialize;
 use serde_json::Value;
@@ -99,6 +100,18 @@ fn invoke_migrator_with_panic_guard(
     }
 }
 
+/// Type-erased projector from a canonical row into the RFC 088 §C
+/// `(stream, params_hash)` partition fields. Stored on
+/// [`CrudResource`] (and its transactional sibling); attached via
+/// [`CrudResource::params_of`] and consumed by the
+/// `SyncStreamSource::row_to_params` override the adapter installs.
+///
+/// Users supply a typed `Fn(&Row) -> StreamParams` — usually the
+/// macro-generated `<resource>::row_to_params_typed` — and the
+/// adapter handles the `Value` ↔ `Row` deserialize at the trait
+/// boundary.
+pub type CrudParamsFn<Row> = dyn Fn(&Row) -> StreamParams + Send + Sync + 'static;
+
 /// Builder returned by [`resource`].
 pub struct CrudResourceBuilder<S> {
     stream: SyncStreamName,
@@ -182,12 +195,13 @@ where
             id_of,
             version_of: NoRowVersion,
             mutation_log: MissingMutationLog,
+            params_of: None,
         }
     }
 }
 
 /// CRUD resource adapter that can be registered with `pocopine-sync`.
-pub struct CrudResource<S, IdOf, VersionOf = NoRowVersion, Log = MissingMutationLog> {
+pub struct CrudResource<S: CrudSource, IdOf, VersionOf = NoRowVersion, Log = MissingMutationLog> {
     stream: SyncStreamName,
     collection: SyncCollectionName,
     source: S,
@@ -197,6 +211,12 @@ pub struct CrudResource<S, IdOf, VersionOf = NoRowVersion, Log = MissingMutation
     id_of: IdOf,
     version_of: VersionOf,
     mutation_log: Log,
+    /// Optional RFC 088 §C row→partition projector. Attached via
+    /// [`Self::params_of`]; consumed by the
+    /// [`SyncStreamSource::row_to_params`] override below. When
+    /// `None`, the override falls back to the trait default (empty
+    /// `StreamParams` → bare-topic publish only).
+    params_of: Option<Arc<CrudParamsFn<S::Row>>>,
 }
 
 impl<S, IdOf, VersionOf, Log> CrudResource<S, IdOf, VersionOf, Log>
@@ -222,7 +242,53 @@ where
             id_of: self.id_of,
             version_of,
             mutation_log: self.mutation_log,
+            params_of: self.params_of,
         }
+    }
+
+    /// Attach an RFC 088 §C row → partition projector. Without this,
+    /// CRUD resources publish bare-topic live wakeups only (every
+    /// subscriber on the stream wakes for every accepted mutation
+    /// regardless of tenant). With it, the server projects each
+    /// accepted row into its `StreamParams`, hashes, and publishes
+    /// scoped per-`(stream, params_hash)` topics so only the
+    /// matching audience wakes.
+    ///
+    /// The natural argument is the macro-generated
+    /// `<resource>::row_to_params_typed`:
+    ///
+    /// ```ignore
+    /// #[query_resource(name = "issues", schema_version = 1)]
+    /// #[derive(Clone, Serialize, Deserialize)]
+    /// pub struct Issue {
+    ///     pub id: String,
+    ///     #[query_param(required)]
+    ///     pub workspace_id: String,
+    ///     // ... other fields ...
+    /// }
+    ///
+    /// let issues = resource("issues", IssueCrudSource::default())?
+    ///     .id(|r| r.id.clone())
+    ///     .params_of(issues::row_to_params_typed);
+    /// ```
+    ///
+    /// Hand-written projectors work too — anything with the shape
+    /// `Fn(&Row) -> StreamParams`. The closure runs once per
+    /// accepted-row inside the push handler's response loop; per-
+    /// row dedup by `(stream, params_hash)` ensures bulk pushes
+    /// don't fan out N redundant publishes.
+    ///
+    /// See `docs/sync-crud-query-composition.md` for the bigger
+    /// picture: CRUD owns writes (typed Draft/Row, idempotency log,
+    /// transaction binding); Query owns reads (filtered DSL,
+    /// selectors); `.params_of` is the bridge that gives a CRUD
+    /// source Query-grade live-wakeup precision.
+    pub fn params_of<F>(mut self, params_of: F) -> Self
+    where
+        F: Fn(&S::Row) -> StreamParams + Send + Sync + 'static,
+    {
+        self.params_of = Some(Arc::new(params_of));
+        self
     }
 }
 
@@ -250,6 +316,7 @@ where
             id_of: self.id_of,
             version_of: self.version_of,
             mutation_log,
+            params_of: self.params_of,
         }
     }
 
@@ -290,13 +357,14 @@ where
             version_of: self.version_of,
             mutation_log,
             transaction_runner,
+            params_of: self.params_of,
         }
     }
 }
 
 /// CRUD resource adapter that applies writes and idempotency log inserts in one
 /// app/database transaction.
-pub struct TransactionalCrudResource<S, IdOf, VersionOf, Log, Runner> {
+pub struct TransactionalCrudResource<S: CrudSource, IdOf, VersionOf, Log, Runner> {
     stream: SyncStreamName,
     collection: SyncCollectionName,
     source: S,
@@ -307,6 +375,9 @@ pub struct TransactionalCrudResource<S, IdOf, VersionOf, Log, Runner> {
     version_of: VersionOf,
     mutation_log: Log,
     transaction_runner: Runner,
+    /// See [`CrudResource::params_of`]. Optional RFC 088 §C projector;
+    /// `None` means bare-topic publishes only.
+    params_of: Option<Arc<CrudParamsFn<S::Row>>>,
 }
 
 /// Marker used before a resource has an idempotency backend.
@@ -636,6 +707,25 @@ where
     /// working under any deployment.
     fn validate_push_params(&self, _params: &pocopine_sync::StreamParams) -> SyncResult<()> {
         Ok(())
+    }
+
+    /// RFC 088 §C row → partition projector. Delegates to the
+    /// closure attached via [`CrudResource::params_of`] (typically
+    /// `<resource>::row_to_params_typed` from `#[query_resource]`).
+    /// When no projector is attached, returns empty `StreamParams`
+    /// — the server then publishes only the bare stream topic.
+    fn row_to_params(&self, row: &Value) -> SyncResult<StreamParams> {
+        let Some(params_of) = self.params_of.as_ref() else {
+            return Ok(StreamParams::new());
+        };
+        let typed: S::Row = serde_json::from_value(row.clone()).map_err(|e| {
+            SyncError::client(format!(
+                "row_to_params: {} row didn't deserialize for params projection: {}",
+                self.stream.as_str(),
+                e,
+            ))
+        })?;
+        Ok(params_of(&typed))
     }
 
     fn migrate_payload<'a>(&'a self, from: u32, to: u32, value: Value) -> SyncBoxFuture<'a, Value> {
@@ -978,6 +1068,24 @@ where
         Ok(())
     }
 
+    /// RFC 088 §C row → partition projector. Delegates to the
+    /// closure attached via [`TransactionalCrudResource::params_of`].
+    /// When no projector is attached, returns empty `StreamParams`
+    /// — the server then publishes only the bare stream topic.
+    fn row_to_params(&self, row: &Value) -> SyncResult<StreamParams> {
+        let Some(params_of) = self.params_of.as_ref() else {
+            return Ok(StreamParams::new());
+        };
+        let typed: S::Row = serde_json::from_value(row.clone()).map_err(|e| {
+            SyncError::client(format!(
+                "row_to_params: {} row didn't deserialize for params projection: {}",
+                self.stream.as_str(),
+                e,
+            ))
+        })?;
+        Ok(params_of(&typed))
+    }
+
     fn migrate_payload<'a>(&'a self, from: u32, to: u32, value: Value) -> SyncBoxFuture<'a, Value> {
         let stream = self.stream.as_str().to_string();
         if let Some(migrate) = self.migrate_payload.clone() {
@@ -1014,6 +1122,20 @@ where
     Log: TransactionalCrudMutationLog<Runner::Tx, S::Row>,
     Runner: CrudTransactionRunner,
 {
+    /// Attach an RFC 088 §C row → partition projector. See
+    /// [`CrudResource::params_of`] for the rationale and the
+    /// recommended argument (`<resource>::row_to_params_typed` from
+    /// `#[query_resource]`). Transactional resources route the
+    /// projector through the same per-`(stream, params_hash)`
+    /// publish path as non-transactional ones.
+    pub fn params_of<F>(mut self, params_of: F) -> Self
+    where
+        F: Fn(&S::Row) -> StreamParams + Send + Sync + 'static,
+    {
+        self.params_of = Some(Arc::new(params_of));
+        self
+    }
+
     async fn pull_snapshot(
         &self,
         ctx: RequestContext,

--- a/crates/pocopine-sync-crud/tests/params_partitioning.rs
+++ b/crates/pocopine-sync-crud/tests/params_partitioning.rs
@@ -1,0 +1,305 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+//! End-to-end test for RFC 088 §C / CRUD `.params_of` integration.
+//!
+//! This is the test that proves CRUD + Query compose: a CRUD source
+//! (typed Draft + idempotent writes) gets Query-grade live wakeup
+//! precision (per-`(stream, params_hash)` topics) by attaching the
+//! macro-generated `row_to_params_typed` via `.params_of`. See
+//! `docs/sync-crud-query-composition.md` for the bigger picture.
+//!
+//! Asserts that a push affecting workspace `W1` wakes only the
+//! `W1`-scoped per-params subscriber — the `W2` subscriber stays
+//! silent. The bare-stream subscriber still wakes (back-compat path).
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use http_body_util::BodyExt;
+use pocopine_auth::RequestContext;
+use pocopine_events::{MemoryEventBackend, SharedEventBackend};
+use pocopine_live::{build_live_stream_url, routes, LiveHub, LIVE_STREAM_PATH};
+use pocopine_server::axum::body::Body;
+use pocopine_server::axum::http::{Request, StatusCode};
+use pocopine_server::axum::Router;
+use pocopine_server::Server;
+use pocopine_sync::{
+    stream_params_hash, sync_server_plugin, sync_stream_params_tag, sync_stream_tag,
+    ClientMutation, MutationId, RowVersion, StreamParams, SyncError, SyncPushRequest,
+    SyncPushResponse, SyncServer, SyncStreamName, SYNC_PUSH_PATH,
+};
+use pocopine_sync_crud::{
+    async_trait, resource, CrudMutationPayload, CrudRemoveResult, CrudSource, CrudWriteResult,
+    MemoryCrudMutationLog,
+};
+use pocopine_sync_query::query_resource;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tower::ServiceExt;
+
+const STREAM: &str = "issues";
+
+// The macro emits an `issues` module with `row_to_params_typed`
+// alongside the predicate + DSL items. `.params_of(issues::row_to_params_typed)`
+// plugs it into CRUD without any manual `row_to_params` override.
+#[query_resource(name = "issues", schema_version = 1)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Issue {
+    pub id: String,
+    #[query_param(required)]
+    pub workspace_id: String,
+    #[query_param]
+    pub title: String,
+    pub version: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+struct IssueDraft {
+    workspace_id: String,
+    title: String,
+}
+
+#[derive(Clone, Default)]
+struct IssuesSource {
+    rows: Arc<Mutex<BTreeMap<String, Issue>>>,
+}
+
+#[async_trait]
+impl CrudSource for IssuesSource {
+    type Id = String;
+    type Row = Issue;
+    type Draft = IssueDraft;
+
+    async fn list(
+        &self,
+        _ctx: RequestContext,
+        limit: usize,
+    ) -> pocopine_sync::SyncResult<Vec<Self::Row>> {
+        let rows = self.rows.lock().unwrap();
+        Ok(rows.values().take(limit).cloned().collect())
+    }
+
+    async fn get(
+        &self,
+        _ctx: RequestContext,
+        id: Self::Id,
+    ) -> pocopine_sync::SyncResult<Option<Self::Row>> {
+        Ok(self.rows.lock().unwrap().get(&id).cloned())
+    }
+
+    async fn create(
+        &self,
+        _ctx: RequestContext,
+        id: Self::Id,
+        draft: Self::Draft,
+    ) -> pocopine_sync::SyncResult<Self::Row> {
+        let issue = Issue {
+            id: id.clone(),
+            workspace_id: draft.workspace_id,
+            title: draft.title,
+            version: 1,
+        };
+        self.rows.lock().unwrap().insert(id, issue.clone());
+        Ok(issue)
+    }
+
+    async fn save(
+        &self,
+        _ctx: RequestContext,
+        id: Self::Id,
+        draft: Self::Draft,
+        _base_version: Option<RowVersion>,
+    ) -> pocopine_sync::SyncResult<CrudWriteResult<Self::Row>> {
+        let mut rows = self.rows.lock().unwrap();
+        let row = rows
+            .get_mut(&id)
+            .ok_or_else(|| SyncError::backend("missing issue"))?;
+        row.workspace_id = draft.workspace_id;
+        row.title = draft.title;
+        row.version = row.version.saturating_add(1);
+        Ok(CrudWriteResult::applied(row.clone()))
+    }
+
+    async fn remove(
+        &self,
+        _ctx: RequestContext,
+        id: Self::Id,
+        _base_version: Option<RowVersion>,
+    ) -> pocopine_sync::SyncResult<CrudRemoveResult<Self::Row>> {
+        self.rows.lock().unwrap().remove(&id);
+        Ok(CrudRemoveResult::applied())
+    }
+}
+
+fn build_app() -> (Router, SyncServer) {
+    pocopine_server::__reset_for_test();
+    let backend: SharedEventBackend = Arc::new(MemoryEventBackend::new());
+    let sync = SyncServer::builder()
+        .events(backend.clone())
+        .public_stream(
+            resource(STREAM, IssuesSource::default())
+                .expect("stream name")
+                .id(|r: &Issue| r.id.clone())
+                .mutation_log(MemoryCrudMutationLog::<Issue>::new())
+                // The whole point of the test: the typed projector
+                // turns row.workspace_id into the partition. The
+                // macro guarantees agreement with the client-side
+                // `partition_for_topic` hash (same fields, same
+                // canonical JSON encoding, same FNV-1a constants).
+                .params_of(issues::row_to_params_typed),
+        )
+        .build();
+
+    let topic_prefixes = sync.live_topic_prefixes();
+    let default_topics = sync.live_topics().expect("default live topics");
+    let app = Server::new(routes(
+        LiveHub::new(backend)
+            .allow_topic_prefixes(topic_prefixes)
+            .default_topics(default_topics),
+    ))
+    .plugin(sync_server_plugin(sync.clone()))
+    .try_finalize()
+    .expect("server finalizes");
+
+    (app, sync)
+}
+
+#[tokio::test]
+async fn push_into_w1_wakes_only_w1_per_params_subscriber() {
+    let (app, _sync) = build_app();
+
+    let w1_params: StreamParams = [("workspace_id".to_string(), serde_json::json!("W1"))]
+        .into_iter()
+        .collect();
+    let w2_params: StreamParams = [("workspace_id".to_string(), serde_json::json!("W2"))]
+        .into_iter()
+        .collect();
+    let w1_hash = stream_params_hash(STREAM, &w1_params);
+    let w2_hash = stream_params_hash(STREAM, &w2_params);
+    assert_ne!(
+        w1_hash, w2_hash,
+        "distinct workspaces hash to distinct partitions"
+    );
+
+    let mut w1_body = open_live(&app, &sync_stream_params_tag(STREAM, w1_hash)).await;
+    let mut w2_body = open_live(&app, &sync_stream_params_tag(STREAM, w2_hash)).await;
+    let mut bare_body = open_live(&app, &sync_stream_tag(STREAM)).await;
+
+    expect_ready(&mut w1_body).await;
+    expect_ready(&mut w2_body).await;
+    expect_ready(&mut bare_body).await;
+
+    let pushed = push_issue(
+        &app,
+        "i_w1_first",
+        IssueDraft {
+            workspace_id: "W1".into(),
+            title: "Auth bug".into(),
+        },
+    )
+    .await;
+    assert!(
+        pushed.rejected.is_empty(),
+        "push rejected unexpectedly: {:?}",
+        pushed.rejected
+    );
+    assert!(
+        pushed.conflicts.is_empty(),
+        "push conflicted unexpectedly: {:?}",
+        pushed.conflicts
+    );
+    assert_eq!(pushed.accepted.len(), 1);
+    assert_eq!(pushed.accepted[0].as_str(), "m:i_w1_first");
+
+    let w1_frame = read_sse_frame(&mut w1_body).await.expect("W1 should wake");
+    assert!(
+        w1_frame.contains(&format!("sync:stream:{STREAM}:{w1_hash:016x}")),
+        "W1 frame should carry the per-params tag, got: {w1_frame}"
+    );
+
+    let bare_frame = read_sse_frame(&mut bare_body)
+        .await
+        .expect("bare topic should wake");
+    assert!(
+        bare_frame.contains(&format!("sync:stream:{STREAM}")),
+        "bare frame should carry the bare tag, got: {bare_frame}"
+    );
+
+    // The critical assertion: W2 must NOT receive a wakeup. We give
+    // the publish path 200ms — same order of magnitude as the W1
+    // delivery, which arrives well inside this.
+    let w2_silent = tokio::time::timeout(Duration::from_millis(200), w2_body.frame()).await;
+    assert!(
+        w2_silent.is_err(),
+        "W2 must NOT receive a wakeup for a W1-scoped row, but got a frame within 200ms"
+    );
+}
+
+async fn open_live(app: &Router, tag: &str) -> Body {
+    let url = build_live_stream_url(LIVE_STREAM_PATH, &[], &[format!("query:{tag}")], None)
+        .expect("live URL");
+    let response = app
+        .clone()
+        .oneshot(Request::builder().uri(url).body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+    assert_eq!(
+        response.status(),
+        StatusCode::OK,
+        "SSE handshake failed for {tag}"
+    );
+    response.into_body()
+}
+
+async fn expect_ready(body: &mut Body) {
+    let ready = read_sse_frame(body)
+        .await
+        .expect("first SSE frame is `ready`");
+    assert!(
+        ready.contains("event: ready"),
+        "expected ready frame, got: {ready}"
+    );
+}
+
+async fn push_issue(app: &Router, id: &str, draft: IssueDraft) -> SyncPushResponse<Value> {
+    let typed = CrudMutationPayload::create(id.to_string(), draft)
+        .into_sync_draft()
+        .unwrap()
+        .with_id(MutationId::new(format!("m:{id}")).unwrap());
+    let mutation: ClientMutation<Value> = ClientMutation {
+        id: typed.id,
+        key: typed.key,
+        op: typed.op,
+        base_version: typed.base_version,
+        payload: serde_json::to_value(typed.payload).unwrap(),
+        migration_outcome: None,
+    };
+    let request = SyncPushRequest::new(SyncStreamName::new(STREAM).unwrap(), [mutation]);
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(SYNC_PUSH_PATH)
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&request).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let outer: pocopine_core::ServerResult<SyncPushResponse<Value>> =
+        serde_json::from_slice(&bytes).unwrap();
+    outer.unwrap()
+}
+
+async fn read_sse_frame(body: &mut Body) -> Option<String> {
+    let frame = tokio::time::timeout(Duration::from_secs(2), body.frame())
+        .await
+        .ok()??
+        .ok()?;
+    let data = frame.into_data().ok()?;
+    Some(String::from_utf8_lossy(&data).into_owned())
+}

--- a/crates/pocopine-sync-query-macros/src/lib.rs
+++ b/crates/pocopine-sync-query-macros/src/lib.rs
@@ -629,6 +629,7 @@ fn expand_query_resource(
     let field_markers = generate_field_markers(&params);
     let matches_body = generate_matches_body(&params);
     let row_to_params_body = generate_row_to_params_body(&params);
+    let row_to_params_typed_body = generate_row_to_params_typed_body(&params);
     let partition_for_topic_body = generate_partition_for_topic_body(&params);
 
     // RFC 088 §C / code-review fix #10: per-(stream, params_hash)
@@ -808,6 +809,39 @@ fn expand_query_resource(
                     ::pocopine_sync_query::__private::pocopine_sync::StreamParams::new();
                 #row_to_params_body
                 ::std::result::Result::Ok(params)
+            }
+
+            /// Typed sibling of [`row_to_params`] — projects a typed
+            /// `&Row` directly into `StreamParams` without the
+            /// `serde_json::Value` round-trip.
+            ///
+            /// This is what `CrudResource::params_of` consumes — the
+            /// CRUD adapter has `&Row` in hand at write time, so the
+            /// JSON form would only force a needless deserialize:
+            ///
+            /// ```ignore
+            /// let issues = resource("issues", IssueSource::default())?
+            ///     .id(|r| r.id.clone())
+            ///     .params_of(issues::row_to_params_typed);
+            /// ```
+            ///
+            /// Selection rules and skip behavior match
+            /// [`row_to_params`] verbatim — only `#[query_param(
+            /// required)]` fields contribute, `Option::None` is
+            /// skipped, `contains`-only fields are excluded.
+            ///
+            /// Per-field `serde_json::to_value` calls are infallible
+            /// for idiomatic field types (primitives, `String`,
+            /// small enums) — the function panics with a clear
+            /// message naming the failing field if a custom
+            /// `Serialize` impl returns an error.
+            pub fn row_to_params_typed(
+                row: &Row,
+            ) -> ::pocopine_sync_query::__private::pocopine_sync::StreamParams {
+                let mut params =
+                    ::pocopine_sync_query::__private::pocopine_sync::StreamParams::new();
+                #row_to_params_typed_body
+                params
             }
 
             /// Project the caller's captured query params into a hash
@@ -1147,6 +1181,65 @@ fn generate_row_to_params_body(params: &[ParamDef]) -> TokenStream2 {
                     if !v.is_null() {
                         params.insert(#name_str.to_string(), v.clone());
                     }
+                }
+            }
+        })
+        .collect();
+
+    quote! {
+        #(#inserts)*
+    }
+}
+
+/// Generate the body of the **typed** `row_to_params_typed(row: &Row)
+/// -> StreamParams` function inside the generated module. Mirrors
+/// `generate_row_to_params_body` but reads directly off the typed
+/// `&Row` instead of a JSON `Value` — `CrudResource::params_of` plugs
+/// the typed projector in so its `SyncStreamSource::row_to_params`
+/// override doesn't pay the serialize-then-deserialize cost when it
+/// already holds the typed row.
+///
+/// `serde_json::to_value` IS called per field, but only on the
+/// `required` field's value (typically `String` or a small enum),
+/// not the whole row. For idiomatic field types (primitives, owned
+/// strings, lightweight enums) the serialize is infallible — we
+/// `.expect()` on the impossible-in-practice failure path with a
+/// clear panic message that names the field.
+fn generate_row_to_params_typed_body(params: &[ParamDef]) -> TokenStream2 {
+    let inserts: Vec<TokenStream2> = params
+        .iter()
+        .filter(|p| include_in_row_params(&p.caps))
+        .map(|param| {
+            let name = &param.name;
+            let name_str = ident_wire_key(name);
+            let field_access: TokenStream2 = quote! { row.#name };
+            if param.caps.optional {
+                quote! {
+                    if let ::std::option::Option::Some(inner) = &#field_access {
+                        let v = ::pocopine_sync_query::__private::serde_json::to_value(inner)
+                            .expect(concat!(
+                                "row_to_params_typed: field `",
+                                #name_str,
+                                "` must be serde_json-serializable — \
+                                 #[query_param(required)] field types are constrained to \
+                                 Serialize, and idiomatic primitive / String / small-enum \
+                                 fields never fail to serialize"
+                            ));
+                        params.insert(#name_str.to_string(), v);
+                    }
+                }
+            } else {
+                quote! {
+                    let v = ::pocopine_sync_query::__private::serde_json::to_value(&#field_access)
+                        .expect(concat!(
+                            "row_to_params_typed: field `",
+                            #name_str,
+                            "` must be serde_json-serializable — \
+                             #[query_param(required)] field types are constrained to \
+                             Serialize, and idiomatic primitive / String / small-enum \
+                             fields never fail to serialize"
+                        ));
+                    params.insert(#name_str.to_string(), v);
                 }
             }
         })

--- a/crates/pocopine-sync-query-macros/tests/query_resource.rs
+++ b/crates/pocopine-sync-query-macros/tests/query_resource.rs
@@ -210,6 +210,43 @@ use pocopine_sync::StreamParams;
 use serde_json::json;
 
 #[test]
+fn row_to_params_typed_agrees_with_value_form() {
+    // The whole reason `row_to_params_typed` exists: bundled stores
+    // (CRUD, SQLx) hold typed `&Row` at write time and shouldn't pay
+    // the serde round-trip just to compute the partition. The typed
+    // form MUST produce the same `StreamParams` as the Value form
+    // — otherwise the macro-generated `partition_for_topic` would
+    // hash to a different value than the server's typed projection
+    // and live wakeups would miss every audience.
+    let issue = sample_issue();
+    let typed = issues::row_to_params_typed(&issue);
+    let value_form = issues::row_to_params(&serde_json::to_value(&issue).unwrap())
+        .expect("value form succeeds for well-formed row");
+    assert_eq!(typed, value_form);
+}
+
+#[test]
+fn row_to_params_typed_skips_none_options_and_only_required_fields() {
+    // Same selection rules as the Value form: only
+    // `#[query_param(required)]` fields, `Option::None` skipped,
+    // `contains`-only fields excluded. assignee_id is `Option<String>`
+    // and NOT required, so it never participates.
+    let issue = Issue {
+        id: "i1".into(),
+        workspace_id: "W1".into(),
+        assignee_id: None,
+        title: "Auth bug".into(),
+        status: Status::Open,
+        priority: 5,
+    };
+    let params = issues::row_to_params_typed(&issue);
+    let expected: StreamParams = [("workspace_id".to_string(), json!("W1"))]
+        .into_iter()
+        .collect();
+    assert_eq!(params, expected);
+}
+
+#[test]
 fn row_to_params_includes_only_required_fields() {
     // Post-codex-review (P2.1): only `required`-flagged fields
     // partition the topic. Anything else would produce a hash on

--- a/docs/sync-crud-query-composition.md
+++ b/docs/sync-crud-query-composition.md
@@ -1,0 +1,230 @@
+# CRUD + Query: How They Compose
+
+`pocopine-sync-crud` and `pocopine-sync-query` are not competing crates.
+They solve different halves of the same problem:
+
+```
+                READS                              WRITES
+                ─────                              ──────
+        pocopine-sync-query              pocopine-sync-crud
+        ───────────────────              ───────────────────
+        Typed query DSL                  Typed Draft + Row split
+        #[query_resource]                #[resource] / resource()
+        sealed-trait field markers       CrudSource trait (CRUD lifecycle)
+        predicate-routed mutations       CrudMutationLog (idempotency)
+        per-query state compartments     CrudTransactionRunner (atomic tx)
+        #[query] reactive selectors      CrudWriteResult / CrudConflict
+        §C per-(stream, params) topics   CrudMigrateFn (schema migration)
+```
+
+**The canonical sync app uses both.** CRUD owns the write path
+(typed mutations, idempotency, transaction-bound database commits).
+Query owns the read path (filtered subscriptions, derived selectors,
+precise live wakeups). They share one row type and one
+`SyncStreamSource`.
+
+## When to use only one
+
+| You need | Pick |
+|---|---|
+| Just `list` / `get` / `create` / `save` / `remove` over a single resource, no filtered views | **CRUD only.** Query adds infrastructure you don't need. |
+| Read-heavy reactive UI over rows you write via a different system (CDC, server-only writes, external DB) | **Query only.** No mutation lifecycle to manage. |
+| Multi-tenant app with filtered views AND optimistic mutations | **Both.** This is the canonical shape. |
+
+Tenancy + filtered views without §C scales like O(N) per push (every
+subscriber wakes for every mutation). With §C wired through the CRUD
+path, fanout collapses to O(matching subscribers).
+
+## The bridge: `.params_of`
+
+`#[query_resource]` emits a typed projector `row_to_params_typed`.
+`CrudResource::params_of(closure)` consumes it. With one line, a CRUD
+source gets Query-grade live wakeup precision.
+
+```rust
+use pocopine_sync_query::query_resource;
+use pocopine_sync_crud::{resource, CrudSource};
+
+#[query_resource(name = "issues", schema_version = 1)]
+#[derive(Clone, Serialize, Deserialize, /* … */)]
+pub struct Issue {
+    pub id: String,
+    #[query_param(required)]    // ← tenant gate; partitions §C topics
+    pub workspace_id: String,
+    #[query_param]
+    pub title: String,
+    #[query_param]
+    pub status: Status,
+    pub version: u64,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+struct IssueDraft { /* fields a client may send */ }
+
+struct IssueSource { /* sqlx pool, etc. */ }
+impl CrudSource for IssueSource { /* list/get/create/save/remove */ }
+
+let issues = resource("issues", IssueSource::default())?
+    .id(|r| r.id.clone())
+    .version(|r| r.version)
+    .mutation_log(MemoryCrudMutationLog::<Issue>::new())
+    .params_of(issues::row_to_params_typed);     // ← the bridge
+```
+
+That's the entire integration. CRUD still handles writes the way it
+always did; the only change is `partition_for_topic` (client) and
+`row_to_params` (server) now hash on `workspace_id` and route wakeups
+to per-`(stream, params_hash)` topics.
+
+## Data flow
+
+```
+                              ┌─────────────────────────┐
+                              │     Browser client      │
+                              └─────────────────────────┘
+                                         │
+            ┌────────────────────────────┼────────────────────────────┐
+            │                            │                            │
+            ▼                            ▼                            ▼
+       reads (Query)              writes (CRUD)              live wakeup (§C)
+   Issue::query()                CrudMutationPayload      query:sync:stream:
+     .eq(workspace_id, "W1")       ::create(id, draft)      issues:<W1-hash>
+     .observe(&client)            POST /sync/v1/push       SSE subscription
+            │                            │                            ▲
+            │                            │                            │
+            └──────── POST /sync/v1/pull ┘                            │
+                                         │                            │
+                                         ▼                            │
+                              ┌─────────────────────────┐             │
+                              │   Server (one source)   │             │
+                              │                         │             │
+                              │  CrudResource           │             │
+                              │   ├─ id_of              │             │
+                              │   ├─ version_of         │             │
+                              │   ├─ mutation_log       │             │
+                              │   ├─ .transactional(…)  │             │
+                              │   └─ .params_of(typed)──┼──┐          │
+                              │                         │  │          │
+                              │  IssueSource (CrudSource)  │          │
+                              │   ├─ list                  │          │
+                              │   ├─ get                   │          │
+                              │   ├─ create  ──┐           │          │
+                              │   ├─ save     ─┼─→ SQL     │          │
+                              │   └─ remove  ──┘           │          │
+                              └────────────────────────────┘          │
+                                         │                            │
+                                         ▼                            │
+                              row → row_to_params_typed(&Issue)       │
+                                  → {workspace_id: "W1"}              │
+                                  → FNV-1a → W1-hash                  │
+                                  → publish to topic ─────────────────┘
+```
+
+The same row type flows through both halves. The same
+`SyncStreamSource` instance serves both `/pull` (reads) and `/push`
+(writes). `.params_of` is the only addition that wasn't already
+possible.
+
+## What lives where
+
+**Read path (`pocopine-sync-query`):**
+
+- `#[query_resource]` on the row struct — generates field markers,
+  predicate evaluator, `row_to_params` + `row_to_params_typed`,
+  `partition_for_topic`.
+- `Query<Row>` + `QueryBuilder` — the typed filter DSL.
+- `QueryClient` / `QueryView<Row>` — subscription registry; reactive
+  view onto canonical + pending rows.
+- `#[query]` selectors — memoized reactive computations over views.
+
+**Write path (`pocopine-sync-crud`):**
+
+- `CrudSource` trait — `list`, `get`, `create`, `save`, `remove`.
+  App-defined; backed by SQLx / SQLite / Firestore / whatever.
+- `CrudMutationPayload` — typed `Create<Draft>` / `Save<Draft>` /
+  `Remove<Id>` envelope.
+- `CrudMutationLog` — pluggable idempotency (`MemoryCrudMutationLog`
+  for tests, `SqlxCrudMutationLog` for production).
+- `CrudTransactionRunner` + `.transactional(runner, log)` — atomic
+  write + idempotency-log insert in one DB transaction.
+- `CrudWriteResult` / `CrudConflict` / `CrudRemoveResult` — typed
+  optimistic-concurrency outcomes.
+- `CrudMigrateFn` + `.migrate_with(f)` — stale-schema payload
+  migration during push.
+
+**Bridge (`pocopine-sync-crud` consuming `pocopine-sync-query` output):**
+
+- `CrudResource::params_of(closure)` and the same on
+  `TransactionalCrudResource`. Closure is typically
+  `<resource>::row_to_params_typed` from `#[query_resource]`, but any
+  `Fn(&Row) -> StreamParams` works.
+
+## Why a typed sibling, not just `row_to_params(&Value)`
+
+The macro already emits `row_to_params(&Value) -> SyncResult<StreamParams>`
+for the `SyncStreamSource` trait boundary. `row_to_params_typed(&Row)`
+is the sibling that CRUD consumes:
+
+| Form | Signature | Cost | When to use |
+|---|---|---|---|
+| Value | `fn(&Value) -> SyncResult<StreamParams>` | Direct JSON projection — `row.get(name).clone()` per field | Hand-written `SyncStreamSource` impls that already have `&Value` |
+| Typed | `fn(&Row) -> StreamParams` | `serde_json::to_value` per required field only | CRUD adapter, which already has `&Row` |
+
+Both produce byte-identical `StreamParams` for the same row. The
+macro has a test (`row_to_params_typed_agrees_with_value_form`) that
+pins this — a divergence would silently miss every per-params wakeup.
+
+## When to choose Query without CRUD
+
+The audit found one significant gap in Query: there's no server-side
+mutation helper. Users either lean on CRUD (the recommended path) or
+hand-write `SyncStreamSource::push`. If you want filtered subscriptions
+but writes flow through a different system (CDC pipeline, server-only
+RPC, external database that emits change events) — Query alone is the
+right choice, and you wire `SyncStreamSource::row_to_params` directly
+to `<resource>::row_to_params` (the Value form).
+
+## Migration: starting from CRUD-only
+
+You already have a `CrudResource` and want to add filtered views. Three
+steps:
+
+1. Add `#[query_resource(name = "<stream>", schema_version = N)]` to
+   the row struct (above `#[derive(...)]`). Mark the tenant-gate field
+   (e.g. `workspace_id`) with `#[query_param(required)]`. Mark
+   filterable fields with `#[query_param]`.
+2. Add `.params_of(<stream>::row_to_params_typed)` to your CRUD builder
+   chain.
+3. On the host side, switch `LiveHub` from
+   `.allow_topics(sync.live_topics())` to
+   `.allow_topic_prefixes(sync.live_topic_prefixes())` so per-params
+   topics are authorized.
+
+That's it. Existing CRUD client code keeps working. New code can use
+`Issue::query().eq(field::workspace_id, "W1").observe(&client)` for
+filtered subscriptions.
+
+## Migration: starting from Query-only
+
+Less common, but: you have a hand-written `SyncStreamSource` with
+filtered reads and want typed-Draft writes + idempotency. Steps:
+
+1. Implement `CrudSource` for your existing storage backend (most of
+   the work is already done — `pull` → `list`, `push` → `create` /
+   `save` / `remove`).
+2. Replace your hand-written `SyncStreamSource` registration with
+   `resource(name, source).id(…).mutation_log(…).params_of(…)`.
+3. Existing `Query<Row>` subscriptions keep working byte-for-byte —
+   the macro-emitted `partition_for_topic` and `row_to_params` agree
+   regardless of who's calling them.
+
+## Related
+
+- [`sync.md`](./sync.md) — sync protocol, stream registration, live
+  wakeup, server plugin
+- [`sync-crud.md`](./sync-crud.md) — CRUD design, `CrudSource` API,
+  mutation log, transaction binding
+- [`sync-query-design.md`](./sync-query-design.md) — Query
+  implementation design, predicate routing, `#[query_resource]` codegen
+- [`sync-query-selector-mechanism.md`](./sync-query-selector-mechanism.md)
+  — `#[query]` selectors and memoization

--- a/docs/sync-crud-query-composition.md
+++ b/docs/sync-crud-query-composition.md
@@ -220,6 +220,9 @@ filtered reads and want typed-Draft writes + idempotency. Steps:
 
 ## Related
 
+- [`sync-crud-query-tutorial.md`](./sync-crud-query-tutorial.md) —
+  full step-by-step build of a SQLite-backed multi-workspace issue
+  tracker using this pattern
 - [`sync.md`](./sync.md) — sync protocol, stream registration, live
   wakeup, server plugin
 - [`sync-crud.md`](./sync-crud.md) — CRUD design, `CrudSource` API,

--- a/docs/sync-crud-query-tutorial.md
+++ b/docs/sync-crud-query-tutorial.md
@@ -449,14 +449,47 @@ the standard `self.plugin::<T>()` accessor.
 
 ## 6. A component that subscribes + pushes
 
-This is where CRUD and Query both show up at once.
+This is where CRUD and Query both show up at once. The component
+carries **two** pieces of sync state side by side:
+
+- `QueryView<Issue>` — the filtered, reactive **read** handle. This
+  is what the template renders.
+- `CollectionState<Issue>` — the **write-side bookkeeping** the
+  `SyncClient` needs: local mutation queue, pending overlay, cursor
+  for confirmation pulls. Doesn't drive the UI directly.
+
+```
+                         ┌─────────────────────────────┐
+                         │       IssueList             │
+                         │                             │
+   reads ◄── view.rows() │  view:    QueryView<Issue> ─┼──► /sync/v1/pull
+                         │                             │      filtered by
+                         │                             │      workspace_id
+                         │                             │
+   writes ── push ─────► │  writes:  CollectionState   ─┼──► /sync/v1/push
+                         │           <Issue>           │
+                         └─────────────────────────────┘
+                                  one canonical store on the wire;
+                                  two client-side handles onto it
+```
+
+Why two fields? `QueryView` and `CollectionState` are independent
+client-side caches today — `QueryView` subscribes through the query
+driver (one pull per `(stream, params)`), `CollectionState` carries
+the SyncClient's mutation queue. A future `#[resource]`-macro release
+will collapse the write side into the same Query subscription; until
+then the two coexist. The wire side is unified — both pull from one
+canonical row store on the server.
 
 ```rust
 // issues-browser/src/components/issue_list.rs
 use pocopine::prelude::*;
+use pocopine_sync::{ClientMutationDraft, CollectionState, SyncClient, SyncRow};
 use pocopine_sync_query::{QueryClient, QueryView};
 use serde::{Deserialize, Serialize};
 use std::rc::Rc;
+
+use pocopine_sync_crud::CrudMutationPayload;
 
 use issues::{field, Issue, IssueDraft, Status, STREAM};
 
@@ -467,26 +500,54 @@ pub struct IssueList {
     draft_title: String,
     rows: Vec<Issue>,
     status: String,
+
+    /// Write-side bookkeeping for the SyncClient: local mutation
+    /// queue, pending overlay, cursor. Not rendered directly — the
+    /// UI reads come from `view`.
+    writes: CollectionState<Issue>,
+
+    /// Filtered reactive read handle. Holds the §C subscription
+    /// alive; drops on component teardown.
     #[serde(skip)]
     view: Option<Rc<QueryView<Issue>>>,
+    next_local_id: u64,
 }
 
 #[handlers]
 impl IssueList {
     pub fn on_mount(&mut self) {
-        // Hardcode workspace for the tutorial; in a real app you'd
-        // read this from the URL / auth context / app state.
+        // Hardcode the workspace for the tutorial; in a real app
+        // you'd read it from the URL / auth context / app state.
         self.workspace = "W1".to_string();
-        self.subscribe();
+        self.open_writes();
+        self.subscribe_reads();
     }
 
-    fn subscribe(&mut self) {
+    /// Wire up the write-side: SyncClient opens the stream against
+    /// our `writes` field, which gives us the local mutation queue
+    /// and the cursor used to confirm pushes.
+    fn open_writes(&mut self) {
+        let result = self
+            .plugin::<SyncClient>()
+            .collection(pocopine::this::<Self>(), |s: &mut Self| &mut s.writes)
+            .stream(STREAM)
+            .and_then(|collection| collection.open());
+        if let Err(err) = result {
+            self.status = format!("sync open failed: {err}");
+        }
+    }
+
+    /// Wire up the read-side: a typed Query subscribed to this
+    /// workspace, status ∈ {Open, InProgress}. The §C `partition_hash`
+    /// (from `#[query_resource]`'s `partition_for_topic`) subscribes
+    /// the SSE stream to `query:sync:stream:issues:<W1-hash>`.
+    fn subscribe_reads(&mut self) {
         let client = self.plugin::<Rc<QueryClient>>().clone();
 
         // The typed DSL. `field::workspace_id` is a zero-sized
-        // marker the macro emits; the `.eq()` call is compile-time
-        // checked against the field's declared type (String here).
-        // Drop the workspace_id filter and the macro-generated
+        // marker the macro emits; `.eq()` is compile-time checked
+        // against the field's declared type (String here). Drop
+        // the workspace_id filter and the macro-generated
         // `matches()` predicate rejects every row — required-field
         // gating prevents accidental cross-tenant leaks.
         let query = Issue::query()
@@ -496,16 +557,14 @@ impl IssueList {
             .build();
 
         // .observe() returns a `QueryView<Row>` — the reactive
-        // handle. Drop it and the subscription unregisters; hold
-        // it on `self` to keep it alive.
+        // handle. Drop it and the subscription unregisters; we
+        // park it on `self.view` to keep it alive.
         let view = Rc::new(client.observe(query));
-
-        // Initial paint.
         self.rows = view.rows();
 
-        // Wire the listener. Fires whenever the canonical or pending
-        // overlays change. `view.rows()` returns the merged result
-        // (server-confirmed + optimistic).
+        // Re-render whenever canonical or pending overlays change.
+        // `view.rows()` returns the merged result (server-confirmed
+        // + optimistic) every time it's called.
         let handle = pocopine::this::<Self>();
         let view_clone = view.clone();
         view.on_update(move || {
@@ -515,56 +574,98 @@ impl IssueList {
         });
 
         self.view = Some(view);
-        self.status = format!("subscribed to {} (workspace={})", STREAM, self.workspace);
+        self.status = format!("subscribed to {STREAM} (workspace={})", self.workspace);
     }
 
     pub fn on_create_clicked(&mut self) {
-        // CRUD push. `ClientMutationDraft::upsert` is the wire-level
-        // builder; a higher-level typed API will land with the
-        // `#[resource]` proc-macro (planned).
+        let title = std::mem::take(&mut self.draft_title);
+        if title.trim().is_empty() {
+            self.status = "title required".to_string();
+            return;
+        }
+
+        self.next_local_id = self.next_local_id.saturating_add(1);
+        let id = format!("issue_local_{}", self.next_local_id);
         let draft = IssueDraft {
             workspace_id: self.workspace.clone(),
             status: Status::Open,
-            title: std::mem::take(&mut self.draft_title),
+            title: title.clone(),
             body: String::new(),
         };
-        let id = format!("issue_{}", uuid::Uuid::new_v4());
 
-        let payload = pocopine_sync_crud::CrudMutationPayload::create(id.clone(), draft);
-        let mutation = payload
-            .into_sync_draft()
-            .expect("draft serializes")
-            .key(id.clone())
-            .expect("row key");
+        // Two pieces of mutation state to construct:
+        //
+        //   1. The wire envelope — `CrudMutationPayload::create(id,
+        //      draft)`. The server's `CrudResource` decodes this
+        //      shape and dispatches to `IssuesSource::create`. Note
+        //      the payload is generic over `<Id, Draft>`, NOT `Row`
+        //      — the row id and the editable fields, not the full
+        //      stored row.
+        //
+        //   2. The optimistic row — a placeholder `Issue` that
+        //      paints immediately while the server confirms. The
+        //      version starts at 0; the server's `create` sets it
+        //      to 1 and the canonical row replaces this one when
+        //      the response arrives.
+        let result = (|| -> pocopine_sync::SyncResult<()> {
+            let mutation = CrudMutationPayload::create(id.clone(), draft)
+                .into_sync_draft()?
+                .key(id.clone())?;
+            let optimistic = SyncRow::new(
+                id.clone(),
+                Issue {
+                    id: id.clone(),
+                    workspace_id: self.workspace.clone(),
+                    status: Status::Open,
+                    title,
+                    body: String::new(),
+                    version: 0,
+                },
+            )?;
 
-        // Hand off to the sync client. It writes to the local
-        // store, optimistically applies to the pending overlay,
-        // and POSTs to /sync/v1/push in the background. When the
-        // server's response arrives, the row swaps from pending
-        // to canonical and the live wakeup brings any other
-        // tabs in the same workspace up to date.
-        self.plugin::<pocopine_sync::SyncClient>()
-            .collection(pocopine::this::<Self>(), |s: &mut Self| {
-                // CRUD writes don't currently route through a
-                // typed CollectionState on Query-only views — the
-                // local mutation queue is on the sync client side.
-                // This callback returns the rendered view's
-                // backing state for optimistic overlay purposes.
-                // For pure-Query apps with no per-resource state,
-                // the upcoming #[resource] macro will hide this.
-                unreachable!("placeholder — see note below");
-            });
+            // Hand off to SyncClient.
+            //
+            //   1. The mutation lands in `writes`'s local queue
+            //      (durable across reloads via IndexedDbLocalStore).
+            //   2. The optimistic Issue lands in the pending overlay.
+            //      The Query routing engine evaluates the macro-
+            //      generated `matches()` predicate against the row
+            //      — `workspace_id == "W1"` AND status ∈ {Open,
+            //      InProgress} both hold, so `view.rows()` returns
+            //      the new issue and the listener fires.
+            //   3. POST /sync/v1/push runs in the background. The
+            //      response either confirms (row moves from pending
+            //      → canonical) or conflicts (handled by your
+            //      `CrudSource::save`'s base_version logic).
+            //   4. The server publishes to
+            //      `query:sync:stream:issues:<W1-hash>`. Other tabs
+            //      subscribed to this workspace wake and pull;
+            //      tabs in W2 stay silent.
+            //
+            // `push_with_generated_id` has two generics: M (the
+            // wire payload, here `CrudMutationPayload<String,
+            // IssueDraft>`) and T (the optimistic row type, here
+            // `Issue` matching `CollectionState<Issue>`).
+            self.plugin::<SyncClient>()
+                .collection(pocopine::this::<Self>(), |s: &mut Self| &mut s.writes)
+                .stream(STREAM)
+                .and_then(|c| c.push_with_generated_id(mutation, Some(optimistic)))
+        })();
+
+        if let Err(err) = result {
+            self.status = format!("push failed: {err}");
+        }
     }
 }
 ```
 
-> The "placeholder" at the end is the one rough edge today. The
-> CRUD typed client API (`Resource<C>::create(...)`) ships with the
-> `#[resource]` proc-macro that's currently in design. Until then,
-> the pattern is "use `ClientMutationDraft::upsert` directly and
-> hand off to `SyncClient::collection(...).push(draft)`". See
-> [`examples/sync`](../examples/sync/) for the full hand-wired
-> shape.
+The two fields don't double-store rows. `CollectionState<Issue>`
+holds the local mutation queue + pending overlay for writes;
+`QueryView<Issue>` holds the filtered subscription state for reads.
+Both pull canonical rows from the same server-side store. The
+"two handles, one truth" shape is the honest version of CRUD+Query
+composition today — once the `#[resource]` macro lands, the write
+field collapses into the same `QueryView` and you'll only see one.
 
 The component file (`issue_list.poco`) is conventional Pocopine:
 

--- a/docs/sync-crud-query-tutorial.md
+++ b/docs/sync-crud-query-tutorial.md
@@ -1,0 +1,705 @@
+# Sync Tutorial: Build a Multi-Workspace Issue Tracker
+
+This walks through building a complete sync app end-to-end:
+
+- **Server**: SQLite-backed `CrudSource` serving a multi-tenant `issues` stream
+- **Browser**: IndexedDB local cache + filtered subscriptions via the typed query DSL
+- **Live wakeup**: RFC 088 §C precise routing — a push into workspace `W1` only wakes `W1` subscribers, `W2` stays silent
+
+The end product is the canonical pattern from
+[`sync-crud-query-composition.md`](./sync-crud-query-composition.md):
+CRUD owns the write path, Query owns the read path, `.params_of` is
+the bridge.
+
+If you only need filtered reads OR typed writes (not both), skip to
+the relevant section in the composition doc.
+
+## Prerequisites
+
+- Rust toolchain with `wasm32-unknown-unknown` target
+  (`rustup target add wasm32-unknown-unknown`)
+- A workspace using `pocopine` (or this repository's workspace if
+  you're contributing)
+- Familiarity with `pocopine::prelude::*` and the component model
+  (see [`docs/sync.md`](./sync.md) for the basics)
+
+## What you'll build
+
+```
+┌─────────────────────────────┐         ┌─────────────────────────────┐
+│         Browser             │         │           Server            │
+│                             │         │                             │
+│  ┌──────────────────────┐   │         │   ┌──────────────────────┐  │
+│  │ <IssueList>          │   │         │   │ CrudResource         │  │
+│  │  filter: workspace_W1│   │  /pull  │   │  + .params_of(typed) │  │
+│  │  view: rows()        │◄──┼─────────┼──►│                      │  │
+│  │  Issue::query()      │   │         │   │ IssuesSource         │  │
+│  │    .eq(workspace,W1) │   │  /push  │   │  (SQLx + SQLite)     │  │
+│  │    .observe(client)  │◄──┼─────────┼──►│                      │  │
+│  └──────────────────────┘   │         │   └──────────────────────┘  │
+│                             │         │                             │
+│  IndexedDbLocalStore        │  SSE    │   LiveHub + MemoryEvent     │
+│  (offline cache)            │◄────────┼── (sync:stream:issues:<W1>) │
+└─────────────────────────────┘         └─────────────────────────────┘
+```
+
+We'll get there in eight steps:
+
+1. Workspace dependencies
+2. Define the row type with both macros
+3. Implement `CrudSource` with SQLite storage
+4. Build the sync server with the `.params_of` bridge
+5. Wire the browser with `IndexedDbLocalStore` and the query client plugin
+6. Write a component that subscribes to a filtered view + pushes mutations
+7. Run it and observe the live wakeup
+8. Add a second workspace and watch §C precision in action
+
+## 1. Workspace dependencies
+
+Two crates: a host binary, a browser crate.
+
+```toml
+# Cargo.toml (workspace member: issues-server)
+[dependencies]
+pocopine = { workspace = true }
+pocopine-sync = { workspace = true }
+pocopine-sync-crud = { workspace = true }
+pocopine-sync-query = { workspace = true }
+serde = { workspace = true }
+
+[target.'cfg(pocopine_host)'.dependencies]
+pocopine-events = { workspace = true }
+pocopine-live = { workspace = true }
+pocopine-server = { workspace = true }
+sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+async-trait = "0.1"
+serde_json = { workspace = true }
+```
+
+```toml
+# Cargo.toml (workspace member: issues-browser)
+[dependencies]
+pocopine = { workspace = true }
+pocopine-sync = { workspace = true }
+pocopine-sync-query = { workspace = true }
+serde = { workspace = true }
+
+[target.'cfg(pocopine_browser)'.dependencies]
+pocopine-sync-indexdb = { workspace = true }
+wasm-bindgen = { workspace = true }
+```
+
+The `cfg(pocopine_host)` / `cfg(pocopine_browser)` gates keep
+server-only deps (SQLx, tokio, axum) out of the wasm bundle and
+browser-only deps (wasm-bindgen, indexdb) off the server side.
+
+## 2. Define the row type
+
+One struct, two macros. `#[query_resource]` declares the read shape;
+`#[derive(Serialize, Deserialize)]` covers the wire encoding for
+CRUD writes.
+
+```rust
+// issues/src/lib.rs (shared between host + browser)
+use pocopine_sync_query::query_resource;
+use serde::{Deserialize, Serialize};
+
+pub const STREAM: &str = "issues";
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[serde(rename_all = "snake_case")]
+pub enum Status {
+    Open,
+    InProgress,
+    Closed,
+}
+
+// `#[query_resource]` MUST come before `#[derive(...)]` so it strips
+// the `#[query_param]` annotations before serde sees them.
+#[query_resource(name = "issues", schema_version = 1)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct Issue {
+    pub id: String,
+
+    /// Tenant gate. `required` makes the predicate reject any query
+    /// that doesn't filter on `workspace_id` — cross-tenant safety
+    /// at compile time. This is also the §C partition key.
+    #[query_param(required)]
+    pub workspace_id: String,
+
+    #[query_param]
+    pub status: Status,
+
+    #[query_param]
+    pub title: String,
+
+    pub body: String,
+    pub version: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct IssueDraft {
+    pub workspace_id: String,
+    pub status: Status,
+    pub title: String,
+    pub body: String,
+}
+```
+
+What the macro generates (you'll consume it in steps 4 and 6):
+
+- `Issue::query()` — typed query builder
+- `issues::field::{workspace_id, status, title}` — field markers
+- `issues::matches(query, row)` — predicate evaluator
+- `issues::row_to_params(&Value)` and `issues::row_to_params_typed(&Issue)` — §C projectors
+- `issues::partition_for_topic(captured_params)` — client-side hash
+
+The `Draft` type is a separate struct: it represents "what a client
+can send when creating or editing an issue." Server-controlled fields
+like `id` and `version` aren't on the Draft.
+
+## 3. Implement `CrudSource` with SQLite
+
+This is your code. Pocopine doesn't generate SQL; you write idiomatic
+SQLx.
+
+```rust
+// issues-server/src/source.rs
+use async_trait::async_trait;
+use pocopine_auth::RequestContext;
+use pocopine_sync::{RowVersion, SyncError, SyncResult};
+use pocopine_sync_crud::{CrudRemoveResult, CrudSource, CrudWriteResult};
+use sqlx::SqlitePool;
+
+use issues::{Issue, IssueDraft, Status};
+
+#[derive(Clone)]
+pub struct IssuesSource {
+    pub pool: SqlitePool,
+}
+
+impl IssuesSource {
+    pub async fn new(database_url: &str) -> sqlx::Result<Self> {
+        let pool = SqlitePool::connect(database_url).await?;
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS issues (
+                id            TEXT    PRIMARY KEY,
+                workspace_id  TEXT    NOT NULL,
+                status        TEXT    NOT NULL,
+                title         TEXT    NOT NULL,
+                body          TEXT    NOT NULL,
+                version       INTEGER NOT NULL
+            );
+            CREATE INDEX IF NOT EXISTS issues_by_workspace
+              ON issues(workspace_id);
+            "#,
+        )
+        .execute(&pool)
+        .await?;
+        Ok(Self { pool })
+    }
+}
+
+#[async_trait]
+impl CrudSource for IssuesSource {
+    type Id = String;
+    type Row = Issue;
+    type Draft = IssueDraft;
+
+    async fn list(&self, _ctx: RequestContext, limit: usize) -> SyncResult<Vec<Issue>> {
+        let rows = sqlx::query_as::<_, Issue>(
+            "SELECT id, workspace_id, status, title, body, version
+               FROM issues
+               ORDER BY id
+               LIMIT ?",
+        )
+        .bind(limit as i64)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| SyncError::backend(e.to_string()))?;
+        Ok(rows)
+    }
+
+    async fn get(&self, _ctx: RequestContext, id: String) -> SyncResult<Option<Issue>> {
+        let row = sqlx::query_as::<_, Issue>(
+            "SELECT id, workspace_id, status, title, body, version
+               FROM issues
+              WHERE id = ?",
+        )
+        .bind(&id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| SyncError::backend(e.to_string()))?;
+        Ok(row)
+    }
+
+    async fn create(
+        &self,
+        _ctx: RequestContext,
+        id: String,
+        draft: IssueDraft,
+    ) -> SyncResult<Issue> {
+        let issue = Issue {
+            id: id.clone(),
+            workspace_id: draft.workspace_id,
+            status: draft.status,
+            title: draft.title,
+            body: draft.body,
+            version: 1,
+        };
+        sqlx::query(
+            "INSERT INTO issues (id, workspace_id, status, title, body, version)
+             VALUES (?, ?, ?, ?, ?, ?)",
+        )
+        .bind(&issue.id)
+        .bind(&issue.workspace_id)
+        .bind(serde_json::to_string(&issue.status).unwrap())
+        .bind(&issue.title)
+        .bind(&issue.body)
+        .bind(issue.version as i64)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| SyncError::backend(e.to_string()))?;
+        Ok(issue)
+    }
+
+    async fn save(
+        &self,
+        _ctx: RequestContext,
+        id: String,
+        draft: IssueDraft,
+        base_version: Option<RowVersion>,
+    ) -> SyncResult<CrudWriteResult<Issue>> {
+        // Optimistic-concurrency guard: if the client sent
+        // `base_version`, fail the save if the stored version
+        // doesn't match.
+        let current = self.get(_ctx.clone(), id.clone()).await?
+            .ok_or_else(|| SyncError::backend("missing issue"))?;
+        if let Some(expected) = &base_version {
+            if expected.as_str() != current.version.to_string() {
+                return Ok(CrudWriteResult::stale(Some(current)));
+            }
+        }
+        let next = Issue {
+            id: current.id,
+            workspace_id: draft.workspace_id,
+            status: draft.status,
+            title: draft.title,
+            body: draft.body,
+            version: current.version.saturating_add(1),
+        };
+        sqlx::query(
+            "UPDATE issues
+                SET workspace_id = ?, status = ?, title = ?, body = ?, version = ?
+              WHERE id = ?",
+        )
+        .bind(&next.workspace_id)
+        .bind(serde_json::to_string(&next.status).unwrap())
+        .bind(&next.title)
+        .bind(&next.body)
+        .bind(next.version as i64)
+        .bind(&next.id)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| SyncError::backend(e.to_string()))?;
+        Ok(CrudWriteResult::applied(next))
+    }
+
+    async fn remove(
+        &self,
+        _ctx: RequestContext,
+        id: String,
+        _base_version: Option<RowVersion>,
+    ) -> SyncResult<CrudRemoveResult<Issue>> {
+        sqlx::query("DELETE FROM issues WHERE id = ?")
+            .bind(&id)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| SyncError::backend(e.to_string()))?;
+        Ok(CrudRemoveResult::applied())
+    }
+}
+```
+
+Most of the work is your existing SQL knowledge. The Pocopine contract
+adds: `RequestContext` (for tenant headers / auth), `CrudWriteResult`
+(typed conflict outcomes), and `RowVersion` (the concurrency token).
+
+For production-grade idempotency you'd pair this with
+`.transactional(SqlxCrudTransactionRunner::new(pool), SqlxCrudMutationLog::new(scope_fn))`
+so the row write and the accepted-mutation log insert share one DB
+transaction. The basic `MemoryCrudMutationLog` is fine for tutorial
+purposes.
+
+## 4. Build the sync server with the `.params_of` bridge
+
+```rust
+// issues-server/src/main.rs
+use std::sync::Arc;
+
+use pocopine_events::{MemoryEventBackend, SharedEventBackend};
+use pocopine_live::{routes, LiveHub};
+use pocopine_server::{axum::Router, static_files, Server};
+use pocopine_sync::{sync_server_plugin, SyncServer};
+use pocopine_sync_crud::{resource, MemoryCrudMutationLog};
+
+use issues::{Issue, STREAM};
+use issues_server::source::IssuesSource;
+
+#[tokio::main]
+async fn main() -> std::io::Result<()> {
+    pocopine_logging::init_default().map_err(std::io::Error::other)?;
+
+    // 1. Storage.
+    let source = IssuesSource::new("sqlite://issues.db?mode=rwc")
+        .await
+        .map_err(std::io::Error::other)?;
+
+    // 2. Sync server. The .params_of line is the bridge — it plugs
+    //    the macro-generated typed projector into the CRUD adapter
+    //    so RFC 088 §C per-(stream, params_hash) live wakeups route
+    //    precisely.
+    let backend: SharedEventBackend = Arc::new(MemoryEventBackend::new());
+    let sync = SyncServer::builder()
+        .events(backend.clone())
+        .public_stream(
+            resource(STREAM, source)
+                .expect("stream name")
+                .id(|r: &Issue| r.id.clone())
+                .version(|r: &Issue| r.version)
+                .mutation_log(MemoryCrudMutationLog::<Issue>::new())
+                .params_of(issues::row_to_params_typed),
+        )
+        .build();
+
+    // 3. Live hub. allow_topic_prefixes (NOT allow_topics) is
+    //    critical — it authorizes both the bare `query:sync:stream:issues`
+    //    topic AND every per-(stream, params_hash) extension.
+    let topic_prefixes = sync.live_topic_prefixes();
+    let default_topics = sync.live_topics().map_err(std::io::Error::other)?;
+    let live_hub = LiveHub::new(backend)
+        .allow_topic_prefixes(topic_prefixes)
+        .default_topics(default_topics);
+
+    // 4. Mount routes.
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let router = Router::new()
+        .merge(routes(live_hub))
+        .fallback_service(static_files(manifest_dir));
+
+    Server::new(router)
+        .plugin(sync_server_plugin(sync))
+        .serve("127.0.0.1:3021")
+        .await
+}
+```
+
+Three things to notice:
+
+- `.params_of(issues::row_to_params_typed)` is the only Query-aware
+  line. Drop it and you're back to bare-topic broadcasts — every
+  subscriber wakes for every mutation.
+- `MemoryEventBackend` is fine for single-process. For multi-node
+  production use `RedisEventBackend::new(url, app)?` and put a Redis
+  instance behind both processes. See
+  [`docs/live.md`](./live.md) for the wire contract.
+- `allow_topic_prefixes` (not `allow_topics`) is required for §C. The
+  exact-match variant would silently reject every per-params
+  subscription because the hashes are computed at runtime.
+
+## 5. Wire the browser
+
+The browser does three things: install the sync plugin with IndexedDB
+storage, install the query client plugin, and register your components.
+
+```rust
+// issues-browser/src/main.rs
+use pocopine::prelude::*;
+use pocopine_sync::sync_plugin;
+use pocopine_sync_indexdb::IndexedDbLocalStore;
+use pocopine_sync_query::query_client_plugin;
+use wasm_bindgen::prelude::*;
+
+use issues_browser::components::IssueList;
+
+#[wasm_bindgen(start)]
+pub fn main() {
+    App::new()
+        .plugin(
+            sync_plugin()
+                // Live wakeup over SSE; without this the client
+                // polls on a timer.
+                .with_live_wakeup(true)
+                // Durable browser cache so reloads don't restart
+                // from an empty snapshot.
+                .local_store(IndexedDbLocalStore::new()),
+        )
+        // Query subscriptions + reactive views. Independent of CRUD;
+        // installs the registry every component will pull from.
+        .plugin(query_client_plugin())
+        .register::<IssueList>()
+        .run();
+}
+```
+
+That's all the framework glue. Components access both plugins through
+the standard `self.plugin::<T>()` accessor.
+
+## 6. A component that subscribes + pushes
+
+This is where CRUD and Query both show up at once.
+
+```rust
+// issues-browser/src/components/issue_list.rs
+use pocopine::prelude::*;
+use pocopine_sync_query::{QueryClient, QueryView};
+use serde::{Deserialize, Serialize};
+use std::rc::Rc;
+
+use issues::{field, Issue, IssueDraft, Status, STREAM};
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(style = "issue_list.css")]
+pub struct IssueList {
+    workspace: String,
+    draft_title: String,
+    rows: Vec<Issue>,
+    status: String,
+    #[serde(skip)]
+    view: Option<Rc<QueryView<Issue>>>,
+}
+
+#[handlers]
+impl IssueList {
+    pub fn on_mount(&mut self) {
+        // Hardcode workspace for the tutorial; in a real app you'd
+        // read this from the URL / auth context / app state.
+        self.workspace = "W1".to_string();
+        self.subscribe();
+    }
+
+    fn subscribe(&mut self) {
+        let client = self.plugin::<Rc<QueryClient>>().clone();
+
+        // The typed DSL. `field::workspace_id` is a zero-sized
+        // marker the macro emits; the `.eq()` call is compile-time
+        // checked against the field's declared type (String here).
+        // Drop the workspace_id filter and the macro-generated
+        // `matches()` predicate rejects every row — required-field
+        // gating prevents accidental cross-tenant leaks.
+        let query = Issue::query()
+            .eq(field::workspace_id, self.workspace.clone())
+            .any_of(field::status, [Status::Open, Status::InProgress])
+            .unwrap()
+            .build();
+
+        // .observe() returns a `QueryView<Row>` — the reactive
+        // handle. Drop it and the subscription unregisters; hold
+        // it on `self` to keep it alive.
+        let view = Rc::new(client.observe(query));
+
+        // Initial paint.
+        self.rows = view.rows();
+
+        // Wire the listener. Fires whenever the canonical or pending
+        // overlays change. `view.rows()` returns the merged result
+        // (server-confirmed + optimistic).
+        let handle = pocopine::this::<Self>();
+        let view_clone = view.clone();
+        view.on_update(move || {
+            handle.update(|this: &mut Self| {
+                this.rows = view_clone.rows();
+            });
+        });
+
+        self.view = Some(view);
+        self.status = format!("subscribed to {} (workspace={})", STREAM, self.workspace);
+    }
+
+    pub fn on_create_clicked(&mut self) {
+        // CRUD push. `ClientMutationDraft::upsert` is the wire-level
+        // builder; a higher-level typed API will land with the
+        // `#[resource]` proc-macro (planned).
+        let draft = IssueDraft {
+            workspace_id: self.workspace.clone(),
+            status: Status::Open,
+            title: std::mem::take(&mut self.draft_title),
+            body: String::new(),
+        };
+        let id = format!("issue_{}", uuid::Uuid::new_v4());
+
+        let payload = pocopine_sync_crud::CrudMutationPayload::create(id.clone(), draft);
+        let mutation = payload
+            .into_sync_draft()
+            .expect("draft serializes")
+            .key(id.clone())
+            .expect("row key");
+
+        // Hand off to the sync client. It writes to the local
+        // store, optimistically applies to the pending overlay,
+        // and POSTs to /sync/v1/push in the background. When the
+        // server's response arrives, the row swaps from pending
+        // to canonical and the live wakeup brings any other
+        // tabs in the same workspace up to date.
+        self.plugin::<pocopine_sync::SyncClient>()
+            .collection(pocopine::this::<Self>(), |s: &mut Self| {
+                // CRUD writes don't currently route through a
+                // typed CollectionState on Query-only views — the
+                // local mutation queue is on the sync client side.
+                // This callback returns the rendered view's
+                // backing state for optimistic overlay purposes.
+                // For pure-Query apps with no per-resource state,
+                // the upcoming #[resource] macro will hide this.
+                unreachable!("placeholder — see note below");
+            });
+    }
+}
+```
+
+> The "placeholder" at the end is the one rough edge today. The
+> CRUD typed client API (`Resource<C>::create(...)`) ships with the
+> `#[resource]` proc-macro that's currently in design. Until then,
+> the pattern is "use `ClientMutationDraft::upsert` directly and
+> hand off to `SyncClient::collection(...).push(draft)`". See
+> [`examples/sync`](../examples/sync/) for the full hand-wired
+> shape.
+
+The component file (`issue_list.poco`) is conventional Pocopine:
+
+```html
+<!-- issues-browser/src/components/issue_list.poco -->
+<div>
+  <header>
+    <h2>Issues — {{workspace}}</h2>
+    <p>{{status}}</p>
+  </header>
+
+  <form @submit.prevent="on_create_clicked">
+    <input pp-model="draft_title" placeholder="New issue title" />
+    <button type="submit">Create</button>
+  </form>
+
+  <ul>
+    <li pp-for="issue in rows" :key="issue.id">
+      <span class="status">{{issue.status}}</span>
+      <span class="title">{{issue.title}}</span>
+    </li>
+  </ul>
+</div>
+```
+
+## 7. Run it
+
+In two terminals:
+
+```bash
+# Terminal 1: server
+cargo run -p issues-server
+
+# Terminal 2: browser dev server (Pocopine CLI)
+pocopine dev --path issues-browser
+```
+
+Open `http://localhost:3000` (browser) — it talks to
+`http://127.0.0.1:3021` (server). The first paint shows whatever's
+already in `issues.db` (initially nothing). Type a title and click
+"Create."
+
+Expected behavior:
+
+1. The new issue appears immediately (optimistic overlay).
+2. The server accepts it; the row swaps from pending → canonical.
+3. The server publishes to topic
+   `query:sync:stream:issues:<W1-hash>` over SSE.
+4. The browser's live wakeup fires `/pull` with a cursor; the canonical
+   row gets confirmed (no UI change, since the optimistic value matched).
+
+Open a **second tab** at the same URL. You'll see the issue appear in
+both tabs after the live wakeup propagates.
+
+## 8. Watch §C precision
+
+Now the payoff. Change the workspace on one tab and observe that the
+two tabs no longer interfere.
+
+In Tab A, the component subscribes to `W1` (default). In Tab B, edit
+`on_mount` to use `"W2"` instead, reload.
+
+Tab B sees zero issues — correct, because no `W2` issues exist yet.
+Now create an issue from Tab A (in `W1`). What happens:
+
+- Tab A sees the new issue.
+- Tab B does **not** wake. Its SSE subscription is to
+  `query:sync:stream:issues:<W2-hash>`, and the server only publishes
+  to `<W1-hash>` for this push.
+
+This is the fanout-reduction §C delivers. Without `.params_of` (and
+without the topic-prefix allowlist), Tab B would wake for every
+mutation on the stream regardless of workspace, then `/pull` to
+discover nothing changed for its filter. With §C, the server routes
+the wakeup precisely.
+
+You can verify this with the integration test pattern in
+[`crates/pocopine-sync-crud/tests/params_partitioning.rs`](../crates/pocopine-sync-crud/tests/params_partitioning.rs)
+— a non-UI assertion that the W2 SSE body stays silent for 200ms
+after a W1 push.
+
+## Reactive selectors (bonus)
+
+`#[query]` is Query's memoization layer for derived computations.
+Imagine you want "open issue count by workspace" as a piece of
+reactive state.
+
+```rust
+use pocopine_sync_query::query;
+
+#[query]
+pub fn open_count(workspace: String) -> usize {
+    let view = Issue::query()
+        .eq(field::workspace_id, workspace)
+        .eq(field::status, Status::Open)
+        .observe(&Self::query_client());   // implicit; see the macro docs
+    view.rows().len()
+}
+```
+
+The selector re-runs only when the underlying view's `rows()` change.
+A header component reading `open_count("W1".into())` gets a cached
+number plus an `on_update` callback for free.
+
+See
+[`sync-query-selector-mechanism.md`](./sync-query-selector-mechanism.md)
+for the full mechanics.
+
+## What you didn't have to do
+
+- Write a `SyncStreamSource` impl by hand — CRUD's adapter generates
+  it from your `CrudSource`.
+- Wire SSE topics manually — `LiveHub::allow_topic_prefixes(sync.live_topic_prefixes())`
+  is one line.
+- Compute `params_hash` on either side — the macro emits both halves
+  (`row_to_params_typed` on server, `partition_for_topic` on client)
+  and the wire contract pins they agree byte-for-byte.
+- Manage the local cache — `IndexedDbLocalStore` handles hydration
+  and persistence; the sync client uses it transparently.
+
+## Where to go next
+
+- **Production idempotency**: swap `MemoryCrudMutationLog` for
+  `SqlxCrudMutationLog::new(scope_fn)` with a tenant-scoped log key
+  so the same `MutationId` from two tenants doesn't collide. See
+  [`docs/sync-crud.md`](./sync-crud.md) §6 ("Mutation Lifecycle").
+- **Atomic writes**: chain `.transactional(runner, log)` to put the
+  row write and log insert in one DB transaction. See
+  [`docs/sync-sqlx.md`](./sync-sqlx.md).
+- **Multi-node deployment**: switch the live backend from
+  `MemoryEventBackend` to `RedisEventBackend::new(url, app)?`. See
+  [`docs/live.md`](./live.md).
+- **Schema evolution**: bump `schema_version = 2` and register
+  `.migrate_with(|from, to, value| { … })` to transform stale-schema
+  client payloads on the wire. See
+  [`docs/sync-schema-versioning.md`](./sync-schema-versioning.md).
+- **Selectors deep-dive**:
+  [`docs/sync-query-selector-mechanism.md`](./sync-query-selector-mechanism.md).

--- a/docs/sync-crud.md
+++ b/docs/sync-crud.md
@@ -14,6 +14,13 @@ The concrete macro API is documented in
 [`sync-crud-macro-contract.md`](./sync-crud-macro-contract.md). That file
 is the review target for generated server/client API shape.
 
+CRUD is the **write** half of the sync story. Filtered reads,
+reactive selectors, and RFC 088 §C precise live wakeups belong to
+`pocopine-sync-query`. The two compose via `CrudResource::params_of`
+— see
+[`sync-crud-query-composition.md`](./sync-crud-query-composition.md)
+for when to use one, the other, or both.
+
 ## Goal
 
 Most CRUD apps need the same sync behavior:

--- a/docs/sync-query-design.md
+++ b/docs/sync-query-design.md
@@ -32,7 +32,7 @@ crates/
 └── pocopine-sync-query-sqlite/ # OPTIONAL adapter (Phase 3.5)
 ```
 
-Independent crate boundary. `pocopine-sync-query` depends on `pocopine-sync` directly, not on `pocopine-sync-crud`. Apps that use Query don't pull in CRUD; apps that use CRUD don't pull in Query.
+Independent crate boundary. `pocopine-sync-query` depends on `pocopine-sync` directly, not on `pocopine-sync-crud`. The two are decoupled at the crate level, but apps frequently use both — Query for filtered reads, CRUD for typed-Draft writes, with `CrudResource::params_of(<resource>::row_to_params_typed)` bridging them so a CRUD-built source gets §C precise live wakeups for free. See [`sync-crud-query-composition.md`](./sync-crud-query-composition.md) for the canonical pattern.
 
 The proc-macro crate splits the same way as CRUD's does (binary boundary). Naming convention: `pocopine-<thing>-macros` matches the existing pattern.
 

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -49,6 +49,16 @@ Proc-macro generated typed CRUD methods now cover `open`, `pull`,
 `use_server`, `retry_local`, and `merge_with`. SQL and persistence
 ownership stay with the app.
 
+The Query layer ([`sync-query-design.md`](./sync-query-design.md))
+sits beside CRUD, not on top of it: typed filter DSL, predicate-
+routed subscriptions, RFC 088 §C per-`(stream, params_hash)` live
+wakeups, and `#[query]` reactive selectors. CRUD owns writes, Query
+owns reads, and `.params_of` is the bridge that gives a CRUD-built
+source Query-grade live-wakeup precision. The canonical sync app
+uses both — see
+[`sync-crud-query-composition.md`](./sync-crud-query-composition.md)
+for the worked example.
+
 The runnable source of truth is [`examples/sync`](../examples/sync/).
 When the sync API changes, update this document and the example in the
 same PR.

--- a/docs/sync.md
+++ b/docs/sync.md
@@ -57,7 +57,10 @@ owns reads, and `.params_of` is the bridge that gives a CRUD-built
 source Query-grade live-wakeup precision. The canonical sync app
 uses both — see
 [`sync-crud-query-composition.md`](./sync-crud-query-composition.md)
-for the worked example.
+for the worked example, or
+[`sync-crud-query-tutorial.md`](./sync-crud-query-tutorial.md) for a
+step-by-step walkthrough that builds a multi-workspace issue tracker
+with SQLite + IndexedDB.
 
 The runnable source of truth is [`examples/sync`](../examples/sync/).
 When the sync API changes, update this document and the example in the


### PR DESCRIPTION
## Summary

Frames CRUD and Query as complementary halves of the same sync app:

* **CRUD owns writes** — typed `Draft`/`Row` split, `CrudMutationLog` idempotency, atomic `.transactional(runner, log)` binding, `CrudMigrateFn` schema migration.
* **Query owns reads** — typed filter DSL, predicate-routed subscriptions, RFC 088 §C per-`(stream, params_hash)` live wakeups, `#[query]` reactive selectors.

They share one row type and one `SyncStreamSource`. The bridge is one builder method:

```rust
let issues = resource("issues", IssueSource::default())?
    .id(|r| r.id.clone())
    .mutation_log(MemoryCrudMutationLog::<Issue>::new())
    .params_of(issues::row_to_params_typed);  // ← the bridge
```

A CRUD source now gets Query-grade live wakeup precision automatically. Before this PR, every CRUD push woke every subscriber on the stream; after, a push into workspace `W1` wakes only `W1`-scoped subscribers.

## What changed

* `#[query_resource]` emits a typed `row_to_params_typed(&Row) -> StreamParams` sibling alongside the existing Value form. Tests pin that the two agree byte-for-byte.
* `CrudResource::params_of(closure)` and the same on `TransactionalCrudResource`. The adapter overrides `SyncStreamSource::row_to_params` to deserialize once + invoke the closure. No projector → empty params → bare-topic publish (back-compat).
* New `docs/sync-crud-query-composition.md` with the worked example, ASCII data-flow diagram, and migration recipes. Cross-linked from `sync.md`, `sync-crud.md`, and `sync-query-design.md`.
* Two-workspace integration test in `pocopine-sync-crud` that subscribes to both `W1` and `W2` per-params topics, pushes into `W1`, and asserts `W2` stays silent within a 200ms window while `W1` wakes.

## Test plan

- [x] `cargo test -p pocopine-sync-query-macros` (22 macro tests, including 2 new for typed form)
- [x] `cargo test -p pocopine-sync-crud` (params_partitioning passes, existing tests untouched)
- [x] `cargo clippy -p pocopine-sync-crud -p pocopine-sync-query -p pocopine-sync-query-macros --tests -- -D warnings`
- [x] `cargo fmt --all -- --check`