### PR TITLE
docs: add state ownership RFC and recipes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,10 @@ looks the way it does — the code itself tells you *what*.
   the JS `Proxy` bridge, and everything we want to bolt on next.
 - [`poco/`](./poco/) — the `.poco` template format (HTML + directives),
   paired with sibling `.rs` + `.css` files. No mixed-language SFCs.
+- [`recipes/`](./recipes/) — applied implementation recipes for using
+  Pocopine primitives in real app structure.
+- [`issue-drafts/`](./issue-drafts/) — issue-ready proposal text kept
+  local until we are ready to publish it on GitHub.
 - [`client-modules.md`](./client-modules.md) — optional typed
   `.client.ts` modules, npm package imports, node_modules ownership,
   package-manager selection, and dev-watch behavior.

--- a/docs/components/02-state.md
+++ b/docs/components/02-state.md
@@ -13,6 +13,15 @@ answering a single question.
 If none of the four fits, the state probably doesn't belong where
 you're trying to put it. Check again before inventing a fifth pattern.
 
+For larger app structure, see:
+
+- [RFC 091](../../rfcs/rfc-091-store-state-ownership.md) for the
+  store ownership contract,
+- [`docs/recipes/state-ownership.md`](../recipes/state-ownership.md)
+  for the decision checklist,
+- [`docs/recipes/form-state.md`](../recipes/form-state.md) for
+  keeping form drafts local.
+
 ---
 
 ## 1. Local state

--- a/docs/issue-drafts/form-state-and-validation.md
+++ b/docs/issue-drafts/form-state-and-validation.md
@@ -1,0 +1,139 @@
+# Issue Draft — Add `pocopine-form` form state and validation
+
+## Title
+
+Add `pocopine-form`: React-style typed form state and validation
+
+## Body
+
+### Problem
+
+Complex Pocopine forms currently require every component to hand-roll
+the same mechanics:
+
+- default values and reset/reinitialize behavior,
+- field registration,
+- local draft values,
+- dirty/touched/visited/submitting flags,
+- `formState`-style derived status,
+- duplicate-submit guards,
+- client validation,
+- server validation mapping,
+- field error maps for `pine-field-root`,
+- programmatic `setValue`, `setError`, `clearError`, and `watch`
+  behavior.
+
+The existing Pine primitives are useful but intentionally low-level:
+
+- `pine-form-root` intercepts submit and propagates an error map,
+- `pine-field-root` wires label/control/error accessibility,
+- `pp-model` moves values into component state.
+
+There is no reusable middle layer that owns a typed form instance and
+normalizes validation behavior with the ergonomics people expect from
+React Hook Form or TanStack Form. The storage-browser connection dialog
+is already showing the failure mode: provider-specific fields,
+modal-local errors, save state, validation hints, and reset behavior
+are all custom code.
+
+### Proposal
+
+Implement the draft design in [RFC 090 — Form state and validation](../../rfcs/rfc-090-form-state-and-validation.md).
+
+Add a new `crates/pocopine-form` crate with:
+
+- `use_form(default_values)` / `FormBuilder<V>` as the Pocopine
+  equivalent of `useForm({ defaultValues })`,
+- `Form<V>` for typed values, initial values, `FormMeta`,
+  submit count, field metadata, registered fields, and errors,
+- `register`, `unregister`, `set_value`, `set_error`, `clear_error`,
+  `reset`, and `watch` methods,
+- `handle_submit` returning a `SubmitDecision<V>` so components can
+  follow the React `handleSubmit(onValid)` mental model without
+  introducing hooks or a new async runtime,
+- `FormResolver<V>` and `ValidationMode` for resolver-style validation
+  on submit, blur, input, or manual triggers,
+- `FieldErrors` / `FormError` / `FormFailure` shared shapes,
+- sync validation traits and lightweight validators,
+- server-error application helpers,
+- duplicate-submit guards,
+- reset/reinitialize helpers,
+- first-message flattening for Pine field integration.
+
+Keep `pine-form-root` and `pine-field-root` as the DOM/accessibility
+layer. The new crate should feed them error state; it should not
+replace native forms or invent a schema DSL in the first slice.
+
+Add a controller bridge for compound controls that cannot be wired like
+a plain input:
+
+- `pine-form-controller` observes field metadata/errors by `name`,
+  stamps common state on its host, and lets the component keep binding
+  values with `pp-model`.
+- This gives Pocopine the same escape hatch React Hook Form's
+  `Controller` gives React apps.
+
+### Suggested Phases
+
+1. Add `pocopine-form` core types and tests.
+2. Add React-form-equivalent helpers: `use_form`, `register`,
+   `handle_submit`, `set_value`, `set_error`, `reset`, `watch`, and
+   `meta`.
+3. Bridge `FieldErrors` to existing Pine field error maps.
+4. Add a `pine-form-controller` path for compound Pine controls.
+5. Migrate the storage-browser connection dialog to prove the API.
+6. Add docs and a simple signup/edit-dialog recipe.
+7. Consider a derive/macro layer only after the explicit API settles.
+
+### Acceptance Criteria
+
+- `pocopine-form` compiles on host and `wasm32-unknown-unknown`.
+- A component can store `Form<MyValues>` locally.
+- The public API has Pocopine-native equivalents for React forms:
+  `useForm`, `register`, `handleSubmit`, `setValue`, `setError`,
+  `reset`, `watch`, and `formState`.
+- Client validators can produce field errors without a DOM.
+- Server validation failures can map into the same error shape.
+- Pine fields can display errors by field name.
+- Pine has a controller path for tabs, selects, uploads, and other
+  compound controls.
+- Duplicate submits are guarded consistently.
+- The storage-browser connection dialog can use the form object without
+  moving transient draft state back into `StorageBrowserStore`.
+
+### Non-goals
+
+- No schema macro in the first implementation.
+- No ORM or database-model form generation.
+- No replacement for browser-native forms or autofill.
+- No automatic global-store form state.
+- No nested field-path system unless the flat field-name API proves
+  insufficient during implementation.
+- No direct clone of React hooks or non-serializable closures inside
+  component state; the API should preserve the mental model while
+  staying Rust/Pocopine-native.
+
+### Open Questions
+
+- Should `pine` depend on `pocopine-form`, or should the bridge be
+  feature-gated?
+- Should native constraint-validation failures become
+  `FormError { source: Native }`?
+- Should `FormFailure` live in `pocopine-form` or be re-exported from
+  `pocopine` for server-function ergonomics?
+- Should the exported constructor be named `use_form` for familiarity,
+  or should `Form::builder` be primary with `use_form` as a small
+  alias?
+
+## Labels
+
+- `enhancement`
+- `forms`
+- `pine`
+- `rfc`
+
+## Links
+
+- RFC draft: `rfcs/rfc-090-form-state-and-validation.md`
+- Existing primitives: `crates/pine/src/form`, `crates/pine/src/field`
+- Proving-ground form: `examples/file-browser/src/components/connection_dialog`

--- a/docs/recipes/README.md
+++ b/docs/recipes/README.md
@@ -1,0 +1,14 @@
+# Pocopine Recipes
+
+Applied implementation recipes for turning the framework primitives into
+maintainable application structure.
+
+- [Storage browser state refactor](./storage-browser-state-refactor.md) -
+  split a large app store into local component state, prop surfaces, route
+  props, and server-function modules.
+- [State ownership](./state-ownership.md) - choose between component
+  state, `Form<V>`, props/models, route identity, stores, sync/query
+  state, and derived values.
+- [Form state](./form-state.md) - keep form drafts local with
+  `pocopine-form`, submit through resolvers, and apply server errors
+  without moving draft fields into stores.

