### PR TITLE
sync-query: macro auto-wiring for resource + optimistic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6058,7 +6058,9 @@ dependencies = [
 name = "pocopine-sync-query-macros"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "futures",
+ "http 1.4.0",
  "pocopine-auth",
  "pocopine-core",
  "pocopine-sync",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6058,6 +6058,8 @@ dependencies = [
 name = "pocopine-sync-query-macros"
 version = "0.1.0"
 dependencies = [
+ "futures",
+ "pocopine-auth",
  "pocopine-core",
  "pocopine-sync",
  "pocopine-sync-query",

--- a/crates/pocopine-sync-query-macros/Cargo.toml
+++ b/crates/pocopine-sync-query-macros/Cargo.toml
@@ -29,3 +29,7 @@ trybuild = "1"
 # emitted `tasks::resource(...)` convenience compiles only on host.
 pocopine-auth = { workspace = true }
 futures = "0.3"
+# Required by the `Source::mutation_log` integration test that
+# impls MutationLog directly on a store.
+async-trait = "0.1"
+http = { workspace = true }

--- a/crates/pocopine-sync-query-macros/Cargo.toml
+++ b/crates/pocopine-sync-query-macros/Cargo.toml
@@ -22,3 +22,10 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { version = "1", features = ["macros", "rt"] }
 trybuild = "1"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+# Required by host-only tests that build a stub `Source` impl —
+# `Source::extract_context` takes a `RequestContext` and the macro-
+# emitted `tasks::resource(...)` convenience compiles only on host.
+pocopine-auth = { workspace = true }
+futures = "0.3"

--- a/crates/pocopine-sync-query-macros/src/lib.rs
+++ b/crates/pocopine-sync-query-macros/src/lib.rs
@@ -663,50 +663,92 @@ fn expand_query_resource(
     let field_markers = generate_field_markers(&params);
     let matches_body = generate_matches_body(&params);
     let row_to_params_body = generate_row_to_params_body(&params);
+    let row_to_params_typed_body = generate_row_to_params_typed_body(&params);
+
+    // Auto-wiring sugar: when the row has a literal `id` field and an
+    // optional `version` field, the macro emits a `resource(impl_)`
+    // convenience constructor that pre-wires `.id(...)`,
+    // `.version_field(...)` (if `version` exists), and `.partition_by`.
+    // User opts out of any default by chaining the matching builder
+    // method on the result.
+    let id_field =
+        find_named_struct_field(&item, "id").map(|f| (f.ident.clone().unwrap(), f.ty.clone()));
+    let version_field_ident =
+        find_named_struct_field(&item, "version").map(|f| f.ident.clone().unwrap());
+    let resource_fn = generate_resource_fn(&row_ident, id_field, version_field_ident);
 
     // RFC 090 Phase 4: emit typed write methods only when the
     // user opted in via `draft = MyDraft`. Without it, `#typed_writes`
     // is empty and `impl Row { ... }` carries only `query()`.
     let typed_writes = if writes_enabled {
         quote! {
-            /// RFC 090 Phase 4: typed `create` mutation. Returns a
-            /// [`pocopine_sync_query::TypedMutation`] builder you can
-            /// optionally annotate with `.optimistic(closure)` and
-            /// then `.push(&client, mutation_id, push_url)`.
+            /// Typed `create` mutation. Returns a
+            /// [`pocopine_sync_query::TypedMutation`] pre-wired with
+            /// a default optimistic overlay computed via
+            /// `Self::from((id, draft))` — so a bare
+            /// `Issue::create(id, draft).push(&qc).await` already
+            /// renders the new row in matching views immediately.
             ///
-            /// `Id` defaults to `String` (override with
-            /// `#[query_resource(..., id = MyId)]`).
+            /// **Bound:** `Self: From<(Id, Draft)>`. Implement
+            /// `From<(Id, Draft)> for Row` once per resource (or
+            /// derive a converter — usually a 5-line impl that fills
+            /// server-controlled fields with defaults). Override the
+            /// default by chaining `.optimistic(custom_closure)`
+            /// before `.push(&qc)`; opt out entirely with
+            /// `.no_optimistic()`.
             pub fn create(
                 id: #id_ty,
                 draft: #draft_ty,
-            ) -> ::pocopine_sync_query::TypedMutation<Self, #id_ty, #draft_ty> {
+            ) -> ::pocopine_sync_query::TypedMutation<Self, #id_ty, #draft_ty>
+            where
+                Self: ::core::convert::From<(#id_ty, #draft_ty)> + 'static,
+                #id_ty: ::core::clone::Clone + 'static,
+                #draft_ty: ::core::clone::Clone + 'static,
+            {
                 let __wire_key = ::pocopine_sync_query::__private::pocopine_sync::RowKey::new(
                     ::std::string::ToString::to_string(&id),
                 )
                 .ok();
                 let __wire_stream = ::pocopine_sync_query::__private::pocopine_sync::SyncStreamName::new(#name_lit).ok();
+                let __id_for_optimistic = ::core::clone::Clone::clone(&id);
+                let __draft_for_optimistic = ::core::clone::Clone::clone(&draft);
                 ::pocopine_sync_query::TypedMutation::new(
                     ::pocopine_sync_query::MutationPayload::create(id, draft),
                 )
                 .with_wire_row_key(__wire_key)
                 .with_wire_stream(__wire_stream)
+                .optimistic(move |_payload| {
+                    <Self as ::core::convert::From<(#id_ty, #draft_ty)>>::from(
+                        (__id_for_optimistic, __draft_for_optimistic),
+                    )
+                })
             }
 
-            /// RFC 090 Phase 4: typed `update` mutation. Pass an
+            /// Typed `update` mutation. Same auto-optimistic via
+            /// `From<(Id, Draft)>` as [`Self::create`]. Pass an
             /// optional `expected_version` for optimistic-concurrency
-            /// (None = unconditional update).
+            /// (None = unconditional update). Override the optimistic
+            /// closure with `.optimistic(...)` or opt out with
+            /// `.no_optimistic()`.
             pub fn update(
                 id: #id_ty,
                 draft: #draft_ty,
                 expected_version: ::std::option::Option<
                     ::pocopine_sync_query::__private::pocopine_sync::RowVersion,
                 >,
-            ) -> ::pocopine_sync_query::TypedMutation<Self, #id_ty, #draft_ty> {
+            ) -> ::pocopine_sync_query::TypedMutation<Self, #id_ty, #draft_ty>
+            where
+                Self: ::core::convert::From<(#id_ty, #draft_ty)> + 'static,
+                #id_ty: ::core::clone::Clone + 'static,
+                #draft_ty: ::core::clone::Clone + 'static,
+            {
                 let __wire_key = ::pocopine_sync_query::__private::pocopine_sync::RowKey::new(
                     ::std::string::ToString::to_string(&id),
                 )
                 .ok();
                 let __wire_stream = ::pocopine_sync_query::__private::pocopine_sync::SyncStreamName::new(#name_lit).ok();
+                let __id_for_optimistic = ::core::clone::Clone::clone(&id);
+                let __draft_for_optimistic = ::core::clone::Clone::clone(&draft);
                 let mut payload =
                     ::pocopine_sync_query::write::UpdatePayload::new(id, draft);
                 payload.expected_version = expected_version;
@@ -715,10 +757,18 @@ fn expand_query_resource(
                 )
                 .with_wire_row_key(__wire_key)
                 .with_wire_stream(__wire_stream)
+                .optimistic(move |_payload| {
+                    <Self as ::core::convert::From<(#id_ty, #draft_ty)>>::from(
+                        (__id_for_optimistic, __draft_for_optimistic),
+                    )
+                })
             }
 
-            /// RFC 090 Phase 4: typed `delete` mutation. Pass an
-            /// optional `expected_version` for optimistic-concurrency.
+            /// Typed `delete` mutation. No `From` bound — delete's
+            /// optimistic shape is a row removal keyed on the id;
+            /// the framework derives it from `wire_row_key`. Pass
+            /// an optional `expected_version` for optimistic
+            /// concurrency.
             pub fn delete(
                 id: #id_ty,
                 expected_version: ::std::option::Option<
@@ -965,6 +1015,21 @@ fn expand_query_resource(
                     ),
                 )
             }
+
+            /// Typed sibling of [`row_to_params`] — reads `&Row` directly
+            /// instead of `&serde_json::Value`. The macro-emitted
+            /// `resource(impl_)` convenience wires this into
+            /// `SourceResource::partition_by(...)` automatically.
+            pub fn row_to_params_typed(
+                row: &Row,
+            ) -> ::pocopine_sync_query::__private::pocopine_sync::StreamParams {
+                let mut params =
+                    ::pocopine_sync_query::__private::pocopine_sync::StreamParams::new();
+                #row_to_params_typed_body
+                params
+            }
+
+            #resource_fn
         }
     })
 }
@@ -1223,31 +1288,155 @@ fn generate_matches_body(params: &[ParamDef]) -> TokenStream2 {
     }
 }
 
+/// Typed sibling of `generate_row_to_params_body` below. Reads each
+/// required field off `&row` (typed) instead of `row.get(...)`
+/// (`&Value`). Same field-selection rules — only `required`-flagged
+/// fields contribute. Used by the macro-emitted `row_to_params_typed`
+/// that `SourceResource::partition_by(...)` consumes directly.
+fn generate_row_to_params_typed_body(params: &[ParamDef]) -> TokenStream2 {
+    let inserts: Vec<TokenStream2> = params
+        .iter()
+        .filter(|p| include_in_row_params(&p.caps))
+        .map(|param| {
+            let name = &param.name;
+            let name_str = ident_wire_key(name);
+            if param.caps.optional {
+                quote! {
+                    if let ::std::option::Option::Some(__v) = &row.#name {
+                        if let ::std::result::Result::Ok(__as_value) =
+                            ::pocopine_sync_query::__private::serde_json::to_value(__v)
+                        {
+                            if !__as_value.is_null() {
+                                params.insert(#name_str.to_string(), __as_value);
+                            }
+                        }
+                    }
+                }
+            } else {
+                quote! {
+                    if let ::std::result::Result::Ok(__as_value) =
+                        ::pocopine_sync_query::__private::serde_json::to_value(&row.#name)
+                    {
+                        if !__as_value.is_null() {
+                            params.insert(#name_str.to_string(), __as_value);
+                        }
+                    }
+                }
+            }
+        })
+        .collect();
+
+    quote! {
+        #(#inserts)*
+    }
+}
+
+/// Find a struct field by its literal Rust ident name. Returns the
+/// field's `Type` (the declared `field: T`) when present. Used by
+/// the macro to detect a conventionally-named `id` or `version`
+/// field for the `resource(impl_)` convenience wiring.
+fn find_named_struct_field<'a>(item: &'a ItemStruct, name: &str) -> Option<&'a syn::Field> {
+    let fields = match &item.fields {
+        Fields::Named(named) => named,
+        _ => return None,
+    };
+    fields
+        .named
+        .iter()
+        .find(|f| f.ident.as_ref().is_some_and(|i| i == name))
+}
+
+/// Generate the macro-emitted `resource<S>(impl_: S) -> SourceResource<…>`
+/// convenience constructor, pre-wired with `.id(...)`,
+/// `.version_field(...)` (when a `version` field exists), and
+/// `.partition_by(row_to_params_typed)`. Emitted only when the row
+/// has a literal `id` field; without it, the macro emits nothing
+/// and the user must call `source(name, impl_).id(...)` directly.
+fn generate_resource_fn(
+    row_ident: &Ident,
+    id_field: Option<(Ident, syn::Type)>,
+    version_field_ident: Option<Ident>,
+) -> TokenStream2 {
+    let Some((id_field, id_field_ty)) = id_field else {
+        return quote! {};
+    };
+
+    let version_chain = match version_field_ident {
+        Some(v) => quote! {
+            .version_field(|row: &super::#row_ident| {
+                let __raw = ::std::string::ToString::to_string(&row.#v);
+                ::pocopine_sync_query::__private::pocopine_sync::RowVersion::new(__raw)
+                    .map(::std::option::Option::Some)
+            })
+        },
+        None => quote! {},
+    };
+
+    quote! {
+        /// Macro-emitted `SourceResource` builder pre-wired from
+        /// `#[query_resource]` metadata: `.id(...)` (from the row's
+        /// `id` field), `.version_field(...)` (from the row's
+        /// `version` field if present), and `.partition_by(...)`
+        /// (from `row_to_params_typed`).
+        ///
+        /// Drops 3–4 lines of boilerplate per resource. Override any
+        /// default by chaining the matching builder method on the
+        /// returned value:
+        ///
+        /// ```ignore
+        /// let resource = issues::resource(IssueStore::new(db))
+        ///     .mutation_log(MemoryMutationLog::with_scope_fn(|ctx| {
+        ///         Ok(ctx.tenant_id()?.to_string())
+        ///     }));
+        /// ```
+        pub fn resource<S>(
+            impl_: S,
+        ) -> ::pocopine_sync_query::source::SourceResource<
+            S,
+            impl ::core::ops::Fn(&super::#row_ident) -> #id_field_ty
+                + ::core::marker::Send
+                + ::core::marker::Sync
+                + 'static,
+        >
+        where
+            S: ::pocopine_sync_query::source::Source<
+                Row = super::#row_ident,
+                Id = #id_field_ty,
+            >,
+        {
+            // `Source<Id = T>` is bound to the row's `id` field
+            // type, so the closure's return matches S::Id without
+            // any conversion. Users with a different id type (e.g.
+            // a newtype around String) either change the row's `id`
+            // field to match OR drop the convenience and call
+            // `source(NAME, impl_).id(custom_projector)` directly.
+            ::pocopine_sync_query::source::source(NAME, impl_)
+                .expect("hardcoded resource name passed validation at macro expansion")
+                .id(|row: &super::#row_ident| ::core::clone::Clone::clone(&row.#id_field))
+                #version_chain
+                .partition_by(row_to_params_typed)
+        }
+    }
+}
+
 /// Generate the body of the `row_to_params(row: &Value) ->
 /// SyncResult<StreamParams>` function inside the generated module
 /// (see RFC 088 §C). Iterates the same `#[query_param]` fields the
 /// matches() body iterates, but:
 ///
-/// 1. **Skips contains-only fields.** A field whose only emitted
+/// 1. Skips contains-only fields. A field whose only emitted
 ///    comparator is `FieldContains` (substring search) can't
-///    partition the topic space — a `.contains(field::title,
-///    "auth")?` filter matches an unbounded set of row values, so
-///    including the row's title in the params map would generate a
-///    distinct topic per row and defeat the fanout-reduction goal.
-///    Fields that ALSO carry `range`/`required`/or-are-non-String
-///    stay in the map.
-///
-/// 2. **Drops `None` from `Option<T>` fields.** Inserting a JSON
-///    null into params would partition `Option::None` rows into a
-///    distinct topic — almost always not what the user wants. The
-///    routing engine's predicate evaluator (matches() body) already
-///    handles `None` symmetry.
-///
-/// 3. **Uses each field's wire-key** (raw-ident-stripped) so the
-///    emitted topic keys match `serde_json::to_value(row)`'s field
-///    names. If the user later adds `#[serde(rename = "…")]`, the
-///    macro doesn't currently follow it — same limitation as the
-///    existing matches() body and the existing macro tests.
+///    partition the topic space — including the row's title in
+///    the params map would generate a distinct topic per row and
+///    defeat the fanout-reduction goal. Fields that ALSO carry
+///    `range`/`required`/or-are-non-String stay in the map.
+/// 2. Drops `None` from `Option<T>` fields. Inserting a JSON null
+///    into params would partition `Option::None` rows into a
+///    distinct topic — almost always not what the user wants.
+/// 3. Uses each field's wire-key (raw-ident-stripped) so the
+///    emitted topic keys match `serde_json::to_value(row)`'s
+///    field names. `#[serde(rename = "…")]` is not currently
+///    followed (same limitation as `matches()`).
 fn generate_row_to_params_body(params: &[ParamDef]) -> TokenStream2 {
     let inserts: Vec<TokenStream2> = params
         .iter()

--- a/crates/pocopine-sync-query-macros/src/lib.rs
+++ b/crates/pocopine-sync-query-macros/src/lib.rs
@@ -695,7 +695,7 @@ fn expand_query_resource(
             /// server-controlled fields with defaults). Override the
             /// default by chaining `.optimistic(custom_closure)`
             /// before `.push(&qc)`; opt out entirely with
-            /// `.no_optimistic()`.
+            /// `.server_only()`.
             pub fn create(
                 id: #id_ty,
                 draft: #draft_ty,
@@ -729,7 +729,7 @@ fn expand_query_resource(
             /// optional `expected_version` for optimistic-concurrency
             /// (None = unconditional update). Override the optimistic
             /// closure with `.optimistic(...)` or opt out with
-            /// `.no_optimistic()`.
+            /// `.server_only()`.
             pub fn update(
                 id: #id_ty,
                 draft: #draft_ty,

--- a/crates/pocopine-sync-query-macros/tests/query_resource.rs
+++ b/crates/pocopine-sync-query-macros/tests/query_resource.rs
@@ -599,6 +599,155 @@ fn no_optimistic_clears_default() {
     );
 }
 
+#[tokio::test]
+async fn source_provided_mutation_log_skips_auto_default() {
+    // The Source impl returns `Some(self.clone())` from
+    // `mutation_log()`, so the SourceResource picks it up at
+    // construction without `.mutation_log(...)` on the builder.
+    // We verify reservations land in the *Source-provided* log,
+    // not a fresh `MemoryMutationLog`.
+    use pocopine_auth::RequestContext;
+    use pocopine_sync::{MutationId, SyncOp};
+    use pocopine_sync_query::source::{
+        DeleteResult, Source, SourceFuture, SourceStream, WriteResult,
+    };
+    use pocopine_sync_query::write::{
+        AcceptedMutation, MemoryMutationLog, MutationLog, MutationReservation,
+    };
+    use pocopine_sync_query::Query;
+    use std::sync::Arc;
+
+    #[derive(Clone)]
+    struct CountedLogStore {
+        inner: Arc<MemoryMutationLog<Task>>,
+    }
+
+    impl CountedLogStore {
+        fn new() -> Self {
+            Self {
+                inner: Arc::new(MemoryMutationLog::new()),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl MutationLog<Task> for CountedLogStore {
+        async fn reserve_mutation(
+            &self,
+            ctx: &RequestContext,
+            candidate: AcceptedMutation,
+        ) -> pocopine_sync::SyncResult<MutationReservation> {
+            self.inner.reserve_mutation(ctx, candidate).await
+        }
+
+        async fn accepted_mutation(
+            &self,
+            ctx: &RequestContext,
+            mutation_id: &MutationId,
+        ) -> pocopine_sync::SyncResult<Option<AcceptedMutation>> {
+            self.inner.accepted_mutation(ctx, mutation_id).await
+        }
+    }
+
+    impl Source for CountedLogStore {
+        type Id = String;
+        type Row = Task;
+        type Draft = TaskDraft;
+        type Context = ();
+
+        fn extract_context<'a>(
+            &'a self,
+            _ctx: RequestContext,
+        ) -> SourceFuture<'a, pocopine_sync::SyncResult<Self::Context>> {
+            Box::pin(async { Ok(()) })
+        }
+        fn list_stream<'a>(
+            &'a self,
+            _ctx: (),
+            _query: &'a Query<Self::Row>,
+        ) -> SourceStream<'a, Self::Row> {
+            Box::pin(futures::stream::iter(::std::iter::empty()))
+        }
+        fn get<'a>(
+            &'a self,
+            _ctx: (),
+            _id: Self::Id,
+        ) -> SourceFuture<'a, pocopine_sync::SyncResult<Option<Self::Row>>> {
+            Box::pin(async { Ok(None) })
+        }
+        fn create<'a>(
+            &'a self,
+            _ctx: (),
+            _id: Self::Id,
+            _draft: Self::Draft,
+        ) -> SourceFuture<'a, pocopine_sync::SyncResult<Self::Row>> {
+            Box::pin(async { Err(pocopine_sync::SyncError::unsupported("stub")) })
+        }
+        fn update<'a>(
+            &'a self,
+            _ctx: (),
+            _id: Self::Id,
+            _draft: Self::Draft,
+            _expected: Option<pocopine_sync::RowVersion>,
+        ) -> SourceFuture<'a, pocopine_sync::SyncResult<WriteResult<Self::Row>>> {
+            Box::pin(async { Err(pocopine_sync::SyncError::unsupported("stub")) })
+        }
+        fn delete<'a>(
+            &'a self,
+            _ctx: (),
+            _id: Self::Id,
+            _expected: Option<pocopine_sync::RowVersion>,
+        ) -> SourceFuture<'a, pocopine_sync::SyncResult<DeleteResult<Self::Row>>> {
+            Box::pin(async { Err(pocopine_sync::SyncError::unsupported("stub")) })
+        }
+
+        // The whole point of this test: returning Some here tells
+        // `SourceResource` to use the store's own log instead of
+        // auto-provisioning a fresh `MemoryMutationLog`.
+        fn mutation_log(&self) -> Option<Arc<dyn MutationLog<Self::Row>>> {
+            Some(Arc::new(self.clone()))
+        }
+    }
+
+    let store = CountedLogStore::new();
+    let inner_log = store.inner.clone();
+
+    // No `.mutation_log(...)` on the builder — the auto-wiring
+    // picks up the Source-provided log via `Source::mutation_log()`.
+    let _resource = tasks::resource(store);
+
+    // Seed the log directly through the Source-provided instance.
+    // If the SourceResource HAD provisioned a fresh
+    // MemoryMutationLog instead, this insert would not be visible
+    // to subsequent push handlers. We assert visibility by reading
+    // back through the same `inner_log` we wrote to.
+    let ctx = RequestContext::new(
+        http::Method::POST,
+        "/__pocopine/sync/v1/push".parse().unwrap(),
+        http::HeaderMap::new(),
+    );
+    let mid = MutationId::new("auto_wired_mid").unwrap();
+    let candidate = AcceptedMutation::new(
+        mid.clone(),
+        SyncOp::Upsert,
+        Some(pocopine_sync::RowKey::new("t1").unwrap()),
+        serde_json::json!({"op": "create", "id": "t1", "draft": {}}),
+    );
+    let reservation = inner_log
+        .reserve_mutation(&ctx, candidate)
+        .await
+        .expect("reservation must succeed");
+    assert!(matches!(reservation, MutationReservation::Reserved));
+    let prior = inner_log
+        .accepted_mutation(&ctx, &mid)
+        .await
+        .expect("readback");
+    assert!(
+        prior.is_some(),
+        "auto-wired Source-provided log must hold the reservation"
+    );
+}
+
 #[test]
 fn tasks_resource_convenience_compiles_with_stub_source() {
     // The macro-emitted `tasks::resource(impl_)` pre-wires `.id`

--- a/crates/pocopine-sync-query-macros/tests/query_resource.rs
+++ b/crates/pocopine-sync-query-macros/tests/query_resource.rs
@@ -455,6 +455,18 @@ pub struct TaskDraft {
     pub title: String,
 }
 
+// Required by the macro-emitted `Task::create / update` for the
+// auto-optimistic overlay (default = Self::from((id, draft))).
+impl From<(String, TaskDraft)> for Task {
+    fn from((id, draft): (String, TaskDraft)) -> Self {
+        Self {
+            id,
+            workspace_id: draft.workspace_id,
+            title: draft.title,
+        }
+    }
+}
+
 #[test]
 fn create_emits_typed_builder() {
     use pocopine_sync_query::MutationPayload;
@@ -548,4 +560,135 @@ fn wire_shape_is_flat() {
             "draft": {"workspace_id": "W1", "title": "Hello"}
         })
     );
