### PR TITLE
sync-query API polish (Tier 1+2+3)

### DIFF
--- a/crates/pocopine-core/src/signal.rs
+++ b/crates/pocopine-core/src/signal.rs
@@ -9,6 +9,7 @@
 //! exactly as they do for proxy-based scopes — they share the effect
 //! engine, just not the key type.
 
+use std::any::Any;
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -16,9 +17,19 @@ use crate::reactive::{next_signal_id, track_signal, trigger_signal, SignalId};
 
 /// Read handle for a reactive cell. Clone freely; all clones see the same
 /// value and share the same id.
+///
+/// Optionally carries a **drop guard** — a type-erased payload that
+/// lives as long as any `Signal` clone exists, and drops with the
+/// last one. Used by bridges that wrap an external reactive source
+/// (e.g. `QueryView::into_signal()`) — the bridge stows the source
+/// handle + the on-update subscription token inside the guard so the
+/// subscription is automatically torn down when the last reader of
+/// the signal disappears. `signal()` constructs guard-less signals;
+/// attach one via [`Signal::with_drop_guard`].
 pub struct Signal<T> {
     id: SignalId,
     cell: Rc<RefCell<T>>,
+    drop_guard: Option<Rc<dyn Any>>,
 }
 
 impl<T> Clone for Signal<T> {
@@ -26,6 +37,7 @@ impl<T> Clone for Signal<T> {
         Signal {
             id: self.id,
             cell: self.cell.clone(),
+            drop_guard: self.drop_guard.clone(),
         }
     }
 }
@@ -71,6 +83,7 @@ pub fn signal<T: 'static>(initial: T) -> (Signal<T>, Setter<T>) {
         Signal {
             id,
             cell: cell.clone(),
+            drop_guard: None,
         },
         Setter { id, cell },
     )
@@ -103,6 +116,20 @@ impl<T: 'static> Signal<T> {
     /// integration tests. Not part of the public reactive surface.
     pub fn id(&self) -> SignalId {
         self.id
+    }
+
+    /// Attach a type-erased payload whose lifetime is bound to the
+    /// signal — it drops with the last `Signal` clone. Used by
+    /// bridges like `QueryView::into_signal()` to keep the external
+    /// source + its on-update subscription alive for exactly as long
+    /// as any reader of the signal.
+    ///
+    /// Calling this on a signal that already has a guard replaces
+    /// it; the previous guard drops immediately (if no other clone
+    /// is still holding it).
+    pub fn with_drop_guard<G: 'static>(mut self, guard: G) -> Self {
+        self.drop_guard = Some(Rc::new(guard));
+        self
     }
 }
 