--- a/docs/recipes/form-state.md
+++ b/docs/recipes/form-state.md
@@ -1,0 +1,160 @@
+# Form State
+
+Use `Form<V>` for form drafts, validation, field metadata, submit
+status, and server-error mapping. Keep it local to the component that
+renders the form.
+
+## When To Use A Form
+
+Use `Form<V>` when a workflow needs:
+
+- default values,
+- editable draft values,
+- field registration,
+- dirty/touched/focused metadata,
+- client validation,
+- server validation mapped back to fields,
+- submit guards,
+- reset/reinitialize behavior.
+
+Do not put those draft fields into a global store unless the draft must
+survive route changes or be shared by unrelated subtrees.
+
+## Basic Shape
+
+```rust
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct ConnectionValues {
+    pub name: String,
+    pub bucket: String,
+    pub region: String,
+}
+
+#[derive(Serialize, Deserialize)]
+#[component(template = "ConnectionDialog.poco")]
+pub struct ConnectionDialog {
+    pub form: Form<ConnectionValues>,
+    pub error: String,
+}
+```
+
+Initialize it with defaults:
+
+```rust
+impl Default for ConnectionDialog {
+    fn default() -> Self {
+        Self {
+            form: use_form(ConnectionValues::default())
+                .mode(ValidationMode::OnSubmit)
+                .build(),
+            error: String::new(),
+        }
+    }
+}
+```
+
+## Submit Flow
+
+```rust
+#[handlers]
+impl ConnectionDialog {
+    pub fn save(&mut self) {
+        let decision = self.form.handle_submit(&ConnectionResolver);
+        let Some(values) = decision.valid_values() else {
+            return;
+        };
+
+        dispatch!(crate::save_connection(values).await, |s, result| {
+            match result {
+                Ok(saved) => {
+                    s.form.finish_submit();
+                    s.close(saved);
+                }
+                Err(err) => s.form.apply_failure(err.into()),
+            }
+        });
+    }
+}
+```
+
+The form object handles validation and submit phase. The component still
+owns the async dispatch because Pocopine handlers stay synchronous.
+
+## Template Bridge
+
+First-slice templates can stay explicit:
+
+```html
+<pine-form-root pp-bind:errors="form_errors"
+                pp-bind:submitting="form_submitting"
+                @submit="save">
+  <pine-field-root name="bucket">
+    <pine-field-label>Bucket</pine-field-label>
+    <pine-field-control>
+      <pine-input pp-model:value="form.values.bucket"
+                  @blur="touch_bucket"
+                  required></pine-input>
+    </pine-field-control>
+    <pine-field-error pp-text="form_errors.bucket || 'Bucket is required.'"></pine-field-error>
+  </pine-field-root>
+</pine-form-root>
+```
+
+The component can expose simple view fields such as `form_errors` and
+`form_submitting` until Pine grows a richer `form-meta` bridge.
+
+## Controller Controls
+
+For compound controls, use a controller wrapper instead of forcing a
+fake input event:
+
+```html
+<pine-form-controller name="auth_mode"
+                      pp-bind:form-meta="form.meta"
+                      @field-blur="touch_auth_mode">
+  <pine-tabs-root pp-model:value="form.values.auth_mode">
+    ...
+  </pine-tabs-root>
+</pine-form-controller>
+```
+
+The controller observes field meta/errors and stamps state. The value
+still flows through the component's `pp-model` binding.
+
+## Store Boundary
+
+Good:
+
+```rust
+pub struct ConnectionDialog {
+    pub form: Form<ConnectionValues>,
+}
+
+impl ConnectionDialog {
+    pub fn close(&mut self, saved: StorageConnectionSummary) {
+        pocopine::store::<StorageStore>().update(move |store| {
+            store.upsert_connection(saved);
+        });
+    }
+}
+```
+
+Bad:
+
+```rust
+pub struct StorageStore {
+    pub connection_name_input: String,
+    pub connection_bucket_input: String,
+    pub connection_secret_input: String,
+    pub connection_dialog_error: String,
+}
+```
+
+The store should receive saved domain state. It should not own every
+keystroke in the dialog.
+
+## References
+
+- RFC 090: `rfcs/rfc-090-form-state-and-validation.md`
+- RFC 091: `rfcs/rfc-091-store-state-ownership.md`
+- Store recipe: `docs/recipes/state-ownership.md`

--- a/docs/recipes/state-ownership.md
+++ b/docs/recipes/state-ownership.md
@@ -1,0 +1,184 @@
+# State Ownership
+
+Use the narrowest owner that can complete the workflow. Stores are not
+the default place for state; they are the place for durable state shared
+across unrelated subtrees.
+
+## Decision Table
+
+| Need | Use |
+|---|---|
+| One component renders and mutates it | component field |
+| A dialog/editor has draft values and validation | `Form<V>` local to that component |
+| A parent configures a child | `#[prop]` or `#[model]` |
+| A route provides identity | route props or a tiny shared route field |
+| Shell/sidebar/content need the same durable value | `#[store]` |
+| Server/source data has a protocol owner | server DTO, sync collection, or query state |
+| It can be calculated from other state | derived function/computed value |
+
+## Good Store Candidates
+
+- current session identity,
+- app theme/preferences,
+- cart contents,
+- selected account/project/connection id,
+- route identity that multiple subtrees must observe,
+- synced collections,
+- long-lived app capability metadata.
+
+## Poor Store Candidates
+
+- form inputs before save,
+- dialog-local errors,
+- upload dock expansion,
+- command palette query/results,
+- loading flags for one component request,
+- labels such as "12 files" or "Root / Videos",
+- selected object copies that duplicate a selected id.
+
+## Shape Shared Stores By Domain
+
+Prefer:
+
+```rust
+#[derive(Default, Serialize, Deserialize)]
+#[store(name = "storage")]
+pub struct StorageStore {
+    pub connections: Vec<StorageConnectionSummary>,
+    pub selected_connection_id: String,
+    pub current_prefix: String,
+    pub phase: LoadPhase,
+    pub error: String,
+}
+```
+
+Avoid:
+
+```rust
+pub struct StorageStore {
+    pub connection_dialog_name: String,
+    pub command_query: String,
+    pub upload_dock_expanded: bool,
+    pub listed_size_label: String,
+    pub selected_connection: StorageConnectionSummary,
+}
+```
+
+The first store represents durable browser state. The second store is a
+collection of component internals and derived labels.
+
+## Use Phase Enums
+
+Avoid contradictory boolean clusters:
+
+```rust
+pub loading: bool,
+pub saving: bool,
+pub saved: bool,
+pub failed: bool,
+```
+
+Prefer one workflow phase:
+
+```rust
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub enum LoadPhase {
+    #[default]
+    Idle,
+    Loading,
+    Ready,
+    Failed,
+}
+```
+
+Templates can still read helper booleans from a component or store
+method when needed.
+
+## Keep Derived Data Derived
+
+Do not store values that can be calculated cheaply:
+
+- count labels,
+- filtered count labels,
+- path titles,
+- breadcrumbs,
+- selected connection name,
+- capability badges.
+
+Store the canonical values:
+
+- entries,
+- selected id,
+- current prefix,
+- connection summaries.
+
+Compute the labels near the component that renders them.
+
+## Normalize Shared Collections
+
+If many components need the same collection, keep one copy and store
+ids for selection.
+
+```rust
+pub struct NotesStore {
+    pub notes: Vec<NoteRow>,
+    pub selected_note_ids: Vec<String>,
+}
+```
+
+Do not keep duplicate selected rows unless there is a measured
+performance reason and a clear invalidation point.
+
+## Mutate Through Store Actions
+
+Put multi-field transitions in Rust methods:
+
+```rust
+#[handlers]
+impl StorageStore {
+    pub fn select_connection(&mut self, id: String) {
+        self.selected_connection_id = id;
+        self.current_prefix.clear();
+        self.phase = LoadPhase::Idle;
+        self.error.clear();
+    }
+}
+```
+
+Then call the method from a component handler. Avoid templates that
+assign several `$store.*` fields to complete one workflow.
+
+## Reset Explicitly
+
+If a store has semantic defaults, expose the reset operation by name:
+
+```rust
+impl PreferencesStore {
+    pub fn reset(&mut self) {
+        *self = Self::default();
+    }
+}
+```
+
+If some durable identity must survive reset, make that visible in the
+method name and body.
+
+## Migration Checklist
+
+When a store is getting too large:
+
+1. List every field and the component that renders it.
+2. Move dialog/editor fields into a local `Form<V>`.
+3. Move upload/search/popover fields into their rendering component.
+4. Replace derived labels with local helper methods.
+5. Keep route/shared identity in the store.
+6. Normalize duplicated selected objects into selected ids.
+7. Replace boolean clusters with phase enums.
+8. Keep server DTOs and provider SDK calls outside components.
+
+## References
+
+- RFC 091: `rfcs/rfc-091-store-state-ownership.md`
+- RFC 090: `rfcs/rfc-090-form-state-and-validation.md`
+- Existing guide: `docs/components/02-state.md`
+- Storage-browser recipe: `docs/recipes/storage-browser-state-refactor.md`

