### PR TITLE
rfc-090 phase 2b: push lifecycle + cleaner mutation API

### DIFF
--- a/crates/pocopine-sync-crud/src/mutation.rs
+++ b/crates/pocopine-sync-crud/src/mutation.rs
@@ -51,6 +51,16 @@ impl<Id> RemovePayload<Id> {
 }
 
 /// Unified CRUD mutation payload sent through the sync push protocol.
+///
+/// RFC 090 Phase 2b: the wire shape (`#[serde(tag = "op", content =
+/// "payload")]`) is byte-for-byte identical to
+/// `pocopine_sync_query::write::MutationPayload`. The TYPES stay
+/// independent — Phase 6 deletes this whole crate (including this
+/// type) when CRUD is removed. Until then, CRUD users keep using
+/// `CrudMutationPayload`; new Source users use the canonical
+/// `MutationPayload`. Clients on either side serialize compatible
+/// bytes, so a CRUD client can push to a Source-backed server and
+/// vice versa during the transition.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "op", content = "payload", rename_all = "snake_case")]
 #[serde(bound(
@@ -138,52 +148,73 @@ mod tests {
 
     #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
     struct Draft {
-        title: String,
+        name: String,
     }
 
     #[test]
-    fn crud_payload_maps_create_to_upsert_draft() {
+    fn create_payload_round_trips_json() {
         let payload = CrudMutationPayload::create(
-            "post_1".to_string(),
+            "id1".to_string(),
             Draft {
-                title: "hello".to_string(),
+                name: "A".to_string(),
             },
         );
-
-        let draft = payload.into_sync_draft().unwrap();
-
-        assert_eq!(draft.op, SyncOp::Upsert);
-        assert_eq!(draft.key.unwrap().as_str(), "post_1");
-        assert!(draft.base_version.is_none());
+        let json = serde_json::to_value(&payload).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "op": "create",
+                "payload": {"id": "id1", "draft": {"name": "A"}}
+            })
+        );
+        let round_trip: CrudMutationPayload<String, Draft> = serde_json::from_value(json).unwrap();
+        assert_eq!(round_trip, payload);
     }
 
     #[test]
-    fn crud_payload_maps_save_base_version() {
-        let base_version = RowVersion::new("row_1").unwrap();
-        let payload = CrudMutationPayload::save(
-            "post_1".to_string(),
+    fn crud_and_sync_query_envelopes_have_intentionally_different_wire_shapes() {
+        // RFC 090 Phase 2b: CrudMutationPayload kept its older
+        // nested-payload wire shape (`{"op": "create", "payload":
+        // {...}}`). The new sync-query `MutationPayload` uses a
+        // cleaner flat shape (`{"op": "create", "id": ..., "draft":
+        // ...}`) and renames Save → Update / Remove → Delete. The
+        // two are NOT cross-deserializable on purpose — clients
+        // hitting a Source-backed server use the new envelope,
+        // clients hitting a CRUD-backed server use the old one.
+        // Phase 6 deletes CRUD and the old shape with it.
+        use pocopine_sync_query::write::MutationPayload;
+
+        let crud = CrudMutationPayload::create(
+            "id1".to_string(),
             Draft {
-                title: "updated".to_string(),
+                name: "A".to_string(),
+            },
+        );
+        let canonical: MutationPayload<String, Draft> = MutationPayload::create(
+            "id1".to_string(),
+            Draft {
+                name: "A".to_string(),
             },
         );
 
-        let draft = payload
-            .into_sync_draft_with_base_version(Some(base_version.clone()))
-            .unwrap();
-
-        assert_eq!(draft.op, SyncOp::Upsert);
-        assert_eq!(draft.key.unwrap().as_str(), "post_1");
-        assert_eq!(draft.base_version, Some(base_version));
-    }
-
-    #[test]
-    fn crud_payload_maps_remove_to_delete_draft() {
-        let payload: CrudMutationPayload<String, Draft> =
-            CrudMutationPayload::remove("post_1".to_string());
-
-        let draft = payload.into_sync_draft().unwrap();
-
-        assert_eq!(draft.op, SyncOp::Delete);
-        assert_eq!(draft.key.unwrap().as_str(), "post_1");
+        let crud_wire = serde_json::to_value(&crud).unwrap();
+        let canonical_wire = serde_json::to_value(&canonical).unwrap();
+        assert_eq!(
+            crud_wire,
+            serde_json::json!({
+                "op": "create",
+                "payload": {"id": "id1", "draft": {"name": "A"}}
+            }),
+            "CRUD keeps the legacy nested wire shape"
+        );
+        assert_eq!(
+            canonical_wire,
+            serde_json::json!({
+                "op": "create",
+                "id": "id1",
+                "draft": {"name": "A"}
+            }),
+            "Source uses the flat wire shape"
+        );
     }
 }

--- a/crates/pocopine-sync-crud/src/source.rs
+++ b/crates/pocopine-sync-crud/src/source.rs
@@ -12,7 +12,7 @@ use crate::ResourceId;
 // in sync-query; Phase 6 deletes CRUD entirely and downstream code
 // drops the `Crud` prefix.
 pub use pocopine_sync_query::write::{
-    Conflict as CrudConflict, RemoveResult as CrudRemoveResult, WriteResult as CrudWriteResult,
+    Conflict as CrudConflict, DeleteResult as CrudRemoveResult, WriteResult as CrudWriteResult,
 };
 
 /// Server-side CRUD source contract.

--- a/crates/pocopine-sync-query/src/lib.rs
+++ b/crates/pocopine-sync-query/src/lib.rs
@@ -102,8 +102,8 @@ pub use source::{
 // the old `Crud*` names for back-compat.
 #[cfg(not(target_arch = "wasm32"))]
 pub use write::{
-    AcceptedMutation, Conflict, MemoryMutationLog, MemoryScopeFn, MutationLog, MutationReservation,
-    RemoveResult, WriteResult,
+    AcceptedMutation, Conflict, CreatePayload, DeletePayload, DeleteResult, MemoryMutationLog,
+    MemoryScopeFn, MutationLog, MutationPayload, MutationReservation, UpdatePayload, WriteResult,
 };
 
 // The macro lives in its own crate (proc-macros must), but downstream

--- a/crates/pocopine-sync-query/src/source.rs
+++ b/crates/pocopine-sync-query/src/source.rs
@@ -32,19 +32,26 @@
 use std::sync::Arc;
 
 use pocopine_sync::{
-    RowVersion, StreamParams, SyncCollectionName, SyncError, SyncResult, SyncRow, SyncStreamName,
+    RowVersion, StreamParams, SyncCollectionName, SyncError, SyncOp, SyncRejectedMutation,
+    SyncResult, SyncRow, SyncStreamName,
 };
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use serde_json::Value;
 
 use crate::query::Query;
+use crate::write::{AcceptedMutation, MutationLog, MutationPayload};
 
 /// Identity boundary for `Source` rows. Mirrors
 /// `pocopine_sync_crud::ResourceId` — Query reuses the same contract
 /// so a `Source` and a `CrudSource` impl can share the same `Id`
 /// type in apps that adopt Source incrementally.
-pub trait SourceId: Clone + Send + Sync + 'static {
+///
+/// The `Serialize + DeserializeOwned` bounds let `Source::push`
+/// decode the wire mutation payload (`MutationPayload<Id, Draft>`)
+/// directly. Phase 1 only required `to_row_key`; Phase 2b widens to
+/// the full identity contract now that push lands.
+pub trait SourceId: Clone + Serialize + DeserializeOwned + Send + Sync + 'static {
     /// Project this id into a sync row key. Used by the adapter to
     /// fill the `key` field on `SyncRow<Value>` envelopes.
     fn to_row_key(&self) -> SyncResult<pocopine_sync::RowKey>;
@@ -56,15 +63,15 @@ impl SourceId for String {
     }
 }
 
-// RFC 090 Phase 2a — `WriteResult`/`RemoveResult`/`Conflict` were
+// RFC 090 Phase 2a — `WriteResult`/`DeleteResult`/`Conflict` were
 // briefly defined here in Phase 1 because they appear in `Source`
 // method signatures. Phase 2a moved them to `crate::write` (their
 // long-term home alongside the mutation log + idempotency
 // infrastructure). The `pub use` here keeps the Phase 1 public
 // surface working — code that wrote
-// `use pocopine_sync_query::source::{WriteResult, Conflict, RemoveResult};`
+// `use pocopine_sync_query::source::{WriteResult, Conflict, DeleteResult};`
 // keeps compiling.
-pub use crate::write::{Conflict, RemoveResult, WriteResult};
+pub use crate::write::{Conflict, DeleteResult, WriteResult};
 
 /// Boxed async-trait future. Sources don't need to name this — the
 /// `#[async_trait]` macro generates the right wrappers automatically.
@@ -181,25 +188,26 @@ pub trait Source: Send + Sync + 'static {
         draft: Self::Draft,
     ) -> SourceFuture<'a, SyncResult<Self::Row>>;
 