+}
+
+#[test]
+fn create_attaches_default_optimistic_from_from_impl() {
+    // The macro pre-wires `.optimistic(|_| Self::from((id, draft)))`
+    // on `Task::create` because Task: From<(String, TaskDraft)>.
+    let m = Task::create(
+        "t1".to_string(),
+        TaskDraft {
+            workspace_id: "W1".to_string(),
+            title: "from default".to_string(),
+        },
+    );
+    let (payload, opt) = m.into_parts();
+    let row = opt.expect("auto-optimistic should be attached")(&payload);
+    assert_eq!(row.id, "t1");
+    assert_eq!(row.workspace_id, "W1");
+    assert_eq!(row.title, "from default");
+}
+
+#[test]
+fn no_optimistic_clears_default() {
+    // `.no_optimistic()` clears the auto-default. The mutation still
+    // pushes correctly; the view just won't update until /pull confirms.
+    let m = Task::create(
+        "t1".to_string(),
+        TaskDraft {
+            workspace_id: "W1".to_string(),
+            title: "no-overlay".to_string(),
+        },
+    )
+    .no_optimistic();
+    let (_payload, opt) = m.into_parts();
+    assert!(
+        opt.is_none(),
+        "no_optimistic must clear the default closure"
+    );
+}
+
+#[test]
+fn tasks_resource_convenience_compiles_with_stub_source() {
+    // The macro-emitted `tasks::resource(impl_)` pre-wires `.id`
+    // (from the row's `id` field) and `.partition_by` (from
+    // `row_to_params_typed`). This stub Source carries no `version`
+    // field on the row, so `version_field` is not pre-wired.
+    use pocopine_auth::RequestContext;
+    use pocopine_sync_query::source::{
+        DeleteResult, Source, SourceFuture, SourceStream, WriteResult,
+    };
+    use pocopine_sync_query::Query;
+
+    pub struct TaskStore;
+
+    impl Source for TaskStore {
+        type Id = String;
+        type Row = Task;
+        type Draft = TaskDraft;
+        type Context = ();
+
+        fn extract_context<'a>(
+            &'a self,
+            _ctx: RequestContext,
+        ) -> SourceFuture<'a, pocopine_sync::SyncResult<Self::Context>> {
+            Box::pin(async { Ok(()) })
+        }
+        fn list_stream<'a>(
+            &'a self,
+            _ctx: (),
+            _query: &'a Query<Self::Row>,
+        ) -> SourceStream<'a, Self::Row> {
+            Box::pin(futures::stream::iter(::std::iter::empty()))
+        }
+        fn get<'a>(
+            &'a self,
+            _ctx: (),
+            _id: Self::Id,
+        ) -> SourceFuture<'a, pocopine_sync::SyncResult<Option<Self::Row>>> {
+            Box::pin(async { Ok(None) })
+        }
+        fn create<'a>(
+            &'a self,
+            _ctx: (),
+            _id: Self::Id,
+            _draft: Self::Draft,
+        ) -> SourceFuture<'a, pocopine_sync::SyncResult<Self::Row>> {
+            Box::pin(async { Err(pocopine_sync::SyncError::unsupported("stub")) })
+        }
+        fn update<'a>(
+            &'a self,
+            _ctx: (),
+            _id: Self::Id,
+            _draft: Self::Draft,
+            _expected_version: Option<pocopine_sync::RowVersion>,
+        ) -> SourceFuture<'a, pocopine_sync::SyncResult<WriteResult<Self::Row>>> {
+            Box::pin(async { Err(pocopine_sync::SyncError::unsupported("stub")) })
+        }
+        fn delete<'a>(
+            &'a self,
+            _ctx: (),
+            _id: Self::Id,
+            _expected_version: Option<pocopine_sync::RowVersion>,
+        ) -> SourceFuture<'a, pocopine_sync::SyncResult<DeleteResult<Self::Row>>> {
+            Box::pin(async { Err(pocopine_sync::SyncError::unsupported("stub")) })
+        }
+    }
+
+    // The actual test — `tasks::resource(impl_)` returns a
+    // SourceResource with id + partition_by pre-wired. We can then
+    // chain `.mutation_log(...)` (and override defaults if needed).
+    let _resource = tasks::resource(TaskStore)
+        .mutation_log(pocopine_sync_query::write::MemoryMutationLog::<Task>::new());
+}
+
+#[test]
+fn explicit_optimistic_overrides_default() {
+    let m = Task::create(
+        "t1".to_string(),
+        TaskDraft {
+            workspace_id: "W1".to_string(),
+            title: "default".to_string(),
+        },
+    )
+    .optimistic(|_| Task {
+        id: "explicit_t1".to_string(),
+        workspace_id: "explicit_W1".to_string(),
+        title: "explicit override".to_string(),
+    });
+    let (payload, opt) = m.into_parts();
+    let row = opt.unwrap()(&payload);
+    assert_eq!(row.id, "explicit_t1");
+    assert_eq!(row.title, "explicit override");
 }

