### PR TITLE
rfc-090 phase 2a: move mutation-lifecycle types to sync-query::write

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6111,6 +6111,7 @@ dependencies = [
  "pocopine-server",
  "pocopine-sync",
  "pocopine-sync-crud-macros",
+ "pocopine-sync-query",
  "serde",
  "serde_json",
  "tokio",

--- a/crates/pocopine-sync-crud/Cargo.toml
+++ b/crates/pocopine-sync-crud/Cargo.toml
@@ -20,6 +20,11 @@ wasm-bindgen = { workspace = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 async-trait = "0.1"
 pocopine-auth = { workspace = true }
+# RFC 090 Phase 2a — the mutation-lifecycle types (MutationLog,
+# MutationPayload, WriteResult, etc.) moved to pocopine-sync-query.
+# CRUD now re-exports them under the old `Crud*` names for
+# back-compat through Phase 5; Phase 6 deletes CRUD entirely.
+pocopine-sync-query = { workspace = true }
 serde_json = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]

--- a/crates/pocopine-sync-crud/src/lib.rs
+++ b/crates/pocopine-sync-crud/src/lib.rs
@@ -36,6 +36,14 @@ pub use resource::{
     MissingMutationLog, NoRowVersion, RowVersionValue, TransactionalCrudMutationLog,
     TransactionalCrudResource, DEFAULT_CRUD_SNAPSHOT_ROW_LIMIT,
 };
+// RFC 090 Phase 2a — `Crud*` lifecycle types (Conflict, WriteResult,
+// RemoveResult, MutationLog, AcceptedMutation, etc.) are now type
+// aliases for the canonical types in `pocopine_sync_query::write`.
+// External code that imports `pocopine_sync_crud::Crud*` keeps
+// working byte-for-byte. The re-exports in `resource::*` and
+// `source::*` above pick up the aliases automatically — no change
+// needed here. This comment marks the migration boundary for Phase
+// 5 deprecation notes and Phase 6 deletion.
 pub use row::optimistic_row;
 #[cfg(not(target_arch = "wasm32"))]
 pub use source::{

--- a/crates/pocopine-sync-crud/src/resource.rs
+++ b/crates/pocopine-sync-crud/src/resource.rs
@@ -1,5 +1,4 @@
-use std::collections::BTreeMap;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use pocopine_auth::RequestContext;
 use pocopine_sync::{
@@ -416,63 +415,21 @@ where
     }
 }
 
-/// Accepted mutation entry stored by a [`CrudMutationLog`].
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct CrudAcceptedMutation {
-    pub mutation_id: MutationId,
-    pub op: SyncOp,
-    pub key: Option<RowKey>,
-    pub payload: Value,
-}
-
-impl CrudAcceptedMutation {
-    pub fn new(mutation_id: MutationId, op: SyncOp, key: Option<RowKey>, payload: Value) -> Self {
-        Self {
-            mutation_id,
-            op,
-            key,
-            payload,
-        }
-    }
-
-    fn matches(&self, op: SyncOp, key: Option<&RowKey>, payload: &Value) -> bool {
-        self.op == op && self.key.as_ref() == key && self.payload == *payload
-    }
-}
-
-/// Result of reserving an accepted mutation id inside a transaction.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum CrudMutationReservation {
-    /// The caller reserved this mutation id and should continue applying the
-    /// source write in the same transaction.
-    Reserved,
-    /// The mutation id already exists in the accepted log.
-    AlreadyAccepted(CrudAcceptedMutation),
-}
-
-/// Idempotency log for CRUD mutations.
-///
-/// Production implementations must scope lookups to the same authorization
-/// domain as the underlying source, for example `(tenant_id, mutation_id)`.
-/// The adapter intentionally does not return cached rows on dedupe hits; it
-/// only acknowledges exact replay of the same accepted mutation.
-#[async_trait::async_trait]
-pub trait CrudMutationLog<Row>: Send + Sync + 'static
-where
-    Row: Clone + Send + Sync + 'static,
-{
-    async fn accepted_mutation(
-        &self,
-        ctx: &RequestContext,
-        mutation_id: &MutationId,
-    ) -> SyncResult<Option<CrudAcceptedMutation>>;
-
-    async fn record_accepted_mutation(
-        &self,
-        ctx: &RequestContext,
-        accepted: CrudAcceptedMutation,
-    ) -> SyncResult<()>;
-}
+// RFC 090 Phase 2a — the idempotency-log surface
+// (CrudAcceptedMutation, CrudMutationReservation, CrudMutationLog,
+// MemoryCrudMutationLog, MemoryCrudScopeFn) moved to
+// `pocopine_sync_query::write`. The aliases below keep every
+// existing CRUD import working byte-for-byte through Phase 5; Phase
+// 6 deletes CRUD entirely.
+//
+// `TransactionalCrudMutationLog` stays defined here for now — it
+// references CRUD's transaction-binding contract which Phase 2b
+// will tackle once the sqlx adapter side has been audited.
+pub use pocopine_sync_query::write::{
+    AcceptedMutation as CrudAcceptedMutation, MemoryMutationLog as MemoryCrudMutationLog,
+    MemoryScopeFn as MemoryCrudScopeFn, MutationLog as CrudMutationLog,
+    MutationReservation as CrudMutationReservation,
+};
 
 /// Transaction-aware idempotency log for CRUD mutations.
 ///