-    /// Save an existing row. `base_version` is the optimistic-
-    /// concurrency token the client read before editing. Source MUST
-    /// compare it against the stored row's version in the same DB
-    /// operation as the write.
-    fn save<'a>(
+    /// Update an existing row. `expected_version` is the optimistic-
+    /// concurrency token the client observed before editing. Source
+    /// MUST compare it against the stored row's version in the same
+    /// DB operation as the write. Return `WriteResult::Conflict` if
+    /// the versions differ.
+    fn update<'a>(
         &'a self,
         ctx: pocopine_auth::RequestContext,
         id: Self::Id,
         draft: Self::Draft,
-        base_version: Option<RowVersion>,
+        expected_version: Option<RowVersion>,
     ) -> SourceFuture<'a, SyncResult<WriteResult<Self::Row>>>;
 
-    /// Remove an existing row. Same concurrency contract as `save`.
-    fn remove<'a>(
+    /// Delete an existing row. Same concurrency contract as `update`.
+    fn delete<'a>(
         &'a self,
         ctx: pocopine_auth::RequestContext,
         id: Self::Id,
-        base_version: Option<RowVersion>,
-    ) -> SourceFuture<'a, SyncResult<RemoveResult<Self::Row>>>;
+        expected_version: Option<RowVersion>,
+    ) -> SourceFuture<'a, SyncResult<DeleteResult<Self::Row>>>;
 }
 
 /// Reconstruct a `Query<Row>` from a wire `SyncPullRequest`. The
@@ -306,6 +314,7 @@ impl<S: Source> SourceResourceBuilder<S> {
             id_of: Arc::new(id_of),
             version_of: None,
             params_of: None,
+            mutation_log: None,
         }
     }
 }
@@ -330,6 +339,15 @@ pub struct SourceResource<S: Source, IdOf> {
     /// disabled and the server publishes only the bare stream
     /// topic. Phase 4 will auto-wire this from `#[query_resource]`.
     params_of: Option<Arc<SourceParamsFn<S::Row>>>,
+    /// Idempotency log for push mutations. Set via
+    /// [`Self::mutation_log`] (RFC 090 Phase 2b). When `None`,
+    /// `push` rejects with an `unsupported` error — the adapter
+    /// won't perform writes without an idempotency boundary because
+    /// a retry without dedup would run `Source::create`/`save`
+    /// twice on the same mutation_id, double-applying writes
+    /// under client retries. Apps that genuinely want non-
+    /// idempotent push should attach a no-op log explicitly.
+    mutation_log: Option<Arc<dyn MutationLog<S::Row>>>,
 }
 
 impl<S, IdOf> SourceResource<S, IdOf>