--- a/crates/pocopine-sync-query-macros/tests/query_resource.rs
+++ b/crates/pocopine-sync-query-macros/tests/query_resource.rs
@@ -593,10 +593,7 @@ fn server_only_clears_default() {
     )
     .server_only();
     let (_payload, opt) = m.into_parts();
-    assert!(
-        opt.is_none(),
-        "server_only must clear the default closure"
-    );
+    assert!(opt.is_none(), "server_only must clear the default closure");
 }
 
 #[tokio::test]

--- a/crates/pocopine-sync-query-macros/tests/query_resource.rs
+++ b/crates/pocopine-sync-query-macros/tests/query_resource.rs
@@ -581,8 +581,8 @@ fn create_attaches_default_optimistic_from_from_impl() {
 }
 
 #[test]
-fn no_optimistic_clears_default() {
-    // `.no_optimistic()` clears the auto-default. The mutation still
+fn server_only_clears_default() {
+    // `.server_only()` clears the auto-default. The mutation still
     // pushes correctly; the view just won't update until /pull confirms.
     let m = Task::create(
         "t1".to_string(),
@@ -591,11 +591,11 @@ fn no_optimistic_clears_default() {
             title: "no-overlay".to_string(),
         },
     )
-    .no_optimistic();
+    .server_only();
     let (_payload, opt) = m.into_parts();
     assert!(
         opt.is_none(),
-        "no_optimistic must clear the default closure"
+        "server_only must clear the default closure"
     );
 }
 

--- a/crates/pocopine-sync-query/src/source.rs
+++ b/crates/pocopine-sync-query/src/source.rs
@@ -245,6 +245,30 @@ pub trait Source: Send + Sync + 'static {
         id: Self::Id,
         expected_version: Option<RowVersion>,
     ) -> SourceFuture<'a, SyncResult<DeleteResult<Self::Row>>>;
