### PR TITLE
storage: memory-efficient native uploads (S3 multipart / GCS compose / Azure block blob) — #176 Phase 0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5704,6 +5704,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pocopine-codec"
+version = "0.1.0"
+dependencies = [
+ "base64",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "pocopine-core"
 version = "0.1.0"
 dependencies = [
@@ -5970,6 +5979,8 @@ dependencies = [
  "google-cloud-gax",
  "google-cloud-storage",
  "percent-encoding",
+ "pocopine-codec",
+ "pocopine-crypto",
  "pocopine-storage",
  "reqwest 0.13.4",
  "serde",
@@ -5986,8 +5997,8 @@ name = "pocopine-storage-s3"
 version = "0.1.0"
 dependencies = [
  "aws-sdk-s3",
- "base64",
  "bytes",
+ "pocopine-codec",
  "pocopine-crypto",
  "pocopine-storage",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5972,6 +5972,7 @@ dependencies = [
  "futures-util",
  "hmac 0.12.1",
  "percent-encoding",
+ "pocopine-codec",
  "pocopine-crypto",
  "pocopine-storage",
  "reqwest 0.13.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5972,6 +5972,7 @@ dependencies = [
  "futures-util",
  "hmac 0.12.1",
  "percent-encoding",
+ "pocopine-crypto",
  "pocopine-storage",
  "reqwest 0.13.4",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1625,17 +1625,20 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
+ "futures",
  "is-terminal",
  "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
  "plotters",
+ "rayon",
  "regex",
  "serde",
  "serde_derive",
  "serde_json",
  "tinytemplate",
+ "tokio",
  "walkdir",
 ]
 
@@ -1672,6 +1675,16 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
@@ -5927,6 +5940,7 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "bytes",
+ "criterion",
  "http-body-util",
  "js-sys",
  "pocopine",
@@ -6586,6 +6600,26 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "reactive_graph"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "md-5",
+ "md-5 0.11.0",
  "pin-project-lite",
  "sha1",
  "sha2 0.11.0",
@@ -4532,6 +4532,16 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
@@ -5713,6 +5723,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pocopine-crypto"
+version = "0.1.0"
+dependencies = [
+ "crc32c",
+ "md-5 0.10.6",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "pocopine-deploy"
 version = "0.1.0"
 dependencies = [
@@ -5903,10 +5922,10 @@ dependencies = [
  "js-sys",
  "pocopine",
  "pocopine-core",
+ "pocopine-crypto",
  "pocopine-server",
  "serde",
  "serde_json",
- "sha2 0.10.9",
  "tempfile",
  "time",
  "tokio",
@@ -5968,10 +5987,10 @@ version = "0.1.0"
 dependencies = [
  "aws-sdk-s3",
  "bytes",
+ "pocopine-crypto",
  "pocopine-storage",
  "serde",
  "serde_json",
- "sha2 0.10.9",
  "testcontainers",
  "testcontainers-modules",
  "time",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5986,6 +5986,7 @@ name = "pocopine-storage-s3"
 version = "0.1.0"
 dependencies = [
  "aws-sdk-s3",
+ "base64",
  "bytes",
  "pocopine-crypto",
  "pocopine-storage",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/pocopine-client-codegen",
     "crates/pocopine-cli",
     "crates/pocopine-core",
+    "crates/pocopine-crypto",
     "crates/pocopine-deploy",
     "crates/pocopine-deploy-fly",
     "crates/pocopine-deploy-railway",
@@ -94,6 +95,7 @@ pocopine-auth-credentials = { path = "crates/pocopine-auth-credentials", version
 pocopine-auth-jwt = { path = "crates/pocopine-auth-jwt", version = "0.1.0" }
 pocopine-client-codegen = { path = "crates/pocopine-client-codegen", version = "0.1.0" }
 pocopine-core = { path = "crates/pocopine-core", version = "0.1.0", default-features = false }
+pocopine-crypto = { path = "crates/pocopine-crypto", version = "0.1.0" }
 pocopine-deploy = { path = "crates/pocopine-deploy", version = "0.1.0" }
 pocopine-deploy-fly = { path = "crates/pocopine-deploy-fly", version = "0.1.0" }
 pocopine-deploy-railway = { path = "crates/pocopine-deploy-railway", version = "0.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "crates/pocopine-auth-jwt",
     "crates/pocopine-client-codegen",
     "crates/pocopine-cli",
+    "crates/pocopine-codec",
     "crates/pocopine-core",
     "crates/pocopine-crypto",
     "crates/pocopine-deploy",
@@ -94,6 +95,7 @@ pocopine-auth-client = { path = "crates/pocopine-auth-client", version = "0.1.0"
 pocopine-auth-credentials = { path = "crates/pocopine-auth-credentials", version = "0.1.0" }
 pocopine-auth-jwt = { path = "crates/pocopine-auth-jwt", version = "0.1.0" }
 pocopine-client-codegen = { path = "crates/pocopine-client-codegen", version = "0.1.0" }
+pocopine-codec = { path = "crates/pocopine-codec", version = "0.1.0" }
 pocopine-core = { path = "crates/pocopine-core", version = "0.1.0", default-features = false }
 pocopine-crypto = { path = "crates/pocopine-crypto", version = "0.1.0" }
 pocopine-deploy = { path = "crates/pocopine-deploy", version = "0.1.0" }

--- a/crates/pocopine-codec/Cargo.toml
+++ b/crates/pocopine-codec/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "pocopine-codec"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Shared encoding/codec utilities (base64, serde adapters) for the pocopine workspace."
+
+[dependencies]
+# `no_std` + `alloc`: base64 and serde both build without `std`.
+base64 = { version = "0.22", default-features = false, features = ["alloc"] }
+serde = { version = "1", default-features = false, features = ["alloc", "derive"] }
+
+[dev-dependencies]
+serde_json = "1"

--- a/crates/pocopine-codec/src/lib.rs
+++ b/crates/pocopine-codec/src/lib.rs
@@ -1,0 +1,115 @@
+//! Shared encoding / codec utilities for the pocopine workspace.
+//!
+//! The point of this crate is that crates never re-implement encoding helpers or
+//! their serde adapters. Today it covers base64; add new codecs here rather than
+//! inlining them per crate.
+//!
+//! ```
+//! use pocopine_codec::{base64_decode, base64_encode};
+//!
+//! assert_eq!(base64_encode(b"hi"), "aGk=");
+//! assert_eq!(base64_decode("aGk=").unwrap(), b"hi");
+//! ```
+//!
+//! For a `Vec<u8>` struct field that should serialize as a base64 string, use the
+//! [`base64_bytes`] serde adapter:
+//!
+//! ```
+//! use serde::{Deserialize, Serialize};
+//!
+//! #[derive(Serialize, Deserialize)]
+//! struct Chunk {
+//!     #[serde(with = "pocopine_codec::base64_bytes", default, skip_serializing_if = "Vec::is_empty")]
+//!     payload: Vec<u8>,
+//! }
+//! ```
+//!
+//! This crate is `no_std` (it only needs `alloc`).
+
+#![cfg_attr(not(test), no_std)]
+
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+pub use base64;
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine as _;
+
+/// Encode bytes as a standard (padded) base64 string.
+pub fn base64_encode(bytes: &[u8]) -> String {
+    STANDARD.encode(bytes)
+}
+
+/// Decode a standard (padded) base64 string.
+pub fn base64_decode(encoded: &str) -> Result<Vec<u8>, base64::DecodeError> {
+    STANDARD.decode(encoded)
+}
+
+/// Serde adapter for a `Vec<u8>` field encoded as a base64 string.
+///
+/// Use via `#[serde(with = "pocopine_codec::base64_bytes")]`. Pair with
+/// `#[serde(default, skip_serializing_if = "Vec::is_empty")]` to omit empty values.
+pub mod base64_bytes {
+    use alloc::string::String;
+    use alloc::vec::Vec;
+
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&super::base64_encode(bytes))
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Vec<u8>, D::Error> {
+        let encoded = String::deserialize(deserializer)?;
+        super::base64_decode(&encoded).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base64_round_trips() {
+        for input in [b"".as_slice(), b"a", b"hello world", &[0u8, 255, 128, 1]] {
+            let encoded = base64_encode(input);
+            assert_eq!(base64_decode(&encoded).unwrap(), input);
+        }
+    }
+
+    #[test]
+    fn known_base64_vectors() {
+        assert_eq!(base64_encode(b"hi"), "aGk=");
+        assert_eq!(base64_decode("aGk=").unwrap(), b"hi");
+    }
+
+    #[test]
+    fn invalid_base64_is_rejected() {
+        assert!(base64_decode("not valid base64!!!").is_err());
+    }
+
+    #[derive(serde::Serialize, serde::Deserialize, PartialEq, Debug)]
+    struct Chunk {
+        #[serde(with = "base64_bytes", default, skip_serializing_if = "Vec::is_empty")]
+        payload: Vec<u8>,
+    }
+
+    #[test]
+    fn serde_adapter_round_trips_and_omits_empty() {
+        let chunk = Chunk {
+            payload: alloc::vec![1, 2, 3, 4],
+        };
+        let json = serde_json::to_string(&chunk).unwrap();
+        assert!(json.contains("AQIDBA=="));
+        assert_eq!(serde_json::from_str::<Chunk>(&json).unwrap(), chunk);
+
+        let empty = Chunk {
+            payload: Vec::new(),
+        };
+        let json = serde_json::to_string(&empty).unwrap();
+        assert_eq!(json, "{}");
+        assert_eq!(serde_json::from_str::<Chunk>("{}").unwrap(), empty);
+    }
+}

--- a/crates/pocopine-crypto/Cargo.toml
+++ b/crates/pocopine-crypto/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "pocopine-crypto"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Centralized cryptographic hash and checksum primitives for the pocopine workspace."
+
+[dependencies]
+# `no_std` + `alloc`: all three hash crates build without `std` (they lose only
+# runtime CPU-feature detection / SIMD acceleration, never correctness).
+sha2 = { version = "0.10", default-features = false }
+md-5 = { version = "0.10", default-features = false }
+crc32c = { version = "0.6", default-features = false }

--- a/crates/pocopine-crypto/src/lib.rs
+++ b/crates/pocopine-crypto/src/lib.rs
@@ -1,0 +1,187 @@
+//! Centralized cryptographic hash and checksum primitives for the pocopine
+//! workspace.
+//!
+//! The point of this crate is that the rest of the workspace never reaches for
+//! `sha2`, `md-5`, or `crc32c` directly and never re-implements hex encoding or
+//! incremental hashing. Everything goes through one small, algorithm-agnostic
+//! API:
+//!
+//! ```
+//! use pocopine_crypto::{Algorithm, Hasher, digest_hex, sha256_hex};
+//!
+//! // One-shot.
+//! assert_eq!(sha256_hex(b""),
+//!     "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+//! assert_eq!(digest_hex(Algorithm::Crc32c, b""), "00000000");
+//!
+//! // Streaming (for data that never fits in one buffer).
+//! let mut hasher = Hasher::new(Algorithm::Sha256);
+//! hasher.update(b"hello ");
+//! hasher.update(b"world");
+//! let _hex = hasher.finalize_hex();
+//! ```
+//!
+//! The underlying crates are re-exported (`pocopine_crypto::{sha2, md5,
+//! crc32c}`) for the rare case a caller needs a primitive this API does not
+//! wrap yet — but prefer adding to this API over reaching for them.
+//!
+//! This crate is `no_std` (it only needs `alloc` for the returned hex
+//! `String`).
+
+#![cfg_attr(not(test), no_std)]
+
+extern crate alloc;
+
+use alloc::format;
+use alloc::string::String;
+
+pub use crc32c;
+pub use md5;
+pub use sha2;
+
+use md5::Md5;
+use sha2::{Digest, Sha256};
+
+/// A digest/checksum algorithm supported across the workspace.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum Algorithm {
+    /// SHA-256 — 32-byte cryptographic digest (64 hex chars).
+    Sha256,
+    /// MD5 — 16-byte digest (32 hex chars). Non-cryptographic; content
+    /// integrity / provider-compat only.
+    Md5,
+    /// CRC32C (Castagnoli) — 32-bit checksum (8 hex chars).
+    Crc32c,
+}
+
+impl Algorithm {
+    /// Lowercase canonical name (`"sha256"`, `"md5"`, `"crc32c"`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Algorithm::Sha256 => "sha256",
+            Algorithm::Md5 => "md5",
+            Algorithm::Crc32c => "crc32c",
+        }
+    }
+}
+
+/// Streaming, algorithm-agnostic hasher.
+///
+/// Feed bytes with [`Hasher::update`] as they stream and call
+/// [`Hasher::finalize_hex`] once. Use this when the data never fits in a single
+/// buffer (e.g. hashing an object as it streams from a storage backend).
+pub struct Hasher {
+    inner: Inner,
+}
+
+enum Inner {
+    Sha256(Sha256),
+    Md5(Md5),
+    Crc32c(u32),
+}
+
+impl Hasher {
+    /// Create a streaming hasher for `algorithm`.
+    pub fn new(algorithm: Algorithm) -> Self {
+        let inner = match algorithm {
+            Algorithm::Sha256 => Inner::Sha256(Sha256::new()),
+            Algorithm::Md5 => Inner::Md5(Md5::new()),
+            Algorithm::Crc32c => Inner::Crc32c(0),
+        };
+        Self { inner }
+    }
+
+    /// Absorb a chunk of bytes.
+    pub fn update(&mut self, bytes: &[u8]) {
+        match &mut self.inner {
+            Inner::Sha256(h) => h.update(bytes),
+            Inner::Md5(h) => h.update(bytes),
+            Inner::Crc32c(crc) => *crc = crc32c::crc32c_append(*crc, bytes),
+        }
+    }
+
+    /// Finish hashing and return the lowercase-hex digest.
+    pub fn finalize_hex(self) -> String {
+        match self.inner {
+            Inner::Sha256(h) => hex(h.finalize()),
+            Inner::Md5(h) => hex(h.finalize()),
+            Inner::Crc32c(crc) => format!("{crc:08x}"),
+        }
+    }
+}
+
+/// One-shot lowercase-hex digest of `bytes` under `algorithm`.
+pub fn digest_hex(algorithm: Algorithm, bytes: &[u8]) -> String {
+    match algorithm {
+        Algorithm::Sha256 => hex(Sha256::digest(bytes)),
+        Algorithm::Md5 => hex(Md5::digest(bytes)),
+        Algorithm::Crc32c => format!("{:08x}", crc32c::crc32c(bytes)),
+    }
+}
+
+/// One-shot SHA-256 hex digest.
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    digest_hex(Algorithm::Sha256, bytes)
+}
+
+/// One-shot MD5 hex digest.
+pub fn md5_hex(bytes: &[u8]) -> String {
+    digest_hex(Algorithm::Md5, bytes)
+}
+
+/// One-shot CRC32C hex digest.
+pub fn crc32c_hex(bytes: &[u8]) -> String {
+    digest_hex(Algorithm::Crc32c, bytes)
+}
+
+fn hex(bytes: impl AsRef<[u8]>) -> String {
+    use core::fmt::Write as _;
+    let bytes = bytes.as_ref();
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        // Writing a byte to a String is infallible.
+        let _ = write!(&mut out, "{byte:02x}");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_sha256_vectors() {
+        assert_eq!(
+            sha256_hex(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert_eq!(
+            sha256_hex(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn known_md5_vectors() {
+        assert_eq!(md5_hex(b""), "d41d8cd98f00b204e9800998ecf8427e");
+        assert_eq!(md5_hex(b"abc"), "900150983cd24fb0d6963f7d28e17f72");
+    }
+
+    #[test]
+    fn known_crc32c_vectors() {
+        // CRC32C of the empty input is 0.
+        assert_eq!(crc32c_hex(b""), "00000000");
+        // CRC32C("123456789") == 0xE3069283 (Castagnoli check value).
+        assert_eq!(crc32c_hex(b"123456789"), "e3069283");
+    }
+
+    #[test]
+    fn streaming_matches_one_shot() {
+        for alg in [Algorithm::Sha256, Algorithm::Md5, Algorithm::Crc32c] {
+            let mut hasher = Hasher::new(alg);
+            hasher.update(b"hello ");
+            hasher.update(b"world");
+            assert_eq!(hasher.finalize_hex(), digest_hex(alg, b"hello world"));
+        }
+    }
+}

--- a/crates/pocopine-storage-azure/Cargo.toml
+++ b/crates/pocopine-storage-azure/Cargo.toml
@@ -23,6 +23,7 @@ uuid = { version = "1", features = ["v4"] }
 base64 = "0.22"
 hmac = "0.12"
 percent-encoding = "2"
+pocopine-crypto = { workspace = true }
 reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
 sha2 = "0.10"
 testcontainers = { version = "0.23", features = ["http_wait"] }

--- a/crates/pocopine-storage-azure/Cargo.toml
+++ b/crates/pocopine-storage-azure/Cargo.toml
@@ -11,6 +11,8 @@ azure_core = "1"
 azure_storage_blob = "1"
 bytes = "1"
 futures-util = "0.3"
+pocopine-codec = { workspace = true }
+pocopine-crypto = { workspace = true }
 pocopine-storage = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/pocopine-storage-azure/src/state.rs
+++ b/crates/pocopine-storage-azure/src/state.rs
@@ -35,18 +35,30 @@ pub(crate) enum NativeUploadState {
     /// Legacy staged-object rewrite (download → extend → re-upload per append).
     #[default]
     LegacyProxy,
-    /// Native block blob: each `PATCH` stages one block (`Put Block`), and
-    /// completion assembles them with `Put Block List`. No bytes are re-written.
+    /// Native block blob: sub-block `PATCH` chunks are coalesced into a bounded
+    /// tail and flushed as blocks (`Put Block`); completion assembles them with
+    /// `Put Block List`. No bytes are re-written.
     Block(AzureBlockState),
 }
 
-/// Block-blob bookkeeping for one session. Block ids are derived from the index,
-/// so only the count of staged blocks is tracked.
+/// Block-blob bookkeeping for one session. Block ids are derived from the index
+/// (and the session id), so only counts/lengths are tracked.
 #[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
 pub(crate) struct AzureBlockState {
     /// Number of blocks staged so far; the next block uses index `next_index`.
     #[serde(default)]
     pub(crate) next_index: u64,
+    /// Total bytes already flushed to staged blocks (excludes the pending tail).
+    #[serde(default)]
+    pub(crate) flushed_len: u64,
+    /// Bytes received but not yet flushed to a block (smaller than one block,
+    /// except the final remainder at completion). Base64 inline in the metadata.
+    #[serde(
+        default,
+        with = "pocopine_codec::base64_bytes",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub(crate) pending_tail: Vec<u8>,
 }
 
 impl NativeUploadState {

--- a/crates/pocopine-storage-azure/src/state.rs
+++ b/crates/pocopine-storage-azure/src/state.rs
@@ -19,8 +19,57 @@ pub(crate) struct StoredUploadSession {
     pub(crate) completion_object_key: Option<String>,
     #[serde(default)]
     pub(crate) cleanup_pending: bool,
+    /// Transfer mechanism. Sessions written before native block-blob support
+    /// omit this field and deserialize as [`NativeUploadState::LegacyProxy`], so
+    /// in-flight uploads from an older build keep the staged-object rewrite path.
+    #[serde(default)]
+    pub(crate) native: NativeUploadState,
     #[serde(skip)]
     pub(crate) meta_etag: Option<String>,
+}
+
+/// Backend transfer mechanism for an upload session.
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum NativeUploadState {
+    /// Legacy staged-object rewrite (download → extend → re-upload per append).
+    #[default]
+    LegacyProxy,
+    /// Native block blob: each `PATCH` stages one block (`Put Block`), and
+    /// completion assembles them with `Put Block List`. No bytes are re-written.
+    Block(AzureBlockState),
+}
+
+/// Block-blob bookkeeping for one session. Block ids are derived from the index,
+/// so only the count of staged blocks is tracked.
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+pub(crate) struct AzureBlockState {
+    /// Number of blocks staged so far; the next block uses index `next_index`.
+    #[serde(default)]
+    pub(crate) next_index: u64,
+}
+
+impl NativeUploadState {
+    pub(crate) fn block(&self) -> Option<&AzureBlockState> {
+        match self {
+            NativeUploadState::Block(state) => Some(state),
+            NativeUploadState::LegacyProxy => None,
+        }
+    }
+
+    pub(crate) fn block_mut(&mut self) -> Option<&mut AzureBlockState> {
+        match self {
+            NativeUploadState::Block(state) => Some(state),
+            NativeUploadState::LegacyProxy => None,
+        }
+    }
+}
+
+/// Full object attributes including the ownership marker in custom metadata.
+pub(crate) struct AzureObjectAttrs {
+    pub(crate) etag: Option<String>,
+    pub(crate) version_id: Option<String>,
+    pub(crate) owner_session: Option<String>,
 }
 
 pub(crate) struct AzureObjectBytes {
@@ -115,6 +164,7 @@ mod tests {
             object: None,
             completion_object_key: None,
             cleanup_pending: false,
+            native: NativeUploadState::default(),
             meta_etag: None,
         };
         let bytes = serde_json::to_vec(&stored).unwrap();

--- a/crates/pocopine-storage-azure/src/storage.rs
+++ b/crates/pocopine-storage-azure/src/storage.rs
@@ -48,11 +48,34 @@ const MAX_SESSION_METADATA_BYTES: u64 = 256 * 1024;
 /// underscores.
 const SESSION_OWNER_META_KEY: &str = "pocopine_upload_session";
 
-/// Deterministic, fixed-width block id for a block index. Azure requires every
-/// block id in a blob to be the same (pre-base64) length, and the id is stable
-/// per index so a retried `PATCH` re-stages the same block.
-fn block_id(index: u64) -> Vec<u8> {
-    format!("{index:016x}").into_bytes()
+/// Azure allows at most 50,000 committed blocks per blob. Blocks are sized so the
+/// count never exceeds this for an upload up to the backend's size cap.
+const AZURE_MAX_BLOCKS: u64 = 50_000;
+
+/// Floor for a coalesced block, to bound the block count and per-append churn.
+const MIN_BLOCK_SIZE: u64 = 1024 * 1024;
+
+/// Session-isolated, fixed-width block id for a block index.
+///
+/// Azure block ids must be <= 64 base64 bytes and equal-length within a single
+/// commit. A 96-bit token derived from the session id namespaces the (otherwise
+/// per-blob) uncommitted block space so a different upload targeting the same
+/// destination key can never contribute blocks to our commit. The id is stable
+/// per (session, index) so a retried `PATCH` re-stages the same block.
+fn block_id(session: &UploadSessionId, index: u64) -> Vec<u8> {
+    let token = &pocopine_crypto::sha256_hex(session.as_str().as_bytes())[..24];
+    format!("{token}{index:012x}").into_bytes()
+}
+
+/// Block size for a session whose maximum object size is `max_bytes`. Scaled
+/// (rounded to a whole MiB) so the block count stays within [`AZURE_MAX_BLOCKS`];
+/// never below [`MIN_BLOCK_SIZE`]. For the default 64 MiB cap this is 1 MiB.
+fn block_size_for(max_bytes: u64) -> u64 {
+    let by_count = max_bytes
+        .div_ceil(AZURE_MAX_BLOCKS)
+        .div_ceil(MIN_BLOCK_SIZE)
+        * MIN_BLOCK_SIZE;
+    by_count.max(MIN_BLOCK_SIZE)
 }
 
 #[derive(Clone, Debug)]
@@ -217,8 +240,17 @@ impl AzureBlobStorageBackend {
         session: &UploadSessionId,
     ) -> StorageResult<AzureObjectBytes> {
         let key = self.layout.session_meta_key(session);
-        self.get_object_bytes_with_limit(&key, MAX_SESSION_METADATA_BYTES)
+        self.get_object_bytes_with_limit(&key, self.session_metadata_read_limit())
             .await
+    }
+
+    /// Read cap for `session.json`. Native block sessions buffer their tail inline
+    /// (base64), so the cap must accommodate one block plus the fixed metadata,
+    /// above the bare [`MAX_SESSION_METADATA_BYTES`] used for the non-tail fields.
+    fn session_metadata_read_limit(&self) -> u64 {
+        block_size_for(self.max_proxy_upload_bytes)
+            .saturating_mul(2)
+            .saturating_add(MAX_SESSION_METADATA_BYTES)
     }
 
     async fn create_session(
@@ -699,8 +731,14 @@ impl AzureBlobStorageBackend {
 
     /// Stage one block (`Put Block`). Re-staging the same index overwrites the
     /// uncommitted block, so retries are idempotent.
-    async fn stage_block(&self, object_key: &str, index: u64, bytes: Bytes) -> StorageResult<()> {
-        let id = block_id(index);
+    async fn stage_block(
+        &self,
+        object_key: &str,
+        session: &UploadSessionId,
+        index: u64,
+        bytes: Bytes,
+    ) -> StorageResult<()> {
+        let id = block_id(session, index);
         let len = bytes.len() as u64;
         let content: RequestContent<Bytes, NoFormat> = bytes.into();
         self.container
@@ -723,7 +761,7 @@ impl AzureBlobStorageBackend {
         no_overwrite: bool,
     ) -> StorageResult<AzureObjectWrite> {
         let blocklist = BlockLookupList {
-            latest: Some((0..count).map(block_id).collect()),
+            latest: Some((0..count).map(|index| block_id(session, index)).collect()),
             ..Default::default()
         };
         let mut options = BlockBlobClientCommitBlockListOptions {
@@ -861,14 +899,34 @@ impl AzureBlobStorageBackend {
         if bytes.is_empty() {
             return Ok(stored.public);
         }
-        let index = stored.native.block().expect("block state").next_index;
         let object_key = self.layout.object_key(stored.storage_key.key.as_str());
-        // Stage the block first; the index is only recorded once the metadata
-        // write below lands, so a crash leaves the durable offset unchanged and a
-        // retry re-stages the same (idempotent) block.
-        self.stage_block(&object_key, index, bytes).await?;
+
+        // Coalesce sub-block chunks so the committed block count stays within
+        // Azure's 50,000-block limit. The tail is durable in `stored` until the
+        // single atomic metadata write below.
+        let tail =
+            std::mem::take(&mut stored.native.block_mut().expect("block state").pending_tail);
+        let combined: Bytes = if tail.is_empty() {
+            bytes
+        } else {
+            let mut combined = tail;
+            combined.extend_from_slice(&bytes);
+            Bytes::from(combined)
+        };
+        let block_size = block_size_for(stored.max_bytes) as usize;
+        let mut pos = 0usize;
+        while combined.len() - pos >= block_size {
+            let index = stored.native.block().expect("block state").next_index;
+            let part = combined.slice(pos..pos + block_size);
+            self.stage_block(&object_key, session, index, part).await?;
+            if let Some(state) = stored.native.block_mut() {
+                state.next_index = index + 1;
+                state.flushed_len += block_size as u64;
+            }
+            pos += block_size;
+        }
         if let Some(state) = stored.native.block_mut() {
-            state.next_index = index + 1;
+            state.pending_tail = combined.slice(pos..).to_vec();
         }
         stored.public.next_offset = Some(new_offset);
         self.write_session(session, &mut stored).await?;
@@ -892,17 +950,12 @@ impl AzureBlobStorageBackend {
         ensure_size_limit(stored.max_bytes, stored.public.size, total)?;
         let object_key = self.layout.object_key(stored.storage_key.key.as_str());
 
-        let (written, checksum) = match self
+        // complete_with_blocks owns session-state changes on failure: it reopens
+        // for pre-commit errors, and terminally aborts on a post-commit checksum
+        // mismatch (the consumed blocks cannot be re-committed).
+        let (written, checksum) = self
             .complete_with_blocks(session, &mut stored, &object_key, provided_checksum)
-            .await
-        {
-            Ok(pair) => pair,
-            Err(err) => {
-                self.reopen_if_object_absent(session, &mut stored, &object_key)
-                    .await;
-                return Err(err);
-            }
-        };
+            .await?;
 
         let object = self.object_ref(&stored, total, written, checksum);
         stored.public.status = UploadSessionStatus::Complete;
@@ -925,7 +978,6 @@ impl AzureBlobStorageBackend {
         // committing, while the session is still resumable.
         precheck_checksum(&stored.checksum_policy, provided_checksum.as_ref())?;
         let total = stored.public.next_offset.unwrap_or(0);
-        let count = stored.native.block().expect("block state").next_index;
 
         // HEAD on every attempt: adopt our own already-committed blob (matched by
         // the ownership marker), reject a foreign one. `If-None-Match: *` on the
@@ -937,6 +989,8 @@ impl AzureBlobStorageBackend {
                     version_id: attrs.version_id,
                 }
             } else {
+                // Foreign blob (session still Open here): reject without
+                // overwriting.
                 return Err(StorageError::policy_rejected(format!(
                     "Azure blob key already exists: {object_key}"
                 )));
@@ -951,6 +1005,37 @@ impl AzureBlobStorageBackend {
                 stored.completion_object_key = Some(object_key.to_string());
                 self.write_session(session, stored).await?;
             }
+            // Flush the final remainder as the last block. Failures here are
+            // pre-commit (blocks not yet consumed), so reopen for retry.
+            let tail = stored
+                .native
+                .block()
+                .expect("block state")
+                .pending_tail
+                .clone();
+            if !tail.is_empty() {
+                let index = stored.native.block().expect("block state").next_index;
+                let tail_len = tail.len() as u64;
+                if let Err(err) = self
+                    .stage_block(object_key, session, index, Bytes::from(tail))
+                    .await
+                {
+                    self.reopen_if_object_absent(session, stored, object_key)
+                        .await;
+                    return Err(err);
+                }
+                if let Some(state) = stored.native.block_mut() {
+                    state.next_index = index + 1;
+                    state.flushed_len += tail_len;
+                    state.pending_tail = Vec::new();
+                }
+                if let Err(err) = self.write_session(session, stored).await {
+                    self.reopen_if_object_absent(session, stored, object_key)
+                        .await;
+                    return Err(err);
+                }
+            }
+            let count = stored.native.block().expect("block state").next_index;
             match self
                 .commit_block_list(
                     object_key,
@@ -964,30 +1049,49 @@ impl AzureBlobStorageBackend {
                 Ok(written) => written,
                 Err(StorageError::Conflict { .. }) => {
                     // A blob appeared at the key during completion; adopt it only
-                    // if it is ours.
-                    match self.get_object_attrs(object_key).await? {
-                        Some(attrs) if attrs.owner_session.as_deref() == Some(session.as_str()) => {
+                    // if it is ours, otherwise reject and reopen for the owner.
+                    match self.get_object_attrs(object_key).await {
+                        Ok(Some(attrs))
+                            if attrs.owner_session.as_deref() == Some(session.as_str()) =>
+                        {
                             AzureObjectWrite {
                                 etag: attrs.etag,
                                 version_id: attrs.version_id,
                             }
                         }
-                        _ => {
+                        Ok(_) => {
+                            self.reopen_if_object_absent(session, stored, object_key)
+                                .await;
                             return Err(StorageError::policy_rejected(format!(
                                 "Azure blob key already exists: {object_key}"
-                            )))
+                            )));
+                        }
+                        Err(err) => {
+                            self.reopen_if_object_absent(session, stored, object_key)
+                                .await;
+                            return Err(err);
                         }
                     }
                 }
-                Err(err) => return Err(err),
+                Err(err) => {
+                    // Commit failed without consuming the blocks; reopen unless our
+                    // blob is actually live (a lost response), in which case a
+                    // retry adopts it.
+                    self.reopen_if_object_absent(session, stored, object_key)
+                        .await;
+                    return Err(err);
+                }
             }
         };
 
+        // Validate the checksum by streaming the committed blob.
         let checksum = match checksum_algorithm_to_compute(
             &stored.checksum_policy,
             provided_checksum.as_ref(),
         ) {
             Some(algorithm) => {
+                // A transient read failure leaves the blob live and the session
+                // Completing, so a retry adopts and re-verifies it.
                 let computed = self.stream_object_checksum(object_key, algorithm).await?;
                 match validate_complete_checksum_precomputed(
                     &stored.checksum_policy,
@@ -996,18 +1100,14 @@ impl AzureBlobStorageBackend {
                 ) {
                     Ok(checksum) => checksum,
                     Err(err) => {
-                        // Remove the committed-but-invalid blob; surface a delete
-                        // failure (a live invalid object is worse).
-                        self.delete_object(object_key).await.map_err(|delete_err| {
-                            tracing::error!(
-                                target: "pocopine.log",
-                                event_name = "pocopine.storage.azure_invalid_object_cleanup_failed",
-                                object_key = %object_key,
-                                checksum_error = %err,
-                                delete_error = %delete_err,
-                            );
-                            delete_err
-                        })?;
+                        // The bytes do not match the supplied checksum. The blocks
+                        // were already consumed by the commit, so this upload cannot
+                        // be re-committed: delete the invalid blob and mark the
+                        // session terminally aborted (the client must re-initiate)
+                        // rather than reopening it to a state that cannot succeed.
+                        let _ = self.delete_object(object_key).await;
+                        stored.public.status = UploadSessionStatus::Aborted;
+                        let _ = self.write_session(session, stored).await;
                         return Err(err);
                     }
                 }

--- a/crates/pocopine-storage-azure/src/storage.rs
+++ b/crates/pocopine-storage-azure/src/storage.rs
@@ -1,9 +1,13 @@
 use std::sync::Arc;
 
+use std::collections::HashMap;
+
 use azure_core::http::{Etag, NoFormat, RequestContent};
 use azure_storage_blob::models::{
     BlobClientDeleteOptions, BlobClientDownloadOptions, BlobClientGetPropertiesResultHeaders,
-    BlobClientUploadOptions, DeleteSnapshotsOptionType, HttpRange,
+    BlobClientUploadOptions, BlockBlobClientCommitBlockListOptions,
+    BlockBlobClientCommitBlockListResultHeaders, BlockLookupList, DeleteSnapshotsOptionType,
+    HttpRange,
 };
 use azure_storage_blob::{BlobContainerClient, BlobServiceClient};
 use bytes::Bytes;
@@ -13,18 +17,21 @@ use pocopine_storage::backend_common::{
     ensure_upload_length_can_be_set, expires_at, selected_strategy, UploadSessionLockCleanup,
     UploadSessionLockRegistry,
 };
-use pocopine_storage::checksum::{ensure_supported_checksum_policy, validate_complete_checksum};
+use pocopine_storage::checksum::{
+    checksum_algorithm_to_compute, ensure_supported_checksum_policy, precheck_checksum,
+    validate_complete_checksum, validate_complete_checksum_precomputed, StreamingChecksum,
+};
 use pocopine_storage::{
-    CompleteUpload, InitiateUpload, ObjectChecksum, ObjectRef, StorageActor, StorageBackend,
-    StorageBoxFuture, StorageContext, StorageError, StorageResult, TransferPlan, UploadSession,
-    UploadSessionId, UploadSessionStatus, UploadStrategy,
+    ChecksumAlgorithm, CompleteUpload, InitiateUpload, ObjectChecksum, ObjectRef, StorageActor,
+    StorageBackend, StorageBoxFuture, StorageContext, StorageError, StorageResult, TransferPlan,
+    UploadSession, UploadSessionId, UploadSessionStatus, UploadStrategy,
 };
 use uuid::Uuid;
 
 use crate::layout::{AzureKeyLayout, DEFAULT_INTERNAL_PREFIX};
 use crate::state::{
-    decode_session_object, AbortSessionRead, AzureObjectBytes, AzureObjectMetadata,
-    AzureObjectWrite, StoredUploadSession,
+    decode_session_object, AbortSessionRead, AzureObjectAttrs, AzureObjectBytes,
+    AzureObjectMetadata, AzureObjectWrite, NativeUploadState, StoredUploadSession,
 };
 use crate::util::{
     azure_error, bytes_match_at, ensure_completable, is_azure_already_exists, is_azure_not_found,
@@ -34,6 +41,19 @@ use crate::util::{
 const DEFAULT_BACKEND_NAME: &str = "azure";
 const DEFAULT_MAX_PROXY_UPLOAD_BYTES: u64 = 64 * 1024 * 1024;
 const MAX_SESSION_METADATA_BYTES: u64 = 256 * 1024;
+
+/// Blob custom-metadata key stamping the owning upload session onto the final
+/// committed blob, so a retry can recognize its own object after a crash.
+/// Azure metadata names must be valid C# identifiers (no hyphens), hence the
+/// underscores.
+const SESSION_OWNER_META_KEY: &str = "pocopine_upload_session";
+
+/// Deterministic, fixed-width block id for a block index. Azure requires every
+/// block id in a blob to be the same (pre-base64) length, and the id is stable
+/// per index so a retried `PATCH` re-stages the same block.
+fn block_id(index: u64) -> Vec<u8> {
+    format!("{index:016x}").into_bytes()
+}
 
 #[derive(Clone, Debug)]
 enum BlobWritePrecondition {
@@ -674,6 +694,460 @@ impl AzureBlobStorageBackend {
             metadata,
         }
     }
+
+    // --- native block-blob helpers --------------------------------------------
+
+    /// Stage one block (`Put Block`). Re-staging the same index overwrites the
+    /// uncommitted block, so retries are idempotent.
+    async fn stage_block(&self, object_key: &str, index: u64, bytes: Bytes) -> StorageResult<()> {
+        let id = block_id(index);
+        let len = bytes.len() as u64;
+        let content: RequestContent<Bytes, NoFormat> = bytes.into();
+        self.container
+            .blob_client(object_key)
+            .block_blob_client()
+            .stage_block(&id, len, content, None)
+            .await
+            .map_err(|err| azure_error("stage block", err))?;
+        Ok(())
+    }
+
+    /// Assemble blocks `0..count` into the destination blob (`Put Block List`),
+    /// stamping the owning session and (optionally) refusing to overwrite.
+    async fn commit_block_list(
+        &self,
+        object_key: &str,
+        count: u64,
+        content_type: Option<&str>,
+        session: &UploadSessionId,
+        no_overwrite: bool,
+    ) -> StorageResult<AzureObjectWrite> {
+        let blocklist = BlockLookupList {
+            latest: Some((0..count).map(block_id).collect()),
+            ..Default::default()
+        };
+        let mut options = BlockBlobClientCommitBlockListOptions {
+            metadata: Some(HashMap::from([(
+                SESSION_OWNER_META_KEY.to_string(),
+                session.as_str().to_string(),
+            )])),
+            ..Default::default()
+        };
+        if let Some(content_type) = content_type {
+            options.blob_content_type = Some(content_type.to_string());
+        }
+        if no_overwrite {
+            options.if_none_match = Some(Etag::from("*"));
+        }
+        let content = blocklist
+            .try_into()
+            .map_err(|err| azure_error("encode block list", err))?;
+        let response = self
+            .container
+            .blob_client(object_key)
+            .block_blob_client()
+            .commit_block_list(content, Some(options))
+            .await
+            .map_err(|err| {
+                if is_azure_precondition_failed(&err) || is_azure_already_exists(&err) {
+                    StorageError::conflict("Azure blob write precondition failed")
+                } else {
+                    azure_error("commit block list", err)
+                }
+            })?;
+        Ok(AzureObjectWrite {
+            etag: response
+                .etag()
+                .map_err(|err| azure_error("read commit etag", err))?
+                .map(|etag| etag.to_string()),
+            version_id: response
+                .version_id()
+                .map_err(|err| azure_error("read commit version id", err))?,
+        })
+    }
+
+    /// Fetch a blob's etag/version plus the ownership marker in custom metadata.
+    /// `None` when the blob does not exist.
+    async fn get_object_attrs(&self, key: &str) -> StorageResult<Option<AzureObjectAttrs>> {
+        match self.container.blob_client(key).get_properties(None).await {
+            Ok(response) => {
+                let etag = response
+                    .etag()
+                    .map_err(|err| azure_error("read blob etag", err))?
+                    .map(|etag| etag.to_string());
+                let version_id = response
+                    .version_id()
+                    .map_err(|err| azure_error("read blob version id", err))?;
+                let owner_session = response
+                    .metadata()
+                    .map_err(|err| azure_error("read blob metadata", err))?
+                    .get(SESSION_OWNER_META_KEY)
+                    .cloned();
+                Ok(Some(AzureObjectAttrs {
+                    etag,
+                    version_id,
+                    owner_session,
+                }))
+            }
+            Err(err) if is_azure_not_found(&err) => Ok(None),
+            Err(err) => Err(azure_error("read blob metadata", err)),
+        }
+    }
+
+    /// Stream the committed blob through `algorithm` without buffering it.
+    async fn stream_object_checksum(
+        &self,
+        key: &str,
+        algorithm: ChecksumAlgorithm,
+    ) -> StorageResult<ObjectChecksum> {
+        let response = self
+            .container
+            .blob_client(key)
+            .download(None)
+            .await
+            .map_err(|err| azure_error("download blob for checksum", err))?;
+        let mut body = response.body;
+        let mut hasher = StreamingChecksum::new(algorithm);
+        while let Some(chunk) = body.next().await {
+            let chunk = chunk.map_err(|err| azure_error("read blob body for checksum", err))?;
+            hasher.update(&chunk);
+        }
+        Ok(hasher.finalize())
+    }
+
+    /// Reopen a failed completion ONLY when the destination blob is definitively
+    /// absent or foreign (see the GCS backend for the rationale). An
+    /// indeterminate lookup keeps the session `Completing`.
+    async fn reopen_if_object_absent(
+        &self,
+        session: &UploadSessionId,
+        stored: &mut StoredUploadSession,
+        object_key: &str,
+    ) {
+        let absent_or_foreign = match self.get_object_attrs(object_key).await {
+            Ok(None) => true,
+            Ok(Some(attrs)) => attrs.owner_session.as_deref() != Some(session.as_str()),
+            Err(_) => false,
+        };
+        if absent_or_foreign {
+            stored.public.status = UploadSessionStatus::Open;
+            stored.completion_object_key = None;
+            let _ = self.write_session(session, stored).await;
+        }
+    }
+
+    // --- native block-blob upload flow ----------------------------------------
+
+    async fn append_block(
+        &self,
+        session: &UploadSessionId,
+        mut stored: StoredUploadSession,
+        offset: u64,
+        bytes: Bytes,
+    ) -> StorageResult<UploadSession> {
+        let expected = stored.public.next_offset.unwrap_or(0);
+        if expected != offset {
+            tracing::debug!(
+                target: "pocopine.log",
+                event_name = "pocopine.storage.offset_mismatch",
+                session = %session,
+                expected,
+                provided = offset,
+            );
+            return Err(StorageError::offset_mismatch(expected, offset));
+        }
+        let new_offset = checked_new_offset(offset, bytes.len())?;
+        ensure_size_limit(stored.max_bytes, stored.public.size, new_offset)?;
+        if bytes.is_empty() {
+            return Ok(stored.public);
+        }
+        let index = stored.native.block().expect("block state").next_index;
+        let object_key = self.layout.object_key(stored.storage_key.key.as_str());
+        // Stage the block first; the index is only recorded once the metadata
+        // write below lands, so a crash leaves the durable offset unchanged and a
+        // retry re-stages the same (idempotent) block.
+        self.stage_block(&object_key, index, bytes).await?;
+        if let Some(state) = stored.native.block_mut() {
+            state.next_index = index + 1;
+        }
+        stored.public.next_offset = Some(new_offset);
+        self.write_session(session, &mut stored).await?;
+        Ok(stored.public)
+    }
+
+    async fn complete_block(
+        &self,
+        session: &UploadSessionId,
+        mut stored: StoredUploadSession,
+        provided_checksum: Option<ObjectChecksum>,
+    ) -> StorageResult<ObjectRef> {
+        let total = stored.public.next_offset.unwrap_or(0);
+        if let Some(expected) = stored.public.size {
+            if total != expected {
+                return Err(StorageError::policy_rejected(format!(
+                    "upload is incomplete: expected {expected} bytes, got {total}"
+                )));
+            }
+        }
+        ensure_size_limit(stored.max_bytes, stored.public.size, total)?;
+        let object_key = self.layout.object_key(stored.storage_key.key.as_str());
+
+        let (written, checksum) = match self
+            .complete_with_blocks(session, &mut stored, &object_key, provided_checksum)
+            .await
+        {
+            Ok(pair) => pair,
+            Err(err) => {
+                self.reopen_if_object_absent(session, &mut stored, &object_key)
+                    .await;
+                return Err(err);
+            }
+        };
+
+        let object = self.object_ref(&stored, total, written, checksum);
+        stored.public.status = UploadSessionStatus::Complete;
+        stored.public.next_offset = Some(total);
+        stored.object = Some(object.clone());
+        self.write_session(session, &mut stored).await?;
+        Ok(object)
+    }
+
+    /// Finalize a block session. The caller reopens the (possibly `Completing`)
+    /// session on any error.
+    async fn complete_with_blocks(
+        &self,
+        session: &UploadSessionId,
+        stored: &mut StoredUploadSession,
+        object_key: &str,
+        provided_checksum: Option<ObjectChecksum>,
+    ) -> StorageResult<(AzureObjectWrite, Option<ObjectChecksum>)> {
+        // Reject a missing-required / disallowed-algorithm checksum before
+        // committing, while the session is still resumable.
+        precheck_checksum(&stored.checksum_policy, provided_checksum.as_ref())?;
+        let total = stored.public.next_offset.unwrap_or(0);
+        let count = stored.native.block().expect("block state").next_index;
+
+        // HEAD on every attempt: adopt our own already-committed blob (matched by
+        // the ownership marker), reject a foreign one. `If-None-Match: *` on the
+        // commit closes the TOCTOU window.
+        let written = if let Some(attrs) = self.get_object_attrs(object_key).await? {
+            if attrs.owner_session.as_deref() == Some(session.as_str()) {
+                AzureObjectWrite {
+                    etag: attrs.etag,
+                    version_id: attrs.version_id,
+                }
+            } else {
+                return Err(StorageError::policy_rejected(format!(
+                    "Azure blob key already exists: {object_key}"
+                )));
+            }
+        } else {
+            if stored.public.status == UploadSessionStatus::Open
+                || stored.public.next_offset != Some(total)
+                || stored.completion_object_key.as_deref() != Some(object_key)
+            {
+                stored.public.status = UploadSessionStatus::Completing;
+                stored.public.next_offset = Some(total);
+                stored.completion_object_key = Some(object_key.to_string());
+                self.write_session(session, stored).await?;
+            }
+            match self
+                .commit_block_list(
+                    object_key,
+                    count,
+                    stored.public.content_type.as_deref(),
+                    session,
+                    true,
+                )
+                .await
+            {
+                Ok(written) => written,
+                Err(StorageError::Conflict { .. }) => {
+                    // A blob appeared at the key during completion; adopt it only
+                    // if it is ours.
+                    match self.get_object_attrs(object_key).await? {
+                        Some(attrs) if attrs.owner_session.as_deref() == Some(session.as_str()) => {
+                            AzureObjectWrite {
+                                etag: attrs.etag,
+                                version_id: attrs.version_id,
+                            }
+                        }
+                        _ => {
+                            return Err(StorageError::policy_rejected(format!(
+                                "Azure blob key already exists: {object_key}"
+                            )))
+                        }
+                    }
+                }
+                Err(err) => return Err(err),
+            }
+        };
+
+        let checksum = match checksum_algorithm_to_compute(
+            &stored.checksum_policy,
+            provided_checksum.as_ref(),
+        ) {
+            Some(algorithm) => {
+                let computed = self.stream_object_checksum(object_key, algorithm).await?;
+                match validate_complete_checksum_precomputed(
+                    &stored.checksum_policy,
+                    Some(computed),
+                    provided_checksum,
+                ) {
+                    Ok(checksum) => checksum,
+                    Err(err) => {
+                        // Remove the committed-but-invalid blob; surface a delete
+                        // failure (a live invalid object is worse).
+                        self.delete_object(object_key).await.map_err(|delete_err| {
+                            tracing::error!(
+                                target: "pocopine.log",
+                                event_name = "pocopine.storage.azure_invalid_object_cleanup_failed",
+                                object_key = %object_key,
+                                checksum_error = %err,
+                                delete_error = %delete_err,
+                            );
+                            delete_err
+                        })?;
+                        return Err(err);
+                    }
+                }
+            }
+            None => validate_complete_checksum_precomputed(
+                &stored.checksum_policy,
+                None,
+                provided_checksum,
+            )?,
+        };
+        Ok((written, checksum))
+    }
+
+    // --- legacy staged-object rewrite flow (pre-block sessions) ---------------
+
+    async fn append_legacy(
+        &self,
+        session: &UploadSessionId,
+        mut stored: StoredUploadSession,
+        offset: u64,
+        bytes: Bytes,
+    ) -> StorageResult<UploadSession> {
+        let expected = stored.public.next_offset.unwrap_or(0);
+        let new_offset = checked_new_offset(offset, bytes.len())?;
+        let read_limit = expected
+            .max(new_offset)
+            .checked_add(1)
+            .ok_or_else(|| StorageError::policy_rejected("upload byte offset overflowed"))?;
+        let mut staged_object = self.get_staged_bytes(session, read_limit).await?;
+        let staged_len = staged_object.bytes.len() as u64;
+        if expected != offset {
+            if new_offset == expected
+                && bytes_match_at(&staged_object.bytes, offset, bytes.as_ref())?
+            {
+                return Ok(stored.public);
+            }
+            tracing::debug!(
+                target: "pocopine.log",
+                event_name = "pocopine.storage.offset_mismatch",
+                session = %session,
+                expected,
+                provided = offset,
+            );
+            return Err(StorageError::offset_mismatch(expected, offset));
+        }
+        if staged_len > expected {
+            if staged_len == new_offset
+                && bytes_match_at(&staged_object.bytes, expected, bytes.as_ref())?
+            {
+                stored.public.next_offset = Some(new_offset);
+                self.write_session(session, &mut stored).await?;
+                return Ok(stored.public);
+            }
+            tracing::warn!(
+                target: "pocopine.log",
+                event_name = "pocopine.storage.azure_staged_bytes_truncated",
+                session = %session,
+                actual = staged_len,
+                trusted = expected,
+            );
+            staged_object.bytes.truncate(usize_from_u64(expected)?);
+            let written = self
+                .put_staged_bytes(
+                    session,
+                    Bytes::from(staged_object.bytes.clone()),
+                    staged_object
+                        .etag
+                        .clone()
+                        .map(BlobWritePrecondition::IfMatch),
+                )
+                .await?;
+            staged_object.etag = written.etag;
+        } else if staged_len < expected {
+            return Err(StorageError::backend(format!(
+                "Azure staged upload blob is shorter than committed metadata: expected {expected} bytes, got {staged_len}"
+            )));
+        }
+        ensure_size_limit(stored.max_bytes, stored.public.size, new_offset)?;
+        staged_object.bytes.extend_from_slice(&bytes);
+        self.put_staged_bytes(
+            session,
+            Bytes::from(staged_object.bytes),
+            staged_object.etag.map(BlobWritePrecondition::IfMatch),
+        )
+        .await?;
+        stored.public.next_offset = Some(new_offset);
+        self.write_session(session, &mut stored).await?;
+        Ok(stored.public)
+    }
+
+    async fn complete_legacy(
+        &self,
+        session: &UploadSessionId,
+        mut stored: StoredUploadSession,
+        provided_checksum: Option<ObjectChecksum>,
+    ) -> StorageResult<ObjectRef> {
+        let trusted = stored.public.next_offset.unwrap_or(0);
+        let staged = self.reconcile_staged_bytes(session, trusted).await?;
+        let actual = staged.len() as u64;
+        if let Some(expected) = stored.public.size {
+            if actual != expected {
+                return Err(StorageError::policy_rejected(format!(
+                    "upload is incomplete: expected {expected} bytes, got {actual}"
+                )));
+            }
+        }
+        ensure_size_limit(stored.max_bytes, stored.public.size, actual)?;
+        let checksum =
+            validate_complete_checksum(&stored.checksum_policy, &staged, provided_checksum)?;
+        let object_key = self.layout.object_key(stored.storage_key.key.as_str());
+        if stored.public.status == UploadSessionStatus::Open
+            || stored.public.next_offset != Some(actual)
+            || stored.completion_object_key.as_deref() != Some(object_key.as_str())
+        {
+            stored.public.status = UploadSessionStatus::Completing;
+            stored.public.next_offset = Some(actual);
+            stored.completion_object_key = Some(object_key.clone());
+            self.write_session(session, &mut stored).await?;
+        }
+        let staged = Bytes::from(staged);
+        let written = match self
+            .put_completed_object(&object_key, staged, stored.public.content_type.as_deref())
+            .await
+        {
+            Ok(written) => written,
+            Err(err) => {
+                return Err(self
+                    .rollback_completion_after_error(session, &mut stored, err)
+                    .await);
+            }
+        };
+        let object = self.object_ref(&stored, actual, written, checksum);
+        stored.public.status = UploadSessionStatus::Complete;
+        stored.public.next_offset = Some(actual);
+        stored.object = Some(object.clone());
+        stored.cleanup_pending = true;
+        self.write_session(session, &mut stored).await?;
+        self.cleanup_staged_bytes(session, &mut stored).await?;
+        Ok(object)
+    }
 }
 
 impl StorageBackend for AzureBlobStorageBackend {
@@ -725,18 +1199,12 @@ impl StorageBackend for AzureBlobStorageBackend {
                 object: None,
                 completion_object_key: None,
                 cleanup_pending: false,
+                native: NativeUploadState::Block(Default::default()),
                 meta_etag: None,
             };
+            // Native sessions stage blocks directly against the destination blob;
+            // there is no separate staged `bytes.tmp` object to create up front.
             self.create_session(&id, &mut stored).await?;
-            if let Err(err) = self
-                .put_staged_bytes(&id, Bytes::new(), Some(BlobWritePrecondition::IfNotExists))
-                .await
-            {
-                let _ = self
-                    .delete_object_if_exists(&self.layout.session_meta_key(&id))
-                    .await;
-                return Err(err);
-            }
             Ok(session)
         })
     }
@@ -752,7 +1220,10 @@ impl StorageBackend for AzureBlobStorageBackend {
             let _guard = lock.lock().await;
             let stored = self.read_session(&session).await?;
             ensure_owner(&ctx.actor, &stored.owner)?;
-            if stored.public.status == UploadSessionStatus::Open {
+            // Native block sessions keep an authoritative offset in the metadata;
+            // only the legacy staged-object path reconciles against storage.
+            if stored.public.status == UploadSessionStatus::Open && stored.native.block().is_none()
+            {
                 self.ensure_staged_not_shorter_than_metadata(
                     &session,
                     stored.public.next_offset.unwrap_or(0),
@@ -779,8 +1250,10 @@ impl StorageBackend for AzureBlobStorageBackend {
             self.persist_expired_if_needed(&session, &mut stored)
                 .await?;
             let committed_offset = stored.public.next_offset.unwrap_or(0);
-            self.ensure_staged_not_shorter_than_metadata(&session, committed_offset)
-                .await?;
+            if stored.native.block().is_none() {
+                self.ensure_staged_not_shorter_than_metadata(&session, committed_offset)
+                    .await?;
+            }
             ensure_upload_length_can_be_set(
                 stored.max_bytes,
                 &stored.public,
@@ -814,72 +1287,11 @@ impl StorageBackend for AzureBlobStorageBackend {
                     "Azure backend currently supports sequential proxy uploads only",
                 ));
             }
-            let expected = stored.public.next_offset.unwrap_or(0);
-            let new_offset = checked_new_offset(offset, bytes.len())?;
-            let read_limit = expected
-                .max(new_offset)
-                .checked_add(1)
-                .ok_or_else(|| StorageError::policy_rejected("upload byte offset overflowed"))?;
-            let mut staged_object = self.get_staged_bytes(&session, read_limit).await?;
-            let staged_len = staged_object.bytes.len() as u64;
-            if expected != offset {
-                if new_offset == expected
-                    && bytes_match_at(&staged_object.bytes, offset, bytes.as_ref())?
-                {
-                    return Ok(stored.public);
-                }
-                tracing::debug!(
-                    target: "pocopine.log",
-                    event_name = "pocopine.storage.offset_mismatch",
-                    session = %session,
-                    expected,
-                    provided = offset,
-                );
-                return Err(StorageError::offset_mismatch(expected, offset));
+            if stored.native.block().is_some() {
+                self.append_block(&session, stored, offset, bytes).await
+            } else {
+                self.append_legacy(&session, stored, offset, bytes).await
             }
-            if staged_len > expected {
-                if staged_len == new_offset
-                    && bytes_match_at(&staged_object.bytes, expected, bytes.as_ref())?
-                {
-                    stored.public.next_offset = Some(new_offset);
-                    self.write_session(&session, &mut stored).await?;
-                    return Ok(stored.public);
-                }
-                tracing::warn!(
-                    target: "pocopine.log",
-                    event_name = "pocopine.storage.azure_staged_bytes_truncated",
-                    session = %session,
-                    actual = staged_len,
-                    trusted = expected,
-                );
-                staged_object.bytes.truncate(usize_from_u64(expected)?);
-                let written = self
-                    .put_staged_bytes(
-                        &session,
-                        Bytes::from(staged_object.bytes.clone()),
-                        staged_object
-                            .etag
-                            .clone()
-                            .map(BlobWritePrecondition::IfMatch),
-                    )
-                    .await?;
-                staged_object.etag = written.etag;
-            } else if staged_len < expected {
-                return Err(StorageError::backend(format!(
-                    "Azure staged upload blob is shorter than committed metadata: expected {expected} bytes, got {staged_len}"
-                )));
-            }
-            ensure_size_limit(stored.max_bytes, stored.public.size, new_offset)?;
-            staged_object.bytes.extend_from_slice(&bytes);
-            self.put_staged_bytes(
-                &session,
-                Bytes::from(staged_object.bytes),
-                staged_object.etag.map(BlobWritePrecondition::IfMatch),
-            )
-            .await?;
-            stored.public.next_offset = Some(new_offset);
-            self.write_session(&session, &mut stored).await?;
-            Ok(stored.public)
         })
     }
 
@@ -903,52 +1315,14 @@ impl StorageBackend for AzureBlobStorageBackend {
             self.persist_expired_if_needed(&request.session, &mut stored)
                 .await?;
             ensure_completable(&stored.public)?;
-            let trusted = stored.public.next_offset.unwrap_or(0);
-            let staged = self
-                .reconcile_staged_bytes(&request.session, trusted)
-                .await?;
-            let actual = staged.len() as u64;
-            if let Some(expected) = stored.public.size {
-                if actual != expected {
-                    return Err(StorageError::policy_rejected(format!(
-                        "upload is incomplete: expected {expected} bytes, got {actual}"
-                    )));
-                }
+            let session = request.session.clone();
+            if stored.native.block().is_some() {
+                self.complete_block(&session, stored, request.checksum)
+                    .await
+            } else {
+                self.complete_legacy(&session, stored, request.checksum)
+                    .await
             }
-            ensure_size_limit(stored.max_bytes, stored.public.size, actual)?;
-            let checksum =
-                validate_complete_checksum(&stored.checksum_policy, &staged, request.checksum)?;
-            let object_key = self.layout.object_key(stored.storage_key.key.as_str());
-            if stored.public.status == UploadSessionStatus::Open
-                || stored.public.next_offset != Some(actual)
-                || stored.completion_object_key.as_deref() != Some(object_key.as_str())
-            {
-                stored.public.status = UploadSessionStatus::Completing;
-                stored.public.next_offset = Some(actual);
-                stored.completion_object_key = Some(object_key.clone());
-                self.write_session(&request.session, &mut stored).await?;
-            }
-            let staged = Bytes::from(staged);
-            let written = match self
-                .put_completed_object(&object_key, staged, stored.public.content_type.as_deref())
-                .await
-            {
-                Ok(written) => written,
-                Err(err) => {
-                    return Err(self
-                        .rollback_completion_after_error(&request.session, &mut stored, err)
-                        .await);
-                }
-            };
-            let object = self.object_ref(&stored, actual, written, checksum);
-            stored.public.status = UploadSessionStatus::Complete;
-            stored.public.next_offset = Some(actual);
-            stored.object = Some(object.clone());
-            stored.cleanup_pending = true;
-            self.write_session(&request.session, &mut stored).await?;
-            self.cleanup_staged_bytes(&request.session, &mut stored)
-                .await?;
-            Ok(object)
         })
     }
 

--- a/crates/pocopine-storage-azure/src/storage.rs
+++ b/crates/pocopine-storage-azure/src/storage.rs
@@ -1105,9 +1105,33 @@ impl AzureBlobStorageBackend {
                         // be re-committed: delete the invalid blob and mark the
                         // session terminally aborted (the client must re-initiate)
                         // rather than reopening it to a state that cannot succeed.
-                        let _ = self.delete_object(object_key).await;
+                        //
+                        // Surface a failure of either cleanup step — a live invalid
+                        // blob, or a session left `Completing` with consumed blocks,
+                        // is more severe than the checksum rejection.
+                        self.delete_object(object_key).await.map_err(|delete_err| {
+                            tracing::error!(
+                                target: "pocopine.log",
+                                event_name = "pocopine.storage.azure_invalid_object_cleanup_failed",
+                                object_key = %object_key,
+                                checksum_error = %err,
+                                delete_error = %delete_err,
+                            );
+                            delete_err
+                        })?;
                         stored.public.status = UploadSessionStatus::Aborted;
-                        let _ = self.write_session(session, stored).await;
+                        self.write_session(session, stored)
+                            .await
+                            .map_err(|write_err| {
+                                tracing::error!(
+                                    target: "pocopine.log",
+                                    event_name = "pocopine.storage.azure_abort_persist_failed",
+                                    object_key = %object_key,
+                                    checksum_error = %err,
+                                    write_error = %write_err,
+                                );
+                                write_err
+                            })?;
                         return Err(err);
                     }
                 }

--- a/crates/pocopine-storage-azure/src/storage.rs
+++ b/crates/pocopine-storage-azure/src/storage.rs
@@ -1108,17 +1108,21 @@ impl AzureBlobStorageBackend {
                         //
                         // Surface a failure of either cleanup step — a live invalid
                         // blob, or a session left `Completing` with consumed blocks,
-                        // is more severe than the checksum rejection.
-                        self.delete_object(object_key).await.map_err(|delete_err| {
-                            tracing::error!(
-                                target: "pocopine.log",
-                                event_name = "pocopine.storage.azure_invalid_object_cleanup_failed",
-                                object_key = %object_key,
-                                checksum_error = %err,
-                                delete_error = %delete_err,
-                            );
-                            delete_err
-                        })?;
+                        // is more severe than the checksum rejection. An
+                        // already-absent blob (a retry after a prior cleanup) is
+                        // fine and must still advance to the abort write.
+                        self.delete_object_if_exists(object_key)
+                            .await
+                            .map_err(|delete_err| {
+                                tracing::error!(
+                                    target: "pocopine.log",
+                                    event_name = "pocopine.storage.azure_invalid_object_cleanup_failed",
+                                    object_key = %object_key,
+                                    checksum_error = %err,
+                                    delete_error = %delete_err,
+                                );
+                                delete_err
+                            })?;
                         stored.public.status = UploadSessionStatus::Aborted;
                         self.write_session(session, stored)
                             .await

--- a/crates/pocopine-storage-azure/tests/azurite.rs
+++ b/crates/pocopine-storage-azure/tests/azurite.rs
@@ -794,3 +794,42 @@ async fn block_complete_does_not_overwrite_existing_object_key() -> StorageResul
     );
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn block_buffers_large_inline_tail_in_metadata_against_azurite() -> StorageResult<()> {
+    let container = create_container("block-tail").await;
+    let backend = AzureBlobStorageBackend::new(container.client())?;
+    // 500 KiB stays below the 1 MiB block size, so it is buffered entirely in the
+    // inline (base64) tail — over the 256 KiB non-tail metadata bound. inspect +
+    // complete must still read the session metadata.
+    let total = 500 * 1024usize;
+    let session = initiate_large_checked(
+        &backend,
+        "files/tail.bin",
+        total as u64,
+        ChecksumPolicy::None,
+    )
+    .await?;
+    backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, pattern_bytes(0, total))
+        .await?;
+
+    let inspected = backend.inspect_upload(&ctx(), session.id.clone()).await?;
+    assert_eq!(inspected.next_offset, Some(total as u64));
+
+    let object = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(object.size, total as u64);
+    assert_eq!(
+        object_bytes(&container, "files/tail.bin").await,
+        pattern_bytes(0, total).to_vec()
+    );
+    Ok(())
+}

--- a/crates/pocopine-storage-azure/tests/azurite.rs
+++ b/crates/pocopine-storage-azure/tests/azurite.rs
@@ -17,9 +17,9 @@ use bytes::Bytes;
 use hmac::{Hmac, Mac};
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use pocopine_storage::{
-    CompleteUpload, InitiateUpload, PrincipalRef, SafeObjectKey, StorageActor, StorageBackend,
-    StorageContext, StorageError, StorageKey, StorageResult, UploadPolicy, UploadSession,
-    UploadSessionStatus, UploadStrategy,
+    ChecksumAlgorithm, ChecksumPolicy, CompleteUpload, InitiateUpload, ObjectChecksum,
+    PrincipalRef, SafeObjectKey, StorageActor, StorageBackend, StorageContext, StorageError,
+    StorageKey, StorageResult, UploadPolicy, UploadSession, UploadSessionStatus, UploadStrategy,
 };
 use pocopine_storage_azure::AzureBlobStorageBackend;
 use sha2::Sha256;
@@ -445,22 +445,35 @@ async fn duplicate_append_retry_after_staged_write_advances_metadata() -> Storag
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn append_refreshes_staged_etag_after_truncating_rogue_bytes() -> StorageResult<()> {
+async fn rogue_staged_object_does_not_corrupt_native_upload() -> StorageResult<()> {
     let container = create_container("truncate-append").await;
     let backend = AzureBlobStorageBackend::new(container.client())?;
     let session = initiate(&backend, Some(6)).await?;
+    // Native block sessions stage blocks against the destination blob; the legacy
+    // `bytes.tmp` staging object is not part of the protocol, so a rogue one must
+    // not affect the committed result.
     let bytes_key = session_object_key(&backend, &session, "bytes.tmp");
 
     backend
         .append_upload_bytes(&ctx(), session.id.clone(), 0, Bytes::from_static(b"abc"))
         .await?;
     put_object(&container, bytes_key.clone(), b"abcjunk").await;
-
     let updated = backend
         .append_upload_bytes(&ctx(), session.id.clone(), 3, Bytes::from_static(b"def"))
         .await?;
     assert_eq!(updated.next_offset, Some(6));
-    assert_eq!(object_bytes(&container, &bytes_key).await, b"abcdef");
+
+    let object = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(object.size, 6);
+    assert_eq!(object_bytes(&container, "files/hello.txt").await, b"abcdef");
     Ok(())
 }
 
@@ -503,15 +516,15 @@ async fn non_system_actor_cannot_abort_corrupt_upload_metadata() -> StorageResul
     let backend = AzureBlobStorageBackend::new(container.client())?;
     let session = initiate(&backend, Some(5)).await?;
     let meta_key = session_object_key(&backend, &session, "session.json");
-    let bytes_key = session_object_key(&backend, &session, "bytes.tmp");
     put_object(&container, meta_key.clone(), b"{not-json").await;
 
     let rejected = backend
         .abort_upload(&principal_ctx("tenant-b"), session.id.clone())
         .await;
     assert!(matches!(rejected, Err(StorageError::Forbidden { .. })));
+    // The refused abort left the (corrupt) session metadata in place. Native
+    // sessions have no separate `bytes.tmp` staging object to check.
     assert!(blob_exists(&container, &meta_key).await);
-    assert!(blob_exists(&container, &bytes_key).await);
 
     backend.abort_upload(&ctx(), session.id).await?;
     Ok(())
@@ -585,5 +598,199 @@ async fn initiate_rejects_policy_above_proxy_cap_for_streaming_upload() -> Stora
         rejected,
         Err(StorageError::PayloadTooLarge { limit: 8 })
     ));
+    Ok(())
+}
+
+fn large_policy() -> StorageResult<UploadPolicy> {
+    let mut policy = UploadPolicy::new("azure")?
+        .max_bytes(32 * 1024 * 1024)
+        .preferred_chunk_size(1024 * 1024);
+    policy.expires_after = Duration::from_secs(60 * 60);
+    Ok(policy)
+}
+
+async fn initiate_large_checked(
+    backend: &AzureBlobStorageBackend,
+    key: &str,
+    size: u64,
+    checksum: ChecksumPolicy,
+) -> StorageResult<UploadSession> {
+    let mut policy = large_policy()?;
+    policy.checksum = checksum;
+    backend
+        .initiate_upload(
+            &ctx(),
+            InitiateUpload {
+                scope: "files".to_string(),
+                storage_key: StorageKey::new(SafeObjectKey::parse(key)?),
+                file_name: "large.bin".to_string(),
+                size: Some(size),
+                content_type: Some("application/octet-stream".to_string()),
+                metadata: BTreeMap::new(),
+                requested_strategy: UploadStrategy::Auto,
+                policy,
+            },
+        )
+        .await
+}
+
+fn pattern_bytes(start: usize, len: usize) -> Bytes {
+    let mut buf = Vec::with_capacity(len);
+    for i in 0..len {
+        buf.push(((start + i) % 251) as u8);
+    }
+    Bytes::from(buf)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn block_upload_assembles_multiple_blocks_against_azurite() -> StorageResult<()> {
+    let container = create_container("blocks").await;
+    let backend = AzureBlobStorageBackend::new(container.client())?;
+    let chunk = 1024 * 1024usize;
+    let total = 4 * chunk;
+    let session = initiate_large_checked(
+        &backend,
+        "files/large.bin",
+        total as u64,
+        ChecksumPolicy::None,
+    )
+    .await?;
+
+    let mut offset = 0u64;
+    for index in 0..4 {
+        let updated = backend
+            .append_upload_bytes(
+                &ctx(),
+                session.id.clone(),
+                offset,
+                pattern_bytes(index * chunk, chunk),
+            )
+            .await?;
+        offset += chunk as u64;
+        assert_eq!(updated.next_offset, Some(offset));
+    }
+
+    let object = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(object.size, total as u64);
+    assert_eq!(
+        object_bytes(&container, "files/large.bin").await,
+        pattern_bytes(0, total).to_vec()
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn block_completion_is_idempotent_against_azurite() -> StorageResult<()> {
+    let container = create_container("block-idem").await;
+    let backend = AzureBlobStorageBackend::new(container.client())?;
+    let total = 3 * 1024 * 1024usize;
+    let session = initiate_large_checked(
+        &backend,
+        "files/large.bin",
+        total as u64,
+        ChecksumPolicy::None,
+    )
+    .await?;
+    backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, pattern_bytes(0, total))
+        .await?;
+
+    let first = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id.clone(),
+                checksum: None,
+            },
+        )
+        .await?;
+    let second = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(first, second);
+    assert_eq!(first.size, total as u64);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn block_upload_verifies_streaming_sha256_against_azurite() -> StorageResult<()> {
+    let container = create_container("block-sha").await;
+    let backend = AzureBlobStorageBackend::new(container.client())?;
+    let total = 3 * 1024 * 1024usize;
+    let data = pattern_bytes(0, total);
+    let expected = ObjectChecksum {
+        algorithm: ChecksumAlgorithm::Sha256,
+        value: pocopine_crypto::sha256_hex(&data),
+    };
+    let session = initiate_large_checked(
+        &backend,
+        "files/checked.bin",
+        total as u64,
+        ChecksumPolicy::Required(ChecksumAlgorithm::Sha256),
+    )
+    .await?;
+    backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, data)
+        .await?;
+
+    let object = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: Some(expected.clone()),
+            },
+        )
+        .await?;
+    assert_eq!(object.checksum, Some(expected));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn block_complete_does_not_overwrite_existing_object_key() -> StorageResult<()> {
+    let container = create_container("block-collision").await;
+    put_object(&container, "files/large.bin", b"existing").await;
+
+    let backend = AzureBlobStorageBackend::new(container.client())?;
+    let total = 2 * 1024 * 1024usize;
+    let session = initiate_large_checked(
+        &backend,
+        "files/large.bin",
+        total as u64,
+        ChecksumPolicy::None,
+    )
+    .await?;
+    backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, pattern_bytes(0, total))
+        .await?;
+
+    let rejected = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await;
+    assert!(matches!(rejected, Err(StorageError::PolicyRejected { .. })));
+    assert_eq!(
+        object_bytes(&container, "files/large.bin").await,
+        b"existing"
+    );
     Ok(())
 }

--- a/crates/pocopine-storage-gcs/Cargo.toml
+++ b/crates/pocopine-storage-gcs/Cargo.toml
@@ -11,6 +11,7 @@ bytes = "1"
 google-cloud-storage = "1"
 google-cloud-gax = "1"
 percent-encoding = "2"
+pocopine-codec = { workspace = true }
 pocopine-storage = { workspace = true }
 reqwest = { version = "0.13", default-features = false, features = ["json", "query", "rustls"] }
 serde = { workspace = true }
@@ -22,5 +23,6 @@ uuid = { version = "1", features = ["v4"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 google-cloud-auth = "1"
+pocopine-crypto = { workspace = true }
 testcontainers = { version = "0.23", features = ["http_wait"] }
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/crates/pocopine-storage-gcs/src/control.rs
+++ b/crates/pocopine-storage-gcs/src/control.rs
@@ -1,12 +1,32 @@
+use std::collections::BTreeMap;
 use std::time::Duration;
 
 use google_cloud_gax::options::RequestOptionsBuilder;
 use google_cloud_storage::client::StorageControl;
+use google_cloud_storage::model::compose_object_request::SourceObject;
+use google_cloud_storage::model::Object;
 use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 use pocopine_storage::{StorageError, StorageResult};
 
 use crate::layout::GcsKeyLayout;
-use crate::util::{gcs_error, is_gcs_not_found};
+use crate::state::{GcsObjectAttrs, GcsObjectWrite};
+use crate::util::{gcs_error, is_gcs_not_found, is_gcs_precondition_failed, non_empty};
+
+/// One source component for a compose request.
+pub(crate) struct ComposeSource {
+    pub(crate) key: String,
+    pub(crate) generation: Option<i64>,
+}
+
+/// A request to assemble `sources` into the destination object `dest_key`.
+pub(crate) struct ComposeRequest<'a> {
+    pub(crate) dest_key: &'a str,
+    pub(crate) content_type: Option<&'a str>,
+    pub(crate) metadata: BTreeMap<String, String>,
+    pub(crate) sources: Vec<ComposeSource>,
+    /// `Some(0)` refuses to overwrite an existing destination object.
+    pub(crate) if_generation_match: Option<i64>,
+}
 
 const JSON_CONTROL_TIMEOUT: Duration = Duration::from_secs(30);
 const GCS_JSON_PATH_ENCODE_SET: &AsciiSet = &CONTROLS
@@ -46,6 +66,112 @@ impl GcsControl {
             Self::Json(control) => control.delete_object(layout, key).await,
         }
     }
+
+    pub(crate) async fn compose_object(
+        &self,
+        layout: &GcsKeyLayout,
+        request: ComposeRequest<'_>,
+    ) -> StorageResult<GcsObjectWrite> {
+        match self {
+            Self::Google(control) => compose_with_google_control(control, layout, request).await,
+            Self::Json(control) => control.compose_object(layout, request).await,
+        }
+    }
+
+    /// Fetch an object's etag/generation plus the value of its `marker_key`
+    /// custom-metadata entry. `None` when the object does not exist.
+    pub(crate) async fn get_object_attrs(
+        &self,
+        layout: &GcsKeyLayout,
+        key: &str,
+        marker_key: &str,
+    ) -> StorageResult<Option<GcsObjectAttrs>> {
+        match self {
+            Self::Google(control) => {
+                get_object_attrs_with_google_control(control, layout, key, marker_key).await
+            }
+            Self::Json(control) => control.get_object_attrs(layout, key, marker_key).await,
+        }
+    }
+}
+
+async fn get_object_attrs_with_google_control(
+    control: &StorageControl,
+    layout: &GcsKeyLayout,
+    key: &str,
+    marker_key: &str,
+) -> StorageResult<Option<GcsObjectAttrs>> {
+    match control
+        .get_object()
+        .set_bucket(layout.bucket_resource())
+        .set_object(key)
+        .send()
+        .await
+    {
+        Ok(object) => Ok(Some(GcsObjectAttrs {
+            etag: non_empty(object.etag),
+            generation: if object.generation > 0 {
+                Some(object.generation)
+            } else {
+                None
+            },
+            owner_session: object.metadata.get(marker_key).cloned(),
+        })),
+        Err(err) if is_gcs_not_found(&err) => Ok(None),
+        Err(err) => Err(gcs_error("get object", err)),
+    }
+}
+
+async fn compose_with_google_control(
+    control: &StorageControl,
+    layout: &GcsKeyLayout,
+    request: ComposeRequest<'_>,
+) -> StorageResult<GcsObjectWrite> {
+    let mut destination = Object::new()
+        .set_bucket(layout.bucket_resource())
+        .set_name(request.dest_key)
+        .set_metadata(request.metadata);
+    if let Some(content_type) = request.content_type {
+        destination = destination.set_content_type(content_type);
+    }
+    let sources: Vec<SourceObject> = request
+        .sources
+        .iter()
+        .map(|source| {
+            let builder = SourceObject::new().set_name(source.key.clone());
+            match source.generation {
+                Some(generation) => builder.set_generation(generation),
+                None => builder,
+            }
+        })
+        .collect();
+    let mut builder = control
+        .compose_object()
+        .set_destination(destination)
+        .set_source_objects(sources);
+    if let Some(generation) = request.if_generation_match {
+        builder = builder.set_if_generation_match(generation);
+    }
+    let object = builder.send().await.map_err(|err| {
+        if is_gcs_precondition_failed(&err) {
+            StorageError::policy_rejected("GCS compose precondition failed")
+        } else {
+            gcs_error("compose object", err)
+        }
+    })?;
+    Ok(GcsObjectWrite {
+        etag: non_empty(object.etag),
+        generation: if object.generation > 0 {
+            Some(object.generation.to_string())
+        } else {
+            None
+        },
+        generation_match: if object.generation > 0 {
+            Some(object.generation)
+        } else {
+            None
+        },
+    })
 }
 
 #[derive(Clone)]
@@ -95,6 +221,145 @@ impl GcsJsonControl {
         }
         Ok(())
     }
+
+    async fn compose_object(
+        &self,
+        layout: &GcsKeyLayout,
+        request: ComposeRequest<'_>,
+    ) -> StorageResult<GcsObjectWrite> {
+        let url = format!(
+            "{}/storage/v1/b/{}/o/{}/compose",
+            self.endpoint,
+            encode_uri_component(layout.bucket()),
+            encode_uri_component(request.dest_key)
+        );
+        let mut destination = serde_json::Map::new();
+        if let Some(content_type) = request.content_type {
+            destination.insert("contentType".to_string(), content_type.into());
+        }
+        if !request.metadata.is_empty() {
+            destination.insert(
+                "metadata".to_string(),
+                serde_json::to_value(&request.metadata)
+                    .map_err(|err| gcs_error("encode compose metadata", err))?,
+            );
+        }
+        let source_objects: Vec<serde_json::Value> = request
+            .sources
+            .iter()
+            .map(|source| {
+                let mut entry = serde_json::Map::new();
+                entry.insert("name".to_string(), source.key.clone().into());
+                if let Some(generation) = source.generation {
+                    entry.insert("generation".to_string(), generation.into());
+                }
+                serde_json::Value::Object(entry)
+            })
+            .collect();
+        let body = serde_json::json!({
+            "sourceObjects": source_objects,
+            "destination": serde_json::Value::Object(destination),
+        });
+
+        let mut builder = self.http.post(url).json(&body);
+        if let Some(generation) = request.if_generation_match {
+            builder = builder.query(&[("ifGenerationMatch", generation.to_string())]);
+        }
+        let response = builder
+            .send()
+            .await
+            .map_err(|err| gcs_error("compose object", err))?;
+        let status = response.status();
+        if status.as_u16() == 412 {
+            return Err(StorageError::policy_rejected(
+                "GCS compose precondition failed",
+            ));
+        }
+        if !status.is_success() {
+            return Err(StorageError::backend(format!(
+                "GCS compose object: HTTP {status}"
+            )));
+        }
+        let object: ComposedObject = response
+            .json()
+            .await
+            .map_err(|err| gcs_error("decode composed object", err))?;
+        let generation = object
+            .generation
+            .as_deref()
+            .and_then(|value| value.parse::<i64>().ok())
+            .filter(|generation| *generation > 0);
+        Ok(GcsObjectWrite {
+            etag: object.etag.and_then(non_empty),
+            generation: generation.map(|value| value.to_string()),
+            generation_match: generation,
+        })
+    }
+}
+
+impl GcsJsonControl {
+    async fn get_object_attrs(
+        &self,
+        layout: &GcsKeyLayout,
+        key: &str,
+        marker_key: &str,
+    ) -> StorageResult<Option<GcsObjectAttrs>> {
+        let url = format!(
+            "{}/storage/v1/b/{}/o/{}",
+            self.endpoint,
+            encode_uri_component(layout.bucket()),
+            encode_uri_component(key)
+        );
+        let response = self
+            .http
+            .get(url)
+            .send()
+            .await
+            .map_err(|err| gcs_error("get object", err))?;
+        if response.status().as_u16() == 404 {
+            return Ok(None);
+        }
+        if !response.status().is_success() {
+            return Err(StorageError::backend(format!(
+                "GCS get object: HTTP {}",
+                response.status()
+            )));
+        }
+        let object: FetchedObject = response
+            .json()
+            .await
+            .map_err(|err| gcs_error("decode object metadata", err))?;
+        let generation = object
+            .generation
+            .as_deref()
+            .and_then(|value| value.parse::<i64>().ok())
+            .filter(|generation| *generation > 0);
+        Ok(Some(GcsObjectAttrs {
+            etag: object.etag.and_then(non_empty),
+            generation,
+            owner_session: object
+                .metadata
+                .and_then(|metadata| metadata.get(marker_key).cloned()),
+        }))
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct ComposedObject {
+    #[serde(default)]
+    generation: Option<String>,
+    #[serde(default)]
+    etag: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
+struct FetchedObject {
+    #[serde(default)]
+    generation: Option<String>,
+    #[serde(default)]
+    etag: Option<String>,
+    #[serde(default)]
+    metadata: Option<BTreeMap<String, String>>,
 }
 
 async fn delete_object_with_google_control(

--- a/crates/pocopine-storage-gcs/src/layout.rs
+++ b/crates/pocopine-storage-gcs/src/layout.rs
@@ -82,6 +82,15 @@ impl GcsKeyLayout {
     pub(crate) fn session_bytes_key(&self, session: &UploadSessionId) -> String {
         format!("{}/{}/bytes.tmp", self.internal_prefix, session.as_str())
     }
+
+    /// Key for one native-compose component object.
+    pub(crate) fn session_component_key(&self, session: &UploadSessionId, index: u32) -> String {
+        format!(
+            "{}/{}/components/comp-{index:05}",
+            self.internal_prefix,
+            session.as_str()
+        )
+    }
 }
 
 fn normalize_object_prefix(prefix: String) -> StorageResult<Option<String>> {

--- a/crates/pocopine-storage-gcs/src/state.rs
+++ b/crates/pocopine-storage-gcs/src/state.rs
@@ -19,8 +19,81 @@ pub(crate) struct StoredUploadSession {
     pub(crate) completion_object_key: Option<String>,
     #[serde(default)]
     pub(crate) cleanup_pending: bool,
+    /// Transfer mechanism. Sessions written before native compose support omit
+    /// this field and deserialize as [`NativeUploadState::LegacyProxy`], so
+    /// in-flight uploads from an older build keep the staged-object rewrite path.
+    #[serde(default)]
+    pub(crate) native: NativeUploadState,
     #[serde(skip)]
     pub(crate) meta_generation: Option<i64>,
+}
+
+/// Backend transfer mechanism for an upload session.
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum NativeUploadState {
+    /// Legacy staged-object rewrite (download → extend → re-upload per append).
+    #[default]
+    LegacyProxy,
+    /// Native compose: each flushed block is written once as a component object
+    /// and the final object is assembled with a single `ComposeObject`. Only an
+    /// unflushed tail (smaller than one component) is buffered, inline in this
+    /// metadata so the tail and bookkeeping persist in one atomic write.
+    Compose(GcsComposeState),
+}
+
+/// Compose bookkeeping for one session.
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+pub(crate) struct GcsComposeState {
+    /// Component objects already written, in order.
+    #[serde(default)]
+    pub(crate) components: Vec<GcsComponent>,
+    /// Next component index to assign.
+    #[serde(default)]
+    pub(crate) next_index: u32,
+    /// Bytes received but not yet flushed to a component (always < one component,
+    /// except the final remainder at completion). Base64 inline in the metadata.
+    #[serde(
+        default,
+        with = "pocopine_codec::base64_bytes",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub(crate) pending_tail: Vec<u8>,
+}
+
+/// One written component object.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub(crate) struct GcsComponent {
+    pub(crate) key: String,
+    pub(crate) size: u64,
+    #[serde(default)]
+    pub(crate) generation: Option<i64>,
+}
+
+impl NativeUploadState {
+    pub(crate) fn compose(&self) -> Option<&GcsComposeState> {
+        match self {
+            NativeUploadState::Compose(state) => Some(state),
+            NativeUploadState::LegacyProxy => None,
+        }
+    }
+
+    pub(crate) fn compose_mut(&mut self) -> Option<&mut GcsComposeState> {
+        match self {
+            NativeUploadState::Compose(state) => Some(state),
+            NativeUploadState::LegacyProxy => None,
+        }
+    }
+}
+
+impl GcsComposeState {
+    pub(crate) fn flushed_len(&self) -> u64 {
+        self.components.iter().map(|component| component.size).sum()
+    }
+
+    pub(crate) fn committed_len(&self) -> u64 {
+        self.flushed_len() + self.pending_tail.len() as u64
+    }
 }
 
 pub(crate) struct GcsObjectBytes {
@@ -48,6 +121,14 @@ pub(crate) struct GcsObjectMetadata {
     pub(crate) etag: Option<String>,
     pub(crate) generation: Option<String>,
     pub(crate) generation_match: Option<i64>,
+}
+
+/// Full object attributes including custom metadata (fetched via the control
+/// layer, since the streaming read only exposes lightweight highlights).
+pub(crate) struct GcsObjectAttrs {
+    pub(crate) etag: Option<String>,
+    pub(crate) generation: Option<i64>,
+    pub(crate) owner_session: Option<String>,
 }
 
 pub(crate) struct GcsObjectWrite {

--- a/crates/pocopine-storage-gcs/src/storage.rs
+++ b/crates/pocopine-storage-gcs/src/storage.rs
@@ -5,19 +5,22 @@ use pocopine_storage::backend_common::{
     ensure_upload_length_can_be_set, expires_at, selected_strategy, UploadSessionLockCleanup,
     UploadSessionLockRegistry,
 };
-use pocopine_storage::checksum::{ensure_supported_checksum_policy, validate_complete_checksum};
+use pocopine_storage::checksum::{
+    checksum_algorithm_to_compute, ensure_supported_checksum_policy, precheck_checksum,
+    validate_complete_checksum, validate_complete_checksum_precomputed, StreamingChecksum,
+};
 use pocopine_storage::{
-    CompleteUpload, InitiateUpload, ObjectChecksum, ObjectRef, StorageActor, StorageBackend,
-    StorageBoxFuture, StorageContext, StorageError, StorageResult, TransferPlan, UploadSession,
-    UploadSessionId, UploadSessionStatus, UploadStrategy,
+    ChecksumAlgorithm, CompleteUpload, InitiateUpload, ObjectChecksum, ObjectRef, StorageActor,
+    StorageBackend, StorageBoxFuture, StorageContext, StorageError, StorageResult, TransferPlan,
+    UploadSession, UploadSessionId, UploadSessionStatus, UploadStrategy,
 };
 use uuid::Uuid;
 
-use crate::control::{GcsControl, GcsJsonControl};
+use crate::control::{ComposeRequest, ComposeSource, GcsControl, GcsJsonControl};
 use crate::layout::{GcsKeyLayout, DEFAULT_INTERNAL_PREFIX};
 use crate::state::{
-    decode_session_object, AbortSessionRead, GcsObjectBytes, GcsObjectMetadata, GcsObjectWrite,
-    StoredUploadSession,
+    decode_session_object, AbortSessionRead, GcsComponent, GcsObjectAttrs, GcsObjectBytes,
+    GcsObjectMetadata, GcsObjectWrite, NativeUploadState, StoredUploadSession,
 };
 use crate::util::{
     bytes_match_at, ensure_completable, gcs_error, is_gcs_not_found, is_gcs_precondition_failed,
@@ -27,6 +30,30 @@ use crate::util::{
 const DEFAULT_BACKEND_NAME: &str = "gcs";
 const DEFAULT_MAX_PROXY_UPLOAD_BYTES: u64 = 64 * 1024 * 1024;
 const MAX_SESSION_METADATA_BYTES: u64 = 256 * 1024;
+
+/// GCS allows up to 32 source objects per `ComposeObject`. Components are sized
+/// so their count never exceeds this, keeping completion to a single compose.
+const GCS_MAX_COMPOSE_SOURCES: u64 = 32;
+
+/// Floor for a coalesced component, to avoid many tiny component objects.
+const MIN_COMPONENT_SIZE: u64 = 1024 * 1024;
+
+/// Object custom-metadata key stamping the owning upload session onto the final
+/// composed object, so a retry can recognize its own object after a crash.
+const SESSION_OWNER_META_KEY: &str = "pocopine-upload-session";
+
+/// Component size for a session whose maximum object size is `max_bytes`.
+///
+/// Scaled (rounded to a whole MiB) so component count stays within
+/// [`GCS_MAX_COMPOSE_SOURCES`]; never below [`MIN_COMPONENT_SIZE`]. For the
+/// default 64 MiB cap this is 2 MiB.
+fn component_size_for(max_bytes: u64) -> u64 {
+    let by_count = max_bytes
+        .div_ceil(GCS_MAX_COMPOSE_SOURCES)
+        .div_ceil(MIN_COMPONENT_SIZE)
+        * MIN_COMPONENT_SIZE;
+    by_count.max(MIN_COMPONENT_SIZE)
+}
 
 /// Storage backend backed by Google Cloud Storage.
 ///
@@ -406,6 +433,14 @@ impl GcsStorageBackend {
         })
     }
 
+    /// Fetch full object attributes (including the ownership marker in custom
+    /// metadata) via the control layer. Returns `None` if the object is absent.
+    async fn get_object_attrs(&self, key: &str) -> StorageResult<Option<GcsObjectAttrs>> {
+        self.control
+            .get_object_attrs(&self.layout, key, SESSION_OWNER_META_KEY)
+            .await
+    }
+
     async fn put_object_bytes(
         &self,
         key: &str,
@@ -500,6 +535,96 @@ impl GcsStorageBackend {
         }))
     }
 
+    // --- native compose helpers ----------------------------------------------
+
+    /// Write one component object (each written exactly once; rewriting the same
+    /// index with the same bytes on a retry is an idempotent overwrite).
+    async fn write_component(
+        &self,
+        session: &UploadSessionId,
+        index: u32,
+        bytes: Bytes,
+    ) -> StorageResult<GcsComponent> {
+        let key = self.layout.session_component_key(session, index);
+        let size = bytes.len() as u64;
+        let written = self
+            .put_object_bytes(&key, bytes, Some("application/octet-stream"), None)
+            .await?;
+        Ok(GcsComponent {
+            key,
+            size,
+            generation: written.generation_match,
+        })
+    }
+
+    /// Assemble the recorded components into the destination object, stamping the
+    /// owning session so a crashed retry can recognize its own object.
+    async fn compose_components(
+        &self,
+        session: &UploadSessionId,
+        stored: &StoredUploadSession,
+        object_key: &str,
+        if_generation_match: Option<i64>,
+    ) -> StorageResult<GcsObjectWrite> {
+        let state = stored.native.compose().expect("compose state");
+        let sources = state
+            .components
+            .iter()
+            .map(|component| ComposeSource {
+                key: component.key.clone(),
+                generation: component.generation,
+            })
+            .collect();
+        let mut metadata = std::collections::BTreeMap::new();
+        metadata.insert(
+            SESSION_OWNER_META_KEY.to_string(),
+            session.as_str().to_string(),
+        );
+        self.control
+            .compose_object(
+                &self.layout,
+                ComposeRequest {
+                    dest_key: object_key,
+                    content_type: stored.public.content_type.as_deref(),
+                    metadata,
+                    sources,
+                    if_generation_match,
+                },
+            )
+            .await
+    }
+
+    /// Stream the stored object through `algorithm` without buffering it.
+    async fn stream_object_checksum(
+        &self,
+        key: &str,
+        algorithm: ChecksumAlgorithm,
+    ) -> StorageResult<ObjectChecksum> {
+        let mut response = self
+            .storage
+            .read_object(self.layout.bucket_resource(), key)
+            .send()
+            .await
+            .map_err(|err| gcs_error("read object for checksum", err))?;
+        let mut hasher = StreamingChecksum::new(algorithm);
+        while let Some(chunk) = response
+            .next()
+            .await
+            .transpose()
+            .map_err(|err| gcs_error("read object body for checksum", err))?
+        {
+            hasher.update(&chunk);
+        }
+        Ok(hasher.finalize())
+    }
+
+    /// Best-effort deletion of a session's component objects.
+    async fn delete_components(&self, components: &[GcsComponent]) {
+        for component in components {
+            let _ = self.delete_object_if_exists(&component.key).await;
+        }
+    }
+
     async fn delete_object(&self, key: &str) -> StorageResult<()> {
         self.control.delete_object(&self.layout, key).await
     }
@@ -574,6 +699,391 @@ impl GcsStorageBackend {
             metadata,
         }
     }
+
+    // --- native compose upload flow -------------------------------------------
+
+    async fn append_compose(
+        &self,
+        session: &UploadSessionId,
+        mut stored: StoredUploadSession,
+        offset: u64,
+        bytes: Bytes,
+    ) -> StorageResult<UploadSession> {
+        // Copy the buffered tail; it stays durable in `stored` until the single
+        // atomic session write at the end (so a crash mid-append leaves the
+        // durable metadata unchanged and the client re-sends from the old offset).
+        let (flushed, tail) = {
+            let state = stored.native.compose().expect("compose state");
+            (state.flushed_len(), state.pending_tail.clone())
+        };
+        let expected = flushed + tail.len() as u64;
+        if expected != offset {
+            tracing::debug!(
+                target: "pocopine.log",
+                event_name = "pocopine.storage.offset_mismatch",
+                session = %session,
+                expected,
+                provided = offset,
+            );
+            return Err(StorageError::offset_mismatch(expected, offset));
+        }
+        let new_offset = checked_new_offset(offset, bytes.len())?;
+        ensure_size_limit(stored.max_bytes, stored.public.size, new_offset)?;
+        if bytes.is_empty() {
+            return Ok(stored.public);
+        }
+
+        let combined: Bytes = if tail.is_empty() {
+            bytes
+        } else {
+            let mut combined = tail;
+            combined.extend_from_slice(&bytes);
+            Bytes::from(combined)
+        };
+
+        // Flush full-size components (each written once); the remainder is the
+        // new tail. Component size keeps the count within the single-compose cap.
+        let component_size = component_size_for(stored.max_bytes) as usize;
+        let mut pos = 0usize;
+        while combined.len() - pos >= component_size {
+            let index = stored.native.compose().expect("compose state").next_index;
+            let part = combined.slice(pos..pos + component_size);
+            let component = self.write_component(session, index, part).await?;
+            if let Some(state) = stored.native.compose_mut() {
+                state.components.push(component);
+                state.next_index = index + 1;
+            }
+            pos += component_size;
+        }
+        if let Some(state) = stored.native.compose_mut() {
+            state.pending_tail = combined.slice(pos..).to_vec();
+        }
+        stored.public.next_offset = Some(new_offset);
+        self.write_session(session, &mut stored).await?;
+        Ok(stored.public)
+    }
+
+    async fn complete_compose(
+        &self,
+        session: &UploadSessionId,
+        mut stored: StoredUploadSession,
+        provided_checksum: Option<ObjectChecksum>,
+    ) -> StorageResult<ObjectRef> {
+        let total = stored.public.next_offset.unwrap_or(0);
+        if let Some(expected) = stored.public.size {
+            if total != expected {
+                return Err(StorageError::policy_rejected(format!(
+                    "upload is incomplete: expected {expected} bytes, got {total}"
+                )));
+            }
+        }
+        ensure_size_limit(stored.max_bytes, stored.public.size, total)?;
+        // Reject a missing-required / disallowed-algorithm checksum before any
+        // finalize work, while the session is still resumable.
+        precheck_checksum(&stored.checksum_policy, provided_checksum.as_ref())?;
+
+        let object_key = self.layout.object_key(stored.storage_key.key.as_str());
+        let has_components = !stored
+            .native
+            .compose()
+            .expect("compose state")
+            .components
+            .is_empty();
+
+        let (written, checksum) = if !has_components {
+            // Whole object fits in the tail (or is empty): a single direct PUT,
+            // atomic and collision-guarded by `put_completed_object`. The checksum
+            // is validated before the write, so a bad checksum leaves the session
+            // open and resumable.
+            let tail = stored
+                .native
+                .compose()
+                .expect("compose state")
+                .pending_tail
+                .clone();
+            let checksum =
+                validate_complete_checksum(&stored.checksum_policy, &tail, provided_checksum)?;
+            let written = self
+                .put_completed_object(
+                    &object_key,
+                    Bytes::from(tail),
+                    stored.public.content_type.as_deref(),
+                )
+                .await?;
+            (written, checksum)
+        } else {
+            // HEAD on every attempt: adopt our own already-composed object
+            // (matched by the ownership marker), reject a foreign one. Works on
+            // stores that ignore compose preconditions; `if_generation_match: 0`
+            // closes the TOCTOU window on real GCS.
+            let written = if let Some(attrs) = self.get_object_attrs(&object_key).await? {
+                if attrs.owner_session.as_deref() == Some(session.as_str()) {
+                    GcsObjectWrite {
+                        etag: attrs.etag,
+                        generation: attrs.generation.map(|generation| generation.to_string()),
+                        generation_match: attrs.generation,
+                    }
+                } else {
+                    let components = stored
+                        .native
+                        .compose()
+                        .expect("compose state")
+                        .components
+                        .clone();
+                    self.delete_components(&components).await;
+                    return Err(StorageError::policy_rejected(format!(
+                        "GCS object key already exists: {object_key}"
+                    )));
+                }
+            } else {
+                if stored.public.status == UploadSessionStatus::Open
+                    || stored.public.next_offset != Some(total)
+                    || stored.completion_object_key.as_deref() != Some(object_key.as_str())
+                {
+                    stored.public.status = UploadSessionStatus::Completing;
+                    stored.public.next_offset = Some(total);
+                    stored.completion_object_key = Some(object_key.clone());
+                    self.write_session(session, &mut stored).await?;
+                }
+                // Flush the final remainder as the last component, then compose.
+                let tail = stored
+                    .native
+                    .compose()
+                    .expect("compose state")
+                    .pending_tail
+                    .clone();
+                if !tail.is_empty() {
+                    let index = stored.native.compose().expect("compose state").next_index;
+                    let component = self
+                        .write_component(session, index, Bytes::from(tail))
+                        .await?;
+                    if let Some(state) = stored.native.compose_mut() {
+                        state.components.push(component);
+                        state.next_index = index + 1;
+                        state.pending_tail = Vec::new();
+                    }
+                    self.write_session(session, &mut stored).await?;
+                }
+                match self
+                    .compose_components(session, &stored, &object_key, Some(0))
+                    .await
+                {
+                    Ok(written) => written,
+                    Err(StorageError::PolicyRejected { .. }) => {
+                        // An object appeared at the key during completion; adopt it
+                        // only if it is ours, otherwise reject (and clean up).
+                        match self.get_object_attrs(&object_key).await? {
+                            Some(attrs)
+                                if attrs.owner_session.as_deref() == Some(session.as_str()) =>
+                            {
+                                GcsObjectWrite {
+                                    etag: attrs.etag,
+                                    generation: attrs
+                                        .generation
+                                        .map(|generation| generation.to_string()),
+                                    generation_match: attrs.generation,
+                                }
+                            }
+                            _ => {
+                                let components = stored
+                                    .native
+                                    .compose()
+                                    .expect("compose state")
+                                    .components
+                                    .clone();
+                                self.delete_components(&components).await;
+                                return Err(StorageError::policy_rejected(format!(
+                                    "GCS object key already exists: {object_key}"
+                                )));
+                            }
+                        }
+                    }
+                    Err(err) => return Err(err),
+                }
+            };
+
+            // Validate the checksum by streaming the composed object (only when a
+            // checksum was supplied; the default path never hashes).
+            let checksum = match checksum_algorithm_to_compute(
+                &stored.checksum_policy,
+                provided_checksum.as_ref(),
+            ) {
+                Some(algorithm) => {
+                    let computed = self.stream_object_checksum(&object_key, algorithm).await?;
+                    match validate_complete_checksum_precomputed(
+                        &stored.checksum_policy,
+                        Some(computed),
+                        provided_checksum,
+                    ) {
+                        Ok(checksum) => checksum,
+                        Err(err) => {
+                            // Remove the composed-but-invalid object; surface a
+                            // delete failure (a live invalid object is worse).
+                            self.delete_object(&object_key).await.map_err(|delete_err| {
+                                tracing::error!(
+                                    target: "pocopine.log",
+                                    event_name = "pocopine.storage.gcs_invalid_object_cleanup_failed",
+                                    object_key = %object_key,
+                                    checksum_error = %err,
+                                    delete_error = %delete_err,
+                                );
+                                delete_err
+                            })?;
+                            return Err(err);
+                        }
+                    }
+                }
+                None => validate_complete_checksum_precomputed(
+                    &stored.checksum_policy,
+                    None,
+                    provided_checksum,
+                )?,
+            };
+            (written, checksum)
+        };
+
+        let object = self.object_ref(&stored, total, written, checksum);
+        stored.public.status = UploadSessionStatus::Complete;
+        stored.public.next_offset = Some(total);
+        stored.object = Some(object.clone());
+        let components = stored
+            .native
+            .compose()
+            .map(|state| state.components.clone())
+            .unwrap_or_default();
+        if let Some(state) = stored.native.compose_mut() {
+            state.pending_tail = Vec::new();
+        }
+        self.write_session(session, &mut stored).await?;
+        // Component objects are temporary; remove them after the object is live.
+        self.delete_components(&components).await;
+        Ok(object)
+    }
+
+    // --- legacy staged-object rewrite flow (pre-compose sessions) -------------
+
+    async fn append_legacy(
+        &self,
+        session: &UploadSessionId,
+        mut stored: StoredUploadSession,
+        offset: u64,
+        bytes: Bytes,
+    ) -> StorageResult<UploadSession> {
+        let expected = stored.public.next_offset.unwrap_or(0);
+        let new_offset = checked_new_offset(offset, bytes.len())?;
+        let read_limit = expected
+            .max(new_offset)
+            .checked_add(1)
+            .ok_or_else(|| StorageError::policy_rejected("upload byte offset overflowed"))?;
+        let mut staged_object = self.get_staged_bytes(session, read_limit).await?;
+        let staged_len = staged_object.bytes.len() as u64;
+        if expected != offset {
+            if new_offset == expected
+                && bytes_match_at(&staged_object.bytes, offset, bytes.as_ref())?
+            {
+                return Ok(stored.public);
+            }
+            tracing::debug!(
+                target: "pocopine.log",
+                event_name = "pocopine.storage.offset_mismatch",
+                session = %session,
+                expected,
+                provided = offset,
+            );
+            return Err(StorageError::offset_mismatch(expected, offset));
+        }
+        if staged_len > expected {
+            if staged_len == new_offset
+                && bytes_match_at(&staged_object.bytes, expected, bytes.as_ref())?
+            {
+                stored.public.next_offset = Some(new_offset);
+                self.write_session(session, &mut stored).await?;
+                return Ok(stored.public);
+            }
+            tracing::warn!(
+                target: "pocopine.log",
+                event_name = "pocopine.storage.gcs_staged_bytes_truncated",
+                session = %session,
+                actual = staged_len,
+                trusted = expected,
+            );
+            staged_object.bytes.truncate(usize_from_u64(expected)?);
+            self.put_staged_bytes(
+                session,
+                Bytes::from(staged_object.bytes.clone()),
+                staged_object.generation_match,
+            )
+            .await?;
+        } else if staged_len < expected {
+            return Err(StorageError::backend(format!(
+                "GCS staged upload object is shorter than committed metadata: expected {expected} bytes, got {staged_len}"
+            )));
+        }
+        ensure_size_limit(stored.max_bytes, stored.public.size, new_offset)?;
+        staged_object.bytes.extend_from_slice(&bytes);
+        self.put_staged_bytes(
+            session,
+            Bytes::from(staged_object.bytes),
+            staged_object.generation_match,
+        )
+        .await?;
+        stored.public.next_offset = Some(new_offset);
+        self.write_session(session, &mut stored).await?;
+        Ok(stored.public)
+    }
+
+    async fn complete_legacy(
+        &self,
+        session: &UploadSessionId,
+        mut stored: StoredUploadSession,
+        provided_checksum: Option<ObjectChecksum>,
+    ) -> StorageResult<ObjectRef> {
+        let trusted = stored.public.next_offset.unwrap_or(0);
+        let staged = self.reconcile_staged_bytes(session, trusted).await?;
+        let actual = staged.len() as u64;
+        if let Some(expected) = stored.public.size {
+            if actual != expected {
+                return Err(StorageError::policy_rejected(format!(
+                    "upload is incomplete: expected {expected} bytes, got {actual}"
+                )));
+            }
+        }
+        ensure_size_limit(stored.max_bytes, stored.public.size, actual)?;
+        let checksum =
+            validate_complete_checksum(&stored.checksum_policy, &staged, provided_checksum)?;
+        let object_key = self.layout.object_key(stored.storage_key.key.as_str());
+        if stored.public.status == UploadSessionStatus::Open
+            || stored.public.next_offset != Some(actual)
+            || stored.completion_object_key.as_deref() != Some(object_key.as_str())
+        {
+            stored.public.status = UploadSessionStatus::Completing;
+            stored.public.next_offset = Some(actual);
+            stored.completion_object_key = Some(object_key.clone());
+            self.write_session(session, &mut stored).await?;
+        }
+        let staged = Bytes::from(staged);
+        let written = match self
+            .put_completed_object(&object_key, staged, stored.public.content_type.as_deref())
+            .await
+        {
+            Ok(written) => written,
+            Err(err @ StorageError::PolicyRejected { .. }) => {
+                stored.public.status = UploadSessionStatus::Open;
+                stored.completion_object_key = None;
+                let _ = self.write_session(session, &mut stored).await;
+                return Err(err);
+            }
+            Err(err) => return Err(err),
+        };
+        let object = self.object_ref(&stored, actual, written, checksum);
+        stored.public.status = UploadSessionStatus::Complete;
+        stored.public.next_offset = Some(actual);
+        stored.object = Some(object.clone());
+        stored.cleanup_pending = true;
+        self.write_session(session, &mut stored).await?;
+        self.cleanup_staged_bytes(session, &mut stored).await?;
+        Ok(object)
+    }
 }
 
 impl StorageBackend for GcsStorageBackend {
@@ -625,15 +1135,12 @@ impl StorageBackend for GcsStorageBackend {
                 object: None,
                 completion_object_key: None,
                 cleanup_pending: false,
+                native: NativeUploadState::Compose(Default::default()),
                 meta_generation: None,
             };
+            // Native sessions buffer their tail inline in the metadata, so no
+            // separate staged `bytes.tmp` object is created up front.
             self.create_session(&id, &mut stored).await?;
-            if let Err(err) = self.put_staged_bytes(&id, Bytes::new(), Some(0)).await {
-                let _ = self
-                    .delete_object_if_exists(&self.layout.session_meta_key(&id))
-                    .await;
-                return Err(err);
-            }
             Ok(session)
         })
     }
@@ -649,7 +1156,11 @@ impl StorageBackend for GcsStorageBackend {
             let _guard = lock.lock().await;
             let mut stored = self.read_session(&session).await?;
             ensure_owner(&ctx.actor, &stored.owner)?;
-            if stored.public.status == UploadSessionStatus::Open {
+            // Native sessions keep an authoritative offset in the metadata; only
+            // the legacy staged-object path needs reconciliation against storage.
+            if stored.public.status == UploadSessionStatus::Open
+                && stored.native.compose().is_none()
+            {
                 let staged = self
                     .reconcile_staged_bytes(&session, stored.public.next_offset.unwrap_or(0))
                     .await?;
@@ -678,10 +1189,15 @@ impl StorageBackend for GcsStorageBackend {
             ensure_owner(&ctx.actor, &stored.owner)?;
             self.persist_expired_if_needed(&session, &mut stored)
                 .await?;
-            let committed_offset = stored.public.next_offset.unwrap_or(0);
-            let _staged = self
-                .reconcile_staged_bytes(&session, committed_offset)
-                .await?;
+            let committed_offset = match stored.native.compose() {
+                Some(state) => state.committed_len(),
+                None => {
+                    let staged = self
+                        .reconcile_staged_bytes(&session, stored.public.next_offset.unwrap_or(0))
+                        .await?;
+                    staged.len() as u64
+                }
+            };
             ensure_upload_length_can_be_set(
                 stored.max_bytes,
                 &stored.public,
@@ -715,67 +1231,11 @@ impl StorageBackend for GcsStorageBackend {
                     "GCS backend currently supports sequential proxy uploads only",
                 ));
             }
-            let expected = stored.public.next_offset.unwrap_or(0);
-            let new_offset = checked_new_offset(offset, bytes.len())?;
-            let read_limit = expected
-                .max(new_offset)
-                .checked_add(1)
-                .ok_or_else(|| StorageError::policy_rejected("upload byte offset overflowed"))?;
-            let mut staged_object = self.get_staged_bytes(&session, read_limit).await?;
-            let staged_len = staged_object.bytes.len() as u64;
-            if expected != offset {
-                if new_offset == expected
-                    && bytes_match_at(&staged_object.bytes, offset, bytes.as_ref())?
-                {
-                    return Ok(stored.public);
-                }
-                tracing::debug!(
-                    target: "pocopine.log",
-                    event_name = "pocopine.storage.offset_mismatch",
-                    session = %session,
-                    expected,
-                    provided = offset,
-                );
-                return Err(StorageError::offset_mismatch(expected, offset));
+            if stored.native.compose().is_some() {
+                self.append_compose(&session, stored, offset, bytes).await
+            } else {
+                self.append_legacy(&session, stored, offset, bytes).await
             }
-            if staged_len > expected {
-                if staged_len == new_offset
-                    && bytes_match_at(&staged_object.bytes, expected, bytes.as_ref())?
-                {
-                    stored.public.next_offset = Some(new_offset);
-                    self.write_session(&session, &mut stored).await?;
-                    return Ok(stored.public);
-                }
-                tracing::warn!(
-                    target: "pocopine.log",
-                    event_name = "pocopine.storage.gcs_staged_bytes_truncated",
-                    session = %session,
-                    actual = staged_len,
-                    trusted = expected,
-                );
-                staged_object.bytes.truncate(usize_from_u64(expected)?);
-                self.put_staged_bytes(
-                    &session,
-                    Bytes::from(staged_object.bytes.clone()),
-                    staged_object.generation_match,
-                )
-                .await?;
-            } else if staged_len < expected {
-                return Err(StorageError::backend(format!(
-                    "GCS staged upload object is shorter than committed metadata: expected {expected} bytes, got {staged_len}"
-                )));
-            }
-            ensure_size_limit(stored.max_bytes, stored.public.size, new_offset)?;
-            staged_object.bytes.extend_from_slice(&bytes);
-            self.put_staged_bytes(
-                &session,
-                Bytes::from(staged_object.bytes),
-                staged_object.generation_match,
-            )
-            .await?;
-            stored.public.next_offset = Some(new_offset);
-            self.write_session(&session, &mut stored).await?;
-            Ok(stored.public)
         })
     }
 
@@ -799,54 +1259,14 @@ impl StorageBackend for GcsStorageBackend {
             self.persist_expired_if_needed(&request.session, &mut stored)
                 .await?;
             ensure_completable(&stored.public)?;
-            let trusted = stored.public.next_offset.unwrap_or(0);
-            let staged = self
-                .reconcile_staged_bytes(&request.session, trusted)
-                .await?;
-            let actual = staged.len() as u64;
-            if let Some(expected) = stored.public.size {
-                if actual != expected {
-                    return Err(StorageError::policy_rejected(format!(
-                        "upload is incomplete: expected {expected} bytes, got {actual}"
-                    )));
-                }
+            let session = request.session.clone();
+            if stored.native.compose().is_some() {
+                self.complete_compose(&session, stored, request.checksum)
+                    .await
+            } else {
+                self.complete_legacy(&session, stored, request.checksum)
+                    .await
             }
-            ensure_size_limit(stored.max_bytes, stored.public.size, actual)?;
-            let checksum =
-                validate_complete_checksum(&stored.checksum_policy, &staged, request.checksum)?;
-            let object_key = self.layout.object_key(stored.storage_key.key.as_str());
-            if stored.public.status == UploadSessionStatus::Open
-                || stored.public.next_offset != Some(actual)
-                || stored.completion_object_key.as_deref() != Some(object_key.as_str())
-            {
-                stored.public.status = UploadSessionStatus::Completing;
-                stored.public.next_offset = Some(actual);
-                stored.completion_object_key = Some(object_key.clone());
-                self.write_session(&request.session, &mut stored).await?;
-            }
-            let staged = Bytes::from(staged);
-            let written = match self
-                .put_completed_object(&object_key, staged, stored.public.content_type.as_deref())
-                .await
-            {
-                Ok(written) => written,
-                Err(err @ StorageError::PolicyRejected { .. }) => {
-                    stored.public.status = UploadSessionStatus::Open;
-                    stored.completion_object_key = None;
-                    let _ = self.write_session(&request.session, &mut stored).await;
-                    return Err(err);
-                }
-                Err(err) => return Err(err),
-            };
-            let object = self.object_ref(&stored, actual, written, checksum);
-            stored.public.status = UploadSessionStatus::Complete;
-            stored.public.next_offset = Some(actual);
-            stored.object = Some(object.clone());
-            stored.cleanup_pending = true;
-            self.write_session(&request.session, &mut stored).await?;
-            self.cleanup_staged_bytes(&request.session, &mut stored)
-                .await?;
-            Ok(object)
         })
     }
 
@@ -867,6 +1287,19 @@ impl StorageBackend for GcsStorageBackend {
                         return Err(StorageError::UploadClosed {
                             session: session.to_string(),
                         });
+                    }
+                    // Remove native component objects so they do not linger.
+                    if let Some(state) = stored.native.compose() {
+                        self.delete_components(&state.components).await;
+                        // The next, not-yet-recorded component index may have been
+                        // written just before a crash; clean it up too.
+                        let _ = self
+                            .delete_object_if_exists(
+                                &self
+                                    .layout
+                                    .session_component_key(&session, state.next_index),
+                            )
+                            .await;
                     }
                 }
                 AbortSessionRead::Missing => {}

--- a/crates/pocopine-storage-gcs/src/storage.rs
+++ b/crates/pocopine-storage-gcs/src/storage.rs
@@ -578,7 +578,19 @@ impl GcsStorageBackend {
                 // concurrent worker). Adopt it only if its bytes match what this
                 // append intends to write; otherwise the index is being reused
                 // for different content and must not be silently accepted.
-                let existing = self.get_object_bytes_with_limit(&key, size).await?;
+                let existing = match self.get_object_bytes_with_limit(&key, size).await {
+                    Ok(existing) => existing,
+                    // The conflicting component was removed between the create-only
+                    // PUT and this read (a concurrent race on an internal key). This
+                    // is a write conflict, not a missing user session — don't leak a
+                    // 404 for the session.
+                    Err(StorageError::UnknownUploadSession { .. }) => {
+                        return Err(StorageError::conflict(
+                            "GCS upload component changed during a concurrent write",
+                        ))
+                    }
+                    Err(err) => return Err(err),
+                };
                 if existing.truncated
                     || existing.bytes.len() as u64 != size
                     || existing.bytes.as_slice() != bytes.as_ref()
@@ -871,131 +883,19 @@ impl GcsStorageBackend {
                 .await?;
             (written, checksum)
         } else {
-            // HEAD on every attempt: adopt our own already-composed object
-            // (matched by the ownership marker), reject a foreign one. Works on
-            // stores that ignore compose preconditions; `if_generation_match: 0`
-            // closes the TOCTOU window on real GCS.
-            let written = if let Some(attrs) = self.get_object_attrs(&object_key).await? {
-                if attrs.owner_session.as_deref() == Some(session.as_str()) {
-                    GcsObjectWrite {
-                        etag: attrs.etag,
-                        generation: attrs.generation.map(|generation| generation.to_string()),
-                        generation_match: attrs.generation,
-                    }
-                } else {
-                    // Foreign object at the destination (the session is still
-                    // Open here): clean up our components and reject without
-                    // overwriting it.
-                    self.delete_component_chain(session).await;
-                    return Err(StorageError::policy_rejected(format!(
-                        "GCS object key already exists: {object_key}"
-                    )));
+            // Finalize via components/compose. Any failure after the session is
+            // marked `Completing` reopens it so the owner can retry or abort
+            // rather than be stranded (the reopen is a no-op while still `Open`).
+            match self
+                .complete_with_components(session, &mut stored, &object_key, provided_checksum)
+                .await
+            {
+                Ok(pair) => pair,
+                Err(err) => {
+                    self.reopen_session(session, &mut stored).await;
+                    return Err(err);
                 }
-            } else {
-                if stored.public.status == UploadSessionStatus::Open
-                    || stored.public.next_offset != Some(total)
-                    || stored.completion_object_key.as_deref() != Some(object_key.as_str())
-                {
-                    stored.public.status = UploadSessionStatus::Completing;
-                    stored.public.next_offset = Some(total);
-                    stored.completion_object_key = Some(object_key.clone());
-                    self.write_session(session, &mut stored).await?;
-                }
-                // Flush the final remainder as the last component, then compose.
-                let tail = stored
-                    .native
-                    .compose()
-                    .expect("compose state")
-                    .pending_tail
-                    .clone();
-                if !tail.is_empty() {
-                    let index = stored.native.compose().expect("compose state").next_index;
-                    let component = self
-                        .write_component(session, index, Bytes::from(tail))
-                        .await?;
-                    if let Some(state) = stored.native.compose_mut() {
-                        state.components.push(component);
-                        state.next_index = index + 1;
-                        state.pending_tail = Vec::new();
-                    }
-                    self.write_session(session, &mut stored).await?;
-                }
-                match self
-                    .compose_components(session, &stored, &object_key, Some(0))
-                    .await
-                {
-                    Ok(written) => written,
-                    Err(StorageError::PolicyRejected { .. }) => {
-                        // An object appeared at the key during completion; adopt it
-                        // only if it is ours, otherwise reject (and clean up).
-                        match self.get_object_attrs(&object_key).await? {
-                            Some(attrs)
-                                if attrs.owner_session.as_deref() == Some(session.as_str()) =>
-                            {
-                                GcsObjectWrite {
-                                    etag: attrs.etag,
-                                    generation: attrs
-                                        .generation
-                                        .map(|generation| generation.to_string()),
-                                    generation_match: attrs.generation,
-                                }
-                            }
-                            _ => {
-                                self.delete_component_chain(session).await;
-                                // The session reached Completing; reopen it so the
-                                // owner can abort or retry rather than be stranded.
-                                self.reopen_session(session, &mut stored).await;
-                                return Err(StorageError::policy_rejected(format!(
-                                    "GCS object key already exists: {object_key}"
-                                )));
-                            }
-                        }
-                    }
-                    Err(err) => return Err(err),
-                }
-            };
-
-            // Validate the checksum by streaming the composed object (only when a
-            // checksum was supplied; the default path never hashes).
-            let checksum = match checksum_algorithm_to_compute(
-                &stored.checksum_policy,
-                provided_checksum.as_ref(),
-            ) {
-                Some(algorithm) => {
-                    let computed = self.stream_object_checksum(&object_key, algorithm).await?;
-                    match validate_complete_checksum_precomputed(
-                        &stored.checksum_policy,
-                        Some(computed),
-                        provided_checksum,
-                    ) {
-                        Ok(checksum) => checksum,
-                        Err(err) => {
-                            // Remove the composed-but-invalid object; surface a
-                            // delete failure (a live invalid object is worse).
-                            self.delete_object(&object_key).await.map_err(|delete_err| {
-                                tracing::error!(
-                                    target: "pocopine.log",
-                                    event_name = "pocopine.storage.gcs_invalid_object_cleanup_failed",
-                                    object_key = %object_key,
-                                    checksum_error = %err,
-                                    delete_error = %delete_err,
-                                );
-                                delete_err
-                            })?;
-                            // Reopen so the client can retry with a correct
-                            // checksum (components remain for re-compose).
-                            self.reopen_session(session, &mut stored).await;
-                            return Err(err);
-                        }
-                    }
-                }
-                None => validate_complete_checksum_precomputed(
-                    &stored.checksum_policy,
-                    None,
-                    provided_checksum,
-                )?,
-            };
-            (written, checksum)
+            }
         };
 
         let object = self.object_ref(&stored, total, written, checksum);
@@ -1010,6 +910,132 @@ impl GcsStorageBackend {
         // live (the compose copied their bytes into it).
         self.delete_component_chain(session).await;
         Ok(object)
+    }
+
+    /// Finalize a session that has flushed components. The caller wraps this so
+    /// any error reopens the (possibly `Completing`) session.
+    async fn complete_with_components(
+        &self,
+        session: &UploadSessionId,
+        stored: &mut StoredUploadSession,
+        object_key: &str,
+        provided_checksum: Option<ObjectChecksum>,
+    ) -> StorageResult<(GcsObjectWrite, Option<ObjectChecksum>)> {
+        let total = stored.public.next_offset.unwrap_or(0);
+        // HEAD on every attempt: adopt our own already-composed object (matched by
+        // the ownership marker), reject a foreign one. Works on stores that ignore
+        // compose preconditions; `if_generation_match: 0` closes the TOCTOU window
+        // on real GCS.
+        let written = if let Some(attrs) = self.get_object_attrs(object_key).await? {
+            if attrs.owner_session.as_deref() == Some(session.as_str()) {
+                GcsObjectWrite {
+                    etag: attrs.etag,
+                    generation: attrs.generation.map(|generation| generation.to_string()),
+                    generation_match: attrs.generation,
+                }
+            } else {
+                self.delete_component_chain(session).await;
+                return Err(StorageError::policy_rejected(format!(
+                    "GCS object key already exists: {object_key}"
+                )));
+            }
+        } else {
+            if stored.public.status == UploadSessionStatus::Open
+                || stored.public.next_offset != Some(total)
+                || stored.completion_object_key.as_deref() != Some(object_key)
+            {
+                stored.public.status = UploadSessionStatus::Completing;
+                stored.public.next_offset = Some(total);
+                stored.completion_object_key = Some(object_key.to_string());
+                self.write_session(session, stored).await?;
+            }
+            // Flush the final remainder as the last component, then compose.
+            let tail = stored
+                .native
+                .compose()
+                .expect("compose state")
+                .pending_tail
+                .clone();
+            if !tail.is_empty() {
+                let index = stored.native.compose().expect("compose state").next_index;
+                let component = self
+                    .write_component(session, index, Bytes::from(tail))
+                    .await?;
+                if let Some(state) = stored.native.compose_mut() {
+                    state.components.push(component);
+                    state.next_index = index + 1;
+                    state.pending_tail = Vec::new();
+                }
+                self.write_session(session, stored).await?;
+            }
+            match self
+                .compose_components(session, stored, object_key, Some(0))
+                .await
+            {
+                Ok(written) => written,
+                Err(StorageError::PolicyRejected { .. }) => {
+                    // An object appeared at the key during completion; adopt it
+                    // only if it is ours, otherwise clean up and reject.
+                    match self.get_object_attrs(object_key).await? {
+                        Some(attrs) if attrs.owner_session.as_deref() == Some(session.as_str()) => {
+                            GcsObjectWrite {
+                                etag: attrs.etag,
+                                generation: attrs
+                                    .generation
+                                    .map(|generation| generation.to_string()),
+                                generation_match: attrs.generation,
+                            }
+                        }
+                        _ => {
+                            self.delete_component_chain(session).await;
+                            return Err(StorageError::policy_rejected(format!(
+                                "GCS object key already exists: {object_key}"
+                            )));
+                        }
+                    }
+                }
+                Err(err) => return Err(err),
+            }
+        };
+
+        // Validate the checksum by streaming the composed object (only when a
+        // checksum was supplied; the default path never hashes).
+        let checksum = match checksum_algorithm_to_compute(
+            &stored.checksum_policy,
+            provided_checksum.as_ref(),
+        ) {
+            Some(algorithm) => {
+                let computed = self.stream_object_checksum(object_key, algorithm).await?;
+                match validate_complete_checksum_precomputed(
+                    &stored.checksum_policy,
+                    Some(computed),
+                    provided_checksum,
+                ) {
+                    Ok(checksum) => checksum,
+                    Err(err) => {
+                        // Remove the composed-but-invalid object; surface a
+                        // delete failure (a live invalid object is worse).
+                        self.delete_object(object_key).await.map_err(|delete_err| {
+                            tracing::error!(
+                                target: "pocopine.log",
+                                event_name = "pocopine.storage.gcs_invalid_object_cleanup_failed",
+                                object_key = %object_key,
+                                checksum_error = %err,
+                                delete_error = %delete_err,
+                            );
+                            delete_err
+                        })?;
+                        return Err(err);
+                    }
+                }
+            }
+            None => validate_complete_checksum_precomputed(
+                &stored.checksum_policy,
+                None,
+                provided_checksum,
+            )?,
+        };
+        Ok((written, checksum))
     }
 
     // --- legacy staged-object rewrite flow (pre-compose sessions) -------------

--- a/crates/pocopine-storage-gcs/src/storage.rs
+++ b/crates/pocopine-storage-gcs/src/storage.rs
@@ -635,6 +635,29 @@ impl GcsStorageBackend {
         let _ = self.write_session(session, stored).await;
     }
 
+    /// Reopen a failed completion ONLY when no live object owned by this session
+    /// exists at the destination.
+    ///
+    /// If compose already produced our object (e.g. a later checksum-stream error,
+    /// or a lost compose response), reopening would let a subsequent append change
+    /// the committed bytes while a retry still adopts the already-live object —
+    /// serving stale data. In that case the session stays `Completing` and a retry
+    /// adopts-and-finishes idempotently. Reopening is safe only when the object is
+    /// absent (compose never landed) or foreign (never ours to serve).
+    async fn reopen_if_object_absent(
+        &self,
+        session: &UploadSessionId,
+        stored: &mut StoredUploadSession,
+        object_key: &str,
+    ) {
+        if let Ok(Some(attrs)) = self.get_object_attrs(object_key).await {
+            if attrs.owner_session.as_deref() == Some(session.as_str()) {
+                return;
+            }
+        }
+        self.reopen_session(session, stored).await;
+    }
+
     /// Assemble the recorded components into the destination object, stamping the
     /// owning session so a crashed retry can recognize its own object.
     async fn compose_components(
@@ -892,7 +915,8 @@ impl GcsStorageBackend {
             {
                 Ok(pair) => pair,
                 Err(err) => {
-                    self.reopen_session(session, &mut stored).await;
+                    self.reopen_if_object_absent(session, &mut stored, &object_key)
+                        .await;
                     return Err(err);
                 }
             }

--- a/crates/pocopine-storage-gcs/src/storage.rs
+++ b/crates/pocopine-storage-gcs/src/storage.rs
@@ -650,12 +650,18 @@ impl GcsStorageBackend {
         stored: &mut StoredUploadSession,
         object_key: &str,
     ) {
-        if let Ok(Some(attrs)) = self.get_object_attrs(object_key).await {
-            if attrs.owner_session.as_deref() == Some(session.as_str()) {
-                return;
-            }
+        // Reopen only when the HEAD *definitively* shows the object is absent or
+        // foreign. An indeterminate lookup (transient/backend error) must keep the
+        // session `Completing`: a live owned object might exist, and reopening
+        // would let a later append change the bytes a retry then adopts.
+        let absent_or_foreign = match self.get_object_attrs(object_key).await {
+            Ok(None) => true,
+            Ok(Some(attrs)) => attrs.owner_session.as_deref() != Some(session.as_str()),
+            Err(_) => false,
+        };
+        if absent_or_foreign {
+            self.reopen_session(session, stored).await;
         }
-        self.reopen_session(session, stored).await;
     }
 
     /// Assemble the recorded components into the destination object, stamping the

--- a/crates/pocopine-storage-gcs/src/storage.rs
+++ b/crates/pocopine-storage-gcs/src/storage.rs
@@ -564,18 +564,31 @@ impl GcsStorageBackend {
         let key = self.layout.session_component_key(session, index);
         let size = bytes.len() as u64;
         let generation = match self
-            .put_object_bytes(&key, bytes, Some("application/octet-stream"), Some(0))
+            .put_object_bytes(
+                &key,
+                bytes.clone(),
+                Some("application/octet-stream"),
+                Some(0),
+            )
             .await
         {
             Ok(written) => written.generation_match,
-            Err(StorageError::PolicyRejected { .. }) => match self.get_object_attrs(&key).await? {
-                Some(attrs) => attrs.generation,
-                None => {
-                    return Err(StorageError::backend(
-                        "GCS component vanished after a create-only conflict".to_string(),
-                    ))
+            Err(StorageError::PolicyRejected { .. }) => {
+                // A component already exists at this index (a retry or a
+                // concurrent worker). Adopt it only if its bytes match what this
+                // append intends to write; otherwise the index is being reused
+                // for different content and must not be silently accepted.
+                let existing = self.get_object_bytes_with_limit(&key, size).await?;
+                if existing.truncated
+                    || existing.bytes.len() as u64 != size
+                    || existing.bytes.as_slice() != bytes.as_ref()
+                {
+                    return Err(StorageError::conflict(
+                        "GCS upload component already exists with different bytes",
+                    ));
                 }
-            },
+                existing.generation_match
+            }
             Err(err) => return Err(err),
         };
         Ok(GcsComponent {

--- a/crates/pocopine-storage-gcs/src/storage.rs
+++ b/crates/pocopine-storage-gcs/src/storage.rs
@@ -231,8 +231,19 @@ impl GcsStorageBackend {
         session: &UploadSessionId,
     ) -> StorageResult<GcsObjectBytes> {
         let key = self.layout.session_meta_key(session);
-        self.get_object_bytes_with_limit(&key, MAX_SESSION_METADATA_BYTES)
+        self.get_object_bytes_with_limit(&key, self.session_metadata_read_limit())
             .await
+    }
+
+    /// Read cap for `session.json`. Native compose sessions buffer their tail
+    /// inline (base64), so the cap must accommodate one component plus the
+    /// fixed metadata, well above the bare [`MAX_SESSION_METADATA_BYTES`] used
+    /// for the non-tail fields. Derived from the backend's absolute size cap so
+    /// it is an upper bound for every session's `component_size_for(max_bytes)`.
+    fn session_metadata_read_limit(&self) -> u64 {
+        component_size_for(self.max_proxy_upload_bytes)
+            .saturating_mul(2)
+            .saturating_add(MAX_SESSION_METADATA_BYTES)
     }
 
     async fn create_session(
@@ -537,8 +548,13 @@ impl GcsStorageBackend {
 
     // --- native compose helpers ----------------------------------------------
 
-    /// Write one component object (each written exactly once; rewriting the same
-    /// index with the same bytes on a retry is an idempotent overwrite).
+    /// Write one component object.
+    ///
+    /// Uses a create-only precondition (`if_generation_match: 0`) so a concurrent
+    /// or retried attempt at the same index can never clobber a component another
+    /// worker already recorded. A component's content is deterministic for its
+    /// index (it covers a fixed, append-only byte range), so an already-present
+    /// object is correct — adopt its generation instead of overwriting it.
     async fn write_component(
         &self,
         session: &UploadSessionId,
@@ -547,14 +563,51 @@ impl GcsStorageBackend {
     ) -> StorageResult<GcsComponent> {
         let key = self.layout.session_component_key(session, index);
         let size = bytes.len() as u64;
-        let written = self
-            .put_object_bytes(&key, bytes, Some("application/octet-stream"), None)
-            .await?;
+        let generation = match self
+            .put_object_bytes(&key, bytes, Some("application/octet-stream"), Some(0))
+            .await
+        {
+            Ok(written) => written.generation_match,
+            Err(StorageError::PolicyRejected { .. }) => match self.get_object_attrs(&key).await? {
+                Some(attrs) => attrs.generation,
+                None => {
+                    return Err(StorageError::backend(
+                        "GCS component vanished after a create-only conflict".to_string(),
+                    ))
+                }
+            },
+            Err(err) => return Err(err),
+        };
         Ok(GcsComponent {
             key,
             size,
-            generation: written.generation_match,
+            generation,
         })
+    }
+
+    /// Best-effort deletion of every component object for a session.
+    ///
+    /// Component indices are contiguous from 0 (sequential, append-only), so this
+    /// also removes components written just before a crash but not yet recorded
+    /// in the session metadata. Stops at the first missing index.
+    async fn delete_component_chain(&self, session: &UploadSessionId) {
+        let mut index = 0u32;
+        loop {
+            let key = self.layout.session_component_key(session, index);
+            match self.delete_object(&key).await {
+                Ok(()) => index += 1,
+                Err(_) => break,
+            }
+        }
+    }
+
+    /// Return a session that reached `Completing` back to `Open` after a
+    /// recoverable completion failure, so the caller can retry or abort from a
+    /// valid state instead of being stranded. Best-effort.
+    async fn reopen_session(&self, session: &UploadSessionId, stored: &mut StoredUploadSession) {
+        stored.public.status = UploadSessionStatus::Open;
+        stored.completion_object_key = None;
+        let _ = self.write_session(session, stored).await;
     }
 
     /// Assemble the recorded components into the destination object, stamping the
@@ -616,13 +669,6 @@ impl GcsStorageBackend {
             hasher.update(&chunk);
         }
         Ok(hasher.finalize())
-    }
-
-    /// Best-effort deletion of a session's component objects.
-    async fn delete_components(&self, components: &[GcsComponent]) {
-        for component in components {
-            let _ = self.delete_object_if_exists(&component.key).await;
-        }
     }
 
     async fn delete_object(&self, key: &str) -> StorageResult<()> {
@@ -824,13 +870,10 @@ impl GcsStorageBackend {
                         generation_match: attrs.generation,
                     }
                 } else {
-                    let components = stored
-                        .native
-                        .compose()
-                        .expect("compose state")
-                        .components
-                        .clone();
-                    self.delete_components(&components).await;
+                    // Foreign object at the destination (the session is still
+                    // Open here): clean up our components and reject without
+                    // overwriting it.
+                    self.delete_component_chain(session).await;
                     return Err(StorageError::policy_rejected(format!(
                         "GCS object key already exists: {object_key}"
                     )));
@@ -885,13 +928,10 @@ impl GcsStorageBackend {
                                 }
                             }
                             _ => {
-                                let components = stored
-                                    .native
-                                    .compose()
-                                    .expect("compose state")
-                                    .components
-                                    .clone();
-                                self.delete_components(&components).await;
+                                self.delete_component_chain(session).await;
+                                // The session reached Completing; reopen it so the
+                                // owner can abort or retry rather than be stranded.
+                                self.reopen_session(session, &mut stored).await;
                                 return Err(StorageError::policy_rejected(format!(
                                     "GCS object key already exists: {object_key}"
                                 )));
@@ -929,6 +969,9 @@ impl GcsStorageBackend {
                                 );
                                 delete_err
                             })?;
+                            // Reopen so the client can retry with a correct
+                            // checksum (components remain for re-compose).
+                            self.reopen_session(session, &mut stored).await;
                             return Err(err);
                         }
                     }
@@ -946,17 +989,13 @@ impl GcsStorageBackend {
         stored.public.status = UploadSessionStatus::Complete;
         stored.public.next_offset = Some(total);
         stored.object = Some(object.clone());
-        let components = stored
-            .native
-            .compose()
-            .map(|state| state.components.clone())
-            .unwrap_or_default();
         if let Some(state) = stored.native.compose_mut() {
             state.pending_tail = Vec::new();
         }
         self.write_session(session, &mut stored).await?;
-        // Component objects are temporary; remove them after the object is live.
-        self.delete_components(&components).await;
+        // Component objects are temporary; remove them now the final object is
+        // live (the compose copied their bytes into it).
+        self.delete_component_chain(session).await;
         Ok(object)
     }
 
@@ -1288,18 +1327,10 @@ impl StorageBackend for GcsStorageBackend {
                             session: session.to_string(),
                         });
                     }
-                    // Remove native component objects so they do not linger.
-                    if let Some(state) = stored.native.compose() {
-                        self.delete_components(&state.components).await;
-                        // The next, not-yet-recorded component index may have been
-                        // written just before a crash; clean it up too.
-                        let _ = self
-                            .delete_object_if_exists(
-                                &self
-                                    .layout
-                                    .session_component_key(&session, state.next_index),
-                            )
-                            .await;
+                    // Remove every component object (including any written just
+                    // before a crash but not yet recorded) so none linger.
+                    if stored.native.compose().is_some() {
+                        self.delete_component_chain(&session).await;
                     }
                 }
                 AbortSessionRead::Missing => {}

--- a/crates/pocopine-storage-gcs/tests/fake_gcs.rs
+++ b/crates/pocopine-storage-gcs/tests/fake_gcs.rs
@@ -851,3 +851,44 @@ async fn compose_upload_verifies_streaming_sha256_against_fake_gcs() -> StorageR
     assert_eq!(object.checksum, Some(expected));
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn compose_buffers_large_inline_tail_in_metadata_against_fake_gcs() -> StorageResult<()> {
+    let clients = gcs_clients().await;
+    let bucket = create_bucket(&clients, "compose-tail").await;
+    let backend =
+        GcsStorageBackend::emulator(clients.storage.clone(), clients.endpoint.clone(), bucket)?;
+    // 500 KiB stays below the 1 MiB component size, so it is buffered entirely
+    // in the inline (base64) tail — well over the 256 KiB non-tail metadata
+    // bound. inspect + complete must still read the session metadata.
+    let total = 500 * 1024usize;
+    let session = initiate_large_checked(
+        &backend,
+        "files/tail.bin",
+        total as u64,
+        ChecksumPolicy::None,
+    )
+    .await?;
+    backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, pattern_bytes(0, total))
+        .await?;
+
+    let inspected = backend.inspect_upload(&ctx(), session.id.clone()).await?;
+    assert_eq!(inspected.next_offset, Some(total as u64));
+
+    let object = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(object.size, total as u64);
+    assert_eq!(
+        object_bytes(&clients.storage, backend.bucket(), "files/tail.bin").await,
+        pattern_bytes(0, total).to_vec()
+    );
+    Ok(())
+}

--- a/crates/pocopine-storage-gcs/tests/fake_gcs.rs
+++ b/crates/pocopine-storage-gcs/tests/fake_gcs.rs
@@ -14,9 +14,9 @@ use bytes::Bytes;
 use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
 use google_cloud_storage::client::Storage;
 use pocopine_storage::{
-    CompleteUpload, InitiateUpload, PrincipalRef, SafeObjectKey, StorageActor, StorageBackend,
-    StorageContext, StorageError, StorageKey, StorageResult, UploadPolicy, UploadSession,
-    UploadSessionStatus, UploadStrategy,
+    ChecksumAlgorithm, ChecksumPolicy, CompleteUpload, InitiateUpload, ObjectChecksum,
+    PrincipalRef, SafeObjectKey, StorageActor, StorageBackend, StorageContext, StorageError,
+    StorageKey, StorageResult, UploadPolicy, UploadSession, UploadSessionStatus, UploadStrategy,
 };
 use pocopine_storage_gcs::GcsStorageBackend;
 use testcontainers::core::{wait::HttpWaitStrategy, ContainerPort, WaitFor};
@@ -154,6 +154,55 @@ async fn initiate(backend: &GcsStorageBackend, size: Option<u64>) -> StorageResu
             },
         )
         .await
+}
+
+fn large_policy() -> StorageResult<UploadPolicy> {
+    let mut policy = UploadPolicy::new("gcs")?
+        .max_bytes(32 * 1024 * 1024)
+        .preferred_chunk_size(1024 * 1024);
+    policy.expires_after = Duration::from_secs(60 * 60);
+    Ok(policy)
+}
+
+async fn initiate_large_checked(
+    backend: &GcsStorageBackend,
+    key: &str,
+    size: u64,
+    checksum: ChecksumPolicy,
+) -> StorageResult<UploadSession> {
+    let mut policy = large_policy()?;
+    policy.checksum = checksum;
+    backend
+        .initiate_upload(
+            &ctx(),
+            InitiateUpload {
+                scope: "files".to_string(),
+                storage_key: StorageKey::new(SafeObjectKey::parse(key)?),
+                file_name: "large.bin".to_string(),
+                size: Some(size),
+                content_type: Some("application/octet-stream".to_string()),
+                metadata: BTreeMap::new(),
+                requested_strategy: UploadStrategy::Auto,
+                policy,
+            },
+        )
+        .await
+}
+
+fn pattern_bytes(start: usize, len: usize) -> Bytes {
+    let mut buf = Vec::with_capacity(len);
+    for i in 0..len {
+        buf.push(((start + i) % 251) as u8);
+    }
+    Bytes::from(buf)
+}
+
+async fn object_exists(storage: &Storage, bucket: &str, key: &str) -> bool {
+    storage
+        .read_object(bucket_resource(bucket), key)
+        .send()
+        .await
+        .is_ok()
 }
 
 async fn object_bytes(storage: &Storage, bucket: &str, key: &str) -> Vec<u8> {
@@ -459,12 +508,15 @@ async fn duplicate_append_retry_after_staged_write_advances_metadata() -> Storag
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn inspect_truncates_rogue_staged_bytes_back_to_committed_offset() -> StorageResult<()> {
+async fn rogue_staged_object_does_not_promote_committed_offset() -> StorageResult<()> {
     let clients = gcs_clients().await;
     let bucket = create_bucket(&clients, "truncate").await;
     let backend =
         GcsStorageBackend::emulator(clients.storage.clone(), clients.endpoint.clone(), bucket)?;
     let session = initiate(&backend, Some(5)).await?;
+    // Native compose sessions buffer their tail inline in the metadata; the
+    // legacy `bytes.tmp` staging object is not part of the protocol, so a rogue
+    // one must never be mistaken for committed bytes.
     let bytes_key = session_object_key(&backend, &session, "bytes.tmp");
     clients
         .storage
@@ -479,10 +531,6 @@ async fn inspect_truncates_rogue_staged_bytes_back_to_committed_offset() -> Stor
 
     let inspected = backend.inspect_upload(&ctx(), session.id).await?;
     assert_eq!(inspected.next_offset, Some(0));
-    assert_eq!(
-        object_bytes(&clients.storage, backend.bucket(), &bytes_key).await,
-        b""
-    );
     Ok(())
 }
 
@@ -633,5 +681,173 @@ async fn initiate_rejects_policy_above_proxy_cap_for_streaming_upload() -> Stora
         rejected,
         Err(StorageError::PayloadTooLarge { limit: 8 })
     ));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn compose_upload_assembles_large_object_against_fake_gcs() -> StorageResult<()> {
+    let clients = gcs_clients().await;
+    let bucket = create_bucket(&clients, "compose").await;
+    let backend =
+        GcsStorageBackend::emulator(clients.storage.clone(), clients.endpoint.clone(), bucket)?;
+
+    // 4 MiB in 2 MiB chunks; with a 1 MiB component size this writes several
+    // component objects that are composed into the final object.
+    let chunk = 2 * 1024 * 1024usize;
+    let total = 2 * chunk;
+    let session = initiate_large_checked(
+        &backend,
+        "files/large.bin",
+        total as u64,
+        ChecksumPolicy::None,
+    )
+    .await?;
+
+    let mut offset = 0u64;
+    for index in 0..2 {
+        let updated = backend
+            .append_upload_bytes(
+                &ctx(),
+                session.id.clone(),
+                offset,
+                pattern_bytes(index * chunk, chunk),
+            )
+            .await?;
+        offset += chunk as u64;
+        assert_eq!(updated.next_offset, Some(offset));
+    }
+
+    let object = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id.clone(),
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(object.size, total as u64);
+    assert_eq!(
+        object_bytes(&clients.storage, backend.bucket(), "files/large.bin").await,
+        pattern_bytes(0, total).to_vec()
+    );
+    // Component objects are temporary and removed after completion.
+    let first_component = session_object_key(&backend, &session, "components/comp-00000");
+    assert!(!object_exists(&clients.storage, backend.bucket(), &first_component).await);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn compose_abort_removes_component_objects_against_fake_gcs() -> StorageResult<()> {
+    let clients = gcs_clients().await;
+    let bucket = create_bucket(&clients, "compose-abort").await;
+    let backend =
+        GcsStorageBackend::emulator(clients.storage.clone(), clients.endpoint.clone(), bucket)?;
+    let session = initiate_large_checked(
+        &backend,
+        "files/large.bin",
+        2 * 1024 * 1024,
+        ChecksumPolicy::None,
+    )
+    .await?;
+
+    // 2 MiB at a 1 MiB component size writes component objects.
+    backend
+        .append_upload_bytes(
+            &ctx(),
+            session.id.clone(),
+            0,
+            pattern_bytes(0, 2 * 1024 * 1024),
+        )
+        .await?;
+    let first_component = session_object_key(&backend, &session, "components/comp-00000");
+    assert!(object_exists(&clients.storage, backend.bucket(), &first_component).await);
+
+    backend.abort_upload(&ctx(), session.id.clone()).await?;
+
+    assert!(!object_exists(&clients.storage, backend.bucket(), &first_component).await);
+    assert!(!object_exists(&clients.storage, backend.bucket(), "files/large.bin").await);
+    let inspected = backend.inspect_upload(&ctx(), session.id).await;
+    assert!(matches!(
+        inspected,
+        Err(StorageError::UnknownUploadSession { .. })
+    ));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn compose_completion_is_idempotent_against_fake_gcs() -> StorageResult<()> {
+    let clients = gcs_clients().await;
+    let bucket = create_bucket(&clients, "compose-idem").await;
+    let backend =
+        GcsStorageBackend::emulator(clients.storage.clone(), clients.endpoint.clone(), bucket)?;
+    let total = 3 * 1024 * 1024usize;
+    let session = initiate_large_checked(
+        &backend,
+        "files/large.bin",
+        total as u64,
+        ChecksumPolicy::None,
+    )
+    .await?;
+    backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, pattern_bytes(0, total))
+        .await?;
+
+    let first = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id.clone(),
+                checksum: None,
+            },
+        )
+        .await?;
+    let second = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(first, second);
+    assert_eq!(first.size, total as u64);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn compose_upload_verifies_streaming_sha256_against_fake_gcs() -> StorageResult<()> {
+    let clients = gcs_clients().await;
+    let bucket = create_bucket(&clients, "compose-sha").await;
+    let backend =
+        GcsStorageBackend::emulator(clients.storage.clone(), clients.endpoint.clone(), bucket)?;
+    let total = 3 * 1024 * 1024usize;
+    let data = pattern_bytes(0, total);
+    let expected = ObjectChecksum {
+        algorithm: ChecksumAlgorithm::Sha256,
+        value: pocopine_crypto::sha256_hex(&data),
+    };
+    let session = initiate_large_checked(
+        &backend,
+        "files/checked.bin",
+        total as u64,
+        ChecksumPolicy::Required(ChecksumAlgorithm::Sha256),
+    )
+    .await?;
+    backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, data)
+        .await?;
+
+    let object = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: Some(expected.clone()),
+            },
+        )
+        .await?;
+    assert_eq!(object.checksum, Some(expected));
     Ok(())
 }

--- a/crates/pocopine-storage-s3/Cargo.toml
+++ b/crates/pocopine-storage-s3/Cargo.toml
@@ -8,6 +8,7 @@ description = "S3-compatible backend adapter for pocopine-storage."
 
 [dependencies]
 aws-sdk-s3 = "1"
+base64 = "0.22"
 bytes = "1"
 pocopine-storage = { workspace = true }
 serde = { workspace = true }

--- a/crates/pocopine-storage-s3/Cargo.toml
+++ b/crates/pocopine-storage-s3/Cargo.toml
@@ -12,13 +12,15 @@ bytes = "1"
 pocopine-storage = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-sha2 = "0.10"
 time = { version = "0.3", features = ["serde"] }
-tokio = { version = "1", default-features = false, features = ["sync"] }
+# `io-util` powers the streaming checksum read-back (`ByteStream::into_async_read`)
+# so checksum verification never buffers the whole object.
+tokio = { version = "1", default-features = false, features = ["io-util", "sync"] }
 tracing = { workspace = true }
 uuid = { version = "1", features = ["v4"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+pocopine-crypto = { workspace = true }
 testcontainers = "0.23"
 testcontainers-modules = { version = "0.11", features = ["minio"] }
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/crates/pocopine-storage-s3/Cargo.toml
+++ b/crates/pocopine-storage-s3/Cargo.toml
@@ -8,8 +8,8 @@ description = "S3-compatible backend adapter for pocopine-storage."
 
 [dependencies]
 aws-sdk-s3 = "1"
-base64 = "0.22"
 bytes = "1"
+pocopine-codec = { workspace = true }
 pocopine-storage = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/pocopine-storage-s3/src/state.rs
+++ b/crates/pocopine-storage-s3/src/state.rs
@@ -55,11 +55,34 @@ pub(crate) struct S3MultipartState {
     /// Next part number to assign (S3 part numbers are 1-based).
     #[serde(default)]
     pub(crate) next_part_number: i32,
-    /// Bytes currently buffered in `bytes.tmp` that have not yet been flushed to
-    /// a part. Always smaller than one part (the S3 5 MiB minimum), except just
-    /// before completion when the final remainder becomes the last part.
-    #[serde(default)]
-    pub(crate) pending_tail_len: u64,
+    /// Bytes received but not yet flushed to a part. Always smaller than one
+    /// part (the S3 5 MiB minimum), except just before completion when the final
+    /// remainder becomes the last part.
+    ///
+    /// Stored inline (base64) in the session metadata rather than a separate
+    /// object, so the tail and the part bookkeeping are persisted in a single
+    /// atomic `PutObject`. A crash can never leave the tail and metadata
+    /// describing different states (which would corrupt the object around a part
+    /// boundary on resume).
+    #[serde(default, with = "base64_bytes", skip_serializing_if = "Vec::is_empty")]
+    pub(crate) pending_tail: Vec<u8>,
+}
+
+mod base64_bytes {
+    use base64::engine::general_purpose::STANDARD;
+    use base64::Engine as _;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub(super) fn serialize<S: Serializer>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&STANDARD.encode(bytes))
+    }
+
+    pub(super) fn deserialize<'de, D: Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<Vec<u8>, D::Error> {
+        let encoded = String::deserialize(deserializer)?;
+        STANDARD.decode(encoded).map_err(serde::de::Error::custom)
+    }
 }
 
 /// One uploaded multipart part.
@@ -90,5 +113,10 @@ impl S3MultipartState {
     /// Total bytes already committed to provider parts (excludes the pending tail).
     pub(crate) fn flushed_len(&self) -> u64 {
         self.parts.iter().map(|part| part.size).sum()
+    }
+
+    /// Total bytes accepted so far (flushed parts plus the buffered tail).
+    pub(crate) fn committed_len(&self) -> u64 {
+        self.flushed_len() + self.pending_tail.len() as u64
     }
 }

--- a/crates/pocopine-storage-s3/src/state.rs
+++ b/crates/pocopine-storage-s3/src/state.rs
@@ -16,4 +16,79 @@ pub(crate) struct StoredUploadSession {
     pub(crate) object: Option<ObjectRef>,
     #[serde(default)]
     pub(crate) cleanup_pending: bool,
+    /// Transfer mechanism backing this session.
+    ///
+    /// Sessions written before native multipart support omit this field and
+    /// deserialize as [`NativeUploadState::LegacyProxy`], so in-flight uploads
+    /// created by an older build keep working on the staged-object rewrite path.
+    #[serde(default)]
+    pub(crate) native: NativeUploadState,
+}
+
+/// Backend transfer mechanism for an upload session.
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum NativeUploadState {
+    /// Legacy staged-object rewrite (download → extend → re-upload per append).
+    ///
+    /// Only used for sessions created before native multipart was introduced.
+    #[default]
+    LegacyProxy,
+    /// S3 native multipart upload: each flushed block is an `UploadPart`, the
+    /// final object is assembled by `CompleteMultipartUpload`, and only an
+    /// unflushed tail (smaller than one part) is ever staged in memory/`bytes.tmp`.
+    Multipart(S3MultipartState),
+}
+
+/// Provider-side multipart bookkeeping for one session.
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+pub(crate) struct S3MultipartState {
+    /// `UploadId` returned by `CreateMultipartUpload`.
+    ///
+    /// Created lazily on the first part flush so an initiated-but-abandoned
+    /// session leaves no provider-side multipart upload behind.
+    #[serde(default)]
+    pub(crate) upload_id: Option<String>,
+    /// Parts already uploaded to S3, in ascending part-number order.
+    #[serde(default)]
+    pub(crate) parts: Vec<S3CompletedPart>,
+    /// Next part number to assign (S3 part numbers are 1-based).
+    #[serde(default)]
+    pub(crate) next_part_number: i32,
+    /// Bytes currently buffered in `bytes.tmp` that have not yet been flushed to
+    /// a part. Always smaller than one part (the S3 5 MiB minimum), except just
+    /// before completion when the final remainder becomes the last part.
+    #[serde(default)]
+    pub(crate) pending_tail_len: u64,
+}
+
+/// One uploaded multipart part.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub(crate) struct S3CompletedPart {
+    pub(crate) number: i32,
+    pub(crate) etag: String,
+    pub(crate) size: u64,
+}
+
+impl NativeUploadState {
+    pub(crate) fn multipart_mut(&mut self) -> Option<&mut S3MultipartState> {
+        match self {
+            NativeUploadState::Multipart(state) => Some(state),
+            NativeUploadState::LegacyProxy => None,
+        }
+    }
+
+    pub(crate) fn multipart(&self) -> Option<&S3MultipartState> {
+        match self {
+            NativeUploadState::Multipart(state) => Some(state),
+            NativeUploadState::LegacyProxy => None,
+        }
+    }
+}
+
+impl S3MultipartState {
+    /// Total bytes already committed to provider parts (excludes the pending tail).
+    pub(crate) fn flushed_len(&self) -> u64 {
+        self.parts.iter().map(|part| part.size).sum()
+    }
 }

--- a/crates/pocopine-storage-s3/src/state.rs
+++ b/crates/pocopine-storage-s3/src/state.rs
@@ -64,25 +64,12 @@ pub(crate) struct S3MultipartState {
     /// atomic `PutObject`. A crash can never leave the tail and metadata
     /// describing different states (which would corrupt the object around a part
     /// boundary on resume).
-    #[serde(default, with = "base64_bytes", skip_serializing_if = "Vec::is_empty")]
+    #[serde(
+        default,
+        with = "pocopine_codec::base64_bytes",
+        skip_serializing_if = "Vec::is_empty"
+    )]
     pub(crate) pending_tail: Vec<u8>,
-}
-
-mod base64_bytes {
-    use base64::engine::general_purpose::STANDARD;
-    use base64::Engine as _;
-    use serde::{Deserialize, Deserializer, Serializer};
-
-    pub(super) fn serialize<S: Serializer>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&STANDARD.encode(bytes))
-    }
-
-    pub(super) fn deserialize<'de, D: Deserializer<'de>>(
-        deserializer: D,
-    ) -> Result<Vec<u8>, D::Error> {
-        let encoded = String::deserialize(deserializer)?;
-        STANDARD.decode(encoded).map_err(serde::de::Error::custom)
-    }
 }
 
 /// One uploaded multipart part.

--- a/crates/pocopine-storage-s3/src/storage.rs
+++ b/crates/pocopine-storage-s3/src/storage.rs
@@ -457,9 +457,14 @@ impl S3StorageBackend {
             .await
         {
             Ok(output) => Ok(output.e_tag().map(|etag| normalize_etag(etag.to_string()))),
-            Err(err) if is_precondition_failed(&err) => Err(StorageError::policy_rejected(
-                format!("S3 object key already exists: {object_key}"),
-            )),
+            Err(err) if is_precondition_failed(&err) => {
+                // A foreign object won the race; our upload is still active, so
+                // abort it to avoid leaking parts before reporting the collision.
+                let _ = self.abort_multipart(object_key, upload_id).await;
+                Err(StorageError::policy_rejected(format!(
+                    "S3 object key already exists: {object_key}"
+                )))
+            }
             Err(err) if is_no_such_upload(&err) => {
                 match self.head_object(object_key).await? {
                     // Adopt the existing object only if it was stamped by this
@@ -716,38 +721,25 @@ impl S3StorageBackend {
         precheck_checksum(&stored.checksum_policy, request.checksum.as_ref())?;
 
         let object_key = self.layout.object_key(stored.storage_key.key.as_str());
-        // `Completing` means a prior completion attempt got at least as far as
-        // finalizing the object, so a retry must treat an existing key as ours.
-        let first_attempt = stored.public.status == UploadSessionStatus::Open;
-        // Defense in depth against overwriting a foreign object:
-        //  - this preflight HEAD catches a pre-existing key and works on every
-        //    S3-compatible store (including emulators that ignore the condition);
-        //  - `CompleteMultipartUpload` additionally uses `If-None-Match: *` to
-        //    close the TOCTOU window on real S3.
-        // Retries (status `Completing`) skip the preflight: the key may exist
-        // from our own prior completion and is reconciled idempotently.
-        if first_attempt && self.head_object(&object_key).await?.is_some() {
-            return Err(StorageError::policy_rejected(format!(
-                "S3 object key already exists: {object_key}"
-            )));
-        }
-        if stored.public.status == UploadSessionStatus::Open
-            || stored.public.next_offset != Some(total)
-        {
-            stored.public.status = UploadSessionStatus::Completing;
-            stored.public.next_offset = Some(total);
-            self.write_session(session, &stored).await?;
-        }
-
-        let (has_upload_id, tail) = {
-            let state = stored.native.multipart().expect("multipart state");
-            (state.upload_id.is_some(), state.pending_tail.clone())
-        };
+        let has_upload_id = stored
+            .native
+            .multipart()
+            .expect("multipart state")
+            .upload_id
+            .is_some();
 
         let (etag, checksum) = if !has_upload_id {
-            // Whole object fits within one part (or is empty): a single direct
-            // PUT, no multipart overhead. We already have the bytes, so validate
-            // the checksum directly.
+            // Single direct-PUT path: the whole object fits in the buffered tail
+            // (or is empty). It is atomic — `put_completed_object` refuses to
+            // overwrite an existing key — and the checksum is validated before any
+            // state change, so a rejected checksum leaves the session open and
+            // resumable rather than stranded in `Completing`.
+            let tail = stored
+                .native
+                .multipart()
+                .expect("multipart state")
+                .pending_tail
+                .clone();
             let checksum =
                 validate_complete_checksum(&stored.checksum_policy, &tail, request.checksum)?;
             let etag = self
@@ -759,8 +751,39 @@ impl S3StorageBackend {
                 .await?;
             (etag, checksum)
         } else {
-            // Flush the final remainder as the last part (the last part is exempt
-            // from the minimum-size rule), then assemble the object.
+            // Multipart path. `Completing` means a prior attempt already reached
+            // the finalize stage, so a retry must treat an existing key as
+            // potentially ours.
+            let first_attempt = stored.public.status == UploadSessionStatus::Open;
+            // Defense in depth against overwriting a foreign object: this preflight
+            // HEAD works on every store (including emulators that ignore the
+            // condition), and `CompleteMultipartUpload` additionally uses
+            // `If-None-Match: *` to close the TOCTOU window on real S3. Retries
+            // skip the preflight; the key may exist from our own prior completion.
+            if first_attempt && self.head_object(&object_key).await?.is_some() {
+                // Abort the now-orphaned provider upload before reporting so its
+                // parts do not linger and accrue storage cost.
+                let _ = self.abort_multipart_session(&stored).await;
+                return Err(StorageError::policy_rejected(format!(
+                    "S3 object key already exists: {object_key}"
+                )));
+            }
+            if stored.public.status == UploadSessionStatus::Open
+                || stored.public.next_offset != Some(total)
+            {
+                stored.public.status = UploadSessionStatus::Completing;
+                stored.public.next_offset = Some(total);
+                self.write_session(session, &stored).await?;
+            }
+
+            // Flush the final remainder as the last part (exempt from the
+            // minimum-size rule), then assemble the object.
+            let tail = stored
+                .native
+                .multipart()
+                .expect("multipart state")
+                .pending_tail
+                .clone();
             if !tail.is_empty() {
                 let tail_len = tail.len() as u64;
                 let upload_id = stored

--- a/crates/pocopine-storage-s3/src/storage.rs
+++ b/crates/pocopine-storage-s3/src/storage.rs
@@ -751,75 +751,84 @@ impl S3StorageBackend {
                 .await?;
             (etag, checksum)
         } else {
-            // Multipart path. `Completing` means a prior attempt already reached
-            // the finalize stage, so a retry must treat an existing key as
-            // potentially ours.
-            let first_attempt = stored.public.status == UploadSessionStatus::Open;
-            // Defense in depth against overwriting a foreign object: this preflight
-            // HEAD works on every store (including emulators that ignore the
-            // condition), and `CompleteMultipartUpload` additionally uses
-            // `If-None-Match: *` to close the TOCTOU window on real S3. Retries
-            // skip the preflight; the key may exist from our own prior completion.
-            if first_attempt && self.head_object(&object_key).await?.is_some() {
-                // Abort the now-orphaned provider upload before reporting so its
-                // parts do not linger and accrue storage cost.
-                let _ = self.abort_multipart_session(&stored).await;
-                return Err(StorageError::policy_rejected(format!(
-                    "S3 object key already exists: {object_key}"
-                )));
-            }
-            if stored.public.status == UploadSessionStatus::Open
-                || stored.public.next_offset != Some(total)
-            {
-                stored.public.status = UploadSessionStatus::Completing;
-                stored.public.next_offset = Some(total);
-                self.write_session(session, &stored).await?;
-            }
+            // Multipart path.
+            // HEAD on every attempt (not just the first). This is the only
+            // overwrite guard that works on stores which ignore `If-None-Match`
+            // on `CompleteMultipartUpload`, and it distinguishes our own
+            // already-finalized object (adopt idempotently) from a foreign object
+            // that won the key (reject). The `If-None-Match: *` on completion is
+            // an additional atomic guard for the HEAD→complete window on real S3.
+            let existing_etag = match self.head_object(&object_key).await? {
+                Some(info) if info.owner_session.as_deref() == Some(session.as_str()) => {
+                    Some(info.etag)
+                }
+                Some(_) => {
+                    // Foreign object at the destination: abort our orphaned upload
+                    // (best effort) and reject rather than overwrite it.
+                    let _ = self.abort_multipart_session(&stored).await;
+                    return Err(StorageError::policy_rejected(format!(
+                        "S3 object key already exists: {object_key}"
+                    )));
+                }
+                None => None,
+            };
 
-            // Flush the final remainder as the last part (exempt from the
-            // minimum-size rule), then assemble the object.
-            let tail = stored
-                .native
-                .multipart()
-                .expect("multipart state")
-                .pending_tail
-                .clone();
-            if !tail.is_empty() {
-                let tail_len = tail.len() as u64;
-                let upload_id = stored
-                    .native
-                    .multipart()
-                    .and_then(|state| state.upload_id.clone())
-                    .expect("multipart upload id");
-                let number = stored
+            let etag = if let Some(etag) = existing_etag {
+                // A prior attempt already finalized this object; reuse it.
+                etag
+            } else {
+                if stored.public.status == UploadSessionStatus::Open
+                    || stored.public.next_offset != Some(total)
+                {
+                    stored.public.status = UploadSessionStatus::Completing;
+                    stored.public.next_offset = Some(total);
+                    self.write_session(session, &stored).await?;
+                }
+
+                // Flush the final remainder as the last part (exempt from the
+                // minimum-size rule), then assemble the object.
+                let tail = stored
                     .native
                     .multipart()
                     .expect("multipart state")
-                    .next_part_number;
-                let etag = self
-                    .upload_part(&object_key, &upload_id, number, Bytes::from(tail))
-                    .await?;
-                if let Some(state) = stored.native.multipart_mut() {
-                    state.parts.push(S3CompletedPart {
-                        number,
-                        etag,
-                        size: tail_len,
-                    });
-                    state.next_part_number = number + 1;
-                    state.pending_tail = Vec::new();
+                    .pending_tail
+                    .clone();
+                if !tail.is_empty() {
+                    let tail_len = tail.len() as u64;
+                    let upload_id = stored
+                        .native
+                        .multipart()
+                        .and_then(|state| state.upload_id.clone())
+                        .expect("multipart upload id");
+                    let number = stored
+                        .native
+                        .multipart()
+                        .expect("multipart state")
+                        .next_part_number;
+                    let etag = self
+                        .upload_part(&object_key, &upload_id, number, Bytes::from(tail))
+                        .await?;
+                    if let Some(state) = stored.native.multipart_mut() {
+                        state.parts.push(S3CompletedPart {
+                            number,
+                            etag,
+                            size: tail_len,
+                        });
+                        state.next_part_number = number + 1;
+                        state.pending_tail = Vec::new();
+                    }
+                    self.write_session(session, &stored).await?;
                 }
-                self.write_session(session, &stored).await?;
-            }
-            let (upload_id, parts) = {
-                let state = stored.native.multipart().expect("multipart state");
-                (
-                    state.upload_id.clone().expect("multipart upload id"),
-                    state.parts.clone(),
-                )
+                let (upload_id, parts) = {
+                    let state = stored.native.multipart().expect("multipart state");
+                    (
+                        state.upload_id.clone().expect("multipart upload id"),
+                        state.parts.clone(),
+                    )
+                };
+                self.complete_multipart(&object_key, &upload_id, &parts, session)
+                    .await?
             };
-            let etag = self
-                .complete_multipart(&object_key, &upload_id, &parts, session)
-                .await?;
 
             // Validate the checksum by streaming the finished object (only when a
             // checksum was actually supplied; the default path never hashes).
@@ -843,9 +852,20 @@ impl S3StorageBackend {
                     ) {
                         Ok(checksum) => checksum,
                         Err(err) => {
-                            // The object is live but failed verification: remove
-                            // it so a bad upload is not observable.
-                            let _ = self.delete_object(&object_key).await;
+                            // The object is live but failed verification: remove it
+                            // so a bad upload is never observable. If the delete
+                            // itself fails, surface that — leaving a checksum-invalid
+                            // object live is more severe than the rejection.
+                            self.delete_object(&object_key).await.map_err(|delete_err| {
+                                tracing::error!(
+                                    target: "pocopine.log",
+                                    event_name = "pocopine.storage.s3_invalid_object_cleanup_failed",
+                                    object_key = %object_key,
+                                    checksum_error = %err,
+                                    delete_error = %delete_err,
+                                );
+                                delete_err
+                            })?;
                             return Err(err);
                         }
                     }

--- a/crates/pocopine-storage-s3/src/storage.rs
+++ b/crates/pocopine-storage-s3/src/storage.rs
@@ -33,8 +33,26 @@ const DEFAULT_MAX_PROXY_UPLOAD_BYTES: u64 = 64 * 1024 * 1024;
 /// bounded tail buffer until they reach it.
 const S3_MIN_PART_SIZE: u64 = 5 * 1024 * 1024;
 
+/// S3 maximum size of a single part (5 GiB).
+const S3_MAX_PART_SIZE: u64 = 5 * 1024 * 1024 * 1024;
+
+/// S3 maximum number of parts in one multipart upload.
+const S3_MAX_PARTS: u64 = 10_000;
+
 /// Read granularity for the streaming checksum read-back.
 const CHECKSUM_READ_CHUNK: usize = 256 * 1024;
+
+/// Part size to coalesce to for a session whose maximum object size is
+/// `max_bytes`.
+///
+/// Scales up from the 5 MiB floor (rounded to a whole MiB) so the worst-case
+/// object stays within S3's 10,000-part limit, and never exceeds the 5 GiB
+/// per-part ceiling. For the default 64 MiB cap this is exactly 5 MiB.
+fn part_size_for(max_bytes: u64) -> u64 {
+    const MIB: u64 = 1024 * 1024;
+    let by_part_count = max_bytes.div_ceil(S3_MAX_PARTS).div_ceil(MIB) * MIB;
+    by_part_count.clamp(S3_MIN_PART_SIZE, S3_MAX_PART_SIZE)
+}
 
 /// Storage backend backed by an S3-compatible object store.
 ///
@@ -380,15 +398,19 @@ impl S3StorageBackend {
     /// Assemble the final object from its parts.
     ///
     /// Uses `If-None-Match: *` so completion atomically refuses to overwrite an
-    /// existing destination key (no TOCTOU window). `first_attempt` distinguishes
-    /// a genuine collision (reject) from our own already-finalized object on a
-    /// retry (recover the ETag — idempotent).
+    /// existing destination key (no TOCTOU window) on real S3. The two failure
+    /// modes are distinct and unambiguous:
+    ///   - `412 PreconditionFailed`: the key exists but *our* multipart upload was
+    ///     not consumed, so the object was created by someone else — always
+    ///     reject, never adopt it.
+    ///   - `NoSuchUpload`: our upload id was consumed by a prior completion (a
+    ///     crash before the session metadata was updated), so the existing object
+    ///     is ours — recover its ETag idempotently.
     async fn complete_multipart(
         &self,
         object_key: &str,
         upload_id: &str,
         parts: &[S3CompletedPart],
-        first_attempt: bool,
     ) -> StorageResult<Option<String>> {
         let completed_parts: Vec<CompletedPart> = parts
             .iter()
@@ -414,23 +436,9 @@ impl S3StorageBackend {
             .await
         {
             Ok(output) => Ok(output.e_tag().map(|etag| normalize_etag(etag.to_string()))),
-            // The destination key already exists. On the first attempt that is a
-            // foreign collision (reject); on a retry it is our own prior
-            // completion (recover the ETag).
-            Err(err) if is_precondition_failed(&err) => {
-                if first_attempt {
-                    Err(StorageError::policy_rejected(format!(
-                        "S3 object key already exists: {object_key}"
-                    )))
-                } else {
-                    match self.head_object(object_key).await? {
-                        Some(info) => Ok(info.etag),
-                        None => Err(s3_error("complete multipart upload", err)),
-                    }
-                }
-            }
-            // The upload id was consumed by a prior completion (crash before the
-            // session metadata was updated): recover the existing object's ETag.
+            Err(err) if is_precondition_failed(&err) => Err(StorageError::policy_rejected(
+                format!("S3 object key already exists: {object_key}"),
+            )),
             Err(err) if is_no_such_upload(&err) => match self.head_object(object_key).await? {
                 Some(info) => Ok(info.etag),
                 None => Err(s3_error("complete multipart upload", err)),
@@ -621,7 +629,10 @@ impl S3StorageBackend {
         // that write leaves the durable metadata unchanged, so the client simply
         // re-sends from the old offset and we recompute the same parts (uploading
         // a part is idempotent — the same part number overwrites).
-        let part_size = S3_MIN_PART_SIZE as usize;
+        //
+        // `part_size` is derived from the (fixed) session max so it is stable
+        // across appends and resumes, and large uploads stay under the part cap.
+        let part_size = part_size_for(stored.max_bytes) as usize;
         let mut pos = 0usize;
         while combined.len() - pos >= part_size {
             let upload_id = self
@@ -640,7 +651,7 @@ impl S3StorageBackend {
                 state.parts.push(S3CompletedPart {
                     number,
                     etag,
-                    size: S3_MIN_PART_SIZE,
+                    size: part_size as u64,
                 });
                 state.next_part_number = number + 1;
             }
@@ -754,7 +765,7 @@ impl S3StorageBackend {
                 )
             };
             let etag = self
-                .complete_multipart(&object_key, &upload_id, &parts, first_attempt)
+                .complete_multipart(&object_key, &upload_id, &parts)
                 .await?;
 
             // Validate the checksum by streaming the finished object (only when a
@@ -1105,5 +1116,35 @@ impl StorageBackend for S3StorageBackend {
             }
             Ok(())
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{part_size_for, S3_MAX_PARTS, S3_MAX_PART_SIZE, S3_MIN_PART_SIZE};
+
+    #[test]
+    fn part_size_stays_at_floor_for_small_caps() {
+        // The default 64 MiB cap (and anything that fits in <=10k 5 MiB parts)
+        // uses the 5 MiB floor unchanged.
+        assert_eq!(part_size_for(64 * 1024 * 1024), S3_MIN_PART_SIZE);
+        assert_eq!(
+            part_size_for(S3_MIN_PART_SIZE * S3_MAX_PARTS),
+            S3_MIN_PART_SIZE
+        );
+    }
+
+    #[test]
+    fn part_size_scales_to_stay_under_part_cap() {
+        let max_bytes = 200 * 1024 * 1024 * 1024; // 200 GiB
+        let part = part_size_for(max_bytes);
+        assert!(part > S3_MIN_PART_SIZE);
+        assert!(part.is_multiple_of(1024 * 1024), "rounded to a whole MiB");
+        assert!(max_bytes.div_ceil(part) <= S3_MAX_PARTS);
+    }
+
+    #[test]
+    fn part_size_never_exceeds_provider_max() {
+        assert_eq!(part_size_for(u64::MAX), S3_MAX_PART_SIZE);
     }
 }

--- a/crates/pocopine-storage-s3/src/storage.rs
+++ b/crates/pocopine-storage-s3/src/storage.rs
@@ -8,8 +8,8 @@ use pocopine_storage::backend_common::{
     UploadSessionLockCleanup, UploadSessionLockRegistry,
 };
 use pocopine_storage::checksum::{
-    checksum_algorithm_to_compute, ensure_supported_checksum_policy, validate_complete_checksum,
-    validate_complete_checksum_precomputed, StreamingChecksum,
+    checksum_algorithm_to_compute, ensure_supported_checksum_policy, precheck_checksum,
+    validate_complete_checksum, validate_complete_checksum_precomputed, StreamingChecksum,
 };
 use pocopine_storage::{
     ChecksumAlgorithm, CompleteUpload, InitiateUpload, ObjectChecksum, ObjectRef, StorageBackend,
@@ -22,7 +22,7 @@ use crate::layout::{S3KeyLayout, DEFAULT_INTERNAL_PREFIX};
 use crate::state::{NativeUploadState, S3CompletedPart, S3MultipartState, StoredUploadSession};
 use crate::util::{
     ensure_completable, is_get_object_not_found, is_head_object_not_found, is_no_such_upload,
-    is_put_precondition_failed, normalize_etag, s3_error,
+    is_precondition_failed, is_put_precondition_failed, normalize_etag, s3_error,
 };
 
 const DEFAULT_BACKEND_NAME: &str = "s3";
@@ -377,11 +377,18 @@ impl S3StorageBackend {
             .ok_or_else(|| StorageError::backend("S3 upload part returned no etag".to_string()))
     }
 
+    /// Assemble the final object from its parts.
+    ///
+    /// Uses `If-None-Match: *` so completion atomically refuses to overwrite an
+    /// existing destination key (no TOCTOU window). `first_attempt` distinguishes
+    /// a genuine collision (reject) from our own already-finalized object on a
+    /// retry (recover the ETag — idempotent).
     async fn complete_multipart(
         &self,
         object_key: &str,
         upload_id: &str,
         parts: &[S3CompletedPart],
+        first_attempt: bool,
     ) -> StorageResult<Option<String>> {
         let completed_parts: Vec<CompletedPart> = parts
             .iter()
@@ -401,14 +408,29 @@ impl S3StorageBackend {
             .bucket(&self.layout.bucket)
             .key(object_key)
             .upload_id(upload_id)
+            .if_none_match("*")
             .multipart_upload(completed)
             .send()
             .await
         {
             Ok(output) => Ok(output.e_tag().map(|etag| normalize_etag(etag.to_string()))),
-            // A prior completion already finalized the object (idempotent retry
-            // after a crash before the session metadata was updated): recover the
-            // existing object's ETag instead of failing.
+            // The destination key already exists. On the first attempt that is a
+            // foreign collision (reject); on a retry it is our own prior
+            // completion (recover the ETag).
+            Err(err) if is_precondition_failed(&err) => {
+                if first_attempt {
+                    Err(StorageError::policy_rejected(format!(
+                        "S3 object key already exists: {object_key}"
+                    )))
+                } else {
+                    match self.head_object(object_key).await? {
+                        Some(info) => Ok(info.etag),
+                        None => Err(s3_error("complete multipart upload", err)),
+                    }
+                }
+            }
+            // The upload id was consumed by a prior completion (crash before the
+            // session metadata was updated): recover the existing object's ETag.
             Err(err) if is_no_such_upload(&err) => match self.head_object(object_key).await? {
                 Some(info) => Ok(info.etag),
                 None => Err(s3_error("complete multipart upload", err)),
@@ -552,26 +574,19 @@ impl S3StorageBackend {
         offset: u64,
         bytes: Bytes,
     ) -> StorageResult<UploadSession> {
-        // Take the buffered tail out of the session so it can be prepended to the
-        // incoming chunk without an extra copy; it is rewritten below.
-        let tail = {
+        // Copy the buffered tail to prepend to the incoming chunk. The copy
+        // (bounded by one part) leaves the tail durable in `stored` so the lazy
+        // `ensure_upload_id` write below still persists it; the tail is only
+        // replaced by the remainder in the single atomic write at the end.
+        let (flushed, tail) = {
             let state = stored
                 .native
-                .multipart_mut()
+                .multipart()
                 .expect("append_multipart called for a non-multipart session");
-            std::mem::take(&mut state.pending_tail)
+            (state.flushed_len(), state.pending_tail.clone())
         };
-        let flushed = stored
-            .native
-            .multipart()
-            .expect("multipart state")
-            .flushed_len();
         let expected = flushed + tail.len() as u64;
         if expected != offset {
-            // Restore the tail we took before bailing so `stored` is unchanged.
-            if let Some(state) = stored.native.multipart_mut() {
-                state.pending_tail = tail;
-            }
             tracing::debug!(
                 target: "pocopine.log",
                 event_name = "pocopine.storage.offset_mismatch",
@@ -584,9 +599,6 @@ impl S3StorageBackend {
         let new_offset = checked_new_offset(offset, bytes.len())?;
         ensure_size_limit(stored.max_bytes, stored.public.size, new_offset)?;
         if bytes.is_empty() {
-            if let Some(state) = stored.native.multipart_mut() {
-                state.pending_tail = tail;
-            }
             return Ok(stored.public);
         }
 
@@ -658,17 +670,22 @@ impl S3StorageBackend {
             }
         }
         ensure_size_limit(stored.max_bytes, stored.public.size, total)?;
+        // Reject a missing-required or disallowed-algorithm checksum up front, so
+        // a config error never assembles (and then deletes) the object.
+        precheck_checksum(&stored.checksum_policy, request.checksum.as_ref())?;
 
         let object_key = self.layout.object_key(stored.storage_key.key.as_str());
-        // On the first completion attempt the destination key has not been
-        // written yet (multipart parts live in the upload, not at the key). If an
-        // object already exists there it is a foreign collision, so reject rather
-        // than overwrite — matching the single-part `put_completed_object` guard.
-        // Retries (status `Completing`) skip this: the key may exist from our own
-        // prior completion and is reconciled by the idempotent-completion path.
-        if stored.public.status == UploadSessionStatus::Open
-            && self.head_object(&object_key).await?.is_some()
-        {
+        // `Completing` means a prior completion attempt got at least as far as
+        // finalizing the object, so a retry must treat an existing key as ours.
+        let first_attempt = stored.public.status == UploadSessionStatus::Open;
+        // Defense in depth against overwriting a foreign object:
+        //  - this preflight HEAD catches a pre-existing key and works on every
+        //    S3-compatible store (including emulators that ignore the condition);
+        //  - `CompleteMultipartUpload` additionally uses `If-None-Match: *` to
+        //    close the TOCTOU window on real S3.
+        // Retries (status `Completing`) skip the preflight: the key may exist
+        // from our own prior completion and is reconciled idempotently.
+        if first_attempt && self.head_object(&object_key).await?.is_some() {
             return Err(StorageError::policy_rejected(format!(
                 "S3 object key already exists: {object_key}"
             )));
@@ -737,7 +754,7 @@ impl S3StorageBackend {
                 )
             };
             let etag = self
-                .complete_multipart(&object_key, &upload_id, &parts)
+                .complete_multipart(&object_key, &upload_id, &parts, first_attempt)
                 .await?;
 
             // Validate the checksum by streaming the finished object (only when a

--- a/crates/pocopine-storage-s3/src/storage.rs
+++ b/crates/pocopine-storage-s3/src/storage.rs
@@ -1,4 +1,5 @@
 use aws_sdk_s3::primitives::ByteStream;
+use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart};
 use aws_sdk_s3::Client;
 use bytes::Bytes;
 use pocopine_storage::backend_common::{
@@ -6,32 +7,45 @@ use pocopine_storage::backend_common::{
     ensure_upload_length_can_be_set, expires_at, refresh_expired, selected_strategy,
     UploadSessionLockCleanup, UploadSessionLockRegistry,
 };
-use pocopine_storage::checksum::{ensure_supported_checksum_policy, validate_complete_checksum};
+use pocopine_storage::checksum::{
+    checksum_algorithm_to_compute, ensure_supported_checksum_policy, validate_complete_checksum,
+    validate_complete_checksum_precomputed, StreamingChecksum,
+};
 use pocopine_storage::{
-    CompleteUpload, InitiateUpload, ObjectChecksum, ObjectRef, StorageBackend, StorageBoxFuture,
-    StorageContext, StorageError, StorageResult, TransferPlan, UploadSession, UploadSessionId,
-    UploadSessionStatus, UploadStrategy,
+    ChecksumAlgorithm, CompleteUpload, InitiateUpload, ObjectChecksum, ObjectRef, StorageBackend,
+    StorageBoxFuture, StorageContext, StorageError, StorageResult, TransferPlan, UploadSession,
+    UploadSessionId, UploadSessionStatus, UploadStrategy,
 };
 use uuid::Uuid;
 
 use crate::layout::{S3KeyLayout, DEFAULT_INTERNAL_PREFIX};
-use crate::state::StoredUploadSession;
+use crate::state::{NativeUploadState, S3CompletedPart, S3MultipartState, StoredUploadSession};
 use crate::util::{
-    ensure_completable, is_get_object_not_found, is_put_precondition_failed, normalize_etag,
-    s3_error,
+    ensure_completable, is_get_object_not_found, is_head_object_not_found, is_no_such_upload,
+    is_put_precondition_failed, normalize_etag, s3_error,
 };
 
 const DEFAULT_BACKEND_NAME: &str = "s3";
 const DEFAULT_MAX_PROXY_UPLOAD_BYTES: u64 = 64 * 1024 * 1024;
 
+/// S3 minimum part size. Every multipart part except the last must be at least
+/// this large, so sequential `PATCH` chunks smaller than this are coalesced in a
+/// bounded tail buffer until they reach it.
+const S3_MIN_PART_SIZE: u64 = 5 * 1024 * 1024;
+
+/// Read granularity for the streaming checksum read-back.
+const CHECKSUM_READ_CHUNK: usize = 256 * 1024;
+
 /// Storage backend backed by an S3-compatible object store.
 ///
-/// The adapter stores temporary upload bytes as an internal object and rewrites
-/// that object on each sequential `PATCH`. That keeps the first S3 backend
-/// compatible with Pocopine's existing resumable upload protocol for bounded
-/// uploads, but it is not the high-throughput/direct multipart path. A later
-/// direct/multipart backend can add provider-side multipart uploads without
-/// changing the public `StorageBackend` contract.
+/// Uploads use S3 native multipart: each sequential `PATCH` is appended to a
+/// bounded tail buffer and, once the tail reaches [`S3_MIN_PART_SIZE`], flushed
+/// to a provider `UploadPart`. The final object is assembled by
+/// `CompleteMultipartUpload`. Peak memory is one part regardless of object size,
+/// and every byte is sent to S3 exactly once (no per-`PATCH` full-object
+/// rewrite). Sessions created by an older build deserialize as
+/// [`NativeUploadState::LegacyProxy`] and keep using the staged-object rewrite
+/// path until they drain.
 #[derive(Clone)]
 pub struct S3StorageBackend {
     name: &'static str,
@@ -39,6 +53,10 @@ pub struct S3StorageBackend {
     layout: S3KeyLayout,
     max_proxy_upload_bytes: u64,
     session_locks: UploadSessionLockRegistry,
+}
+
+struct HeadObjectInfo {
+    etag: Option<String>,
 }
 
 impl std::fmt::Debug for S3StorageBackend {
@@ -89,12 +107,7 @@ impl S3StorageBackend {
         Ok(self)
     }
 
-    /// Override the maximum size accepted by this sequential proxy backend.
-    ///
-    /// The default is 64 MiB because each append rewrites the staged object and
-    /// completion loads the staged bytes before the final S3 write. Larger
-    /// values are possible, but applications should prefer the future multipart
-    /// backend for large uploads.
+    /// Override the maximum upload size accepted by this backend.
     pub fn with_max_proxy_upload_bytes(mut self, max_bytes: u64) -> StorageResult<Self> {
         if max_bytes == 0 {
             return Err(StorageError::policy_rejected(
@@ -156,6 +169,31 @@ impl S3StorageBackend {
             Err(StorageError::UnknownUploadSession { .. }) => Ok(Vec::new()),
             Err(err) => Err(err),
         }
+    }
+
+    /// Read the persisted tail buffer for a native multipart session.
+    ///
+    /// The tail is always smaller than one part, so this read is bounded; it is
+    /// not a full-object read.
+    async fn read_tail(
+        &self,
+        session: &UploadSessionId,
+        expected_len: u64,
+    ) -> StorageResult<Vec<u8>> {
+        let tail = self.get_staged_bytes(session).await?;
+        if tail.len() as u64 != expected_len {
+            // Metadata and the staged tail disagree (e.g. a crash between the S3
+            // write and the metadata write). Trust the persisted object; the
+            // client re-sends from the metadata offset and we converge.
+            tracing::warn!(
+                target: "pocopine.log",
+                event_name = "pocopine.storage.s3_tail_len_mismatch",
+                session = %session,
+                metadata = expected_len,
+                staged = tail.len(),
+            );
+        }
+        Ok(tail)
     }
 
     async fn reconcile_staged_bytes(
@@ -297,29 +335,180 @@ impl S3StorageBackend {
         Ok(())
     }
 
-    async fn persist_expired_if_needed(
-        &self,
-        session: &UploadSessionId,
-        stored: &StoredUploadSession,
-    ) -> StorageResult<()> {
-        if stored.public.status == UploadSessionStatus::Expired {
-            self.write_session(session, stored).await?;
+    async fn head_object(&self, key: &str) -> StorageResult<Option<HeadObjectInfo>> {
+        match self
+            .client
+            .head_object()
+            .bucket(&self.layout.bucket)
+            .key(key)
+            .send()
+            .await
+        {
+            Ok(output) => Ok(Some(HeadObjectInfo {
+                etag: output.e_tag.map(normalize_etag),
+            })),
+            Err(err) if is_head_object_not_found(&err) => Ok(None),
+            Err(err) => Err(s3_error("head object", err)),
         }
-        Ok(())
     }
 
-    async fn cleanup_staged_bytes(
+    // --- native multipart helpers --------------------------------------------
+
+    async fn create_multipart(
+        &self,
+        object_key: &str,
+        content_type: Option<&str>,
+    ) -> StorageResult<String> {
+        let mut request = self
+            .client
+            .create_multipart_upload()
+            .bucket(&self.layout.bucket)
+            .key(object_key);
+        if let Some(content_type) = content_type {
+            request = request.content_type(content_type);
+        }
+        let output = request
+            .send()
+            .await
+            .map_err(|err| s3_error("create multipart upload", err))?;
+        output.upload_id().map(str::to_string).ok_or_else(|| {
+            StorageError::backend("S3 create multipart upload returned no upload id".to_string())
+        })
+    }
+
+    async fn upload_part(
+        &self,
+        object_key: &str,
+        upload_id: &str,
+        part_number: i32,
+        body: Bytes,
+    ) -> StorageResult<String> {
+        let output = self
+            .client
+            .upload_part()
+            .bucket(&self.layout.bucket)
+            .key(object_key)
+            .upload_id(upload_id)
+            .part_number(part_number)
+            .body(ByteStream::from(body))
+            .send()
+            .await
+            .map_err(|err| s3_error("upload part", err))?;
+        // Keep the ETag verbatim (quotes included) so CompleteMultipartUpload
+        // matches what S3 returned for the part.
+        output
+            .e_tag()
+            .map(str::to_string)
+            .ok_or_else(|| StorageError::backend("S3 upload part returned no etag".to_string()))
+    }
+
+    async fn complete_multipart(
+        &self,
+        object_key: &str,
+        upload_id: &str,
+        parts: &[S3CompletedPart],
+    ) -> StorageResult<Option<String>> {
+        let completed_parts: Vec<CompletedPart> = parts
+            .iter()
+            .map(|part| {
+                CompletedPart::builder()
+                    .part_number(part.number)
+                    .e_tag(part.etag.clone())
+                    .build()
+            })
+            .collect();
+        let completed = CompletedMultipartUpload::builder()
+            .set_parts(Some(completed_parts))
+            .build();
+        match self
+            .client
+            .complete_multipart_upload()
+            .bucket(&self.layout.bucket)
+            .key(object_key)
+            .upload_id(upload_id)
+            .multipart_upload(completed)
+            .send()
+            .await
+        {
+            Ok(output) => Ok(output.e_tag().map(|etag| normalize_etag(etag.to_string()))),
+            // A prior completion already finalized the object (idempotent retry
+            // after a crash before the session metadata was updated): recover the
+            // existing object's ETag instead of failing.
+            Err(err) if is_no_such_upload(&err) => match self.head_object(object_key).await? {
+                Some(info) => Ok(info.etag),
+                None => Err(s3_error("complete multipart upload", err)),
+            },
+            Err(err) => Err(s3_error("complete multipart upload", err)),
+        }
+    }
+
+    async fn abort_multipart(&self, object_key: &str, upload_id: &str) -> StorageResult<()> {
+        match self
+            .client
+            .abort_multipart_upload()
+            .bucket(&self.layout.bucket)
+            .key(object_key)
+            .upload_id(upload_id)
+            .send()
+            .await
+        {
+            Ok(_) => Ok(()),
+            Err(err) if is_no_such_upload(&err) => Ok(()),
+            Err(err) => Err(s3_error("abort multipart upload", err)),
+        }
+    }
+
+    /// Stream the stored object through `algorithm` without buffering it.
+    async fn stream_object_checksum(
+        &self,
+        key: &str,
+        algorithm: ChecksumAlgorithm,
+    ) -> StorageResult<ObjectChecksum> {
+        use tokio::io::AsyncReadExt as _;
+        let output = self
+            .client
+            .get_object()
+            .bucket(&self.layout.bucket)
+            .key(key)
+            .send()
+            .await
+            .map_err(|err| s3_error("get object for checksum", err))?;
+        let mut reader = output.body.into_async_read();
+        let mut hasher = StreamingChecksum::new(algorithm);
+        let mut buffer = vec![0u8; CHECKSUM_READ_CHUNK];
+        loop {
+            let read = reader
+                .read(&mut buffer)
+                .await
+                .map_err(|err| s3_error("read object body for checksum", err))?;
+            if read == 0 {
+                break;
+            }
+            hasher.update(&buffer[..read]);
+        }
+        Ok(hasher.finalize())
+    }
+
+    /// Create the provider multipart upload on first use and persist its id.
+    async fn ensure_upload_id(
         &self,
         session: &UploadSessionId,
         stored: &mut StoredUploadSession,
-    ) -> StorageResult<()> {
-        if !stored.cleanup_pending {
-            return Ok(());
+        object_key: &str,
+    ) -> StorageResult<String> {
+        if let Some(state) = stored.native.multipart() {
+            if let Some(upload_id) = &state.upload_id {
+                return Ok(upload_id.clone());
+            }
         }
-        self.delete_object(&self.layout.session_bytes_key(session))
+        let upload_id = self
+            .create_multipart(object_key, stored.public.content_type.as_deref())
             .await?;
-        stored.cleanup_pending = false;
-        self.write_session(session, stored).await
+        if let Some(state) = stored.native.multipart_mut() {
+            state.upload_id = Some(upload_id.clone());
+        }
+        self.write_session(session, stored).await?;
+        Ok(upload_id)
     }
 
     fn ensure_requested_size_is_supported(&self, size: Option<u64>) -> StorageResult<()> {
@@ -352,6 +541,346 @@ impl S3StorageBackend {
             visibility: stored.visibility,
             metadata,
         }
+    }
+
+    async fn persist_expired_if_needed(
+        &self,
+        session: &UploadSessionId,
+        stored: &StoredUploadSession,
+    ) -> StorageResult<()> {
+        if stored.public.status == UploadSessionStatus::Expired {
+            self.write_session(session, stored).await?;
+        }
+        Ok(())
+    }
+
+    async fn cleanup_staged_bytes(
+        &self,
+        session: &UploadSessionId,
+        stored: &mut StoredUploadSession,
+    ) -> StorageResult<()> {
+        if !stored.cleanup_pending {
+            return Ok(());
+        }
+        self.delete_object(&self.layout.session_bytes_key(session))
+            .await?;
+        stored.cleanup_pending = false;
+        self.write_session(session, stored).await
+    }
+
+    // --- native multipart upload flow ----------------------------------------
+
+    async fn append_multipart(
+        &self,
+        session: &UploadSessionId,
+        mut stored: StoredUploadSession,
+        offset: u64,
+        bytes: Bytes,
+    ) -> StorageResult<UploadSession> {
+        let (flushed, tail_len) = {
+            let state = stored
+                .native
+                .multipart()
+                .expect("append_multipart called for a non-multipart session");
+            (state.flushed_len(), state.pending_tail_len)
+        };
+        let expected = flushed + tail_len;
+        if expected != offset {
+            tracing::debug!(
+                target: "pocopine.log",
+                event_name = "pocopine.storage.offset_mismatch",
+                session = %session,
+                expected,
+                provided = offset,
+            );
+            return Err(StorageError::offset_mismatch(expected, offset));
+        }
+        let new_offset = checked_new_offset(offset, bytes.len())?;
+        ensure_size_limit(stored.max_bytes, stored.public.size, new_offset)?;
+        if bytes.is_empty() {
+            return Ok(stored.public);
+        }
+
+        let object_key = self.layout.object_key(stored.storage_key.key.as_str());
+
+        // Combine the persisted tail (bounded by one part) with the incoming
+        // chunk. When the tail is empty we slice the incoming `Bytes` directly,
+        // avoiding any copy.
+        let combined: Bytes = if tail_len > 0 {
+            let mut tail = self.read_tail(session, tail_len).await?;
+            tail.extend_from_slice(&bytes);
+            Bytes::from(tail)
+        } else {
+            bytes
+        };
+
+        // Flush every full-size part; the remainder becomes the new tail.
+        let part_size = S3_MIN_PART_SIZE as usize;
+        let mut pos = 0usize;
+        while combined.len() - pos >= part_size {
+            let upload_id = self
+                .ensure_upload_id(session, &mut stored, &object_key)
+                .await?;
+            let number = stored
+                .native
+                .multipart()
+                .expect("multipart state")
+                .next_part_number;
+            let part = combined.slice(pos..pos + part_size);
+            let etag = self
+                .upload_part(&object_key, &upload_id, number, part)
+                .await?;
+            if let Some(state) = stored.native.multipart_mut() {
+                state.parts.push(S3CompletedPart {
+                    number,
+                    etag,
+                    size: S3_MIN_PART_SIZE,
+                });
+                state.next_part_number = number + 1;
+            }
+            pos += part_size;
+        }
+
+        let remainder = combined.slice(pos..);
+        let remainder_len = remainder.len() as u64;
+        if remainder.is_empty() {
+            if tail_len > 0 {
+                self.delete_object(&self.layout.session_bytes_key(session))
+                    .await?;
+            }
+        } else {
+            self.put_staged_bytes(session, remainder.to_vec()).await?;
+        }
+        if let Some(state) = stored.native.multipart_mut() {
+            state.pending_tail_len = remainder_len;
+        }
+        stored.public.next_offset = Some(new_offset);
+        self.write_session(session, &stored).await?;
+        Ok(stored.public)
+    }
+
+    async fn complete_multipart_upload_flow(
+        &self,
+        session: &UploadSessionId,
+        mut stored: StoredUploadSession,
+        request: CompleteUpload,
+    ) -> StorageResult<ObjectRef> {
+        let total = stored.public.next_offset.unwrap_or(0);
+        if let Some(expected) = stored.public.size {
+            if total != expected {
+                return Err(StorageError::policy_rejected(format!(
+                    "upload is incomplete: expected {expected} bytes, got {total}"
+                )));
+            }
+        }
+        ensure_size_limit(stored.max_bytes, stored.public.size, total)?;
+
+        let object_key = self.layout.object_key(stored.storage_key.key.as_str());
+        if stored.public.status == UploadSessionStatus::Open
+            || stored.public.next_offset != Some(total)
+        {
+            stored.public.status = UploadSessionStatus::Completing;
+            stored.public.next_offset = Some(total);
+            self.write_session(session, &stored).await?;
+        }
+
+        let (has_upload_id, tail_len) = {
+            let state = stored.native.multipart().expect("multipart state");
+            (state.upload_id.is_some(), state.pending_tail_len)
+        };
+
+        let (etag, checksum) = if !has_upload_id {
+            // Whole object fits within one part (or is empty): a single direct
+            // PUT, no multipart overhead. We already have the bytes, so validate
+            // the checksum directly.
+            let bytes = if tail_len > 0 {
+                self.read_tail(session, tail_len).await?
+            } else {
+                Vec::new()
+            };
+            let checksum =
+                validate_complete_checksum(&stored.checksum_policy, &bytes, request.checksum)?;
+            let etag = self
+                .put_completed_object(
+                    &object_key,
+                    Bytes::from(bytes),
+                    stored.public.content_type.as_deref(),
+                )
+                .await?;
+            (etag, checksum)
+        } else {
+            // Flush the final remainder as the last part (the last part is exempt
+            // from the minimum-size rule), then assemble the object.
+            if tail_len > 0 {
+                let upload_id = stored
+                    .native
+                    .multipart()
+                    .and_then(|state| state.upload_id.clone())
+                    .expect("multipart upload id");
+                let number = stored
+                    .native
+                    .multipart()
+                    .expect("multipart state")
+                    .next_part_number;
+                let tail = self.read_tail(session, tail_len).await?;
+                let etag = self
+                    .upload_part(&object_key, &upload_id, number, Bytes::from(tail))
+                    .await?;
+                if let Some(state) = stored.native.multipart_mut() {
+                    state.parts.push(S3CompletedPart {
+                        number,
+                        etag,
+                        size: tail_len,
+                    });
+                    state.next_part_number = number + 1;
+                    state.pending_tail_len = 0;
+                }
+                self.write_session(session, &stored).await?;
+            }
+            let (upload_id, parts) = {
+                let state = stored.native.multipart().expect("multipart state");
+                (
+                    state.upload_id.clone().expect("multipart upload id"),
+                    state.parts.clone(),
+                )
+            };
+            let etag = self
+                .complete_multipart(&object_key, &upload_id, &parts)
+                .await?;
+
+            // Validate the checksum by streaming the finished object (only when a
+            // checksum was actually supplied; the default path never hashes).
+            //
+            // NOTE: multipart parts cannot be read before `CompleteMultipartUpload`,
+            // so verification necessarily happens after the object is assembled. A
+            // mismatch therefore deletes the (already-finalized) object and the
+            // session cannot be retried — the client must re-initiate. Phase 0
+            // accepts this; a later phase computes the checksum incrementally as
+            // parts stream so it can be verified before completion.
+            let checksum = match checksum_algorithm_to_compute(
+                &stored.checksum_policy,
+                request.checksum.as_ref(),
+            ) {
+                Some(algorithm) => {
+                    let computed = self.stream_object_checksum(&object_key, algorithm).await?;
+                    match validate_complete_checksum_precomputed(
+                        &stored.checksum_policy,
+                        Some(computed),
+                        request.checksum,
+                    ) {
+                        Ok(checksum) => checksum,
+                        Err(err) => {
+                            // The object is live but failed verification: remove
+                            // it so a bad upload is not observable.
+                            let _ = self.delete_object(&object_key).await;
+                            return Err(err);
+                        }
+                    }
+                }
+                None => validate_complete_checksum_precomputed(
+                    &stored.checksum_policy,
+                    None,
+                    request.checksum,
+                )?,
+            };
+            (etag, checksum)
+        };
+
+        let object = self.object_ref(&stored, total, etag, checksum);
+        stored.public.status = UploadSessionStatus::Complete;
+        stored.public.next_offset = Some(total);
+        stored.object = Some(object.clone());
+        stored.cleanup_pending = true;
+        self.write_session(session, &stored).await?;
+        self.cleanup_staged_bytes(session, &mut stored).await?;
+        Ok(object)
+    }
+
+    async fn abort_multipart_session(&self, stored: &StoredUploadSession) -> StorageResult<()> {
+        if let Some(state) = stored.native.multipart() {
+            if let Some(upload_id) = &state.upload_id {
+                let object_key = self.layout.object_key(stored.storage_key.key.as_str());
+                self.abort_multipart(&object_key, upload_id).await?;
+            }
+        }
+        Ok(())
+    }
+
+    // --- legacy staged-object rewrite flow (pre-multipart sessions) -----------
+
+    async fn append_legacy(
+        &self,
+        session: &UploadSessionId,
+        mut stored: StoredUploadSession,
+        offset: u64,
+        bytes: Bytes,
+    ) -> StorageResult<UploadSession> {
+        let mut expected = stored.public.next_offset.unwrap_or(0);
+        let mut staged = self.reconcile_staged_bytes(session, expected).await?;
+        let staged_len = staged.len() as u64;
+        if staged_len > expected {
+            expected = staged_len;
+            stored.public.next_offset = Some(staged_len);
+            self.write_session(session, &stored).await?;
+        }
+        if expected != offset {
+            tracing::debug!(
+                target: "pocopine.log",
+                event_name = "pocopine.storage.offset_mismatch",
+                session = %session,
+                expected,
+                provided = offset,
+            );
+            return Err(StorageError::offset_mismatch(expected, offset));
+        }
+        let new_offset = checked_new_offset(offset, bytes.len())?;
+        ensure_size_limit(stored.max_bytes, stored.public.size, new_offset)?;
+        staged.extend_from_slice(&bytes);
+        self.put_staged_bytes(session, staged).await?;
+        stored.public.next_offset = Some(new_offset);
+        self.write_session(session, &stored).await?;
+        Ok(stored.public)
+    }
+
+    async fn complete_legacy(
+        &self,
+        session: &UploadSessionId,
+        mut stored: StoredUploadSession,
+        request: CompleteUpload,
+    ) -> StorageResult<ObjectRef> {
+        let trusted = stored.public.next_offset.unwrap_or(0);
+        let staged = self.reconcile_staged_bytes(session, trusted).await?;
+        let actual = staged.len() as u64;
+        if let Some(expected) = stored.public.size {
+            if actual != expected {
+                return Err(StorageError::policy_rejected(format!(
+                    "upload is incomplete: expected {expected} bytes, got {actual}"
+                )));
+            }
+        }
+        ensure_size_limit(stored.max_bytes, stored.public.size, actual)?;
+        let checksum =
+            validate_complete_checksum(&stored.checksum_policy, &staged, request.checksum)?;
+        let object_key = self.layout.object_key(stored.storage_key.key.as_str());
+        if stored.public.status == UploadSessionStatus::Open
+            || stored.public.next_offset != Some(actual)
+        {
+            stored.public.status = UploadSessionStatus::Completing;
+            stored.public.next_offset = Some(actual);
+            self.write_session(session, &stored).await?;
+        }
+        let staged = Bytes::from(staged);
+        let etag = self
+            .put_completed_object(&object_key, staged, stored.public.content_type.as_deref())
+            .await?;
+        let object = self.object_ref(&stored, actual, etag, checksum);
+        stored.public.status = UploadSessionStatus::Complete;
+        stored.public.next_offset = Some(actual);
+        stored.object = Some(object.clone());
+        stored.cleanup_pending = true;
+        self.write_session(session, &stored).await?;
+        self.cleanup_staged_bytes(session, &mut stored).await?;
+        Ok(object)
     }
 }
 
@@ -402,12 +931,16 @@ impl StorageBackend for S3StorageBackend {
                 request_metadata: request.metadata,
                 object: None,
                 cleanup_pending: false,
+                native: NativeUploadState::Multipart(S3MultipartState {
+                    upload_id: None,
+                    parts: Vec::new(),
+                    next_part_number: 1,
+                    pending_tail_len: 0,
+                }),
             };
+            // No staged `bytes.tmp` is created up front; native sessions only
+            // write a tail object once there are sub-part bytes to buffer.
             self.write_session(&id, &stored).await?;
-            if let Err(err) = self.put_staged_bytes(&id, Vec::new()).await {
-                let _ = self.delete_object(&self.layout.session_meta_key(&id)).await;
-                return Err(err);
-            }
             Ok(session)
         })
     }
@@ -423,7 +956,10 @@ impl StorageBackend for S3StorageBackend {
             let _guard = lock.lock().await;
             let mut stored = self.read_session(&session).await?;
             ensure_owner(&ctx.actor, &stored.owner)?;
-            if stored.public.status == UploadSessionStatus::Open {
+            if stored.public.status == UploadSessionStatus::Open
+                && stored.native.multipart().is_none()
+            {
+                // Legacy sessions recover their offset from the staged object.
                 let staged = self
                     .reconcile_staged_bytes(&session, stored.public.next_offset.unwrap_or(0))
                     .await?;
@@ -451,14 +987,21 @@ impl StorageBackend for S3StorageBackend {
             let mut stored = self.read_session(&session).await?;
             ensure_owner(&ctx.actor, &stored.owner)?;
             self.persist_expired_if_needed(&session, &stored).await?;
-            let committed_offset = stored.public.next_offset.unwrap_or(0);
-            let staged_len = self
-                .reconcile_staged_bytes(&session, committed_offset)
-                .await?
-                .len() as u64;
-            ensure_upload_length_can_be_set(stored.max_bytes, &stored.public, staged_len, size)?;
+            let committed_offset = match stored.native.multipart() {
+                Some(state) => state.flushed_len() + state.pending_tail_len,
+                None => self
+                    .reconcile_staged_bytes(&session, stored.public.next_offset.unwrap_or(0))
+                    .await?
+                    .len() as u64,
+            };
+            ensure_upload_length_can_be_set(
+                stored.max_bytes,
+                &stored.public,
+                committed_offset,
+                size,
+            )?;
             stored.public.size = Some(size);
-            stored.public.next_offset = Some(staged_len);
+            stored.public.next_offset = Some(committed_offset);
             self.write_session(&session, &stored).await?;
             Ok(stored.public)
         })
@@ -475,7 +1018,7 @@ impl StorageBackend for S3StorageBackend {
             let lock = self.session_locks.lock(&session);
             let _cleanup = UploadSessionLockCleanup::new(&self.session_locks, &session);
             let _guard = lock.lock().await;
-            let mut stored = self.read_session(&session).await?;
+            let stored = self.read_session(&session).await?;
             ensure_owner(&ctx.actor, &stored.owner)?;
             self.persist_expired_if_needed(&session, &stored).await?;
             ensure_open(&stored.public)?;
@@ -484,31 +1027,11 @@ impl StorageBackend for S3StorageBackend {
                     "S3 backend currently supports sequential proxy uploads only",
                 ));
             }
-            let mut expected = stored.public.next_offset.unwrap_or(0);
-            let mut staged = self.reconcile_staged_bytes(&session, expected).await?;
-            let staged_len = staged.len() as u64;
-            if staged_len > expected {
-                expected = staged_len;
-                stored.public.next_offset = Some(staged_len);
-                self.write_session(&session, &stored).await?;
+            if stored.native.multipart().is_some() {
+                self.append_multipart(&session, stored, offset, bytes).await
+            } else {
+                self.append_legacy(&session, stored, offset, bytes).await
             }
-            if expected != offset {
-                tracing::debug!(
-                    target: "pocopine.log",
-                    event_name = "pocopine.storage.offset_mismatch",
-                    session = %session,
-                    expected,
-                    provided = offset,
-                );
-                return Err(StorageError::offset_mismatch(expected, offset));
-            }
-            let new_offset = checked_new_offset(offset, bytes.len())?;
-            ensure_size_limit(stored.max_bytes, stored.public.size, new_offset)?;
-            staged.extend_from_slice(&bytes);
-            self.put_staged_bytes(&session, staged).await?;
-            stored.public.next_offset = Some(new_offset);
-            self.write_session(&session, &stored).await?;
-            Ok(stored.public)
         })
     }
 
@@ -532,42 +1055,13 @@ impl StorageBackend for S3StorageBackend {
             self.persist_expired_if_needed(&request.session, &stored)
                 .await?;
             ensure_completable(&stored.public)?;
-            let trusted = stored.public.next_offset.unwrap_or(0);
-            let staged = self
-                .reconcile_staged_bytes(&request.session, trusted)
-                .await?;
-            let actual = staged.len() as u64;
-            if let Some(expected) = stored.public.size {
-                if actual != expected {
-                    return Err(StorageError::policy_rejected(format!(
-                        "upload is incomplete: expected {expected} bytes, got {actual}"
-                    )));
-                }
+            let session = request.session.clone();
+            if stored.native.multipart().is_some() {
+                self.complete_multipart_upload_flow(&session, stored, request)
+                    .await
+            } else {
+                self.complete_legacy(&session, stored, request).await
             }
-            ensure_size_limit(stored.max_bytes, stored.public.size, actual)?;
-            let checksum =
-                validate_complete_checksum(&stored.checksum_policy, &staged, request.checksum)?;
-            let object_key = self.layout.object_key(stored.storage_key.key.as_str());
-            if stored.public.status == UploadSessionStatus::Open
-                || stored.public.next_offset != Some(actual)
-            {
-                stored.public.status = UploadSessionStatus::Completing;
-                stored.public.next_offset = Some(actual);
-                self.write_session(&request.session, &stored).await?;
-            }
-            let staged = Bytes::from(staged);
-            let etag = self
-                .put_completed_object(&object_key, staged, stored.public.content_type.as_deref())
-                .await?;
-            let object = self.object_ref(&stored, actual, etag, checksum);
-            stored.public.status = UploadSessionStatus::Complete;
-            stored.public.next_offset = Some(actual);
-            stored.object = Some(object.clone());
-            stored.cleanup_pending = true;
-            self.write_session(&request.session, &stored).await?;
-            self.cleanup_staged_bytes(&request.session, &mut stored)
-                .await?;
-            Ok(object)
         })
     }
 
@@ -583,6 +1077,9 @@ impl StorageBackend for S3StorageBackend {
             let known_session = match self.read_session(&session).await {
                 Ok(stored) => {
                     ensure_owner(&ctx.actor, &stored.owner)?;
+                    // Best-effort abort of the provider multipart upload before
+                    // dropping local state.
+                    self.abort_multipart_session(&stored).await?;
                     true
                 }
                 Err(StorageError::UnknownUploadSession { .. }) => false,

--- a/crates/pocopine-storage-s3/src/storage.rs
+++ b/crates/pocopine-storage-s3/src/storage.rs
@@ -171,31 +171,6 @@ impl S3StorageBackend {
         }
     }
 
-    /// Read the persisted tail buffer for a native multipart session.
-    ///
-    /// The tail is always smaller than one part, so this read is bounded; it is
-    /// not a full-object read.
-    async fn read_tail(
-        &self,
-        session: &UploadSessionId,
-        expected_len: u64,
-    ) -> StorageResult<Vec<u8>> {
-        let tail = self.get_staged_bytes(session).await?;
-        if tail.len() as u64 != expected_len {
-            // Metadata and the staged tail disagree (e.g. a crash between the S3
-            // write and the metadata write). Trust the persisted object; the
-            // client re-sends from the metadata offset and we converge.
-            tracing::warn!(
-                target: "pocopine.log",
-                event_name = "pocopine.storage.s3_tail_len_mismatch",
-                session = %session,
-                metadata = expected_len,
-                staged = tail.len(),
-            );
-        }
-        Ok(tail)
-    }
-
     async fn reconcile_staged_bytes(
         &self,
         session: &UploadSessionId,
@@ -577,15 +552,26 @@ impl S3StorageBackend {
         offset: u64,
         bytes: Bytes,
     ) -> StorageResult<UploadSession> {
-        let (flushed, tail_len) = {
+        // Take the buffered tail out of the session so it can be prepended to the
+        // incoming chunk without an extra copy; it is rewritten below.
+        let tail = {
             let state = stored
                 .native
-                .multipart()
+                .multipart_mut()
                 .expect("append_multipart called for a non-multipart session");
-            (state.flushed_len(), state.pending_tail_len)
+            std::mem::take(&mut state.pending_tail)
         };
-        let expected = flushed + tail_len;
+        let flushed = stored
+            .native
+            .multipart()
+            .expect("multipart state")
+            .flushed_len();
+        let expected = flushed + tail.len() as u64;
         if expected != offset {
+            // Restore the tail we took before bailing so `stored` is unchanged.
+            if let Some(state) = stored.native.multipart_mut() {
+                state.pending_tail = tail;
+            }
             tracing::debug!(
                 target: "pocopine.log",
                 event_name = "pocopine.storage.offset_mismatch",
@@ -598,23 +584,31 @@ impl S3StorageBackend {
         let new_offset = checked_new_offset(offset, bytes.len())?;
         ensure_size_limit(stored.max_bytes, stored.public.size, new_offset)?;
         if bytes.is_empty() {
+            if let Some(state) = stored.native.multipart_mut() {
+                state.pending_tail = tail;
+            }
             return Ok(stored.public);
         }
 
         let object_key = self.layout.object_key(stored.storage_key.key.as_str());
 
-        // Combine the persisted tail (bounded by one part) with the incoming
+        // Combine the buffered tail (bounded by one part) with the incoming
         // chunk. When the tail is empty we slice the incoming `Bytes` directly,
         // avoiding any copy.
-        let combined: Bytes = if tail_len > 0 {
-            let mut tail = self.read_tail(session, tail_len).await?;
-            tail.extend_from_slice(&bytes);
-            Bytes::from(tail)
-        } else {
+        let combined: Bytes = if tail.is_empty() {
             bytes
+        } else {
+            let mut combined = tail;
+            combined.extend_from_slice(&bytes);
+            Bytes::from(combined)
         };
 
-        // Flush every full-size part; the remainder becomes the new tail.
+        // Flush every full-size part; the remainder becomes the new tail. Parts
+        // are uploaded to S3 first, then the resulting state (parts + remainder
+        // tail) is persisted in a single atomic write at the end. A crash before
+        // that write leaves the durable metadata unchanged, so the client simply
+        // re-sends from the old offset and we recompute the same parts (uploading
+        // a part is idempotent — the same part number overwrites).
         let part_size = S3_MIN_PART_SIZE as usize;
         let mut pos = 0usize;
         while combined.len() - pos >= part_size {
@@ -641,18 +635,8 @@ impl S3StorageBackend {
             pos += part_size;
         }
 
-        let remainder = combined.slice(pos..);
-        let remainder_len = remainder.len() as u64;
-        if remainder.is_empty() {
-            if tail_len > 0 {
-                self.delete_object(&self.layout.session_bytes_key(session))
-                    .await?;
-            }
-        } else {
-            self.put_staged_bytes(session, remainder.to_vec()).await?;
-        }
         if let Some(state) = stored.native.multipart_mut() {
-            state.pending_tail_len = remainder_len;
+            state.pending_tail = combined.slice(pos..).to_vec();
         }
         stored.public.next_offset = Some(new_offset);
         self.write_session(session, &stored).await?;
@@ -676,6 +660,19 @@ impl S3StorageBackend {
         ensure_size_limit(stored.max_bytes, stored.public.size, total)?;
 
         let object_key = self.layout.object_key(stored.storage_key.key.as_str());
+        // On the first completion attempt the destination key has not been
+        // written yet (multipart parts live in the upload, not at the key). If an
+        // object already exists there it is a foreign collision, so reject rather
+        // than overwrite — matching the single-part `put_completed_object` guard.
+        // Retries (status `Completing`) skip this: the key may exist from our own
+        // prior completion and is reconciled by the idempotent-completion path.
+        if stored.public.status == UploadSessionStatus::Open
+            && self.head_object(&object_key).await?.is_some()
+        {
+            return Err(StorageError::policy_rejected(format!(
+                "S3 object key already exists: {object_key}"
+            )));
+        }
         if stored.public.status == UploadSessionStatus::Open
             || stored.public.next_offset != Some(total)
         {
@@ -684,26 +681,21 @@ impl S3StorageBackend {
             self.write_session(session, &stored).await?;
         }
 
-        let (has_upload_id, tail_len) = {
+        let (has_upload_id, tail) = {
             let state = stored.native.multipart().expect("multipart state");
-            (state.upload_id.is_some(), state.pending_tail_len)
+            (state.upload_id.is_some(), state.pending_tail.clone())
         };
 
         let (etag, checksum) = if !has_upload_id {
             // Whole object fits within one part (or is empty): a single direct
             // PUT, no multipart overhead. We already have the bytes, so validate
             // the checksum directly.
-            let bytes = if tail_len > 0 {
-                self.read_tail(session, tail_len).await?
-            } else {
-                Vec::new()
-            };
             let checksum =
-                validate_complete_checksum(&stored.checksum_policy, &bytes, request.checksum)?;
+                validate_complete_checksum(&stored.checksum_policy, &tail, request.checksum)?;
             let etag = self
                 .put_completed_object(
                     &object_key,
-                    Bytes::from(bytes),
+                    Bytes::from(tail),
                     stored.public.content_type.as_deref(),
                 )
                 .await?;
@@ -711,7 +703,8 @@ impl S3StorageBackend {
         } else {
             // Flush the final remainder as the last part (the last part is exempt
             // from the minimum-size rule), then assemble the object.
-            if tail_len > 0 {
+            if !tail.is_empty() {
+                let tail_len = tail.len() as u64;
                 let upload_id = stored
                     .native
                     .multipart()
@@ -722,7 +715,6 @@ impl S3StorageBackend {
                     .multipart()
                     .expect("multipart state")
                     .next_part_number;
-                let tail = self.read_tail(session, tail_len).await?;
                 let etag = self
                     .upload_part(&object_key, &upload_id, number, Bytes::from(tail))
                     .await?;
@@ -733,7 +725,7 @@ impl S3StorageBackend {
                         size: tail_len,
                     });
                     state.next_part_number = number + 1;
-                    state.pending_tail_len = 0;
+                    state.pending_tail = Vec::new();
                 }
                 self.write_session(session, &stored).await?;
             }
@@ -790,9 +782,12 @@ impl S3StorageBackend {
         stored.public.status = UploadSessionStatus::Complete;
         stored.public.next_offset = Some(total);
         stored.object = Some(object.clone());
-        stored.cleanup_pending = true;
+        // Native sessions buffer the tail inline in the metadata, so there is no
+        // separate staged object to delete.
+        if let Some(state) = stored.native.multipart_mut() {
+            state.pending_tail = Vec::new();
+        }
         self.write_session(session, &stored).await?;
-        self.cleanup_staged_bytes(session, &mut stored).await?;
         Ok(object)
     }
 
@@ -935,7 +930,7 @@ impl StorageBackend for S3StorageBackend {
                     upload_id: None,
                     parts: Vec::new(),
                     next_part_number: 1,
-                    pending_tail_len: 0,
+                    pending_tail: Vec::new(),
                 }),
             };
             // No staged `bytes.tmp` is created up front; native sessions only
@@ -988,7 +983,7 @@ impl StorageBackend for S3StorageBackend {
             ensure_owner(&ctx.actor, &stored.owner)?;
             self.persist_expired_if_needed(&session, &stored).await?;
             let committed_offset = match stored.native.multipart() {
-                Some(state) => state.flushed_len() + state.pending_tail_len,
+                Some(state) => state.committed_len(),
                 None => self
                     .reconcile_staged_bytes(&session, stored.public.next_offset.unwrap_or(0))
                     .await?

--- a/crates/pocopine-storage-s3/src/storage.rs
+++ b/crates/pocopine-storage-s3/src/storage.rs
@@ -42,6 +42,13 @@ const S3_MAX_PARTS: u64 = 10_000;
 /// Read granularity for the streaming checksum read-back.
 const CHECKSUM_READ_CHUNK: usize = 256 * 1024;
 
+/// Object user-metadata key stamped at `CreateMultipartUpload` with the upload
+/// session id. It proves ownership when reconciling an existing key after S3
+/// reports `NoSuchUpload` (which can mean either "we already completed" or "the
+/// upload was aborted/expired"). Only an object carrying our session id is
+/// adopted on recovery.
+const SESSION_OWNER_META_KEY: &str = "pocopine-upload-session";
+
 /// Part size to coalesce to for a session whose maximum object size is
 /// `max_bytes`.
 ///
@@ -75,6 +82,8 @@ pub struct S3StorageBackend {
 
 struct HeadObjectInfo {
     etag: Option<String>,
+    /// Value of the [`SESSION_OWNER_META_KEY`] user-metadata entry, if present.
+    owner_session: Option<String>,
 }
 
 impl std::fmt::Debug for S3StorageBackend {
@@ -337,9 +346,15 @@ impl S3StorageBackend {
             .send()
             .await
         {
-            Ok(output) => Ok(Some(HeadObjectInfo {
-                etag: output.e_tag.map(normalize_etag),
-            })),
+            Ok(output) => {
+                let owner_session = output
+                    .metadata()
+                    .and_then(|metadata| metadata.get(SESSION_OWNER_META_KEY).cloned());
+                Ok(Some(HeadObjectInfo {
+                    etag: output.e_tag.map(normalize_etag),
+                    owner_session,
+                }))
+            }
             Err(err) if is_head_object_not_found(&err) => Ok(None),
             Err(err) => Err(s3_error("head object", err)),
         }
@@ -351,12 +366,16 @@ impl S3StorageBackend {
         &self,
         object_key: &str,
         content_type: Option<&str>,
+        session: &UploadSessionId,
     ) -> StorageResult<String> {
         let mut request = self
             .client
             .create_multipart_upload()
             .bucket(&self.layout.bucket)
-            .key(object_key);
+            .key(object_key)
+            // Stamp ownership so the final object can be attributed to this
+            // session when reconciling `NoSuchUpload` on a retry.
+            .metadata(SESSION_OWNER_META_KEY, session.as_str());
         if let Some(content_type) = content_type {
             request = request.content_type(content_type);
         }
@@ -398,19 +417,21 @@ impl S3StorageBackend {
     /// Assemble the final object from its parts.
     ///
     /// Uses `If-None-Match: *` so completion atomically refuses to overwrite an
-    /// existing destination key (no TOCTOU window) on real S3. The two failure
-    /// modes are distinct and unambiguous:
+    /// existing destination key (no TOCTOU window) on real S3. Failure modes:
     ///   - `412 PreconditionFailed`: the key exists but *our* multipart upload was
     ///     not consumed, so the object was created by someone else — always
     ///     reject, never adopt it.
-    ///   - `NoSuchUpload`: our upload id was consumed by a prior completion (a
-    ///     crash before the session metadata was updated), so the existing object
-    ///     is ours — recover its ETag idempotently.
+    ///   - `NoSuchUpload`: the upload id is gone. This is ambiguous — either a
+    ///     prior completion consumed it (object is ours) or it was aborted/expired
+    ///     (any object at the key is foreign). We disambiguate via the
+    ///     [`SESSION_OWNER_META_KEY`] marker stamped at create time: adopt the key
+    ///     only when it carries this session's id, otherwise the upload is gone.
     async fn complete_multipart(
         &self,
         object_key: &str,
         upload_id: &str,
         parts: &[S3CompletedPart],
+        session: &UploadSessionId,
     ) -> StorageResult<Option<String>> {
         let completed_parts: Vec<CompletedPart> = parts
             .iter()
@@ -439,10 +460,19 @@ impl S3StorageBackend {
             Err(err) if is_precondition_failed(&err) => Err(StorageError::policy_rejected(
                 format!("S3 object key already exists: {object_key}"),
             )),
-            Err(err) if is_no_such_upload(&err) => match self.head_object(object_key).await? {
-                Some(info) => Ok(info.etag),
-                None => Err(s3_error("complete multipart upload", err)),
-            },
+            Err(err) if is_no_such_upload(&err) => {
+                match self.head_object(object_key).await? {
+                    // Adopt the existing object only if it was stamped by this
+                    // session; a foreign object (or none) means this upload was
+                    // aborted/expired and can no longer be completed.
+                    Some(info) if info.owner_session.as_deref() == Some(session.as_str()) => {
+                        Ok(info.etag)
+                    }
+                    _ => Err(StorageError::UploadClosed {
+                        session: session.to_string(),
+                    }),
+                }
+            }
             Err(err) => Err(s3_error("complete multipart upload", err)),
         }
     }
@@ -507,7 +537,7 @@ impl S3StorageBackend {
             }
         }
         let upload_id = self
-            .create_multipart(object_key, stored.public.content_type.as_deref())
+            .create_multipart(object_key, stored.public.content_type.as_deref(), session)
             .await?;
         if let Some(state) = stored.native.multipart_mut() {
             state.upload_id = Some(upload_id.clone());
@@ -765,7 +795,7 @@ impl S3StorageBackend {
                 )
             };
             let etag = self
-                .complete_multipart(&object_key, &upload_id, &parts)
+                .complete_multipart(&object_key, &upload_id, &parts, session)
                 .await?;
 
             // Validate the checksum by streaming the finished object (only when a

--- a/crates/pocopine-storage-s3/src/util.rs
+++ b/crates/pocopine-storage-s3/src/util.rs
@@ -1,5 +1,6 @@
-use aws_sdk_s3::error::SdkError;
+use aws_sdk_s3::error::{ProvideErrorMetadata, SdkError};
 use aws_sdk_s3::operation::get_object::GetObjectError;
+use aws_sdk_s3::operation::head_object::HeadObjectError;
 use aws_sdk_s3::operation::put_object::PutObjectError;
 use pocopine_storage::backend_common::ensure_open;
 use pocopine_storage::{StorageError, StorageResult, UploadSession, UploadSessionStatus};
@@ -21,10 +22,26 @@ pub(crate) fn is_get_object_not_found(err: &SdkError<GetObjectError>) -> bool {
         .is_some_and(GetObjectError::is_no_such_key)
 }
 
+pub(crate) fn is_head_object_not_found(err: &SdkError<HeadObjectError>) -> bool {
+    err.as_service_error()
+        .is_some_and(HeadObjectError::is_not_found)
+}
+
 pub(crate) fn is_put_precondition_failed(err: &SdkError<PutObjectError>) -> bool {
     err.as_service_error()
         .and_then(|err| err.meta().code())
         .is_some_and(|code| code == "PreconditionFailed")
+}
+
+/// True when an S3 multipart operation failed because the upload id is gone
+/// (already completed or aborted). Used to make completion/abort idempotent.
+pub(crate) fn is_no_such_upload<E>(err: &SdkError<E>) -> bool
+where
+    E: ProvideErrorMetadata,
+{
+    err.as_service_error()
+        .and_then(ProvideErrorMetadata::code)
+        .is_some_and(|code| code == "NoSuchUpload")
 }
 
 pub(crate) fn s3_error(operation: &'static str, err: impl std::fmt::Display) -> StorageError {

--- a/crates/pocopine-storage-s3/src/util.rs
+++ b/crates/pocopine-storage-s3/src/util.rs
@@ -28,8 +28,17 @@ pub(crate) fn is_head_object_not_found(err: &SdkError<HeadObjectError>) -> bool 
 }
 
 pub(crate) fn is_put_precondition_failed(err: &SdkError<PutObjectError>) -> bool {
+    is_precondition_failed(err)
+}
+
+/// True when an S3 operation failed its `If-None-Match: *` precondition because
+/// the destination key already exists (HTTP 412).
+pub(crate) fn is_precondition_failed<E>(err: &SdkError<E>) -> bool
+where
+    E: ProvideErrorMetadata,
+{
     err.as_service_error()
-        .and_then(|err| err.meta().code())
+        .and_then(ProvideErrorMetadata::code)
         .is_some_and(|code| code == "PreconditionFailed")
 }
 

--- a/crates/pocopine-storage-s3/tests/minio.rs
+++ b/crates/pocopine-storage-s3/tests/minio.rs
@@ -473,6 +473,57 @@ async fn multipart_upload_verifies_streaming_sha256_against_minio() -> StorageRe
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn multipart_missing_required_checksum_is_rejected_and_retryable() -> StorageResult<()> {
+    let client = minio_client().await;
+    let bucket = create_bucket(&client, "mp-reqsum").await;
+    let backend = S3StorageBackend::new(client.clone(), bucket.clone())?;
+    let total = 6 * 1024 * 1024usize;
+    let data = pattern_bytes(0, total);
+    let expected = ObjectChecksum {
+        algorithm: ChecksumAlgorithm::Sha256,
+        value: pocopine_crypto::sha256_hex(&data),
+    };
+
+    let session = initiate_checked(
+        &backend,
+        "files/reqsum.bin",
+        total as u64,
+        ChecksumPolicy::Required(ChecksumAlgorithm::Sha256),
+    )
+    .await?;
+    backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, data)
+        .await?;
+
+    // Missing the required checksum is rejected before the object is assembled,
+    // so the session stays open and a follow-up completion with the correct
+    // checksum still succeeds.
+    let rejected = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id.clone(),
+                checksum: None,
+            },
+        )
+        .await;
+    assert!(matches!(rejected, Err(StorageError::PolicyRejected { .. })));
+    assert!(!object_exists(&client, &bucket, "files/reqsum.bin").await);
+
+    let object = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: Some(expected.clone()),
+            },
+        )
+        .await?;
+    assert_eq!(object.checksum, Some(expected));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn single_part_upload_verifies_crc32c_against_minio() -> StorageResult<()> {
     let client = minio_client().await;
     let bucket = create_bucket(&client, "sp-crc").await;

--- a/crates/pocopine-storage-s3/tests/minio.rs
+++ b/crates/pocopine-storage-s3/tests/minio.rs
@@ -15,8 +15,9 @@ use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::Client;
 use bytes::Bytes;
 use pocopine_storage::{
-    CompleteUpload, InitiateUpload, SafeObjectKey, StorageBackend, StorageContext, StorageError,
-    StorageKey, StorageResult, UploadPolicy, UploadSession, UploadStrategy,
+    ChecksumAlgorithm, ChecksumPolicy, CompleteUpload, InitiateUpload, ObjectChecksum,
+    SafeObjectKey, StorageBackend, StorageContext, StorageError, StorageKey, StorageResult,
+    UploadPolicy, UploadSession, UploadStrategy,
 };
 use pocopine_storage_s3::S3StorageBackend;
 use testcontainers::runners::AsyncRunner;
@@ -112,6 +113,81 @@ async fn initiate(backend: &S3StorageBackend, size: Option<u64>) -> StorageResul
             },
         )
         .await
+}
+
+/// Policy that allows large uploads so tests can cross the S3 5 MiB part floor.
+fn large_policy() -> StorageResult<UploadPolicy> {
+    let mut policy = UploadPolicy::new("s3")?
+        .max_bytes(32 * 1024 * 1024)
+        .preferred_chunk_size(1024 * 1024);
+    policy.expires_after = Duration::from_secs(60 * 60);
+    Ok(policy)
+}
+
+async fn initiate_large(
+    backend: &S3StorageBackend,
+    size: Option<u64>,
+) -> StorageResult<UploadSession> {
+    backend
+        .initiate_upload(
+            &ctx(),
+            InitiateUpload {
+                scope: "files".to_string(),
+                storage_key: StorageKey::new(SafeObjectKey::parse("files/large.bin")?),
+                file_name: "large.bin".to_string(),
+                size,
+                content_type: Some("application/octet-stream".to_string()),
+                metadata: BTreeMap::new(),
+                requested_strategy: UploadStrategy::Auto,
+                policy: large_policy()?,
+            },
+        )
+        .await
+}
+
+async fn initiate_checked(
+    backend: &S3StorageBackend,
+    key: &str,
+    size: u64,
+    checksum: ChecksumPolicy,
+) -> StorageResult<UploadSession> {
+    let mut policy = large_policy()?;
+    policy.checksum = checksum;
+    backend
+        .initiate_upload(
+            &ctx(),
+            InitiateUpload {
+                scope: "files".to_string(),
+                storage_key: StorageKey::new(SafeObjectKey::parse(key)?),
+                file_name: "checked.bin".to_string(),
+                size: Some(size),
+                content_type: Some("application/octet-stream".to_string()),
+                metadata: BTreeMap::new(),
+                requested_strategy: UploadStrategy::Auto,
+                policy,
+            },
+        )
+        .await
+}
+
+/// Deterministic, position-dependent bytes so assembled-object comparisons catch
+/// any part ordering / offset bug.
+fn pattern_bytes(start: usize, len: usize) -> Bytes {
+    let mut buf = Vec::with_capacity(len);
+    for i in 0..len {
+        buf.push(((start + i) % 251) as u8);
+    }
+    Bytes::from(buf)
+}
+
+async fn object_exists(client: &Client, bucket: &str, key: &str) -> bool {
+    client
+        .head_object()
+        .bucket(bucket)
+        .key(key)
+        .send()
+        .await
+        .is_ok()
 }
 
 async fn object_bytes(client: &Client, bucket: &str, key: &str) -> Vec<u8> {
@@ -245,6 +321,204 @@ async fn changing_upload_length_uses_shared_invalid_value_error() -> StorageResu
         rejected,
         Err(StorageError::InvalidValue { field, .. }) if field == "Upload-Length"
     ));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn multipart_upload_assembles_large_object_against_minio() -> StorageResult<()> {
+    let client = minio_client().await;
+    let bucket = create_bucket(&client, "multipart").await;
+    let backend = S3StorageBackend::new(client.clone(), bucket.clone())?;
+
+    // 6 MiB sent as 3 x 2 MiB chunks. This crosses the 5 MiB part floor: the
+    // first 5 MiB flush as one provider part, the trailing 1 MiB is the final
+    // part written at completion.
+    let chunk = 2 * 1024 * 1024usize;
+    let total = 3 * chunk;
+    let session = initiate_large(&backend, Some(total as u64)).await?;
+
+    let mut offset = 0u64;
+    for index in 0..3 {
+        let bytes = pattern_bytes(index * chunk, chunk);
+        let updated = backend
+            .append_upload_bytes(&ctx(), session.id.clone(), offset, bytes)
+            .await?;
+        offset += chunk as u64;
+        assert_eq!(updated.next_offset, Some(offset));
+    }
+
+    let object = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id.clone(),
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(object.size, total as u64);
+    // Bytes match exactly across the 5 MiB part boundary, proving the parts were
+    // uploaded and assembled in order (not rewritten as one staged object).
+    assert_eq!(
+        object_bytes(&client, &bucket, "files/large.bin").await,
+        pattern_bytes(0, total).to_vec()
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn aborting_multipart_upload_removes_provider_parts_against_minio() -> StorageResult<()> {
+    let client = minio_client().await;
+    let bucket = create_bucket(&client, "mp-abort").await;
+    let backend = S3StorageBackend::new(client.clone(), bucket.clone())?;
+    let session = initiate_large(&backend, None).await?;
+
+    // Push past the 5 MiB floor so a provider multipart upload actually exists.
+    backend
+        .append_upload_bytes(
+            &ctx(),
+            session.id.clone(),
+            0,
+            pattern_bytes(0, 6 * 1024 * 1024),
+        )
+        .await?;
+
+    // Aborting issues `AbortMultipartUpload` (so this returns `Ok` only if the
+    // provider accepted the abort) and drops local session state. (MinIO's
+    // `ListMultipartUploads` does not report in-progress uploads, so cleanup is
+    // verified via the observable effects below rather than by listing.)
+    backend.abort_upload(&ctx(), session.id.clone()).await?;
+
+    let inspected = backend.inspect_upload(&ctx(), session.id).await;
+    assert!(matches!(
+        inspected,
+        Err(StorageError::UnknownUploadSession { .. })
+    ));
+    // The aborted upload never produced a final object.
+    assert!(!object_exists(&client, &bucket, "files/large.bin").await);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn multipart_completion_is_idempotent_against_minio() -> StorageResult<()> {
+    let client = minio_client().await;
+    let bucket = create_bucket(&client, "mp-idem").await;
+    let backend = S3StorageBackend::new(client.clone(), bucket.clone())?;
+    let total = 6 * 1024 * 1024usize;
+    let session = initiate_large(&backend, Some(total as u64)).await?;
+
+    backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, pattern_bytes(0, total))
+        .await?;
+
+    let first = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id.clone(),
+                checksum: None,
+            },
+        )
+        .await?;
+    let second = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(first, second);
+    assert_eq!(first.size, total as u64);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn multipart_upload_verifies_streaming_sha256_against_minio() -> StorageResult<()> {
+    let client = minio_client().await;
+    let bucket = create_bucket(&client, "mp-sha").await;
+    let backend = S3StorageBackend::new(client.clone(), bucket.clone())?;
+    let total = 6 * 1024 * 1024usize;
+    let data = pattern_bytes(0, total);
+    let expected = ObjectChecksum {
+        algorithm: ChecksumAlgorithm::Sha256,
+        value: pocopine_crypto::sha256_hex(&data),
+    };
+
+    let session = initiate_checked(
+        &backend,
+        "files/checked.bin",
+        total as u64,
+        ChecksumPolicy::Required(ChecksumAlgorithm::Sha256),
+    )
+    .await?;
+    backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, data)
+        .await?;
+
+    // The checksum is verified by streaming the assembled object back through the
+    // multipart path (no full in-memory buffer).
+    let object = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: Some(expected.clone()),
+            },
+        )
+        .await?;
+    assert_eq!(object.checksum, Some(expected));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn single_part_upload_verifies_crc32c_against_minio() -> StorageResult<()> {
+    let client = minio_client().await;
+    let bucket = create_bucket(&client, "sp-crc").await;
+    let backend = S3StorageBackend::new(client.clone(), bucket.clone())?;
+    // Below the 5 MiB floor: completes via the single direct-PUT path.
+    let data = pattern_bytes(0, 4096);
+    let expected = ObjectChecksum {
+        algorithm: ChecksumAlgorithm::Crc32c,
+        value: pocopine_crypto::crc32c_hex(&data),
+    };
+
+    let session = initiate_checked(
+        &backend,
+        "files/crc.bin",
+        data.len() as u64,
+        ChecksumPolicy::Required(ChecksumAlgorithm::Crc32c),
+    )
+    .await?;
+    backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, data)
+        .await?;
+
+    let wrong = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id.clone(),
+                checksum: Some(ObjectChecksum {
+                    algorithm: ChecksumAlgorithm::Crc32c,
+                    value: "deadbeef".to_string(),
+                }),
+            },
+        )
+        .await;
+    assert!(matches!(wrong, Err(StorageError::PolicyRejected { .. })));
+
+    let object = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: Some(expected.clone()),
+            },
+        )
+        .await?;
+    assert_eq!(object.checksum, Some(expected));
     Ok(())
 }
 

--- a/crates/pocopine-storage-s3/tests/minio.rs
+++ b/crates/pocopine-storage-s3/tests/minio.rs
@@ -557,3 +557,42 @@ async fn complete_does_not_overwrite_existing_object_key() -> StorageResult<()> 
     );
     Ok(())
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn multipart_complete_does_not_overwrite_existing_object_key() -> StorageResult<()> {
+    let client = minio_client().await;
+    let bucket = create_bucket(&client, "mp-collision").await;
+    client
+        .put_object()
+        .bucket(&bucket)
+        .key("files/large.bin")
+        .body(ByteStream::from_static(b"existing"))
+        .send()
+        .await
+        .expect("seed existing object");
+
+    let backend = S3StorageBackend::new(client.clone(), bucket.clone())?;
+    let total = 6 * 1024 * 1024usize;
+    let session = initiate_large(&backend, Some(total as u64)).await?;
+    backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, pattern_bytes(0, total))
+        .await?;
+
+    // The multipart completion path must also refuse to clobber an existing key
+    // (CompleteMultipartUpload would otherwise overwrite it).
+    let rejected = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await;
+    assert!(matches!(rejected, Err(StorageError::PolicyRejected { .. })));
+    assert_eq!(
+        object_bytes(&client, &bucket, "files/large.bin").await,
+        b"existing"
+    );
+    Ok(())
+}

--- a/crates/pocopine-storage/Cargo.toml
+++ b/crates/pocopine-storage/Cargo.toml
@@ -43,6 +43,11 @@ tower = { version = "0.5", features = ["util"] }
 name = "upload"
 harness = false
 
+# Provider-write amplification: legacy O(n^2) rewrite vs native O(n) strategies.
+[[bench]]
+name = "amplification"
+harness = false
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = { workspace = true }
 wasm-bindgen = { workspace = true }

--- a/crates/pocopine-storage/Cargo.toml
+++ b/crates/pocopine-storage/Cargo.toml
@@ -25,7 +25,7 @@ uuid = { version = "1", features = ["v4", "js"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 pocopine-server = { workspace = true }
-sha2 = "0.10"
+pocopine-crypto = { workspace = true }
 # Per-session async mutex (tokio::sync::Mutex) for the local-fs backend, plus
 # spawn_blocking to keep the std::fs I/O off the tokio worker threads.
 tokio = { version = "1", default-features = false, features = ["rt", "sync"] }

--- a/crates/pocopine-storage/Cargo.toml
+++ b/crates/pocopine-storage/Cargo.toml
@@ -32,10 +32,16 @@ tokio = { version = "1", default-features = false, features = ["rt", "sync"] }
 tracing = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion = { version = "0.5", features = ["async_tokio"] }
 http-body-util = "0.1"
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt", "time"] }
 tower = { version = "0.5", features = ["util"] }
+
+# Upload hot-path throughput benchmark (in-memory backend; host only).
+[[bench]]
+name = "upload"
+harness = false
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 js-sys = { workspace = true }

--- a/crates/pocopine-storage/benches/amplification.rs
+++ b/crates/pocopine-storage/benches/amplification.rs
@@ -61,22 +61,31 @@ fn gcs_legacy_rewrite(total: usize, chunk: usize) -> Sink {
     sink
 }
 
-/// S3 native multipart: coalesce sub-part chunks, flush each full part once.
+/// S3 native multipart: coalesce sub-part chunks into >=5 MiB parts, flushing
+/// each part's bytes to the provider exactly once via `UploadPart`.
+///
+/// Only the unflushed remainder is buffered (bounded by one part), tracked by
+/// length with no front-shifting, so the model reflects the real cost: every
+/// payload byte is written once. (The real backend additionally rewrites a small
+/// base64 tail in the session metadata per append; that churn is bounded by the
+/// part size and disappears once the client sends part-sized chunks, so it is
+/// not modeled here.)
 fn s3_native_multipart(total: usize, chunk: usize) -> Sink {
     let mut sink = Sink::default();
-    let mut tail: Vec<u8> = Vec::with_capacity(S3_PART + chunk);
+    let part = vec![0xA5u8; S3_PART];
+    let mut pending = 0usize;
     let mut offset = 0;
     while offset < total {
         let n = chunk.min(total - offset);
-        tail.resize(tail.len() + n, 0xA5);
-        while tail.len() >= S3_PART {
-            sink.write(&tail[..S3_PART]); // UploadPart
-            tail.drain(..S3_PART);
+        pending += n;
+        while pending >= S3_PART {
+            sink.write(&part); // UploadPart: one full part, written once
+            pending -= S3_PART;
         }
         offset += n;
     }
-    if !tail.is_empty() {
-        sink.write(&tail); // final part
+    if pending > 0 {
+        sink.write(&part[..pending]); // final part
     }
     sink
 }

--- a/crates/pocopine-storage/benches/amplification.rs
+++ b/crates/pocopine-storage/benches/amplification.rs
@@ -15,6 +15,9 @@
 //!   is uploaded exactly once via `UploadPart`. O(n).
 //! - `gcs_native_compose` (current GCS): each chunk is one component written
 //!   once; the final object is a server-side compose (no client re-upload). O(n).
+//! - `azure_native_blocks` (current Azure): sub-block chunks are coalesced and
+//!   each block's bytes are uploaded once via `Put Block`; `Put Block List` is a
+//!   metadata-only commit (no client re-upload). O(n).
 //!
 //! Run: `cargo bench -p pocopine-storage --bench amplification`.
 
@@ -24,6 +27,7 @@ use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criteri
 
 const CHUNK: usize = 1024 * 1024; // 1 MiB PATCH chunks
 const S3_PART: usize = 5 * 1024 * 1024; // S3 minimum part size
+const AZURE_BLOCK: usize = 1024 * 1024; // Azure block size for the default 64 MiB cap
 const MIB: f64 = 1024.0 * 1024.0;
 
 /// Counts bytes written and folds them so the compiler cannot elide the copy.
@@ -103,6 +107,29 @@ fn gcs_native_compose(total: usize, chunk: usize) -> Sink {
     sink
 }
 
+/// Azure native block blob: coalesce sub-block chunks into fixed-size blocks,
+/// each uploaded once via `Put Block`. `Put Block List` commits the order
+/// server-side, so no payload is re-uploaded.
+fn azure_native_blocks(total: usize, chunk: usize) -> Sink {
+    let mut sink = Sink::default();
+    let block = vec![0xA5u8; AZURE_BLOCK];
+    let mut pending = 0usize;
+    let mut offset = 0;
+    while offset < total {
+        let n = chunk.min(total - offset);
+        pending += n;
+        while pending >= AZURE_BLOCK {
+            sink.write(&block); // Put Block: one full block, written once
+            pending -= AZURE_BLOCK;
+        }
+        offset += n;
+    }
+    if pending > 0 {
+        sink.write(&block[..pending]); // final block
+    }
+    sink
+}
+
 fn amplification(c: &mut Criterion) {
     let totals = [4 * 1024 * 1024usize, 16 * 1024 * 1024, 64 * 1024 * 1024];
 
@@ -112,20 +139,22 @@ fn amplification(c: &mut Criterion) {
         CHUNK / 1024
     );
     eprintln!(
-        "{:>10}  {:>16}  {:>16}  {:>16}  {:>10}",
-        "upload", "gcs_legacy O(n^2)", "s3_multipart O(n)", "gcs_compose O(n)", "legacy x"
+        "{:>9}  {:>15}  {:>13}  {:>13}  {:>13}  {:>9}",
+        "upload", "legacy O(n^2)", "s3 O(n)", "gcs O(n)", "azure O(n)", "legacy x"
     );
     for &total in &totals {
         let legacy = gcs_legacy_rewrite(total, CHUNK).written;
         let s3 = s3_native_multipart(total, CHUNK).written;
         let gcs = gcs_native_compose(total, CHUNK).written;
+        let azure = azure_native_blocks(total, CHUNK).written;
         eprintln!(
-            "{:>7} MiB  {:>12.1} MiB  {:>12.1} MiB  {:>12.1} MiB  {:>9.1}x",
+            "{:>5} MiB  {:>11.1} MiB  {:>9.1} MiB  {:>9.1} MiB  {:>9.1} MiB  {:>8.1}x",
             total / 1024 / 1024,
             legacy as f64 / MIB,
             s3 as f64 / MIB,
             gcs as f64 / MIB,
-            legacy as f64 / gcs as f64,
+            azure as f64 / MIB,
+            legacy as f64 / azure as f64,
         );
     }
     eprintln!();
@@ -148,6 +177,11 @@ fn amplification(c: &mut Criterion) {
             BenchmarkId::new("gcs_native_compose", mib),
             &total,
             |b, &t| b.iter(|| black_box(gcs_native_compose(t, CHUNK).fold)),
+        );
+        group.bench_with_input(
+            BenchmarkId::new("azure_native_blocks", mib),
+            &total,
+            |b, &t| b.iter(|| black_box(azure_native_blocks(t, CHUNK).fold)),
         );
     }
     group.finish();

--- a/crates/pocopine-storage/benches/amplification.rs
+++ b/crates/pocopine-storage/benches/amplification.rs
@@ -1,0 +1,148 @@
+//! Provider-write amplification: the legacy staged-object rewrite vs the native
+//! upload strategies introduced for #176.
+//!
+//! This models the bytes each strategy pushes to the object store for an upload
+//! delivered as a sequence of `PATCH` chunks, and moves those bytes through an
+//! in-memory sink so wall-clock time tracks the I/O volume. It is a Docker-free
+//! proxy for object-store write traffic, not a network benchmark — but the byte
+//! counts it reports are exact.
+//!
+//! Strategies:
+//! - `gcs_legacy_rewrite`: the OLD path (both S3 and GCS) — every `PATCH`
+//!   re-uploads the whole staged object, and completion writes it once more.
+//!   O(n^2) provider bytes.
+//! - `s3_native_multipart` (AWS baseline): coalesce to >=5 MiB parts; each byte
+//!   is uploaded exactly once via `UploadPart`. O(n).
+//! - `gcs_native_compose` (current GCS): each chunk is one component written
+//!   once; the final object is a server-side compose (no client re-upload). O(n).
+//!
+//! Run: `cargo bench -p pocopine-storage --bench amplification`.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+
+const CHUNK: usize = 1024 * 1024; // 1 MiB PATCH chunks
+const S3_PART: usize = 5 * 1024 * 1024; // S3 minimum part size
+const MIB: f64 = 1024.0 * 1024.0;
+
+/// Counts bytes written and folds them so the compiler cannot elide the copy.
+#[derive(Default)]
+struct Sink {
+    written: u64,
+    fold: u64,
+}
+
+impl Sink {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) {
+        self.written += buf.len() as u64;
+        let mut acc = 0u64;
+        for &byte in buf {
+            acc = acc.wrapping_add(byte as u64);
+        }
+        self.fold = self.fold.wrapping_add(acc);
+    }
+}
+
+/// Legacy: re-upload the whole staged object on every append, then once more on
+/// completion. Provider write bytes grow quadratically with object size.
+fn gcs_legacy_rewrite(total: usize, chunk: usize) -> Sink {
+    let mut sink = Sink::default();
+    let mut staged: Vec<u8> = Vec::with_capacity(total);
+    let mut offset = 0;
+    while offset < total {
+        let n = chunk.min(total - offset);
+        staged.resize(staged.len() + n, 0xA5);
+        sink.write(&staged); // put_staged rewrites the entire object
+        offset += n;
+    }
+    sink.write(&staged); // final completed-object write
+    sink
+}
+
+/// S3 native multipart: coalesce sub-part chunks, flush each full part once.
+fn s3_native_multipart(total: usize, chunk: usize) -> Sink {
+    let mut sink = Sink::default();
+    let mut tail: Vec<u8> = Vec::with_capacity(S3_PART + chunk);
+    let mut offset = 0;
+    while offset < total {
+        let n = chunk.min(total - offset);
+        tail.resize(tail.len() + n, 0xA5);
+        while tail.len() >= S3_PART {
+            sink.write(&tail[..S3_PART]); // UploadPart
+            tail.drain(..S3_PART);
+        }
+        offset += n;
+    }
+    if !tail.is_empty() {
+        sink.write(&tail); // final part
+    }
+    sink
+}
+
+/// GCS native compose: each chunk is one component, written once.
+fn gcs_native_compose(total: usize, chunk: usize) -> Sink {
+    let mut sink = Sink::default();
+    let block = vec![0xA5u8; chunk];
+    let mut offset = 0;
+    while offset < total {
+        let n = chunk.min(total - offset);
+        sink.write(&block[..n]); // component write
+        offset += n;
+    }
+    sink
+}
+
+fn amplification(c: &mut Criterion) {
+    let totals = [4 * 1024 * 1024usize, 16 * 1024 * 1024, 64 * 1024 * 1024];
+
+    // Exact provider-write-byte report (the headline numbers).
+    eprintln!(
+        "\n=== provider write volume, {} KiB PATCH chunks ===",
+        CHUNK / 1024
+    );
+    eprintln!(
+        "{:>10}  {:>16}  {:>16}  {:>16}  {:>10}",
+        "upload", "gcs_legacy O(n^2)", "s3_multipart O(n)", "gcs_compose O(n)", "legacy x"
+    );
+    for &total in &totals {
+        let legacy = gcs_legacy_rewrite(total, CHUNK).written;
+        let s3 = s3_native_multipart(total, CHUNK).written;
+        let gcs = gcs_native_compose(total, CHUNK).written;
+        eprintln!(
+            "{:>7} MiB  {:>12.1} MiB  {:>12.1} MiB  {:>12.1} MiB  {:>9.1}x",
+            total / 1024 / 1024,
+            legacy as f64 / MIB,
+            s3 as f64 / MIB,
+            gcs as f64 / MIB,
+            legacy as f64 / gcs as f64,
+        );
+    }
+    eprintln!();
+
+    let mut group = c.benchmark_group("provider_write_cost");
+    for &total in &totals {
+        let mib = total / 1024 / 1024;
+        group.throughput(Throughput::Bytes(total as u64));
+        group.bench_with_input(
+            BenchmarkId::new("gcs_legacy_rewrite", mib),
+            &total,
+            |b, &t| b.iter(|| black_box(gcs_legacy_rewrite(t, CHUNK).fold)),
+        );
+        group.bench_with_input(
+            BenchmarkId::new("s3_native_multipart", mib),
+            &total,
+            |b, &t| b.iter(|| black_box(s3_native_multipart(t, CHUNK).fold)),
+        );
+        group.bench_with_input(
+            BenchmarkId::new("gcs_native_compose", mib),
+            &total,
+            |b, &t| b.iter(|| black_box(gcs_native_compose(t, CHUNK).fold)),
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, amplification);
+criterion_main!(benches);

--- a/crates/pocopine-storage/benches/upload.rs
+++ b/crates/pocopine-storage/benches/upload.rs
@@ -1,0 +1,82 @@
+//! Throughput benchmark for the upload hot path (initiate → N appends →
+//! complete) against the in-memory backend.
+//!
+//! This isolates the framework's per-chunk overhead (session bookkeeping,
+//! per-session locking, offset checks, append handling) from provider network
+//! I/O. The headline #176 win — bounded provider-write amplification for the S3
+//! and GCS native backends — is validated separately by their integration
+//! tests (part/component counts stay O(object_size / part_size), not O(n²)).
+//!
+//! Run with: `cargo bench -p pocopine-storage --bench upload`.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use bytes::Bytes;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use pocopine_storage::{
+    CompleteUpload, InitiateUpload, MemoryStorageBackend, SafeObjectKey, StorageBackend,
+    StorageContext, StorageKey, UploadPolicy, UploadStrategy,
+};
+use tokio::runtime::Builder;
+
+const TOTAL: usize = 16 * 1024 * 1024;
+
+async fn run_upload(total: usize, chunk: usize) {
+    let backend = MemoryStorageBackend::new();
+    let ctx = StorageContext::system("bench");
+    let policy = UploadPolicy::new("memory")
+        .expect("policy")
+        .max_bytes(total as u64);
+    let session = backend
+        .initiate_upload(
+            &ctx,
+            InitiateUpload {
+                scope: "files".to_string(),
+                storage_key: StorageKey::new(SafeObjectKey::parse("files/bench.bin").expect("key")),
+                file_name: "bench.bin".to_string(),
+                size: Some(total as u64),
+                content_type: Some("application/octet-stream".to_string()),
+                metadata: Default::default(),
+                requested_strategy: UploadStrategy::Auto,
+                policy,
+            },
+        )
+        .await
+        .expect("initiate");
+
+    let block = Bytes::from(vec![0u8; chunk]);
+    let mut offset = 0usize;
+    while offset < total {
+        let len = chunk.min(total - offset);
+        backend
+            .append_upload_bytes(&ctx, session.id.clone(), offset as u64, block.slice(0..len))
+            .await
+            .expect("append");
+        offset += len;
+    }
+    backend
+        .complete_upload(
+            &ctx,
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await
+        .expect("complete");
+}
+
+fn upload_throughput(c: &mut Criterion) {
+    let runtime = Builder::new_current_thread().build().expect("runtime");
+    let mut group = c.benchmark_group("memory_upload_16MiB");
+    group.throughput(Throughput::Bytes(TOTAL as u64));
+    for &chunk in &[64 * 1024usize, 256 * 1024, 1024 * 1024, 4 * 1024 * 1024] {
+        group.bench_with_input(BenchmarkId::from_parameter(chunk), &chunk, |b, &chunk| {
+            b.to_async(&runtime).iter(|| run_upload(TOTAL, chunk));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, upload_throughput);
+criterion_main!(benches);

--- a/crates/pocopine-storage/src/checksum.rs
+++ b/crates/pocopine-storage/src/checksum.rs
@@ -33,6 +33,37 @@ impl StreamingChecksum {
     }
 }
 
+/// Cheaply reject a checksum that can never validate, before any expensive
+/// finalize work (e.g. assembling a multipart object).
+///
+/// Catches a missing required checksum or a disallowed/ mismatched algorithm
+/// without hashing. The actual value comparison still happens later.
+pub fn precheck_checksum(
+    policy: &ChecksumPolicy,
+    provided: Option<&ObjectChecksum>,
+) -> StorageResult<()> {
+    match policy {
+        ChecksumPolicy::None => Ok(()),
+        ChecksumPolicy::Optional(allowed) => match provided {
+            Some(checksum) if !allowed.contains(&checksum.algorithm) => Err(
+                StorageError::policy_rejected("checksum algorithm is not allowed"),
+            ),
+            _ => Ok(()),
+        },
+        ChecksumPolicy::Required(algorithm) => {
+            let provided = provided.ok_or_else(|| {
+                StorageError::policy_rejected("required upload checksum is missing")
+            })?;
+            if provided.algorithm != *algorithm {
+                return Err(StorageError::policy_rejected(
+                    "required upload checksum algorithm does not match policy",
+                ));
+            }
+            Ok(())
+        }
+    }
+}
+
 /// The checksum algorithm a completed upload must hash, if any.
 ///
 /// Returns `None` when no verification is needed (no policy, or an `Optional`

--- a/crates/pocopine-storage/src/checksum.rs
+++ b/crates/pocopine-storage/src/checksum.rs
@@ -1,45 +1,79 @@
-use sha2::{Digest, Sha256};
+use pocopine_crypto::{digest_hex, Algorithm, Hasher};
 
 use crate::{ChecksumAlgorithm, ChecksumPolicy, ObjectChecksum, StorageError, StorageResult};
 
-pub fn ensure_supported_checksum_policy(policy: &ChecksumPolicy) -> StorageResult<()> {
-    match policy {
-        ChecksumPolicy::None => Ok(()),
-        ChecksumPolicy::Optional(allowed) => {
-            for algorithm in allowed {
-                ensure_supported_checksum_algorithm(*algorithm)?;
-            }
-            Ok(())
+/// Incremental hasher for streaming upload bytes.
+///
+/// Native multipart/resumable backends never hold a whole object in memory, so
+/// they cannot call [`validate_complete_checksum`] (which takes the full
+/// buffer). They stream the stored object through this hasher and validate the
+/// result with [`validate_complete_checksum_precomputed`].
+pub struct StreamingChecksum {
+    algorithm: ChecksumAlgorithm,
+    hasher: Hasher,
+}
+
+impl StreamingChecksum {
+    pub fn new(algorithm: ChecksumAlgorithm) -> Self {
+        Self {
+            algorithm,
+            hasher: Hasher::new(crypto_algorithm(algorithm)),
         }
-        ChecksumPolicy::Required(algorithm) => ensure_supported_checksum_algorithm(*algorithm),
+    }
+
+    pub fn update(&mut self, chunk: &[u8]) {
+        self.hasher.update(chunk);
+    }
+
+    pub fn finalize(self) -> ObjectChecksum {
+        ObjectChecksum {
+            algorithm: self.algorithm,
+            value: self.hasher.finalize_hex(),
+        }
     }
 }
 
-pub fn validate_complete_checksum(
+/// The checksum algorithm a completed upload must hash, if any.
+///
+/// Returns `None` when no verification is needed (no policy, or an `Optional`
+/// policy with no client-supplied checksum), so a streaming backend can skip
+/// hashing entirely in the common case. Backends should stream-compute this
+/// algorithm and pass the result to [`validate_complete_checksum_precomputed`].
+pub fn checksum_algorithm_to_compute(
     policy: &ChecksumPolicy,
-    bytes: &[u8],
+    provided: Option<&ObjectChecksum>,
+) -> Option<ChecksumAlgorithm> {
+    match policy {
+        ChecksumPolicy::None => None,
+        ChecksumPolicy::Optional(_) => provided.map(|checksum| checksum.algorithm),
+        ChecksumPolicy::Required(algorithm) => Some(*algorithm),
+    }
+}
+
+/// Validate a `provided` checksum against one the backend already computed while
+/// streaming, instead of re-hashing a full in-memory buffer.
+///
+/// `computed` is the checksum the backend streamed for the stored object (or
+/// `None` when [`checksum_algorithm_to_compute`] returned `None`).
+pub fn validate_complete_checksum_precomputed(
+    policy: &ChecksumPolicy,
+    computed: Option<ObjectChecksum>,
     provided: Option<ObjectChecksum>,
 ) -> StorageResult<Option<ObjectChecksum>> {
     ensure_supported_checksum_policy(policy)?;
     match policy {
         ChecksumPolicy::None => Ok(None),
-        ChecksumPolicy::Optional(allowed) => {
-            if let Some(checksum) = &provided {
+        ChecksumPolicy::Optional(allowed) => match provided {
+            Some(checksum) => {
                 if !allowed.contains(&checksum.algorithm) {
                     return Err(StorageError::policy_rejected(
                         "checksum algorithm is not allowed",
                     ));
                 }
-                let computed = compute_checksum(checksum.algorithm, bytes)?;
-                if !checksum.value.eq_ignore_ascii_case(&computed.value) {
-                    return Err(StorageError::policy_rejected(
-                        "upload checksum does not match uploaded bytes",
-                    ));
-                }
-                return Ok(Some(computed));
+                verify_match(&checksum, expect_computed(checksum.algorithm, computed)?)
             }
-            Ok(None)
-        }
+            None => Ok(None),
+        },
         ChecksumPolicy::Required(algorithm) => {
             let provided = provided.ok_or_else(|| {
                 StorageError::policy_rejected("required upload checksum is missing")
@@ -49,40 +83,90 @@ pub fn validate_complete_checksum(
                     "required upload checksum algorithm does not match policy",
                 ));
             }
-            let computed = compute_checksum(*algorithm, bytes)?;
-            if !provided.value.eq_ignore_ascii_case(&computed.value) {
+            verify_match(&provided, expect_computed(*algorithm, computed)?)
+        }
+    }
+}
+
+pub fn ensure_supported_checksum_policy(policy: &ChecksumPolicy) -> StorageResult<()> {
+    // Every `ChecksumAlgorithm` variant is now backed by `pocopine-crypto`, so
+    // there is nothing left to reject. Kept as a public hook so backends keep a
+    // single validation entry point if future algorithms are added.
+    let _ = policy;
+    Ok(())
+}
+
+pub fn validate_complete_checksum(
+    policy: &ChecksumPolicy,
+    bytes: &[u8],
+    provided: Option<ObjectChecksum>,
+) -> StorageResult<Option<ObjectChecksum>> {
+    match policy {
+        ChecksumPolicy::None => Ok(None),
+        ChecksumPolicy::Optional(allowed) => match provided {
+            Some(checksum) => {
+                if !allowed.contains(&checksum.algorithm) {
+                    return Err(StorageError::policy_rejected(
+                        "checksum algorithm is not allowed",
+                    ));
+                }
+                verify_match(&checksum, compute_checksum(checksum.algorithm, bytes))
+            }
+            None => Ok(None),
+        },
+        ChecksumPolicy::Required(algorithm) => {
+            let provided = provided.ok_or_else(|| {
+                StorageError::policy_rejected("required upload checksum is missing")
+            })?;
+            if provided.algorithm != *algorithm {
                 return Err(StorageError::policy_rejected(
-                    "required upload checksum does not match uploaded bytes",
+                    "required upload checksum algorithm does not match policy",
                 ));
             }
-            Ok(Some(computed))
+            verify_match(&provided, compute_checksum(*algorithm, bytes))
         }
     }
 }
 
-fn ensure_supported_checksum_algorithm(algorithm: ChecksumAlgorithm) -> StorageResult<()> {
-    match algorithm {
-        ChecksumAlgorithm::Sha256 => Ok(()),
-        ChecksumAlgorithm::Crc32c | ChecksumAlgorithm::Md5 => Err(StorageError::unsupported(
-            "only sha256 checksum verification is implemented in pocopine-storage PR 1",
-        )),
+/// Confirm a `computed` checksum matches what the client `provided`.
+fn verify_match(
+    provided: &ObjectChecksum,
+    computed: ObjectChecksum,
+) -> StorageResult<Option<ObjectChecksum>> {
+    if !provided.value.eq_ignore_ascii_case(&computed.value) {
+        return Err(StorageError::policy_rejected(
+            "upload checksum does not match uploaded bytes",
+        ));
+    }
+    Ok(Some(computed))
+}
+
+fn expect_computed(
+    algorithm: ChecksumAlgorithm,
+    computed: Option<ObjectChecksum>,
+) -> StorageResult<ObjectChecksum> {
+    let computed = computed.ok_or_else(|| {
+        StorageError::backend("checksum was not computed for the completed object".to_string())
+    })?;
+    if computed.algorithm != algorithm {
+        return Err(StorageError::backend(
+            "computed checksum algorithm does not match the requested algorithm".to_string(),
+        ));
+    }
+    Ok(computed)
+}
+
+fn compute_checksum(algorithm: ChecksumAlgorithm, bytes: &[u8]) -> ObjectChecksum {
+    ObjectChecksum {
+        algorithm,
+        value: digest_hex(crypto_algorithm(algorithm), bytes),
     }
 }
 
-fn compute_checksum(algorithm: ChecksumAlgorithm, bytes: &[u8]) -> StorageResult<ObjectChecksum> {
+fn crypto_algorithm(algorithm: ChecksumAlgorithm) -> Algorithm {
     match algorithm {
-        ChecksumAlgorithm::Sha256 => {
-            let digest = Sha256::digest(bytes);
-            let mut value = String::with_capacity(digest.len() * 2);
-            for byte in digest {
-                use std::fmt::Write as _;
-                write!(&mut value, "{byte:02x}")
-                    .map_err(|err| StorageError::backend(format!("format checksum: {err}")))?;
-            }
-            Ok(ObjectChecksum { algorithm, value })
-        }
-        ChecksumAlgorithm::Crc32c | ChecksumAlgorithm::Md5 => Err(StorageError::unsupported(
-            "only sha256 checksum verification is implemented in pocopine-storage PR 1",
-        )),
+        ChecksumAlgorithm::Sha256 => Algorithm::Sha256,
+        ChecksumAlgorithm::Crc32c => Algorithm::Crc32c,
+        ChecksumAlgorithm::Md5 => Algorithm::Md5,
     }
 }

--- a/crates/pocopine-storage/src/protocol.rs
+++ b/crates/pocopine-storage/src/protocol.rs
@@ -490,14 +490,6 @@ impl UploadPolicy {
                 ));
             }
         }
-        if matches!(
-            self.checksum,
-            ChecksumPolicy::Required(ChecksumAlgorithm::Crc32c | ChecksumAlgorithm::Md5)
-        ) {
-            return Err(StorageError::unsupported(
-                "only sha256 checksum verification is implemented in pocopine-storage PR 1",
-            ));
-        }
         if let (Some(min), Some(preferred)) = (self.min_part_size, self.preferred_chunk_size) {
             if min > preferred {
                 return Err(StorageError::policy_rejected(

--- a/crates/pocopine-storage/src/server.rs
+++ b/crates/pocopine-storage/src/server.rs
@@ -16,7 +16,6 @@ use pocopine_server::axum::http::{
 use pocopine_server::axum::response::{IntoResponse, Json, Response};
 use pocopine_server::axum::routing::{get, head, options, patch, post};
 use pocopine_server::{Server, ServerPlugin};
-use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use crate::{
@@ -1678,16 +1677,10 @@ fn apply_set_cookie(response: &mut Response, set_cookie: Option<String>) {
 /// cookies and replay them via the `Cookie` header. We hash with a domain
 /// separator so a leaked digest is not usable as a "blind hash" elsewhere.
 fn hash_anonymous_binding(raw: &str) -> String {
-    let mut hasher = Sha256::new();
+    let mut hasher = pocopine_crypto::Hasher::new(pocopine_crypto::Algorithm::Sha256);
     hasher.update(b"pocopine.storage.anon.v1\0");
     hasher.update(raw.as_bytes());
-    let digest = hasher.finalize();
-    let mut out = String::with_capacity(digest.len() * 2);
-    for byte in digest {
-        use std::fmt::Write as _;
-        let _ = write!(&mut out, "{byte:02x}");
-    }
-    out
+    hasher.finalize_hex()
 }
 
 fn require_bound_actor(ctx: &StorageContext) -> StorageResult<()> {

--- a/crates/pocopine-storage/tests/storage_host.rs
+++ b/crates/pocopine-storage/tests/storage_host.rs
@@ -1070,12 +1070,15 @@ async fn optional_sha256_checksum_is_verified_when_present() -> StorageResult<()
 }
 
 #[test]
-fn required_unsupported_checksum_algorithms_fail_configuration() -> StorageResult<()> {
-    let mut checksum_policy = policy("memory")?;
-    checksum_policy.checksum = ChecksumPolicy::Required(ChecksumAlgorithm::Md5);
-    let builder = StorageServer::builder().backend("memory", MemoryStorageBackend::new())?;
-    let rejected = builder.public_scope("avatars", checksum_policy);
-    assert!(matches!(rejected, Err(StorageError::Unsupported { .. })));
+fn md5_and_crc32c_checksum_policies_are_now_supported() -> StorageResult<()> {
+    // pocopine-crypto backs all three algorithms, so configuring a scope with a
+    // required MD5 or CRC32C checksum no longer fails as unsupported.
+    for algorithm in [ChecksumAlgorithm::Md5, ChecksumAlgorithm::Crc32c] {
+        let mut checksum_policy = policy("memory")?;
+        checksum_policy.checksum = ChecksumPolicy::Required(algorithm);
+        let builder = StorageServer::builder().backend("memory", MemoryStorageBackend::new())?;
+        assert!(builder.public_scope("avatars", checksum_policy).is_ok());
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## What & why

Phase 0 of #176. The storage upload path rewrote the **entire staged object on every `PATCH`** (download → extend → re-upload), so a 64 MiB upload pushed ~2.1 GiB to the provider — **O(n²)** memory and bandwidth. This replaces that with provider-native uploads so each byte is written to the store **exactly once** (O(n)), per the issue's "proxy-like, no unnecessary cloning" goal.

The wire protocol (sequential TUS) and the browser client are **unchanged**; this is a server-side, drop-in replacement.

```mermaid
flowchart LR
  subgraph Before["Legacy proxy — O(n²)"]
    P1[PATCH chunk] --> R1[download whole staged object] --> R2[extend] --> R3[re-upload whole object]
  end
  subgraph After["Native — O(n)"]
    P2[PATCH chunk] --> C[coalesce to a bounded tail] --> F[flush once: UploadPart / component / Put Block] --> A[assemble: Complete / Compose / Put Block List]
  end
```

## Backends

| Backend | Mechanism | Assembly |
|---|---|---|
| **S3** (canonical) | `UploadPart` per coalesced 5 MiB part | `CompleteMultipartUpload` |
| **GCS** | one component object per coalesced block (chosen over raw resumable to avoid a parallel OAuth path) | server-side `ComposeObject` |
| **Azure** | `Put Block` per coalesced block | `Put Block List` |

Shared design across all three: bounded **inline tail** coalescing (persisted atomically in the session metadata — no two-object desync), part/component/block size **scaled to the provider count limit** (S3 10k parts, GCS 32 compose sources, Azure 50k blocks), no-overwrite on assembly (`If-None-Match`/precondition) **plus** a portable HEAD check **plus** a session-id **ownership marker** in object metadata for safe idempotent recovery, **reopen-only-when-the-object-is-definitively-absent-or-foreign**, **streaming checksum** (never buffers the object), and crash/orphan cleanup.

## New crates (no_std, foundational)

- **`pocopine-crypto`** — centralizes sha2 / md-5 / crc32c behind `Hasher` + `digest_hex`. Checksum support extended to all three algorithms (was sha256-only).
- **`pocopine-codec`** — base64 + a serde adapter; the three backends use it for the inline tail.

(Workspace-wide migration to these is tracked in #177–#182.)

## Benchmarks

`cargo bench -p pocopine-storage --bench amplification` — provider write volume, legacy vs native:

| Upload | legacy O(n²) | s3 / gcs / azure O(n) | reduction |
|---|---|---|---|
| 64 MiB | 2144 MiB | 64 MiB | **33.5×** |

`cargo bench -p pocopine-storage --bench upload` — framework hot-path throughput.

## Tests

MinIO / fake-gcs / Azurite integration suites per backend (multi-part assembly, abort cleanup, idempotent completion, key-collision rejection, streaming checksum), plus `pocopine-crypto`/`pocopine-codec` unit + doctests. Existing sequential tests pass unchanged.

## Reviewing

Each backend was reviewed in checkpoints (commit-by-commit) to a clean verdict; a final multi-angle review found no correctness blockers.

## Follow-ups (not in this PR)
- The three backends share near-identical control flow (`reopen_if_object_absent`, size scaling, the coalesce loop, checksum cleanup) — a deliberate Phase-0 tradeoff; consolidating into `backend_common` is a good follow-up.
- Later phases of #176: capability negotiation, exposing `UploadStrategy::Multipart`, signed direct-to-provider uploads, browser-client provider-native plans, Pine UI retarget.