@@ -337,41 +355,66 @@ where
     S: Source,
     IdOf: Fn(&S::Row) -> S::Id + Send + Sync + 'static,
 {
-    /// Attach a row-version extractor for optimistic concurrency.
-    /// Without it, pulled rows ship with `SyncRow::version = None`
-    /// and Phase 2's `Source::save` `base_version` checks have
-    /// nothing to compare against — concurrent writers can't be
-    /// detected.
+    /// Extract the optimistic-concurrency version from a row.
+    /// Without this, pulled rows ship `SyncRow::version = None` and
+    /// `Source::update`'s `expected_version` check has nothing to
+    /// compare against — concurrent writers go undetected.
     ///
-    /// The closure returns `SyncResult<Option<RowVersion>>` so a
-    /// source can:
-    /// - return `Ok(None)` for rows with no meaningful version
-    ///   (e.g., immutable rows, server-only-write resources)
-    /// - return `Ok(Some(v))` for the canonical version token
-    /// - return `Err(...)` when version extraction itself fails
-    ///   (rare; usually means the row shape is corrupt)
+    /// The closure returns `SyncResult<Option<RowVersion>>`:
+    /// - `Ok(None)` for rows with no meaningful version
+    /// - `Ok(Some(v))` for the canonical version token
+    /// - `Err(...)` when extraction itself fails (corrupt row shape)
     ///
-    /// Most apps use a closure that maps an integer `version`
-    /// field to `RowVersion::new(v.to_string())?`. Phase 2 will
-    /// widen this to a polyglot `RowVersionValue`-style trait so
-    /// users can pass `|r| r.version` (numeric) or
-    /// `|r| r.etag.clone()` (string) directly.
-    pub fn version<F>(mut self, version_of: F) -> Self
+    /// Most apps map an integer `version` field:
+    /// `.version_field(|r| Ok(Some(RowVersion::new(r.version.to_string())?)))`.
+    pub fn version_field<F>(mut self, extract: F) -> Self
     where
         F: Fn(&S::Row) -> SyncResult<Option<RowVersion>> + Send + Sync + 'static,
     {
-        self.version_of = Some(Arc::new(version_of));
+        self.version_of = Some(Arc::new(extract));
         self
     }
 
-    /// Attach an RFC 088 §C row → partition projector. Until Phase 4
-    /// auto-wires this from `#[query_resource]`, callers pass
-    /// `<resource>::row_to_params_typed` explicitly.
-    pub fn params_of<F>(mut self, params_of: F) -> Self
+    /// Partition rows for RFC 088 §C precise live wakeups: the
+    /// closure projects a row into the `StreamParams` that identify
+    /// its tenant/partition. Without this, the server publishes
+    /// only the bare stream topic (every subscriber wakes for every
+    /// row).
+    ///
+    /// Phase 4 will auto-wire this from `#[query_resource]`'s
+    /// macro-emitted `row_to_params_typed`. Until then, pass the
+    /// macro output explicitly:
+    ///
+    /// ```ignore
+    /// source("issues", IssueSource::default())?
+    ///     .id(|r| r.id.clone())
+    ///     .partition_by(issues::row_to_params_typed);
+    /// ```
+    pub fn partition_by<F>(mut self, projector: F) -> Self
     where
         F: Fn(&S::Row) -> StreamParams + Send + Sync + 'static,
     {
-        self.params_of = Some(Arc::new(params_of));
+        self.params_of = Some(Arc::new(projector));
+        self
+    }
+
+    /// Attach an idempotency log for the push lifecycle (RFC 090
+    /// Phase 2b). Without it, `push` rejects with `unsupported`
+    /// because a client retry of the same `mutation_id` would
+    /// otherwise run `Source::create`/`save`/`remove` twice and
+    /// double-apply writes.
+    ///
+    /// For tests and single-process demos, pass
+    /// `MemoryMutationLog::new()`. For production, pair with a
+    /// scoped backend (`MemoryMutationLog::with_scope_fn(...)` or
+    /// the sqlx-backed log in `pocopine-sync-sqlx`) so the
+    /// idempotency boundary aligns with your tenant authorization
+    /// scope.
+    pub fn mutation_log<Log>(mut self, log: Log) -> Self
+    where
+        Log: MutationLog<S::Row>,
+    {
+        self.mutation_log = Some(Arc::new(log));
         self
     }
 }
@@ -512,25 +555,274 @@ where
         })
     }
 
-    /// Phase 1 push: best-effort dispatch to `Source::create` based
-    /// on the wire op. **NO IDEMPOTENCY** — a retry of the same
-    /// mutation_id runs the source method again, which is incorrect
-    /// for production. Phase 2 adds the mutation log that fixes this.
-    /// For the canonical filtered-list demonstration this is fine.
+    /// RFC 090 Phase 2b push lifecycle.
+    ///
+    /// For each mutation in the request:
+    ///   1. Consult `MutationLog::accepted_mutation` for idempotency.
+    ///      A previously-accepted replay with matching wire envelope
+    ///      returns `accepted` directly (no Source call). A replay
+    ///      with different contents is rejected.
+    ///   2. Decode the wire payload as `MutationPayload<S::Id,
+    ///      S::Draft>` and validate it against the wire op.
+    ///   3. Dispatch to `Source::create` / `save` / `remove`.
+    ///   4. On `Accepted`, record in the mutation log and return
+    ///      the canonical row.
+    ///   5. On `Conflict`, surface a `SyncConflict` carrying the
+    ///      server-visible row.
+    ///
+    /// Without a `.mutation_log(...)` attachment, push returns
+    /// `unsupported` — see the field doc on `mutation_log` for
+    /// rationale.
     fn push<'a>(
         &'a self,
-        _ctx: pocopine_auth::RequestContext,
-        _request: pocopine_sync::SyncPushRequest<Value>,
+        ctx: pocopine_auth::RequestContext,
+        request: pocopine_sync::SyncPushRequest<Value>,
     ) -> pocopine_sync::SyncBoxFuture<'a, pocopine_sync::SyncPushResponse<Value>> {