--- a/docs/recipes/storage-browser-state-refactor.md
+++ b/docs/recipes/storage-browser-state-refactor.md
@@ -1,0 +1,192 @@
+# Storage Browser State Refactor
+
+The storage browser example is intentionally becoming a real app: connection
+profiles, S3/GCS browsing, route-backed prefixes, command search, dialogs, and
+uploads. That also means `StorageBrowserStore` has started to hold unrelated
+state. The refactor should use Pocopine's component model instead of adding more
+global fields.
+
+This recipe is the target structure and migration order.
+
+Design references:
+
+- RFC 091: `rfcs/rfc-091-store-state-ownership.md`
+- RFC 090: `rfcs/rfc-090-form-state-and-validation.md`
+- General recipe: `docs/recipes/state-ownership.md`
+
+## Pocopine Tools To Use
+
+Use the narrowest Pocopine primitive that matches the data lifetime:
+
+| Need | Pocopine shape |
+|---|---|
+| One component owns it | local component fields on `#[component]` |
+| Parent configures a child | `#[prop]` fields plus static attrs or `pp-bind:` |
+| Many parent-to-child fields | `#[derive(Props)]` prop bag plus `#[prop(flatten)]` |
+| Route params | route component `#[prop]` fields |
+| Cross-subtree app state | one focused `#[store]` |
+| Browser/server boundary | `#[pocopine::server]` functions with serializable DTOs |
+| Repeated UI rows | keyed `pp-for` with small row DTOs |
+| User-controlled Pine primitives | `pp-model:*` for open/value state when the parent controls it |
+
+Two rules matter most:
+
+- Stores are for durable, cross-subtree state. Dialog inputs, loading flags,
+  command search results, upload expansion, and transient errors should usually
+  live in the component that renders them.
+- Props are an explicit component contract. Mark exposed fields with `#[prop]`;
+  keep everything else as private component state.
+
+## Current Problem Shape
+
+`examples/file-browser/src/store/mod.rs` is doing all of these jobs:
+
+- selected connection and route prefix
+- connection list and selected connection metadata
+- object listing, filters, derived counts, breadcrumbs, path labels
+- connection modal form state for both S3 and GCS
+- command palette state and all-bucket search results
+- upload dock state and upload metadata
+- new-folder dialog state
+- loading, saving, and error flags for several independent workflows
+
+That creates three symptoms:
+
+- Unrelated UI actions invalidate the same global store.
+- Components read many `$store.storage.*` fields they do not own.
+- Derived labels such as `path_meta`, count labels, and prefix labels become
+  cached state instead of local render facts.
+
+## Target Ownership
+
+Keep one small app store for navigation and shared identity:
+
+```rust
+#[derive(Default, Serialize, Deserialize)]
+#[store(name = "storage")]
+pub struct StorageBrowserStore {
+    pub connections: Vec<StorageConnectionSummary>,
+    pub selected_connection_id: String,
+    pub current_prefix: String,
+}
+```
+
+Everything else should move closer to the component that owns the UI.
+
+| Concern | Owner after refactor |
+|---|---|
+| Connection list load/delete/reconnect | `FileBrowserSidebar` |
+| Connection form fields/save errors | `FileBrowserConnectionDialog` |
+| Current object listing/filter/counts | `FileBrowserFileList` or a new `FileBrowserObjectBrowser` |
+| Breadcrumbs/path title/path subtitle | object browser/header local derived state |
+| New folder name/error/saving | `FileBrowserNewFolderDialog` |
+| Upload open/expanded/metadata | `FileBrowserUploadDock` |
+| Command palette open/query/results/errors | `FileBrowserStorageCommand` |
+| Route param synchronization | `FileBrowserRoute` |
+
+## Prop Bags
+
+When a child needs several fields from the selected connection, pass a typed prop
+bag instead of adding more store fields.
+
+```rust
+#[derive(Props, Default, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ConnectionBadgeProps {
+    #[prop] pub id: String,
+    #[prop] pub name: String,
+    #[prop] pub provider_label: String,
+    #[prop] pub bucket: String,
+    #[prop] pub root_prefix: String,
+    #[prop] pub favicon_url: String,
+}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component]
+pub struct FileBrowserHeader {
+    #[prop(flatten)]
+    pub connection: ConnectionBadgeProps,
+
+    #[prop]
+    pub prefix: String,
+}
+```
+
+The caller still writes flat template bindings:
+
+```html
+<file-browser-header
+  pp-bind:id="selected.id"
+  pp-bind:name="selected.name"
+  pp-bind:provider-label="selected.provider_label"
+  pp-bind:bucket="selected.bucket"
+  pp-bind:root-prefix="selected.root_prefix"
+  pp-bind:favicon-url="selected.favicon_url"
+  pp-bind:prefix="$store.storage.current_prefix" />
+```
+
+Use this for UI identity and display metadata. Do not use prop bags to smuggle
+mutable workflow state across the tree.
+
+## Server DTOs Stay Central
+
+Keep provider DTOs and server functions in `examples/file-browser/src/storage_browser/`:
+
+- `mod.rs` exposes serializable DTOs and `#[pocopine::server]` wrappers.
+- `server.rs` owns local config persistence and provider-specific SDK calls.
+- Components call the server functions directly and update their local fields
+  from the response.
+
+This keeps the S3/GCS boundary reusable while letting UI state move out of the
+global store.
+
+## Migration Order
+
+1. Extract `FileBrowserConnectionDialog`.
+   Move `connection_*`, `saving_connection`, and `modal_error` out of the store.
+   Keep the dialog controlled by `pp-model:open` if the shell needs to open it.
+
+2. Extract object-browser state.
+   Move `entries`, `visible_entries`, filters, listing request id, breadcrumbs,
+   counts, and listing errors into the file-list/browser component. Pass only
+   `connection_id` and `prefix` as props.
+
+3. Let route state stay global.
+   Keep `selected_connection_id` and `current_prefix` in the store so sidebar,
+   route sync, upload, and listing agree on the browser location.
+
+4. Move command search into `FileBrowserStorageCommand`.
+   The command palette already owns its visual shell. It should own query,
+   loading, errors, and result rows too.
+
+5. Move upload dock state into `FileBrowserUploadDock`.
+   Pass `connection_id` and `prefix` as props and build upload metadata locally.
+   Keep completion refresh as an explicit event or store update.
+
+6. Delete derived global labels last.
+   Once components own their data, recompute labels locally from the local state:
+   count labels from entries, title from prefix, subtitle from connection props.
+
+## Test Split
+
+As fields move out of the store, move tests with the behavior:
+
+- Store tests: route normalization and selected-connection changes.
+- Connection dialog tests: defaults, service JSON parsing, auth-mode switches.
+- Object browser tests: stale-listing rejection, filters, derived labels.
+- Server tests: provider config, key safety, timestamp formatting, favicon
+  domain mapping.
+
+Avoid one huge "storage browser store" test module. Each owner should have its
+own narrow invariants.
+
+## Stop Criteria
+
+The refactor is complete when:
+
+- `StorageBrowserStore` is under roughly 200 lines and has one reason to change:
+  browser location and shared connection identity.
+- No dialog input is read from `$store.storage.*`.
+- No loading flag in the store represents a component-local request.
+- Main browser content can be reasoned about from its props plus its local
+  listing state.
+- Server DTOs remain stable and provider-specific code stays out of components.

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -95,3 +95,5 @@ Conventions:
 | 087 | [`pocopine-sync-query` driver lifecycle](./rfc-087-sync-query-driver.md) | Draft |
 | 088 | [`pocopine-sync-query` production parity](./rfc-088-sync-query-production-parity.md) | Draft |
 | 089 | [SPA router parity and nested outlets](./rfc-089-spa-router-parity.md) | Draft |
