### PR TITLE
rfc-090 phase 1: Source trait + Query-aware list

### DIFF
--- a/crates/pocopine-sync-query/src/lib.rs
+++ b/crates/pocopine-sync-query/src/lib.rs
@@ -83,7 +83,7 @@ pub use state::QueryState;
 #[cfg(not(target_arch = "wasm32"))]
 pub use source::{
     query_from_pull_request, source, Conflict, RemoveResult, Source, SourceFuture, SourceId,
-    SourceParamsFn, SourceResource, SourceResourceBuilder, WriteResult,
+    SourceParamsFn, SourceResource, SourceResourceBuilder, SourceVersionFn, WriteResult,
     DEFAULT_SOURCE_SNAPSHOT_ROW_LIMIT,
 };
 

--- a/crates/pocopine-sync-query/src/lib.rs
+++ b/crates/pocopine-sync-query/src/lib.rs
@@ -49,6 +49,12 @@ pub mod plugin;
 pub mod predicate;
 pub mod query;
 pub mod selector;
+// `source` is host-only — the trait threads `pocopine_auth::RequestContext`
+// through every method, and `pocopine-auth` is cfg-gated to non-wasm.
+// Browser code doesn't need a Source trait; it only needs the typed
+// query DSL + QueryClient runtime, which live in the modules above.
+#[cfg(not(target_arch = "wasm32"))]
+pub mod source;
 pub mod state;
 pub mod wire;
 
@@ -69,6 +75,17 @@ pub use predicate::{
 pub use query::{MatchFn, Order, OrderBy, PartitionHashFn, Query, QueryBuilder, QueryKey};
 pub use selector::{AnyArgs, AnyTrackable, SelectorId, SelectorView, TrackToken};
 pub use state::QueryState;
+
+// RFC 090 Phase 1 — Query-native server source. The crate also
+// continues to expose CRUD-shaped registration through
+// `pocopine-sync-crud` for back-compat; the `Source` trait is the
+// new direction. See `rfcs/rfc-090-merge-crud-into-query.md`.
+#[cfg(not(target_arch = "wasm32"))]
+pub use source::{
+    query_from_pull_request, source, Conflict, RemoveResult, Source, SourceFuture, SourceId,
+    SourceParamsFn, SourceResource, SourceResourceBuilder, WriteResult,
+    DEFAULT_SOURCE_SNAPSHOT_ROW_LIMIT,
+};
 
 // The macro lives in its own crate (proc-macros must), but downstream
 // code follows the same one-stop-shop import path as

--- a/crates/pocopine-sync-query/src/query.rs
+++ b/crates/pocopine-sync-query/src/query.rs
@@ -124,6 +124,20 @@ impl<Row> Query<Row> {
         self.limit
     }
 
+    /// Override the row cap in place. Used by the host-side
+    /// `SourceResource` adapter to clamp the wire-supplied limit
+    /// to its configured `max_snapshot_rows` before handing the
+    /// query to `Source::list` — a defense in depth so a
+    /// pathological source can't allocate unbounded memory by
+    /// ignoring `query.limit()`.
+    ///
+    /// `pub(crate)` because this only makes sense at the
+    /// trait-boundary translation layer; user code constructs
+    /// queries via the typed DSL.
+    pub(crate) fn set_limit(&mut self, limit: u32) {
+        self.limit = Some(limit);
+    }
+
     /// Stable canonical identity. Two queries with the same stream, params,
     /// order, and limit yield equal `QueryKey`s and (in the runtime) share
     /// one underlying subscription.

--- a/crates/pocopine-sync-query/src/source.rs
+++ b/crates/pocopine-sync-query/src/source.rs
@@ -129,6 +129,20 @@ pub type SourceFuture<'a, T> = std::pin::Pin<Box<dyn std::future::Future<Output 
 /// explicitly.
 pub type SourceParamsFn<Row> = dyn Fn(&Row) -> StreamParams + Send + Sync + 'static;
 
+/// Type-erased extractor that pulls the optimistic-concurrency
+/// version off a typed row. Stored on [`SourceResource`]; attached
+/// via [`SourceResource::version`]. When unset, pulled rows ship
+/// with `SyncRow::version = None` and Phase 2's `Source::save`
+/// `base_version` checks degrade to "no concurrency control."
+///
+/// Phase 2 will accept polyglot input types (numeric versions,
+/// `String`, `Option<String>`, etc.) via a `RowVersionValue`-style
+/// blanket impl. Phase 1 keeps it simple: the user returns an
+/// `Option<RowVersion>` directly. Mechanical to widen later
+/// without breaking the closure-shaped surface.
+pub type SourceVersionFn<Row> =
+    dyn Fn(&Row) -> SyncResult<Option<RowVersion>> + Send + Sync + 'static;
+
 /// Query-native server source. Replaces `CrudSource` in RFC 090's
 /// merged design.
 ///
@@ -341,6 +355,7 @@ impl<S: Source> SourceResourceBuilder<S> {
             max_snapshot_rows: self.max_snapshot_rows,
             schema_version: self.schema_version,
             id_of: Arc::new(id_of),
+            version_of: None,
             params_of: None,
         }
     }