+        let source = self.source.clone();
+        let id_of = self.id_of.clone();
+        let version_of = self.version_of.clone();
+        let mutation_log = self.mutation_log.clone();
+        let stream = self.stream.clone();
+        let collection = self.collection.clone();
         Box::pin(async move {
-            Err(SyncError::unsupported(
-                "Source push is intentionally unimplemented in Phase 1 of RFC 090 \
-                 (the mutation log + create/save/remove dispatch land in Phase 2). \
-                 For production writes use `pocopine_sync_crud::resource(...)` until \
-                 Phase 2 ships.",
-            ))
+            if request.stream != stream {
+                return Err(SyncError::UnknownStream(request.stream.to_string()));
+            }
+
+            let Some(mutation_log) = mutation_log else {
+                return Err(SyncError::unsupported(
+                    "Source push requires .mutation_log(...) on the builder. \
+                     For tests use MemoryMutationLog::new(); for production pair \
+                     with a scoped backend so idempotency aligns with your \
+                     tenant authorization domain.",
+                ));
+            };
+
+            let mut response = pocopine_sync::SyncPushResponse::new(stream.clone());
+            response.collection = Some(collection.clone());
+
+            for mutation in request.mutations {
+                let mutation_id = mutation.id.clone();
+                let key = mutation.key.clone();
+                let op = mutation.op;
+                let base_version = mutation.base_version;
+                let payload_value = mutation.payload;
+
+                // 1. Idempotency check.
+                if let Some(accepted) = mutation_log.accepted_mutation(&ctx, &mutation_id).await? {
+                    if accepted.matches(op, key.as_ref(), &payload_value) {
+                        response.accepted.push(mutation_id);
+                    } else {
+                        response.rejected.push(SyncRejectedMutation {
+                            mutation_id,
+                            key,
+                            reason: "mutation id was already accepted with different contents"
+                                .to_string(),
+                        });
+                    }
+                    continue;
+                }
+
+                // 2. Decode wire payload.
+                let payload = match serde_json::from_value::<MutationPayload<S::Id, S::Draft>>(
+                    payload_value.clone(),
+                ) {
+                    Ok(p) => p,
+                    Err(err) => {
+                        response.rejected.push(SyncRejectedMutation {
+                            mutation_id,
+                            key,
+                            reason: format!("invalid Source mutation payload: {err}"),
+                        });
+                        continue;
+                    }
+                };
+
+                if payload.sync_op() != op {
+                    response.rejected.push(SyncRejectedMutation {
+                        mutation_id,
+                        key,
+                        reason: "Source payload does not match sync operation".to_string(),
+                    });
+                    continue;
+                }
+
+                let expected_key = payload.id().to_row_key()?;
+                if key.as_ref() != Some(&expected_key) {
+                    response.rejected.push(SyncRejectedMutation {
+                        mutation_id,
+                        key,
+                        reason: "Source mutation row key does not match payload id".to_string(),
+                    });
+                    continue;
+                }
+
+                // 3. Dispatch to the source.
+                let outcome = apply_payload::<S>(
+                    source.as_ref(),
+                    ctx.clone(),
+                    mutation_id.clone(),
+                    expected_key.clone(),
+                    base_version,
+                    payload,
+                )
+                .await?;
+
+                // 4-5. Record + surface.
+                match outcome {
+                    SourceApplyOutcome::Accepted { mutation_id, row } => {
+                        mutation_log
+                            .record_accepted_mutation(
+                                &ctx,
+                                AcceptedMutation::new(
+                                    mutation_id.clone(),
+                                    op,
+                                    Some(expected_key.clone()),
+                                    payload_value,
+                                ),
+                            )
+                            .await?;
+                        response.accepted.push(mutation_id);
+                        if let Some(row) = row {
+                            response.rows.push(row_to_value_with_version(
+                                row,
+                                expected_key,
+                                version_of.as_deref(),
+                            )?);
+                        }
+                    }
+                    SourceApplyOutcome::Rejected(rejected) => response.rejected.push(rejected),
+                    SourceApplyOutcome::Conflict {
+                        mutation_id,
+                        key,
+                        conflict,
+                    } => {
+                        response.conflicts.push(pocopine_sync::SyncConflict {
+                            mutation_id,
+                            key,
+                            server_row: conflict
+                                .server_row
+                                .map(|row| {
+                                    let key = (id_of)(&row).to_row_key()?;
+                                    row_to_value_with_version(row, key, version_of.as_deref())
+                                })
+                                .transpose()?,
+                            reason: conflict.reason,
+                        });
+                    }
+                }
+            }
+
+            Ok(response)
         })
     }
+}
+
+/// Outcome of one mutation's dispatch to `Source::create/save/remove`.
+/// Internal — the `push` method translates these into wire response
+/// variants.
+enum SourceApplyOutcome<Row> {
+    Accepted {
+        mutation_id: pocopine_sync::MutationId,
+        row: Option<Row>,
+    },
+    Rejected(SyncRejectedMutation),
+    Conflict {
+        mutation_id: pocopine_sync::MutationId,
+        key: Option<pocopine_sync::RowKey>,
+        conflict: Conflict<Row>,
+    },
+}
+
+async fn apply_payload<S: Source>(
+    source: &S,
+    ctx: pocopine_auth::RequestContext,
+    mutation_id: pocopine_sync::MutationId,
+    key: pocopine_sync::RowKey,
+    base_version: Option<RowVersion>,
+    payload: MutationPayload<S::Id, S::Draft>,
+) -> SyncResult<SourceApplyOutcome<S::Row>> {
+    match payload {
+        MutationPayload::Create(p) => {
+            if base_version.is_some() {
+                return Ok(SourceApplyOutcome::Rejected(SyncRejectedMutation {
+                    mutation_id,
+                    key: Some(key),
+                    reason: "create does not accept a base row version".to_string(),
+                }));
+            }
+            let row = source.create(ctx, p.id, p.draft).await?;
+            Ok(SourceApplyOutcome::Accepted {
+                mutation_id,
+                row: Some(row),
+            })
+        }
+        MutationPayload::Update(p) => {
+            // Payload-carried expected_version takes precedence over
+            // the wire envelope's base_version. They should agree
+            // (the typed builder fills both) but if they diverge
+            // the payload wins — it's the typed contract the source
+            // understands.
+            let version = p.expected_version.clone().or(base_version);
+            let outcome = source.update(ctx, p.id, p.draft, version).await?;
+            match outcome {
+                WriteResult::Applied(row) => Ok(SourceApplyOutcome::Accepted {
+                    mutation_id,
+                    row: Some(row),
+                }),
+                WriteResult::Conflict(conflict) => Ok(SourceApplyOutcome::Conflict {
+                    mutation_id,
+                    key: Some(key),
+                    conflict,
+                }),
+            }
+        }
+        MutationPayload::Delete(p) => {
+            let version = p.expected_version.clone().or(base_version);
+            let outcome = source.delete(ctx, p.id, version).await?;
+            match outcome {
+                DeleteResult::Applied => Ok(SourceApplyOutcome::Accepted {
+                    mutation_id,
+                    row: None,
+                }),
+                DeleteResult::Conflict(conflict) => Ok(SourceApplyOutcome::Conflict {
+                    mutation_id,
+                    key: Some(key),
+                    conflict,
+                }),
+            }
+        }
+    }
+}
+
+fn row_to_value_with_version<Row>(
+    row: Row,
+    key: pocopine_sync::RowKey,
+    version_of: Option<&SourceVersionFn<Row>>,
+) -> SyncResult<SyncRow<Value>>
+where
+    Row: Serialize,
+{
+    let version = match version_of {
+        Some(extract) => (extract)(&row)?,
+        None => None,
+    };
+    let value = serde_json::to_value(&row)
+        .map_err(|e| SyncError::backend(format!("Source row failed to serialize: {e}")))?;
+    Ok(SyncRow {
+        key,
+        version,
+        value,
+        pending: false,
+        conflict: false,
+    })
+}
+
+// Unused-variable silencer: `SyncOp` is imported for the push impl
+// even when the source tests don't reference it directly.
+#[allow(dead_code)]
+fn _suppress_unused() {
+    let _ = SyncOp::Upsert;
 }
 
 #[cfg(test)]