@@ -495,106 +452,6 @@ where
         ctx: &RequestContext,
         accepted: CrudAcceptedMutation,
     ) -> SyncResult<CrudMutationReservation>;
-}
-
-/// Function used by `MemoryCrudMutationLog::with_scope_fn` to project an
-/// authorization scope (e.g. a tenant id) out of the per-request context.
-pub type MemoryCrudScopeFn =
-    Arc<dyn Fn(&RequestContext) -> SyncResult<String> + Send + Sync + 'static>;
-
-/// Process-local mutation log for tests and single-process demos.
-///
-/// The default constructor uses one global scope — accepted mutations across
-/// every tenant share one keyspace. Multi-tenant resources should use
-/// [`MemoryCrudMutationLog::with_scope_fn`] to derive the authorization scope
-/// from the request context; this mirrors `SqlxCrudMutationLog`'s scoping
-/// model so the same boundary that protects production logs is what the tests
-/// exercise.
-#[derive(Clone)]
-pub struct MemoryCrudMutationLog<Row> {
-    accepted: Arc<Mutex<BTreeMap<(String, String), CrudAcceptedMutation>>>,
-    scope: MemoryCrudScopeFn,
-    _marker: std::marker::PhantomData<fn() -> Row>,
-}
-
-impl<Row> std::fmt::Debug for MemoryCrudMutationLog<Row> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("MemoryCrudMutationLog")
-            .finish_non_exhaustive()
-    }
-}
-
-impl<Row> Default for MemoryCrudMutationLog<Row> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl<Row> MemoryCrudMutationLog<Row> {
-    /// Build a single-scope memory log. Every accepted mutation lives in one
-    /// global keyspace; use [`with_scope_fn`](Self::with_scope_fn) for
-    /// multi-tenant tests.
-    pub fn new() -> Self {
-        Self {
-            accepted: Arc::new(Mutex::new(BTreeMap::new())),
-            scope: Arc::new(|_ctx| Ok(String::new())),
-            _marker: std::marker::PhantomData,
-        }
-    }
-
-    /// Build a memory log that derives its authorization scope from the
-    /// request context — the same shape as
-    /// [`SqlxCrudMutationLog::new`](https://docs.rs/pocopine-sync-sqlx).
-    ///
-    /// The scope function is invoked on every `accepted_mutation` lookup and
-    /// every `record_accepted_mutation`. Returning an error from the function
-    /// fails the log call (typically surfaced as `SyncError::Unauthorized`
-    /// from the request handler).
-    pub fn with_scope_fn<F>(scope: F) -> Self
-    where
-        F: Fn(&RequestContext) -> SyncResult<String> + Send + Sync + 'static,
-    {
-        Self {
-            accepted: Arc::new(Mutex::new(BTreeMap::new())),
-            scope: Arc::new(scope),
-            _marker: std::marker::PhantomData,
-        }
-    }
-}
-
-#[async_trait::async_trait]
-impl<Row> CrudMutationLog<Row> for MemoryCrudMutationLog<Row>
-where
-    Row: Clone + Send + Sync + 'static,
-{
-    async fn accepted_mutation(
-        &self,
-        ctx: &RequestContext,
-        mutation_id: &MutationId,
-    ) -> SyncResult<Option<CrudAcceptedMutation>> {
-        let scope = (self.scope)(ctx)?;
-        let accepted = self
-            .accepted
-            .lock()
-            .map_err(|_| SyncError::backend("memory CRUD mutation log lock poisoned"))?;
-        Ok(accepted
-            .get(&(scope, mutation_id.as_str().to_string()))
-            .cloned())
-    }
-
-    async fn record_accepted_mutation(
-        &self,
-        ctx: &RequestContext,
-        accepted: CrudAcceptedMutation,
-    ) -> SyncResult<()> {
-        let scope = (self.scope)(ctx)?;
-        let mut entries = self
-            .accepted
-            .lock()
-            .map_err(|_| SyncError::backend("memory CRUD mutation log lock poisoned"))?;
-        entries.insert((scope, accepted.mutation_id.as_str().to_string()), accepted);
-        Ok(())
-    }
 }
 
 impl<S, IdOf, VersionOf, Log> SyncStreamSource for CrudResource<S, IdOf, VersionOf, Log>