+
+    /// Provide an idempotency log keyed on this Source's writes.
+    /// Default: `None` — `SourceResource` auto-provisions an
+    /// in-memory log and emits a one-shot dev warning on first push.
+    ///
+    /// Production impls return `Some(...)` so the same backing store
+    /// that handles `create`/`update`/`delete` ALSO handles
+    /// `reserve_mutation` — that's the only way `Source::create` and
+    /// the mutation-id reservation commit in the same transaction.
+    /// Typical shape:
+    ///
+    /// ```ignore
+    /// // Self: Clone + MutationLog<Self::Row>
+    /// fn mutation_log(&self) -> Option<Arc<dyn MutationLog<Self::Row>>> {
+    ///     Some(Arc::new(self.clone()))
+    /// }
+    /// ```
+    ///
+    /// The builder's `.mutation_log(custom)` still wins over this
+    /// when set — use the builder override when the log is hosted by
+    /// a different backend (separate DB, scoped wrapper, …).
+    fn mutation_log(&self) -> Option<Arc<dyn MutationLog<Self::Row>>> {
+        None
+    }
 }
 
 /// Reconstruct a `Query<Row>` from a wire `SyncPullRequest`. The
@@ -342,6 +366,24 @@ impl<S: Source> SourceResourceBuilder<S> {
     where
         IdOf: Fn(&S::Row) -> S::Id + Send + Sync + 'static,
     {
+        // Resolve mutation_log priority at construction time:
+        //   1. `.mutation_log(custom)` (set later on the builder) → that
+        //   2. `Source::mutation_log()` returning Some       → trait-provided
+        //   3. neither                                       → MemoryMutationLog + warn
+        //
+        // The `Source::mutation_log()` lookup happens HERE (before
+        // the user has a chance to call `.mutation_log(...)`) and
+        // is overridden when the user does call it. Three-state
+        // provenance tracks which path supplied the log so the
+        // first-push warn only fires for case 3.
+        let (mutation_log, mutation_log_provenance) = match self.source.mutation_log() {
+            Some(log) => (log, MutationLogProvenance::SourceProvided),
+            None => (
+                Arc::new(crate::write::MemoryMutationLog::<S::Row>::new())
+                    as Arc<dyn MutationLog<S::Row>>,
+                MutationLogProvenance::AutoDefault,
+            ),
+        };
         SourceResource {
             stream: self.stream,
             collection: self.collection,
@@ -351,18 +393,25 @@ impl<S: Source> SourceResourceBuilder<S> {
             id_of: Arc::new(id_of),
             version_of: None,
             params_of: None,
-            // T2.2: provision an in-memory log by default so the
-            // builder accepts `/push` without an explicit
-            // `.mutation_log(...)` call. The user-visible warning
-            // about the default fires once on first push (see the
-            // `mutation_log_default_warned` cell + push handler).
-            // `.mutation_log(...)` replaces it AND sets the
-            // explicit flag, which silences the warn.
-            mutation_log: Arc::new(crate::write::MemoryMutationLog::<S::Row>::new()),
-            mutation_log_explicit: false,
+            mutation_log,
+            mutation_log_provenance,
             mutation_log_default_warned: Arc::new(std::sync::OnceLock::new()),
         }
     }
+}
+
+/// Tracks how `SourceResource` got its `mutation_log`. Drives the
+/// first-push warning: only the `AutoDefault` case fires, because
+/// the trait method's `Some(...)` return and the builder's explicit
+/// override are both deliberate user choices.
+#[derive(Clone, Copy, Debug)]
+enum MutationLogProvenance {
+    /// `.mutation_log(custom)` called on the builder.
+    BuilderExplicit,
+    /// `Source::mutation_log()` returned `Some(...)`.
+    SourceProvided,
+    /// Neither — falling back to `MemoryMutationLog` (warn).
+    AutoDefault,
 }
 
 /// `SyncStreamSource` adapter wrapping a `Source` impl. Phase 1
@@ -385,16 +434,15 @@ pub struct SourceResource<S: Source, IdOf> {
     /// disabled and the server publishes only the bare stream
     /// topic. Phase 4 will auto-wire this from `#[query_resource]`.
     params_of: Option<Arc<SourceParamsFn<S::Row>>>,
-    /// Idempotency log for push mutations. Defaults to
-    /// `MemoryMutationLog::new()` at construction time (T2.2);
-    /// `.mutation_log(...)` replaces it. Production apps SHOULD
-    /// attach a scoped + durable log — see the warning emitted on
-    /// first push when this is still the implicit default.
+    /// Idempotency log for push mutations. Resolved at construction
+    /// in priority order: `.mutation_log(custom)` (builder),
+    /// `Source::mutation_log()` (trait default method), or
+    /// `MemoryMutationLog::new()` (auto-default + warn).
     mutation_log: Arc<dyn MutationLog<S::Row>>,
-    /// Whether `.mutation_log(...)` was called explicitly. When
-    /// `false`, push emits a one-shot `tracing::warn!` so the
-    /// default-in-memory log is visible in dev logs.
-    mutation_log_explicit: bool,
+    /// Which path supplied `mutation_log`. The first-push warning
+    /// fires only when `AutoDefault` — both the builder override
+    /// and the trait method are user-deliberate choices.
+    mutation_log_provenance: MutationLogProvenance,
     /// One-shot latch for the dev warning. `Arc` so cloning the
     /// resource doesn't re-fire; `OnceLock` for thread-safe
     /// single-call semantics.
@@ -466,7 +514,7 @@ where
         Log: MutationLog<S::Row>,
     {
         self.mutation_log = Arc::new(log);
-        self.mutation_log_explicit = true;
+        self.mutation_log_provenance = MutationLogProvenance::BuilderExplicit;
         self
     }
 }
@@ -676,7 +724,7 @@ where
         let id_of = self.id_of.clone();
         let version_of = self.version_of.clone();
         let mutation_log = self.mutation_log.clone();
-        let mutation_log_explicit = self.mutation_log_explicit;
+        let mutation_log_provenance = self.mutation_log_provenance;
         let mutation_log_default_warned = self.mutation_log_default_warned.clone();
         let stream = self.stream.clone();
         let collection = self.collection.clone();
@@ -685,20 +733,24 @@ where
                 return Err(SyncError::UnknownStream(request.stream.to_string()));
             }
 