@@ -608,23 +900,23 @@ mod tests {
             Box::pin(async move { Err(SyncError::unsupported("test stub: create")) })
         }
 
-        fn save<'a>(
+        fn update<'a>(
             &'a self,
             _ctx: pocopine_auth::RequestContext,
             _id: Self::Id,
             _draft: Self::Draft,
-            _base_version: Option<RowVersion>,
+            _expected_version: Option<RowVersion>,
         ) -> SourceFuture<'a, SyncResult<WriteResult<Self::Row>>> {
-            Box::pin(async move { Err(SyncError::unsupported("test stub: save")) })
+            Box::pin(async move { Err(SyncError::unsupported("stub: update")) })
         }
 
-        fn remove<'a>(
+        fn delete<'a>(
             &'a self,
             _ctx: pocopine_auth::RequestContext,
             _id: Self::Id,
-            _base_version: Option<RowVersion>,
-        ) -> SourceFuture<'a, SyncResult<RemoveResult<Self::Row>>> {
-            Box::pin(async move { Err(SyncError::unsupported("test stub: remove")) })
+            _expected_version: Option<RowVersion>,
+        ) -> SourceFuture<'a, SyncResult<DeleteResult<Self::Row>>> {
+            Box::pin(async move { Err(SyncError::unsupported("stub: delete")) })
         }
     }
 

--- a/crates/pocopine-sync-query/src/write.rs
+++ b/crates/pocopine-sync-query/src/write.rs
@@ -39,6 +39,7 @@ use std::sync::{Arc, Mutex};
 
 use pocopine_auth::RequestContext;
 use pocopine_sync::{MutationId, RowKey, SyncError, SyncOp, SyncResult};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 /// Outcome of an optimistic-concurrency `save`.
@@ -76,20 +77,18 @@ impl<Row> WriteResult<Row> {
     }
 }
 
-/// Outcome of an optimistic-concurrency `remove`.
+/// Outcome of an optimistic-concurrency `delete`.
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum RemoveResult<Row> {
+pub enum DeleteResult<Row> {
     Applied,
     Conflict(Conflict<Row>),
 }
 
-impl<Row> RemoveResult<Row> {
+impl<Row> DeleteResult<Row> {
     pub fn applied() -> Self {
         Self::Applied
     }
 
-    /// Construct a conflict with an explicit reason. Mirrors
-    /// `CrudRemoveResult::conflict`.
     pub fn conflict(server_row: Option<Row>, reason: impl Into<String>) -> Self {
         Self::Conflict(Conflict::new(server_row, reason))
     }
@@ -131,14 +130,159 @@ impl<Row> Conflict<Row> {
     }
 }
 
-// MutationPayload + Create/Save/RemovePayload deferred to Phase 2c.
-// CRUD's `CrudMutationPayload` uses a `#[serde(tag = "op", content =
-// "payload", ...)]` wire shape that this module's first cut didn't
-// match. Phase 2c will reconcile the wire shape and move the
-// envelope here; until then, CRUD users keep using
-// `pocopine_sync_crud::CrudMutationPayload` and new `Source` users
-// hand-construct mutations or wait for Phase 4's macro-emitted
-// typed writes.
+/// Payload for a `create` mutation. Mirrors
+/// `pocopine_sync_crud::CreatePayload` byte-for-byte; CRUD's version
+/// is now a `pub use` alias of this type.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "Id: Serialize, Draft: Serialize",
+    deserialize = "Id: Deserialize<'de>, Draft: Deserialize<'de>"
+))]
+pub struct CreatePayload<Id, Draft> {
+    pub id: Id,
+    pub draft: Draft,
+}
+
+impl<Id, Draft> CreatePayload<Id, Draft> {
+    pub fn new(id: Id, draft: Draft) -> Self {
+        Self { id, draft }
+    }
+}
+
+/// Payload for an `update` mutation. The `expected_version` carries
+/// the client's optimistic-concurrency token (the version the client
+/// observed on its last pull). The server fails the update if the
+/// stored row's version differs.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(bound(
+    serialize = "Id: Serialize, Draft: Serialize",
+    deserialize = "Id: Deserialize<'de>, Draft: Deserialize<'de>"
+))]
+pub struct UpdatePayload<Id, Draft> {
+    pub id: Id,
+    pub draft: Draft,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_version: Option<pocopine_sync::RowVersion>,
+}
+
+impl<Id, Draft> UpdatePayload<Id, Draft> {
+    pub fn new(id: Id, draft: Draft) -> Self {
+        Self {
+            id,
+            draft,
+            expected_version: None,
+        }
+    }
+
+    pub fn with_expected_version(mut self, version: pocopine_sync::RowVersion) -> Self {
+        self.expected_version = Some(version);
+        self
+    }
+}
+
+/// Payload for a `delete` mutation. Same optimistic-concurrency
+/// contract as [`UpdatePayload`].
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(bound(serialize = "Id: Serialize", deserialize = "Id: Deserialize<'de>"))]
+pub struct DeletePayload<Id> {
+    pub id: Id,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expected_version: Option<pocopine_sync::RowVersion>,
+}
+
+impl<Id> DeletePayload<Id> {
+    pub fn new(id: Id) -> Self {
+        Self {
+            id,
+            expected_version: None,
+        }
+    }
+
+    pub fn with_expected_version(mut self, version: pocopine_sync::RowVersion) -> Self {
+        self.expected_version = Some(version);
+        self
+    }
+}
+
+/// Unified mutation envelope. Flat wire shape — no nested `payload`
+/// wrapper:
+///
+/// ```json
+/// {"op": "create", "id": "...", "draft": {...}}
+/// {"op": "update", "id": "...", "draft": {...}, "expected_version": "..."}
+/// {"op": "delete", "id": "...", "expected_version": "..."}
+/// ```
+///
+/// Easier for non-Rust clients (one less level of nesting), and
+/// `expected_version` is named for what it does instead of CRUD's
+/// older `base_version`.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "op", rename_all = "snake_case")]
+#[serde(bound(
+    serialize = "Id: Serialize, Draft: Serialize",
+    deserialize = "Id: Deserialize<'de>, Draft: Deserialize<'de>"
+))]
+pub enum MutationPayload<Id, Draft> {
+    Create(CreatePayload<Id, Draft>),
+    Update(UpdatePayload<Id, Draft>),
+    Delete(DeletePayload<Id>),
+}
+
+impl<Id, Draft> MutationPayload<Id, Draft> {
+    pub fn create(id: Id, draft: Draft) -> Self {
+        Self::Create(CreatePayload::new(id, draft))
+    }
+
+    pub fn update(id: Id, draft: Draft) -> Self {
+        Self::Update(UpdatePayload::new(id, draft))
+    }
+
+    pub fn delete(id: Id) -> Self {
+        Self::Delete(DeletePayload::new(id))
+    }
+
+    pub fn id(&self) -> &Id {
+        match self {
+            Self::Create(p) => &p.id,
+            Self::Update(p) => &p.id,
+            Self::Delete(p) => &p.id,
+        }
+    }
+
+    pub fn expected_version(&self) -> Option<&pocopine_sync::RowVersion> {
+        match self {
+            Self::Create(_) => None,
+            Self::Update(p) => p.expected_version.as_ref(),
+            Self::Delete(p) => p.expected_version.as_ref(),
+        }
+    }
+
+    /// Wire-level `SyncOp` for this payload.
+    pub fn sync_op(&self) -> SyncOp {
+        match self {
+            Self::Create(_) | Self::Update(_) => SyncOp::Upsert,
+            Self::Delete(_) => SyncOp::Delete,
+        }
+    }
+}
+
+impl<Id, Draft> From<CreatePayload<Id, Draft>> for MutationPayload<Id, Draft> {
+    fn from(payload: CreatePayload<Id, Draft>) -> Self {
+        Self::Create(payload)
+    }
+}
+
+impl<Id, Draft> From<UpdatePayload<Id, Draft>> for MutationPayload<Id, Draft> {
+    fn from(payload: UpdatePayload<Id, Draft>) -> Self {
+        Self::Update(payload)
+    }
+}
+
+impl<Id, Draft> From<DeletePayload<Id>> for MutationPayload<Id, Draft> {
+    fn from(payload: DeletePayload<Id>) -> Self {
+        Self::Delete(payload)
+    }
+}
 
 /// Accepted-mutation log entry. Mirrors
 /// `pocopine_sync_crud::CrudAcceptedMutation`.