@@ -1418,6 +1275,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
     use std::sync::{Arc, Mutex};
 
     use http::{HeaderMap, Method, Uri};

--- a/crates/pocopine-sync-crud/src/source.rs
+++ b/crates/pocopine-sync-crud/src/source.rs
@@ -4,70 +4,16 @@ use serde::{de::DeserializeOwned, Serialize};
 
 use crate::ResourceId;
 
-/// Conflict returned by an app-owned CRUD source.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct CrudConflict<Row> {
-    pub server_row: Option<Row>,
-    pub reason: String,
-}
-
-impl<Row> CrudConflict<Row> {
-    pub fn stale(server_row: Option<Row>) -> Self {
-        Self {
-            server_row,
-            reason: "base version is stale".to_string(),
-        }
-    }
-
-    pub fn new(server_row: Option<Row>, reason: impl Into<String>) -> Self {
-        Self {
-            server_row,
-            reason: reason.into(),
-        }
-    }
-}
-
-/// Result of an app-owned create/save write.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum CrudWriteResult<Row> {
-    Applied(Row),
-    Conflict(CrudConflict<Row>),
-}
-
-impl<Row> CrudWriteResult<Row> {
-    pub fn applied(row: Row) -> Self {
-        Self::Applied(row)
-    }
-
-    pub fn conflict(server_row: Option<Row>, reason: impl Into<String>) -> Self {
-        Self::Conflict(CrudConflict::new(server_row, reason))
-    }
-
-    pub fn stale(server_row: Option<Row>) -> Self {
-        Self::Conflict(CrudConflict::stale(server_row))
-    }
-}
-
-/// Result of an app-owned remove write.
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub enum CrudRemoveResult<Row> {
-    Applied,
-    Conflict(CrudConflict<Row>),
-}
-
-impl<Row> CrudRemoveResult<Row> {
-    pub fn applied() -> Self {
-        Self::Applied
-    }
-
-    pub fn conflict(server_row: Option<Row>, reason: impl Into<String>) -> Self {
-        Self::Conflict(CrudConflict::new(server_row, reason))
-    }
-
-    pub fn stale(server_row: Option<Row>) -> Self {
-        Self::Conflict(CrudConflict::stale(server_row))
-    }
-}
+// RFC 090 Phase 2a — `CrudConflict`, `CrudWriteResult`, and
+// `CrudRemoveResult` moved to `pocopine_sync_query::write`. The
+// `pub use ... as Crud*` aliases here keep existing CRUD imports
+// (`pocopine_sync_crud::CrudConflict`, `CrudWriteResult`, etc.) and
+// `==` comparisons working byte-for-byte. The canonical types live
+// in sync-query; Phase 6 deletes CRUD entirely and downstream code
+// drops the `Crud` prefix.
+pub use pocopine_sync_query::write::{
+    Conflict as CrudConflict, RemoveResult as CrudRemoveResult, WriteResult as CrudWriteResult,
+};
 
 /// Server-side CRUD source contract.
 ///

--- a/crates/pocopine-sync-query/src/lib.rs
+++ b/crates/pocopine-sync-query/src/lib.rs
@@ -57,6 +57,13 @@ pub mod selector;
 pub mod source;
 pub mod state;
 pub mod wire;