-            // T2.2: emit a one-shot dev warning when the implicit
-            // in-memory mutation log is in use. Production deployments
-            // should attach a durable + scoped log via
-            // `.mutation_log(...)` so idempotency survives process
-            // restarts and aligns with the tenant boundary.
-            if !mutation_log_explicit {
+            // T2.2 + Source::mutation_log() integration: emit a
+            // one-shot dev warning ONLY when neither the builder
+            // override nor the trait method supplied a log — i.e.
+            // we're using the auto-default MemoryMutationLog.
+            // Production deployments should either override the
+            // trait default to return Some(self) (when the store
+            // also impls MutationLog) or call `.mutation_log(...)`
+            // on the builder.
+            if matches!(mutation_log_provenance, MutationLogProvenance::AutoDefault) {
                 mutation_log_default_warned.get_or_init(|| {
                     tracing::warn!(
                         target: "pocopine.log",
                         stream = %stream,
                         "SourceResource using the default in-memory MutationLog. \
                          Replays after process restart will be lost. Production: \
-                         call .mutation_log(MemoryMutationLog::with_scope_fn(...)) \
-                         on the builder, or attach a durable backend."
+                         override `Source::mutation_log()` to return `Some(self)` \
+                         (when the store impls MutationLog), or call \
+                         `.mutation_log(...)` on the builder with a durable backend."
                     );
                 });
             }

--- a/crates/pocopine-sync-query/src/write.rs
+++ b/crates/pocopine-sync-query/src/write.rs
@@ -630,13 +630,16 @@ impl<Row, Id, Draft> TypedMutation<Row, Id, Draft> {
         self
     }
 
-    /// Force this mutation to push WITHOUT an optimistic overlay.
+    /// Make this mutation server-only — push the wire envelope and
+    /// wait for the server to confirm before the view updates.
     /// Clears any default optimistic closure the macro attached.
     ///
-    /// Use when you want a server-confirmed-only write — the view
-    /// only updates after the next `/pull` (or live SSE wake-up)
-    /// brings the canonical row down.
-    pub fn no_optimistic(mut self) -> Self {
+    /// The view only updates after the next `/pull` (or live SSE
+    /// wake-up) brings the canonical row down. Use when the optimistic
+    /// shape is hard to predict (server-assigned fields beyond `id` +
+    /// `version`) or when showing a brief flicker is better than
+    /// showing a rolled-back row.
+    pub fn server_only(mut self) -> Self {
         self.optimistic = None;
         self
     }

--- a/crates/pocopine-sync-query/src/write.rs
+++ b/crates/pocopine-sync-query/src/write.rs
@@ -618,11 +618,26 @@ impl<Row, Id, Draft> TypedMutation<Row, Id, Draft> {
     /// every matching `QueryView`'s pending overlay. Without this,
     /// the mutation only becomes visible after the server confirms
     /// it (next `/pull`).
+    ///
+    /// Replaces any default optimistic closure attached by the
+    /// macro-emitted `Issue::create / update` (which auto-wire
+    /// `Self::from((id, draft))` via `From<(Id, Draft)>`).
     pub fn optimistic<F>(mut self, build: F) -> Self
     where
         F: FnOnce(&MutationPayload<Id, Draft>) -> Row + 'static,
     {
         self.optimistic = Some(Box::new(build));
+        self
+    }
+
+    /// Force this mutation to push WITHOUT an optimistic overlay.
+    /// Clears any default optimistic closure the macro attached.
+    ///
+    /// Use when you want a server-confirmed-only write — the view
+    /// only updates after the next `/pull` (or live SSE wake-up)
+    /// brings the canonical row down.
+    pub fn no_optimistic(mut self) -> Self {
+        self.optimistic = None;
         self
     }
 


### PR DESCRIPTION
## Summary

Two boilerplate reductions you flagged after praising the docs:

### Server side — `issues::resource(impl_)` convenience

Macro emits a sibling `resource<S>(impl_: S)` inside the per-resource module, pre-wiring `.id` (from row's literal `id` field), `.version_field` (when the row has a `version` field), and `.partition_by(row_to_params_typed)`. New typed sibling `row_to_params_typed(&Row)` mirrors the existing Value-shaped `row_to_params(&Value)` — same field-selection rules.

**Before:**

```rust
source("issues", store)?
    .id(|row: &Issue| row.id.clone())
    .version_field(|row| Ok(Some(RowVersion::new(&row.version)?)))
    .partition_by(issues::row_to_params)
    .mutation_log(...)
```

**After:**

```rust
issues::resource(store).mutation_log(...)
```

Each default is overridable — chain `.id(custom)` / `.partition_by(…)` / `.version_field(…)` to replace.

### Client side — auto-optimistic via `From<(Id, Draft)> for Row`

`Issue::create(id, draft)` and `Issue::update(id, draft, ev)` now carry a default optimistic-row closure computed from `Self::from((id.clone(), draft.clone()))`. The user impls `From<(Id, Draft)> for Row` once per resource (5–10 lines of field mapping); every typed write call drops its 10-line closure.

**Override:** `.optimistic(custom_closure)` (existing).
**Opt out:** new `TypedMutation::server_only()` — push as a server-only operation; the view updates after the server confirms.

`Issue::delete(id, ev)` is unchanged: no `From` bound; delete overlays key off `wire_row_key`, not a payload-built Row.

## Verification

- `cargo test -p pocopine-sync-query -p pocopine-sync-query-macros` — 160+ tests pass (4 new)
- `cargo clippy --target wasm32-unknown-unknown -p pocopine-sync-query -p pocopine-sync-query-macros -- -D warnings` — clean
- `cargo fmt --check` — clean

## Follow-up

PR #167 (docs) needs a rebase + small touch-ups to:
- Show `issues::resource(store)` in sync.md / sync-server.md
- Show `impl From<(String, IssueDraft)> for Issue` once, then bare `Issue::create(id, draft).push(&qc)` calls
- Mention `.server_only()` in sync-client.md

I'll rebase #167 on this once merged.

## Breaking

The `From<(Id, Draft)> for Row` bound is required for typed `create`/`update` calls. Apps using `#[query_resource(draft = …)]` need to add the impl OR continue using `TypedMutation::new(...)` directly. Test fixtures in the workspace updated to add the impl.