--- a/crates/pocopine-sync-query/tests/source_phase1.rs
+++ b/crates/pocopine-sync-query/tests/source_phase1.rs
@@ -27,7 +27,7 @@ use pocopine_sync::{
     SyncStreamName, SYNC_PULL_PATH,
 };
 use pocopine_sync_query::source::{
-    query_from_pull_request, source as build_source, RemoveResult, Source, SourceFuture,
+    query_from_pull_request, source as build_source, DeleteResult, Source, SourceFuture,
     WriteResult,
 };
 use pocopine_sync_query::Query;
@@ -162,22 +162,22 @@ impl Source for IssuesSource {
         })
     }
 
-    fn save<'a>(
+    fn update<'a>(
         &'a self,
         _ctx: RequestContext,
         _id: Self::Id,
         _draft: Self::Draft,
-        _base_version: Option<pocopine_sync::RowVersion>,
+        _expected_version: Option<pocopine_sync::RowVersion>,
     ) -> SourceFuture<'a, SyncResult<WriteResult<Self::Row>>> {
         Box::pin(async move { Err(pocopine_sync::SyncError::unsupported("Phase 1 stub: save")) })
     }
 
-    fn remove<'a>(
+    fn delete<'a>(
         &'a self,
         _ctx: RequestContext,
         _id: Self::Id,