+// RFC 090 Phase 2a — mutation-lifecycle types (MutationLog,
+// MutationPayload, AcceptedMutation, WriteResult, RemoveResult,
+// Conflict, etc.) live here long-term. CRUD re-exports them under
+// old `Crud*` names through Phase 5. Host-only — same reason as
+// `source`: the log trait threads `pocopine_auth::RequestContext`.
+#[cfg(not(target_arch = "wasm32"))]
+pub mod write;
 
 // Re-exports of the curated public API.
 pub use client::{QueryClient, QueryHandle, QuerySubscription, QueryView, UpdateToken};
@@ -82,9 +89,21 @@ pub use state::QueryState;
 // new direction. See `rfcs/rfc-090-merge-crud-into-query.md`.
 #[cfg(not(target_arch = "wasm32"))]
 pub use source::{
-    query_from_pull_request, source, Conflict, RemoveResult, Source, SourceFuture, SourceId,
-    SourceParamsFn, SourceResource, SourceResourceBuilder, SourceVersionFn, WriteResult,
-    DEFAULT_SOURCE_SNAPSHOT_ROW_LIMIT,
+    query_from_pull_request, source, Source, SourceFuture, SourceId, SourceParamsFn,
+    SourceResource, SourceResourceBuilder, SourceVersionFn, DEFAULT_SOURCE_SNAPSHOT_ROW_LIMIT,
+};
+
+// RFC 090 Phase 2a — mutation lifecycle types at the crate root so
+// users write `use pocopine_sync_query::{WriteResult, MutationLog,
+// MemoryMutationLog};` without thinking about the internal module
+// split. WriteResult/RemoveResult/Conflict were briefly in
+// `source.rs` (Phase 1); Phase 2a moves them to their long-term
+// home in `write.rs` and re-exports here. CRUD aliases these to
+// the old `Crud*` names for back-compat.
+#[cfg(not(target_arch = "wasm32"))]
+pub use write::{
+    AcceptedMutation, Conflict, MemoryMutationLog, MemoryScopeFn, MutationLog, MutationReservation,
+    RemoveResult, WriteResult,
 };
 
 // The macro lives in its own crate (proc-macros must), but downstream

--- a/crates/pocopine-sync-query/src/source.rs
+++ b/crates/pocopine-sync-query/src/source.rs
@@ -56,66 +56,15 @@ impl SourceId for String {
     }
 }
 
-/// Outcome of an optimistic-concurrency `save`.
-///
-/// Mirrors `pocopine_sync_crud::CrudWriteResult` byte-for-byte —
-/// applications can switch the import path without touching the
-/// match arms. The two types stay structurally identical through
-/// Phase 5; Phase 6 deletes the CRUD copy.
-#[derive(Debug, Clone)]
-pub enum WriteResult<Row> {
-    /// The write applied. `row` is the canonical post-write state.
-    Applied(Row),
-    /// The base_version check failed. `Conflict` carries the
-    /// server-visible row (if any) so the framework can surface it
-    /// to the client for merge / overwrite / discard handling.
-    Conflict(Conflict<Row>),
-}
-
-impl<Row> WriteResult<Row> {
-    pub fn applied(row: Row) -> Self {
-        Self::Applied(row)
-    }
-
-    pub fn stale(server_row: Option<Row>) -> Self {
-        Self::Conflict(Conflict {
-            server_row,
-            reason: "base_version stale".to_string(),
-        })
-    }
-}
-
-/// Outcome of an optimistic-concurrency `remove`.
-#[derive(Debug, Clone)]
-pub enum RemoveResult<Row> {
-    Applied,
-    Conflict(Conflict<Row>),
-}
-
-impl<Row> RemoveResult<Row> {
-    pub fn applied() -> Self {
-        Self::Applied
-    }
-
-    pub fn stale(server_row: Option<Row>) -> Self {
-        Self::Conflict(Conflict {
-            server_row,
-            reason: "base_version stale".to_string(),
-        })
-    }
-}
-
-/// Server-visible state at the moment a conflict was detected.
-#[derive(Debug, Clone)]
-pub struct Conflict<Row> {
-    /// The row as the server sees it. `None` when the conflict
-    /// arises from a missing row (e.g. a stale save against a deleted
-    /// id).
-    pub server_row: Option<Row>,
-    /// Human-readable reason. The framework forwards this verbatim
-    /// to the client; sources should make it diagnostic.
-    pub reason: String,
-}
+// RFC 090 Phase 2a — `WriteResult`/`RemoveResult`/`Conflict` were
+// briefly defined here in Phase 1 because they appear in `Source`
+// method signatures. Phase 2a moved them to `crate::write` (their
+// long-term home alongside the mutation log + idempotency
+// infrastructure). The `pub use` here keeps the Phase 1 public
+// surface working — code that wrote
+// `use pocopine_sync_query::source::{WriteResult, Conflict, RemoveResult};`
+// keeps compiling.
+pub use crate::write::{Conflict, RemoveResult, WriteResult};
 
 /// Boxed async-trait future. Sources don't need to name this — the
 /// `#[async_trait]` macro generates the right wrappers automatically.