@@ -356,6 +371,11 @@ pub struct SourceResource<S: Source, IdOf> {
     max_snapshot_rows: usize,
     schema_version: u32,
     id_of: Arc<IdOf>,
+    /// Row-version extractor for optimistic-concurrency. Set via
+    /// [`Self::version`]. When `None`, pulled rows ship with
+    /// `SyncRow::version = None` and Phase 2's `Source::save`
+    /// `base_version` checks degrade to "no concurrency control."
+    version_of: Option<Arc<SourceVersionFn<S::Row>>>,
     /// RFC 088 §C row → partition projector. Set via
     /// [`Self::params_of`]. When `None`, per-params publishes are
     /// disabled and the server publishes only the bare stream
@@ -368,6 +388,33 @@ where
     S: Source,
     IdOf: Fn(&S::Row) -> S::Id + Send + Sync + 'static,
 {
+    /// Attach a row-version extractor for optimistic concurrency.
+    /// Without it, pulled rows ship with `SyncRow::version = None`
+    /// and Phase 2's `Source::save` `base_version` checks have
+    /// nothing to compare against — concurrent writers can't be
+    /// detected.
+    ///
+    /// The closure returns `SyncResult<Option<RowVersion>>` so a
+    /// source can:
+    /// - return `Ok(None)` for rows with no meaningful version
+    ///   (e.g., immutable rows, server-only-write resources)
+    /// - return `Ok(Some(v))` for the canonical version token
+    /// - return `Err(...)` when version extraction itself fails
+    ///   (rare; usually means the row shape is corrupt)
+    ///
+    /// Most apps use a closure that maps an integer `version`
+    /// field to `RowVersion::new(v.to_string())?`. Phase 2 will
+    /// widen this to a polyglot `RowVersionValue`-style trait so
+    /// users can pass `|r| r.version` (numeric) or
+    /// `|r| r.etag.clone()` (string) directly.
+    pub fn version<F>(mut self, version_of: F) -> Self
+    where
+        F: Fn(&S::Row) -> SyncResult<Option<RowVersion>> + Send + Sync + 'static,
+    {
+        self.version_of = Some(Arc::new(version_of));
+        self
+    }
+
     /// Attach an RFC 088 §C row → partition projector. Until Phase 4
     /// auto-wires this from `#[query_resource]`, callers pass
     /// `<resource>::row_to_params_typed` explicitly.
@@ -417,9 +464,15 @@ where
         let Some(params_of) = self.params_of.as_ref() else {
             return Ok(StreamParams::new());
         };
+        // The row reaches `row_to_params` from the push-publish path
+        // (after `Source::create`/`save` already returned it); it's
+        // server-controlled state, not the client's request body.
+        // A deserialize failure here therefore signals a Source impl
+        // bug or schema drift, not bad client input — classify as
+        // `backend` so observability tools blame the right side.
         let typed: S::Row = serde_json::from_value(row.clone()).map_err(|e| {
-            SyncError::client(format!(
-                "row_to_params: {} row didn't deserialize: {}",
+            SyncError::backend(format!(
+                "row_to_params: {} row didn't deserialize for §C projection: {}",
                 self.stream.as_str(),
                 e
             ))
@@ -434,6 +487,7 @@ where
     ) -> pocopine_sync::SyncBoxFuture<'a, pocopine_sync::SyncPullResponse<Value>> {
         let source = self.source.clone();
         let id_of = self.id_of.clone();
+        let version_of = self.version_of.clone();
         let stream = self.stream.clone();
         let collection = self.collection.clone();
         let max_snapshot_rows = self.max_snapshot_rows;
@@ -446,26 +500,57 @@ where
             // Query reconstructed from the wire request. SQLx-style
             // impls translate `query.params()` to SQL filters; CRUD-
             // style fallbacks ignore the params and use `query.limit()`.
-            let query: Query<S::Row> = query_from_pull_request(&request);
+            //
+            // Clamp the query's `limit()` to `max_snapshot_rows`
+            // BEFORE calling `Source::list`. This is a defense in
+            // depth against pathological sources that ignore the
+            // limit altogether: even a buggy `list` impl that
+            // `SELECT *`s a 10M-row table sees a bounded `limit()`
+            // and can't allocate unbounded memory if it honors it
+            // at all. The post-call `rows.len()` check below is the
+            // belt-and-braces — it still catches sources that ALSO
+            // ignore the clamped value, but at least the memory
+            // ceiling is now visible from the contract.
+            let mut query: Query<S::Row> = query_from_pull_request(&request);
+            let effective_limit = query
+                .limit()
+                .map(|l| l.min(max_snapshot_rows as u32))
+                .unwrap_or(max_snapshot_rows as u32);
+            query.set_limit(effective_limit);
 
             let rows = source.list(ctx, &query).await?;
             if rows.len() > max_snapshot_rows {
                 return Err(SyncError::backend(format!(
-                    "Source returned {} rows, exceeding max snapshot row limit {}",
+                    "Source returned {} rows, exceeding max snapshot row limit {} \
+                     (the adapter clamped the query's limit to {} before calling list — \
+                     this source impl is ignoring `query.limit()` entirely)",
                     rows.len(),
-                    max_snapshot_rows
+                    max_snapshot_rows,
+                    effective_limit
                 )));
             }
 
             let mut sync_rows: Vec<SyncRow<Value>> = Vec::with_capacity(rows.len());
             for row in rows {
                 let key = (id_of)(&row).to_row_key()?;
+                // Extract the row's optimistic-concurrency version
+                // BEFORE serializing — the closure operates on the
+                // typed `&S::Row`, not the JSON Value. A `None`
+                // extractor means the source has opted out of
+                // version tracking (`SyncRow::version = None`,
+                // Phase 2's `base_version` checks degrade to
+                // "trust the client"). This is the fix for
+                // RFC 090 phase 1 code-review finding #1.
+                let version = match version_of.as_ref() {
+                    Some(extract) => (extract)(&row)?,
+                    None => None,
+                };
                 let value = serde_json::to_value(&row).map_err(|e| {
                     SyncError::backend(format!("Source row failed to serialize: {e}"))
                 })?;
                 sync_rows.push(SyncRow {
                     key,
-                    version: None,
+                    version,
                     value,
                     pending: false,
                     conflict: false,

--- a/crates/pocopine-sync-query/src/source.rs
+++ b/crates/pocopine-sync-query/src/source.rs
@@ -1,0 +1,656 @@
+//! Server-side `Source` trait for Query-native resources.
+//!
+//! This is the **read-and-write** counterpart to `Query<Row>` /
+//! `QueryView<Row>`. See [RFC 090](../../rfcs/rfc-090-merge-crud-into-query.md)
+//! for the motivation; in short:
+//!
+//! - `pocopine-sync-crud`'s `CrudSource::list(ctx, limit)` is
+//!   bandwidth-blind. It fetches every row the caller could see, then
+//!   the macro's predicate evaluator filters client-side.
+//! - `Source::list(ctx, &Query<Row>)` hands the typed query to the
+//!   source so SQLx / SQLite / Firestore can push a `WHERE
+//!   workspace_id = ? AND status IN (?)` clause down to storage.
+//!
+//! At 1M users that's the difference between a working multi-tenant
+//! app and one that times out. This is the "Phase 1" deliverable
+//! from RFC 090: trait shape + a thin adapter that proves the
+//! Query-aware list works end-to-end via `SyncStreamSource`.
+//!
+//! # Status — Phase 1 of RFC 090
+//!
+//! Phase 1 ships the trait and a minimal `Resource<S>` adapter that
+//! handles the **pull** lifecycle (Query-aware `list`). The **push**
+//! side is best-effort: every push attempt re-runs (no idempotency
+//! log yet). The mutation log moves into `pocopine-sync-query` in
+//! Phase 2; client-side push routing lands in Phase 3.
+//!
+//! Apps that need production-grade idempotency / atomic transactions
+//! TODAY should use `pocopine-sync-crud::resource(...).mutation_log(
+//! ...).transactional(...)`. After Phase 2 the same primitives live
+//! in `pocopine-sync-query` under shorter names.
+
+use std::sync::Arc;
+
+use pocopine_sync::{
+    RowVersion, StreamParams, SyncCollectionName, SyncError, SyncResult, SyncRow, SyncStreamName,
+};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use serde_json::Value;
+
+use crate::query::Query;
+
+/// Identity boundary for `Source` rows. Mirrors
+/// `pocopine_sync_crud::ResourceId` — Query reuses the same contract
+/// so a `Source` and a `CrudSource` impl can share the same `Id`
+/// type in apps that adopt Source incrementally.
+pub trait SourceId: Clone + Send + Sync + 'static {
+    /// Project this id into a sync row key. Used by the adapter to
+    /// fill the `key` field on `SyncRow<Value>` envelopes.
+    fn to_row_key(&self) -> SyncResult<pocopine_sync::RowKey>;
+}
+
+impl SourceId for String {
+    fn to_row_key(&self) -> SyncResult<pocopine_sync::RowKey> {
+        pocopine_sync::RowKey::new(self.clone())
+    }
+}
+
+/// Outcome of an optimistic-concurrency `save`.
+///
+/// Mirrors `pocopine_sync_crud::CrudWriteResult` byte-for-byte —
+/// applications can switch the import path without touching the
+/// match arms. The two types stay structurally identical through
+/// Phase 5; Phase 6 deletes the CRUD copy.
+#[derive(Debug, Clone)]
+pub enum WriteResult<Row> {
+    /// The write applied. `row` is the canonical post-write state.
+    Applied(Row),
+    /// The base_version check failed. `Conflict` carries the
+    /// server-visible row (if any) so the framework can surface it
+    /// to the client for merge / overwrite / discard handling.
+    Conflict(Conflict<Row>),
+}
+
+impl<Row> WriteResult<Row> {
+    pub fn applied(row: Row) -> Self {
+        Self::Applied(row)
+    }
+
+    pub fn stale(server_row: Option<Row>) -> Self {
+        Self::Conflict(Conflict {
+            server_row,
+            reason: "base_version stale".to_string(),
+        })
+    }
+}
+
+/// Outcome of an optimistic-concurrency `remove`.
+#[derive(Debug, Clone)]
+pub enum RemoveResult<Row> {
+    Applied,
+    Conflict(Conflict<Row>),
+}
+
+impl<Row> RemoveResult<Row> {
+    pub fn applied() -> Self {
+        Self::Applied
+    }
+
+    pub fn stale(server_row: Option<Row>) -> Self {
+        Self::Conflict(Conflict {
+            server_row,
+            reason: "base_version stale".to_string(),
+        })
+    }
+}
+
+/// Server-visible state at the moment a conflict was detected.
+#[derive(Debug, Clone)]
+pub struct Conflict<Row> {
+    /// The row as the server sees it. `None` when the conflict
+    /// arises from a missing row (e.g. a stale save against a deleted
+    /// id).
+    pub server_row: Option<Row>,
+    /// Human-readable reason. The framework forwards this verbatim
+    /// to the client; sources should make it diagnostic.
+    pub reason: String,
+}
+
+/// Boxed async-trait future. Sources don't need to name this — the
+/// `#[async_trait]` macro generates the right wrappers automatically.
+pub type SourceFuture<'a, T> = std::pin::Pin<Box<dyn std::future::Future<Output = T> + Send + 'a>>;
+
+/// Type-erased projector from a canonical row into the RFC 088 §C
+/// `(stream, params_hash)` partition fields. Stored on
+/// [`SourceResource`]; attached via [`SourceResource::params_of`].
+/// Phase 4 of RFC 090 auto-wires this from `#[query_resource]`;
+/// until then, callers pass `<resource>::row_to_params_typed`
+/// explicitly.
+pub type SourceParamsFn<Row> = dyn Fn(&Row) -> StreamParams + Send + Sync + 'static;
+
+/// Query-native server source. Replaces `CrudSource` in RFC 090's
+/// merged design.
+///
+/// **Key shape difference from `CrudSource`**: `list` receives a
+/// `&Query<Self::Row>` instead of a `limit`. The source can
+/// introspect the query's params and translate them into a storage
+/// filter (`WHERE workspace_id = ? …`) instead of fetching every
+/// row and relying on client-side predicate matching.
+///
+/// # Use cases
+///
+/// - **Reads only** (CDC-fed streams, server-rendered views): implement
+///   `list` + `get`; mark `create`/`save`/`remove` `unsupported()`.
+/// - **Writes only** (auth-gated write endpoints with no filtered
+///   reads): implement `create`/`save`/`remove`; `list` can return
+///   an empty vec.
+/// - **Both** (the canonical multi-tenant app): implement everything.
+///
+/// # Migration from `CrudSource`
+///
+/// Most CrudSource impls port mechanically:
+///
+/// ```ignore
+/// // Before
+/// async fn list(&self, ctx: RequestContext, limit: usize) -> ... {
+///     /* fetch first `limit` rows */
+/// }
+///
+/// // After
+/// async fn list(&self, ctx: RequestContext, query: &Query<Row>) -> ... {
+///     let limit = query.limit().unwrap_or(DEFAULT_LIMIT) as usize;
+///     /* fetch first `limit` rows */   // identical body
+/// }
+/// ```
+///
+/// Sources that want the §C scaling win override `list` to honor
+/// `query.params()`:
+///
+/// ```ignore
+/// async fn list(&self, ctx: RequestContext, query: &Query<Issue>) -> ... {
+///     let ws = query.params().get("workspace_id")
+///         .and_then(|v| v.as_str())
+///         .ok_or_else(|| SyncError::client("workspace_id required"))?;
+///     sqlx::query_as::<_, Issue>("SELECT * FROM issues WHERE workspace_id = ? LIMIT ?")
+///         .bind(ws)
+///         .bind(query.limit().unwrap_or(1000) as i64)
+///         .fetch_all(&self.pool)
+///         .await
+///         .map_err(|e| SyncError::backend(e.to_string()))
+/// }
+/// ```
+#[allow(async_fn_in_trait)]
+pub trait Source: Send + Sync + 'static {
+    type Id: SourceId;
+    type Row: Clone + Serialize + DeserializeOwned + Send + Sync + 'static;
+    type Draft: Clone + Serialize + DeserializeOwned + Send + Sync + 'static;
+
+    /// Snapshot pull. The query is server-reconstructed from the
+    /// wire `SyncPullRequest`'s `params`, `order_by`, and `limit`
+    /// fields. Implementations SHOULD honor `query.params()` and
+    /// `query.limit()`; the default behavior is "ignore the query
+    /// shape and return up to `limit` rows", which preserves
+    /// `CrudSource::list(ctx, limit)` semantics for incremental
+    /// migration.
+    fn list<'a>(
+        &'a self,
+        ctx: pocopine_auth::RequestContext,
+        query: &'a Query<Self::Row>,
+    ) -> SourceFuture<'a, SyncResult<Vec<Self::Row>>>;
+
+    /// Point lookup. Returns `None` for missing rows AND for rows the
+    /// caller cannot see — the source decides whether to leak
+    /// existence.
+    fn get<'a>(
+        &'a self,
+        ctx: pocopine_auth::RequestContext,
+        id: Self::Id,
+    ) -> SourceFuture<'a, SyncResult<Option<Self::Row>>>;
+
+    /// Create a row. Server-controlled fields (id, version, created_at)
+    /// are filled by the implementation; the `Draft` carries only
+    /// client-supplied fields.
+    fn create<'a>(
+        &'a self,
+        ctx: pocopine_auth::RequestContext,
+        id: Self::Id,
+        draft: Self::Draft,
+    ) -> SourceFuture<'a, SyncResult<Self::Row>>;
+
+    /// Save an existing row. `base_version` is the optimistic-
+    /// concurrency token the client read before editing. Source MUST
+    /// compare it against the stored row's version in the same DB
+    /// operation as the write.
+    fn save<'a>(
+        &'a self,
+        ctx: pocopine_auth::RequestContext,
+        id: Self::Id,
+        draft: Self::Draft,
+        base_version: Option<RowVersion>,
+    ) -> SourceFuture<'a, SyncResult<WriteResult<Self::Row>>>;
+
+    /// Remove an existing row. Same concurrency contract as `save`.
+    fn remove<'a>(
+        &'a self,
+        ctx: pocopine_auth::RequestContext,
+        id: Self::Id,
+        base_version: Option<RowVersion>,
+    ) -> SourceFuture<'a, SyncResult<RemoveResult<Self::Row>>>;
+}
+
+/// Reconstruct a `Query<Row>` from a wire `SyncPullRequest`. The
+/// reconstructed query has no `matches_fn` / `partition_hash_fn`
+/// because those are macro-emitted client-side and irrelevant for
+/// the server's filter translation — sources read `query.params()`,
+/// `query.order_by()`, `query.limit()` and never call `.matches()`
+/// in their `list` impls.
+///
+/// `cfg(not(target_arch = "wasm32"))` because the server adapter is
+/// host-only.
+pub fn query_from_pull_request<Row>(request: &pocopine_sync::SyncPullRequest) -> Query<Row> {
+    let mut builder = Query::<Row>::builder(request.stream.clone());
+    for (key, value) in request.params.iter() {
+        builder = builder.raw_param(key.clone(), value.clone());
+    }
+    // The wire `SyncPullRequest` carries `limit: u32`, with `0`
+    // meaning "use the source's default". Translate the zero
+    // sentinel to `None` so sources can pattern-match
+    // `query.limit()` cleanly.
+    //
+    // `order_by` doesn't ride on the pull request today (the
+    // server defines snapshot ordering). When the wire protocol
+    // grows ordering, this is where it lands.
+    if request.limit > 0 {
+        builder = builder.limit(request.limit);
+    }
+    builder.build()
+}
+
+/// Default snapshot row cap when the request doesn't carry one.
+/// Matches `pocopine_sync_crud::DEFAULT_CRUD_SNAPSHOT_ROW_LIMIT` so
+/// migration doesn't shift the silent fallback.
+pub const DEFAULT_SOURCE_SNAPSHOT_ROW_LIMIT: usize = 1_000;
+
+/// Builder returned by [`source`]. Phase 1 keeps it minimal —
+/// `.id(...)` is the only required call. `.mutation_log(...)`,
+/// `.params_of(...)`, `.transactional(...)` land in Phases 2-4 as
+/// the lifecycle pieces migrate over.
+pub struct SourceResourceBuilder<S: Source> {
+    stream: SyncStreamName,
+    collection: SyncCollectionName,
+    source: S,
+    max_snapshot_rows: usize,
+    schema_version: u32,
+}
+
+/// Start building a Query-native sync stream from a `Source` impl.
+///
+/// Phase 1 of RFC 090 — the entry point that demonstrates Query-aware
+/// `list` works end-to-end. Phase 2 adds `.mutation_log(...)` for
+/// idempotency; Phase 3 hooks `QueryClient::push` for client-side
+/// optimistic routing.
+pub fn source<S>(name: impl Into<String>, source: S) -> SyncResult<SourceResourceBuilder<S>>
+where
+    S: Source,
+{
+    let name = name.into();
+    Ok(SourceResourceBuilder {
+        stream: SyncStreamName::new(name.clone())?,
+        collection: SyncCollectionName::new(name)?,
+        source,
+        max_snapshot_rows: DEFAULT_SOURCE_SNAPSHOT_ROW_LIMIT,
+        schema_version: pocopine_sync::default_schema_version_one(),
+    })
+}
+
+impl<S: Source> SourceResourceBuilder<S> {
+    /// Override the default snapshot row cap.
+    pub fn max_snapshot_rows(mut self, limit: usize) -> SyncResult<Self> {
+        if limit == 0 {
+            return Err(SyncError::client(
+                "Source max snapshot rows must be greater than zero",
+            ));
+        }
+        self.max_snapshot_rows = limit;
+        Ok(self)
+    }
+
+    /// Set the schema version advertised on `/open` responses.
+    pub fn schema_version(mut self, version: u32) -> SyncResult<Self> {
+        if version == 0 {
+            return Err(SyncError::client(
+                "schema_version must be >= 1 (versions start at 1)",
+            ));
+        }
+        self.schema_version = version;
+        Ok(self)
+    }
+
+    /// Attach the row id extractor. Required because the wire layer
+    /// keys every row by `RowKey` and the source's `Id` type might
+    /// not be `String`-shaped.
+    pub fn id<IdOf>(self, id_of: IdOf) -> SourceResource<S, IdOf>
+    where
+        IdOf: Fn(&S::Row) -> S::Id + Send + Sync + 'static,
+    {
+        SourceResource {
+            stream: self.stream,
+            collection: self.collection,
+            source: Arc::new(self.source),
+            max_snapshot_rows: self.max_snapshot_rows,
+            schema_version: self.schema_version,
+            id_of: Arc::new(id_of),
+            params_of: None,
+        }
+    }
+}
+
+/// `SyncStreamSource` adapter wrapping a `Source` impl. Phase 1
+/// handles `pull` end-to-end (Query-aware `list`); `push` is
+/// best-effort (no idempotency log until Phase 2).
+pub struct SourceResource<S: Source, IdOf> {
+    stream: SyncStreamName,
+    collection: SyncCollectionName,
+    source: Arc<S>,
+    max_snapshot_rows: usize,
+    schema_version: u32,
+    id_of: Arc<IdOf>,
+    /// RFC 088 §C row → partition projector. Set via
+    /// [`Self::params_of`]. When `None`, per-params publishes are
+    /// disabled and the server publishes only the bare stream
+    /// topic. Phase 4 will auto-wire this from `#[query_resource]`.
+    params_of: Option<Arc<SourceParamsFn<S::Row>>>,
+}
+
+impl<S, IdOf> SourceResource<S, IdOf>
+where
+    S: Source,
+    IdOf: Fn(&S::Row) -> S::Id + Send + Sync + 'static,
+{
+    /// Attach an RFC 088 §C row → partition projector. Until Phase 4
+    /// auto-wires this from `#[query_resource]`, callers pass
+    /// `<resource>::row_to_params_typed` explicitly.
+    pub fn params_of<F>(mut self, params_of: F) -> Self
+    where
+        F: Fn(&S::Row) -> StreamParams + Send + Sync + 'static,
+    {
+        self.params_of = Some(Arc::new(params_of));
+        self
+    }
+}
+
+impl<S, IdOf> pocopine_sync::SyncStreamSource for SourceResource<S, IdOf>
+where
+    S: Source,
+    IdOf: Fn(&S::Row) -> S::Id + Send + Sync + 'static,
+{
+    fn stream(&self) -> &SyncStreamName {
+        &self.stream
+    }
+
+    fn collection(&self) -> &SyncCollectionName {
+        &self.collection
+    }
+
+    fn schema_version(&self) -> u32 {
+        self.schema_version
+    }
+
+    /// Query-native sources accept arbitrary params (the source
+    /// decides which shapes it can serve). Reserved-key-only param
+    /// maps pass; non-reserved keys go through to the source's
+    /// `list` for translation.
+    fn validate_params(&self, _params: &StreamParams) -> SyncResult<()> {
+        Ok(())
+    }
+
+    /// Source pushes don't carry params on the wire today; accept any.
+    fn validate_push_params(&self, _params: &StreamParams) -> SyncResult<()> {
+        Ok(())
+    }
+
+    /// RFC 088 §C: delegate to the closure attached via
+    /// [`SourceResource::params_of`]. Phase 4 will auto-wire from the
+    /// macro.
+    fn row_to_params(&self, row: &Value) -> SyncResult<StreamParams> {
+        let Some(params_of) = self.params_of.as_ref() else {
+            return Ok(StreamParams::new());
+        };
+        let typed: S::Row = serde_json::from_value(row.clone()).map_err(|e| {
+            SyncError::client(format!(
+                "row_to_params: {} row didn't deserialize: {}",
+                self.stream.as_str(),
+                e
+            ))
+        })?;
+        Ok(params_of(&typed))
+    }
+
+    fn pull<'a>(
+        &'a self,
+        ctx: pocopine_auth::RequestContext,
+        request: pocopine_sync::SyncPullRequest,
+    ) -> pocopine_sync::SyncBoxFuture<'a, pocopine_sync::SyncPullResponse<Value>> {
+        let source = self.source.clone();
+        let id_of = self.id_of.clone();
+        let stream = self.stream.clone();
+        let collection = self.collection.clone();
+        let max_snapshot_rows = self.max_snapshot_rows;
+        Box::pin(async move {
+            if request.stream != stream {
+                return Err(SyncError::UnknownStream(request.stream.to_string()));
+            }
+
+            // The whole point of Phase 1: hand the Source a typed
+            // Query reconstructed from the wire request. SQLx-style
+            // impls translate `query.params()` to SQL filters; CRUD-
+            // style fallbacks ignore the params and use `query.limit()`.
+            let query: Query<S::Row> = query_from_pull_request(&request);
+
+            let rows = source.list(ctx, &query).await?;
+            if rows.len() > max_snapshot_rows {
+                return Err(SyncError::backend(format!(
+                    "Source returned {} rows, exceeding max snapshot row limit {}",
+                    rows.len(),
+                    max_snapshot_rows
+                )));
+            }
+
+            let mut sync_rows: Vec<SyncRow<Value>> = Vec::with_capacity(rows.len());
+            for row in rows {
+                let key = (id_of)(&row).to_row_key()?;
+                let value = serde_json::to_value(&row).map_err(|e| {
+                    SyncError::backend(format!("Source row failed to serialize: {e}"))
+                })?;
+                sync_rows.push(SyncRow {
+                    key,
+                    version: None,
+                    value,
+                    pending: false,
+                    conflict: false,
+                });
+            }
+
+            Ok(pocopine_sync::SyncPullResponse::snapshot(
+                stream, collection, sync_rows, None,
+            ))
+        })
+    }
+
+    /// Phase 1 push: best-effort dispatch to `Source::create` based
+    /// on the wire op. **NO IDEMPOTENCY** — a retry of the same
+    /// mutation_id runs the source method again, which is incorrect
+    /// for production. Phase 2 adds the mutation log that fixes this.
+    /// For the canonical filtered-list demonstration this is fine.
+    fn push<'a>(
+        &'a self,
+        _ctx: pocopine_auth::RequestContext,
+        _request: pocopine_sync::SyncPushRequest<Value>,
+    ) -> pocopine_sync::SyncBoxFuture<'a, pocopine_sync::SyncPushResponse<Value>> {
+        Box::pin(async move {
+            Err(SyncError::unsupported(
+                "Source push is intentionally unimplemented in Phase 1 of RFC 090 \
+                 (the mutation log + create/save/remove dispatch land in Phase 2). \
+                 For production writes use `pocopine_sync_crud::resource(...)` until \
+                 Phase 2 ships.",
+            ))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pocopine_sync::SyncResult;
+
+    fn test_ctx() -> pocopine_auth::RequestContext {
+        pocopine_auth::RequestContext::new(
+            http::Method::POST,
+            "/__pocopine/sync/v1/pull".parse().unwrap(),
+            http::HeaderMap::new(),
+        )
+    }
+
+    // A trivial Source impl used to verify the trait shape compiles
+    // and that `list` actually receives the typed Query.
+
+    #[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+    struct Issue {
+        id: String,
+        workspace_id: String,
+    }
+
+    #[derive(Clone, serde::Serialize, serde::Deserialize)]
+    struct IssueDraft {
+        workspace_id: String,
+    }
+
+    struct StubSource;
+
+    impl Source for StubSource {
+        type Id = String;
+        type Row = Issue;
+        type Draft = IssueDraft;
+
+        fn list<'a>(
+            &'a self,
+            _ctx: pocopine_auth::RequestContext,
+            query: &'a Query<Self::Row>,
+        ) -> SourceFuture<'a, SyncResult<Vec<Self::Row>>> {
+            // The test below asserts the query reached us with the
+            // expected wire params — proves the wire reconstruction
+            // works end-to-end. We return rows tagged with whatever
+            // workspace_id we received so the assertion can read it
+            // back.
+            let ws = query
+                .params()
+                .get("workspace_id")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            Box::pin(async move {
+                Ok(vec![Issue {
+                    id: "stub_1".into(),
+                    workspace_id: ws,
+                }])
+            })
+        }
+
+        fn get<'a>(
+            &'a self,
+            _ctx: pocopine_auth::RequestContext,
+            _id: Self::Id,
+        ) -> SourceFuture<'a, SyncResult<Option<Self::Row>>> {
+            Box::pin(async move { Ok(None) })
+        }
+
+        fn create<'a>(
+            &'a self,
+            _ctx: pocopine_auth::RequestContext,
+            _id: Self::Id,
+            _draft: Self::Draft,
+        ) -> SourceFuture<'a, SyncResult<Self::Row>> {
+            Box::pin(async move { Err(SyncError::unsupported("test stub: create")) })
+        }
+
+        fn save<'a>(
+            &'a self,
+            _ctx: pocopine_auth::RequestContext,
+            _id: Self::Id,
+            _draft: Self::Draft,
+            _base_version: Option<RowVersion>,
+        ) -> SourceFuture<'a, SyncResult<WriteResult<Self::Row>>> {
+            Box::pin(async move { Err(SyncError::unsupported("test stub: save")) })
+        }
+
+        fn remove<'a>(
+            &'a self,
+            _ctx: pocopine_auth::RequestContext,
+            _id: Self::Id,
+            _base_version: Option<RowVersion>,
+        ) -> SourceFuture<'a, SyncResult<RemoveResult<Self::Row>>> {
+            Box::pin(async move { Err(SyncError::unsupported("test stub: remove")) })
+        }
+    }
+
+    #[test]
+    fn query_from_pull_request_round_trips_params() {
+        // The cross-language wire contract for the Source trait: the
+        // server reconstructs Query<Row> from wire params. A
+        // round-trip regression here would silently break server-
+        // side filtering.
+        let mut request =
+            pocopine_sync::SyncPullRequest::new(SyncStreamName::new("issues").unwrap());
+        request
+            .params
+            .insert("workspace_id".to_string(), serde_json::json!("W1"));
+        request.params.insert(
+            "status".to_string(),
+            serde_json::json!({"in": ["open", "in_progress"]}),
+        );
+        request.limit = 50;
+
+        let q: Query<Issue> = query_from_pull_request(&request);
+        assert_eq!(q.stream().as_str(), "issues");
+        assert_eq!(q.params().len(), 2);
+        assert_eq!(
+            q.params().get("workspace_id").unwrap(),
+            &serde_json::json!("W1")
+        );
+        assert_eq!(q.limit(), Some(50));
+    }
+
+    #[test]
+    fn query_from_pull_request_zero_limit_means_unset() {
+        // The wire protocol's `limit: u32` field uses 0 to mean
+        // "use the source's default". Make sure the reconstructed
+        // Query reflects that as `limit().is_none()` so sources can
+        // pattern-match without thinking about the sentinel.
+        let mut request =
+            pocopine_sync::SyncPullRequest::new(SyncStreamName::new("issues").unwrap());
+        request.limit = 0;
+        let q: Query<Issue> = query_from_pull_request(&request);
+        assert_eq!(q.limit(), None);
+    }
+
+    #[tokio::test]
+    async fn stub_source_receives_query_params_via_list() {
+        // Verifies the Source trait's `list(ctx, &Query<Row>)` shape
+        // works: a wire-reconstructed query passes its params through
+        // to the source, which can introspect them and return
+        // filtered rows. This is the basic Phase 1 contract.
+        let source = StubSource;
+        let mut request =
+            pocopine_sync::SyncPullRequest::new(SyncStreamName::new("issues").unwrap());
+        request
+            .params
+            .insert("workspace_id".to_string(), serde_json::json!("W42"));
+        let query: Query<Issue> = query_from_pull_request(&request);
+
+        let ctx = test_ctx();
+        let rows = source.list(ctx, &query).await.expect("stub list");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].workspace_id, "W42");
+    }
+}