-        _base_version: Option<pocopine_sync::RowVersion>,
-    ) -> SourceFuture<'a, SyncResult<RemoveResult<Self::Row>>> {
+        _expected_version: Option<pocopine_sync::RowVersion>,
+    ) -> SourceFuture<'a, SyncResult<DeleteResult<Self::Row>>> {
         Box::pin(async move {
             Err(pocopine_sync::SyncError::unsupported(
                 "Phase 1 stub: remove",
@@ -329,7 +329,7 @@ async fn version_extractor_populates_sync_row_version() {
                 // not meaningful semantically, just deterministic so
                 // the assertion below can predict the expected
                 // string.
-                .version(|r: &Issue| {
+                .version_field(|r: &Issue| {
                     Ok(Some(
                         RowVersion::new(r.title.len().to_string()).expect("valid version"),
                     ))

--- a/crates/pocopine-sync-query/tests/source_phase2b_push.rs
+++ b/crates/pocopine-sync-query/tests/source_phase2b_push.rs
@@ -1,0 +1,350 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+//! RFC 090 Phase 2b: end-to-end push lifecycle through `SourceResource`.
+//!
+//! Proves the new `.mutation_log(...)` builder + push handler:
+//!
+//! - Without `.mutation_log()`: push returns `unsupported`.
+//! - With `MemoryMutationLog::new()`: a `MutationPayload::create(...)` posts
+//!   through `/sync/v1/push`, the source's `create` runs once, the
+//!   accepted mutation is logged, and the canonical row appears in
+//!   the response.
+//! - Idempotency: a second push of the same `mutation_id` with the
+//!   same payload returns `accepted` WITHOUT re-running
+//!   `Source::create`.
+//! - Mismatched replay: a push of the same `mutation_id` with a
+//!   DIFFERENT payload is rejected.
+
+use std::collections::BTreeMap;
+use std::sync::{Arc, Mutex};
+
+use http_body_util::BodyExt;
+use pocopine_auth::RequestContext;
+use pocopine_server::axum::body::Body;
+use pocopine_server::axum::http::{Request, StatusCode};
+use pocopine_server::Server;
+use pocopine_sync::{
+    sync_server_plugin, ClientMutation, ClientMutationDraft, MutationId, RowVersion, SyncOp,
+    SyncPushRequest, SyncPushResponse, SyncResult, SyncServer, SyncStreamName, SYNC_PUSH_PATH,
+};
+use pocopine_sync_query::source::{
+    source as build_source, DeleteResult, Source, SourceFuture, WriteResult,
+};
+use pocopine_sync_query::write::{MemoryMutationLog, MutationPayload};
+use pocopine_sync_query::Query;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tower::ServiceExt;
+
+const STREAM: &str = "issues";
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct Issue {
+    id: String,
+    workspace_id: String,
+    title: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct IssueDraft {
+    workspace_id: String,
+    title: String,
+}
+
+#[derive(Clone, Default)]
+struct IssuesSource {
+    rows: Arc<Mutex<BTreeMap<String, Issue>>>,
+    create_calls: Arc<Mutex<u32>>,
+}
+
+impl Source for IssuesSource {
+    type Id = String;
+    type Row = Issue;
+    type Draft = IssueDraft;
+
+    fn list<'a>(
+        &'a self,
+        _ctx: RequestContext,
+        _query: &'a Query<Self::Row>,
+    ) -> SourceFuture<'a, SyncResult<Vec<Self::Row>>> {
+        let rows = self.rows.lock().unwrap().values().cloned().collect();
+        Box::pin(async move { Ok(rows) })
+    }
+
+    fn get<'a>(
+        &'a self,
+        _ctx: RequestContext,
+        id: Self::Id,
+    ) -> SourceFuture<'a, SyncResult<Option<Self::Row>>> {
+        let row = self.rows.lock().unwrap().get(&id).cloned();
+        Box::pin(async move { Ok(row) })
+    }
+
+    fn create<'a>(
+        &'a self,
+        _ctx: RequestContext,
+        id: Self::Id,
+        draft: Self::Draft,
+    ) -> SourceFuture<'a, SyncResult<Self::Row>> {
+        *self.create_calls.lock().unwrap() += 1;
+        let issue = Issue {
+            id: id.clone(),
+            workspace_id: draft.workspace_id,
+            title: draft.title,
+        };
+        self.rows.lock().unwrap().insert(id, issue.clone());
+        Box::pin(async move { Ok(issue) })
+    }
+
+    fn update<'a>(
+        &'a self,
+        _ctx: RequestContext,
+        _id: Self::Id,
+        _draft: Self::Draft,
+        _expected_version: Option<RowVersion>,
+    ) -> SourceFuture<'a, SyncResult<WriteResult<Self::Row>>> {
+        Box::pin(async move { Err(pocopine_sync::SyncError::unsupported("stub: update")) })
+    }
+
+    fn delete<'a>(
+        &'a self,
+        _ctx: RequestContext,
+        _id: Self::Id,
+        _expected_version: Option<RowVersion>,
+    ) -> SourceFuture<'a, SyncResult<DeleteResult<Self::Row>>> {
+        Box::pin(async move { Err(pocopine_sync::SyncError::unsupported("stub: delete")) })
+    }
+}
+
+fn build_app(source: IssuesSource, with_log: bool) -> pocopine_server::axum::Router {
+    pocopine_server::__reset_for_test();
+    let mut builder = build_source(STREAM, source)
+        .expect("stream name")
+        .id(|r: &Issue| r.id.clone());
+    if with_log {
+        builder = builder.mutation_log(MemoryMutationLog::<Issue>::new());
+    }
+    let sync = SyncServer::builder().public_stream(builder).build();
+    Server::new(pocopine_server::axum::Router::new())
+        .plugin(sync_server_plugin(sync))
+        .try_finalize()
+        .expect("server finalizes")
+}
+
+async fn push(
+    app: &pocopine_server::axum::Router,
+    mutation_id: &str,
+    payload: MutationPayload<String, IssueDraft>,
+) -> Result<SyncPushResponse<Value>, String> {
+    let key = pocopine_sync::RowKey::new(payload.id().clone()).unwrap();
+    let mutation = ClientMutationDraft::new(payload.sync_op(), payload)
+        .row_key(key)
+        .with_id(MutationId::new(mutation_id).unwrap());
+    // Erase to ClientMutation<Value> for the wire (the push handler
+    // is generic over payload).
+    let typed_value = serde_json::to_value(&mutation.payload).unwrap();
+    let mutation_value: ClientMutation<Value> = ClientMutation {
+        id: mutation.id,
+        key: mutation.key,
+        op: mutation.op,
+        base_version: mutation.base_version,
+        payload: typed_value,
+        migration_outcome: None,
+    };
+
+    let request = SyncPushRequest::new(SyncStreamName::new(STREAM).unwrap(), [mutation_value]);
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(SYNC_PUSH_PATH)
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&request).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let status = response.status();
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let outer: pocopine_core::ServerResult<SyncPushResponse<Value>> =
+        serde_json::from_slice(&bytes).unwrap();
+    if status != StatusCode::OK {
+        return Err(format!("status {status}: {outer:?}"));
+    }
+    outer.map_err(|e| format!("{e:?}"))
+}
+
+#[tokio::test]
+async fn push_without_mutation_log_rejects_with_clear_error() {
+    let source = IssuesSource::default();
+    let app = build_app(source.clone(), /* with_log */ false);
+
+    let result = push(
+        &app,
+        "m_first",
+        MutationPayload::create(
+            "i1".into(),
+            IssueDraft {
+                workspace_id: "W1".into(),
+                title: "Auth bug".into(),
+            },
+        ),
+    )
+    .await;
+    assert!(result.is_err(), "push must fail without mutation log");
+    let err = result.unwrap_err();
+    assert!(
+        err.contains("mutation_log"),
+        "error should name the missing builder method, got: {err}"
+    );
+    assert_eq!(
+        *source.create_calls.lock().unwrap(),
+        0,
+        "source.create must not run when push is unsupported"
+    );
+}
+
+#[tokio::test]
+async fn push_with_log_dispatches_create_and_returns_canonical_row() {
+    let source = IssuesSource::default();
+    let create_calls = source.create_calls.clone();
+    let app = build_app(source, /* with_log */ true);
+
+    let response = push(
+        &app,
+        "m_first",
+        MutationPayload::create(
+            "i1".into(),
+            IssueDraft {
+                workspace_id: "W1".into(),
+                title: "Auth bug".into(),
+            },
+        ),
+    )
+    .await
+    .expect("push succeeds");
+
+    assert_eq!(response.accepted.len(), 1);
+    assert_eq!(response.accepted[0].as_str(), "m_first");
+    assert!(response.rejected.is_empty());
+    assert!(response.conflicts.is_empty());
+    assert_eq!(response.rows.len(), 1);
+    assert_eq!(
+        response.rows[0].value.get("title").and_then(|v| v.as_str()),
+        Some("Auth bug")
+    );
+    assert_eq!(
+        *create_calls.lock().unwrap(),
+        1,
+        "Source::create should run exactly once"
+    );
+}
+
+#[tokio::test]
+async fn idempotent_replay_skips_source_create() {
+    let source = IssuesSource::default();
+    let create_calls = source.create_calls.clone();
+    let app = build_app(source, /* with_log */ true);
+
+    let payload = MutationPayload::create(
+        "i1".into(),
+        IssueDraft {
+            workspace_id: "W1".into(),
+            title: "Auth bug".into(),
+        },
+    );
+
+    let first = push(&app, "m_replay", payload.clone()).await.unwrap();
+    assert_eq!(first.accepted[0].as_str(), "m_replay");
+
+    let second = push(&app, "m_replay", payload).await.unwrap();
+    assert_eq!(second.accepted[0].as_str(), "m_replay");
+
+    assert_eq!(
+        *create_calls.lock().unwrap(),
+        1,
+        "replay must hit the idempotency log, not Source::create"
+    );
+}
+
+#[tokio::test]
+async fn mismatched_replay_is_rejected() {
+    let source = IssuesSource::default();
+    let app = build_app(source, /* with_log */ true);
+
+    let original = MutationPayload::create(
+        "i1".into(),
+        IssueDraft {
+            workspace_id: "W1".into(),
+            title: "Auth bug".into(),
+        },
+    );
+    let _ = push(&app, "m_mismatch", original).await.unwrap();
+
+    // Same mutation_id, DIFFERENT payload contents.
+    let mutated = MutationPayload::create(
+        "i1".into(),
+        IssueDraft {
+            workspace_id: "W1".into(),
+            title: "Different title".into(),
+        },
+    );
+    let result = push(&app, "m_mismatch", mutated).await.unwrap();
+    assert!(result.accepted.is_empty());
+    assert_eq!(result.rejected.len(), 1);
+    assert!(result.rejected[0]
+        .reason
+        .contains("already accepted with different contents"));
+}
+
+#[tokio::test]
+async fn create_with_base_version_is_rejected() {
+    // RFC 090 Phase 2b push handler: create does NOT accept a base
+    // row version. Mirrors CRUD's existing semantic.
+    let source = IssuesSource::default();
+    let app = build_app(source, /* with_log */ true);
+
+    let payload: MutationPayload<String, IssueDraft> = MutationPayload::create(
+        "i1".into(),
+        IssueDraft {
+            workspace_id: "W1".into(),
+            title: "Auth bug".into(),
+        },
+    );
+    let key = pocopine_sync::RowKey::new(payload.id().clone()).unwrap();
+    let mutation = ClientMutationDraft::new(SyncOp::Upsert, payload)
+        .row_key(key)
+        .base_row_version(Some(RowVersion::new("1").unwrap()))
+        .with_id(MutationId::new("m_bv").unwrap());
+    let mutation_value: ClientMutation<Value> = ClientMutation {
+        id: mutation.id,
+        key: mutation.key,
+        op: mutation.op,
+        base_version: mutation.base_version,
+        payload: serde_json::to_value(&mutation.payload).unwrap(),
+        migration_outcome: None,
+    };
+    let request = SyncPushRequest::new(SyncStreamName::new(STREAM).unwrap(), [mutation_value]);
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(SYNC_PUSH_PATH)
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&request).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    let outer: pocopine_core::ServerResult<SyncPushResponse<Value>> =
+        serde_json::from_slice(&bytes).unwrap();
+    let response = outer.unwrap();
+    assert_eq!(response.rejected.len(), 1);
+    assert!(response.rejected[0]
+        .reason
+        .contains("create does not accept a base row version"));
+}