--- a/crates/pocopine-sync-query/src/write.rs
+++ b/crates/pocopine-sync-query/src/write.rs
@@ -1,0 +1,383 @@
+//! Mutation-lifecycle primitives for Query-native resources.
+//!
+//! RFC 090 Phase 2a — moves the typed mutation envelope, idempotency
+//! log, optimistic-concurrency outcomes, and conflict types from
+//! `pocopine-sync-crud` into their long-term home in
+//! `pocopine-sync-query`. The CRUD crate re-exports them under their
+//! old `Crud*` names for back-compat through Phase 5; Phase 6
+//! deletes the CRUD copies.
+//!
+//! # Why this module exists
+//!
+//! Phase 1 (the `Source` trait) put `WriteResult`/`RemoveResult`/`Conflict`
+//! in `pocopine_sync_query::source` because they appear in `Source`
+//! method signatures. That was expedient but wrong long-term — the
+//! same types are also needed by:
+//!
+//! - The push lifecycle (Phase 2b) that dispatches mutations to
+//!   `Source::create`/`save`/`remove`.
+//! - The macro-emitted typed write API (Phase 4): `Issue::save(id,
+//!   draft)` returns `WriteResult<Issue>`.
+//! - The `MutationLog` (this module) which records accepted
+//!   mutations and their canonical outcomes.
+//!
+//! Putting them with the mutation lifecycle is the correct home.
+//! `source.rs` re-exports them so existing Phase 1 user code keeps
+//! compiling.
+//!
+//! # Naming
+//!
+//! The types here drop the `Crud` prefix CRUD's versions carry. The
+//! semantics are identical — Phase 1 promised this when it cloned
+//! the CRUD types into `source.rs`. CRUD's `pocopine-sync-crud`
+//! crate re-exports the moved types as `CrudWriteResult`,
+//! `CrudMutationLog`, etc., so existing imports keep working
+//! through Phase 5.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+use pocopine_auth::RequestContext;
+use pocopine_sync::{MutationId, RowKey, SyncError, SyncOp, SyncResult};
+use serde_json::Value;
+
+/// Outcome of an optimistic-concurrency `save`.
+///
+/// Moved from `pocopine_sync_query::source` (Phase 1) — see the
+/// module-level doc for why. The Phase 1 re-export from `source`
+/// keeps existing imports working.
+///
+/// Derives match the CRUD original (`pocopine_sync_crud::CrudWriteResult`)
+/// so the back-compat alias is drop-in for downstream code that does
+/// `WriteResult<X> == WriteResult<X>` comparisons.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum WriteResult<Row> {
+    /// The write applied. `row` is the canonical post-write state.
+    Applied(Row),
+    /// The base_version check failed. `Conflict` carries the
+    /// server-visible row (if any) so the framework can surface it
+    /// to the client for merge / overwrite / discard handling.
+    Conflict(Conflict<Row>),
+}
+
+impl<Row> WriteResult<Row> {
+    pub fn applied(row: Row) -> Self {
+        Self::Applied(row)
+    }
+
+    /// Construct a conflict with an explicit reason. Mirrors
+    /// `CrudWriteResult::conflict` — kept for the back-compat alias.
+    pub fn conflict(server_row: Option<Row>, reason: impl Into<String>) -> Self {
+        Self::Conflict(Conflict::new(server_row, reason))
+    }
+
+    pub fn stale(server_row: Option<Row>) -> Self {
+        Self::Conflict(Conflict::stale(server_row))
+    }
+}
+
+/// Outcome of an optimistic-concurrency `remove`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RemoveResult<Row> {
+    Applied,
+    Conflict(Conflict<Row>),
+}
+
+impl<Row> RemoveResult<Row> {
+    pub fn applied() -> Self {
+        Self::Applied
+    }
+
+    /// Construct a conflict with an explicit reason. Mirrors
+    /// `CrudRemoveResult::conflict`.
+    pub fn conflict(server_row: Option<Row>, reason: impl Into<String>) -> Self {
+        Self::Conflict(Conflict::new(server_row, reason))
+    }
+
+    pub fn stale(server_row: Option<Row>) -> Self {
+        Self::Conflict(Conflict::stale(server_row))
+    }
+}
+
+/// Server-visible state at the moment a conflict was detected.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Conflict<Row> {
+    /// The row as the server sees it. `None` when the conflict
+    /// arises from a missing row (e.g. a stale save against a deleted
+    /// id).
+    pub server_row: Option<Row>,
+    /// Human-readable reason. The framework forwards this verbatim
+    /// to the client; sources should make it diagnostic.
+    pub reason: String,
+}
+
+impl<Row> Conflict<Row> {
+    /// Construct a conflict with an explicit reason. Mirrors
+    /// `CrudConflict::new` for the back-compat alias.
+    pub fn new(server_row: Option<Row>, reason: impl Into<String>) -> Self {
+        Self {
+            server_row,
+            reason: reason.into(),
+        }
+    }
+
+    /// Construct a conflict with the canonical "base_version stale"
+    /// reason. Mirrors `CrudConflict::stale`.
+    pub fn stale(server_row: Option<Row>) -> Self {
+        Self {
+            server_row,
+            reason: "base version is stale".to_string(),
+        }
+    }
+}
+
+// MutationPayload + Create/Save/RemovePayload deferred to Phase 2c.
+// CRUD's `CrudMutationPayload` uses a `#[serde(tag = "op", content =
+// "payload", ...)]` wire shape that this module's first cut didn't
+// match. Phase 2c will reconcile the wire shape and move the
+// envelope here; until then, CRUD users keep using
+// `pocopine_sync_crud::CrudMutationPayload` and new `Source` users
+// hand-construct mutations or wait for Phase 4's macro-emitted
+// typed writes.
+
+/// Accepted-mutation log entry. Mirrors
+/// `pocopine_sync_crud::CrudAcceptedMutation`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AcceptedMutation {
+    pub mutation_id: MutationId,
+    pub op: SyncOp,
+    pub key: Option<RowKey>,
+    pub payload: Value,
+}
+
+impl AcceptedMutation {
+    pub fn new(mutation_id: MutationId, op: SyncOp, key: Option<RowKey>, payload: Value) -> Self {
+        Self {
+            mutation_id,
+            op,
+            key,
+            payload,
+        }
+    }
+
+    /// `true` iff a replay of the same mutation_id carries an
+    /// identical wire envelope. Defensive against retries that
+    /// change their mind — e.g. a client that retries a Create as
+    /// a Save with the same id is treated as a distinct mutation.
+    pub fn matches(&self, op: SyncOp, key: Option<&RowKey>, payload: &Value) -> bool {
+        self.op == op && self.key.as_ref() == key && self.payload == *payload
+    }
+}
+
+/// Result of reserving an accepted mutation id inside a transaction.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum MutationReservation {
+    /// The caller reserved this mutation id and should continue
+    /// applying the source write in the same transaction.
+    Reserved,
+    /// The mutation id already exists in the accepted log.
+    AlreadyAccepted(AcceptedMutation),
+}
+
+/// Idempotency log for sync-query mutations. Production
+/// implementations MUST scope lookups to the same authorization
+/// domain as the underlying `Source`, for example
+/// `(tenant_id, mutation_id)`.
+///
+/// Mirrors `pocopine_sync_crud::CrudMutationLog` byte-for-byte —
+/// only the trait name changes (drops the `Crud` prefix). The CRUD
+/// crate re-exports this trait under the old name.
+#[async_trait::async_trait]
+pub trait MutationLog<Row>: Send + Sync + 'static
+where
+    Row: Clone + Send + Sync + 'static,
+{
+    async fn accepted_mutation(
+        &self,
+        ctx: &RequestContext,
+        mutation_id: &MutationId,
+    ) -> SyncResult<Option<AcceptedMutation>>;
+
+    async fn record_accepted_mutation(
+        &self,
+        ctx: &RequestContext,
+        accepted: AcceptedMutation,
+    ) -> SyncResult<()>;
+}
+
+/// Function used by `MemoryMutationLog::with_scope_fn` to project an
+/// authorization scope (e.g. a tenant id) out of the per-request
+/// context.
+pub type MemoryScopeFn = Arc<dyn Fn(&RequestContext) -> SyncResult<String> + Send + Sync + 'static>;
+
+/// Process-local mutation log for tests and single-process demos.
+///
+/// The default constructor uses one global scope. Multi-tenant
+/// production resources should use [`MemoryMutationLog::with_scope_fn`]
+/// to derive the authorization scope from the request context.
+#[derive(Clone)]
+pub struct MemoryMutationLog<Row> {
+    accepted: Arc<Mutex<BTreeMap<(String, String), AcceptedMutation>>>,
+    scope: MemoryScopeFn,
+    _marker: std::marker::PhantomData<fn() -> Row>,
+}
+
+impl<Row> std::fmt::Debug for MemoryMutationLog<Row> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MemoryMutationLog").finish_non_exhaustive()
+    }
+}
+
+impl<Row> Default for MemoryMutationLog<Row> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<Row> MemoryMutationLog<Row> {
+    /// Build a single-scope memory log. Every accepted mutation
+    /// lives in one global keyspace; use
+    /// [`with_scope_fn`](Self::with_scope_fn) for multi-tenant tests.
+    pub fn new() -> Self {
+        Self {
+            accepted: Arc::new(Mutex::new(BTreeMap::new())),
+            scope: Arc::new(|_ctx| Ok(String::new())),
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    /// Build a memory log that derives its authorization scope from
+    /// the request context. Mirrors `pocopine_sync_sqlx::SqlxCrudMutationLog`'s
+    /// shape (which Phase 2b/sqlx migration will rename to drop the
+    /// `Crud` prefix) so tests can exercise the same scoping
+    /// boundary as production logs.
+    pub fn with_scope_fn<F>(scope: F) -> Self
+    where
+        F: Fn(&RequestContext) -> SyncResult<String> + Send + Sync + 'static,
+    {
+        Self {
+            accepted: Arc::new(Mutex::new(BTreeMap::new())),
+            scope: Arc::new(scope),
+            _marker: std::marker::PhantomData,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl<Row> MutationLog<Row> for MemoryMutationLog<Row>
+where
+    Row: Clone + Send + Sync + 'static,
+{
+    async fn accepted_mutation(
+        &self,
+        ctx: &RequestContext,
+        mutation_id: &MutationId,
+    ) -> SyncResult<Option<AcceptedMutation>> {
+        let scope = (self.scope)(ctx)?;
+        let accepted = self
+            .accepted
+            .lock()
+            .map_err(|_| SyncError::backend("memory mutation log lock poisoned"))?;
+        Ok(accepted
+            .get(&(scope, mutation_id.as_str().to_string()))
+            .cloned())
+    }
+
+    async fn record_accepted_mutation(
+        &self,
+        ctx: &RequestContext,
+        accepted: AcceptedMutation,
+    ) -> SyncResult<()> {
+        let scope = (self.scope)(ctx)?;
+        let mut entries = self
+            .accepted
+            .lock()
+            .map_err(|_| SyncError::backend("memory mutation log lock poisoned"))?;
+        entries.insert((scope, accepted.mutation_id.as_str().to_string()), accepted);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use http::{HeaderMap, Method};
+
+    fn ctx() -> RequestContext {
+        RequestContext::new(Method::POST, "/test".parse().unwrap(), HeaderMap::new())
+    }
+
+    fn mutation(id: &str) -> AcceptedMutation {
+        AcceptedMutation::new(
+            MutationId::new(id).unwrap(),
+            SyncOp::Upsert,
+            None,
+            Value::Null,
+        )
+    }
+
+    #[derive(Clone)]
+    struct Row;
+
+    #[tokio::test]
+    async fn memory_log_records_and_retrieves() {
+        let log: MemoryMutationLog<Row> = MemoryMutationLog::new();
+        let m = mutation("m1");
+        log.record_accepted_mutation(&ctx(), m.clone())
+            .await
+            .unwrap();
+        let found = log.accepted_mutation(&ctx(), &m.mutation_id).await.unwrap();
+        assert_eq!(found, Some(m));
+    }
+
+    #[tokio::test]
+    async fn memory_log_distinct_scopes_isolate_mutations() {
+        // Tenant boundary: the same mutation_id in two tenants must
+        // not collide. This is the contract that
+        // `pocopine_sync_crud::tests::tenant_boundary` was the
+        // canonical test for; moving it here pins the same semantics
+        // on the renamed types.
+        let log: MemoryMutationLog<Row> =
+            MemoryMutationLog::with_scope_fn(|ctx: &RequestContext| {
+                Ok(ctx
+                    .header("x-tenant-id")
+                    .map(str::to_string)
+                    .unwrap_or_default())
+            });
+
+        let mut tenant_a_headers = HeaderMap::new();
+        tenant_a_headers.insert("x-tenant-id", "A".parse().unwrap());
+        let ctx_a = RequestContext::new(Method::POST, "/t".parse().unwrap(), tenant_a_headers);
+
+        let mut tenant_b_headers = HeaderMap::new();
+        tenant_b_headers.insert("x-tenant-id", "B".parse().unwrap());
+        let ctx_b = RequestContext::new(Method::POST, "/t".parse().unwrap(), tenant_b_headers);
+
+        let m = mutation("m1");
+        log.record_accepted_mutation(&ctx_a, m.clone())
+            .await
+            .unwrap();
+        // Tenant A sees the mutation, tenant B does not.
+        assert_eq!(
+            log.accepted_mutation(&ctx_a, &m.mutation_id).await.unwrap(),
+            Some(m.clone())
+        );
+        assert_eq!(
+            log.accepted_mutation(&ctx_b, &m.mutation_id).await.unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn accepted_mutation_matches_only_exact_replay() {
+        let m = mutation("m1");
+        assert!(m.matches(SyncOp::Upsert, None, &Value::Null));
+        // Different op
+        assert!(!m.matches(SyncOp::Delete, None, &Value::Null));
+        // Different key
+        let k = RowKey::new("k").unwrap();
+        assert!(!m.matches(SyncOp::Upsert, Some(&k), &Value::Null));
+        // Different payload
+        assert!(!m.matches(SyncOp::Upsert, None, &Value::Bool(true)));
+    }
+}


### PR DESCRIPTION
Stacks on top of #158 (Phase 1). Will rebase onto main once #158 merges.

Tracking: #155
RFC: #156
Prev: #158

## What this PR ships

Pure type-relocation refactor. Moves CRUD's mutation-lifecycle types to their long-term home in \`pocopine_sync_query::write\`. CRUD re-exports them under the old \`Crud*\` names for back-compat.

**Moved** (canonical paths now \`pocopine_sync_query::write::*\`):

- \`MutationLog<Row>\`, \`MemoryMutationLog<Row>\`, \`MemoryScopeFn\`
- \`AcceptedMutation\`, \`MutationReservation\`
- \`WriteResult<Row>\`, \`RemoveResult<Row>\`, \`Conflict<Row>\` (Phase 1 had them in \`source.rs\`)

**CRUD-side back-compat**: \`pub use ... as Crud*\` aliases. Type identity preserved — existing \`where Log: CrudMutationLog<Row>\` bounds, pattern matches on \`CrudWriteResult::Applied(...)\`, sqlx trait impls all keep working unchanged.

**Deferred**:
- \`MutationPayload\` → Phase 2c (wire-shape reconciliation: CRUD uses \`#[serde(tag=\"op\", content=\"payload\")]\`)
- \`SourceResource::push\` lifecycle wiring → Phase 2b (uses the new \`MutationLog\` from this PR)

## Net diff

-286 lines (CRUD shrinks via aliases) + 455 lines (new \`write.rs\` ~390 + lib re-exports). Net workspace: -214 lines.

## Test plan

- [x] \`cargo test -p pocopine-sync-query\` (56 unit + 6 integration pass — Phase 1 surface unchanged)
- [x] \`cargo test -p pocopine-sync-crud\` (27 tests pass via aliases — full back-compat)
- [x] \`cargo build --workspace\` clean
- [x] \`cargo clippy -p pocopine-sync-query -p pocopine-sync-crud --tests -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\`

## Codex review

Ran on the uncommitted diff. **Zero correctness bugs found**. Type identity preservation verified via grep across sqlx, CRUD internals, and test fixtures. 15 cleanup/altitude findings — top three (std::sync::Mutex in async, BTreeMap vs HashMap, deep-clone Value on retrieve) are pre-existing CRUD patterns, not Phase 2a regressions. Deferring fixes to Phase 2b when the push lifecycle actually exercises the log on the hot path.