--- a/crates/pocopine-sync-query/tests/source_phase1.rs
+++ b/crates/pocopine-sync-query/tests/source_phase1.rs
@@ -1,0 +1,330 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+//! Phase 1 of RFC 090: end-to-end integration test for the new
+//! `Source` trait + `SyncStreamSource` adapter.
+//!
+//! Proves the **Query-aware list** unlock: a Source impl can
+//! introspect `&Query<Row>` and translate `query.params()` into a
+//! filter applied BEFORE rows leave storage. CRUD's `list(ctx,
+//! limit)` couldn't do this — every workspace's rows came back
+//! and the predicate filtered client-side.
+//!
+//! Two workspaces (`W1` / `W2`) live in the source. A pull request
+//! with `params.workspace_id = "W1"` returns only `W1` rows. A
+//! pull with `workspace_id = "W2"` returns only `W2` rows. An
+//! unfiltered pull (no params) returns everything.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+use http_body_util::BodyExt;
+use pocopine_auth::RequestContext;
+use pocopine_server::axum::body::Body;
+use pocopine_server::axum::http::{Request, StatusCode};
+use pocopine_server::Server;
+use pocopine_sync::{
+    sync_server_plugin, SyncPullMode, SyncPullRequest, SyncPullResponse, SyncResult, SyncServer,
+    SyncStreamName, SYNC_PULL_PATH,
+};
+use pocopine_sync_query::source::{
+    query_from_pull_request, source as build_source, RemoveResult, Source, SourceFuture,
+    WriteResult,
+};
+use pocopine_sync_query::Query;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tower::ServiceExt;
+
+const STREAM: &str = "issues";
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct Issue {
+    id: String,
+    workspace_id: String,
+    title: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct IssueDraft {
+    workspace_id: String,
+    title: String,
+}
+
+/// Test instrumentation — records every (query.params,
+/// query.limit) pair the trait method observed. The integration
+/// test asserts the source SAW the filter, not just that the
+/// output happened to be right.
+type ObservedCalls = Arc<Mutex<Vec<(BTreeMap<String, Value>, Option<u32>)>>>;
+
+/// A Source impl that demonstrates the Query-aware filter pattern.
+/// In a real app this would translate `query.params()` into SQL
+/// (`WHERE workspace_id = ? AND status IN (?)`); here we filter
+/// an in-memory `Vec<Issue>` so the test stays small.
+#[derive(Clone)]
+struct IssuesSource {
+    rows: Arc<Mutex<Vec<Issue>>>,
+    observed: ObservedCalls,
+}
+
+impl IssuesSource {
+    fn seeded() -> Self {
+        let rows = vec![
+            Issue {
+                id: "i_w1_a".into(),
+                workspace_id: "W1".into(),
+                title: "Auth bug".into(),
+            },
+            Issue {
+                id: "i_w1_b".into(),
+                workspace_id: "W1".into(),
+                title: "Routing".into(),
+            },
+            Issue {
+                id: "i_w2_a".into(),
+                workspace_id: "W2".into(),
+                title: "Different tenant".into(),
+            },
+        ];
+        Self {
+            rows: Arc::new(Mutex::new(rows)),
+            observed: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+}
+
+impl Source for IssuesSource {
+    type Id = String;
+    type Row = Issue;
+    type Draft = IssueDraft;
+
+    fn list<'a>(
+        &'a self,
+        _ctx: RequestContext,
+        query: &'a Query<Self::Row>,
+    ) -> SourceFuture<'a, SyncResult<Vec<Self::Row>>> {
+        // Record what the source saw — instrumentation for the
+        // integration test, not part of the production pattern.
+        self.observed
+            .lock()
+            .unwrap()
+            .push((query.params().clone(), query.limit()));
+
+        // The whole point of Phase 1: this filter runs HERE
+        // (= "in storage"), not after the wire round-trip. In a
+        // real SQLx source, the params drive a WHERE clause; here
+        // we Vec::filter. The shape is the same.
+        let workspace_filter = query
+            .params()
+            .get("workspace_id")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let limit = query.limit().unwrap_or(u32::MAX) as usize;
+
+        let rows = self.rows.lock().unwrap().clone();
+        Box::pin(async move {
+            let filtered = rows
+                .into_iter()
+                .filter(|r| {
+                    workspace_filter
+                        .as_deref()
+                        .is_none_or(|w| r.workspace_id == w)
+                })
+                .take(limit)
+                .collect();
+            Ok(filtered)
+        })
+    }
+
+    fn get<'a>(
+        &'a self,
+        _ctx: RequestContext,
+        id: Self::Id,
+    ) -> SourceFuture<'a, SyncResult<Option<Self::Row>>> {
+        let rows = self.rows.lock().unwrap().clone();
+        Box::pin(async move { Ok(rows.into_iter().find(|r| r.id == id)) })
+    }
+
+    fn create<'a>(
+        &'a self,
+        _ctx: RequestContext,
+        id: Self::Id,
+        draft: Self::Draft,
+    ) -> SourceFuture<'a, SyncResult<Self::Row>> {
+        let rows = self.rows.clone();
+        Box::pin(async move {
+            let issue = Issue {
+                id: id.clone(),
+                workspace_id: draft.workspace_id,
+                title: draft.title,
+            };
+            rows.lock().unwrap().push(issue.clone());
+            Ok(issue)
+        })
+    }
+
+    fn save<'a>(
+        &'a self,
+        _ctx: RequestContext,
+        _id: Self::Id,
+        _draft: Self::Draft,
+        _base_version: Option<pocopine_sync::RowVersion>,
+    ) -> SourceFuture<'a, SyncResult<WriteResult<Self::Row>>> {
+        Box::pin(async move { Err(pocopine_sync::SyncError::unsupported("Phase 1 stub: save")) })
+    }
+
+    fn remove<'a>(
+        &'a self,
+        _ctx: RequestContext,
+        _id: Self::Id,
+        _base_version: Option<pocopine_sync::RowVersion>,
+    ) -> SourceFuture<'a, SyncResult<RemoveResult<Self::Row>>> {
+        Box::pin(async move {
+            Err(pocopine_sync::SyncError::unsupported(
+                "Phase 1 stub: remove",
+            ))
+        })
+    }
+}
+
+fn build_app(source: IssuesSource) -> pocopine_server::axum::Router {
+    pocopine_server::__reset_for_test();
+    let sync = SyncServer::builder()
+        .public_stream(
+            build_source(STREAM, source)
+                .expect("stream name")
+                .id(|r: &Issue| r.id.clone()),
+        )
+        .build();
+    Server::new(pocopine_server::axum::Router::new())
+        .plugin(sync_server_plugin(sync))
+        .try_finalize()
+        .expect("server finalizes")
+}
+
+async fn pull(
+    app: &pocopine_server::axum::Router,
+    workspace: Option<&str>,
+) -> SyncPullResponse<Value> {
+    let mut request = SyncPullRequest::new(SyncStreamName::new(STREAM).unwrap());
+    if let Some(w) = workspace {
+        request
+            .params
+            .insert("workspace_id".to_string(), serde_json::json!(w));
+    }
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(SYNC_PULL_PATH)
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&request).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let outer: pocopine_core::ServerResult<SyncPullResponse<Value>> =
+        serde_json::from_slice(&bytes).unwrap();
+    outer.unwrap()
+}
+
+#[tokio::test]
+async fn workspace_filter_pushes_into_source_not_client() {
+    // The headline Phase 1 test: a /pull with params.workspace_id =
+    // "W1" routes through the SyncStreamSource adapter, which
+    // reconstructs a typed Query<Issue> and hands it to
+    // Source::list. The source sees the filter and returns only W1
+    // rows. CRUD's CrudSource::list(ctx, limit) had no path to
+    // observe the workspace_id — every workspace's rows came back
+    // and the macro's predicate filtered client-side.
+    let source = IssuesSource::seeded();
+    let observed = source.observed.clone();
+    let app = build_app(source);
+
+    let response = pull(&app, Some("W1")).await;
+    assert_eq!(response.mode, SyncPullMode::Snapshot);
+    assert_eq!(response.rows.len(), 2);
+    for row in &response.rows {
+        assert_eq!(
+            row.value.get("workspace_id").and_then(|v| v.as_str()),
+            Some("W1"),
+            "Source should not have returned non-W1 rows"
+        );
+    }
+
+    // Cross-check that the source's `list` actually OBSERVED the
+    // workspace filter — distinguishes "filter ran in storage"
+    // from "filter ran in the test harness."
+    let observed = observed.lock().unwrap();
+    assert_eq!(observed.len(), 1);
+    assert_eq!(
+        observed[0].0.get("workspace_id").and_then(|v| v.as_str()),
+        Some("W1"),
+        "Source should have seen workspace_id=W1 in query.params()"
+    );
+}
+
+#[tokio::test]
+async fn distinct_workspaces_yield_distinct_filters() {
+    // Two pulls with different workspaces hit the source with
+    // different `query.params()` and get disjoint result sets.
+    // This is the multi-tenant contract Phase 1 makes possible.
+    let source = IssuesSource::seeded();
+    let app = build_app(source);
+
+    let w1 = pull(&app, Some("W1")).await;
+    let w2 = pull(&app, Some("W2")).await;
+
+    assert_eq!(w1.rows.len(), 2);
+    assert_eq!(w2.rows.len(), 1);
+    assert_eq!(
+        w2.rows[0]
+            .value
+            .get("workspace_id")
+            .and_then(|v| v.as_str()),
+        Some("W2")
+    );
+
+    // Sanity: no row from W2 appears in W1's response (would
+    // signal the filter regressed to "ignored").
+    for row in &w1.rows {
+        assert_ne!(
+            row.value.get("workspace_id").and_then(|v| v.as_str()),
+            Some("W2")
+        );
+    }
+}
+
+#[tokio::test]
+async fn unfiltered_pull_returns_everything() {
+    // A /pull with no params reconstructs a Query with no filter.
+    // The source's pattern-match returns all rows — preserves the
+    // CRUD-style "list(ctx, limit)" semantics when callers don't
+    // care about filtering.
+    let source = IssuesSource::seeded();
+    let app = build_app(source);
+
+    let all = pull(&app, None).await;
+    assert_eq!(all.rows.len(), 3);
+}
+
+#[test]
+fn query_reconstruction_smoke_test() {
+    // Pure unit-level check on the wire→Query function — covers
+    // the regression path where the SyncPullRequest field shape
+    // changes (e.g. `limit: u32` → `Option<u32>`) and the
+    // reconstructor silently drops the filter.
+    let mut request = SyncPullRequest::new(SyncStreamName::new("issues").unwrap());
+    request
+        .params
+        .insert("workspace_id".to_string(), serde_json::json!("W1"));
+    request.limit = 25;
+    let q: Query<Issue> = query_from_pull_request(&request);
+    assert_eq!(
+        q.params().get("workspace_id").unwrap(),
+        &serde_json::json!("W1")
+    );
+    assert_eq!(q.limit(), Some(25));
+}