### PR DESCRIPTION
Stacks on top of #159 (Phase 2a). Will rebase on merge.

Tracking: #155 / RFC: #156 / Prev: #158, #159

## What's in this PR

1. **`SourceResource::push` lifecycle** — wires the new `MutationLog` (Phase 2a) into a real push handler. Idempotency check, payload decode, dispatch to `Source::create`/`update`/`delete`, record-on-accept. Without `.mutation_log(...)` push returns `unsupported` with a clear builder-method pointer.

2. **API renames** (per user direction: no production usage yet, take the chance to make it nicer):
   - `Source::save` → `update`, `Source::remove` → `delete`
   - `RemoveResult` → `DeleteResult`, `SavePayload` → `UpdatePayload`, `RemovePayload` → `DeletePayload`
   - `base_version` → `expected_version` everywhere
   - `.params_of(...)` → `.partition_by(...)`
   - `.version(...)` → `.version_field(...)`

3. **Wire shape cleanup** — sync-query's `MutationPayload` drops CRUD's nested `content = \"payload\"` for a flat shape:
   ```json
   {\"op\": \"create\", \"id\": \"...\", \"draft\": {...}}
   {\"op\": \"update\", \"id\": \"...\", \"draft\": {...}, \"expected_version\": \"...\"}
   {\"op\": \"delete\", \"id\": \"...\", \"expected_version\": \"...\"}
   ```
   CRUD's `CrudMutationPayload` keeps its old shape — the two are intentionally NOT cross-deserializable. Phase 6 deletes CRUD with the old shape.

## Tests

5 new integration tests in `tests/source_phase2b_push.rs`:
- push without mutation_log → unsupported error names the builder method
- create dispatches, records, returns canonical row, runs source.create exactly once
- idempotent replay → accepted without re-running source.create
- mismatched replay → rejected
- create rejects base_version

Phase 1's 6 integration + 59 unit tests pass. CRUD's 54 tests pass through the unchanged `CrudMutationPayload`.

## What's deferred

- Transaction binding (`.transactional()`) — Phase 2b doesn't wire SQLx-style atomic write + log insert in one DB tx. Could land in Phase 2c if you want it before Phase 3, or roll into Phase 4 when SourceResource grows the typed mutation API.