+| 090 | [Form state and validation](./rfc-090-form-state-and-validation.md) | Draft |
+| 091 | [Store state ownership and durable app state](./rfc-091-store-state-ownership.md) | Draft |

--- a/rfcs/rfc-090-form-state-and-validation.md
+++ b/rfcs/rfc-090-form-state-and-validation.md
@@ -1,0 +1,684 @@
+# RFC 090 — Form state and validation
+
+| Field | Value |
+|---|---|
+| **Status** | Draft |
+| **Author** | pocopine team |
+| **Created** | 2026-05-29 |
+| **Builds on** | [RFC 009](./rfc-009-pp-model-components.md), [RFC 031](./rfc-031-prop-vs-state.md), [RFC 044](./rfc-044-model-fields.md), existing `pine-form-root` / `pine-field-root` primitives |
+| **Related** | [RFC 091](./rfc-091-store-state-ownership.md), `crates/pine/src/form`, `crates/pine/src/field`, storage-browser connection dialog, signup showcase |
+
+## 1. Summary
+
+Add a first-party `pocopine-form` crate that gives components a
+serializable, typed **form object** for values, field metadata,
+validation errors, submit lifecycle, and server-error mapping.
+The author experience should intentionally feel closer to React form
+libraries such as React Hook Form or TanStack Form than to a plain
+`HashMap` of errors:
+
+- create a form from default values,
+- register fields by name,
+- validate through a resolver,
+- read `meta`,
+- call `handle_submit`,
+- set/reset values and errors programmatically,
+- and let form/field primitives consume the same field metadata.
+
+The goal is not to replace native forms or Pine form primitives.
+Instead:
+
+- `pocopine-form` owns value state, validation state, error shape,
+  and submit helpers.
+- `pine-form-root` / `pine-field-root` own DOM, accessibility,
+  native constraint-validation hooks, and visual state propagation.
+- App components keep their form instance local unless the app
+  deliberately promotes it into a store.
+
+This lets Pocopine apps avoid the common pattern we are seeing in the
+storage-browser work: many ad hoc component fields, custom error
+strings, custom submit guards, custom "server error to field error"
+mapping, and duplicated dirty/touched/submitting behavior.
+
+## 2. Motivation
+
+Pocopine already has the low-level pieces:
+
+- `pp-model` moves input values into component state.
+- `pine-form-root` intercepts submit and carries an `errors` map.
+- `pine-field-root` wires label/control/error accessibility and flips
+  `invalid` when its `name` appears in the form errors map.
+- Server functions can return domain errors.
+
+What is missing is the middle layer that normal applications need:
+
+1. a stable form object shape that can be serialized in component state,
+2. field errors with codes, messages, and source,
+3. submit status and duplicate-submit protection,
+4. dirty/touched/visited/pending metadata,
+5. client validation before server submission,
+6. server validation mapping back into the same field-error shape,
+7. reset/reinitialize helpers for edit dialogs,
+8. ergonomic tests that do not require a browser.
+
+Without this layer, complex forms either become global-store blobs or
+large component structs with every field and error hand-written.
+That is manageable for one dialog, but it scales poorly for auth,
+storage connections, settings, CRUD editors, and sync conflict
+resolution forms.
+
+## 3. Design Goals
+
+- **Local by default.** A form object belongs in the component that owns
+  the interaction. Stores should hold durable app state, not every
+  transient draft field.
+- **Typed values, generic errors.** Value structs are app-owned Rust
+  types. Error transport is framework-owned and reusable.
+- **Works with `.poco`.** Templates should bind to normal fields and
+  maps; no magic form parser is required in the template language.
+- **Browser and server compatible.** The core crate must compile on
+  wasm and host targets.
+- **No schema lock-in.** The first version should not force a Zod-like
+  DSL, validator macro, ORM, or server framework.
+- **React-form ergonomics.** The public API should resemble
+  `useForm`, `register`, `handleSubmit`, `setValue`, `setError`,
+  `reset`, `watch`, and `formState`, adapted to Rust and Pocopine's
+  component model.
+- **Accessible by construction.** Pine form primitives continue to own
+  `aria-*`, labels, descriptions, and error visibility.
+- **Testable without DOM.** Most validation and submit-state behavior
+  should be unit-testable in Rust.
+
+## 4. Non-goals
+
+- Replacing native `<form>`, `FormData`, browser autofill, or native
+  constraint validation.
+- Building a full schema language in the first slice.
+- Generating forms from database models.
+- Owning business validation that belongs to the application or server.
+- Solving every nested-field path shape immediately. Flat field names
+  are enough for the first implementation; nested paths can layer on
+  the same key type later.
+- Moving form drafts into global stores automatically.
+
+## 5. React-style Target Model
+
+The target mental model is:
+
+```tsx
+const form = useForm({
+  defaultValues,
+  resolver,
+});
+
+<form onSubmit={form.handleSubmit(onValid)}>
+  <input {...form.register("bucket")} />
+  {form.formState.errors.bucket?.message}
+</form>
+```
+
+The Pocopine equivalent should be explicit Rust, but preserve that
+shape:
+
+```rust
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct ConnectionValues {
+    pub provider: String,
+    pub name: String,
+    pub bucket: String,
+    pub endpoint_url: String,
+}
+
+pub struct ConnectionDialog {
+    pub form: Form<ConnectionValues>,
+}
+
+impl Default for ConnectionDialog {
+    fn default() -> Self {
+        Self {
+            form: use_form(ConnectionValues::default())
+                .mode(ValidationMode::OnSubmit)
+                .build(),
+        }
+    }
+}
+
+#[handlers]
+impl ConnectionDialog {
+    pub fn save(&mut self) {
+        let decision = self.form.handle_submit(&ConnectionResolver);
+        let Some(values) = decision.valid_values() else {
+            return;
+        };
+
+        dispatch!(crate::save_connection(values).await, |s, result| {
+            match result {
+                Ok(saved) => {
+                    s.form.finish_submit();
+                    s.close(saved);
+                }
+                Err(err) => s.form.apply_failure(err.into()),
+            }
+        });
+    }
+}
+```
+
+The template should stay close to today's Pine primitives:
+
+```html
+<pine-form-root pp-bind:errors="form_first_errors"
+                pp-bind:submitting="form_is_submitting"
+                @submit="save">
+  <pine-field-root name="bucket">
+    <pine-field-label>Bucket</pine-field-label>
+    <pine-field-control>
+      <pine-input pp-model:value="form.values.bucket"
+                  @blur="touch_field('bucket')"
+                  required></pine-input>
+    </pine-field-control>
+    <pine-field-error pp-text="form_first_errors.bucket || 'Bucket is required.'"></pine-field-error>
+  </pine-field-root>
+</pine-form-root>
+```
+
+That is the minimum viable bridge. A later Pine bridge can reduce the
+remaining event wiring:
+
+```html
+<pine-form-root pp-bind:form-meta="form.meta" @submit="save">
+  <pine-form-field name="bucket">
+    <pine-input pp-form-control pp-model:value="form.values.bucket"></pine-input>
+  </pine-form-field>
+</pine-form-root>
+```
+
+The important design choice is that the framework owns the same
+concepts React form libraries expose, but Pocopine does not need React
+hooks. The form object is ordinary component state.
+
+The intended vocabulary mapping is:
+
+| React form concept | Pocopine shape | Notes |
+|---|---|---|
+| `useForm({ defaultValues })` | `use_form(default_values).build()` | Constructor/builder, not a hook. |
+| `register("field")` | `form.register("field")` | Tracks metadata and error participation by field name. |
+| `handleSubmit(onValid)` | `form.handle_submit(&resolver)` | Returns a decision; the component dispatches async work. |
+| `setValue` / `setError` | `set_value` / `set_error` | Explicit Rust methods on `Form`. |
+| `reset` | `reset(values)` | Reinitializes values, errors, and field metadata. |
+| `watch` | `watch(path)` | Reads a typed field descriptor. |
+| `formState` | `form.meta` | Serializable status, validity, dirty, and submit flags. |
+| `Controller` | `pine-form-controller` | Bridge for compound Pine controls. |
+
+## 6. Proposed Crate
+
+Add `crates/pocopine-form`.
+
+The core crate should have no Pine dependency in its base module. Pine
+integration can be either a feature module or direct integration from
+`crates/pine`.
+
+```rust
+pub fn use_form<V>(default_values: V) -> FormBuilder<V>;
+
+pub struct FormBuilder<V> {
+    default_values: V,
+    mode: ValidationMode,
+}
+
+impl<V> FormBuilder<V> {
+    pub fn mode(self, mode: ValidationMode) -> Self;
+    pub fn build(self) -> Form<V>;
+}
+
+pub struct Form<V> {
+    pub values: V,
+    pub initial: V,
+    pub errors: FieldErrors,
+    pub fields: FieldMetaMap,
+    pub meta: FormMeta,
+    pub registered: std::collections::BTreeSet<FieldName>,
+}
+
+pub struct FormMeta {
+    pub status: FormStatus,
+    pub is_dirty: bool,
+    pub is_valid: bool,
+    pub is_validating: bool,
+    pub is_submitting: bool,
+    pub is_submitted: bool,
+    pub submit_count: u32,
+    pub form_error: String,
+}
+
+pub type FieldName = String;
+pub type FieldErrors = std::collections::BTreeMap<FieldName, Vec<FormError>>;
+pub type FieldMetaMap = std::collections::BTreeMap<FieldName, FieldMeta>;
+
+pub struct FieldMeta {
+    pub dirty: bool,
+    pub touched: bool,
+    pub focused: bool,
+    pub pending: bool,
+    pub visited: bool,
+}
+
+pub struct FormError {
+    pub code: String,
+    pub message: String,
+    pub source: ErrorSource,
+}
+
+pub enum ErrorSource {
+    Client,
+    Native,
+    Server,
+}
+
+pub enum FormStatus {
+    Idle,
+    Validating,
+    Submitting,
+    Submitted,
+    Failed,
+}
+```
+
+All public structs must derive `Clone`, `Debug`, `Serialize`,
+`Deserialize`, and `Default` where practical so they can live directly
+inside component state.
+
+The first slice should not store a resolver inside `Form`.
+Resolvers can be closures, structs with dependencies, or async-adjacent
+application objects, and those are not reliably serializable. Passing
+the resolver to `handle_submit` keeps the form object ordinary state
+while preserving the React `handleSubmit` mental model.
+
+### 6.1 Registration and Field Paths
+
+React form libraries return input props from `register("field")`.
+Pocopine cannot literally return DOM props into a template, but it can
+own the same concept:
+
+```rust
+impl<V> Form<V> {
+    pub fn register(&mut self, name: impl Into<FieldName>);
+    pub fn unregister(&mut self, name: &str);
+    pub fn touch(&mut self, name: &str);
+    pub fn focus(&mut self, name: &str);
+    pub fn blur(&mut self, name: &str);
+    pub fn set_error(&mut self, name: &str, error: FormError);
+    pub fn clear_error(&mut self, name: &str);
+}
+```
+
+For typed value reads/writes, use field descriptors rather than storing
+non-serializable closures inside `Form`:
+
+```rust
+pub struct FieldPath<V, T> {
+    pub name: &'static str,
+    pub get: fn(&V) -> &T,
+    pub set: fn(&mut V, T),
+}
+
+impl<V> Form<V> {
+    pub fn value<T: Clone>(&self, path: FieldPath<V, T>) -> T;
+    pub fn set_value<T>(&mut self, path: FieldPath<V, T>, value: T);
+    pub fn watch<T: Clone>(&self, path: FieldPath<V, T>) -> T;
+}
+```
+
+A later `#[derive(FormValues)]` can generate these descriptors, but the
+core API should work without the derive.
+
+## 7. Validation Model
+
+The first version should use explicit Rust functions and traits.
+Macros can come later.
+
+```rust
+pub trait FormResolver<V> {
+    fn resolve(&self, values: &V, registered: &std::collections::BTreeSet<FieldName>) -> FormResolution;
+}
+
+pub struct FormResolution {
+    pub errors: FieldErrors,
+}
+
+impl FormResolution {
+    pub fn valid() -> Self;
+    pub fn invalid(errors: FieldErrors) -> Self;
+    pub fn is_valid(&self) -> bool;
+}
+
+pub trait ValidateField<V> {
+    fn validate_field(&self, field: &str, values: &V, errors: &mut FieldErrors);
+}
+```
+
+For app code, lightweight helpers should be enough:
+
+```rust
+pub fn required(errors: &mut FieldErrors, field: &str, value: &str, message: &str);
+pub fn min_len(errors: &mut FieldErrors, field: &str, value: &str, min: usize, message: &str);
+pub fn matches(errors: &mut FieldErrors, field: &str, left: &str, right: &str, message: &str);
+```
+
+The important contract is that all validators write into the same
+`FieldErrors` map. `pine-form-root` already understands an errors map;
+we can either pass a flattened first-message map into Pine or teach
+Pine to accept the richer error type.
+
+Validation mode should be configurable:
+
+```rust
+pub enum ValidationMode {
+    OnSubmit,
+    OnBlur,
+    OnInput,
+    Manual,
+}
+```
+
+This mirrors React form libraries while keeping the implementation
+simple: the component or Pine bridge calls `touch`, `set_value`, or
+`validate_field` at the configured points.
+
+## 8. Submit Lifecycle
+
+`Form` should provide conservative submit helpers:
+
+```rust
+impl<V> Form<V> {
+    pub fn handle_submit<R: FormResolver<V>>(&mut self, resolver: &R) -> SubmitDecision<V>
+    where
+        V: Clone;
+    pub fn finish_submit(&mut self);
+    pub fn apply_failure(&mut self, failure: FormFailure);
+    pub fn reset(&mut self, values: V);
+    pub fn set_values(&mut self, values: V);
+    pub fn clear_errors(&mut self);
+    pub fn first_error_map(&self) -> std::collections::HashMap<String, String>;
+}
+```
+
+The decision type is deliberately small:
+
+```rust
+pub enum SubmitDecision<V> {
+    Valid(V),
+    Invalid(FieldErrors),
+    Busy,
+}
+
+impl<V> SubmitDecision<V> {
+    pub fn valid_values(self) -> Option<V>;
+    pub fn is_valid(&self) -> bool;
+}
+```
+
+`handle_submit` is the React-style entrypoint. It should:
+
+1. guard duplicate submits,
+2. increment submit count,
+3. run the resolver,
+4. set `is_submitting` only when values are valid,
+5. return either valid cloned values or invalid errors.
+
+```rust
+pub fn save(&mut self) {
+    let decision = self.form.handle_submit(&ConnectionResolver);
+    let Some(input) = decision.valid_values() else {
+        return;
+    };
+    dispatch!(crate::save_connection(input).await, |s, result| {
+        match result {
+            Ok(saved) => {
+                s.form.finish_submit();
+                s.close(saved);
+            }
+            Err(err) => s.form.apply_failure(err.into()),
+        }
+    });
+}
+```
+
+The helper should leave async ownership to existing Pocopine patterns
+instead of inventing a new async runtime abstraction.
+
+## 9. Server Error Shape
+
+Server functions need a conventional form-validation failure shape:
+
+```rust
+pub struct FormFailure {
+    pub message: String,
+    pub fields: FieldErrors,
+}
+
+pub type FormResult<T> = Result<T, FormFailure>;
+```
+
+Applications can still return domain-specific errors, but the form
+crate should provide conversions from common server validation errors
+into `FormFailure`.
+
+The field-error source should be set to `ErrorSource::Server` when a
+server response is applied.
+
+## 10. Pine Integration
+
+The existing Pine primitives remain the visual/accessibility layer.
+This RFC proposes incremental upgrades:
+
+### 10.1 `pine-form-root`
+
+Add optional support for:
+
+- `errors: HashMap<String, String>` remains supported.
+- `field_errors: FieldErrors` may be added when `pine` depends on or
+  feature-gates `pocopine-form`.
+- `submitting: bool` can stamp `data-submitting` and block duplicate
+  native submit emissions if configured.
+- `meta: FormMeta` can stamp `data-dirty`, `data-valid`,
+  `data-submitting`, and `data-submitted`.
+- `pp:form:submit` can carry a small detail payload with `submit_count`
+  and `valid` when supplied by a form object.
+
+The existing `pp:submit` event should remain for compatibility.
+
+### 10.2 `pine-field-root`
+
+Continue observing the enclosing form's errors by `name`. Later, if
+`FieldErrors` is accepted directly, the field can expose:
+
+- first message,
+- all messages,
+- first code,
+- source.
+
+`pine-field-error` should be able to show slotted fallback text or the
+current first error message.
+
+### 10.3 Controller Components
+
+React Hook Form uses `Controller` for controlled widgets. Pocopine
+needs the same escape hatch for Pine inputs and compound controls that
+do not expose a plain native input event.
+
+The first bridge can be explicit:
+
+```html
+<pine-form-controller name="auth_mode"
+                      pp-bind:form-meta="form.meta"
+                      @field-blur="touch_field('auth_mode')">
+  <pine-tabs-root pp-model:value="form.values.auth_mode">
+    ...
+  </pine-tabs-root>
+</pine-form-controller>
+```
+
+The controller observes field meta/errors by `name` and stamps common
+state onto its host. It does not own the value; the component still
+binds value through `pp-model`.
+
+## 11. Template Usage
+
+First slice usage should remain explicit and readable:
+
+```html
+<pine-form-root pp-bind:errors="form_error_map"
+                @submit="save">
+  <pine-field-root name="bucket">
+    <pine-field-label>Bucket</pine-field-label>
+    <pine-field-control>
+      <pine-input pp-model:value="form.values.bucket" required></pine-input>
+    </pine-field-control>
+    <pine-field-error pp-text="form_error_map.bucket || 'Bucket is required.'"></pine-field-error>
+  </pine-field-root>
+
+  <button type="submit" :disabled="form_submitting">Save</button>
+</pine-form-root>
+```
+
+Because `.poco` expressions intentionally stay simple, components may
+mirror derived view fields such as `form_error_map` and
+`form_submitting` from the form object until expression support grows.
+
+## 12. Example Target: Storage Connection Dialog
+
+The storage-browser connection dialog should be a proving ground:
+
+- `ConnectionFormValues` holds provider, name, bucket, endpoint,
+  credentials, GCS auth mode, emulator flags, and root prefix.
+- `ConnectionFormValidator` owns client-side checks:
+  - bucket is required,
+  - S3 region and access key are required,
+  - new S3 connection requires secret key,
+  - GCS service JSON is required for new service-json connections,
+  - JSON paste extracts project id,
+  - unsupported auth mode is rejected.
+- Server-side save maps provider-specific errors back to the same
+  `FieldErrors`.
+- The dialog keeps local form state; the store only receives the
+  saved connection summary.
+
+This should remove most one-off fields from the dialog component and
+make edit/new/reset behavior explicit.
+
+## 13. Implementation Plan
+
+### Phase 1 — Core crate
+
+- Add `crates/pocopine-form`.
+- Define `use_form`, `Form`, `FormMeta`, `FieldMeta`,
+  `FormError`, `FieldErrors`, `FormStatus`, `FormFailure`,
+  `SubmitDecision`, and resolver/validator helpers.
+- Add unit tests for duplicate submit guards, reset, dirty/touched
+  mutation, first-message flattening, and server-error application.
+
+### Phase 2 — Pine bridge
+
+- Keep current `pine-form-root` API working.
+- Add opt-in helpers for richer errors if dependency direction is
+  acceptable.
+- Add tests proving `pine-field-root` reacts to field errors and clears
+  when errors clear.
+- Add a controller wrapper for non-native or compound controls.
+
+### Phase 3 — Example migration
+
+- Migrate the storage-browser connection dialog to `Form`.
+- Keep the current visual UI and behavior.
+- Use the migration to tune helper names before broad docs.
+
+### Phase 4 — Docs and recipes
+
+- Add a form guide under `docs/`.
+- Add one simple signup example and one async edit-dialog example.
+- Document when form state belongs in a component versus a store.
+
+### Phase 5 — Optional derive/macro layer
+
+Only after the explicit API stabilizes, consider:
+
+```rust
+#[derive(FormValues)]
+pub struct ConnectionFormValues {
+    #[field(required)]
+    pub bucket: String,
+}
+```
+
+This is deliberately deferred so the core contract is not blocked on a
+macro design.
+
+## 14. Open Questions
+
+- Should `pine` depend on `pocopine-form`, or should integration live
+  behind a feature to keep Pine primitives lighter?
+- Should first-slice field names remain flat strings, or should we
+  introduce `FieldPath` now?
+- Should native constraint-validation failures be normalized into
+  `FormError { source: Native }`, or should they remain a Pine-only
+  visual state?
+- Should `FormFailure` live in `pocopine-form` or in `pocopine` so
+  server functions can use it without another explicit dependency?
+- How much derived view state should `Form` expose for `.poco`
+  templates given the current expression limitations?
+- Is `use_form` the right exported name in Rust, or should it be
+  `Form::builder` with `use_form` as a convenience alias?
+
+## 15. Drawbacks
+
+- Another crate adds API surface and maintenance cost.
+- A generic form object can become too abstract if we try to solve
+  nested schema validation too early.
+- Pine integration creates dependency-direction pressure between UI
+  primitives and framework helpers.
+- A React-like API can feel alien if copied too literally into Rust.
+  The implementation must preserve the mental model without forcing
+  hooks or non-serializable closures into component state.
+- If app authors put every form object into a global store, this will
+  recreate the store-bloat problem in a new shape. Docs must steer the
+  local-component default clearly.
+
+## 16. Alternatives
+
+### Keep only Pine form primitives
+
+This is the current state. It is good for accessibility wiring, but it
+does not solve typed values, submit status, error normalization, reset,
+or server validation mapping.
+
+### Adopt an external validation crate directly
+
+Apps can do this today, but Pocopine still needs a common error shape
+for Pine fields, server functions, and examples.
+
+### Build a schema macro first
+
+This may become useful, but it would lock the public shape before the
+runtime contract has been proven in real forms.
+
+### Treat forms as stores
+
+This works for multi-page wizards, but it is too heavy for dialogs and
+ordinary editors. The default should be local form objects, with stores
+reserved for durable or cross-route draft state.
+
+## 17. Acceptance Criteria
+
+- A new `pocopine-form` crate can compile on host and wasm targets.
+- A component can hold `Form<MyValues>` in local state.
+- The public API includes React-form equivalents for `use_form`,
+  `register`, `handle_submit`, `set_value`, `set_error`, `reset`,
+  `watch`, and `meta`.
+- Client validation can produce field errors without DOM.
+- Server validation failures can map into the same field-error shape.
+- Pine fields can display those errors by `name`.
+- Pine has a controller path for compound controls.
+- Duplicate submits are guarded consistently.
+- The storage-browser connection dialog can be migrated without
+  losing provider-specific behavior.