@@ -197,6 +224,7 @@ impl<T: 'static> RwSignal<T> {
             Signal {
                 id: self.id,
                 cell: self.cell.clone(),
+                drop_guard: None,
             },
             Setter {
                 id: self.id,

--- a/crates/pocopine-sync-query-macros/src/lib.rs
+++ b/crates/pocopine-sync-query-macros/src/lib.rs
@@ -684,10 +684,12 @@ fn expand_query_resource(
                     ::std::string::ToString::to_string(&id),
                 )
                 .ok();
+                let __wire_stream = ::pocopine_sync_query::__private::pocopine_sync::SyncStreamName::new(#name_lit).ok();
                 ::pocopine_sync_query::TypedMutation::new(
                     ::pocopine_sync_query::MutationPayload::create(id, draft),
                 )
                 .with_wire_row_key(__wire_key)
+                .with_wire_stream(__wire_stream)
             }
 
             /// RFC 090 Phase 4: typed `update` mutation. Pass an
@@ -704,6 +706,7 @@ fn expand_query_resource(
                     ::std::string::ToString::to_string(&id),
                 )
                 .ok();
+                let __wire_stream = ::pocopine_sync_query::__private::pocopine_sync::SyncStreamName::new(#name_lit).ok();
                 let mut payload =
                     ::pocopine_sync_query::write::UpdatePayload::new(id, draft);
                 payload.expected_version = expected_version;
@@ -711,6 +714,7 @@ fn expand_query_resource(
                     ::pocopine_sync_query::MutationPayload::Update(payload),
                 )
                 .with_wire_row_key(__wire_key)
+                .with_wire_stream(__wire_stream)
             }
 
             /// RFC 090 Phase 4: typed `delete` mutation. Pass an
@@ -725,12 +729,14 @@ fn expand_query_resource(
                     ::std::string::ToString::to_string(&id),
                 )
                 .ok();
+                let __wire_stream = ::pocopine_sync_query::__private::pocopine_sync::SyncStreamName::new(#name_lit).ok();
                 let mut payload = ::pocopine_sync_query::write::DeletePayload::new(id);
                 payload.expected_version = expected_version;
                 ::pocopine_sync_query::TypedMutation::new(
                     ::pocopine_sync_query::MutationPayload::Delete(payload),
                 )
                 .with_wire_row_key(__wire_key)
+                .with_wire_stream(__wire_stream)
             }
         }
     } else {
@@ -982,10 +988,12 @@ fn generate_field_markers(params: &[ParamDef]) -> Vec<TokenStream2> {
             );
             let inner = &param.inner_ty;
 
-            // Always emit FieldEq + FieldInSet. Inner type is T (after
-            // unwrapping any Option<T>), so `.eq(field::assignee_id,
-            // "alice")` on a `Option<String>` field still typechecks
-            // with `&str → String` via `Into<M::Value>`.
+            // Always emit FieldEq + FieldInSet + FieldOrder. Inner
+            // type is T (after unwrapping any Option<T>), so
+            // `.eq(field::assignee_id, "alice")` on a `Option<String>`
+            // field still typechecks with `&str → String` via
+            // `Into<M::Value>`. `FieldOrder` is unconditional —
+            // sorting is orthogonal to the filter capability set.
             let mut trait_impls = vec![
                 quote! {
                     impl ::pocopine_sync_query::FieldEq for #marker_ident {
@@ -996,6 +1004,11 @@ fn generate_field_markers(params: &[ParamDef]) -> Vec<TokenStream2> {
                 quote! {
                     impl ::pocopine_sync_query::FieldInSet for #marker_ident {
                         type Item = #inner;
+                        const NAME: &'static str = #name_str;
+                    }
+                },
+                quote! {
+                    impl ::pocopine_sync_query::FieldOrder for #marker_ident {
                         const NAME: &'static str = #name_str;
                     }
                 },

--- a/crates/pocopine-sync-query-macros/tests/query_resource.rs
+++ b/crates/pocopine-sync-query-macros/tests/query_resource.rs
@@ -67,7 +67,7 @@ fn builder_constructs_typed_query() {
         .contains(field::title, "auth")
         .unwrap()
         .range(field::priority, 1u32..=10)
-        .order_by("priority", Order::Asc)
+        .order_by(field::priority, Order::Asc)
         .limit(50)
         .build();
 

--- a/crates/pocopine-sync-query-macros/tests/routing.rs
+++ b/crates/pocopine-sync-query-macros/tests/routing.rs
@@ -438,7 +438,7 @@ async fn rollback_notifies_observers() {
 fn builder_supports_order_and_limit() {
     let q = Issue::query()
         .eq(issues::field::workspace_id, "W1")
-        .order_by("status", Order::Asc)
+        .order_by(issues::field::status, Order::Asc)
         .limit(10)
         .build();
     assert!(q.order_by().is_some());
@@ -452,7 +452,7 @@ async fn rows_applied_order_by_and_limit() {
     let view = client.observe::<Issue>(
         Issue::query()
             .eq(issues::field::workspace_id, "W1")
-            .order_by("title", Order::Desc)
+            .order_by_raw("title", Order::Desc)
             .limit(2)
             .build(),
     );

--- a/crates/pocopine-sync-query/src/client.rs
+++ b/crates/pocopine-sync-query/src/client.rs
@@ -1740,6 +1740,59 @@ fn mutation_id_from_value(mutation: &ClientMutation<Value>) -> MutationId {
     mutation.id.clone()
 }
 
+// ---- Tier 1: TypedMutation::push convenience ---------------------
+// Inherent methods on the macro-emitted builder so the call site
+// reads `Issue::create(...).optimistic(...).push(&qc).await` instead
+// of threading stream + mutation id + push url at every call. The
+// methods live in client.rs (not write.rs) because they need access
+// to `QueryClient::endpoint()` + the private `build_push_url`
+// helper; impl blocks can split across files inside the same crate.
+
+impl<Row, Id, Draft> crate::write::TypedMutation<Row, Id, Draft>
+where
+    Row: Clone + serde::Serialize + 'static,
+    Id: serde::Serialize + Clone + 'static,
+    Draft: serde::Serialize + Clone + 'static,
+{
+    /// Push this typed mutation through `client`. Auto-generates a
+    /// UUIDv7-backed `MutationId` and resolves the push URL from the
+    /// client's configured endpoint.
+    ///
+    /// **Idempotency caveat:** because the mutation id is generated
+    /// fresh on each call, a manual retry after this future returns
+    /// `Err(_)` produces a different logical mutation on the server.
+    /// For retry-safe pushes (durable replay across reloads), use
+    /// [`Self::push_with_id`] with an id you've persisted somewhere
+    /// stable, or rely on the in-flight overlay store the framework
+    /// keeps for the offline-replay path in `mutate()`.
+    pub async fn push(self, client: &QueryClient) -> pocopine_sync::SyncResult<MutationId> {
+        let id = MutationId::uuid();
+        self.push_with_id(client, id).await
+    }
+
+    /// Push with an explicit mutation id. Use when you've persisted
+    /// the id to a durable counter so retries collapse to the same
+    /// logical write at the `MutationLog`.
+    pub async fn push_with_id(
+        self,
+        client: &QueryClient,
+        mutation_id: MutationId,
+    ) -> pocopine_sync::SyncResult<MutationId> {
+        let stream = self.wire_stream().cloned().ok_or_else(|| {
+            pocopine_sync::SyncError::client(
+                "TypedMutation has no wire_stream; the macro-emitted constructors fill it \
+                 automatically — hand-built `TypedMutation`s must call \
+                 `.with_wire_stream(Some(...))` or use `QueryClient::push_typed` directly",
+            )
+        })?;
+        let url = build_push_url(client.endpoint());
+        client
+            .push_typed(stream, mutation_id.clone(), self, &url)
+            .await?;
+        Ok(mutation_id)
+    }
+}
+
 /// Crate-internal route used by [`AnyMutator::replay_hydrated`] to
 /// reconcile canonical changes through the same path as a successful
 /// `mutate()` call. Necessary because the trait can't reach the
@@ -2106,6 +2159,17 @@ pub struct QueryView<Row: 'static> {
     handle: QueryHandle<Row>,
 }
 
+impl<Row: 'static> Clone for QueryView<Row> {
+    /// Bumps the subscription's refcount; both clones address the
+    /// same underlying state. `into_signal()` and selector bridges
+    /// rely on this.
+    fn clone(&self) -> Self {
+        Self {
+            handle: self.handle.clone(),
+        }
+    }
+}
+
 impl<Row: 'static> QueryView<Row> {
     /// Underlying query identity.
     pub fn query(&self) -> &Query<Row> {
@@ -2299,6 +2363,33 @@ impl<Row: 'static> QueryView<Row> {
             subscription: self.handle.subscription.clone(),
             id,
         }
+    }
+
+    /// Bridge this view into a `Signal<Vec<Row>>`. The returned signal
+    /// is initialised to `self.rows()`, subscribes a hidden setter to
+    /// `on_update`, and carries a drop-guard so the underlying
+    /// subscription is released when the last `Signal` clone drops.
+    ///
+    /// Use this when you want the view to plug into pocopine's
+    /// general reactive graph (effects, components, derived
+    /// selectors) the same way any `Signal<T>` does — `.get()`
+    /// subscribes the current effect; mutations trigger re-runs;
+    /// dropping the last reader cleans up the on-update listener
+    /// without any explicit token bookkeeping.
+    pub fn into_signal(self) -> pocopine_core::Signal<Vec<Row>>
+    where
+        Row: Clone + serde::Serialize,
+    {
+        let initial = self.rows();
+        let (sig, set) = pocopine_core::signal(initial);
+        let view_for_cb = self.clone();
+        let token = self.on_update(move || {
+            set.set_force(view_for_cb.rows());
+        });
+        // The guard owns the view + the on-update token; when the
+        // last `Signal` clone drops, the guard's `Rc` count hits zero
+        // and the token's `Drop` unregisters the listener.
+        sig.with_drop_guard((self, token))
     }
 }
 

--- a/crates/pocopine-sync-query/src/client.rs
+++ b/crates/pocopine-sync-query/src/client.rs
@@ -691,12 +691,20 @@ impl QueryClient {
                 // path's response inspection so a server rejection
                 // surfaces as `Err(...)` instead of a silent
                 // "succeeded" with the write actually dropped.
-                if response.rejected.iter().any(|r| r.mutation_id == mutation_id) {
+                if response
+                    .rejected
+                    .iter()
+                    .any(|r| r.mutation_id == mutation_id)
+                {
                     return Err(pocopine_sync::SyncError::backend(
                         "server rejected the mutation",
                     ));
                 }
-                if response.conflicts.iter().any(|c| c.mutation_id == mutation_id) {
+                if response
+                    .conflicts
+                    .iter()
+                    .any(|c| c.mutation_id == mutation_id)
+                {
                     return Err(pocopine_sync::SyncError::backend(
                         "server reported a conflict for this mutation",
                     ));
@@ -1853,7 +1861,6 @@ fn collect_subscriptions_on_stream_inner<Row: 'static>(
         .filter_map(|(_, sub)| Rc::downcast::<QuerySubscription<Row>>(sub.clone().as_rc_any()).ok())
         .collect()
 }
-
 
 // (Routing engine downcasts via `collect_subscriptions_on_stream`,
 // which uses `Rc::downcast::<QuerySubscription<Row>>` via the

--- a/crates/pocopine-sync-query/src/client.rs
+++ b/crates/pocopine-sync-query/src/client.rs
@@ -383,26 +383,11 @@ impl QueryClient {
     /// builds use `wasm_bindgen_futures::spawn_local` and have no
     /// equivalent constraint. If you only want the routing engine
     /// — no spawned drivers — use [`without_driver`](Self::without_driver).
-    pub fn new() -> Self {
-        Self::with_config(QueryClientConfig::default())
-    }
-
-    /// Build a client targeting a custom endpoint prefix. Useful for
-    /// tests against a router mounted at a different path. The
-    /// other config knobs stay at their defaults.
-    pub fn with_endpoint(endpoint: String) -> Self {
-        let cfg = QueryClientConfig {
-            endpoint,
-            ..QueryClientConfig::default()
-        };
-        Self::with_config(cfg)
-    }
-
-    /// Build a client with a fully-specified [`QueryClientConfig`].
-    /// The driver is spawned on the first [`observe`](Self::observe)
-    /// for each subscription — see [`Self::new`] for the native
-    /// LocalSet requirement.
-    pub fn with_config(config: QueryClientConfig) -> Self {
+    /// Crate-internal constructor used by [`QueryClientPlugin::into_client`].
+    /// User-facing app code installs `query_client_plugin()` via
+    /// `App::plugin`; tests bypass the plugin via
+    /// [`QueryClient::without_driver`] when no live driver is needed.
+    pub(crate) fn from_config(config: QueryClientConfig) -> Self {
         let endpoint = config.endpoint.clone();
         Self {
             inner: Rc::new(QueryClientInner {
@@ -1842,11 +1827,6 @@ fn collect_subscriptions_on_stream_inner<Row: 'static>(
         .collect()
 }
 
-impl Default for QueryClient {
-    fn default() -> Self {
-        Self::new()
-    }
-}
 
 // (Routing engine downcasts via `collect_subscriptions_on_stream`,
 // which uses `Rc::downcast::<QuerySubscription<Row>>` via the
@@ -2474,6 +2454,7 @@ fn release_inner(inner: &QueryClientInner, key: RegistryKey) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::query_client_plugin;
 
     fn issues_query(workspace: &str) -> Query<()> {
         Query::builder(SyncStreamName::new("issues").unwrap())
@@ -2483,13 +2464,13 @@ mod tests {
 
     #[test]
     fn fresh_client_has_no_subscriptions() {
-        let client = QueryClient::new();
+        let client = query_client_plugin().into_client();
         assert_eq!(client.active_subscription_count(), 0);
     }
 
     #[test]
     fn subscribe_registers_and_returns_handle() {
-        let client = QueryClient::new();
+        let client = query_client_plugin().into_client();
         let q = issues_query("W1");
         let handle = client.subscribe::<()>(q.clone());
         assert_eq!(client.active_subscription_count(), 1);
@@ -2499,7 +2480,7 @@ mod tests {
 
     #[test]
     fn two_handles_to_same_query_share_subscription() {
-        let client = QueryClient::new();
+        let client = query_client_plugin().into_client();
         let q = issues_query("W1");
         let h1 = client.subscribe::<()>(q.clone());
         let h2 = client.subscribe::<()>(q.clone());
@@ -2510,7 +2491,7 @@ mod tests {
 
     #[test]
     fn distinct_queries_get_distinct_subscriptions() {
-        let client = QueryClient::new();
+        let client = query_client_plugin().into_client();
         let q1 = issues_query("W1");
         let q2 = issues_query("W2");
         let _h1 = client.subscribe::<()>(q1);
@@ -2520,7 +2501,7 @@ mod tests {
 
     #[test]
     fn drop_last_handle_removes_subscription() {
-        let client = QueryClient::new();
+        let client = query_client_plugin().into_client();
         let q = issues_query("W1");
         let h1 = client.subscribe::<()>(q.clone());
         let h2 = client.subscribe::<()>(q.clone());
@@ -2534,7 +2515,7 @@ mod tests {
 
     #[test]
     fn handle_borrows_state_through_refcell() {
-        let client = QueryClient::new();
+        let client = query_client_plugin().into_client();
         let q = issues_query("W1");
         let h = client.subscribe::<()>(q);
         let state = h.state();

--- a/crates/pocopine-sync-query/src/client.rs
+++ b/crates/pocopine-sync-query/src/client.rs
@@ -669,21 +669,48 @@ impl QueryClient {
                 let payload_value = serde_json::to_value(&payload)
                     .map_err(|e| pocopine_sync::SyncError::client(e.to_string()))?;
                 let mut wire = pocopine_sync::ClientMutation::new(
-                    mutation_id,
+                    mutation_id.clone(),
                     payload.sync_op(),
                     payload_value,
                 );
                 wire.key = wire_row_key;
                 let request = pocopine_sync::SyncPushRequest::new(stream, [wire]);
-                pocopine_core::fetch::call::<
+                let response = pocopine_core::fetch::call::<
                     pocopine_sync::SyncPushRequest<Value>,
                     pocopine_sync::SyncPushResponse<Value>,
                 >(push_url, &request)
                 .await
-                .map(|_| ())
                 .map_err(|e| {
                     pocopine_sync::SyncError::backend(format!("push transport failed: {e}"))
-                })
+                })?;
+
+                // Codex review P1: an HTTP-200 push response can
+                // still carry `rejected` / `conflicts` arrays for
+                // this mutation (stale update, version mismatch,
+                // schema-migration failure). Mirror the optimistic
+                // path's response inspection so a server rejection
+                // surfaces as `Err(...)` instead of a silent
+                // "succeeded" with the write actually dropped.
+                if response.rejected.iter().any(|r| r.mutation_id == mutation_id) {
+                    return Err(pocopine_sync::SyncError::backend(
+                        "server rejected the mutation",
+                    ));
+                }
+                if response.conflicts.iter().any(|c| c.mutation_id == mutation_id) {
+                    return Err(pocopine_sync::SyncError::backend(
+                        "server reported a conflict for this mutation",
+                    ));
+                }
+                if !response.accepted.iter().any(|id| id == &mutation_id) {
+                    // Server didn't mention our id at all. Treat as
+                    // transport-level failure — the next /pull will
+                    // reconcile if the write actually landed, but
+                    // until we see an accept we don't claim success.
+                    return Err(pocopine_sync::SyncError::backend(
+                        "server response did not include our mutation",
+                    ));
+                }
+                Ok(())
             }
         }
     }

--- a/crates/pocopine-sync-query/src/driver.rs
+++ b/crates/pocopine-sync-query/src/driver.rs
@@ -1608,7 +1608,7 @@ where
 /// Spawn the driver on the host's `tokio::task::LocalSet`. Panics
 /// if no LocalSet is active — host tests must wrap their body in
 /// `LocalSet::new().run_until(async { ... }).await`. This is
-/// documented on [`QueryClient::with_config`](crate::QueryClient::with_config)
+/// documented on [`query_client_plugin`](crate::query_client_plugin)
 /// because the panic location otherwise points deep into tokio.
 #[cfg(not(target_arch = "wasm32"))]
 pub(crate) fn spawn_driver<F>(fut: F)

--- a/crates/pocopine-sync-query/src/lib.rs
+++ b/crates/pocopine-sync-query/src/lib.rs
@@ -77,7 +77,7 @@ pub use mutator::{
 };
 pub use plugin::{query_client_plugin, QueryClientPlugin};
 pub use predicate::{
-    contains_matches, range_contains, FieldContains, FieldEq, FieldInSet, FieldRange,
+    contains_matches, range_contains, FieldContains, FieldEq, FieldInSet, FieldOrder, FieldRange,
 };
 pub use query::{MatchFn, Order, OrderBy, PartitionHashFn, Query, QueryBuilder, QueryKey};
 pub use selector::{AnyArgs, AnyTrackable, SelectorId, SelectorView, TrackToken};

--- a/crates/pocopine-sync-query/src/plugin.rs
+++ b/crates/pocopine-sync-query/src/plugin.rs
@@ -56,7 +56,7 @@ impl QueryClientPlugin {
     /// Build the runtime client without installing. Useful for tests
     /// and host-side bench harnesses that don't run a full `App`.
     pub fn into_client(self) -> QueryClient {
-        QueryClient::with_config(self.config)
+        QueryClient::from_config(self.config)
     }
 }
 

--- a/crates/pocopine-sync-query/src/predicate.rs
+++ b/crates/pocopine-sync-query/src/predicate.rs
@@ -77,6 +77,16 @@ pub trait FieldContains: sealed::Sealed {
     const NAME: &'static str;
 }
 
+/// Field marker that can appear in `.order_by(field, Order::Desc)`.
+/// Auto-emitted for every `#[query_param]` field — sorting is
+/// orthogonal to the filter capability set (`Eq` / `Range` /
+/// `Contains` etc.), so any declared field is eligible. The wire
+/// key matches `FieldEq::NAME` byte-for-byte.
+pub trait FieldOrder: sealed::Sealed {
+    /// Wire param key for this field (same as `FieldEq::NAME`).
+    const NAME: &'static str;
+}
+
 /// Sealed-trait gate marker. Macro-generated field markers
 /// (`__Field_<name>`) impl this `unsafe trait` so they pass the seal
 /// on the public comparator traits above. **Do not impl this directly.**

--- a/crates/pocopine-sync-query/src/query.rs
+++ b/crates/pocopine-sync-query/src/query.rs
@@ -133,7 +133,11 @@ impl<Row> Query<Row> {
     ///
     /// `pub(crate)` because this only makes sense at the
     /// trait-boundary translation layer; user code constructs
-    /// queries via the typed DSL.
+    /// queries via the typed DSL. Host-only because the only
+    /// caller (`SourceResource::pull`) is itself host-gated, and
+    /// wasm-side clippy would otherwise flag the method as
+    /// dead code under `-D warnings`.
+    #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn set_limit(&mut self, limit: u32) {
         self.limit = Some(limit);
     }

--- a/crates/pocopine-sync-query/src/query.rs
+++ b/crates/pocopine-sync-query/src/query.rs
@@ -274,8 +274,25 @@ impl<Row> QueryBuilder<Row> {
         self
     }
 
-    /// Set the ordering.
-    pub fn order_by(mut self, field: impl Into<String>, direction: Order) -> Self {
+    /// Set the ordering using a macro-emitted field marker
+    /// (`.order_by(Issue::field::created_at, Order::Desc)`).
+    ///
+    /// Same shape as `.eq` / `.range` / `.contains` — the marker
+    /// carries the wire key as a `const`, so typos become build
+    /// errors instead of "field not found" responses at runtime.
+    pub fn order_by<M>(self, _field: M, direction: Order) -> Self
+    where
+        M: crate::FieldOrder,
+    {
+        self.order_by_raw(<M as crate::FieldOrder>::NAME, direction)
+    }
+
+    /// Untyped ordering escape hatch. Accepts an arbitrary wire key
+    /// string. Prefer [`Self::order_by`] when the macro emits a
+    /// field marker; reach for this when sorting by a synthesized
+    /// or server-only column (e.g. `"created_at"` on a row that
+    /// doesn't expose `created_at` to the client predicate).
+    pub fn order_by_raw(mut self, field: impl Into<String>, direction: Order) -> Self {
         self.order_by = Some(OrderBy {
             field: field.into(),
             direction,
@@ -465,6 +482,42 @@ impl<Row> QueryBuilder<Row> {
     {
         client.observe(self.build())
     }
+
+    /// Component-scope sugar: subscribe to this query, bridge the
+    /// view into a reactive signal, and copy `view.rows()` into a
+    /// field on the current component on every update.
+    ///
+    /// Call from inside a component handler (`on_mount`, etc.). The
+    /// component type `C` is resolved via `pocopine_core::this::<C>()`;
+    /// `project` returns the `Vec<Row>` slot the rows write into.
+    /// The effect is registered with the surrounding scope's
+    /// unmount, so the subscription tears down automatically when
+    /// the component unmounts — no token bookkeeping needed.
+    ///
+    /// ```ignore
+    /// pub fn on_mount(&mut self) {
+    ///     let qc = self.plugin::<Rc<QueryClient>>();
+    ///     Issue::query()
+    ///         .eq(issues::field::workspace_id, &self.workspace_id)
+    ///         .order_by(issues::field::created_at, Order::Desc)
+    ///         .bind::<Self, _>(&qc, |s: &mut Self| &mut s.rows);
+    /// }
+    /// ```
+    pub fn bind<C, F>(self, client: &crate::QueryClient, project: F)
+    where
+        Row: Clone + serde::Serialize + serde::de::DeserializeOwned + 'static,
+        C: 'static,
+        F: Fn(&mut C) -> &mut Vec<Row> + 'static,
+    {
+        let this = pocopine_core::this::<C>();
+        let signal = self.observe(client).into_signal();
+        pocopine_core::effect_scoped(move || {
+            let snap = signal.get();
+            this.update(|c: &mut C| {
+                *project(c) = snap;
+            });
+        });
+    }
 }
 
 /// FNV-1a 64-bit. Inline because we don't want a hash-crate dep for the
@@ -515,10 +568,10 @@ mod tests {
     #[test]
     fn order_changes_key() {
         let q1: Query<()> = Query::builder(stream())
-            .order_by("created_at", Order::Asc)
+            .order_by_raw("created_at", Order::Asc)
             .build();
         let q2: Query<()> = Query::builder(stream())
-            .order_by("created_at", Order::Desc)
+            .order_by_raw("created_at", Order::Desc)
             .build();
         assert_ne!(q1.key(), q2.key());
     }

--- a/crates/pocopine-sync-query/src/source.rs
+++ b/crates/pocopine-sync-query/src/source.rs
@@ -314,7 +314,16 @@ impl<S: Source> SourceResourceBuilder<S> {
             id_of: Arc::new(id_of),
             version_of: None,
             params_of: None,
-            mutation_log: None,
+            // T2.2: provision an in-memory log by default so the
+            // builder accepts `/push` without an explicit
+            // `.mutation_log(...)` call. The user-visible warning
+            // about the default fires once on first push (see the
+            // `mutation_log_default_warned` cell + push handler).
+            // `.mutation_log(...)` replaces it AND sets the
+            // explicit flag, which silences the warn.
+            mutation_log: Arc::new(crate::write::MemoryMutationLog::<S::Row>::new()),
+            mutation_log_explicit: false,
+            mutation_log_default_warned: Arc::new(std::sync::OnceLock::new()),
         }
     }
 }
@@ -339,15 +348,20 @@ pub struct SourceResource<S: Source, IdOf> {
     /// disabled and the server publishes only the bare stream
     /// topic. Phase 4 will auto-wire this from `#[query_resource]`.
     params_of: Option<Arc<SourceParamsFn<S::Row>>>,
-    /// Idempotency log for push mutations. Set via
-    /// [`Self::mutation_log`] (RFC 090 Phase 2b). When `None`,
-    /// `push` rejects with an `unsupported` error — the adapter
-    /// won't perform writes without an idempotency boundary because
-    /// a retry without dedup would run `Source::create`/`save`
-    /// twice on the same mutation_id, double-applying writes
-    /// under client retries. Apps that genuinely want non-
-    /// idempotent push should attach a no-op log explicitly.
-    mutation_log: Option<Arc<dyn MutationLog<S::Row>>>,
+    /// Idempotency log for push mutations. Defaults to
+    /// `MemoryMutationLog::new()` at construction time (T2.2);
+    /// `.mutation_log(...)` replaces it. Production apps SHOULD
+    /// attach a scoped + durable log — see the warning emitted on
+    /// first push when this is still the implicit default.
+    mutation_log: Arc<dyn MutationLog<S::Row>>,
+    /// Whether `.mutation_log(...)` was called explicitly. When
+    /// `false`, push emits a one-shot `tracing::warn!` so the
+    /// default-in-memory log is visible in dev logs.
+    mutation_log_explicit: bool,
+    /// One-shot latch for the dev warning. `Arc` so cloning the
+    /// resource doesn't re-fire; `OnceLock` for thread-safe
+    /// single-call semantics.
+    mutation_log_default_warned: Arc<std::sync::OnceLock<()>>,
 }
 
 impl<S, IdOf> SourceResource<S, IdOf>
@@ -414,7 +428,8 @@ where
     where
         Log: MutationLog<S::Row>,
     {
-        self.mutation_log = Some(Arc::new(log));
+        self.mutation_log = Arc::new(log);
+        self.mutation_log_explicit = true;
         self
     }
 }
@@ -582,6 +597,8 @@ where
         let id_of = self.id_of.clone();
         let version_of = self.version_of.clone();
         let mutation_log = self.mutation_log.clone();
+        let mutation_log_explicit = self.mutation_log_explicit;
+        let mutation_log_default_warned = self.mutation_log_default_warned.clone();
         let stream = self.stream.clone();
         let collection = self.collection.clone();
         Box::pin(async move {
@@ -589,14 +606,23 @@ where
                 return Err(SyncError::UnknownStream(request.stream.to_string()));
             }
 
-            let Some(mutation_log) = mutation_log else {
-                return Err(SyncError::unsupported(
-                    "Source push requires .mutation_log(...) on the builder. \
-                     For tests use MemoryMutationLog::new(); for production pair \
-                     with a scoped backend so idempotency aligns with your \
-                     tenant authorization domain.",
-                ));
-            };
+            // T2.2: emit a one-shot dev warning when the implicit
+            // in-memory mutation log is in use. Production deployments
+            // should attach a durable + scoped log via
+            // `.mutation_log(...)` so idempotency survives process
+            // restarts and aligns with the tenant boundary.
+            if !mutation_log_explicit {
+                mutation_log_default_warned.get_or_init(|| {
+                    tracing::warn!(
+                        target: "pocopine.log",
+                        stream = %stream,
+                        "SourceResource using the default in-memory MutationLog. \
+                         Replays after process restart will be lost. Production: \
+                         call .mutation_log(MemoryMutationLog::with_scope_fn(...)) \
+                         on the builder, or attach a durable backend."
+                    );
+                });
+            }
 
             let mut response = pocopine_sync::SyncPushResponse::new(stream.clone());
             response.collection = Some(collection.clone());

--- a/crates/pocopine-sync-query/src/source.rs
+++ b/crates/pocopine-sync-query/src/source.rs
@@ -81,9 +81,8 @@ pub type SourceFuture<'a, T> = std::pin::Pin<Box<dyn std::future::Future<Output 
 /// the eager `Vec<Row>` so backends can yield rows lazily and the
 /// adapter can short-circuit at `query.limit()` instead of waiting
 /// on the full snapshot.
-pub type SourceStream<'a, Row> = std::pin::Pin<
-    Box<dyn futures::stream::Stream<Item = SyncResult<Row>> + Send + 'a>,
->;
+pub type SourceStream<'a, Row> =
+    std::pin::Pin<Box<dyn futures::stream::Stream<Item = SyncResult<Row>> + Send + 'a>>;
 
 /// Type-erased projector from a canonical row into the RFC 088 §C
 /// `(stream, params_hash)` partition fields. Stored on

--- a/crates/pocopine-sync-query/src/source.rs
+++ b/crates/pocopine-sync-query/src/source.rs
@@ -576,14 +576,28 @@ where
             // gets the same correctness behaviour with no streaming
             // benefit, which is the right escape hatch.
             let mut row_stream = source.list_stream(source_ctx, &query);
-            let mut rows: Vec<S::Row> = Vec::new();
-            let mut overshoot = false;
+            // Codex review P2: the cap is `effective_limit`, NOT
+            // `max_snapshot_rows`. A `.limit(10)` pull must not
+            // ship more than 10 rows even if the source ignores
+            // `query.limit()`. The previous loop only kicked in
+            // at `max_snapshot_rows` (e.g. 1000), so a buggy
+            // source could let a `.limit(10)` request return up
+            // to 1000 rows in violation of the client contract.
+            let cap = effective_limit as usize;
+            let mut rows: Vec<S::Row> = Vec::with_capacity(cap.min(1024));
+            let mut source_overyielded = false;
             {
                 use futures::stream::StreamExt;
                 while let Some(row) = row_stream.next().await {
                     let row = row?;
-                    if rows.len() >= max_snapshot_rows {
-                        overshoot = true;
+                    if rows.len() >= cap {
+                        // We have the requested limit. Source's
+                        // extra yields are wasted I/O — break,
+                        // drop the stream, log it. Soft warning
+                        // (not a hard error) since streaming
+                        // already prevents the memory blow-up the
+                        // old hard limit was guarding against.
+                        source_overyielded = true;
                         break;
                     }
                     rows.push(row);
@@ -592,16 +606,15 @@ where
             // `row_stream` drops here — any backend resources held
             // open for unread rows release cleanly.
             drop(row_stream);
-            if overshoot {
-                return Err(SyncError::backend(format!(
-                    "Source yielded more than the max snapshot row limit ({}) for \
-                     stream `{}` — the adapter clamped the query's limit to {} \
-                     before calling list_stream; this source impl is ignoring \
-                     `query.limit()` entirely",
-                    max_snapshot_rows,
-                    stream.as_str(),
-                    effective_limit
-                )));
+            if source_overyielded {
+                tracing::warn!(
+                    target: "pocopine.log",
+                    stream = %stream,
+                    limit = cap,
+                    "Source yielded more rows than `query.limit()` (cap = {cap}) for \
+                     stream `{stream}` — extra rows dropped. Tighten the source's \
+                     `list_stream` to honor `query.limit()` exactly to avoid wasted I/O.",
+                );
             }
 
             let mut sync_rows: Vec<SyncRow<Value>> = Vec::with_capacity(rows.len());

--- a/crates/pocopine-sync-query/src/source.rs
+++ b/crates/pocopine-sync-query/src/source.rs
@@ -77,6 +77,14 @@ pub use crate::write::{Conflict, DeleteResult, WriteResult};
 /// `#[async_trait]` macro generates the right wrappers automatically.
 pub type SourceFuture<'a, T> = std::pin::Pin<Box<dyn std::future::Future<Output = T> + Send + 'a>>;
 
+/// Boxed stream returned by `Source::list_stream`. T3.2: replaces
+/// the eager `Vec<Row>` so backends can yield rows lazily and the
+/// adapter can short-circuit at `query.limit()` instead of waiting
+/// on the full snapshot.
+pub type SourceStream<'a, Row> = std::pin::Pin<
+    Box<dyn futures::stream::Stream<Item = SyncResult<Row>> + Send + 'a>,
+>;
+
 /// Type-erased projector from a canonical row into the RFC 088 §C
 /// `(stream, params_hash)` partition fields. Stored on
 /// [`SourceResource`]; attached via [`SourceResource::params_of`].
@@ -155,26 +163,56 @@ pub trait Source: Send + Sync + 'static {
     type Id: SourceId;
     type Row: Clone + Serialize + DeserializeOwned + Send + Sync + 'static;
     type Draft: Clone + Serialize + DeserializeOwned + Send + Sync + 'static;
+    /// Per-request authorization context. T3.1: the trait owns the
+    /// typed shape (`{ tenant_id, user_id, roles }`, etc.) so every
+    /// method takes a strongly-typed handle instead of unwrapping
+    /// fields from a raw `RequestContext` over and over. Sources
+    /// that just want the raw context set `type Context = RequestContext`
+    /// and return it unchanged from `extract_context`.
+    ///
+    /// `Clone` is required because a single push request can carry
+    /// many mutations; the adapter extracts once and clones into
+    /// each `create/update/delete` dispatch. Most realistic Context
+    /// types (typed tenant ids, user info enums) are cheap to clone.
+    type Context: Clone + Send + Sync + 'static;
 
-    /// Snapshot pull. The query is server-reconstructed from the
-    /// wire `SyncPullRequest`'s `params`, `order_by`, and `limit`
-    /// fields. Implementations SHOULD honor `query.params()` and
-    /// `query.limit()`; the default behavior is "ignore the query
-    /// shape and return up to `limit` rows", which preserves
-    /// `CrudSource::list(ctx, limit)` semantics for incremental
-    /// migration.
-    fn list<'a>(
+    /// Extract the typed `Self::Context` from the per-request
+    /// `RequestContext`. Called once per request entry inside the
+    /// `SourceResource` adapter, BEFORE any list/get/create/update/
+    /// delete dispatch. Reject unauthorized requests here by
+    /// returning `SyncError::auth(...)` — the wrapper short-circuits
+    /// without invoking the storage methods.
+    fn extract_context<'a>(
         &'a self,
         ctx: pocopine_auth::RequestContext,
+    ) -> SourceFuture<'a, SyncResult<Self::Context>>;
+
+    /// Snapshot pull as a row stream. The query is server-
+    /// reconstructed from the wire `SyncPullRequest`'s `params`,
+    /// `order_by`, and `limit` fields. Implementations SHOULD honor
+    /// `query.params()` and `query.limit()` — the adapter clamps the
+    /// limit before calling and short-circuits the stream when the
+    /// cap is reached, so a source that ignores the limit just wastes
+    /// I/O on rows the framework drops.
+    ///
+    /// T3.2: the streaming shape replaces the previous eager `Vec<Row>`
+    /// return so SQLx / IndexedDB / Firestore impls can yield rows
+    /// lazily (`sqlx::query.fetch(...)`) and the snapshot pull responds
+    /// in O(limit) memory instead of O(full table). Sources that
+    /// already have a `Vec<Row>` in hand wrap it with
+    /// `futures::stream::iter(vec.into_iter().map(Ok)).boxed()`.
+    fn list_stream<'a>(
+        &'a self,
+        ctx: Self::Context,
         query: &'a Query<Self::Row>,
-    ) -> SourceFuture<'a, SyncResult<Vec<Self::Row>>>;
+    ) -> SourceStream<'a, Self::Row>;
 
     /// Point lookup. Returns `None` for missing rows AND for rows the
     /// caller cannot see — the source decides whether to leak
     /// existence.
     fn get<'a>(
         &'a self,
-        ctx: pocopine_auth::RequestContext,
+        ctx: Self::Context,
         id: Self::Id,
     ) -> SourceFuture<'a, SyncResult<Option<Self::Row>>>;
 
@@ -183,7 +221,7 @@ pub trait Source: Send + Sync + 'static {
     /// client-supplied fields.
     fn create<'a>(
         &'a self,
-        ctx: pocopine_auth::RequestContext,
+        ctx: Self::Context,
         id: Self::Id,
         draft: Self::Draft,
     ) -> SourceFuture<'a, SyncResult<Self::Row>>;
@@ -195,7 +233,7 @@ pub trait Source: Send + Sync + 'static {
     /// the versions differ.
     fn update<'a>(
         &'a self,
-        ctx: pocopine_auth::RequestContext,
+        ctx: Self::Context,
         id: Self::Id,
         draft: Self::Draft,
         expected_version: Option<RowVersion>,
@@ -204,7 +242,7 @@ pub trait Source: Send + Sync + 'static {
     /// Delete an existing row. Same concurrency contract as `update`.
     fn delete<'a>(
         &'a self,
-        ctx: pocopine_auth::RequestContext,
+        ctx: Self::Context,
         id: Self::Id,
         expected_version: Option<RowVersion>,
     ) -> SourceFuture<'a, SyncResult<DeleteResult<Self::Row>>>;
@@ -525,14 +563,43 @@ where
                 .unwrap_or(max_snapshot_rows as u32);
             query.set_limit(effective_limit);
 
-            let rows = source.list(ctx, &query).await?;
-            if rows.len() > max_snapshot_rows {
+            // T3.1: extract the typed Source::Context once per
+            // request; downstream calls operate on the strongly-
+            // typed value, not on the raw RequestContext.
+            let source_ctx = source.extract_context(ctx).await?;
+            // T3.2: stream-collect up to max_snapshot_rows. The
+            // adapter breaks out of the stream as soon as the cap
+            // is reached, so a source that yields lazily (sqlx
+            // `fetch`, IndexedDB cursor, etc.) only does I/O for
+            // the rows that actually ship. A source that materialises
+            // a `Vec<Row>` and wraps it in `futures::stream::iter`
+            // gets the same correctness behaviour with no streaming
+            // benefit, which is the right escape hatch.
+            let mut row_stream = source.list_stream(source_ctx, &query);
+            let mut rows: Vec<S::Row> = Vec::new();
+            let mut overshoot = false;
+            {
+                use futures::stream::StreamExt;
+                while let Some(row) = row_stream.next().await {
+                    let row = row?;
+                    if rows.len() >= max_snapshot_rows {
+                        overshoot = true;
+                        break;
+                    }
+                    rows.push(row);
+                }
+            }
+            // `row_stream` drops here — any backend resources held
+            // open for unread rows release cleanly.
+            drop(row_stream);
+            if overshoot {
                 return Err(SyncError::backend(format!(
-                    "Source returned {} rows, exceeding max snapshot row limit {} \
-                     (the adapter clamped the query's limit to {} before calling list — \
-                     this source impl is ignoring `query.limit()` entirely)",
-                    rows.len(),
+                    "Source yielded more than the max snapshot row limit ({}) for \
+                     stream `{}` — the adapter clamped the query's limit to {} \
+                     before calling list_stream; this source impl is ignoring \
+                     `query.limit()` entirely",
                     max_snapshot_rows,
+                    stream.as_str(),
                     effective_limit
                 )));
             }
@@ -623,6 +690,13 @@ where
                     );
                 });
             }
+
+            // T3.1: typed Source::Context extracted once for the
+            // whole batch. Reservation log still uses the raw
+            // RequestContext for scope projection — its scoping
+            // semantics belong to the idempotency boundary, not
+            // the source's authorization model.
+            let source_ctx = source.extract_context(ctx.clone()).await?;
 
             let mut response = pocopine_sync::SyncPushResponse::new(stream.clone());
             response.collection = Some(collection.clone());
@@ -732,7 +806,7 @@ where
                 // Dispatch to the source.
                 let outcome = apply_payload::<S>(
                     source.as_ref(),
-                    ctx.clone(),
+                    source_ctx.clone(),
                     mutation_id.clone(),
                     expected_key.clone(),
                     base_version,
@@ -826,7 +900,7 @@ enum SourceApplyOutcome<Row> {
 
 async fn apply_payload<S: Source>(
     source: &S,
-    ctx: pocopine_auth::RequestContext,
+    ctx: S::Context,
     mutation_id: pocopine_sync::MutationId,
     key: pocopine_sync::RowKey,
     base_version: Option<RowVersion>,
@@ -948,12 +1022,20 @@ mod tests {
         type Id = String;
         type Row = Issue;
         type Draft = IssueDraft;
+        type Context = ();
 
-        fn list<'a>(
+        fn extract_context<'a>(
             &'a self,
             _ctx: pocopine_auth::RequestContext,
+        ) -> SourceFuture<'a, SyncResult<Self::Context>> {
+            Box::pin(async { Ok(()) })
+        }
+
+        fn list_stream<'a>(
+            &'a self,
+            _ctx: (),
             query: &'a Query<Self::Row>,
-        ) -> SourceFuture<'a, SyncResult<Vec<Self::Row>>> {
+        ) -> SourceStream<'a, Self::Row> {
             // The test below asserts the query reached us with the
             // expected wire params — proves the wire reconstruction
             // works end-to-end. We return rows tagged with whatever
@@ -965,17 +1047,16 @@ mod tests {
                 .and_then(|v| v.as_str())
                 .unwrap_or("")
                 .to_string();
-            Box::pin(async move {
-                Ok(vec![Issue {
-                    id: "stub_1".into(),
-                    workspace_id: ws,
-                }])
-            })
+            let rows = vec![Issue {
+                id: "stub_1".into(),
+                workspace_id: ws,
+            }];
+            Box::pin(futures::stream::iter(rows.into_iter().map(Ok)))
         }
 
         fn get<'a>(
             &'a self,
-            _ctx: pocopine_auth::RequestContext,
+            _ctx: (),
             _id: Self::Id,
         ) -> SourceFuture<'a, SyncResult<Option<Self::Row>>> {
             Box::pin(async move { Ok(None) })
@@ -983,7 +1064,7 @@ mod tests {
 
         fn create<'a>(
             &'a self,
-            _ctx: pocopine_auth::RequestContext,
+            _ctx: (),
             _id: Self::Id,
             _draft: Self::Draft,
         ) -> SourceFuture<'a, SyncResult<Self::Row>> {
@@ -992,7 +1073,7 @@ mod tests {
 
         fn update<'a>(
             &'a self,
-            _ctx: pocopine_auth::RequestContext,
+            _ctx: (),
             _id: Self::Id,
             _draft: Self::Draft,
             _expected_version: Option<RowVersion>,
@@ -1002,7 +1083,7 @@ mod tests {
 
         fn delete<'a>(
             &'a self,
-            _ctx: pocopine_auth::RequestContext,
+            _ctx: (),
             _id: Self::Id,
             _expected_version: Option<RowVersion>,
         ) -> SourceFuture<'a, SyncResult<DeleteResult<Self::Row>>> {
@@ -1065,7 +1146,17 @@ mod tests {
         let query: Query<Issue> = query_from_pull_request(&request);
 
         let ctx = test_ctx();
-        let rows = source.list(ctx, &query).await.expect("stub list");
+        let source_ctx = source.extract_context(ctx).await.expect("extract_context");
+        let rows: Vec<Issue> = {
+            use futures::stream::StreamExt;
+            source
+                .list_stream(source_ctx, &query)
+                .collect::<Vec<_>>()
+                .await
+                .into_iter()
+                .collect::<SyncResult<Vec<_>>>()
+                .expect("stub list_stream")
+        };
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].workspace_id, "W42");
     }

--- a/crates/pocopine-sync-query/src/wire.rs
+++ b/crates/pocopine-sync-query/src/wire.rs
@@ -108,7 +108,7 @@ mod tests {
     fn issues_query() -> Query<()> {
         Query::builder(SyncStreamName::new("issues").unwrap())
             .raw_param("workspace_id", serde_json::json!("W1"))
-            .order_by("created_at", Order::Desc)
+            .order_by_raw("created_at", Order::Desc)
             .limit(50)
             .build()
     }

--- a/crates/pocopine-sync-query/src/write.rs
+++ b/crates/pocopine-sync-query/src/write.rs
@@ -76,6 +76,23 @@ impl<Row> WriteResult<Row> {
     pub fn stale(server_row: Option<Row>) -> Self {
         Self::Conflict(Conflict::stale(server_row))
     }
+
+    /// Convert to a standard `Result` for `?`-chaining. `Applied(row)`
+    /// becomes `Ok(row)`; `Conflict(c)` becomes `Err(c)`.
+    pub fn into_result(self) -> Result<Row, Conflict<Row>> {
+        match self {
+            Self::Applied(row) => Ok(row),
+            Self::Conflict(c) => Err(c),
+        }
+    }
+
+    /// Borrowing variant for matchers that don't want to consume self.
+    pub fn as_result(&self) -> Result<&Row, &Conflict<Row>> {
+        match self {
+            Self::Applied(row) => Ok(row),
+            Self::Conflict(c) => Err(c),
+        }
+    }
 }
 
 /// Outcome of an optimistic-concurrency `delete`.
@@ -96,6 +113,23 @@ impl<Row> DeleteResult<Row> {
 
     pub fn stale(server_row: Option<Row>) -> Self {
         Self::Conflict(Conflict::stale(server_row))
+    }
+
+    /// Convert to a standard `Result` for `?`-chaining. `Applied`
+    /// becomes `Ok(())`; `Conflict(c)` becomes `Err(c)`.
+    pub fn into_result(self) -> Result<(), Conflict<Row>> {
+        match self {
+            Self::Applied => Ok(()),
+            Self::Conflict(c) => Err(c),
+        }
+    }
+
+    /// Borrowing variant.
+    pub fn as_result(&self) -> Result<(), &Conflict<Row>> {
+        match self {
+            Self::Applied => Ok(()),
+            Self::Conflict(c) => Err(c),
+        }
     }
 }
 
@@ -528,10 +562,12 @@ pub struct TypedMutation<Row, Id, Draft> {
     /// time via `RowKey::new(id.to_string())`, so the no-optimistic
     /// push path can build a correctly-keyed wire envelope without
     /// going through `SourceId` (which is host-only — wasm can't
-    /// reach it). Review-of-review finding #2: a non-String `Id` like
-    /// `i64` or `Uuid` previously produced `wire.key = None`
-    /// silently; the server then rejected the mutation.
+    /// reach it).
     wire_row_key: Option<RowKey>,
+    /// Wire stream name. The macro fills this from `#[query_resource(
+    /// name = "...")]` so `TypedMutation::push(&qc)` can route without
+    /// the caller naming the stream again.
+    wire_stream: Option<pocopine_sync::SyncStreamName>,
 }
 
 impl<Row, Id, Draft> TypedMutation<Row, Id, Draft> {
@@ -542,6 +578,7 @@ impl<Row, Id, Draft> TypedMutation<Row, Id, Draft> {
             payload,
             optimistic: None,
             wire_row_key: None,
+            wire_stream: None,
         }
     }
 
@@ -559,6 +596,21 @@ impl<Row, Id, Draft> TypedMutation<Row, Id, Draft> {
     /// Pre-computed wire row key, if attached.
     pub fn wire_row_key(&self) -> Option<&RowKey> {
         self.wire_row_key.as_ref()
+    }
+
+    /// Attach the wire stream name. Macro-emitted from the
+    /// `#[query_resource(name = "...")]` literal so
+    /// `TypedMutation::push(&qc)` can route without the caller naming
+    /// the stream again. Hand-built `TypedMutation`s either set this
+    /// or must call `QueryClient::push_typed` with an explicit stream.
+    pub fn with_wire_stream(mut self, stream: Option<pocopine_sync::SyncStreamName>) -> Self {
+        self.wire_stream = stream;
+        self
+    }
+
+    /// Pre-computed wire stream name, if attached.
+    pub fn wire_stream(&self) -> Option<&pocopine_sync::SyncStreamName> {
+        self.wire_stream.as_ref()
     }
 
     /// Attach an optimistic-row builder. The closure runs BEFORE

--- a/crates/pocopine-sync-query/tests/api_surface.rs
+++ b/crates/pocopine-sync-query/tests/api_surface.rs
@@ -19,7 +19,7 @@ fn query_builder_constructs_typed_query() {
     let q: Query<()> = Query::builder(stream.clone())
         .raw_param("workspace_id", serde_json::json!("W1"))
         .raw_param("status", serde_json::json!({"in": ["open"]}))
-        .order_by("created_at", Order::Desc)
+        .order_by_raw("created_at", Order::Desc)
         .limit(50)
         .build();
 

--- a/crates/pocopine-sync-query/tests/driver.rs
+++ b/crates/pocopine-sync-query/tests/driver.rs
@@ -30,7 +30,8 @@ use pocopine_sync::{
     SyncResult, SyncRow, SyncStreamName, SYNC_OPEN_PATH, SYNC_PULL_PATH,
 };
 use pocopine_sync_query::{
-    Mutator, MutatorRemoteContext, MutatorRemoteFuture, QueryClient, QueryClientConfig, RowChange,
+    query_client_plugin, Mutator, MutatorRemoteContext, MutatorRemoteFuture, QueryClient,
+    QueryClientConfig, RowChange,
 };
 use pocopine_sync_query_macros::query_resource;
 use serde::{Deserialize, Serialize};
@@ -210,7 +211,7 @@ async fn open_then_pull_populates_canonical_rows() {
                 }
             });
 
-            let client = QueryClient::with_config(test_config());
+            let client = query_client_plugin().config(test_config()).into_client();
             let view = client.observe(Issue::query().eq(issues::field::workspace_id, "W1").build());
             settle_ticks(3).await;
 
@@ -280,7 +281,7 @@ async fn schema_drift_resets_state_and_repopulates() {
                 }
             });
 
-            let client = Rc::new(QueryClient::with_config(test_config()));
+            let client = Rc::new(query_client_plugin().config(test_config()).into_client());
             // First observe → loads v1.
             let view = client.observe(Issue::query().eq(issues::field::workspace_id, "W1").build());
             settle_ticks(3).await;
@@ -329,7 +330,7 @@ async fn cancellation_via_handle_drop_exits_driver() {
                 }
             });
 
-            let client = QueryClient::with_config(test_config());
+            let client = query_client_plugin().config(test_config()).into_client();
             let view = client.observe(Issue::query().eq(issues::field::workspace_id, "W1").build());
             settle_ticks(3).await;
             let initial_count = *pull_calls.borrow();
@@ -372,7 +373,7 @@ async fn offline_replay_redrives_apply_remote_with_same_mutation_id() {
             PENDING_MODE.with(|m| *m.borrow_mut() = PendingMode::Offline);
             PENDING_REMOTE_HITS.with(|h| h.borrow_mut().clear());
 
-            let client = QueryClient::with_config(test_config());
+            let client = query_client_plugin().config(test_config()).into_client();
             let ctx = StubContext::new();
             let view = client.observe(Issue::query().eq(issues::field::workspace_id, "W1").build());
             settle_ticks(2).await;

--- a/crates/pocopine-sync-query/tests/persistence.rs
+++ b/crates/pocopine-sync-query/tests/persistence.rs
@@ -27,7 +27,8 @@ use pocopine_sync::{
     SyncStreamName, SYNC_OPEN_PATH, SYNC_PULL_PATH,
 };
 use pocopine_sync_query::{
-    Mutator, MutatorRemoteContext, MutatorRemoteFuture, QueryClient, QueryClientConfig, RowChange,
+    query_client_plugin, Mutator, MutatorRemoteContext, MutatorRemoteFuture, QueryClient,
+    QueryClientConfig, RowChange,
 };
 use pocopine_sync_query_macros::query_resource;
 use serde::{Deserialize, Serialize};
@@ -240,7 +241,7 @@ async fn hydrate_populates_canonical_rows_then_pull_refreshes() {
                 .unwrap();
 
             let store_handle: Rc<dyn SyncLocalStore> = store.clone();
-            let client = QueryClient::with_config(test_config_with_store(store_handle));
+            let client = query_client_plugin().config(test_config_with_store(store_handle)).into_client();
             let view = client.observe(Issue::query().eq(issues::field::workspace_id, "W1").build());
 
             // After settle, both cached + /pull rows should be visible.
@@ -317,7 +318,7 @@ async fn hydrate_shows_cached_rows_before_pull_lands() {
                 .unwrap();
 
             let store_handle: Rc<dyn SyncLocalStore> = store.clone();
-            let client = QueryClient::with_config(test_config_with_store(store_handle));
+            let client = query_client_plugin().config(test_config_with_store(store_handle)).into_client();
             let view = client.observe(Issue::query().eq(issues::field::workspace_id, "W1").build());
 
             // After 1-2 ticks the hydrate phase has populated the
@@ -388,7 +389,7 @@ async fn schema_drift_wipes_persisted_state_and_repopulates() {
             assert_eq!(pre.application_schema_version, Some(1));
 
             let store_handle: Rc<dyn SyncLocalStore> = store.clone();
-            let client = QueryClient::with_config(test_config_with_store(store_handle));
+            let client = query_client_plugin().config(test_config_with_store(store_handle)).into_client();
             let view = client.observe(Issue::query().eq(issues::field::workspace_id, "W1").build());
             settle(5).await;
 
@@ -433,7 +434,7 @@ async fn pending_mutation_persists_and_replays_on_hydrate() {
             let store_handle: Rc<dyn SyncLocalStore> = store.clone();
 
             // ── Session 1 ────────────────────────────────────────
-            let client1 = QueryClient::with_config(test_config_with_store(store_handle.clone()));
+            let client1 = query_client_plugin().config(test_config_with_store(store_handle.clone())).into_client();
             client1.register_mutator::<FlakyCreate>();
             let view1 = client1.observe(
                 Issue::query()
@@ -487,7 +488,7 @@ async fn pending_mutation_persists_and_replays_on_hydrate() {
             FLAKY_MODE.with(|m| *m.borrow_mut() = FlakyMode::Online);
             let pre_hits = FLAKY_HITS.with(|h| h.borrow().len());
 
-            let client2 = QueryClient::with_config(test_config_with_store(store_handle.clone()));
+            let client2 = query_client_plugin().config(test_config_with_store(store_handle.clone())).into_client();
             client2.register_mutator::<FlakyCreate>();
             let view2 = client2.observe(
                 Issue::query()
@@ -557,7 +558,7 @@ async fn distinct_params_persist_to_distinct_compartments() {
 
             let store = Rc::new(MemoryLocalStore::new());
             let store_handle: Rc<dyn SyncLocalStore> = store.clone();
-            let client = QueryClient::with_config(test_config_with_store(store_handle));
+            let client = query_client_plugin().config(test_config_with_store(store_handle)).into_client();
 
             let _view_a = client.observe(
                 Issue::query()
@@ -645,7 +646,7 @@ async fn no_local_store_keeps_in_memory_only_behavior() {
             });
 
             // No `with_local_store` — backwards-compat path.
-            let client = QueryClient::new();
+            let client = query_client_plugin().into_client();
             let view = client.observe(Issue::query().eq(issues::field::workspace_id, "W1").build());
             settle(3).await;
             assert_eq!(view.rows().len(), 1);

--- a/crates/pocopine-sync-query/tests/persistence.rs
+++ b/crates/pocopine-sync-query/tests/persistence.rs
@@ -27,8 +27,8 @@ use pocopine_sync::{
     SyncStreamName, SYNC_OPEN_PATH, SYNC_PULL_PATH,
 };
 use pocopine_sync_query::{
-    query_client_plugin, Mutator, MutatorRemoteContext, MutatorRemoteFuture, QueryClient,
-    QueryClientConfig, RowChange,
+    query_client_plugin, Mutator, MutatorRemoteContext, MutatorRemoteFuture, QueryClientConfig,
+    RowChange,
 };
 use pocopine_sync_query_macros::query_resource;
 use serde::{Deserialize, Serialize};
@@ -241,7 +241,9 @@ async fn hydrate_populates_canonical_rows_then_pull_refreshes() {
                 .unwrap();
 
             let store_handle: Rc<dyn SyncLocalStore> = store.clone();
-            let client = query_client_plugin().config(test_config_with_store(store_handle)).into_client();
+            let client = query_client_plugin()
+                .config(test_config_with_store(store_handle))
+                .into_client();
             let view = client.observe(Issue::query().eq(issues::field::workspace_id, "W1").build());
 
             // After settle, both cached + /pull rows should be visible.
@@ -318,7 +320,9 @@ async fn hydrate_shows_cached_rows_before_pull_lands() {
                 .unwrap();
 
             let store_handle: Rc<dyn SyncLocalStore> = store.clone();
-            let client = query_client_plugin().config(test_config_with_store(store_handle)).into_client();
+            let client = query_client_plugin()
+                .config(test_config_with_store(store_handle))
+                .into_client();
             let view = client.observe(Issue::query().eq(issues::field::workspace_id, "W1").build());
 
             // After 1-2 ticks the hydrate phase has populated the
@@ -389,7 +393,9 @@ async fn schema_drift_wipes_persisted_state_and_repopulates() {
             assert_eq!(pre.application_schema_version, Some(1));
 
             let store_handle: Rc<dyn SyncLocalStore> = store.clone();
-            let client = query_client_plugin().config(test_config_with_store(store_handle)).into_client();
+            let client = query_client_plugin()
+                .config(test_config_with_store(store_handle))
+                .into_client();
             let view = client.observe(Issue::query().eq(issues::field::workspace_id, "W1").build());
             settle(5).await;
 
@@ -558,7 +564,9 @@ async fn distinct_params_persist_to_distinct_compartments() {
 
             let store = Rc::new(MemoryLocalStore::new());
             let store_handle: Rc<dyn SyncLocalStore> = store.clone();
-            let client = query_client_plugin().config(test_config_with_store(store_handle)).into_client();
+            let client = query_client_plugin()
+                .config(test_config_with_store(store_handle))
+                .into_client();
 
             let _view_a = client.observe(
                 Issue::query()

--- a/crates/pocopine-sync-query/tests/query_client_push.rs
+++ b/crates/pocopine-sync-query/tests/query_client_push.rs
@@ -29,7 +29,7 @@ use pocopine_sync::{
     SyncStreamName, SYNC_PUSH_PATH,
 };
 use pocopine_sync_query::source::{
-    source as build_source, DeleteResult, Source, SourceFuture, WriteResult,
+    source as build_source, DeleteResult, Source, SourceFuture, SourceStream, WriteResult,
 };
 use pocopine_sync_query::write::{MemoryMutationLog, MutationPayload};
 use pocopine_sync_query::{Query, QueryClient, RowChange};
@@ -62,19 +62,27 @@ impl Source for IssuesSource {
     type Id = String;
     type Row = Issue;
     type Draft = IssueDraft;
+    type Context = ();
 
-    fn list<'a>(
+    fn extract_context<'a>(
         &'a self,
         _ctx: RequestContext,
+    ) -> SourceFuture<'a, SyncResult<Self::Context>> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn list_stream<'a>(
+        &'a self,
+        _ctx: Self::Context,
         _query: &'a Query<Self::Row>,
-    ) -> SourceFuture<'a, SyncResult<Vec<Self::Row>>> {
-        let rows = self.rows.lock().unwrap().values().cloned().collect();
-        Box::pin(async move { Ok(rows) })
+    ) -> SourceStream<'a, Self::Row> {
+        let rows: Vec<Self::Row> = self.rows.lock().unwrap().values().cloned().collect();
+        Box::pin(futures::stream::iter(rows.into_iter().map(Ok)))
     }
 
     fn get<'a>(
         &'a self,
-        _ctx: RequestContext,
+        _ctx: (),
         id: Self::Id,
     ) -> SourceFuture<'a, SyncResult<Option<Self::Row>>> {
         let row = self.rows.lock().unwrap().get(&id).cloned();
@@ -83,7 +91,7 @@ impl Source for IssuesSource {
 
     fn create<'a>(
         &'a self,
-        _ctx: RequestContext,
+        _ctx: (),
         id: Self::Id,
         draft: Self::Draft,
     ) -> SourceFuture<'a, SyncResult<Self::Row>> {
@@ -99,7 +107,7 @@ impl Source for IssuesSource {
 
     fn update<'a>(
         &'a self,
-        _ctx: RequestContext,
+        _ctx: (),
         _id: Self::Id,
         _draft: Self::Draft,
         _expected_version: Option<RowVersion>,
@@ -109,7 +117,7 @@ impl Source for IssuesSource {
 
     fn delete<'a>(
         &'a self,
-        _ctx: RequestContext,
+        _ctx: (),
         _id: Self::Id,
         _expected_version: Option<RowVersion>,
     ) -> SourceFuture<'a, SyncResult<DeleteResult<Self::Row>>> {

--- a/crates/pocopine-sync-query/tests/source_phase1.rs
+++ b/crates/pocopine-sync-query/tests/source_phase1.rs
@@ -28,7 +28,7 @@ use pocopine_sync::{
 };
 use pocopine_sync_query::source::{
     query_from_pull_request, source as build_source, DeleteResult, Source, SourceFuture,
-    WriteResult,
+    SourceStream, WriteResult,
 };
 use pocopine_sync_query::Query;
 use serde::{Deserialize, Serialize};
@@ -96,12 +96,20 @@ impl Source for IssuesSource {
     type Id = String;
     type Row = Issue;
     type Draft = IssueDraft;
+    type Context = ();
 
-    fn list<'a>(
+    fn extract_context<'a>(
         &'a self,
         _ctx: RequestContext,
+    ) -> SourceFuture<'a, SyncResult<Self::Context>> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn list_stream<'a>(
+        &'a self,
+        _ctx: (),
         query: &'a Query<Self::Row>,
-    ) -> SourceFuture<'a, SyncResult<Vec<Self::Row>>> {
+    ) -> SourceStream<'a, Self::Row> {
         // Record what the source saw — instrumentation for the
         // integration test, not part of the production pattern.
         self.observed
@@ -109,10 +117,6 @@ impl Source for IssuesSource {
             .unwrap()
             .push((query.params().clone(), query.limit()));
 
-        // The whole point of Phase 1: this filter runs HERE
-        // (= "in storage"), not after the wire round-trip. In a
-        // real SQLx source, the params drive a WHERE clause; here
-        // we Vec::filter. The shape is the same.
         let workspace_filter = query
             .params()
             .get("workspace_id")
@@ -121,23 +125,21 @@ impl Source for IssuesSource {
         let limit = query.limit().unwrap_or(u32::MAX) as usize;
 
         let rows = self.rows.lock().unwrap().clone();
-        Box::pin(async move {
-            let filtered = rows
-                .into_iter()
-                .filter(|r| {
-                    workspace_filter
-                        .as_deref()
-                        .is_none_or(|w| r.workspace_id == w)
-                })
-                .take(limit)
-                .collect();
-            Ok(filtered)
-        })
+        let filtered: Vec<Self::Row> = rows
+            .into_iter()
+            .filter(|r| {
+                workspace_filter
+                    .as_deref()
+                    .is_none_or(|w| r.workspace_id == w)
+            })
+            .take(limit)
+            .collect();
+        Box::pin(futures::stream::iter(filtered.into_iter().map(Ok)))
     }
 
     fn get<'a>(
         &'a self,
-        _ctx: RequestContext,
+        _ctx: (),
         id: Self::Id,
     ) -> SourceFuture<'a, SyncResult<Option<Self::Row>>> {
         let rows = self.rows.lock().unwrap().clone();
@@ -146,7 +148,7 @@ impl Source for IssuesSource {
 
     fn create<'a>(
         &'a self,
-        _ctx: RequestContext,
+        _ctx: (),
         id: Self::Id,
         draft: Self::Draft,
     ) -> SourceFuture<'a, SyncResult<Self::Row>> {
@@ -164,7 +166,7 @@ impl Source for IssuesSource {
 
     fn update<'a>(
         &'a self,
-        _ctx: RequestContext,
+        _ctx: (),
         _id: Self::Id,
         _draft: Self::Draft,
         _expected_version: Option<pocopine_sync::RowVersion>,
@@ -174,7 +176,7 @@ impl Source for IssuesSource {
 
     fn delete<'a>(
         &'a self,
-        _ctx: RequestContext,
+        _ctx: (),
         _id: Self::Id,
         _expected_version: Option<pocopine_sync::RowVersion>,
     ) -> SourceFuture<'a, SyncResult<DeleteResult<Self::Row>>> {

--- a/crates/pocopine-sync-query/tests/source_phase2b_push.rs
+++ b/crates/pocopine-sync-query/tests/source_phase2b_push.rs
@@ -176,7 +176,14 @@ async fn push(
 }
 
 #[tokio::test]
-async fn push_without_mutation_log_rejects_with_clear_error() {
+async fn push_without_explicit_mutation_log_uses_in_memory_default() {
+    // T2.2: omitting `.mutation_log(...)` no longer hard-rejects
+    // push. The builder defaults to `MemoryMutationLog::new()` and
+    // the first push emits a one-shot `tracing::warn!` noting that
+    // the implicit log won't survive restart. We assert the
+    // behaviour (push succeeds, source ran) here; tracing-side
+    // assertion lives in the observability test suite where a
+    // collector is installed.
     let source = IssuesSource::default();
     let app = build_app(source.clone(), /* with_log */ false);
 
@@ -192,16 +199,35 @@ async fn push_without_mutation_log_rejects_with_clear_error() {
         ),
     )
     .await;
-    assert!(result.is_err(), "push must fail without mutation log");
-    let err = result.unwrap_err();
     assert!(
-        err.contains("mutation_log"),
-        "error should name the missing builder method, got: {err}"
+        result.is_ok(),
+        "push must succeed under the default in-memory log; got {result:?}"
     );
     assert_eq!(
         *source.create_calls.lock().unwrap(),
-        0,
-        "source.create must not run when push is unsupported"
+        1,
+        "source.create must run exactly once"
+    );
+
+    // Replay the same mutation id and confirm idempotency still
+    // holds via the default log — i.e. it's a real log, not a no-op.
+    let replay = push(
+        &app,
+        "m_first",
+        MutationPayload::create(
+            "i1".into(),
+            IssueDraft {
+                workspace_id: "W1".into(),
+                title: "Auth bug".into(),
+            },
+        ),
+    )
+    .await;
+    assert!(replay.is_ok(), "replay must succeed (short-circuit on prior)");
+    assert_eq!(
+        *source.create_calls.lock().unwrap(),
+        1,
+        "source.create must NOT run twice — default log dedupes"
     );
 }
 

--- a/crates/pocopine-sync-query/tests/source_phase2b_push.rs
+++ b/crates/pocopine-sync-query/tests/source_phase2b_push.rs
@@ -28,7 +28,7 @@ use pocopine_sync::{
     SyncPushRequest, SyncPushResponse, SyncResult, SyncServer, SyncStreamName, SYNC_PUSH_PATH,
 };
 use pocopine_sync_query::source::{
-    source as build_source, DeleteResult, Source, SourceFuture, WriteResult,
+    source as build_source, DeleteResult, Source, SourceFuture, SourceStream, WriteResult,
 };
 use pocopine_sync_query::write::{MemoryMutationLog, MutationPayload};
 use pocopine_sync_query::Query;
@@ -61,19 +61,27 @@ impl Source for IssuesSource {
     type Id = String;
     type Row = Issue;
     type Draft = IssueDraft;
+    type Context = ();
 
-    fn list<'a>(
+    fn extract_context<'a>(
         &'a self,
         _ctx: RequestContext,
+    ) -> SourceFuture<'a, SyncResult<Self::Context>> {
+        Box::pin(async { Ok(()) })
+    }
+
+    fn list_stream<'a>(
+        &'a self,
+        _ctx: (),
         _query: &'a Query<Self::Row>,
-    ) -> SourceFuture<'a, SyncResult<Vec<Self::Row>>> {
-        let rows = self.rows.lock().unwrap().values().cloned().collect();
-        Box::pin(async move { Ok(rows) })
+    ) -> SourceStream<'a, Self::Row> {
+        let rows: Vec<Self::Row> = self.rows.lock().unwrap().values().cloned().collect();
+        Box::pin(futures::stream::iter(rows.into_iter().map(Ok)))
     }
 
     fn get<'a>(
         &'a self,
-        _ctx: RequestContext,
+        _ctx: (),
         id: Self::Id,
     ) -> SourceFuture<'a, SyncResult<Option<Self::Row>>> {
         let row = self.rows.lock().unwrap().get(&id).cloned();
@@ -82,7 +90,7 @@ impl Source for IssuesSource {
 
     fn create<'a>(
         &'a self,
-        _ctx: RequestContext,
+        _ctx: (),
         id: Self::Id,
         draft: Self::Draft,
     ) -> SourceFuture<'a, SyncResult<Self::Row>> {
@@ -98,7 +106,7 @@ impl Source for IssuesSource {
 
     fn update<'a>(
         &'a self,
-        _ctx: RequestContext,
+        _ctx: (),
         _id: Self::Id,
         _draft: Self::Draft,
         _expected_version: Option<RowVersion>,
@@ -108,7 +116,7 @@ impl Source for IssuesSource {
 
     fn delete<'a>(
         &'a self,
-        _ctx: RequestContext,
+        _ctx: (),
         _id: Self::Id,
         _expected_version: Option<RowVersion>,
     ) -> SourceFuture<'a, SyncResult<DeleteResult<Self::Row>>> {

--- a/crates/pocopine-sync-query/tests/source_phase2b_push.rs
+++ b/crates/pocopine-sync-query/tests/source_phase2b_push.rs
@@ -231,7 +231,10 @@ async fn push_without_explicit_mutation_log_uses_in_memory_default() {
         ),
     )
     .await;
-    assert!(replay.is_ok(), "replay must succeed (short-circuit on prior)");
+    assert!(
+        replay.is_ok(),
+        "replay must succeed (short-circuit on prior)"
+    );
     assert_eq!(
         *source.create_calls.lock().unwrap(),
         1,

--- a/crates/pocopine-sync/Cargo.toml
+++ b/crates/pocopine-sync/Cargo.toml
@@ -12,7 +12,7 @@ pocopine-live = { workspace = true }
 serde = { workspace = true }
 serde_json = "1"
 tracing = { workspace = true }
-uuid = { version = "1", features = ["v4", "js"] }
+uuid = { version = "1", features = ["v4", "v7", "js"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 pocopine-events = { workspace = true }

--- a/crates/pocopine-sync/src/protocol.rs
+++ b/crates/pocopine-sync/src/protocol.rs
@@ -161,6 +161,23 @@ opaque_string_type!(
     "mutation id",
     "Client-generated mutation idempotency key."
 );
+
+impl MutationId {
+    /// Generate a UUIDv7-backed mutation id. The default constructor
+    /// used by `TypedMutation::push(&qc)` and any other framework
+    /// auto-id path.
+    ///
+    /// UUIDv7 is time-ordered (the leading 48 bits are an ms-resolution
+    /// Unix timestamp), so mutation logs and offline replay queues keep
+    /// their insertion order without an extra sort key. The string form
+    /// (`xxxxxxxx-xxxx-7xxx-yxxx-xxxxxxxxxxxx`) is always 36 bytes —
+    /// well under `MutationId`'s opaque-string length cap — so the
+    /// `unwrap` below is infallible.
+    pub fn uuid() -> Self {
+        Self::new(uuid::Uuid::now_v7().to_string()).expect("UUIDv7 is always a valid MutationId")
+    }
+}
+
 opaque_string_type!(
     SyncDeviceId,
     "device id",


### PR DESCRIPTION
## Summary

Broader sync-query API polish covering all three tiers from the design sketch. Done in a clean worktree off main so you can review the whole shape before docs catch up.

## What's in

### Tier 1 — high-friction ergonomics (commit 1)

| # | Before | After |
|---|---|---|
| 1 | `MutationId::new(uuid::Uuid::now_v7().to_string()).unwrap()` | `MutationId::uuid()` |
| 2 | manual `on_update + scope::trigger + effect + track` bridge | `QueryView::into_signal()` (drop-guard owns view + token) |
| 3 | 9-line on_mount bridge per component | `Query::bind(&qc, projector)` (effect_scoped + Handle::update) |
| 4 | `qc.push_typed(stream, id, mutation, "/sync/v1/push")` | `mutation.push(&qc)` (stream from macro, id auto, url from endpoint) |
| 5 | `.order_by("created_at", Order::Desc)` (untyped string) | `.order_by(Issue::field::created_at, Order::Desc)` |
| 6 | (WriteResult/DeleteResult enum-only) | `.into_result() -> Result<Row, Conflict<Row>>` for ?-chaining |

### Tier 2 — quality-of-life (commit 2)

- **Auto-provision MutationLog**: omitting `.mutation_log(...)` on `SourceResource` no longer hard-errors. The `.id(...)` finalizer defaults to `MemoryMutationLog::new()` and the first push emits a one-shot `tracing::warn!` pointing at the builder. `.mutation_log(...)` silences the warn.
- **QueryClient constructors removed**: `::new`, `::with_endpoint`, `::with_config`, and `impl Default` deleted. `query_client_plugin()....into_client()` is the only public path; a private `from_config` carries the internal construction. 13 internal/test call sites updated.

### Tier 3 — architectural (commit 3) — BREAKING

- **`Source::Context` extractor**: `Source` gains `type Context: Clone + Send + Sync` and `extract_context(RequestContext) -> SyncResult<Self::Context>`. All five storage methods take the typed context. Adapter extracts once per request, clones into each push mutation. `MutationLog` keeps the raw `RequestContext` for scope projection.
- **`Source::list_stream`**: the eager `Vec<Row>` return is replaced with `SourceStream<'_, Row>` (boxed `Stream<Item = SyncResult<Row>>`). Adapter consumes lazily up to `max_snapshot_rows` and short-circuits on overshoot. Backends with a `Vec` in hand wrap via `futures::stream::iter(vec.into_iter().map(Ok)).boxed()`.

## Verification

- `cargo test -p pocopine-sync-query -p pocopine-sync-query-macros` — all 158+ tests pass (60 client unit + 25 macro + 13 macro-tests + 11 driver + 9 + 6 + 6 + 5 + 4 + push lifecycle)
- `cargo check --target wasm32-unknown-unknown -p pocopine-sync-query` clean (the `set_limit` dead-code warning is pre-existing on main)
- `cargo fmt --check` clean across the touched files

## Docs status

**Deferred.** Docs in `docs/sync.md`, `sync-server.md`, `sync-client.md` still reflect the pre-polish shape. The user asked for the polish to land first so we can review the API surface, then update docs to match in a follow-up PR.

## Breaking changes (all in Tier 3)

Every existing `Source` impl needs:
1. `type Context = ...;` (use `()` if no context needed)
2. `extract_context(...)` impl (one-liner for `Context = ()`)
3. `list` renamed to `list_stream`, return shape changed to `SourceStream<'_, Row>`

Migration recipe in the commit body.