--- a/crates/pocopine-sync-query/tests/source_phase1.rs
+++ b/crates/pocopine-sync-query/tests/source_phase1.rs
@@ -310,6 +310,86 @@ async fn unfiltered_pull_returns_everything() {
     assert_eq!(all.rows.len(), 3);
 }
 
+#[tokio::test]
+async fn version_extractor_populates_sync_row_version() {
+    // Code-review finding #1: without `.version()`, pulled rows ship
+    // with version=None and Phase 2's `Source::save` base_version
+    // check becomes meaningless. This test wires a version extractor
+    // and asserts each pulled row carries the extracted version on
+    // the wire.
+    use pocopine_sync::RowVersion;
+
+    pocopine_server::__reset_for_test();
+    let sync = SyncServer::builder()
+        .public_stream(
+            build_source(STREAM, IssuesSource::seeded())
+                .expect("stream name")
+                .id(|r: &Issue| r.id.clone())
+                // Synthetic version derived from the title length —
+                // not meaningful semantically, just deterministic so
+                // the assertion below can predict the expected
+                // string.
+                .version(|r: &Issue| {
+                    Ok(Some(
+                        RowVersion::new(r.title.len().to_string()).expect("valid version"),
+                    ))
+                }),
+        )
+        .build();
+    let app = Server::new(pocopine_server::axum::Router::new())
+        .plugin(sync_server_plugin(sync))
+        .try_finalize()
+        .expect("server finalizes");
+
+    let response = pull(&app, Some("W1")).await;
+    assert_eq!(response.rows.len(), 2);
+    for row in &response.rows {
+        let title = row.value.get("title").and_then(|v| v.as_str()).unwrap();
+        let version = row
+            .version
+            .as_ref()
+            .expect("version extractor ran")
+            .as_str();
+        assert_eq!(version, title.len().to_string());
+    }
+}
+
+#[tokio::test]
+async fn limit_clamped_to_max_snapshot_rows_before_calling_source() {
+    // Code-review finding #3: a buggy Source::list that ignores
+    // query.limit() could allocate unbounded memory. Defense in
+    // depth: the adapter clamps query.limit() to max_snapshot_rows
+    // BEFORE calling list. This test asserts the source SEES the
+    // clamped value (and so a well-behaved source can't even ask
+    // for more than the cap).
+    pocopine_server::__reset_for_test();
+    let source = IssuesSource::seeded();
+    let observed = source.observed.clone();
+    let sync = SyncServer::builder()
+        .public_stream(
+            build_source(STREAM, source)
+                .expect("stream name")
+                .max_snapshot_rows(2)
+                .expect("nonzero max")
+                .id(|r: &Issue| r.id.clone()),
+        )
+        .build();
+    let app = Server::new(pocopine_server::axum::Router::new())
+        .plugin(sync_server_plugin(sync))
+        .try_finalize()
+        .expect("server finalizes");
+
+    // Pull with no explicit wire-limit → the adapter substitutes
+    // the configured cap.
+    let _ = pull(&app, None).await;
+    let observed = observed.lock().unwrap();
+    assert_eq!(
+        observed.last().expect("source.list ran").1,
+        Some(2),
+        "adapter must clamp query.limit() to the configured cap"
+    );
+}
+
 #[test]
 fn query_reconstruction_smoke_test() {
     // Pure unit-level check on the wire→Query function — covers


### PR DESCRIPTION
First implementation PR for [RFC 090](https://github.com/mambisi/pocopine/blob/feat/rfc-090-merge-crud-into-query/rfcs/rfc-090-merge-crud-into-query.md). Closes nothing — the merger is six PRs.

Tracking: #155
RFC: #156

## What this PR ships

A new server-side \`Source\` trait alongside \`CrudSource\`. The shape difference that matters:

\`\`\`diff
-async fn list(&self, ctx: RequestContext, limit: usize) -> SyncResult<Vec<Row>>;
+async fn list<'a>(&'a self, ctx: RequestContext, query: &'a Query<Self::Row>) -> ...;
\`\`\`

SQLx/SQLite/Firestore impls can now translate \`query.params()\` into a storage filter (\`WHERE workspace_id = ? AND status IN (?)\`) instead of fetching every row and relying on client-side predicate evaluation. That's the §C scaling unlock — impossible under CRUD's \`list(ctx, limit)\` signature.

### Concretely

- New \`pocopine_sync_query::source\` module (host-only behind \`cfg(not(target_arch = \"wasm32\"))\`). Trait + \`WriteResult\`/\`RemoveResult\`/\`Conflict\` types parallel to CRUD's.
- \`query_from_pull_request<Row>\` reconstructs a typed \`Query<Row>\` from a wire \`SyncPullRequest\`. Treats \`limit == 0\` as \"use default\" (the wire sentinel).
- \`SourceResource<S, IdOf>\` adapter implements \`SyncStreamSource\`. \`pull\` hands the reconstructed query to \`Source::list\`. \`push\` returns an explicit \"Phase 2 deferred\" error — the mutation log moves in Phase 2 per the RFC's phase plan.
- \`.params_of(closure)\` builder method for §C row→partition routing (same shape as \`CrudResource::params_of\` from #154).

### What this PR explicitly does NOT do

- Push lifecycle (mutation log, idempotency, transaction binding) — Phase 2
- Client-side \`QueryClient::push\` with optimistic overlay routing — Phase 3
- Macro typed write codegen (\`Issue::create(draft)\`) — Phase 4
- Touch \`pocopine-sync-crud\` (existing CRUD users keep working unchanged) — Phase 5/6

## Test plan

- [x] 3 unit tests in \`source.rs\` — trait shape compiles, \`query_from_pull_request\` round-trips params, zero-limit sentinel works
- [x] 4 integration tests in \`tests/source_phase1.rs\` — proves the source's \`list\` actually OBSERVES the workspace_id filter (via test instrumentation that records every \`(params, limit)\` pair). Distinguishes \"filter ran in storage\" from \"filter happened to produce the right output.\"
- [x] \`cargo clippy -p pocopine-sync-query --tests -- -D warnings\` (host)
- [x] \`cargo clippy -p pocopine-sync-query -p pocopine-sync -p pocopine-events -p pocopine-live --target wasm32-unknown-unknown -- -D warnings\` (wasm — narrow set; full workspace wasm clippy has pre-existing mio breakage)
- [x] \`cargo fmt --all -- --check\`

## Sizes

| | Lines |
|---|---|
| \`crates/pocopine-sync-query/src/source.rs\` (lib code) | +509 |
| \`crates/pocopine-sync-query/src/source.rs\` (tests in mod) | +112 |
| \`crates/pocopine-sync-query/tests/source_phase1.rs\` | +335 |
| \`crates/pocopine-sync-query/src/lib.rs\` (re-exports) | +18 |
| **Total** | **+974** |

RFC estimate for Phase 1 was +400 LOC. The over-shoot is doc comments (the trait carries ~200 lines of rustdoc explaining the migration path and use cases) and the integration test instrumentation. Net code is roughly on target.