--- a/rfcs/rfc-091-store-state-ownership.md
+++ b/rfcs/rfc-091-store-state-ownership.md
@@ -1,0 +1,434 @@
+# RFC 091 - Store state ownership and durable app state
+
+| Field | Value |
+|---|---|
+| **Status** | Draft |
+| **Author** | pocopine team |
+| **Created** | 2026-05-29 |
+| **Builds on** | [RFC 002](./rfc-002-app-stores-servers.md), [RFC 031](./rfc-031-prop-vs-state.md), [RFC 044](./rfc-044-model-fields.md), [RFC 090](./rfc-090-form-state-and-validation.md) |
+| **Related** | [`docs/components/02-state.md`](../docs/components/02-state.md), [`docs/recipes/state-ownership.md`](../docs/recipes/state-ownership.md), [`docs/recipes/storage-browser-state-refactor.md`](../docs/recipes/storage-browser-state-refactor.md) |
+
+## 1. Summary
+
+`#[store]` is already the framework primitive for shared state. This
+RFC defines the design contract for when a store should exist, what it
+should contain, and which state belongs closer to components, route
+props, forms, or sync/query collections.
+
+The core rule:
+
+> Stores hold durable, cross-subtree app state. They should not become
+> component-local draft state, async request scratch space, or cached
+> render labels.
+
+This RFC does not replace `#[store]`. It tightens its intended use so
+Pocopine examples and app scaffolds do not drift toward one giant
+global state object.
+
+## 2. Motivation
+
+The storage-browser example has become a useful stress test. It needs:
+
+- connection profiles,
+- selected connection and route prefix,
+- object listing,
+- search and command palette state,
+- upload dock state,
+- new-folder and connection dialogs,
+- provider credentials,
+- loading, saving, and error states.
+
+The first implementation naturally put much of that into
+`StorageBrowserStore`. That worked, but it produced a store with many
+unrelated reasons to change. A connection dialog edit could invalidate
+the same store as a listing request, an upload dock interaction, a
+command search, or a breadcrumb label.
+
+Other frameworks converge on the same lesson:
+
+- keep transient interaction state local,
+- shape global state by domain/data, not by component tree,
+- avoid duplicated and redundant state,
+- normalize collections that are shared or relational,
+- model status as finite phases instead of contradictory booleans,
+- keep derived render facts derived.
+
+Pocopine should encode that as framework guidance and, where practical,
+as helpers.
+
+## 3. Design Goals
+
+- **Local first.** Component fields own the state for UI that only the
+  component renders or submits.
+- **Forms stay local.** `Form<V>` from RFC 090 is the default for
+  dialogs and editors. A store should receive the saved result, not
+  every draft field.
+- **Stores are domain-shaped.** Store names and fields should describe
+  durable app concepts such as `session`, `preferences`, `cart`,
+  `storage`, or `keep`, not components such as `top_bar` or
+  `connection_dialog`.
+- **Normalize shared collections.** Shared entity-like data should
+  prefer maps/rows plus selected IDs over duplicated selected objects.
+- **Avoid impossible states.** Workflow status should use enums such as
+  `LoadPhase` or `SubmitPhase` instead of unrelated `loading`, `saved`,
+  `failed`, and `error` flags that can contradict each other.
+- **Derived data stays derived.** Counts, subtitles, breadcrumbs,
+  labels, filtered rows, and capability badges should be recomputed
+  from canonical state unless caching is needed for performance.
+- **Typed store actions.** Multi-field changes should live in Rust
+  methods on the store, not in template assignment chains.
+- **Reset is explicit.** Stores with semantic defaults should expose a
+  reset/reinitialize path.
+- **SSR-safe future.** Store initialization must remain instance-based
+  enough to support per-request store factories when SSR lands.
+
+## 4. Non-goals
+
+- Replacing `#[store]` with a Redux/Pinia clone.
+- Requiring reducers, action enums, or state-machine configs for every
+  store.
+- Preventing direct Rust mutation inside `Handle::update`.
+- Moving all component state into stores.
+- Making stores persistent by default.
+- Solving all local-first sync/query state; `pocopine-sync` and
+  `pocopine-sync-query` own those layers.
+
+## 5. Ownership Model
+
+Pocopine should document and use this ownership ladder:
+
+| State kind | Owner | Example |
+|---|---|---|
+| Single component interaction | component fields | popover open state, local filter input |
+| Form draft and validation | `Form<V>` in the component | connection dialog credentials |
+| Parent-configured child API | `#[prop]` / `#[model]` | selected tab value, dialog open |
+| Route identity | route props or a small route store field | `connection_id`, `prefix` |
+| Durable cross-subtree state | `#[store]` | selected connection id, session user, theme |
+| Server/source data | server DTOs, sync collections, query state | object listing response, notes collection |
+| Render facts | computed/derived local values | count labels, breadcrumbs, subtitles |
+
+When multiple owners look plausible, choose the narrowest owner that
+can still express the workflow without cross-component reach-through.
+
+## 6. Store Shape
+
+A good store has one reason to change. It should read like a domain
+model, not a dump of active widgets.
+
+```rust
+#[derive(Default, Serialize, Deserialize)]
+#[store(name = "storage")]
+pub struct StorageStore {
+    pub connections: Vec<StorageConnectionSummary>,
+    pub selected_connection_id: String,
+    pub current_prefix: String,
+    pub phase: StoragePhase,
+    pub error: String,
+}
+```
+
+The store should not own:
+
+- `connection_name_input`,
+- `saving_connection`,
+- `command_query`,
+- `upload_dock_expanded`,
+- `new_folder_name`,
+- `listed_size_label`,
+- `breadcrumbs`.
+
+Those belong to the component that renders the workflow or to derived
+view helpers.
+
+## 7. Status as Phases
+
+Loose booleans create contradictory states. Prefer an enum that names
+the workflow.
+
+```rust
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub enum LoadPhase {
+    #[default]
+    Idle,
+    Loading,
+    Ready,
+    Failed,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]
+pub enum SubmitPhase {
+    #[default]
+    Idle,
+    Submitting,
+    Submitted,
+    Failed,
+}
+```
+
+Templates can still consume derived booleans:
+
+```rust
+impl StorageStore {
+    pub fn loading(&self) -> bool {
+        self.phase == LoadPhase::Loading
+    }
+}
+```
+
+The important invariant is that the canonical state cannot represent
+both "submitting" and "submitted" at the same time.
+
+## 8. Collections and Selection
+
+Shared collections should avoid duplicating rows.
+
+Preferred:
+
+```rust
+pub struct NotesStore {
+    pub notes: Vec<NoteRow>,
+    pub selected_note_ids: Vec<String>,
+}
+```
+
+Avoid:
+
+```rust
+pub struct NotesStore {
+    pub notes: Vec<NoteRow>,
+    pub selected_notes: Vec<NoteRow>,
+    pub active_note: NoteRow,
+}
+```
+
+If lookup by id becomes important, move to an indexed shape:
+
+```rust
+pub struct EntityMap<T> {
+    pub order: Vec<String>,
+    pub by_id: std::collections::BTreeMap<String, T>,
+}
+```
+
+The first implementation does not need a framework-owned entity store,
+but the recipes should teach the normalized pattern.
+
+## 9. Derived State and Selectors
+
+Derived values should be functions or computed fields, not manually
+maintained state.
+
+Examples:
+
+- `listed_size_label` derives from entries,
+- `visible_entry_count_label` derives from filtered entries,
+- `path_title` derives from current prefix,
+- `selected_connection_name` derives from selected id plus
+  connections,
+- `can_upload` derives from selected connection capabilities.
+
+When a derived value is expensive enough to cache, the owner must name
+the invalidation key and update it in one action. Caching is a
+performance decision, not the default state shape.
+
+## 10. Store Actions
+
+Stores should expose typed Rust methods for workflow transitions:
+
+```rust
+#[handlers]
+impl StorageStore {
+    pub fn select_connection(&mut self, id: String) {
+        self.selected_connection_id = id;
+        self.current_prefix.clear();
+        self.phase = LoadPhase::Idle;
+        self.error.clear();
+    }
+
+    pub fn apply_connections(&mut self, connections: Vec<StorageConnectionSummary>) {
+        self.connections = connections;
+        self.reconcile_selection();
+    }
+}
+```
+
+Template code should call a handler. It should not perform multi-field
+assignment sequences against `$store.*`.
+
+## 11. Reset and Reinitialize
+
+Stores with semantic defaults should have explicit reset methods:
+
+```rust
+impl PreferencesStore {
+    pub fn reset(&mut self) {
+        *self = Self::default();
+    }
+}
+```
+
+When the reset should preserve durable identity, make that visible:
+
+```rust
+impl StorageStore {
+    pub fn reset_browser_state(&mut self) {
+        let connections = std::mem::take(&mut self.connections);
+        *self = Self {
+            connections,
+            ..Self::default()
+        };
+    }
+}
+```
+
+A later helper trait may standardize this:
+
+```rust
+pub trait ResetStore {
+    fn reset(&mut self);
+}
+```
+
+This RFC does not require a new trait in the first slice; explicit
+store methods are enough.
+
+## 12. Store/Component Boundary
+
+Use a store when:
+
+- two unrelated subtrees need the same value,
+- the value must outlive a mounted component,
+- route/shell/sidebar/content must agree on identity,
+- the state is a durable app preference or session,
+- a sync collection or source boundary needs one canonical owner.
+
+Do not use a store when:
+
+- only one component renders the field,
+- the value is a form draft,
+- the value is an upload/dialog/search transient,
+- the value can be derived from existing fields,
+- the value exists only to drive CSS in one component.
+
+## 13. Storage Browser Target
+
+The storage-browser example should eventually converge on this split:
+
+```rust
+#[derive(Default, Serialize, Deserialize)]
+#[store(name = "storage")]
+pub struct StorageStore {
+    pub connections: Vec<StorageConnectionSummary>,
+    pub selected_connection_id: String,
+    pub current_prefix: String,
+    pub phase: LoadPhase,
+    pub error: String,
+}
+```
+
+Local owners:
+
+| Concern | Owner |
+|---|---|
+| Connection form | `FileBrowserConnectionDialog` with `Form<ConnectionValues>` |
+| Object listing rows | object browser/file-list component |
+| Command palette query/results | command component |
+| Upload dock open/expanded/metadata | upload dock component |
+| New-folder draft/errors | new-folder dialog |
+| Breadcrumb labels/count labels | object browser derived state |
+
+The store remains the shared browser location and connection identity,
+not the whole UI.
+
+## 14. Implementation Plan
+
+### Phase 1 - Docs and recipes
+
+- Add this RFC.
+- Add a general state-ownership recipe.
+- Add a form-locality recipe that uses `Form<V>` from RFC 090.
+- Update the storage-browser refactor recipe to reference both RFCs.
+
+### Phase 2 - Example migration
+
+- Continue the storage-browser refactor in narrow slices.
+- Move dialog, upload, command, listing, and derived labels out of
+  `StorageBrowserStore`.
+- Keep route and selected connection identity in the store.
+
+### Phase 3 - Helper APIs
+
+Consider small helpers only after the migration proves repeated need:
+
+- `ResetStore` trait,
+- selector/computed helper conventions,
+- normalized collection helper,
+- devtools grouping for canonical vs derived fields.
+
+### Phase 4 - Diagnostics
+
+Consider optional diagnostics:
+
+- boot/devtools hints for missing store registration already exist,
+- future devtools can surface store size and subscribers,
+- docs/lints can flag template assignment chains to `$store.*`.
+
+## 15. Open Questions
+
+- Should `#[store]` generate a default `reset` helper when `Default`
+  is available?
+- Should Pocopine expose selector helpers before `#[computed]` is
+  settled?
+- Should stores have explicit read/write capability wrappers for
+  component APIs, or is `Handle<T>::with/update` enough?
+- How should route loader state and store state split once nested route
+  loaders mature?
+- Should devtools show "canonical", "workflow", and "derived" field
+  groups based on optional annotations?
+
+## 16. Drawbacks
+
+- Stronger guidance can feel restrictive if an app is small and a
+  large store is temporarily convenient.
+- Moving state local can require more prop/event wiring.
+- Store actions can become too broad if authors treat them as service
+  objects instead of state transitions.
+- Normalized data shapes are more explicit than duplicating selected
+  objects, especially in small examples.
+
+## 17. Alternatives
+
+### Keep stores as generic singleton components
+
+This is today's runtime model and remains correct mechanically, but it
+does not teach ownership boundaries. Examples will keep drifting into
+global state blobs.
+
+### Adopt reducers/actions everywhere
+
+Reducers are useful for some workflows, but Pocopine's handler model
+already gives typed Rust mutation methods. Requiring action enums for
+all stores would add ceremony without enough benefit.
+
+### Make everything local
+
+This avoids global bloat, but breaks shell/sidebar/content workflows
+that genuinely need shared identity and durable app state.
+
+### Add a full state-machine crate first
+
+State machines are valuable for complex finite workflows. They are too
+heavy as the default store model. The first step is to model status as
+enums and keep store ownership narrow.
+
+## 18. Acceptance Criteria
+
+- The docs describe when to use local component state, `Form<V>`,
+  props/models, route state, stores, and sync/query state.
+- Store examples use phase enums instead of contradictory boolean
+  clusters for workflows.
+- Recipes show how to split a large store without losing route/shared
+  identity.
+- Storage-browser refactor work can cite this RFC for why dialog,
+  upload, command, listing, and derived labels move out of the store.
+- No runtime change is required for the first slice.


### PR DESCRIPTION
## Summary
- add RFC 090 for `pocopine-form` with `Form<V>` and `FormMeta` naming
- add RFC 091 for store state ownership and durable app state
- add state ownership and form-state recipes, plus the storage-browser state refactor recipe
- link the new docs from the state guide, docs index, and RFC index

## Verification
- `git diff --cached --check`
- `rg -n "FormFrame|FormState|form_state|form-state=|Recieps|form state and validation frame|by a frame|from the frame" rfcs docs -g "*.md"`