### PR TITLE
Make Pine Stylekit the default CSS stage (RFC 092 step 7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,11 +284,38 @@ decisions are in [`rfcs/`](./rfcs):
 | 006 | [`pp-teleport` dialogs / popovers / portals](./rfcs/rfc-006-pp-teleport.md) |
 | 007 | [`pp-for` keyed iteration](./rfcs/rfc-007-pp-for-keys.md) |
 
-## Styling with Tailwind / DaisyUI
+## Styling
 
-Tailwind v4 is a first-class option — opt in via `Cargo.toml` and
-`pocopine-cli` downloads the standalone Rust binary on first run,
-then spawns it alongside `wasm-pack`:
+**Pine Stylekit is the recommended way to style Pocopine apps** — a
+native utility-CSS compiler with Tailwind-shaped classes, compiled
+in-process at build time (no external watcher, no Node). It runs **by
+default**: write utility classes in your `.poco` templates, declare any
+colours in an `@theme` block, link `/pkg/stylekit.css`, and
+`pocopine build`/`dev` does the rest. It parses `.poco` with the real
+compiler (not text scanning), fails loud on typos with source spans, and
+ships Tailwind's default palette + a Preflight. See
+[`docs/pine-stylekit.md`](./docs/pine-stylekit.md).
+
+```html
+<!-- index.html -->
+<link rel="stylesheet" href="/pkg/stylekit.css" />
+```
+
+```css
+/* app.css — only needed if you use custom colours */
+@theme {
+  --color-surface: #ffffff;
+  --color-accent: oklch(0.54 0.13 252);
+}
+```
+
+### Tailwind / DaisyUI (fallback)
+
+Prefer Tailwind? It stays a first-class option — add a
+`[package.metadata.pocopine.tailwind]` block (with no `[stylekit]`
+block) and Stylekit defers to it. `pocopine-cli` downloads the
+standalone Rust binary on first run, then spawns it alongside
+`wasm-pack`:
 
 ```toml
 [package.metadata.pocopine.tailwind]

--- a/crates/pocopine-cli/src/args.rs
+++ b/crates/pocopine-cli/src/args.rs
@@ -46,10 +46,13 @@ pub struct BuildArgs {
     /// Build in release mode.
     #[arg(long)]
     pub release: bool,
-    /// Opt into the Pine Stylekit CSS stage even if the project has no
-    /// `[package.metadata.pocopine.stylekit]` block (RFC 092 D2).
+    /// Force the Pine Stylekit CSS stage on, even where it would
+    /// otherwise defer (e.g. a Tailwind-only project). On by default.
     #[arg(long)]
     pub stylekit: bool,
+    /// Skip the Pine Stylekit CSS stage (it runs by default, RFC 092).
+    #[arg(long = "no-stylekit", conflicts_with = "stylekit")]
+    pub no_stylekit: bool,
 }
 
 #[derive(Parser, Debug, Clone)]
@@ -67,9 +70,12 @@ pub struct ServeArgs {
     /// Build in release mode.
     #[arg(long)]
     pub release: bool,
-    /// Opt into the Pine Stylekit CSS stage (RFC 092 D2).
+    /// Force the Pine Stylekit CSS stage on. On by default.
     #[arg(long)]
     pub stylekit: bool,
+    /// Skip the Pine Stylekit CSS stage (it runs by default, RFC 092).
+    #[arg(long = "no-stylekit", conflicts_with = "stylekit")]
+    pub no_stylekit: bool,
 }
 
 #[derive(Parser, Debug, Clone)]

--- a/crates/pocopine-cli/src/config.rs
+++ b/crates/pocopine-cli/src/config.rs
@@ -22,9 +22,10 @@ pub struct PocopineConfig {
     /// the Tailwind standalone CLI alongside `wasm-pack` - one-shot
     /// on `build`/`run`, watch mode on `dev`.
     pub tailwind: Option<TailwindConfig>,
-    /// Opt into Pine Stylekit (RFC 092). When present — or when
-    /// `--stylekit` is passed — `pocopine-cli` compiles utility CSS
-    /// from `.poco` sources in-process, no external watcher.
+    /// Pine Stylekit (RFC 092). Runs by default; this block customizes
+    /// it (input/output/preflight) or opts out via `enabled = false`.
+    /// A project with a `[tailwind]` block but no `[stylekit]` block
+    /// defers to Tailwind instead.
     pub stylekit: Option<StylekitConfig>,
 }
 
@@ -48,6 +49,10 @@ pub struct StylekitConfig {
     /// `preflight = false` for pages that bring their own reset.
     #[serde(default = "default_sk_preflight")]
     pub preflight: bool,
+    /// Whether the stage runs. Defaults to `true`; set `enabled = false`
+    /// to keep this config block but opt out of the now-default stage.
+    #[serde(default = "default_sk_enabled")]
+    pub enabled: bool,
 }
 
 impl Default for StylekitConfig {
@@ -57,6 +62,7 @@ impl Default for StylekitConfig {
             output: default_sk_output(),
             src: default_sk_src(),
             preflight: default_sk_preflight(),
+            enabled: default_sk_enabled(),
         }
     }
 }
@@ -66,6 +72,10 @@ fn default_sk_input() -> String {
 }
 
 fn default_sk_preflight() -> bool {
+    true
+}
+
+fn default_sk_enabled() -> bool {
     true
 }
 

--- a/crates/pocopine-cli/src/dev.rs
+++ b/crates/pocopine-cli/src/dev.rs
@@ -51,9 +51,9 @@ pub fn run(args: &ServeArgs) -> Result<()> {
     // Pine Stylekit runs in-process (RFC 092 D2) — no watcher child.
     // The initial compile fails loud; later recompiles ride the src
     // watch tick below.
-    let stylekit_on = stylekit::enabled(&cfg, args.stylekit);
+    let stylekit_on = stylekit::enabled(&cfg, args.stylekit, args.no_stylekit);
     if stylekit_on {
-        stylekit::run_once(&project, &cfg, args.release)?;
+        stylekit::run_once(&project, &cfg, args.stylekit, args.release)?;
     }
 
     // Start the serving side. In bin mode the child owns its ports + routes.

--- a/crates/pocopine-cli/src/main.rs
+++ b/crates/pocopine-cli/src/main.rs
@@ -154,8 +154,8 @@ fn run_build(args: args::BuildArgs) -> Result<()> {
     if let Some(tw) = cfg.tailwind.as_ref() {
         tailwind::run_once(&project, tw, args.release)?;
     }
-    if stylekit::enabled(&cfg, args.stylekit) {
-        stylekit::run_once(&project, &cfg, args.release)?;
+    if stylekit::enabled(&cfg, args.stylekit, args.no_stylekit) {
+        stylekit::run_once(&project, &cfg, args.stylekit, args.release)?;
     }
     Ok(())
 }
@@ -170,8 +170,8 @@ fn run_project(args: args::ServeArgs) -> Result<()> {
     if let Some(tw) = cfg.tailwind.as_ref() {
         tailwind::run_once(&project, tw, args.release)?;
     }
-    if stylekit::enabled(&cfg, args.stylekit) {
-        stylekit::run_once(&project, &cfg, args.release)?;
+    if stylekit::enabled(&cfg, args.stylekit, args.no_stylekit) {
+        stylekit::run_once(&project, &cfg, args.stylekit, args.release)?;
     }
     server::run_project(&args.path, &cfg, args.release, args.port)
 }

--- a/crates/pocopine-cli/src/stylekit.rs
+++ b/crates/pocopine-cli/src/stylekit.rs
@@ -1,10 +1,12 @@
-//! Pine Stylekit build stage (RFC 092 D2/D6).
+//! Pine Stylekit build stage (RFC 092 D2/D6, step 7).
 //!
 //! Compiles utility CSS from a project's `.poco` sources in-process —
-//! no external watcher, no shelling out. Opt-in via `--stylekit` or a
-//! `[package.metadata.pocopine.stylekit]` block. Fails loud: on any
-//! error-severity diagnostic the build aborts and the stale stylesheet
-//! is left untouched rather than silently re-served.
+//! no external watcher, no shelling out. Runs **by default** (RFC 092
+//! step 7); opt out with `--no-stylekit` or `enabled = false`, and a
+//! Tailwind-only project (a `[tailwind]` block with no `[stylekit]`
+//! block) defers automatically. Fails loud: on any error-severity
+//! diagnostic the build aborts and the stale stylesheet is left
+//! untouched rather than silently re-served.
 
 use std::path::{Path, PathBuf};
 
@@ -13,14 +15,33 @@ use pocopine_stylekit::{compile_project, render, CompileOptions, ProjectCss, Sou
 
 use crate::config::{PocopineConfig, StylekitConfig};
 
-/// Whether the Stylekit stage should run: an explicit `--stylekit` flag
-/// or a configured `[…pocopine.stylekit]` block.
-pub fn enabled(cfg: &PocopineConfig, flag: bool) -> bool {
-    flag || cfg.stylekit.is_some()
+/// Whether the Stylekit stage should run (RFC 092 step 7 — on by
+/// default). Precedence: `--no-stylekit` off, `--stylekit` on, then the
+/// config block's `enabled`, else default on *unless* the project opted
+/// into Tailwind only (a `[tailwind]` block with no `[stylekit]` block).
+pub fn enabled(cfg: &PocopineConfig, force_on: bool, force_off: bool) -> bool {
+    if force_off {
+        return false;
+    }
+    if force_on {
+        return true;
+    }
+    match &cfg.stylekit {
+        Some(c) => c.enabled,
+        None => cfg.tailwind.is_none(),
+    }
 }
 
-/// Resolve the effective config (defaults when only `--stylekit` is
-/// passed with no config block).
+/// Whether Stylekit was *explicitly* requested (vs. defaulted on). When
+/// only defaulted, a missing input CSS is a silent skip rather than an
+/// error — config-less projects without an `app.css` just don't get a
+/// stylesheet.
+fn explicit(cfg: &PocopineConfig, force_on: bool) -> bool {
+    force_on || cfg.stylekit.is_some()
+}
+
+/// Resolve the effective config (defaults when Stylekit runs without a
+/// config block).
 fn resolve(cfg: &PocopineConfig) -> StylekitConfig {
     match &cfg.stylekit {
         Some(c) => StylekitConfig {
@@ -28,6 +49,7 @@ fn resolve(cfg: &PocopineConfig) -> StylekitConfig {
             output: c.output.clone(),
             src: c.src.clone(),
             preflight: c.preflight,
+            enabled: c.enabled,
         },
         None => StylekitConfig::default(),
     }
@@ -56,8 +78,21 @@ fn compile(project: &Path, scfg: &StylekitConfig) -> Result<(ProjectCss, Vec<Sou
 
 /// One-shot compile for `build` / `run` / dev startup. Renders every
 /// diagnostic; aborts the build (without writing) if any are errors.
-pub fn run_once(project: &Path, cfg: &PocopineConfig, _release: bool) -> Result<()> {
+///
+/// `force_on` is the `--stylekit` flag. When the stage is only
+/// defaulted on (not explicitly requested or configured) and the
+/// project has no input CSS, it's a silent no-op instead of an error —
+/// so config-less projects without an `app.css` aren't broken.
+pub fn run_once(
+    project: &Path,
+    cfg: &PocopineConfig,
+    force_on: bool,
+    _release: bool,
+) -> Result<()> {
     let scfg = resolve(cfg);
+    if !explicit(cfg, force_on) && !project.join(&scfg.input).exists() {
+        return Ok(());
+    }
     let (out, files) = compile(project, &scfg)?;
     report(&out, &files);
     if out.has_errors() {
@@ -82,6 +117,9 @@ pub fn run_once(project: &Path, cfg: &PocopineConfig, _release: bool) -> Result<
 /// with broken/partial output.
 pub fn recompile_quiet(project: &Path, cfg: &PocopineConfig) {
     let scfg = resolve(cfg);
+    if !project.join(&scfg.input).exists() {
+        return;
+    }
     match compile(project, &scfg) {
         Ok((out, files)) => {
             report(&out, &files);
@@ -175,4 +213,64 @@ pub fn run_command(path: &Path, dump: bool, docs: bool, metadata: bool) -> Resul
 #[allow(dead_code)]
 pub fn output_path(project: &Path, cfg: &PocopineConfig) -> PathBuf {
     project.join(resolve(cfg).output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{StylekitConfig, TailwindConfig};
+
+    #[test]
+    fn default_on_for_bare_project() {
+        // No CSS config at all → Stylekit runs (RFC 092 step 7).
+        assert!(enabled(&PocopineConfig::default(), false, false));
+    }
+
+    #[test]
+    fn tailwind_only_defers_but_flag_forces() {
+        let cfg = PocopineConfig {
+            tailwind: Some(TailwindConfig::default()),
+            ..Default::default()
+        };
+        assert!(!enabled(&cfg, false, false), "tailwind-only project defers");
+        assert!(enabled(&cfg, true, false), "--stylekit forces it on");
+    }
+
+    #[test]
+    fn config_enabled_flag_is_honored() {
+        let on = PocopineConfig {
+            stylekit: Some(StylekitConfig::default()),
+            ..Default::default()
+        };
+        assert!(enabled(&on, false, false));
+        let off = PocopineConfig {
+            stylekit: Some(StylekitConfig {
+                enabled: false,
+                ..StylekitConfig::default()
+            }),
+            ..Default::default()
+        };
+        assert!(!enabled(&off, false, false));
+    }
+
+    #[test]
+    fn no_stylekit_flag_overrides_everything() {
+        let cfg = PocopineConfig {
+            stylekit: Some(StylekitConfig::default()),
+            ..Default::default()
+        };
+        assert!(!enabled(&cfg, false, true));
+    }
+
+    #[test]
+    fn explicit_when_configured_or_forced() {
+        let bare = PocopineConfig::default();
+        assert!(!explicit(&bare, false));
+        assert!(explicit(&bare, true));
+        let configured = PocopineConfig {
+            stylekit: Some(StylekitConfig::default()),
+            ..Default::default()
+        };
+        assert!(explicit(&configured, false));
+    }
 }

--- a/docs/pine-stylekit.md
+++ b/docs/pine-stylekit.md
@@ -11,10 +11,11 @@ class grammar is familiar, but the supported set is the [catalog
 below](#utility-catalog) — that catalog *is* the contract. An unknown
 class is a build error with a suggestion, not a silent miss.
 
-> Status: experimental (RFC 092, Milestone 2). Ported examples:
-> `examples/file-browser` and `examples/tailwind`. The built-in Tailwind
-> colour palette and Preflight ship; Tailwind remains available as a
-> fallback.
+> **Pine Stylekit is the recommended way to style Pocopine apps**, and
+> runs **by default** (RFC 092 step 7) — `pocopine build`/`run`/`dev`
+> compile it in-process with no setup. Tailwind remains supported as an
+> opt-in fallback. Ported examples: `examples/file-browser` and
+> `examples/tailwind`.
 
 ## Why not just Tailwind?
 
@@ -31,35 +32,38 @@ Stylekit instead:
 - **Owns its tokens.** Your `@theme` block is the single source of
   truth, emitted to `:root` so the stylesheet is self-contained.
 
-## Enabling it
+## Using it
 
-Add a Stylekit block to your project's `Cargo.toml`:
-
-```toml
-[package.metadata.pocopine.stylekit]
-input = "app.css"          # CSS holding your @theme tokens
-output = "pkg/stylekit.css" # generated stylesheet
-src = "src"                 # directory scanned for .poco files
-preflight = true            # prepend the base reset (set false to opt out)
-```
-
-The output is self-contained: a base reset (Preflight), your `@theme`
-tokens emitted to `:root`, then the utilities. Set `preflight = false`
-if your page brings its own reset.
-
-Then link the output in `index.html`:
+Stylekit runs by default — `pocopine build`/`run`/`dev` compile your
+CSS in-process (no external watcher). All you do is link the output and,
+if you want colours, declare tokens:
 
 ```html
 <link rel="stylesheet" href="/pkg/stylekit.css" />
 ```
 
-`pocopine build` / `run` / `dev` now compile CSS in-process — no
-external watcher. Or opt in ad-hoc without a config block:
+A project with no `app.css` is a silent no-op, so this is zero-config
+for apps that don't (yet) use utilities.
 
-```sh
-pocopine build --stylekit
-pocopine dev --stylekit
+To customize paths or the base reset, add a config block:
+
+```toml
+[package.metadata.pocopine.stylekit]
+input = "app.css"          # CSS holding your @theme tokens (default)
+output = "pkg/stylekit.css" # generated stylesheet (default)
+src = "src"                 # directory scanned for .poco files (default)
+preflight = true            # prepend the base reset (false to opt out)
+enabled = true              # set false to opt out of the default stage
 ```
+
+The output is self-contained: a base reset (Preflight), your `@theme`
+tokens emitted to `:root`, then the utilities.
+
+**Opting out.** Pass `--no-stylekit`, set `enabled = false`, or — to use
+Tailwind instead — add a `[package.metadata.pocopine.tailwind]` block
+with no `[stylekit]` block (a Tailwind-only project defers
+automatically). `--stylekit` forces the stage on where it would
+otherwise defer.
 
 `pocopine dev` recompiles on every source change and, on a compile
 error, keeps the last good stylesheet while printing the diagnostic
@@ -158,14 +162,14 @@ human catalog below is regenerated with `pocopine stylekit --docs`.
 ## Migrating from Tailwind
 
 1. Keep your `@theme` tokens; remove `@import "tailwindcss"` and
-   `@source`.
-2. Add the `[package.metadata.pocopine.stylekit]` block.
-3. Run `pocopine build --stylekit` and fix the diagnostics — anything
-   outside the catalog (unsupported families) is flagged. Tailwind's
-   default palette (`slate-*`, `rose-*`, …) is built in, so those keep
-   working; a `@theme` token of the same name overrides it.
-4. Point `index.html` at `pkg/stylekit.css`. Keep the Tailwind block to
-   A/B compare during the experiment.
+   `@source`. Remove the `[package.metadata.pocopine.tailwind]` block so
+   Stylekit (the default) stops deferring to it.
+2. Run `pocopine build` and fix the diagnostics — anything outside the
+   catalog (unsupported families) is flagged. Tailwind's default palette
+   (`slate-*`, `rose-*`, …) is built in, so those keep working; a
+   `@theme` token of the same name overrides it.
+3. Point `index.html` at `pkg/stylekit.css`. To A/B compare, keep the
+   Tailwind block and add `--stylekit` to force both.
 
 ## Utility catalog
 


### PR DESCRIPTION
With Milestone 2 (#172, merged) closing the parity gate, this promotes Pine Stylekit from opt-in to **on by default** for `pocopine build`/`run`/`dev`, and documents it as the recommended way to style Pocopine apps.

## Behaviour

- **Default on.** A project with no CSS config gets Stylekit automatically.
- **Defers to Tailwind.** A project with a `[tailwind]` block and no `[stylekit]` block keeps using Tailwind — no double-compile, no breakage for existing Tailwind apps.
- **Safe no-op.** When defaulted on and the project has no input `app.css`, the stage skips silently, so config-less examples (counter, blog, …) build unchanged. An explicitly configured/forced run still errors on a missing input (fails loud).
- **Opt-outs.** `--no-stylekit` or `enabled = false`; `--stylekit` forces it on where it would otherwise defer.

## Why it's safe for CI

The `examples (wasm-pack)` job builds via `wasm-pack build` directly, **not** `pocopine build`, so flipping the CLI default doesn't touch it.

## Docs

- `README.md` styling section now leads with Stylekit (recommended); Tailwind reframed as the opt-in fallback.
- `docs/pine-stylekit.md`: "Using it" rewritten for default-on + opt-outs; status bumped.

## Testing

- 60 `pocopine-cli` tests incl. 5 new `enabled()` cases (default-on, tailwind-defer, `enabled=false`, `--no-stylekit`, explicit detection).
- 45 `pocopine-stylekit` tests green; `clippy -D warnings` + `cargo fmt --all -- --check` clean (pinned nightly).
- Smoke: `pocopine build` on `examples/counter` (no app.css) no-ops cleanly; `examples/tailwind`/`file-browser` still compile 0-diagnostic.

Closes the RFC 092 step-7 decision. Remaining non-blocking tail tracked in #172.