### PR TITLE
storage: memory-efficient native uploads + streaming multipart (S3 / GCS / Azure) — #176

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "md-5",
+ "md-5 0.11.0",
  "pin-project-lite",
  "sha1",
  "sha2 0.11.0",
@@ -1625,17 +1625,20 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
+ "futures",
  "is-terminal",
  "itertools 0.10.5",
  "num-traits",
  "once_cell",
  "oorandom",
  "plotters",
+ "rayon",
  "regex",
  "serde",
  "serde_derive",
  "serde_json",
  "tinytemplate",
+ "tokio",
  "walkdir",
 ]
 
@@ -1672,6 +1675,16 @@ version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
 dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
@@ -4532,6 +4545,16 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
@@ -5694,6 +5717,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pocopine-codec"
+version = "0.1.0"
+dependencies = [
+ "base64",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "pocopine-core"
 version = "0.1.0"
 dependencies = [
@@ -5710,6 +5742,15 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
+]
+
+[[package]]
+name = "pocopine-crypto"
+version = "0.1.0"
+dependencies = [
+ "crc32c",
+ "md-5 0.10.6",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -5899,14 +5940,17 @@ version = "0.1.0"
 dependencies = [
  "base64",
  "bytes",
+ "criterion",
+ "futures-core",
+ "futures-util",
  "http-body-util",
  "js-sys",
  "pocopine",
  "pocopine-core",
+ "pocopine-crypto",
  "pocopine-server",
  "serde",
  "serde_json",
- "sha2 0.10.9",
  "tempfile",
  "time",
  "tokio",
@@ -5930,6 +5974,8 @@ dependencies = [
  "futures-util",
  "hmac 0.12.1",
  "percent-encoding",
+ "pocopine-codec",
+ "pocopine-crypto",
  "pocopine-storage",
  "reqwest 0.13.4",
  "serde",
@@ -5951,6 +5997,8 @@ dependencies = [
  "google-cloud-gax",
  "google-cloud-storage",
  "percent-encoding",
+ "pocopine-codec",
+ "pocopine-crypto",
  "pocopine-storage",
  "reqwest 0.13.4",
  "serde",
@@ -5966,16 +6014,24 @@ dependencies = [
 name = "pocopine-storage-s3"
 version = "0.1.0"
 dependencies = [
+ "aws-runtime",
  "aws-sdk-s3",
+ "aws-smithy-runtime-api",
+ "aws-smithy-types",
  "bytes",
+ "futures-util",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pocopine-codec",
+ "pocopine-crypto",
  "pocopine-storage",
  "serde",
  "serde_json",
- "sha2 0.10.9",
  "testcontainers",
  "testcontainers-modules",
  "time",
  "tokio",
+ "tokio-stream",
  "tracing",
  "uuid",
 ]
@@ -6555,6 +6611,26 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "reactive_graph"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,9 @@ members = [
     "crates/pocopine-auth-jwt",
     "crates/pocopine-client-codegen",
     "crates/pocopine-cli",
+    "crates/pocopine-codec",
     "crates/pocopine-core",
+    "crates/pocopine-crypto",
     "crates/pocopine-deploy",
     "crates/pocopine-deploy-fly",
     "crates/pocopine-deploy-railway",
@@ -93,7 +95,9 @@ pocopine-auth-client = { path = "crates/pocopine-auth-client", version = "0.1.0"
 pocopine-auth-credentials = { path = "crates/pocopine-auth-credentials", version = "0.1.0" }
 pocopine-auth-jwt = { path = "crates/pocopine-auth-jwt", version = "0.1.0" }
 pocopine-client-codegen = { path = "crates/pocopine-client-codegen", version = "0.1.0" }
+pocopine-codec = { path = "crates/pocopine-codec", version = "0.1.0" }
 pocopine-core = { path = "crates/pocopine-core", version = "0.1.0", default-features = false }
+pocopine-crypto = { path = "crates/pocopine-crypto", version = "0.1.0" }
 pocopine-deploy = { path = "crates/pocopine-deploy", version = "0.1.0" }
 pocopine-deploy-fly = { path = "crates/pocopine-deploy-fly", version = "0.1.0" }
 pocopine-deploy-railway = { path = "crates/pocopine-deploy-railway", version = "0.1.0" }

--- a/crates/pine/src/upload/mod.rs
+++ b/crates/pine/src/upload/mod.rs
@@ -1,4 +1,4 @@
-// Host-side compile lacks the `web_sys::File` / `UploadClient`
+// Host-side compile lacks the `web_sys::File` / `StorageClient`
 // paths that drive the queue, so several helpers fall back to
 // dead code there. They're still part of the wasm execution
 // graph, so allow dead_code at the module level rather than
@@ -14,9 +14,12 @@
 //!   (`files: Vec<UploadFile>`), the hidden `<input type="file">`,
 //!   validation against `accept` / `max-files` / `max-size-bytes`,
 //!   the drag-over signal, and per-file lifecycle through
-//!   [`pocopine_storage::UploadClient`]. Emits `pp:upload:complete`
-//!   and `pp:upload:error` per file plus `pp:upload:all-complete`
-//!   when the queue drains without errors. Provides its Handle.
+//!   [`pocopine_storage::StorageClient`] (the JSON upload path that
+//!   negotiates sequential vs. multipart and returns an
+//!   [`pocopine_storage::ObjectRef`]). Emits `pp:upload:complete`
+//!   (carrying the stored object) and `pp:upload:error` per file
+//!   plus `pp:upload:all-complete` when the queue drains without
+//!   errors. Provides its Handle.
 //! - **Trigger** (`pine-upload-trigger`) — `<button>` that opens
 //!   the Root's file picker.
 //! - **Dropzone** (`pine-upload-dropzone`) — drag-drop surface that
@@ -41,7 +44,7 @@
 //!
 //! ```html
 //! <pine-upload-root scope="files" accept="image/*,application/pdf"
-//!                   multiple auto-resume chunk-size="1048576"
+//!                   multiple auto-resume
 //!                   @pp:upload:complete="refresh_files">
 //!   <template pp-slot="default" pp-let="upload">
 //!     <pine-upload-dropzone>
@@ -79,8 +82,9 @@ use web_sys::{Event, HtmlElement, HtmlInputElement};
 #[cfg(target_arch = "wasm32")]
 use std::{cell::RefCell, collections::HashMap};
 
+use pocopine_storage::ObjectVisibility;
 #[cfg(target_arch = "wasm32")]
-use pocopine_storage::{UploadClient, UploadPhase, UploadProgress};
+use pocopine_storage::{ObjectRef, StorageClient, UploadPhase, UploadProgress};
 #[cfg(target_arch = "wasm32")]
 use web_sys::{AbortController, DragEvent, File, FileList};
 
@@ -131,17 +135,24 @@ pub struct UploadFile {
     pub bytes_sent: u64,
     pub bytes_total: u64,
     pub error: String,
-    /// Server-issued resumable URL once known; for app-level use.
-    pub upload_url: String,
+    /// The stored object's key once the upload completes; empty
+    /// until then. For app-level use (referencing the object after
+    /// upload).
+    pub key: String,
 }
 
-/// Detail payload emitted with `pp:upload:complete` per file.
+/// Detail payload emitted with `pp:upload:complete` per file — the
+/// stored [`ObjectRef`](pocopine_storage::ObjectRef) the server
+/// assembled, alongside the queue identity of the file.
 #[derive(Clone, Debug, Serialize)]
 pub struct PineUploadComplete {
     pub file_id: String,
     pub file_name: String,
-    pub upload_url: String,
-    pub bytes_uploaded: u64,
+    pub key: String,
+    pub size: u64,
+    pub etag: Option<String>,
+    pub content_type: Option<String>,
+    pub visibility: ObjectVisibility,
 }
 
 /// Detail payload emitted with `pp:upload:error` per file.
@@ -190,10 +201,6 @@ pub struct PineUploadRoot {
     /// resume of the same file metadata.
     #[prop]
     pub auto_resume: bool,
-    /// PATCH chunk size in bytes. `0` keeps the upload client
-    /// default.
-    #[prop]
-    pub chunk_size: u64,
 
     /// The queue. Authors iterate with
     /// `<template pp-for="file in files">`.
@@ -240,7 +247,6 @@ impl Default for PineUploadRoot {
             max_size_bytes: 0,
             disabled: false,
             auto_resume: true,
-            chunk_size: 0,
             files: Vec::new(),
             busy: false,
             state: "empty".to_string(),
@@ -488,7 +494,7 @@ impl PineUploadRoot {
             bytes_sent: 0,
             bytes_total: size,
             error: String::new(),
-            upload_url: String::new(),
+            key: String::new(),
         };
 
         if let Err(msg) = self.validate(&name, size) {
@@ -577,8 +583,8 @@ impl PineUploadRoot {
 
     #[cfg(target_arch = "wasm32")]
     fn start_upload(&mut self, scope_id: ScopeId, file_id: String, file_name: String, file: File) {
-        let Some(client) = self.plugins().get::<UploadClient>() else {
-            self.finish_item_failure(&file_id, &file_name, "upload plugin is not installed");
+        let Some(client) = self.plugins().get::<StorageClient>() else {
+            self.finish_item_failure(&file_id, &file_name, "storage plugin is not installed");
             return;
         };
         let Ok(controller) = AbortController::new() else {
@@ -591,7 +597,6 @@ impl PineUploadRoot {
         };
         let scope_name = normalized_scope(&self.scope);
         let auto_resume = self.auto_resume;
-        let chunk_size = self.chunk_size;
         let progress_handle = this::<Self>();
         let signal = controller.signal();
 
@@ -608,7 +613,7 @@ impl PineUploadRoot {
         let name_for_dispatch = file_name.clone();
         dispatch!(
             async move {
-                let mut upload = client
+                client
                     .scope(scope_name)
                     .upload(file)
                     .auto_resume(auto_resume)
@@ -618,25 +623,17 @@ impl PineUploadRoot {
                         progress_handle.update(|state| {
                             state.apply_progress(&id, progress);
                         });
-                    });
-                if chunk_size > 0 {
-                    upload = upload.chunk_size(chunk_size);
-                }
-                upload.send().await
+                    })
+                    .send()
+                    .await
             }
             .await,
             |s, result| {
                 clear_abort_for(scope_id, &id_for_dispatch);
                 let canceled = matches!(&result, Err(err) if is_canceled(err));
                 match result {
-                    Ok(upload) => {
-                        s.complete_item(
-                            scope_id,
-                            &id_for_dispatch,
-                            &name_for_dispatch,
-                            &upload.upload_url,
-                            upload.bytes_uploaded,
-                        );
+                    Ok(object) => {
+                        s.complete_item(scope_id, &id_for_dispatch, &name_for_dispatch, &object);
                     }
                     Err(err) => {
                         if canceled {
@@ -662,16 +659,15 @@ impl PineUploadRoot {
         scope_id: ScopeId,
         file_id: &str,
         file_name: &str,
-        upload_url: &str,
-        bytes_uploaded: u64,
+        object: &ObjectRef,
     ) {
         if let Some(file) = self.files.iter_mut().find(|f| f.id == file_id) {
             file.status = "done".to_string();
             file.progress = 100.0;
             file.progress_label = "100%".to_string();
-            file.bytes_sent = bytes_uploaded;
-            file.bytes_total = file.bytes_total.max(bytes_uploaded);
-            file.upload_url = upload_url.to_string();
+            file.bytes_sent = object.size;
+            file.bytes_total = file.bytes_total.max(object.size);
+            file.key = object.key.clone();
             file.error.clear();
         }
         forget_file(Some(scope_id), file_id);
@@ -681,8 +677,11 @@ impl PineUploadRoot {
             PineUploadComplete {
                 file_id: file_id.to_string(),
                 file_name: file_name.to_string(),
-                upload_url: upload_url.to_string(),
-                bytes_uploaded,
+                key: object.key.clone(),
+                size: object.size,
+                etag: object.etag.clone(),
+                content_type: object.content_type.clone(),
+                visibility: object.visibility,
             },
         );
     }
@@ -914,7 +913,7 @@ fn is_canceled(err: &impl ToString) -> bool {
 
 fn user_upload_error_message(message: &str) -> &'static str {
     let normalized = message.to_ascii_lowercase();
-    if normalized.contains("upload plugin is not installed")
+    if normalized.contains("plugin is not installed")
         || normalized.contains("abort controller")
         || normalized.contains("file handle lost")
     {

--- a/crates/pocopine-codec/Cargo.toml
+++ b/crates/pocopine-codec/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "pocopine-codec"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Shared encoding/codec utilities (base64, serde adapters) for the pocopine workspace."
+
+[dependencies]
+# `no_std` + `alloc`: base64 and serde both build without `std`.
+base64 = { version = "0.22", default-features = false, features = ["alloc"] }
+serde = { version = "1", default-features = false, features = ["alloc", "derive"] }
+
+[dev-dependencies]
+serde_json = "1"

--- a/crates/pocopine-codec/src/lib.rs
+++ b/crates/pocopine-codec/src/lib.rs
@@ -1,0 +1,115 @@
+//! Shared encoding / codec utilities for the pocopine workspace.
+//!
+//! The point of this crate is that crates never re-implement encoding helpers or
+//! their serde adapters. Today it covers base64; add new codecs here rather than
+//! inlining them per crate.
+//!
+//! ```
+//! use pocopine_codec::{base64_decode, base64_encode};
+//!
+//! assert_eq!(base64_encode(b"hi"), "aGk=");
+//! assert_eq!(base64_decode("aGk=").unwrap(), b"hi");
+//! ```
+//!
+//! For a `Vec<u8>` struct field that should serialize as a base64 string, use the
+//! [`base64_bytes`] serde adapter:
+//!
+//! ```
+//! use serde::{Deserialize, Serialize};
+//!
+//! #[derive(Serialize, Deserialize)]
+//! struct Chunk {
+//!     #[serde(with = "pocopine_codec::base64_bytes", default, skip_serializing_if = "Vec::is_empty")]
+//!     payload: Vec<u8>,
+//! }
+//! ```
+//!
+//! This crate is `no_std` (it only needs `alloc`).
+
+#![cfg_attr(not(test), no_std)]
+
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+pub use base64;
+use base64::engine::general_purpose::STANDARD;
+use base64::Engine as _;
+
+/// Encode bytes as a standard (padded) base64 string.
+pub fn base64_encode(bytes: &[u8]) -> String {
+    STANDARD.encode(bytes)
+}
+
+/// Decode a standard (padded) base64 string.
+pub fn base64_decode(encoded: &str) -> Result<Vec<u8>, base64::DecodeError> {
+    STANDARD.decode(encoded)
+}
+
+/// Serde adapter for a `Vec<u8>` field encoded as a base64 string.
+///
+/// Use via `#[serde(with = "pocopine_codec::base64_bytes")]`. Pair with
+/// `#[serde(default, skip_serializing_if = "Vec::is_empty")]` to omit empty values.
+pub mod base64_bytes {
+    use alloc::string::String;
+    use alloc::vec::Vec;
+
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&super::base64_encode(bytes))
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(deserializer: D) -> Result<Vec<u8>, D::Error> {
+        let encoded = String::deserialize(deserializer)?;
+        super::base64_decode(&encoded).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base64_round_trips() {
+        for input in [b"".as_slice(), b"a", b"hello world", &[0u8, 255, 128, 1]] {
+            let encoded = base64_encode(input);
+            assert_eq!(base64_decode(&encoded).unwrap(), input);
+        }
+    }
+
+    #[test]
+    fn known_base64_vectors() {
+        assert_eq!(base64_encode(b"hi"), "aGk=");
+        assert_eq!(base64_decode("aGk=").unwrap(), b"hi");
+    }
+
+    #[test]
+    fn invalid_base64_is_rejected() {
+        assert!(base64_decode("not valid base64!!!").is_err());
+    }
+
+    #[derive(serde::Serialize, serde::Deserialize, PartialEq, Debug)]
+    struct Chunk {
+        #[serde(with = "base64_bytes", default, skip_serializing_if = "Vec::is_empty")]
+        payload: Vec<u8>,
+    }
+
+    #[test]
+    fn serde_adapter_round_trips_and_omits_empty() {
+        let chunk = Chunk {
+            payload: alloc::vec![1, 2, 3, 4],
+        };
+        let json = serde_json::to_string(&chunk).unwrap();
+        assert!(json.contains("AQIDBA=="));
+        assert_eq!(serde_json::from_str::<Chunk>(&json).unwrap(), chunk);
+
+        let empty = Chunk {
+            payload: Vec::new(),
+        };
+        let json = serde_json::to_string(&empty).unwrap();
+        assert_eq!(json, "{}");
+        assert_eq!(serde_json::from_str::<Chunk>("{}").unwrap(), empty);
+    }
+}

--- a/crates/pocopine-crypto/Cargo.toml
+++ b/crates/pocopine-crypto/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "pocopine-crypto"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Centralized cryptographic hash and checksum primitives for the pocopine workspace."
+
+[dependencies]
+# `no_std` + `alloc`: all three hash crates build without `std` (they lose only
+# runtime CPU-feature detection / SIMD acceleration, never correctness).
+sha2 = { version = "0.10", default-features = false }
+md-5 = { version = "0.10", default-features = false }
+crc32c = { version = "0.6", default-features = false }

--- a/crates/pocopine-crypto/src/lib.rs
+++ b/crates/pocopine-crypto/src/lib.rs
@@ -1,0 +1,187 @@
+//! Centralized cryptographic hash and checksum primitives for the pocopine
+//! workspace.
+//!
+//! The point of this crate is that the rest of the workspace never reaches for
+//! `sha2`, `md-5`, or `crc32c` directly and never re-implements hex encoding or
+//! incremental hashing. Everything goes through one small, algorithm-agnostic
+//! API:
+//!
+//! ```
+//! use pocopine_crypto::{Algorithm, Hasher, digest_hex, sha256_hex};
+//!
+//! // One-shot.
+//! assert_eq!(sha256_hex(b""),
+//!     "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
+//! assert_eq!(digest_hex(Algorithm::Crc32c, b""), "00000000");
+//!
+//! // Streaming (for data that never fits in one buffer).
+//! let mut hasher = Hasher::new(Algorithm::Sha256);
+//! hasher.update(b"hello ");
+//! hasher.update(b"world");
+//! let _hex = hasher.finalize_hex();
+//! ```
+//!
+//! The underlying crates are re-exported (`pocopine_crypto::{sha2, md5,
+//! crc32c}`) for the rare case a caller needs a primitive this API does not
+//! wrap yet — but prefer adding to this API over reaching for them.
+//!
+//! This crate is `no_std` (it only needs `alloc` for the returned hex
+//! `String`).
+
+#![cfg_attr(not(test), no_std)]
+
+extern crate alloc;
+
+use alloc::format;
+use alloc::string::String;
+
+pub use crc32c;
+pub use md5;
+pub use sha2;
+
+use md5::Md5;
+use sha2::{Digest, Sha256};
+
+/// A digest/checksum algorithm supported across the workspace.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum Algorithm {
+    /// SHA-256 — 32-byte cryptographic digest (64 hex chars).
+    Sha256,
+    /// MD5 — 16-byte digest (32 hex chars). Non-cryptographic; content
+    /// integrity / provider-compat only.
+    Md5,
+    /// CRC32C (Castagnoli) — 32-bit checksum (8 hex chars).
+    Crc32c,
+}
+
+impl Algorithm {
+    /// Lowercase canonical name (`"sha256"`, `"md5"`, `"crc32c"`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Algorithm::Sha256 => "sha256",
+            Algorithm::Md5 => "md5",
+            Algorithm::Crc32c => "crc32c",
+        }
+    }
+}
+
+/// Streaming, algorithm-agnostic hasher.
+///
+/// Feed bytes with [`Hasher::update`] as they stream and call
+/// [`Hasher::finalize_hex`] once. Use this when the data never fits in a single
+/// buffer (e.g. hashing an object as it streams from a storage backend).
+pub struct Hasher {
+    inner: Inner,
+}
+
+enum Inner {
+    Sha256(Sha256),
+    Md5(Md5),
+    Crc32c(u32),
+}
+
+impl Hasher {
+    /// Create a streaming hasher for `algorithm`.
+    pub fn new(algorithm: Algorithm) -> Self {
+        let inner = match algorithm {
+            Algorithm::Sha256 => Inner::Sha256(Sha256::new()),
+            Algorithm::Md5 => Inner::Md5(Md5::new()),
+            Algorithm::Crc32c => Inner::Crc32c(0),
+        };
+        Self { inner }
+    }
+
+    /// Absorb a chunk of bytes.
+    pub fn update(&mut self, bytes: &[u8]) {
+        match &mut self.inner {
+            Inner::Sha256(h) => h.update(bytes),
+            Inner::Md5(h) => h.update(bytes),
+            Inner::Crc32c(crc) => *crc = crc32c::crc32c_append(*crc, bytes),
+        }
+    }
+
+    /// Finish hashing and return the lowercase-hex digest.
+    pub fn finalize_hex(self) -> String {
+        match self.inner {
+            Inner::Sha256(h) => hex(h.finalize()),
+            Inner::Md5(h) => hex(h.finalize()),
+            Inner::Crc32c(crc) => format!("{crc:08x}"),
+        }
+    }
+}
+
+/// One-shot lowercase-hex digest of `bytes` under `algorithm`.
+pub fn digest_hex(algorithm: Algorithm, bytes: &[u8]) -> String {
+    match algorithm {
+        Algorithm::Sha256 => hex(Sha256::digest(bytes)),
+        Algorithm::Md5 => hex(Md5::digest(bytes)),
+        Algorithm::Crc32c => format!("{:08x}", crc32c::crc32c(bytes)),
+    }
+}
+
+/// One-shot SHA-256 hex digest.
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    digest_hex(Algorithm::Sha256, bytes)
+}
+
+/// One-shot MD5 hex digest.
+pub fn md5_hex(bytes: &[u8]) -> String {
+    digest_hex(Algorithm::Md5, bytes)
+}
+
+/// One-shot CRC32C hex digest.
+pub fn crc32c_hex(bytes: &[u8]) -> String {
+    digest_hex(Algorithm::Crc32c, bytes)
+}
+
+fn hex(bytes: impl AsRef<[u8]>) -> String {
+    use core::fmt::Write as _;
+    let bytes = bytes.as_ref();
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        // Writing a byte to a String is infallible.
+        let _ = write!(&mut out, "{byte:02x}");
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_sha256_vectors() {
+        assert_eq!(
+            sha256_hex(b""),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert_eq!(
+            sha256_hex(b"abc"),
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn known_md5_vectors() {
+        assert_eq!(md5_hex(b""), "d41d8cd98f00b204e9800998ecf8427e");
+        assert_eq!(md5_hex(b"abc"), "900150983cd24fb0d6963f7d28e17f72");
+    }
+
+    #[test]
+    fn known_crc32c_vectors() {
+        // CRC32C of the empty input is 0.
+        assert_eq!(crc32c_hex(b""), "00000000");
+        // CRC32C("123456789") == 0xE3069283 (Castagnoli check value).
+        assert_eq!(crc32c_hex(b"123456789"), "e3069283");
+    }
+
+    #[test]
+    fn streaming_matches_one_shot() {
+        for alg in [Algorithm::Sha256, Algorithm::Md5, Algorithm::Crc32c] {
+            let mut hasher = Hasher::new(alg);
+            hasher.update(b"hello ");
+            hasher.update(b"world");
+            assert_eq!(hasher.finalize_hex(), digest_hex(alg, b"hello world"));
+        }
+    }
+}

--- a/crates/pocopine-storage-azure/Cargo.toml
+++ b/crates/pocopine-storage-azure/Cargo.toml
@@ -11,6 +11,8 @@ azure_core = "1"
 azure_storage_blob = "1"
 bytes = "1"
 futures-util = "0.3"
+pocopine-codec = { workspace = true }
+pocopine-crypto = { workspace = true }
 pocopine-storage = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -23,6 +25,7 @@ uuid = { version = "1", features = ["v4"] }
 base64 = "0.22"
 hmac = "0.12"
 percent-encoding = "2"
+pocopine-crypto = { workspace = true }
 reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
 sha2 = "0.10"
 testcontainers = { version = "0.23", features = ["http_wait"] }

--- a/crates/pocopine-storage-azure/src/state.rs
+++ b/crates/pocopine-storage-azure/src/state.rs
@@ -19,8 +19,69 @@ pub(crate) struct StoredUploadSession {
     pub(crate) completion_object_key: Option<String>,
     #[serde(default)]
     pub(crate) cleanup_pending: bool,
+    /// Transfer mechanism. Sessions written before native block-blob support
+    /// omit this field and deserialize as [`NativeUploadState::LegacyProxy`], so
+    /// in-flight uploads from an older build keep the staged-object rewrite path.
+    #[serde(default)]
+    pub(crate) native: NativeUploadState,
     #[serde(skip)]
     pub(crate) meta_etag: Option<String>,
+}
+
+/// Backend transfer mechanism for an upload session.
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum NativeUploadState {
+    /// Legacy staged-object rewrite (download → extend → re-upload per append).
+    #[default]
+    LegacyProxy,
+    /// Native block blob: sub-block `PATCH` chunks are coalesced into a bounded
+    /// tail and flushed as blocks (`Put Block`); completion assembles them with
+    /// `Put Block List`. No bytes are re-written.
+    Block(AzureBlockState),
+}
+
+/// Block-blob bookkeeping for one session. Block ids are derived from the index
+/// (and the session id), so only counts/lengths are tracked.
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+pub(crate) struct AzureBlockState {
+    /// Number of blocks staged so far; the next block uses index `next_index`.
+    #[serde(default)]
+    pub(crate) next_index: u64,
+    /// Total bytes already flushed to staged blocks (excludes the pending tail).
+    #[serde(default)]
+    pub(crate) flushed_len: u64,
+    /// Bytes received but not yet flushed to a block (smaller than one block,
+    /// except the final remainder at completion). Base64 inline in the metadata.
+    #[serde(
+        default,
+        with = "pocopine_codec::base64_bytes",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub(crate) pending_tail: Vec<u8>,
+}
+
+impl NativeUploadState {
+    pub(crate) fn block(&self) -> Option<&AzureBlockState> {
+        match self {
+            NativeUploadState::Block(state) => Some(state),
+            NativeUploadState::LegacyProxy => None,
+        }
+    }
+
+    pub(crate) fn block_mut(&mut self) -> Option<&mut AzureBlockState> {
+        match self {
+            NativeUploadState::Block(state) => Some(state),
+            NativeUploadState::LegacyProxy => None,
+        }
+    }
+}
+
+/// Full object attributes including the ownership marker in custom metadata.
+pub(crate) struct AzureObjectAttrs {
+    pub(crate) etag: Option<String>,
+    pub(crate) version_id: Option<String>,
+    pub(crate) owner_session: Option<String>,
 }
 
 pub(crate) struct AzureObjectBytes {
@@ -115,6 +176,7 @@ mod tests {
             object: None,
             completion_object_key: None,
             cleanup_pending: false,
+            native: NativeUploadState::default(),
             meta_etag: None,
         };
         let bytes = serde_json::to_vec(&stored).unwrap();

--- a/crates/pocopine-storage-azure/src/storage.rs
+++ b/crates/pocopine-storage-azure/src/storage.rs
@@ -1,30 +1,39 @@
 use std::sync::Arc;
 
+use std::collections::{HashMap, HashSet};
+
 use azure_core::http::{Etag, NoFormat, RequestContent};
 use azure_storage_blob::models::{
     BlobClientDeleteOptions, BlobClientDownloadOptions, BlobClientGetPropertiesResultHeaders,
-    BlobClientUploadOptions, DeleteSnapshotsOptionType, HttpRange,
+    BlobClientUploadOptions, BlockBlobClientCommitBlockListOptions,
+    BlockBlobClientCommitBlockListResultHeaders, BlockListType, BlockLookupList,
+    DeleteSnapshotsOptionType, HttpRange,
 };
 use azure_storage_blob::{BlobContainerClient, BlobServiceClient};
 use bytes::Bytes;
 use futures_util::StreamExt;
 use pocopine_storage::backend_common::{
     checked_new_offset, ensure_open, ensure_owner, ensure_size_limit,
-    ensure_upload_length_can_be_set, expires_at, selected_strategy, UploadSessionLockCleanup,
-    UploadSessionLockRegistry,
+    ensure_upload_length_can_be_set, expires_at, select_upload_mode, UploadConcurrencyRegistry,
+    UploadSessionLockCleanup, UploadSessionLockRegistry,
 };
-use pocopine_storage::checksum::{ensure_supported_checksum_policy, validate_complete_checksum};
+use pocopine_storage::checksum::{
+    checksum_algorithm_to_compute, ensure_supported_checksum_policy, precheck_checksum,
+    validate_complete_checksum, validate_complete_checksum_precomputed, StreamingChecksum,
+};
 use pocopine_storage::{
-    CompleteUpload, InitiateUpload, ObjectChecksum, ObjectRef, StorageActor, StorageBackend,
-    StorageBoxFuture, StorageContext, StorageError, StorageResult, TransferPlan, UploadSession,
-    UploadSessionId, UploadSessionStatus, UploadStrategy,
+    BackendCapabilities, ChecksumAlgorithm, CompleteUpload, InitiateUpload, ObjectChecksum,
+    ObjectRef, StorageActor, StorageBackend, StorageBoxFuture, StorageContext, StorageError,
+    StorageResult, TransferPlan, UploadBody, UploadSession, UploadSessionId, UploadSessionStatus,
+    UploadStrategy,
 };
+use time::OffsetDateTime;
 use uuid::Uuid;
 
 use crate::layout::{AzureKeyLayout, DEFAULT_INTERNAL_PREFIX};
 use crate::state::{
-    decode_session_object, AbortSessionRead, AzureObjectBytes, AzureObjectMetadata,
-    AzureObjectWrite, StoredUploadSession,
+    decode_session_object, AbortSessionRead, AzureObjectAttrs, AzureObjectBytes,
+    AzureObjectMetadata, AzureObjectWrite, NativeUploadState, StoredUploadSession,
 };
 use crate::util::{
     azure_error, bytes_match_at, ensure_completable, is_azure_already_exists, is_azure_not_found,
@@ -34,6 +43,42 @@ use crate::util::{
 const DEFAULT_BACKEND_NAME: &str = "azure";
 const DEFAULT_MAX_PROXY_UPLOAD_BYTES: u64 = 64 * 1024 * 1024;
 const MAX_SESSION_METADATA_BYTES: u64 = 256 * 1024;
+
+/// Blob custom-metadata key stamping the owning upload session onto the final
+/// committed blob, so a retry can recognize its own object after a crash.
+/// Azure metadata names must be valid C# identifiers (no hyphens), hence the
+/// underscores.
+const SESSION_OWNER_META_KEY: &str = "pocopine_upload_session";
+
+/// Azure allows at most 50,000 committed blocks per blob. Blocks are sized so the
+/// count never exceeds this for an upload up to the backend's size cap.
+const AZURE_MAX_BLOCKS: u64 = 50_000;
+
+/// Floor for a coalesced block, to bound the block count and per-append churn.
+const MIN_BLOCK_SIZE: u64 = 1024 * 1024;
+
+/// Session-isolated, fixed-width block id for a block index.
+///
+/// Azure block ids must be <= 64 base64 bytes and equal-length within a single
+/// commit. A 96-bit token derived from the session id namespaces the (otherwise
+/// per-blob) uncommitted block space so a different upload targeting the same
+/// destination key can never contribute blocks to our commit. The id is stable
+/// per (session, index) so a retried `PATCH` re-stages the same block.
+fn block_id(session: &UploadSessionId, index: u64) -> Vec<u8> {
+    let token = &pocopine_crypto::sha256_hex(session.as_str().as_bytes())[..24];
+    format!("{token}{index:012x}").into_bytes()
+}
+
+/// Block size for a session whose maximum object size is `max_bytes`. Scaled
+/// (rounded to a whole MiB) so the block count stays within [`AZURE_MAX_BLOCKS`];
+/// never below [`MIN_BLOCK_SIZE`]. For the default 64 MiB cap this is 1 MiB.
+fn block_size_for(max_bytes: u64) -> u64 {
+    let by_count = max_bytes
+        .div_ceil(AZURE_MAX_BLOCKS)
+        .div_ceil(MIN_BLOCK_SIZE)
+        * MIN_BLOCK_SIZE;
+    by_count.max(MIN_BLOCK_SIZE)
+}
 
 #[derive(Clone, Debug)]
 enum BlobWritePrecondition {
@@ -53,6 +98,7 @@ pub struct AzureBlobStorageBackend {
     layout: AzureKeyLayout,
     max_proxy_upload_bytes: u64,
     session_locks: UploadSessionLockRegistry,
+    part_concurrency: UploadConcurrencyRegistry,
 }
 
 impl std::fmt::Debug for AzureBlobStorageBackend {
@@ -98,6 +144,7 @@ impl AzureBlobStorageBackend {
             layout,
             max_proxy_upload_bytes: DEFAULT_MAX_PROXY_UPLOAD_BYTES,
             session_locks: UploadSessionLockRegistry::new(),
+            part_concurrency: UploadConcurrencyRegistry::new(),
         })
     }
 
@@ -197,8 +244,17 @@ impl AzureBlobStorageBackend {
         session: &UploadSessionId,
     ) -> StorageResult<AzureObjectBytes> {
         let key = self.layout.session_meta_key(session);
-        self.get_object_bytes_with_limit(&key, MAX_SESSION_METADATA_BYTES)
+        self.get_object_bytes_with_limit(&key, self.session_metadata_read_limit())
             .await
+    }
+
+    /// Read cap for `session.json`. Native block sessions buffer their tail inline
+    /// (base64), so the cap must accommodate one block plus the fixed metadata,
+    /// above the bare [`MAX_SESSION_METADATA_BYTES`] used for the non-tail fields.
+    fn session_metadata_read_limit(&self) -> u64 {
+        block_size_for(self.max_proxy_upload_bytes)
+            .saturating_mul(2)
+            .saturating_add(MAX_SESSION_METADATA_BYTES)
     }
 
     async fn create_session(
@@ -674,11 +730,777 @@ impl AzureBlobStorageBackend {
             metadata,
         }
     }
+
+    // --- native block-blob helpers --------------------------------------------
+
+    /// Stage one block (`Put Block`). Re-staging the same index overwrites the
+    /// uncommitted block, so retries are idempotent.
+    async fn stage_block(
+        &self,
+        object_key: &str,
+        session: &UploadSessionId,
+        index: u64,
+        bytes: Bytes,
+    ) -> StorageResult<()> {
+        let id = block_id(session, index);
+        let len = bytes.len() as u64;
+        let content: RequestContent<Bytes, NoFormat> = bytes.into();
+        self.container
+            .blob_client(object_key)
+            .block_blob_client()
+            .stage_block(&id, len, content, None)
+            .await
+            .map_err(|err| azure_error("stage block", err))?;
+        Ok(())
+    }
+
+    /// Assemble blocks `0..count` into the destination blob (`Put Block List`),
+    /// stamping the owning session and (optionally) refusing to overwrite.
+    async fn commit_block_list(
+        &self,
+        object_key: &str,
+        count: u64,
+        content_type: Option<&str>,
+        session: &UploadSessionId,
+        no_overwrite: bool,
+    ) -> StorageResult<AzureObjectWrite> {
+        let blocklist = BlockLookupList {
+            latest: Some((0..count).map(|index| block_id(session, index)).collect()),
+            ..Default::default()
+        };
+        let mut options = BlockBlobClientCommitBlockListOptions {
+            metadata: Some(HashMap::from([(
+                SESSION_OWNER_META_KEY.to_string(),
+                session.as_str().to_string(),
+            )])),
+            ..Default::default()
+        };
+        if let Some(content_type) = content_type {
+            options.blob_content_type = Some(content_type.to_string());
+        }
+        if no_overwrite {
+            options.if_none_match = Some(Etag::from("*"));
+        }
+        let content = blocklist
+            .try_into()
+            .map_err(|err| azure_error("encode block list", err))?;
+        let response = self
+            .container
+            .blob_client(object_key)
+            .block_blob_client()
+            .commit_block_list(content, Some(options))
+            .await
+            .map_err(|err| {
+                if is_azure_precondition_failed(&err) || is_azure_already_exists(&err) {
+                    StorageError::conflict("Azure blob write precondition failed")
+                } else {
+                    azure_error("commit block list", err)
+                }
+            })?;
+        Ok(AzureObjectWrite {
+            etag: response
+                .etag()
+                .map_err(|err| azure_error("read commit etag", err))?
+                .map(|etag| etag.to_string()),
+            version_id: response
+                .version_id()
+                .map_err(|err| azure_error("read commit version id", err))?,
+        })
+    }
+
+    /// Fetch a blob's etag/version plus the ownership marker in custom metadata.
+    /// `None` when the blob does not exist.
+    async fn get_object_attrs(&self, key: &str) -> StorageResult<Option<AzureObjectAttrs>> {
+        match self.container.blob_client(key).get_properties(None).await {
+            Ok(response) => {
+                let etag = response
+                    .etag()
+                    .map_err(|err| azure_error("read blob etag", err))?
+                    .map(|etag| etag.to_string());
+                let version_id = response
+                    .version_id()
+                    .map_err(|err| azure_error("read blob version id", err))?;
+                let owner_session = response
+                    .metadata()
+                    .map_err(|err| azure_error("read blob metadata", err))?
+                    .get(SESSION_OWNER_META_KEY)
+                    .cloned();
+                Ok(Some(AzureObjectAttrs {
+                    etag,
+                    version_id,
+                    owner_session,
+                }))
+            }
+            Err(err) if is_azure_not_found(&err) => Ok(None),
+            Err(err) => Err(azure_error("read blob metadata", err)),
+        }
+    }
+
+    /// Stream the committed blob through `algorithm` without buffering it.
+    async fn stream_object_checksum(
+        &self,
+        key: &str,
+        algorithm: ChecksumAlgorithm,
+    ) -> StorageResult<ObjectChecksum> {
+        let response = self
+            .container
+            .blob_client(key)
+            .download(None)
+            .await
+            .map_err(|err| azure_error("download blob for checksum", err))?;
+        let mut body = response.body;
+        let mut hasher = StreamingChecksum::new(algorithm);
+        while let Some(chunk) = body.next().await {
+            let chunk = chunk.map_err(|err| azure_error("read blob body for checksum", err))?;
+            hasher.update(&chunk);
+        }
+        Ok(hasher.finalize())
+    }
+
+    /// Reopen a failed completion ONLY when the destination blob is definitively
+    /// absent or foreign (see the GCS backend for the rationale). An
+    /// indeterminate lookup keeps the session `Completing`.
+    async fn reopen_if_object_absent(
+        &self,
+        session: &UploadSessionId,
+        stored: &mut StoredUploadSession,
+        object_key: &str,
+    ) {
+        let absent_or_foreign = match self.get_object_attrs(object_key).await {
+            Ok(None) => true,
+            Ok(Some(attrs)) => attrs.owner_session.as_deref() != Some(session.as_str()),
+            Err(_) => false,
+        };
+        if absent_or_foreign {
+            stored.public.status = UploadSessionStatus::Open;
+            stored.completion_object_key = None;
+            let _ = self.write_session(session, stored).await;
+        }
+    }
+
+    // --- native block-blob upload flow ----------------------------------------
+
+    async fn append_block(
+        &self,
+        session: &UploadSessionId,
+        mut stored: StoredUploadSession,
+        offset: u64,
+        bytes: Bytes,
+    ) -> StorageResult<UploadSession> {
+        let expected = stored.public.next_offset.unwrap_or(0);
+        if expected != offset {
+            tracing::debug!(
+                target: "pocopine.log",
+                event_name = "pocopine.storage.offset_mismatch",
+                session = %session,
+                expected,
+                provided = offset,
+            );
+            return Err(StorageError::offset_mismatch(expected, offset));
+        }
+        let new_offset = checked_new_offset(offset, bytes.len())?;
+        ensure_size_limit(stored.max_bytes, stored.public.size, new_offset)?;
+        if bytes.is_empty() {
+            return Ok(stored.public);
+        }
+        let object_key = self.layout.object_key(stored.storage_key.key.as_str());
+
+        // Coalesce sub-block chunks so the committed block count stays within
+        // Azure's 50,000-block limit. The tail is durable in `stored` until the
+        // single atomic metadata write below.
+        let tail =
+            std::mem::take(&mut stored.native.block_mut().expect("block state").pending_tail);
+        let combined: Bytes = if tail.is_empty() {
+            bytes
+        } else {
+            let mut combined = tail;
+            combined.extend_from_slice(&bytes);
+            Bytes::from(combined)
+        };
+        let block_size = block_size_for(stored.max_bytes) as usize;
+        let mut pos = 0usize;
+        while combined.len() - pos >= block_size {
+            let index = stored.native.block().expect("block state").next_index;
+            let part = combined.slice(pos..pos + block_size);
+            self.stage_block(&object_key, session, index, part).await?;
+            if let Some(state) = stored.native.block_mut() {
+                state.next_index = index + 1;
+                state.flushed_len += block_size as u64;
+            }
+            pos += block_size;
+        }
+        if let Some(state) = stored.native.block_mut() {
+            state.pending_tail = combined.slice(pos..).to_vec();
+        }
+        stored.public.next_offset = Some(new_offset);
+        self.write_session(session, &mut stored).await?;
+        Ok(stored.public)
+    }
+
+    async fn complete_block(
+        &self,
+        session: &UploadSessionId,
+        mut stored: StoredUploadSession,
+        provided_checksum: Option<ObjectChecksum>,
+    ) -> StorageResult<ObjectRef> {
+        let total = stored.public.next_offset.unwrap_or(0);
+        if let Some(expected) = stored.public.size {
+            if total != expected {
+                return Err(StorageError::policy_rejected(format!(
+                    "upload is incomplete: expected {expected} bytes, got {total}"
+                )));
+            }
+        }
+        ensure_size_limit(stored.max_bytes, stored.public.size, total)?;
+        let object_key = self.layout.object_key(stored.storage_key.key.as_str());
+
+        // complete_with_blocks owns session-state changes on failure: it reopens
+        // for pre-commit errors, and terminally aborts on a post-commit checksum
+        // mismatch (the consumed blocks cannot be re-committed).
+        let (written, checksum) = self
+            .complete_with_blocks(session, &mut stored, &object_key, provided_checksum)
+            .await?;
+
+        let object = self.object_ref(&stored, total, written, checksum);
+        stored.public.status = UploadSessionStatus::Complete;
+        stored.public.next_offset = Some(total);
+        stored.object = Some(object.clone());
+        self.write_session(session, &mut stored).await?;
+        Ok(object)
+    }
+
+    /// Finalize a block session. The caller reopens the (possibly `Completing`)
+    /// session on any error.
+    async fn complete_with_blocks(
+        &self,
+        session: &UploadSessionId,
+        stored: &mut StoredUploadSession,
+        object_key: &str,
+        provided_checksum: Option<ObjectChecksum>,
+    ) -> StorageResult<(AzureObjectWrite, Option<ObjectChecksum>)> {
+        // Reject a missing-required / disallowed-algorithm checksum before
+        // committing, while the session is still resumable.
+        precheck_checksum(&stored.checksum_policy, provided_checksum.as_ref())?;
+        let total = stored.public.next_offset.unwrap_or(0);
+
+        // HEAD on every attempt: adopt our own already-committed blob (matched by
+        // the ownership marker), reject a foreign one. `If-None-Match: *` on the
+        // commit closes the TOCTOU window.
+        let written = if let Some(attrs) = self.get_object_attrs(object_key).await? {
+            if attrs.owner_session.as_deref() == Some(session.as_str()) {
+                AzureObjectWrite {
+                    etag: attrs.etag,
+                    version_id: attrs.version_id,
+                }
+            } else {
+                // Foreign blob (session still Open here): reject without
+                // overwriting.
+                return Err(StorageError::policy_rejected(format!(
+                    "Azure blob key already exists: {object_key}"
+                )));
+            }
+        } else {
+            if stored.public.status == UploadSessionStatus::Open
+                || stored.public.next_offset != Some(total)
+                || stored.completion_object_key.as_deref() != Some(object_key)
+            {
+                stored.public.status = UploadSessionStatus::Completing;
+                stored.public.next_offset = Some(total);
+                stored.completion_object_key = Some(object_key.to_string());
+                self.write_session(session, stored).await?;
+            }
+            // Flush the final remainder as the last block. Failures here are
+            // pre-commit (blocks not yet consumed), so reopen for retry.
+            let tail = stored
+                .native
+                .block()
+                .expect("block state")
+                .pending_tail
+                .clone();
+            if !tail.is_empty() {
+                let index = stored.native.block().expect("block state").next_index;
+                let tail_len = tail.len() as u64;
+                if let Err(err) = self
+                    .stage_block(object_key, session, index, Bytes::from(tail))
+                    .await
+                {
+                    self.reopen_if_object_absent(session, stored, object_key)
+                        .await;
+                    return Err(err);
+                }
+                if let Some(state) = stored.native.block_mut() {
+                    state.next_index = index + 1;
+                    state.flushed_len += tail_len;
+                    state.pending_tail = Vec::new();
+                }
+                if let Err(err) = self.write_session(session, stored).await {
+                    self.reopen_if_object_absent(session, stored, object_key)
+                        .await;
+                    return Err(err);
+                }
+            }
+            let count = stored.native.block().expect("block state").next_index;
+            match self
+                .commit_block_list(
+                    object_key,
+                    count,
+                    stored.public.content_type.as_deref(),
+                    session,
+                    true,
+                )
+                .await
+            {
+                Ok(written) => written,
+                Err(StorageError::Conflict { .. }) => {
+                    // A blob appeared at the key during completion; adopt it only
+                    // if it is ours, otherwise reject and reopen for the owner.
+                    match self.get_object_attrs(object_key).await {
+                        Ok(Some(attrs))
+                            if attrs.owner_session.as_deref() == Some(session.as_str()) =>
+                        {
+                            AzureObjectWrite {
+                                etag: attrs.etag,
+                                version_id: attrs.version_id,
+                            }
+                        }
+                        Ok(_) => {
+                            self.reopen_if_object_absent(session, stored, object_key)
+                                .await;
+                            return Err(StorageError::policy_rejected(format!(
+                                "Azure blob key already exists: {object_key}"
+                            )));
+                        }
+                        Err(err) => {
+                            self.reopen_if_object_absent(session, stored, object_key)
+                                .await;
+                            return Err(err);
+                        }
+                    }
+                }
+                Err(err) => {
+                    // Commit failed without consuming the blocks; reopen unless our
+                    // blob is actually live (a lost response), in which case a
+                    // retry adopts it.
+                    self.reopen_if_object_absent(session, stored, object_key)
+                        .await;
+                    return Err(err);
+                }
+            }
+        };
+
+        let checksum = self
+            .verify_committed_checksum_or_abort(session, stored, object_key, provided_checksum)
+            .await?;
+        Ok((written, checksum))
+    }
+
+    /// Validate a just-committed blob against the checksum policy by streaming it
+    /// (only when a checksum is required/supplied). On mismatch the blocks are
+    /// already consumed by the commit, so the upload cannot be re-committed: the
+    /// invalid blob is deleted and the session is marked terminally `Aborted`
+    /// (the client must re-initiate). A failure of either cleanup step is
+    /// surfaced — a live invalid blob, or a `Completing` session with consumed
+    /// blocks, is worse than the rejection.
+    async fn verify_committed_checksum_or_abort(
+        &self,
+        session: &UploadSessionId,
+        stored: &mut StoredUploadSession,
+        object_key: &str,
+        provided_checksum: Option<ObjectChecksum>,
+    ) -> StorageResult<Option<ObjectChecksum>> {
+        match checksum_algorithm_to_compute(&stored.checksum_policy, provided_checksum.as_ref()) {
+            Some(algorithm) => {
+                // A transient read failure leaves the blob live and the session
+                // Completing, so a retry adopts and re-verifies it.
+                let computed = self.stream_object_checksum(object_key, algorithm).await?;
+                match validate_complete_checksum_precomputed(
+                    &stored.checksum_policy,
+                    Some(computed),
+                    provided_checksum,
+                ) {
+                    Ok(checksum) => Ok(checksum),
+                    Err(err) => {
+                        self.delete_object_if_exists(object_key)
+                            .await
+                            .map_err(|delete_err| {
+                                tracing::error!(
+                                    target: "pocopine.log",
+                                    event_name = "pocopine.storage.azure_invalid_object_cleanup_failed",
+                                    object_key = %object_key,
+                                    checksum_error = %err,
+                                    delete_error = %delete_err,
+                                );
+                                delete_err
+                            })?;
+                        stored.public.status = UploadSessionStatus::Aborted;
+                        self.write_session(session, stored)
+                            .await
+                            .map_err(|write_err| {
+                                tracing::error!(
+                                    target: "pocopine.log",
+                                    event_name = "pocopine.storage.azure_abort_persist_failed",
+                                    object_key = %object_key,
+                                    checksum_error = %err,
+                                    write_error = %write_err,
+                                );
+                                write_err
+                            })?;
+                        // The session is now terminal (`Aborted`): no further part
+                        // upload or abort will arrive, so release its concurrency
+                        // pool here rather than leaking the entry. (A no-op for the
+                        // sequential path, which never registers a semaphore.)
+                        self.part_concurrency.forget(session);
+                        Err(err)
+                    }
+                }
+            }
+            None => validate_complete_checksum_precomputed(
+                &stored.checksum_policy,
+                None,
+                provided_checksum,
+            ),
+        }
+    }
+
+    // --- native block-blob by-number (server-mediated multipart) --------------
+
+    /// Verify every block `0..count` for a by-number multipart upload is staged
+    /// (uncommitted). A missing block means its part was never uploaded, so the
+    /// upload is incomplete. Block sizes are not summed: the declared length is
+    /// the authoritative total (each part's exact length is enforced at upload).
+    async fn ensure_blocks_staged(
+        &self,
+        object_key: &str,
+        session: &UploadSessionId,
+        count: u64,
+    ) -> StorageResult<()> {
+        let response = self
+            .container
+            .blob_client(object_key)
+            .block_blob_client()
+            .get_block_list(BlockListType::Uncommitted, None)
+            .await
+            .map_err(|err| {
+                if is_azure_not_found(&err) {
+                    // No staged blocks at all — part 1 is missing.
+                    StorageError::policy_rejected("upload is incomplete: missing multipart part 1")
+                } else {
+                    azure_error("get block list", err)
+                }
+            })?;
+        let block_list = response
+            .into_model()
+            .map_err(|err| azure_error("decode block list", err))?;
+        let staged: HashSet<Vec<u8>> = block_list
+            .uncommitted_blocks
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|block| block.name)
+            .collect();
+        for index in 0..count {
+            if !staged.contains(&block_id(session, index)) {
+                return Err(StorageError::policy_rejected(format!(
+                    "upload is incomplete: missing multipart part {}",
+                    index + 1
+                )));
+            }
+        }
+        Ok(())
+    }
+
+    /// Assemble a by-number multipart upload (the [`StorageBackend::upload_part`]
+    /// path). Blocks are staged by part number against the destination blob and
+    /// the commit references a fixed `0..count` range derived from the declared
+    /// size — so concurrent, out-of-order part uploads are race-free.
+    async fn complete_block_by_number(
+        &self,
+        session: &UploadSessionId,
+        mut stored: StoredUploadSession,
+        provided_checksum: Option<ObjectChecksum>,
+    ) -> StorageResult<ObjectRef> {
+        precheck_checksum(&stored.checksum_policy, provided_checksum.as_ref())?;
+        let expected_size = stored.public.size.ok_or_else(|| {
+            StorageError::policy_rejected(
+                "multipart upload requires a declared length before completion",
+            )
+        })?;
+        // Enforce the scope size limit (a direct backend caller may have declared
+        // a size above `max_bytes`; `initiate` only checks the backend cap), as
+        // the S3/GCS multipart completions do.
+        ensure_size_limit(stored.max_bytes, stored.public.size, expected_size)?;
+        let object_key = self.layout.object_key(stored.storage_key.key.as_str());
+        let block_size = block_size_for(stored.max_bytes);
+        let count = if expected_size == 0 {
+            0
+        } else {
+            expected_size.div_ceil(block_size)
+        };
+
+        // Idempotent re-complete: adopt our own already-committed blob, reject a
+        // foreign one. (For the absent case the commit below is the authority.)
+        if let Some(attrs) = self.get_object_attrs(&object_key).await? {
+            if attrs.owner_session.as_deref() == Some(session.as_str()) {
+                let written = AzureObjectWrite {
+                    etag: attrs.etag,
+                    version_id: attrs.version_id,
+                };
+                let checksum = self
+                    .verify_committed_checksum_or_abort(
+                        session,
+                        &mut stored,
+                        &object_key,
+                        provided_checksum,
+                    )
+                    .await?;
+                return self
+                    .finalize_block(session, stored, expected_size, written, checksum)
+                    .await;
+            }
+            // Foreign blob at the destination. Reopen first (mirroring the later
+            // conflict paths) so a session a prior attempt left `Completing` is not
+            // stuck — the owner can then abort/clean up rather than being wedged.
+            self.reopen_if_object_absent(session, &mut stored, &object_key)
+                .await;
+            return Err(StorageError::policy_rejected(format!(
+                "Azure blob key already exists: {object_key}"
+            )));
+        }
+
+        // All referenced blocks must be staged, or the commit would silently drop
+        // a missing one. (Empty uploads commit a zero-block list.) No commit has
+        // happened yet, so on failure reopen a session that a prior attempt left
+        // `Completing` (e.g. a crash before commit, then an uncommitted block was
+        // GC'd) — otherwise it would be stuck, rejecting both part uploads and
+        // abort. `reopen_if_object_absent` only reopens when the blob is truly
+        // absent/foreign, so an already-committed object is never reopened.
+        if count > 0 {
+            if let Err(err) = self.ensure_blocks_staged(&object_key, session, count).await {
+                self.reopen_if_object_absent(session, &mut stored, &object_key)
+                    .await;
+                return Err(err);
+            }
+        }
+
+        // Fence: persist Completing before the commit so a concurrent abort is
+        // refused and a crash leaves a recoverable (re-adoptable) session.
+        if stored.public.status == UploadSessionStatus::Open
+            || stored.completion_object_key.as_deref() != Some(object_key.as_str())
+        {
+            stored.public.status = UploadSessionStatus::Completing;
+            stored.public.next_offset = Some(expected_size);
+            stored.completion_object_key = Some(object_key.clone());
+            self.write_session(session, &mut stored).await?;
+        }
+
+        let written = match self
+            .commit_block_list(
+                &object_key,
+                count,
+                stored.public.content_type.as_deref(),
+                session,
+                true,
+            )
+            .await
+        {
+            Ok(written) => written,
+            Err(StorageError::Conflict { .. }) => {
+                // A blob appeared at the key during completion; adopt only if ours.
+                match self.get_object_attrs(&object_key).await {
+                    Ok(Some(attrs)) if attrs.owner_session.as_deref() == Some(session.as_str()) => {
+                        AzureObjectWrite {
+                            etag: attrs.etag,
+                            version_id: attrs.version_id,
+                        }
+                    }
+                    Ok(_) => {
+                        self.reopen_if_object_absent(session, &mut stored, &object_key)
+                            .await;
+                        return Err(StorageError::policy_rejected(format!(
+                            "Azure blob key already exists: {object_key}"
+                        )));
+                    }
+                    Err(err) => {
+                        self.reopen_if_object_absent(session, &mut stored, &object_key)
+                            .await;
+                        return Err(err);
+                    }
+                }
+            }
+            Err(err) => {
+                self.reopen_if_object_absent(session, &mut stored, &object_key)
+                    .await;
+                return Err(err);
+            }
+        };
+
+        let checksum = self
+            .verify_committed_checksum_or_abort(
+                session,
+                &mut stored,
+                &object_key,
+                provided_checksum,
+            )
+            .await?;
+        self.finalize_block(session, stored, expected_size, written, checksum)
+            .await
+    }
+
+    /// Finalize a by-number multipart session: record the object and persist.
+    async fn finalize_block(
+        &self,
+        session: &UploadSessionId,
+        mut stored: StoredUploadSession,
+        total: u64,
+        written: AzureObjectWrite,
+        checksum: Option<ObjectChecksum>,
+    ) -> StorageResult<ObjectRef> {
+        let object = self.object_ref(&stored, total, written, checksum);
+        stored.public.status = UploadSessionStatus::Complete;
+        stored.public.next_offset = Some(total);
+        stored.object = Some(object.clone());
+        self.write_session(session, &mut stored).await?;
+        Ok(object)
+    }
+
+    // --- legacy staged-object rewrite flow (pre-block sessions) ---------------
+
+    async fn append_legacy(
+        &self,
+        session: &UploadSessionId,
+        mut stored: StoredUploadSession,
+        offset: u64,
+        bytes: Bytes,
+    ) -> StorageResult<UploadSession> {
+        let expected = stored.public.next_offset.unwrap_or(0);
+        let new_offset = checked_new_offset(offset, bytes.len())?;
+        let read_limit = expected
+            .max(new_offset)
+            .checked_add(1)
+            .ok_or_else(|| StorageError::policy_rejected("upload byte offset overflowed"))?;
+        let mut staged_object = self.get_staged_bytes(session, read_limit).await?;
+        let staged_len = staged_object.bytes.len() as u64;
+        if expected != offset {
+            if new_offset == expected
+                && bytes_match_at(&staged_object.bytes, offset, bytes.as_ref())?
+            {
+                return Ok(stored.public);
+            }
+            tracing::debug!(
+                target: "pocopine.log",
+                event_name = "pocopine.storage.offset_mismatch",
+                session = %session,
+                expected,
+                provided = offset,
+            );
+            return Err(StorageError::offset_mismatch(expected, offset));
+        }
+        if staged_len > expected {
+            if staged_len == new_offset
+                && bytes_match_at(&staged_object.bytes, expected, bytes.as_ref())?
+            {
+                stored.public.next_offset = Some(new_offset);
+                self.write_session(session, &mut stored).await?;
+                return Ok(stored.public);
+            }
+            tracing::warn!(
+                target: "pocopine.log",
+                event_name = "pocopine.storage.azure_staged_bytes_truncated",
+                session = %session,
+                actual = staged_len,
+                trusted = expected,
+            );
+            staged_object.bytes.truncate(usize_from_u64(expected)?);
+            let written = self
+                .put_staged_bytes(
+                    session,
+                    Bytes::from(staged_object.bytes.clone()),
+                    staged_object
+                        .etag
+                        .clone()
+                        .map(BlobWritePrecondition::IfMatch),
+                )
+                .await?;
+            staged_object.etag = written.etag;
+        } else if staged_len < expected {
+            return Err(StorageError::backend(format!(
+                "Azure staged upload blob is shorter than committed metadata: expected {expected} bytes, got {staged_len}"
+            )));
+        }
+        ensure_size_limit(stored.max_bytes, stored.public.size, new_offset)?;
+        staged_object.bytes.extend_from_slice(&bytes);
+        self.put_staged_bytes(
+            session,
+            Bytes::from(staged_object.bytes),
+            staged_object.etag.map(BlobWritePrecondition::IfMatch),
+        )
+        .await?;
+        stored.public.next_offset = Some(new_offset);
+        self.write_session(session, &mut stored).await?;
+        Ok(stored.public)
+    }
+
+    async fn complete_legacy(
+        &self,
+        session: &UploadSessionId,
+        mut stored: StoredUploadSession,
+        provided_checksum: Option<ObjectChecksum>,
+    ) -> StorageResult<ObjectRef> {
+        let trusted = stored.public.next_offset.unwrap_or(0);
+        let staged = self.reconcile_staged_bytes(session, trusted).await?;
+        let actual = staged.len() as u64;
+        if let Some(expected) = stored.public.size {
+            if actual != expected {
+                return Err(StorageError::policy_rejected(format!(
+                    "upload is incomplete: expected {expected} bytes, got {actual}"
+                )));
+            }
+        }
+        ensure_size_limit(stored.max_bytes, stored.public.size, actual)?;
+        let checksum =
+            validate_complete_checksum(&stored.checksum_policy, &staged, provided_checksum)?;
+        let object_key = self.layout.object_key(stored.storage_key.key.as_str());
+        if stored.public.status == UploadSessionStatus::Open
+            || stored.public.next_offset != Some(actual)
+            || stored.completion_object_key.as_deref() != Some(object_key.as_str())
+        {
+            stored.public.status = UploadSessionStatus::Completing;
+            stored.public.next_offset = Some(actual);
+            stored.completion_object_key = Some(object_key.clone());
+            self.write_session(session, &mut stored).await?;
+        }
+        let staged = Bytes::from(staged);
+        let written = match self
+            .put_completed_object(&object_key, staged, stored.public.content_type.as_deref())
+            .await
+        {
+            Ok(written) => written,
+            Err(err) => {
+                return Err(self
+                    .rollback_completion_after_error(session, &mut stored, err)
+                    .await);
+            }
+        };
+        let object = self.object_ref(&stored, actual, written, checksum);
+        stored.public.status = UploadSessionStatus::Complete;
+        stored.public.next_offset = Some(actual);
+        stored.object = Some(object.clone());
+        stored.cleanup_pending = true;
+        self.write_session(session, &mut stored).await?;
+        self.cleanup_staged_bytes(session, &mut stored).await?;
+        Ok(object)
+    }
 }
 
 impl StorageBackend for AzureBlobStorageBackend {
     fn name(&self) -> &'static str {
         self.name
+    }
+
+    fn capabilities(&self) -> BackendCapabilities {
+        // Sequential proxy (the coalescing-tail block path, the default) and
+        // server-mediated native multipart (the by-number `upload_part` path) are
+        // both assembled with `Put Block` + `Put Block List`.
+        BackendCapabilities::default().with_native_multipart()
     }
 
     fn initiate_upload<'a>(
@@ -687,10 +1509,45 @@ impl StorageBackend for AzureBlobStorageBackend {
         request: InitiateUpload,
     ) -> StorageBoxFuture<'a, UploadSession> {
         Box::pin(async move {
-            let strategy = selected_strategy(request.requested_strategy)?;
+            let strategy = select_upload_mode(request.requested_strategy, self.capabilities())?;
             ensure_supported_checksum_policy(&request.policy.checksum)?;
             self.ensure_policy_is_supported(request.policy.max_bytes)?;
             self.ensure_requested_size_is_supported(request.size)?;
+            // By-number multipart needs the total length up front: blocks are
+            // staged by part number and the commit references a fixed `0..N` block
+            // range derived from the declared size.
+            if strategy == UploadStrategy::Multipart && request.size.is_none() {
+                return Err(StorageError::policy_rejected(
+                    "multipart uploads require a declared length (size) at initiation",
+                ));
+            }
+            let max_bytes = request.policy.max_bytes.min(self.max_proxy_upload_bytes);
+            // For the by-number path, pin the block size and cap the block count;
+            // the sequential path keeps the policy's chunk plan unchanged.
+            let (plan, session_part_size) = if strategy == UploadStrategy::Multipart {
+                let block_size = block_size_for(max_bytes);
+                // min == preferred == max: every non-final part is exactly
+                // `block_size` (the last is the remainder), matching `upload_part`.
+                let plan = TransferPlan {
+                    min_part_size: Some(block_size),
+                    preferred_part_size: Some(block_size),
+                    max_part_size: Some(block_size),
+                    max_parts: Some(max_bytes.div_ceil(block_size).max(1) as u32),
+                    max_concurrent_parts: request.policy.max_concurrent_parts.max(1),
+                    resumable: true,
+                };
+                (plan, Some(block_size))
+            } else {
+                let plan = TransferPlan {
+                    min_part_size: request.policy.min_part_size,
+                    preferred_part_size: request.policy.preferred_chunk_size,
+                    max_part_size: request.policy.max_part_size,
+                    max_parts: request.policy.max_parts,
+                    max_concurrent_parts: 1,
+                    resumable: true,
+                };
+                (plan, request.policy.preferred_chunk_size)
+            };
             let id = UploadSessionId::new(Uuid::new_v4().to_string())?;
             let session = UploadSession {
                 id: id.clone(),
@@ -702,15 +1559,8 @@ impl StorageBackend for AzureBlobStorageBackend {
                 strategy,
                 status: UploadSessionStatus::Open,
                 next_offset: Some(0),
-                part_size: request.policy.preferred_chunk_size,
-                plan: TransferPlan {
-                    min_part_size: request.policy.min_part_size,
-                    preferred_part_size: request.policy.preferred_chunk_size,
-                    max_part_size: request.policy.max_part_size,
-                    max_parts: request.policy.max_parts,
-                    max_concurrent_parts: 1,
-                    resumable: true,
-                },
+                part_size: session_part_size,
+                plan,
                 uploaded_parts: Vec::new(),
                 expires_at: expires_at(request.policy.expires_after),
             };
@@ -719,24 +1569,18 @@ impl StorageBackend for AzureBlobStorageBackend {
                 owner: ctx.actor.clone(),
                 storage_key: request.storage_key,
                 visibility: request.policy.visibility,
-                max_bytes: request.policy.max_bytes.min(self.max_proxy_upload_bytes),
+                max_bytes,
                 checksum_policy: request.policy.checksum,
                 request_metadata: request.metadata,
                 object: None,
                 completion_object_key: None,
                 cleanup_pending: false,
+                native: NativeUploadState::Block(Default::default()),
                 meta_etag: None,
             };
+            // Native sessions stage blocks directly against the destination blob;
+            // there is no separate staged `bytes.tmp` object to create up front.
             self.create_session(&id, &mut stored).await?;
-            if let Err(err) = self
-                .put_staged_bytes(&id, Bytes::new(), Some(BlobWritePrecondition::IfNotExists))
-                .await
-            {
-                let _ = self
-                    .delete_object_if_exists(&self.layout.session_meta_key(&id))
-                    .await;
-                return Err(err);
-            }
             Ok(session)
         })
     }
@@ -752,7 +1596,10 @@ impl StorageBackend for AzureBlobStorageBackend {
             let _guard = lock.lock().await;
             let stored = self.read_session(&session).await?;
             ensure_owner(&ctx.actor, &stored.owner)?;
-            if stored.public.status == UploadSessionStatus::Open {
+            // Native block sessions keep an authoritative offset in the metadata;
+            // only the legacy staged-object path reconciles against storage.
+            if stored.public.status == UploadSessionStatus::Open && stored.native.block().is_none()
+            {
                 self.ensure_staged_not_shorter_than_metadata(
                     &session,
                     stored.public.next_offset.unwrap_or(0),
@@ -779,8 +1626,10 @@ impl StorageBackend for AzureBlobStorageBackend {
             self.persist_expired_if_needed(&session, &mut stored)
                 .await?;
             let committed_offset = stored.public.next_offset.unwrap_or(0);
-            self.ensure_staged_not_shorter_than_metadata(&session, committed_offset)
-                .await?;
+            if stored.native.block().is_none() {
+                self.ensure_staged_not_shorter_than_metadata(&session, committed_offset)
+                    .await?;
+            }
             ensure_upload_length_can_be_set(
                 stored.max_bytes,
                 &stored.public,
@@ -814,71 +1663,119 @@ impl StorageBackend for AzureBlobStorageBackend {
                     "Azure backend currently supports sequential proxy uploads only",
                 ));
             }
-            let expected = stored.public.next_offset.unwrap_or(0);
-            let new_offset = checked_new_offset(offset, bytes.len())?;
-            let read_limit = expected
-                .max(new_offset)
-                .checked_add(1)
-                .ok_or_else(|| StorageError::policy_rejected("upload byte offset overflowed"))?;
-            let mut staged_object = self.get_staged_bytes(&session, read_limit).await?;
-            let staged_len = staged_object.bytes.len() as u64;
-            if expected != offset {
-                if new_offset == expected
-                    && bytes_match_at(&staged_object.bytes, offset, bytes.as_ref())?
-                {
-                    return Ok(stored.public);
-                }
-                tracing::debug!(
-                    target: "pocopine.log",
-                    event_name = "pocopine.storage.offset_mismatch",
-                    session = %session,
-                    expected,
-                    provided = offset,
-                );
-                return Err(StorageError::offset_mismatch(expected, offset));
+            if stored.native.block().is_some() {
+                self.append_block(&session, stored, offset, bytes).await
+            } else {
+                self.append_legacy(&session, stored, offset, bytes).await
             }
-            if staged_len > expected {
-                if staged_len == new_offset
-                    && bytes_match_at(&staged_object.bytes, expected, bytes.as_ref())?
-                {
-                    stored.public.next_offset = Some(new_offset);
-                    self.write_session(&session, &mut stored).await?;
-                    return Ok(stored.public);
-                }
-                tracing::warn!(
-                    target: "pocopine.log",
-                    event_name = "pocopine.storage.azure_staged_bytes_truncated",
-                    session = %session,
-                    actual = staged_len,
-                    trusted = expected,
-                );
-                staged_object.bytes.truncate(usize_from_u64(expected)?);
-                let written = self
-                    .put_staged_bytes(
-                        &session,
-                        Bytes::from(staged_object.bytes.clone()),
-                        staged_object
-                            .etag
-                            .clone()
-                            .map(BlobWritePrecondition::IfMatch),
-                    )
+        })
+    }
+
+    fn upload_part<'a>(
+        &'a self,
+        ctx: &'a StorageContext,
+        session: UploadSessionId,
+        number: u32,
+        body: UploadBody,
+    ) -> StorageBoxFuture<'a, UploadSession> {
+        Box::pin(async move {
+            // Part numbers are 1-based; the route enforces this, but the trait is
+            // directly callable, so guard before the `number - 1` index below.
+            if number == 0 {
+                return Err(StorageError::policy_rejected(
+                    "multipart part number must be at least 1",
+                ));
+            }
+            let (object_key, block_size, expected_part_len, public) = {
+                let lock = self.session_locks.lock(&session);
+                let _cleanup = UploadSessionLockCleanup::new(&self.session_locks, &session);
+                let _guard = lock.lock().await;
+                let mut stored = self.read_session(&session).await?;
+                ensure_owner(&ctx.actor, &stored.owner)?;
+                self.persist_expired_if_needed(&session, &mut stored)
                     .await?;
-                staged_object.etag = written.etag;
-            } else if staged_len < expected {
-                return Err(StorageError::backend(format!(
-                    "Azure staged upload blob is shorter than committed metadata: expected {expected} bytes, got {staged_len}"
+                ensure_open(&stored.public)?;
+                if stored.public.strategy != UploadStrategy::Multipart {
+                    return Err(StorageError::unsupported(
+                        "Azure backend part upload requires the multipart strategy",
+                    ));
+                }
+                // Fixed block layout: parts `1..count` are exactly `block_size`,
+                // the last is the remainder. Pinning each part's length makes the
+                // committed blob's size exactly the declared total and caps the
+                // block count.
+                let block_size = block_size_for(stored.max_bytes);
+                let declared = stored.public.size.ok_or_else(|| {
+                    StorageError::policy_rejected("multipart upload is missing a declared length")
+                })?;
+                let count = declared.div_ceil(block_size).max(1);
+                if u64::from(number) > count {
+                    return Err(StorageError::policy_rejected(format!(
+                        "part number {number} exceeds the maximum of {count} parts for this upload"
+                    )));
+                }
+                let expected_part_len = if u64::from(number) == count {
+                    declared - (count - 1) * block_size
+                } else {
+                    block_size
+                };
+                let object_key = self.layout.object_key(stored.storage_key.key.as_str());
+                (
+                    object_key,
+                    block_size,
+                    expected_part_len,
+                    stored.public.clone(),
+                )
+            };
+
+            // Enforce the advertised concurrency, then re-check the captured expiry
+            // (the permit wait can outlast it).
+            let max_concurrent = public.plan.max_concurrent_parts.max(1) as usize;
+            let _permit = self
+                .part_concurrency
+                .semaphore(&session, max_concurrent)
+                .acquire_owned()
+                .await
+                .map_err(|_| StorageError::UploadClosed {
+                    session: session.to_string(),
+                })?;
+            if OffsetDateTime::now_utc() >= public.expires_at {
+                return Err(StorageError::UploadClosed {
+                    session: session.to_string(),
+                });
+            }
+
+            // Azure stages a whole block per part, so the bounded part is
+            // collected (peak = one block per concurrent upload). Reject a part
+            // whose actual length is not its fixed slot length so the committed
+            // total is exactly the declared size.
+            let bytes = body.collect_capped(block_size).await?;
+            if bytes.len() as u64 != expected_part_len {
+                return Err(StorageError::policy_rejected(format!(
+                    "part {number} must be exactly {expected_part_len} bytes, got {}",
+                    bytes.len()
                 )));
             }
-            ensure_size_limit(stored.max_bytes, stored.public.size, new_offset)?;
-            staged_object.bytes.extend_from_slice(&bytes);
-            self.put_staged_bytes(
-                &session,
-                Bytes::from(staged_object.bytes),
-                staged_object.etag.map(BlobWritePrecondition::IfMatch),
-            )
-            .await?;
-            stored.public.next_offset = Some(new_offset);
-            self.write_session(&session, &mut stored).await?;
+
+            // Re-acquire the lock and re-validate Open immediately before staging,
+            // holding the lock across the stage. This fences against a concurrent
+            // complete/abort (both take the lock): the block either stages before
+            // they run or this re-read sees the closed session and stages nothing.
+            // `stage_block` re-staging the same index overwrites, so a re-PUT is
+            // idempotent.
+            let lock = self.session_locks.lock(&session);
+            let _cleanup = UploadSessionLockCleanup::new(&self.session_locks, &session);
+            let _guard = lock.lock().await;
+            let stored = self.read_session(&session).await?;
+            ensure_owner(&ctx.actor, &stored.owner)?;
+            ensure_open(&stored.public)?;
+            if stored.public.strategy != UploadStrategy::Multipart {
+                return Err(StorageError::unsupported(
+                    "Azure backend part upload requires the multipart strategy",
+                ));
+            }
+            self.stage_block(&object_key, &session, u64::from(number - 1), bytes)
+                .await?;
             Ok(stored.public)
         })
     }
@@ -898,57 +1795,31 @@ impl StorageBackend for AzureBlobStorageBackend {
                 let object = object.clone();
                 self.cleanup_staged_bytes_best_effort(&request.session, &mut stored)
                     .await;
+                self.part_concurrency.forget(&request.session);
                 return Ok(object);
             }
             self.persist_expired_if_needed(&request.session, &mut stored)
                 .await?;
             ensure_completable(&stored.public)?;
-            let trusted = stored.public.next_offset.unwrap_or(0);
-            let staged = self
-                .reconcile_staged_bytes(&request.session, trusted)
-                .await?;
-            let actual = staged.len() as u64;
-            if let Some(expected) = stored.public.size {
-                if actual != expected {
-                    return Err(StorageError::policy_rejected(format!(
-                        "upload is incomplete: expected {expected} bytes, got {actual}"
-                    )));
+            let session = request.session.clone();
+            let result = if stored.native.block().is_some() {
+                if stored.public.strategy == UploadStrategy::Multipart {
+                    self.complete_block_by_number(&session, stored, request.checksum)
+                        .await
+                } else {
+                    self.complete_block(&session, stored, request.checksum)
+                        .await
                 }
-            }
-            ensure_size_limit(stored.max_bytes, stored.public.size, actual)?;
-            let checksum =
-                validate_complete_checksum(&stored.checksum_policy, &staged, request.checksum)?;
-            let object_key = self.layout.object_key(stored.storage_key.key.as_str());
-            if stored.public.status == UploadSessionStatus::Open
-                || stored.public.next_offset != Some(actual)
-                || stored.completion_object_key.as_deref() != Some(object_key.as_str())
-            {
-                stored.public.status = UploadSessionStatus::Completing;
-                stored.public.next_offset = Some(actual);
-                stored.completion_object_key = Some(object_key.clone());
-                self.write_session(&request.session, &mut stored).await?;
-            }
-            let staged = Bytes::from(staged);
-            let written = match self
-                .put_completed_object(&object_key, staged, stored.public.content_type.as_deref())
-                .await
-            {
-                Ok(written) => written,
-                Err(err) => {
-                    return Err(self
-                        .rollback_completion_after_error(&request.session, &mut stored, err)
-                        .await);
-                }
+            } else {
+                self.complete_legacy(&session, stored, request.checksum)
+                    .await
             };
-            let object = self.object_ref(&stored, actual, written, checksum);
-            stored.public.status = UploadSessionStatus::Complete;
-            stored.public.next_offset = Some(actual);
-            stored.object = Some(object.clone());
-            stored.cleanup_pending = true;
-            self.write_session(&request.session, &mut stored).await?;
-            self.cleanup_staged_bytes(&request.session, &mut stored)
-                .await?;
-            Ok(object)
+            // Drop the concurrency pool only on success; a failed attempt leaves
+            // the session resumable and must keep its semaphore.
+            if result.is_ok() {
+                self.part_concurrency.forget(&session);
+            }
+            result
         })
     }
 
@@ -969,6 +1840,16 @@ impl StorageBackend for AzureBlobStorageBackend {
                         return Err(StorageError::UploadClosed {
                             session: session.to_string(),
                         });
+                    }
+                    // Stop concurrent part uploads: queued and future ones fail
+                    // immediately instead of staging blocks after the abort.
+                    // (Uncommitted blocks are never committed, so Azure
+                    // garbage-collects them.)
+                    if stored.public.strategy == UploadStrategy::Multipart {
+                        let max = stored.public.plan.max_concurrent_parts.max(1);
+                        self.part_concurrency
+                            .semaphore(&session, max as usize)
+                            .close();
                     }
                 }
                 AbortSessionRead::Missing => {}
@@ -991,6 +1872,7 @@ impl StorageBackend for AzureBlobStorageBackend {
             };
             bytes_deleted?;
             meta_deleted?;
+            self.part_concurrency.forget(&session);
             Ok(())
         })
     }

--- a/crates/pocopine-storage-azure/tests/azurite.rs
+++ b/crates/pocopine-storage-azure/tests/azurite.rs
@@ -17,9 +17,10 @@ use bytes::Bytes;
 use hmac::{Hmac, Mac};
 use percent_encoding::{utf8_percent_encode, NON_ALPHANUMERIC};
 use pocopine_storage::{
-    CompleteUpload, InitiateUpload, PrincipalRef, SafeObjectKey, StorageActor, StorageBackend,
-    StorageContext, StorageError, StorageKey, StorageResult, UploadPolicy, UploadSession,
-    UploadSessionStatus, UploadStrategy,
+    ChecksumAlgorithm, ChecksumPolicy, CompleteUpload, InitiateUpload, ObjectChecksum,
+    PrincipalRef, SafeObjectKey, StorageActor, StorageBackend, StorageContext, StorageError,
+    StorageKey, StorageResult, UploadBody, UploadPolicy, UploadSession, UploadSessionStatus,
+    UploadStrategy,
 };
 use pocopine_storage_azure::AzureBlobStorageBackend;
 use sha2::Sha256;
@@ -445,22 +446,35 @@ async fn duplicate_append_retry_after_staged_write_advances_metadata() -> Storag
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn append_refreshes_staged_etag_after_truncating_rogue_bytes() -> StorageResult<()> {
+async fn rogue_staged_object_does_not_corrupt_native_upload() -> StorageResult<()> {
     let container = create_container("truncate-append").await;
     let backend = AzureBlobStorageBackend::new(container.client())?;
     let session = initiate(&backend, Some(6)).await?;
+    // Native block sessions stage blocks against the destination blob; the legacy
+    // `bytes.tmp` staging object is not part of the protocol, so a rogue one must
+    // not affect the committed result.
     let bytes_key = session_object_key(&backend, &session, "bytes.tmp");
 
     backend
         .append_upload_bytes(&ctx(), session.id.clone(), 0, Bytes::from_static(b"abc"))
         .await?;
     put_object(&container, bytes_key.clone(), b"abcjunk").await;
-
     let updated = backend
         .append_upload_bytes(&ctx(), session.id.clone(), 3, Bytes::from_static(b"def"))
         .await?;
     assert_eq!(updated.next_offset, Some(6));
-    assert_eq!(object_bytes(&container, &bytes_key).await, b"abcdef");
+
+    let object = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(object.size, 6);
+    assert_eq!(object_bytes(&container, "files/hello.txt").await, b"abcdef");
     Ok(())
 }
 
@@ -503,15 +517,15 @@ async fn non_system_actor_cannot_abort_corrupt_upload_metadata() -> StorageResul
     let backend = AzureBlobStorageBackend::new(container.client())?;
     let session = initiate(&backend, Some(5)).await?;
     let meta_key = session_object_key(&backend, &session, "session.json");
-    let bytes_key = session_object_key(&backend, &session, "bytes.tmp");
     put_object(&container, meta_key.clone(), b"{not-json").await;
 
     let rejected = backend
         .abort_upload(&principal_ctx("tenant-b"), session.id.clone())
         .await;
     assert!(matches!(rejected, Err(StorageError::Forbidden { .. })));
+    // The refused abort left the (corrupt) session metadata in place. Native
+    // sessions have no separate `bytes.tmp` staging object to check.
     assert!(blob_exists(&container, &meta_key).await);
-    assert!(blob_exists(&container, &bytes_key).await);
 
     backend.abort_upload(&ctx(), session.id).await?;
     Ok(())
@@ -585,5 +599,414 @@ async fn initiate_rejects_policy_above_proxy_cap_for_streaming_upload() -> Stora
         rejected,
         Err(StorageError::PayloadTooLarge { limit: 8 })
     ));
+    Ok(())
+}
+
+fn large_policy() -> StorageResult<UploadPolicy> {
+    let mut policy = UploadPolicy::new("azure")?
+        .max_bytes(32 * 1024 * 1024)
+        .preferred_chunk_size(1024 * 1024);
+    policy.expires_after = Duration::from_secs(60 * 60);
+    Ok(policy)
+}
+
+async fn initiate_large_checked(
+    backend: &AzureBlobStorageBackend,
+    key: &str,
+    size: u64,
+    checksum: ChecksumPolicy,
+) -> StorageResult<UploadSession> {
+    let mut policy = large_policy()?;
+    policy.checksum = checksum;
+    backend
+        .initiate_upload(
+            &ctx(),
+            InitiateUpload {
+                scope: "files".to_string(),
+                storage_key: StorageKey::new(SafeObjectKey::parse(key)?),
+                file_name: "large.bin".to_string(),
+                size: Some(size),
+                content_type: Some("application/octet-stream".to_string()),
+                metadata: BTreeMap::new(),
+                requested_strategy: UploadStrategy::Auto,
+                policy,
+            },
+        )
+        .await
+}
+
+fn pattern_bytes(start: usize, len: usize) -> Bytes {
+    let mut buf = Vec::with_capacity(len);
+    for i in 0..len {
+        buf.push(((start + i) % 251) as u8);
+    }
+    Bytes::from(buf)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn block_upload_assembles_multiple_blocks_against_azurite() -> StorageResult<()> {
+    let container = create_container("blocks").await;
+    let backend = AzureBlobStorageBackend::new(container.client())?;
+    let chunk = 1024 * 1024usize;
+    let total = 4 * chunk;
+    let session = initiate_large_checked(
+        &backend,
+        "files/large.bin",
+        total as u64,
+        ChecksumPolicy::None,
+    )
+    .await?;
+
+    let mut offset = 0u64;
+    for index in 0..4 {
+        let updated = backend
+            .append_upload_bytes(
+                &ctx(),
+                session.id.clone(),
+                offset,
+                pattern_bytes(index * chunk, chunk),
+            )
+            .await?;
+        offset += chunk as u64;
+        assert_eq!(updated.next_offset, Some(offset));
+    }
+
+    let object = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(object.size, total as u64);
+    assert_eq!(
+        object_bytes(&container, "files/large.bin").await,
+        pattern_bytes(0, total).to_vec()
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn block_completion_is_idempotent_against_azurite() -> StorageResult<()> {
+    let container = create_container("block-idem").await;
+    let backend = AzureBlobStorageBackend::new(container.client())?;
+    let total = 3 * 1024 * 1024usize;
+    let session = initiate_large_checked(
+        &backend,
+        "files/large.bin",
+        total as u64,
+        ChecksumPolicy::None,
+    )
+    .await?;
+    backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, pattern_bytes(0, total))
+        .await?;
+
+    let first = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id.clone(),
+                checksum: None,
+            },
+        )
+        .await?;
+    let second = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(first, second);
+    assert_eq!(first.size, total as u64);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn block_upload_verifies_streaming_sha256_against_azurite() -> StorageResult<()> {
+    let container = create_container("block-sha").await;
+    let backend = AzureBlobStorageBackend::new(container.client())?;
+    let total = 3 * 1024 * 1024usize;
+    let data = pattern_bytes(0, total);
+    let expected = ObjectChecksum {
+        algorithm: ChecksumAlgorithm::Sha256,
+        value: pocopine_crypto::sha256_hex(&data),
+    };
+    let session = initiate_large_checked(
+        &backend,
+        "files/checked.bin",
+        total as u64,
+        ChecksumPolicy::Required(ChecksumAlgorithm::Sha256),
+    )
+    .await?;
+    backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, data)
+        .await?;
+
+    let object = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: Some(expected.clone()),
+            },
+        )
+        .await?;
+    assert_eq!(object.checksum, Some(expected));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn block_complete_does_not_overwrite_existing_object_key() -> StorageResult<()> {
+    let container = create_container("block-collision").await;
+    put_object(&container, "files/large.bin", b"existing").await;
+
+    let backend = AzureBlobStorageBackend::new(container.client())?;
+    let total = 2 * 1024 * 1024usize;
+    let session = initiate_large_checked(
+        &backend,
+        "files/large.bin",
+        total as u64,
+        ChecksumPolicy::None,
+    )
+    .await?;
+    backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, pattern_bytes(0, total))
+        .await?;
+
+    let rejected = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await;
+    assert!(matches!(rejected, Err(StorageError::PolicyRejected { .. })));
+    assert_eq!(
+        object_bytes(&container, "files/large.bin").await,
+        b"existing"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn block_buffers_large_inline_tail_in_metadata_against_azurite() -> StorageResult<()> {
+    let container = create_container("block-tail").await;
+    let backend = AzureBlobStorageBackend::new(container.client())?;
+    // 500 KiB stays below the 1 MiB block size, so it is buffered entirely in the
+    // inline (base64) tail — over the 256 KiB non-tail metadata bound. inspect +
+    // complete must still read the session metadata.
+    let total = 500 * 1024usize;
+    let session = initiate_large_checked(
+        &backend,
+        "files/tail.bin",
+        total as u64,
+        ChecksumPolicy::None,
+    )
+    .await?;
+    backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, pattern_bytes(0, total))
+        .await?;
+
+    let inspected = backend.inspect_upload(&ctx(), session.id.clone()).await?;
+    assert_eq!(inspected.next_offset, Some(total as u64));
+
+    let object = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(object.size, total as u64);
+    assert_eq!(
+        object_bytes(&container, "files/tail.bin").await,
+        pattern_bytes(0, total).to_vec()
+    );
+    Ok(())
+}
+
+/// Initiate a server-mediated by-number multipart upload (the `upload_part`
+/// path). Block size for the 32 MiB cap is 1 MiB, so parts are <= 1 MiB.
+async fn initiate_multipart(
+    backend: &AzureBlobStorageBackend,
+    key: &str,
+    size: u64,
+) -> StorageResult<UploadSession> {
+    let mut policy = large_policy()?;
+    policy.max_concurrent_parts = 4;
+    backend
+        .initiate_upload(
+            &ctx(),
+            InitiateUpload {
+                scope: "files".to_string(),
+                storage_key: StorageKey::new(SafeObjectKey::parse(key)?),
+                file_name: "bynum.bin".to_string(),
+                size: Some(size),
+                content_type: Some("application/octet-stream".to_string()),
+                metadata: BTreeMap::new(),
+                requested_strategy: UploadStrategy::Multipart,
+                policy,
+            },
+        )
+        .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn multipart_by_number_commits_blocks_concurrently_against_azurite() -> StorageResult<()> {
+    let container = create_container("bynum").await;
+    let backend = AzureBlobStorageBackend::new(container.client())?;
+
+    // 1 MiB block size: two full parts plus a 512 KiB final part.
+    let part = 1024 * 1024usize;
+    let last = 512 * 1024usize;
+    let total = (2 * part + last) as u64;
+    let session = initiate_multipart(&backend, "files/bynum.bin", total).await?;
+    assert_eq!(session.strategy, UploadStrategy::Multipart);
+    assert!(session.plan.max_concurrent_parts >= 2);
+
+    let specs = [
+        (1u32, 0usize, part),
+        (2u32, part, part),
+        (3u32, 2 * part, last),
+    ];
+    let mut handles = Vec::new();
+    for (number, start, len) in specs.into_iter().rev() {
+        let backend = backend.clone();
+        let session_id = session.id.clone();
+        let bytes = pattern_bytes(start, len);
+        handles.push(tokio::spawn(async move {
+            backend
+                .upload_part(&ctx(), session_id, number, UploadBody::from_bytes(bytes))
+                .await
+        }));
+    }
+    for handle in handles {
+        handle.await.expect("join part task")?;
+    }
+
+    let object = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id.clone(),
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(object.size, total);
+    assert_eq!(
+        object_bytes(&container, "files/bynum.bin").await,
+        pattern_bytes(0, total as usize).to_vec()
+    );
+
+    let again = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(again, object);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn multipart_by_number_rejects_missing_block_against_azurite() -> StorageResult<()> {
+    let container = create_container("bynum-gap").await;
+    let backend = AzureBlobStorageBackend::new(container.client())?;
+
+    let part = 1024 * 1024usize;
+    let total = (3 * part) as u64;
+    let session = initiate_multipart(&backend, "files/gap.bin", total).await?;
+    // Stage parts 1 and 3, leaving a gap at 2.
+    backend
+        .upload_part(
+            &ctx(),
+            session.id.clone(),
+            1,
+            UploadBody::from_bytes(pattern_bytes(0, part)),
+        )
+        .await?;
+    backend
+        .upload_part(
+            &ctx(),
+            session.id.clone(),
+            3,
+            UploadBody::from_bytes(pattern_bytes(2 * part, part)),
+        )
+        .await?;
+
+    let rejected = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id.clone(),
+                checksum: None,
+            },
+        )
+        .await;
+    assert!(
+        matches!(rejected, Err(StorageError::PolicyRejected { .. })),
+        "a missing block 2 must be rejected, got {rejected:?}"
+    );
+    assert!(!blob_exists(&container, "files/gap.bin").await);
+
+    // The session stays Open; staging the missing part lets it complete.
+    backend
+        .upload_part(
+            &ctx(),
+            session.id.clone(),
+            2,
+            UploadBody::from_bytes(pattern_bytes(part, part)),
+        )
+        .await?;
+    let object = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(object.size, total);
+    assert_eq!(
+        object_bytes(&container, "files/gap.bin").await,
+        pattern_bytes(0, total as usize).to_vec()
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn multipart_by_number_rejects_wrong_part_length_against_azurite() -> StorageResult<()> {
+    let container = create_container("bynum-len").await;
+    let backend = AzureBlobStorageBackend::new(container.client())?;
+
+    let part = 1024 * 1024usize;
+    let session = initiate_multipart(&backend, "files/len.bin", (2 * part) as u64).await?;
+    let rejected = backend
+        .upload_part(
+            &ctx(),
+            session.id.clone(),
+            1,
+            UploadBody::from_bytes(pattern_bytes(0, part / 2)),
+        )
+        .await;
+    assert!(
+        matches!(rejected, Err(StorageError::PolicyRejected { .. })),
+        "an undersized non-final part must be rejected, got {rejected:?}"
+    );
     Ok(())
 }

--- a/crates/pocopine-storage-gcs/Cargo.toml
+++ b/crates/pocopine-storage-gcs/Cargo.toml
@@ -11,6 +11,7 @@ bytes = "1"
 google-cloud-storage = "1"
 google-cloud-gax = "1"
 percent-encoding = "2"
+pocopine-codec = { workspace = true }
 pocopine-storage = { workspace = true }
 reqwest = { version = "0.13", default-features = false, features = ["json", "query", "rustls"] }
 serde = { workspace = true }
@@ -22,5 +23,6 @@ uuid = { version = "1", features = ["v4"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 google-cloud-auth = "1"
+pocopine-crypto = { workspace = true }
 testcontainers = { version = "0.23", features = ["http_wait"] }
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/crates/pocopine-storage-gcs/src/control.rs
+++ b/crates/pocopine-storage-gcs/src/control.rs
@@ -1,12 +1,32 @@
+use std::collections::BTreeMap;
 use std::time::Duration;
 
 use google_cloud_gax::options::RequestOptionsBuilder;
 use google_cloud_storage::client::StorageControl;
+use google_cloud_storage::model::compose_object_request::SourceObject;
+use google_cloud_storage::model::Object;
 use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
 use pocopine_storage::{StorageError, StorageResult};
 
 use crate::layout::GcsKeyLayout;
-use crate::util::{gcs_error, is_gcs_not_found};
+use crate::state::{GcsObjectAttrs, GcsObjectWrite};
+use crate::util::{gcs_error, is_gcs_not_found, is_gcs_precondition_failed, non_empty};
+
+/// One source component for a compose request.
+pub(crate) struct ComposeSource {
+    pub(crate) key: String,
+    pub(crate) generation: Option<i64>,
+}
+
+/// A request to assemble `sources` into the destination object `dest_key`.
+pub(crate) struct ComposeRequest<'a> {
+    pub(crate) dest_key: &'a str,
+    pub(crate) content_type: Option<&'a str>,
+    pub(crate) metadata: BTreeMap<String, String>,
+    pub(crate) sources: Vec<ComposeSource>,
+    /// `Some(0)` refuses to overwrite an existing destination object.
+    pub(crate) if_generation_match: Option<i64>,
+}
 
 const JSON_CONTROL_TIMEOUT: Duration = Duration::from_secs(30);
 const GCS_JSON_PATH_ENCODE_SET: &AsciiSet = &CONTROLS
@@ -46,6 +66,112 @@ impl GcsControl {
             Self::Json(control) => control.delete_object(layout, key).await,
         }
     }
+
+    pub(crate) async fn compose_object(
+        &self,
+        layout: &GcsKeyLayout,
+        request: ComposeRequest<'_>,
+    ) -> StorageResult<GcsObjectWrite> {
+        match self {
+            Self::Google(control) => compose_with_google_control(control, layout, request).await,
+            Self::Json(control) => control.compose_object(layout, request).await,
+        }
+    }
+
+    /// Fetch an object's etag/generation plus the value of its `marker_key`
+    /// custom-metadata entry. `None` when the object does not exist.
+    pub(crate) async fn get_object_attrs(
+        &self,
+        layout: &GcsKeyLayout,
+        key: &str,
+        marker_key: &str,
+    ) -> StorageResult<Option<GcsObjectAttrs>> {
+        match self {
+            Self::Google(control) => {
+                get_object_attrs_with_google_control(control, layout, key, marker_key).await
+            }
+            Self::Json(control) => control.get_object_attrs(layout, key, marker_key).await,
+        }
+    }
+}
+
+async fn get_object_attrs_with_google_control(
+    control: &StorageControl,
+    layout: &GcsKeyLayout,
+    key: &str,
+    marker_key: &str,
+) -> StorageResult<Option<GcsObjectAttrs>> {
+    match control
+        .get_object()
+        .set_bucket(layout.bucket_resource())
+        .set_object(key)
+        .send()
+        .await
+    {
+        Ok(object) => Ok(Some(GcsObjectAttrs {
+            etag: non_empty(object.etag),
+            generation: if object.generation > 0 {
+                Some(object.generation)
+            } else {
+                None
+            },
+            owner_session: object.metadata.get(marker_key).cloned(),
+        })),
+        Err(err) if is_gcs_not_found(&err) => Ok(None),
+        Err(err) => Err(gcs_error("get object", err)),
+    }
+}
+
+async fn compose_with_google_control(
+    control: &StorageControl,
+    layout: &GcsKeyLayout,
+    request: ComposeRequest<'_>,
+) -> StorageResult<GcsObjectWrite> {
+    let mut destination = Object::new()
+        .set_bucket(layout.bucket_resource())
+        .set_name(request.dest_key)
+        .set_metadata(request.metadata);
+    if let Some(content_type) = request.content_type {
+        destination = destination.set_content_type(content_type);
+    }
+    let sources: Vec<SourceObject> = request
+        .sources
+        .iter()
+        .map(|source| {
+            let builder = SourceObject::new().set_name(source.key.clone());
+            match source.generation {
+                Some(generation) => builder.set_generation(generation),
+                None => builder,
+            }
+        })
+        .collect();
+    let mut builder = control
+        .compose_object()
+        .set_destination(destination)
+        .set_source_objects(sources);
+    if let Some(generation) = request.if_generation_match {
+        builder = builder.set_if_generation_match(generation);
+    }
+    let object = builder.send().await.map_err(|err| {
+        if is_gcs_precondition_failed(&err) {
+            StorageError::policy_rejected("GCS compose precondition failed")
+        } else {
+            gcs_error("compose object", err)
+        }
+    })?;
+    Ok(GcsObjectWrite {
+        etag: non_empty(object.etag),
+        generation: if object.generation > 0 {
+            Some(object.generation.to_string())
+        } else {
+            None
+        },
+        generation_match: if object.generation > 0 {
+            Some(object.generation)
+        } else {
+            None
+        },
+    })
 }
 
 #[derive(Clone)]
@@ -95,6 +221,145 @@ impl GcsJsonControl {
         }
         Ok(())
     }
+
+    async fn compose_object(
+        &self,
+        layout: &GcsKeyLayout,
+        request: ComposeRequest<'_>,
+    ) -> StorageResult<GcsObjectWrite> {
+        let url = format!(
+            "{}/storage/v1/b/{}/o/{}/compose",
+            self.endpoint,
+            encode_uri_component(layout.bucket()),
+            encode_uri_component(request.dest_key)
+        );
+        let mut destination = serde_json::Map::new();
+        if let Some(content_type) = request.content_type {
+            destination.insert("contentType".to_string(), content_type.into());
+        }
+        if !request.metadata.is_empty() {
+            destination.insert(
+                "metadata".to_string(),
+                serde_json::to_value(&request.metadata)
+                    .map_err(|err| gcs_error("encode compose metadata", err))?,
+            );
+        }
+        let source_objects: Vec<serde_json::Value> = request
+            .sources
+            .iter()
+            .map(|source| {
+                let mut entry = serde_json::Map::new();
+                entry.insert("name".to_string(), source.key.clone().into());
+                if let Some(generation) = source.generation {
+                    entry.insert("generation".to_string(), generation.into());
+                }
+                serde_json::Value::Object(entry)
+            })
+            .collect();
+        let body = serde_json::json!({
+            "sourceObjects": source_objects,
+            "destination": serde_json::Value::Object(destination),
+        });
+
+        let mut builder = self.http.post(url).json(&body);
+        if let Some(generation) = request.if_generation_match {
+            builder = builder.query(&[("ifGenerationMatch", generation.to_string())]);
+        }
+        let response = builder
+            .send()
+            .await
+            .map_err(|err| gcs_error("compose object", err))?;
+        let status = response.status();
+        if status.as_u16() == 412 {
+            return Err(StorageError::policy_rejected(
+                "GCS compose precondition failed",
+            ));
+        }
+        if !status.is_success() {
+            return Err(StorageError::backend(format!(
+                "GCS compose object: HTTP {status}"
+            )));
+        }
+        let object: ComposedObject = response
+            .json()
+            .await
+            .map_err(|err| gcs_error("decode composed object", err))?;
+        let generation = object
+            .generation
+            .as_deref()
+            .and_then(|value| value.parse::<i64>().ok())
+            .filter(|generation| *generation > 0);
+        Ok(GcsObjectWrite {
+            etag: object.etag.and_then(non_empty),
+            generation: generation.map(|value| value.to_string()),
+            generation_match: generation,
+        })
+    }
+}
+
+impl GcsJsonControl {
+    async fn get_object_attrs(
+        &self,
+        layout: &GcsKeyLayout,
+        key: &str,
+        marker_key: &str,
+    ) -> StorageResult<Option<GcsObjectAttrs>> {
+        let url = format!(
+            "{}/storage/v1/b/{}/o/{}",
+            self.endpoint,
+            encode_uri_component(layout.bucket()),
+            encode_uri_component(key)
+        );
+        let response = self
+            .http
+            .get(url)
+            .send()
+            .await
+            .map_err(|err| gcs_error("get object", err))?;
+        if response.status().as_u16() == 404 {
+            return Ok(None);
+        }
+        if !response.status().is_success() {
+            return Err(StorageError::backend(format!(
+                "GCS get object: HTTP {}",
+                response.status()
+            )));
+        }
+        let object: FetchedObject = response
+            .json()
+            .await
+            .map_err(|err| gcs_error("decode object metadata", err))?;
+        let generation = object
+            .generation
+            .as_deref()
+            .and_then(|value| value.parse::<i64>().ok())
+            .filter(|generation| *generation > 0);
+        Ok(Some(GcsObjectAttrs {
+            etag: object.etag.and_then(non_empty),
+            generation,
+            owner_session: object
+                .metadata
+                .and_then(|metadata| metadata.get(marker_key).cloned()),
+        }))
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct ComposedObject {
+    #[serde(default)]
+    generation: Option<String>,
+    #[serde(default)]
+    etag: Option<String>,
+}
+
+#[derive(serde::Deserialize)]
+struct FetchedObject {
+    #[serde(default)]
+    generation: Option<String>,
+    #[serde(default)]
+    etag: Option<String>,
+    #[serde(default)]
+    metadata: Option<BTreeMap<String, String>>,
 }
 
 async fn delete_object_with_google_control(

--- a/crates/pocopine-storage-gcs/src/layout.rs
+++ b/crates/pocopine-storage-gcs/src/layout.rs
@@ -82,6 +82,15 @@ impl GcsKeyLayout {
     pub(crate) fn session_bytes_key(&self, session: &UploadSessionId) -> String {
         format!("{}/{}/bytes.tmp", self.internal_prefix, session.as_str())
     }
+
+    /// Key for one native-compose component object.
+    pub(crate) fn session_component_key(&self, session: &UploadSessionId, index: u32) -> String {
+        format!(
+            "{}/{}/components/comp-{index:05}",
+            self.internal_prefix,
+            session.as_str()
+        )
+    }
 }
 
 fn normalize_object_prefix(prefix: String) -> StorageResult<Option<String>> {

--- a/crates/pocopine-storage-gcs/src/state.rs
+++ b/crates/pocopine-storage-gcs/src/state.rs
@@ -19,8 +19,81 @@ pub(crate) struct StoredUploadSession {
     pub(crate) completion_object_key: Option<String>,
     #[serde(default)]
     pub(crate) cleanup_pending: bool,
+    /// Transfer mechanism. Sessions written before native compose support omit
+    /// this field and deserialize as [`NativeUploadState::LegacyProxy`], so
+    /// in-flight uploads from an older build keep the staged-object rewrite path.
+    #[serde(default)]
+    pub(crate) native: NativeUploadState,
     #[serde(skip)]
     pub(crate) meta_generation: Option<i64>,
+}
+
+/// Backend transfer mechanism for an upload session.
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum NativeUploadState {
+    /// Legacy staged-object rewrite (download → extend → re-upload per append).
+    #[default]
+    LegacyProxy,
+    /// Native compose: each flushed block is written once as a component object
+    /// and the final object is assembled with a single `ComposeObject`. Only an
+    /// unflushed tail (smaller than one component) is buffered, inline in this
+    /// metadata so the tail and bookkeeping persist in one atomic write.
+    Compose(GcsComposeState),
+}
+
+/// Compose bookkeeping for one session.
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+pub(crate) struct GcsComposeState {
+    /// Component objects already written, in order.
+    #[serde(default)]
+    pub(crate) components: Vec<GcsComponent>,
+    /// Next component index to assign.
+    #[serde(default)]
+    pub(crate) next_index: u32,
+    /// Bytes received but not yet flushed to a component (always < one component,
+    /// except the final remainder at completion). Base64 inline in the metadata.
+    #[serde(
+        default,
+        with = "pocopine_codec::base64_bytes",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub(crate) pending_tail: Vec<u8>,
+}
+
+/// One written component object.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub(crate) struct GcsComponent {
+    pub(crate) key: String,
+    pub(crate) size: u64,
+    #[serde(default)]
+    pub(crate) generation: Option<i64>,
+}
+
+impl NativeUploadState {
+    pub(crate) fn compose(&self) -> Option<&GcsComposeState> {
+        match self {
+            NativeUploadState::Compose(state) => Some(state),
+            NativeUploadState::LegacyProxy => None,
+        }
+    }
+
+    pub(crate) fn compose_mut(&mut self) -> Option<&mut GcsComposeState> {
+        match self {
+            NativeUploadState::Compose(state) => Some(state),
+            NativeUploadState::LegacyProxy => None,
+        }
+    }
+}
+
+impl GcsComposeState {
+    pub(crate) fn flushed_len(&self) -> u64 {
+        self.components.iter().map(|component| component.size).sum()
+    }
+
+    pub(crate) fn committed_len(&self) -> u64 {
+        self.flushed_len() + self.pending_tail.len() as u64
+    }
 }
 
 pub(crate) struct GcsObjectBytes {
@@ -48,6 +121,14 @@ pub(crate) struct GcsObjectMetadata {
     pub(crate) etag: Option<String>,
     pub(crate) generation: Option<String>,
     pub(crate) generation_match: Option<i64>,
+}
+
+/// Full object attributes including custom metadata (fetched via the control
+/// layer, since the streaming read only exposes lightweight highlights).
+pub(crate) struct GcsObjectAttrs {
+    pub(crate) etag: Option<String>,
+    pub(crate) generation: Option<i64>,
+    pub(crate) owner_session: Option<String>,
 }
 
 pub(crate) struct GcsObjectWrite {

--- a/crates/pocopine-storage-gcs/src/storage.rs
+++ b/crates/pocopine-storage-gcs/src/storage.rs
@@ -2,22 +2,27 @@ use bytes::Bytes;
 use google_cloud_storage::client::{Storage, StorageControl};
 use pocopine_storage::backend_common::{
     checked_new_offset, ensure_open, ensure_owner, ensure_size_limit,
-    ensure_upload_length_can_be_set, expires_at, selected_strategy, UploadSessionLockCleanup,
-    UploadSessionLockRegistry,
+    ensure_upload_length_can_be_set, expires_at, select_upload_mode, UploadConcurrencyRegistry,
+    UploadSessionLockCleanup, UploadSessionLockRegistry,
 };
-use pocopine_storage::checksum::{ensure_supported_checksum_policy, validate_complete_checksum};
+use pocopine_storage::checksum::{
+    checksum_algorithm_to_compute, ensure_supported_checksum_policy, precheck_checksum,
+    validate_complete_checksum, validate_complete_checksum_precomputed, StreamingChecksum,
+};
 use pocopine_storage::{
-    CompleteUpload, InitiateUpload, ObjectChecksum, ObjectRef, StorageActor, StorageBackend,
-    StorageBoxFuture, StorageContext, StorageError, StorageResult, TransferPlan, UploadSession,
-    UploadSessionId, UploadSessionStatus, UploadStrategy,
+    BackendCapabilities, ChecksumAlgorithm, ChecksumPolicy, CompleteUpload, InitiateUpload,
+    ObjectChecksum, ObjectRef, StorageActor, StorageBackend, StorageBoxFuture, StorageContext,
+    StorageError, StorageResult, TransferPlan, UploadBody, UploadSession, UploadSessionId,
+    UploadSessionStatus, UploadStrategy,
 };
+use time::OffsetDateTime;
 use uuid::Uuid;
 
-use crate::control::{GcsControl, GcsJsonControl};
+use crate::control::{ComposeRequest, ComposeSource, GcsControl, GcsJsonControl};
 use crate::layout::{GcsKeyLayout, DEFAULT_INTERNAL_PREFIX};
 use crate::state::{
-    decode_session_object, AbortSessionRead, GcsObjectBytes, GcsObjectMetadata, GcsObjectWrite,
-    StoredUploadSession,
+    decode_session_object, AbortSessionRead, GcsComponent, GcsObjectAttrs, GcsObjectBytes,
+    GcsObjectMetadata, GcsObjectWrite, NativeUploadState, StoredUploadSession,
 };
 use crate::util::{
     bytes_match_at, ensure_completable, gcs_error, is_gcs_not_found, is_gcs_precondition_failed,
@@ -27,6 +32,30 @@ use crate::util::{
 const DEFAULT_BACKEND_NAME: &str = "gcs";
 const DEFAULT_MAX_PROXY_UPLOAD_BYTES: u64 = 64 * 1024 * 1024;
 const MAX_SESSION_METADATA_BYTES: u64 = 256 * 1024;
+
+/// GCS allows up to 32 source objects per `ComposeObject`. Components are sized
+/// so their count never exceeds this, keeping completion to a single compose.
+const GCS_MAX_COMPOSE_SOURCES: u64 = 32;
+
+/// Floor for a coalesced component, to avoid many tiny component objects.
+const MIN_COMPONENT_SIZE: u64 = 1024 * 1024;
+
+/// Object custom-metadata key stamping the owning upload session onto the final
+/// composed object, so a retry can recognize its own object after a crash.
+const SESSION_OWNER_META_KEY: &str = "pocopine-upload-session";
+
+/// Component size for a session whose maximum object size is `max_bytes`.
+///
+/// Scaled (rounded to a whole MiB) so component count stays within
+/// [`GCS_MAX_COMPOSE_SOURCES`]; never below [`MIN_COMPONENT_SIZE`]. For the
+/// default 64 MiB cap this is 2 MiB.
+fn component_size_for(max_bytes: u64) -> u64 {
+    let by_count = max_bytes
+        .div_ceil(GCS_MAX_COMPOSE_SOURCES)
+        .div_ceil(MIN_COMPONENT_SIZE)
+        * MIN_COMPONENT_SIZE;
+    by_count.max(MIN_COMPONENT_SIZE)
+}
 
 /// Storage backend backed by Google Cloud Storage.
 ///
@@ -41,6 +70,7 @@ pub struct GcsStorageBackend {
     layout: GcsKeyLayout,
     max_proxy_upload_bytes: u64,
     session_locks: UploadSessionLockRegistry,
+    part_concurrency: UploadConcurrencyRegistry,
 }
 
 impl std::fmt::Debug for GcsStorageBackend {
@@ -97,6 +127,7 @@ impl GcsStorageBackend {
             layout: GcsKeyLayout::new(bucket.into(), None, DEFAULT_INTERNAL_PREFIX.to_string())?,
             max_proxy_upload_bytes: DEFAULT_MAX_PROXY_UPLOAD_BYTES,
             session_locks: UploadSessionLockRegistry::new(),
+            part_concurrency: UploadConcurrencyRegistry::new(),
         })
     }
 
@@ -114,6 +145,7 @@ impl GcsStorageBackend {
             layout: GcsKeyLayout::new(bucket.into(), None, DEFAULT_INTERNAL_PREFIX.to_string())?,
             max_proxy_upload_bytes: DEFAULT_MAX_PROXY_UPLOAD_BYTES,
             session_locks: UploadSessionLockRegistry::new(),
+            part_concurrency: UploadConcurrencyRegistry::new(),
         })
     }
 
@@ -204,8 +236,19 @@ impl GcsStorageBackend {
         session: &UploadSessionId,
     ) -> StorageResult<GcsObjectBytes> {
         let key = self.layout.session_meta_key(session);
-        self.get_object_bytes_with_limit(&key, MAX_SESSION_METADATA_BYTES)
+        self.get_object_bytes_with_limit(&key, self.session_metadata_read_limit())
             .await
+    }
+
+    /// Read cap for `session.json`. Native compose sessions buffer their tail
+    /// inline (base64), so the cap must accommodate one component plus the
+    /// fixed metadata, well above the bare [`MAX_SESSION_METADATA_BYTES`] used
+    /// for the non-tail fields. Derived from the backend's absolute size cap so
+    /// it is an upper bound for every session's `component_size_for(max_bytes)`.
+    fn session_metadata_read_limit(&self) -> u64 {
+        component_size_for(self.max_proxy_upload_bytes)
+            .saturating_mul(2)
+            .saturating_add(MAX_SESSION_METADATA_BYTES)
     }
 
     async fn create_session(
@@ -406,6 +449,14 @@ impl GcsStorageBackend {
         })
     }
 
+    /// Fetch full object attributes (including the ownership marker in custom
+    /// metadata) via the control layer. Returns `None` if the object is absent.
+    async fn get_object_attrs(&self, key: &str) -> StorageResult<Option<GcsObjectAttrs>> {
+        self.control
+            .get_object_attrs(&self.layout, key, SESSION_OWNER_META_KEY)
+            .await
+    }
+
     async fn put_object_bytes(
         &self,
         key: &str,
@@ -500,6 +551,196 @@ impl GcsStorageBackend {
         }))
     }
 
+    // --- native compose helpers ----------------------------------------------
+
+    /// Write one component object.
+    ///
+    /// Uses a create-only precondition (`if_generation_match: 0`) so a concurrent
+    /// or retried attempt at the same index can never clobber a component another
+    /// worker already recorded. A component's content is deterministic for its
+    /// index (it covers a fixed, append-only byte range), so an already-present
+    /// object is correct — adopt its generation instead of overwriting it.
+    async fn write_component(
+        &self,
+        session: &UploadSessionId,
+        index: u32,
+        bytes: Bytes,
+    ) -> StorageResult<GcsComponent> {
+        let key = self.layout.session_component_key(session, index);
+        let size = bytes.len() as u64;
+        let generation = match self
+            .put_object_bytes(
+                &key,
+                bytes.clone(),
+                Some("application/octet-stream"),
+                Some(0),
+            )
+            .await
+        {
+            Ok(written) => written.generation_match,
+            Err(StorageError::PolicyRejected { .. }) => {
+                // A component already exists at this index (a retry or a
+                // concurrent worker). Adopt it only if its bytes match what this
+                // append intends to write; otherwise the index is being reused
+                // for different content and must not be silently accepted.
+                let existing = match self.get_object_bytes_with_limit(&key, size).await {
+                    Ok(existing) => existing,
+                    // The conflicting component was removed between the create-only
+                    // PUT and this read (a concurrent race on an internal key). This
+                    // is a write conflict, not a missing user session — don't leak a
+                    // 404 for the session.
+                    Err(StorageError::UnknownUploadSession { .. }) => {
+                        return Err(StorageError::conflict(
+                            "GCS upload component changed during a concurrent write",
+                        ))
+                    }
+                    Err(err) => return Err(err),
+                };
+                if existing.truncated
+                    || existing.bytes.len() as u64 != size
+                    || existing.bytes.as_slice() != bytes.as_ref()
+                {
+                    return Err(StorageError::conflict(
+                        "GCS upload component already exists with different bytes",
+                    ));
+                }
+                existing.generation_match
+            }
+            Err(err) => return Err(err),
+        };
+        Ok(GcsComponent {
+            key,
+            size,
+            generation,
+        })
+    }
+
+    /// Best-effort deletion of every component object for a session.
+    ///
+    /// Component indices are contiguous from 0 (sequential, append-only), so this
+    /// also removes components written just before a crash but not yet recorded
+    /// in the session metadata. Stops at the first missing index.
+    async fn delete_component_chain(&self, session: &UploadSessionId) {
+        let mut index = 0u32;
+        loop {
+            let key = self.layout.session_component_key(session, index);
+            match self.delete_object(&key).await {
+                Ok(()) => index += 1,
+                Err(_) => break,
+            }
+        }
+    }
+
+    /// Best-effort deletion of a fixed component-index range `0..count`,
+    /// tolerating gaps. By-number multipart parts can arrive out of order, so a
+    /// missing index does not mean later ones are absent — unlike the contiguous
+    /// [`Self::delete_component_chain`].
+    async fn delete_component_range(&self, session: &UploadSessionId, count: u32) {
+        for index in 0..count {
+            let key = self.layout.session_component_key(session, index);
+            let _ = self.delete_object_if_exists(&key).await;
+        }
+    }
+
+    /// Return a session that reached `Completing` back to `Open` after a
+    /// recoverable completion failure, so the caller can retry or abort from a
+    /// valid state instead of being stranded. Best-effort.
+    async fn reopen_session(&self, session: &UploadSessionId, stored: &mut StoredUploadSession) {
+        stored.public.status = UploadSessionStatus::Open;
+        stored.completion_object_key = None;
+        let _ = self.write_session(session, stored).await;
+    }
+
+    /// Reopen a failed completion ONLY when no live object owned by this session
+    /// exists at the destination.
+    ///
+    /// If compose already produced our object (e.g. a later checksum-stream error,
+    /// or a lost compose response), reopening would let a subsequent append change
+    /// the committed bytes while a retry still adopts the already-live object —
+    /// serving stale data. In that case the session stays `Completing` and a retry
+    /// adopts-and-finishes idempotently. Reopening is safe only when the object is
+    /// absent (compose never landed) or foreign (never ours to serve).
+    async fn reopen_if_object_absent(
+        &self,
+        session: &UploadSessionId,
+        stored: &mut StoredUploadSession,
+        object_key: &str,
+    ) {
+        // Reopen only when the HEAD *definitively* shows the object is absent or
+        // foreign. An indeterminate lookup (transient/backend error) must keep the
+        // session `Completing`: a live owned object might exist, and reopening
+        // would let a later append change the bytes a retry then adopts.
+        let absent_or_foreign = match self.get_object_attrs(object_key).await {
+            Ok(None) => true,
+            Ok(Some(attrs)) => attrs.owner_session.as_deref() != Some(session.as_str()),
+            Err(_) => false,
+        };
+        if absent_or_foreign {
+            self.reopen_session(session, stored).await;
+        }
+    }
+
+    /// Assemble the recorded components into the destination object, stamping the
+    /// owning session so a crashed retry can recognize its own object.
+    async fn compose_components(
+        &self,
+        session: &UploadSessionId,
+        stored: &StoredUploadSession,
+        object_key: &str,
+        if_generation_match: Option<i64>,
+    ) -> StorageResult<GcsObjectWrite> {
+        let state = stored.native.compose().expect("compose state");
+        let sources = state
+            .components
+            .iter()
+            .map(|component| ComposeSource {
+                key: component.key.clone(),
+                generation: component.generation,
+            })
+            .collect();
+        let mut metadata = std::collections::BTreeMap::new();
+        metadata.insert(
+            SESSION_OWNER_META_KEY.to_string(),
+            session.as_str().to_string(),
+        );
+        self.control
+            .compose_object(
+                &self.layout,
+                ComposeRequest {
+                    dest_key: object_key,
+                    content_type: stored.public.content_type.as_deref(),
+                    metadata,
+                    sources,
+                    if_generation_match,
+                },
+            )
+            .await
+    }
+
+    /// Stream the stored object through `algorithm` without buffering it.
+    async fn stream_object_checksum(
+        &self,
+        key: &str,
+        algorithm: ChecksumAlgorithm,
+    ) -> StorageResult<ObjectChecksum> {
+        let mut response = self
+            .storage
+            .read_object(self.layout.bucket_resource(), key)
+            .send()
+            .await
+            .map_err(|err| gcs_error("read object for checksum", err))?;
+        let mut hasher = StreamingChecksum::new(algorithm);
+        while let Some(chunk) = response
+            .next()
+            .await
+            .transpose()
+            .map_err(|err| gcs_error("read object body for checksum", err))?
+        {
+            hasher.update(&chunk);
+        }
+        Ok(hasher.finalize())
+    }
+
     async fn delete_object(&self, key: &str) -> StorageResult<()> {
         self.control.delete_object(&self.layout, key).await
     }
@@ -574,11 +815,701 @@ impl GcsStorageBackend {
             metadata,
         }
     }
+
+    // --- native compose upload flow -------------------------------------------
+
+    async fn append_compose(
+        &self,
+        session: &UploadSessionId,
+        mut stored: StoredUploadSession,
+        offset: u64,
+        bytes: Bytes,
+    ) -> StorageResult<UploadSession> {
+        // Copy the buffered tail; it stays durable in `stored` until the single
+        // atomic session write at the end (so a crash mid-append leaves the
+        // durable metadata unchanged and the client re-sends from the old offset).
+        let (flushed, tail) = {
+            let state = stored.native.compose().expect("compose state");
+            (state.flushed_len(), state.pending_tail.clone())
+        };
+        let expected = flushed + tail.len() as u64;
+        if expected != offset {
+            tracing::debug!(
+                target: "pocopine.log",
+                event_name = "pocopine.storage.offset_mismatch",
+                session = %session,
+                expected,
+                provided = offset,
+            );
+            return Err(StorageError::offset_mismatch(expected, offset));
+        }
+        let new_offset = checked_new_offset(offset, bytes.len())?;
+        ensure_size_limit(stored.max_bytes, stored.public.size, new_offset)?;
+        if bytes.is_empty() {
+            return Ok(stored.public);
+        }
+
+        let combined: Bytes = if tail.is_empty() {
+            bytes
+        } else {
+            let mut combined = tail;
+            combined.extend_from_slice(&bytes);
+            Bytes::from(combined)
+        };
+
+        // Flush full-size components (each written once); the remainder is the
+        // new tail. Component size keeps the count within the single-compose cap.
+        let component_size = component_size_for(stored.max_bytes) as usize;
+        let mut pos = 0usize;
+        while combined.len() - pos >= component_size {
+            let index = stored.native.compose().expect("compose state").next_index;
+            let part = combined.slice(pos..pos + component_size);
+            let component = self.write_component(session, index, part).await?;
+            if let Some(state) = stored.native.compose_mut() {
+                state.components.push(component);
+                state.next_index = index + 1;
+            }
+            pos += component_size;
+        }
+        if let Some(state) = stored.native.compose_mut() {
+            state.pending_tail = combined.slice(pos..).to_vec();
+        }
+        stored.public.next_offset = Some(new_offset);
+        self.write_session(session, &mut stored).await?;
+        Ok(stored.public)
+    }
+
+    async fn complete_compose(
+        &self,
+        session: &UploadSessionId,
+        mut stored: StoredUploadSession,
+        provided_checksum: Option<ObjectChecksum>,
+    ) -> StorageResult<ObjectRef> {
+        let total = stored.public.next_offset.unwrap_or(0);
+        if let Some(expected) = stored.public.size {
+            if total != expected {
+                return Err(StorageError::policy_rejected(format!(
+                    "upload is incomplete: expected {expected} bytes, got {total}"
+                )));
+            }
+        }
+        ensure_size_limit(stored.max_bytes, stored.public.size, total)?;
+        // Reject a missing-required / disallowed-algorithm checksum before any
+        // finalize work, while the session is still resumable.
+        precheck_checksum(&stored.checksum_policy, provided_checksum.as_ref())?;
+
+        let object_key = self.layout.object_key(stored.storage_key.key.as_str());
+        let has_components = !stored
+            .native
+            .compose()
+            .expect("compose state")
+            .components
+            .is_empty();
+
+        let (written, checksum) = if !has_components {
+            // Whole object fits in the tail (or is empty): a single direct PUT,
+            // atomic and collision-guarded by `put_completed_object`. The checksum
+            // is validated before the write, so a bad checksum leaves the session
+            // open and resumable.
+            let tail = stored
+                .native
+                .compose()
+                .expect("compose state")
+                .pending_tail
+                .clone();
+            let checksum =
+                validate_complete_checksum(&stored.checksum_policy, &tail, provided_checksum)?;
+            let written = self
+                .put_completed_object(
+                    &object_key,
+                    Bytes::from(tail),
+                    stored.public.content_type.as_deref(),
+                )
+                .await?;
+            (written, checksum)
+        } else {
+            // Finalize via components/compose. Any failure after the session is
+            // marked `Completing` reopens it so the owner can retry or abort
+            // rather than be stranded (the reopen is a no-op while still `Open`).
+            match self
+                .complete_with_components(session, &mut stored, &object_key, provided_checksum)
+                .await
+            {
+                Ok(pair) => pair,
+                Err(err) => {
+                    self.reopen_if_object_absent(session, &mut stored, &object_key)
+                        .await;
+                    return Err(err);
+                }
+            }
+        };
+
+        let object = self.object_ref(&stored, total, written, checksum);
+        stored.public.status = UploadSessionStatus::Complete;
+        stored.public.next_offset = Some(total);
+        stored.object = Some(object.clone());
+        if let Some(state) = stored.native.compose_mut() {
+            state.pending_tail = Vec::new();
+        }
+        self.write_session(session, &mut stored).await?;
+        // Component objects are temporary; remove them now the final object is
+        // live (the compose copied their bytes into it).
+        self.delete_component_chain(session).await;
+        Ok(object)
+    }
+
+    /// Finalize a session that has flushed components. The caller wraps this so
+    /// any error reopens the (possibly `Completing`) session.
+    async fn complete_with_components(
+        &self,
+        session: &UploadSessionId,
+        stored: &mut StoredUploadSession,
+        object_key: &str,
+        provided_checksum: Option<ObjectChecksum>,
+    ) -> StorageResult<(GcsObjectWrite, Option<ObjectChecksum>)> {
+        let total = stored.public.next_offset.unwrap_or(0);
+        // HEAD on every attempt: adopt our own already-composed object (matched by
+        // the ownership marker), reject a foreign one. Works on stores that ignore
+        // compose preconditions; `if_generation_match: 0` closes the TOCTOU window
+        // on real GCS.
+        let written = if let Some(attrs) = self.get_object_attrs(object_key).await? {
+            if attrs.owner_session.as_deref() == Some(session.as_str()) {
+                GcsObjectWrite {
+                    etag: attrs.etag,
+                    generation: attrs.generation.map(|generation| generation.to_string()),
+                    generation_match: attrs.generation,
+                }
+            } else {
+                self.delete_component_chain(session).await;
+                return Err(StorageError::policy_rejected(format!(
+                    "GCS object key already exists: {object_key}"
+                )));
+            }
+        } else {
+            if stored.public.status == UploadSessionStatus::Open
+                || stored.public.next_offset != Some(total)
+                || stored.completion_object_key.as_deref() != Some(object_key)
+            {
+                stored.public.status = UploadSessionStatus::Completing;
+                stored.public.next_offset = Some(total);
+                stored.completion_object_key = Some(object_key.to_string());
+                self.write_session(session, stored).await?;
+            }
+            // Flush the final remainder as the last component, then compose.
+            let tail = stored
+                .native
+                .compose()
+                .expect("compose state")
+                .pending_tail
+                .clone();
+            if !tail.is_empty() {
+                let index = stored.native.compose().expect("compose state").next_index;
+                let component = self
+                    .write_component(session, index, Bytes::from(tail))
+                    .await?;
+                if let Some(state) = stored.native.compose_mut() {
+                    state.components.push(component);
+                    state.next_index = index + 1;
+                    state.pending_tail = Vec::new();
+                }
+                self.write_session(session, stored).await?;
+            }
+            match self
+                .compose_components(session, stored, object_key, Some(0))
+                .await
+            {
+                Ok(written) => written,
+                Err(StorageError::PolicyRejected { .. }) => {
+                    // An object appeared at the key during completion; adopt it
+                    // only if it is ours, otherwise clean up and reject.
+                    match self.get_object_attrs(object_key).await? {
+                        Some(attrs) if attrs.owner_session.as_deref() == Some(session.as_str()) => {
+                            GcsObjectWrite {
+                                etag: attrs.etag,
+                                generation: attrs
+                                    .generation
+                                    .map(|generation| generation.to_string()),
+                                generation_match: attrs.generation,
+                            }
+                        }
+                        _ => {
+                            self.delete_component_chain(session).await;
+                            return Err(StorageError::policy_rejected(format!(
+                                "GCS object key already exists: {object_key}"
+                            )));
+                        }
+                    }
+                }
+                Err(err) => return Err(err),
+            }
+        };
+
+        let checksum = self
+            .verify_object_checksum(object_key, &stored.checksum_policy, provided_checksum)
+            .await?;
+        Ok((written, checksum))
+    }
+
+    /// Verify the composed object against the checksum policy by streaming it
+    /// back (only when a checksum is required/supplied — the default `None`
+    /// policy never reads the object). On mismatch the live object is deleted so
+    /// a bad upload is never observable; a delete failure is surfaced, since a
+    /// checksum-invalid live object is worse than the error.
+    async fn verify_object_checksum(
+        &self,
+        object_key: &str,
+        policy: &ChecksumPolicy,
+        provided: Option<ObjectChecksum>,
+    ) -> StorageResult<Option<ObjectChecksum>> {
+        match checksum_algorithm_to_compute(policy, provided.as_ref()) {
+            Some(algorithm) => {
+                let computed = self.stream_object_checksum(object_key, algorithm).await?;
+                match validate_complete_checksum_precomputed(policy, Some(computed), provided) {
+                    Ok(checksum) => Ok(checksum),
+                    Err(err) => {
+                        self.delete_object(object_key).await.map_err(|delete_err| {
+                            tracing::error!(
+                                target: "pocopine.log",
+                                event_name = "pocopine.storage.gcs_invalid_object_cleanup_failed",
+                                object_key = %object_key,
+                                checksum_error = %err,
+                                delete_error = %delete_err,
+                            );
+                            delete_err
+                        })?;
+                        Err(err)
+                    }
+                }
+            }
+            None => validate_complete_checksum_precomputed(policy, None, provided),
+        }
+    }
+
+    // --- native compose by-number (server-mediated multipart) -----------------
+
+    /// Probe the `count` component objects of a by-number multipart upload
+    /// (indices `0..count`) for existence, returning each as a compose source
+    /// (key + generation) in order. A missing component means the corresponding
+    /// part was never uploaded, so the upload is incomplete.
+    ///
+    /// Sizes are deliberately not summed here: the declared upload length is the
+    /// authoritative total (some emulators report a zero object size on metadata
+    /// reads), the same way the sequential path trusts its committed offset.
+    async fn probe_by_number_components(
+        &self,
+        session: &UploadSessionId,
+        count: u32,
+    ) -> StorageResult<Vec<ComposeSource>> {
+        let mut sources = Vec::with_capacity(count as usize);
+        for index in 0..count {
+            let key = self.layout.session_component_key(session, index);
+            match self.get_object_metadata(&key).await {
+                Ok(metadata) => sources.push(ComposeSource {
+                    key,
+                    generation: metadata.generation_match,
+                }),
+                Err(StorageError::UnknownUploadSession { .. }) => {
+                    return Err(StorageError::policy_rejected(format!(
+                        "upload is incomplete: missing multipart part {}",
+                        index + 1
+                    )));
+                }
+                Err(err) => return Err(err),
+            }
+        }
+        Ok(sources)
+    }
+
+    /// Write a zero-byte completed object for an empty multipart session, guarding
+    /// ownership by the session marker rather than `put_completed_object`'s
+    /// byte-match fast path (which would wrongly adopt a *foreign* empty object).
+    /// Adopts our own object idempotently, rejects a foreign one, and stamps the
+    /// owner marker (create-only) so a retry can adopt it after a crash.
+    async fn put_empty_owned_object(
+        &self,
+        object_key: &str,
+        session: &UploadSessionId,
+        content_type: Option<&str>,
+    ) -> StorageResult<GcsObjectWrite> {
+        if let Some(attrs) = self.get_object_attrs(object_key).await? {
+            if attrs.owner_session.as_deref() == Some(session.as_str()) {
+                return Ok(GcsObjectWrite {
+                    etag: attrs.etag,
+                    generation: attrs.generation.map(|generation| generation.to_string()),
+                    generation_match: attrs.generation,
+                });
+            }
+            return Err(StorageError::policy_rejected(format!(
+                "GCS object key already exists: {object_key}"
+            )));
+        }
+        let mut request = self
+            .storage
+            .write_object(self.layout.bucket_resource(), object_key, Bytes::new())
+            .set_if_generation_match(0)
+            .set_metadata([(
+                SESSION_OWNER_META_KEY.to_string(),
+                session.as_str().to_string(),
+            )]);
+        if let Some(content_type) = content_type {
+            request = request.set_content_type(content_type);
+        }
+        match request.send_unbuffered().await {
+            Ok(object) => Ok(GcsObjectWrite {
+                etag: non_empty(object.etag),
+                generation: if object.generation > 0 {
+                    Some(object.generation.to_string())
+                } else {
+                    None
+                },
+                generation_match: positive_generation(object.generation),
+            }),
+            Err(err) if is_gcs_precondition_failed(&err) => {
+                // Lost the create race. Adopt if our own session won (idempotent
+                // across processes); otherwise it is a foreign collision.
+                match self.get_object_attrs(object_key).await? {
+                    Some(attrs) if attrs.owner_session.as_deref() == Some(session.as_str()) => {
+                        Ok(GcsObjectWrite {
+                            etag: attrs.etag,
+                            generation: attrs.generation.map(|generation| generation.to_string()),
+                            generation_match: attrs.generation,
+                        })
+                    }
+                    _ => Err(StorageError::policy_rejected(format!(
+                        "GCS object key already exists: {object_key}"
+                    ))),
+                }
+            }
+            Err(err) => Err(gcs_error("write empty object", err)),
+        }
+    }
+
+    /// Assemble a by-number multipart upload (the [`StorageBackend::upload_part`]
+    /// path). Components live as objects keyed by part number, not in the session
+    /// state, so they are probed from the provider here — making concurrent,
+    /// out-of-order part uploads race-free.
+    async fn complete_compose_by_number(
+        &self,
+        session: &UploadSessionId,
+        mut stored: StoredUploadSession,
+        provided_checksum: Option<ObjectChecksum>,
+    ) -> StorageResult<ObjectRef> {
+        precheck_checksum(&stored.checksum_policy, provided_checksum.as_ref())?;
+        // A by-number upload must declare its length: parts arrive concurrently
+        // and `upload_part` writes components without the session lock, so without
+        // a declared total a `complete` racing an in-flight part would compose
+        // only the components present so far and publish a truncated object.
+        let expected_size = stored.public.size.ok_or_else(|| {
+            StorageError::policy_rejected(
+                "multipart upload requires a declared length before completion",
+            )
+        })?;
+        let object_key = self.layout.object_key(stored.storage_key.key.as_str());
+        let component_size = component_size_for(stored.max_bytes);
+        let count = if expected_size == 0 {
+            0
+        } else {
+            expected_size.div_ceil(component_size) as u32
+        };
+
+        if count == 0 {
+            // Empty object: a single direct PUT (GCS `ComposeObject` requires at
+            // least one source). HEAD-guarded by the ownership marker so a foreign
+            // empty object at the key is rejected, not adopted.
+            let checksum =
+                validate_complete_checksum(&stored.checksum_policy, &[], provided_checksum)?;
+            // Fence like the compose path: persist `Completing` before publishing
+            // so a concurrent abort is refused and a crash after the PUT leaves a
+            // recoverable session (a re-complete adopts the owner-stamped object)
+            // rather than an orphaned visible object an abort would leave behind.
+            if stored.public.status == UploadSessionStatus::Open
+                || stored.completion_object_key.as_deref() != Some(object_key.as_str())
+            {
+                stored.public.status = UploadSessionStatus::Completing;
+                stored.public.next_offset = Some(0);
+                stored.completion_object_key = Some(object_key.clone());
+                self.write_session(session, &mut stored).await?;
+            }
+            return match self
+                .put_empty_owned_object(&object_key, session, stored.public.content_type.as_deref())
+                .await
+            {
+                Ok(written) => {
+                    self.finalize_compose(session, stored, 0, written, checksum)
+                        .await
+                }
+                Err(err) => {
+                    self.reopen_if_object_absent(session, &mut stored, &object_key)
+                        .await;
+                    Err(err)
+                }
+            };
+        }
+
+        let sources = self.probe_by_number_components(session, count).await?;
+        let total = expected_size;
+        ensure_size_limit(stored.max_bytes, stored.public.size, total)?;
+
+        let (written, checksum) = match self
+            .compose_by_number(
+                &mut stored,
+                session,
+                &object_key,
+                sources,
+                total,
+                provided_checksum,
+            )
+            .await
+        {
+            Ok(pair) => pair,
+            Err(err) => {
+                self.reopen_if_object_absent(session, &mut stored, &object_key)
+                    .await;
+                return Err(err);
+            }
+        };
+        self.finalize_compose(session, stored, total, written, checksum)
+            .await
+    }
+
+    /// Compose the probed component sources into the destination object,
+    /// idempotently adopting our own already-composed object and rejecting a
+    /// foreign one.
+    async fn compose_by_number(
+        &self,
+        stored: &mut StoredUploadSession,
+        session: &UploadSessionId,
+        object_key: &str,
+        sources: Vec<ComposeSource>,
+        total: u64,
+        provided_checksum: Option<ObjectChecksum>,
+    ) -> StorageResult<(GcsObjectWrite, Option<ObjectChecksum>)> {
+        let written = if let Some(attrs) = self.get_object_attrs(object_key).await? {
+            if attrs.owner_session.as_deref() == Some(session.as_str()) {
+                GcsObjectWrite {
+                    etag: attrs.etag,
+                    generation: attrs.generation.map(|generation| generation.to_string()),
+                    generation_match: attrs.generation,
+                }
+            } else {
+                return Err(StorageError::policy_rejected(format!(
+                    "GCS object key already exists: {object_key}"
+                )));
+            }
+        } else {
+            if stored.public.status == UploadSessionStatus::Open
+                || stored.completion_object_key.as_deref() != Some(object_key)
+            {
+                stored.public.status = UploadSessionStatus::Completing;
+                stored.public.next_offset = Some(total);
+                stored.completion_object_key = Some(object_key.to_string());
+                self.write_session(session, stored).await?;
+            }
+            let mut metadata = std::collections::BTreeMap::new();
+            metadata.insert(
+                SESSION_OWNER_META_KEY.to_string(),
+                session.as_str().to_string(),
+            );
+            match self
+                .control
+                .compose_object(
+                    &self.layout,
+                    ComposeRequest {
+                        dest_key: object_key,
+                        content_type: stored.public.content_type.as_deref(),
+                        metadata,
+                        sources,
+                        if_generation_match: Some(0),
+                    },
+                )
+                .await
+            {
+                Ok(written) => written,
+                Err(StorageError::PolicyRejected { .. }) => {
+                    match self.get_object_attrs(object_key).await? {
+                        Some(attrs) if attrs.owner_session.as_deref() == Some(session.as_str()) => {
+                            GcsObjectWrite {
+                                etag: attrs.etag,
+                                generation: attrs
+                                    .generation
+                                    .map(|generation| generation.to_string()),
+                                generation_match: attrs.generation,
+                            }
+                        }
+                        _ => {
+                            return Err(StorageError::policy_rejected(format!(
+                                "GCS object key already exists: {object_key}"
+                            )))
+                        }
+                    }
+                }
+                Err(err) => return Err(err),
+            }
+        };
+        let checksum = self
+            .verify_object_checksum(object_key, &stored.checksum_policy, provided_checksum)
+            .await?;
+        Ok((written, checksum))
+    }
+
+    /// Finalize a by-number multipart session: record the object, persist, and
+    /// remove the now-redundant component objects (the compose copied them).
+    async fn finalize_compose(
+        &self,
+        session: &UploadSessionId,
+        mut stored: StoredUploadSession,
+        total: u64,
+        written: GcsObjectWrite,
+        checksum: Option<ObjectChecksum>,
+    ) -> StorageResult<ObjectRef> {
+        let object = self.object_ref(&stored, total, written, checksum);
+        stored.public.status = UploadSessionStatus::Complete;
+        stored.public.next_offset = Some(total);
+        stored.object = Some(object.clone());
+        if let Some(state) = stored.native.compose_mut() {
+            state.pending_tail = Vec::new();
+        }
+        self.write_session(session, &mut stored).await?;
+        self.delete_component_chain(session).await;
+        Ok(object)
+    }
+
+    // --- legacy staged-object rewrite flow (pre-compose sessions) -------------
+
+    async fn append_legacy(
+        &self,
+        session: &UploadSessionId,
+        mut stored: StoredUploadSession,
+        offset: u64,
+        bytes: Bytes,
+    ) -> StorageResult<UploadSession> {
+        let expected = stored.public.next_offset.unwrap_or(0);
+        let new_offset = checked_new_offset(offset, bytes.len())?;
+        let read_limit = expected
+            .max(new_offset)
+            .checked_add(1)
+            .ok_or_else(|| StorageError::policy_rejected("upload byte offset overflowed"))?;
+        let mut staged_object = self.get_staged_bytes(session, read_limit).await?;
+        let staged_len = staged_object.bytes.len() as u64;
+        if expected != offset {
+            if new_offset == expected
+                && bytes_match_at(&staged_object.bytes, offset, bytes.as_ref())?
+            {
+                return Ok(stored.public);
+            }
+            tracing::debug!(
+                target: "pocopine.log",
+                event_name = "pocopine.storage.offset_mismatch",
+                session = %session,
+                expected,
+                provided = offset,
+            );
+            return Err(StorageError::offset_mismatch(expected, offset));
+        }
+        if staged_len > expected {
+            if staged_len == new_offset
+                && bytes_match_at(&staged_object.bytes, expected, bytes.as_ref())?
+            {
+                stored.public.next_offset = Some(new_offset);
+                self.write_session(session, &mut stored).await?;
+                return Ok(stored.public);
+            }
+            tracing::warn!(
+                target: "pocopine.log",
+                event_name = "pocopine.storage.gcs_staged_bytes_truncated",
+                session = %session,
+                actual = staged_len,
+                trusted = expected,
+            );
+            staged_object.bytes.truncate(usize_from_u64(expected)?);
+            self.put_staged_bytes(
+                session,
+                Bytes::from(staged_object.bytes.clone()),
+                staged_object.generation_match,
+            )
+            .await?;
+        } else if staged_len < expected {
+            return Err(StorageError::backend(format!(
+                "GCS staged upload object is shorter than committed metadata: expected {expected} bytes, got {staged_len}"
+            )));
+        }
+        ensure_size_limit(stored.max_bytes, stored.public.size, new_offset)?;
+        staged_object.bytes.extend_from_slice(&bytes);
+        self.put_staged_bytes(
+            session,
+            Bytes::from(staged_object.bytes),
+            staged_object.generation_match,
+        )
+        .await?;
+        stored.public.next_offset = Some(new_offset);
+        self.write_session(session, &mut stored).await?;
+        Ok(stored.public)
+    }
+
+    async fn complete_legacy(
+        &self,
+        session: &UploadSessionId,
+        mut stored: StoredUploadSession,
+        provided_checksum: Option<ObjectChecksum>,
+    ) -> StorageResult<ObjectRef> {
+        let trusted = stored.public.next_offset.unwrap_or(0);
+        let staged = self.reconcile_staged_bytes(session, trusted).await?;
+        let actual = staged.len() as u64;
+        if let Some(expected) = stored.public.size {
+            if actual != expected {
+                return Err(StorageError::policy_rejected(format!(
+                    "upload is incomplete: expected {expected} bytes, got {actual}"
+                )));
+            }
+        }
+        ensure_size_limit(stored.max_bytes, stored.public.size, actual)?;
+        let checksum =
+            validate_complete_checksum(&stored.checksum_policy, &staged, provided_checksum)?;
+        let object_key = self.layout.object_key(stored.storage_key.key.as_str());
+        if stored.public.status == UploadSessionStatus::Open
+            || stored.public.next_offset != Some(actual)
+            || stored.completion_object_key.as_deref() != Some(object_key.as_str())
+        {
+            stored.public.status = UploadSessionStatus::Completing;
+            stored.public.next_offset = Some(actual);
+            stored.completion_object_key = Some(object_key.clone());
+            self.write_session(session, &mut stored).await?;
+        }
+        let staged = Bytes::from(staged);
+        let written = match self
+            .put_completed_object(&object_key, staged, stored.public.content_type.as_deref())
+            .await
+        {
+            Ok(written) => written,
+            Err(err @ StorageError::PolicyRejected { .. }) => {
+                stored.public.status = UploadSessionStatus::Open;
+                stored.completion_object_key = None;
+                let _ = self.write_session(session, &mut stored).await;
+                return Err(err);
+            }
+            Err(err) => return Err(err),
+        };
+        let object = self.object_ref(&stored, actual, written, checksum);
+        stored.public.status = UploadSessionStatus::Complete;
+        stored.public.next_offset = Some(actual);
+        stored.object = Some(object.clone());
+        stored.cleanup_pending = true;
+        self.write_session(session, &mut stored).await?;
+        self.cleanup_staged_bytes(session, &mut stored).await?;
+        Ok(object)
+    }
 }
 
 impl StorageBackend for GcsStorageBackend {
     fn name(&self) -> &'static str {
         self.name
+    }
+
+    fn capabilities(&self) -> BackendCapabilities {
+        // Sequential proxy (the coalescing-tail compose path, the default) and
+        // server-mediated native multipart (the by-number `upload_part` path) are
+        // both assembled with a single `ComposeObject`.
+        BackendCapabilities::default().with_native_multipart()
     }
 
     fn initiate_upload<'a>(
@@ -587,10 +1518,48 @@ impl StorageBackend for GcsStorageBackend {
         request: InitiateUpload,
     ) -> StorageBoxFuture<'a, UploadSession> {
         Box::pin(async move {
-            let strategy = selected_strategy(request.requested_strategy)?;
+            let strategy = select_upload_mode(request.requested_strategy, self.capabilities())?;
             ensure_supported_checksum_policy(&request.policy.checksum)?;
             self.ensure_policy_is_supported(request.policy.max_bytes)?;
             self.ensure_requested_size_is_supported(request.size)?;
+            // By-number multipart needs the total length up front: parts are
+            // probed from component objects at completion (not tracked in the
+            // session), so without a declared size neither the part count nor
+            // completion can be reasoned about.
+            if strategy == UploadStrategy::Multipart && request.size.is_none() {
+                return Err(StorageError::policy_rejected(
+                    "multipart uploads require a declared length (size) at initiation",
+                ));
+            }
+            let max_bytes = request.policy.max_bytes.min(self.max_proxy_upload_bytes);
+            // For the by-number path, pin the component size and cap the part
+            // count to a single compose (`GCS_MAX_COMPOSE_SOURCES`); the
+            // sequential path keeps the policy's chunk plan unchanged.
+            let (plan, session_part_size) = if strategy == UploadStrategy::Multipart {
+                let component_size = component_size_for(max_bytes);
+                // min == preferred == max: every non-final part must be exactly
+                // `component_size` (the last is the remainder), which is what
+                // `upload_part` enforces — so the advertised plan matches it.
+                let plan = TransferPlan {
+                    min_part_size: Some(component_size),
+                    preferred_part_size: Some(component_size),
+                    max_part_size: Some(component_size),
+                    max_parts: Some(max_bytes.div_ceil(component_size).max(1) as u32),
+                    max_concurrent_parts: request.policy.max_concurrent_parts.max(1),
+                    resumable: true,
+                };
+                (plan, Some(component_size))
+            } else {
+                let plan = TransferPlan {
+                    min_part_size: request.policy.min_part_size,
+                    preferred_part_size: request.policy.preferred_chunk_size,
+                    max_part_size: request.policy.max_part_size,
+                    max_parts: request.policy.max_parts,
+                    max_concurrent_parts: 1,
+                    resumable: true,
+                };
+                (plan, request.policy.preferred_chunk_size)
+            };
             let id = UploadSessionId::new(Uuid::new_v4().to_string())?;
             let session = UploadSession {
                 id: id.clone(),
@@ -602,15 +1571,8 @@ impl StorageBackend for GcsStorageBackend {
                 strategy,
                 status: UploadSessionStatus::Open,
                 next_offset: Some(0),
-                part_size: request.policy.preferred_chunk_size,
-                plan: TransferPlan {
-                    min_part_size: request.policy.min_part_size,
-                    preferred_part_size: request.policy.preferred_chunk_size,
-                    max_part_size: request.policy.max_part_size,
-                    max_parts: request.policy.max_parts,
-                    max_concurrent_parts: 1,
-                    resumable: true,
-                },
+                part_size: session_part_size,
+                plan,
                 uploaded_parts: Vec::new(),
                 expires_at: expires_at(request.policy.expires_after),
             };
@@ -619,21 +1581,18 @@ impl StorageBackend for GcsStorageBackend {
                 owner: ctx.actor.clone(),
                 storage_key: request.storage_key,
                 visibility: request.policy.visibility,
-                max_bytes: request.policy.max_bytes.min(self.max_proxy_upload_bytes),
+                max_bytes,
                 checksum_policy: request.policy.checksum,
                 request_metadata: request.metadata,
                 object: None,
                 completion_object_key: None,
                 cleanup_pending: false,
+                native: NativeUploadState::Compose(Default::default()),
                 meta_generation: None,
             };
+            // Native sessions buffer their tail inline in the metadata, so no
+            // separate staged `bytes.tmp` object is created up front.
             self.create_session(&id, &mut stored).await?;
-            if let Err(err) = self.put_staged_bytes(&id, Bytes::new(), Some(0)).await {
-                let _ = self
-                    .delete_object_if_exists(&self.layout.session_meta_key(&id))
-                    .await;
-                return Err(err);
-            }
             Ok(session)
         })
     }
@@ -649,7 +1608,11 @@ impl StorageBackend for GcsStorageBackend {
             let _guard = lock.lock().await;
             let mut stored = self.read_session(&session).await?;
             ensure_owner(&ctx.actor, &stored.owner)?;
-            if stored.public.status == UploadSessionStatus::Open {
+            // Native sessions keep an authoritative offset in the metadata; only
+            // the legacy staged-object path needs reconciliation against storage.
+            if stored.public.status == UploadSessionStatus::Open
+                && stored.native.compose().is_none()
+            {
                 let staged = self
                     .reconcile_staged_bytes(&session, stored.public.next_offset.unwrap_or(0))
                     .await?;
@@ -678,10 +1641,15 @@ impl StorageBackend for GcsStorageBackend {
             ensure_owner(&ctx.actor, &stored.owner)?;
             self.persist_expired_if_needed(&session, &mut stored)
                 .await?;
-            let committed_offset = stored.public.next_offset.unwrap_or(0);
-            let _staged = self
-                .reconcile_staged_bytes(&session, committed_offset)
-                .await?;
+            let committed_offset = match stored.native.compose() {
+                Some(state) => state.committed_len(),
+                None => {
+                    let staged = self
+                        .reconcile_staged_bytes(&session, stored.public.next_offset.unwrap_or(0))
+                        .await?;
+                    staged.len() as u64
+                }
+            };
             ensure_upload_length_can_be_set(
                 stored.max_bytes,
                 &stored.public,
@@ -715,66 +1683,118 @@ impl StorageBackend for GcsStorageBackend {
                     "GCS backend currently supports sequential proxy uploads only",
                 ));
             }
-            let expected = stored.public.next_offset.unwrap_or(0);
-            let new_offset = checked_new_offset(offset, bytes.len())?;
-            let read_limit = expected
-                .max(new_offset)
-                .checked_add(1)
-                .ok_or_else(|| StorageError::policy_rejected("upload byte offset overflowed"))?;
-            let mut staged_object = self.get_staged_bytes(&session, read_limit).await?;
-            let staged_len = staged_object.bytes.len() as u64;
-            if expected != offset {
-                if new_offset == expected
-                    && bytes_match_at(&staged_object.bytes, offset, bytes.as_ref())?
-                {
-                    return Ok(stored.public);
-                }
-                tracing::debug!(
-                    target: "pocopine.log",
-                    event_name = "pocopine.storage.offset_mismatch",
-                    session = %session,
-                    expected,
-                    provided = offset,
-                );
-                return Err(StorageError::offset_mismatch(expected, offset));
+            if stored.native.compose().is_some() {
+                self.append_compose(&session, stored, offset, bytes).await
+            } else {
+                self.append_legacy(&session, stored, offset, bytes).await
             }
-            if staged_len > expected {
-                if staged_len == new_offset
-                    && bytes_match_at(&staged_object.bytes, expected, bytes.as_ref())?
-                {
-                    stored.public.next_offset = Some(new_offset);
-                    self.write_session(&session, &mut stored).await?;
-                    return Ok(stored.public);
+        })
+    }
+
+    fn upload_part<'a>(
+        &'a self,
+        ctx: &'a StorageContext,
+        session: UploadSessionId,
+        number: u32,
+        body: UploadBody,
+    ) -> StorageBoxFuture<'a, UploadSession> {
+        Box::pin(async move {
+            // Part numbers are 1-based. The HTTP route enforces this, but the
+            // trait method is directly callable, so guard before the `number - 1`
+            // index conversion below would underflow.
+            if number == 0 {
+                return Err(StorageError::policy_rejected(
+                    "multipart part number must be at least 1",
+                ));
+            }
+            let (component_size, expected_part_len, public) = {
+                let lock = self.session_locks.lock(&session);
+                let _cleanup = UploadSessionLockCleanup::new(&self.session_locks, &session);
+                let _guard = lock.lock().await;
+                let mut stored = self.read_session(&session).await?;
+                ensure_owner(&ctx.actor, &stored.owner)?;
+                self.persist_expired_if_needed(&session, &mut stored)
+                    .await?;
+                ensure_open(&stored.public)?;
+                if stored.public.strategy != UploadStrategy::Multipart {
+                    return Err(StorageError::unsupported(
+                        "GCS backend part upload requires the multipart strategy",
+                    ));
                 }
-                tracing::warn!(
-                    target: "pocopine.log",
-                    event_name = "pocopine.storage.gcs_staged_bytes_truncated",
-                    session = %session,
-                    actual = staged_len,
-                    trusted = expected,
-                );
-                staged_object.bytes.truncate(usize_from_u64(expected)?);
-                self.put_staged_bytes(
-                    &session,
-                    Bytes::from(staged_object.bytes.clone()),
-                    staged_object.generation_match,
-                )
-                .await?;
-            } else if staged_len < expected {
-                return Err(StorageError::backend(format!(
-                    "GCS staged upload object is shorter than committed metadata: expected {expected} bytes, got {staged_len}"
+                // A multipart session always has a declared length (enforced at
+                // initiation). The component layout is fixed: parts `1..count` are
+                // exactly `component_size`, the last part is the remainder. Pinning
+                // each part's length makes the composed object's size exactly the
+                // declared total without trusting (emulator-unreliable) component
+                // metadata sizes, and caps the part count to a single compose.
+                let component_size = component_size_for(stored.max_bytes);
+                let declared = stored.public.size.ok_or_else(|| {
+                    StorageError::policy_rejected("multipart upload is missing a declared length")
+                })?;
+                let count = declared.div_ceil(component_size).max(1);
+                if u64::from(number) > count {
+                    return Err(StorageError::policy_rejected(format!(
+                        "part number {number} exceeds the maximum of {count} parts for this upload"
+                    )));
+                }
+                let expected_part_len = if u64::from(number) == count {
+                    declared - (count - 1) * component_size
+                } else {
+                    component_size
+                };
+                (component_size, expected_part_len, stored.public.clone())
+            };
+
+            // Enforce the advertised concurrency server-side, then re-check the
+            // captured expiry (the permit wait can outlast it).
+            let max_concurrent = public.plan.max_concurrent_parts.max(1) as usize;
+            let _permit = self
+                .part_concurrency
+                .semaphore(&session, max_concurrent)
+                .acquire_owned()
+                .await
+                .map_err(|_| StorageError::UploadClosed {
+                    session: session.to_string(),
+                })?;
+            if OffsetDateTime::now_utc() >= public.expires_at {
+                return Err(StorageError::UploadClosed {
+                    session: session.to_string(),
+                });
+            }
+
+            // GCS writes a whole component object per part, so the bounded part is
+            // collected (peak memory = one component per concurrent upload). Reject
+            // a part whose actual length is not its fixed slot length, so the
+            // composed total is exactly the declared size.
+            let bytes = body.collect_capped(component_size).await?;
+            if bytes.len() as u64 != expected_part_len {
+                return Err(StorageError::policy_rejected(format!(
+                    "part {number} must be exactly {expected_part_len} bytes, got {}",
+                    bytes.len()
                 )));
             }
-            ensure_size_limit(stored.max_bytes, stored.public.size, new_offset)?;
-            staged_object.bytes.extend_from_slice(&bytes);
-            self.put_staged_bytes(
-                &session,
-                Bytes::from(staged_object.bytes),
-                staged_object.generation_match,
-            )
-            .await?;
-            stored.public.next_offset = Some(new_offset);
-            self.write_session(&session, &mut stored).await?;
+
+            // Re-acquire the session lock and re-validate `Open` immediately before
+            // writing the component, holding the lock across the write. This fences
+            // against a concurrent complete/abort: those take the same lock, so the
+            // write either lands before they run or this re-read sees the closed
+            // session and writes nothing — no component is orphaned after cleanup.
+            // (The slow body collection above ran without the lock, preserving
+            // concurrency; only the bounded write is serialized.)
+            let lock = self.session_locks.lock(&session);
+            let _cleanup = UploadSessionLockCleanup::new(&self.session_locks, &session);
+            let _guard = lock.lock().await;
+            let stored = self.read_session(&session).await?;
+            ensure_owner(&ctx.actor, &stored.owner)?;
+            ensure_open(&stored.public)?;
+            if stored.public.strategy != UploadStrategy::Multipart {
+                return Err(StorageError::unsupported(
+                    "GCS backend part upload requires the multipart strategy",
+                ));
+            }
+            // The component is keyed by `number - 1`; `write_component` is
+            // create-or-adopt-by-bytes, so a re-PUT of the same part is idempotent.
+            self.write_component(&session, number - 1, bytes).await?;
             Ok(stored.public)
         })
     }
@@ -794,59 +1814,32 @@ impl StorageBackend for GcsStorageBackend {
                 let object = object.clone();
                 self.cleanup_staged_bytes(&request.session, &mut stored)
                     .await?;
+                self.part_concurrency.forget(&request.session);
                 return Ok(object);
             }
             self.persist_expired_if_needed(&request.session, &mut stored)
                 .await?;
             ensure_completable(&stored.public)?;
-            let trusted = stored.public.next_offset.unwrap_or(0);
-            let staged = self
-                .reconcile_staged_bytes(&request.session, trusted)
-                .await?;
-            let actual = staged.len() as u64;
-            if let Some(expected) = stored.public.size {
-                if actual != expected {
-                    return Err(StorageError::policy_rejected(format!(
-                        "upload is incomplete: expected {expected} bytes, got {actual}"
-                    )));
+            let session = request.session.clone();
+            let result = if stored.native.compose().is_some() {
+                if stored.public.strategy == UploadStrategy::Multipart {
+                    self.complete_compose_by_number(&session, stored, request.checksum)
+                        .await
+                } else {
+                    self.complete_compose(&session, stored, request.checksum)
+                        .await
                 }
-            }
-            ensure_size_limit(stored.max_bytes, stored.public.size, actual)?;
-            let checksum =
-                validate_complete_checksum(&stored.checksum_policy, &staged, request.checksum)?;
-            let object_key = self.layout.object_key(stored.storage_key.key.as_str());
-            if stored.public.status == UploadSessionStatus::Open
-                || stored.public.next_offset != Some(actual)
-                || stored.completion_object_key.as_deref() != Some(object_key.as_str())
-            {
-                stored.public.status = UploadSessionStatus::Completing;
-                stored.public.next_offset = Some(actual);
-                stored.completion_object_key = Some(object_key.clone());
-                self.write_session(&request.session, &mut stored).await?;
-            }
-            let staged = Bytes::from(staged);
-            let written = match self
-                .put_completed_object(&object_key, staged, stored.public.content_type.as_deref())
-                .await
-            {
-                Ok(written) => written,
-                Err(err @ StorageError::PolicyRejected { .. }) => {
-                    stored.public.status = UploadSessionStatus::Open;
-                    stored.completion_object_key = None;
-                    let _ = self.write_session(&request.session, &mut stored).await;
-                    return Err(err);
-                }
-                Err(err) => return Err(err),
+            } else {
+                self.complete_legacy(&session, stored, request.checksum)
+                    .await
             };
-            let object = self.object_ref(&stored, actual, written, checksum);
-            stored.public.status = UploadSessionStatus::Complete;
-            stored.public.next_offset = Some(actual);
-            stored.object = Some(object.clone());
-            stored.cleanup_pending = true;
-            self.write_session(&request.session, &mut stored).await?;
-            self.cleanup_staged_bytes(&request.session, &mut stored)
-                .await?;
-            Ok(object)
+            // Drop the concurrency pool only once completion succeeds; a failed
+            // attempt leaves the session resumable and must keep its semaphore so
+            // a later part can't create a fresh one and bypass the limit.
+            if result.is_ok() {
+                self.part_concurrency.forget(&session);
+            }
+            result
         })
     }
 
@@ -867,6 +1860,28 @@ impl StorageBackend for GcsStorageBackend {
                         return Err(StorageError::UploadClosed {
                             session: session.to_string(),
                         });
+                    }
+                    // Stop concurrent part uploads (queued and future ones fail
+                    // immediately instead of writing components after the abort).
+                    if stored.public.strategy == UploadStrategy::Multipart {
+                        let max = stored.public.plan.max_concurrent_parts.max(1);
+                        self.part_concurrency
+                            .semaphore(&session, max as usize)
+                            .close();
+                    }
+                    // Remove every component object so none linger. By-number
+                    // parts can be sparse, so sweep the whole declared range
+                    // rather than stopping at the first gap.
+                    if stored.public.strategy == UploadStrategy::Multipart {
+                        let component_size = component_size_for(stored.max_bytes);
+                        let count = stored
+                            .public
+                            .size
+                            .map(|size| size.div_ceil(component_size).max(1) as u32)
+                            .unwrap_or(0);
+                        self.delete_component_range(&session, count).await;
+                    } else if stored.native.compose().is_some() {
+                        self.delete_component_chain(&session).await;
                     }
                 }
                 AbortSessionRead::Missing => {}
@@ -889,6 +1904,7 @@ impl StorageBackend for GcsStorageBackend {
             };
             bytes_deleted?;
             meta_deleted?;
+            self.part_concurrency.forget(&session);
             Ok(())
         })
     }

--- a/crates/pocopine-storage-gcs/tests/fake_gcs.rs
+++ b/crates/pocopine-storage-gcs/tests/fake_gcs.rs
@@ -14,9 +14,10 @@ use bytes::Bytes;
 use google_cloud_auth::credentials::anonymous::Builder as Anonymous;
 use google_cloud_storage::client::Storage;
 use pocopine_storage::{
-    CompleteUpload, InitiateUpload, PrincipalRef, SafeObjectKey, StorageActor, StorageBackend,
-    StorageContext, StorageError, StorageKey, StorageResult, UploadPolicy, UploadSession,
-    UploadSessionStatus, UploadStrategy,
+    ChecksumAlgorithm, ChecksumPolicy, CompleteUpload, InitiateUpload, ObjectChecksum,
+    PrincipalRef, SafeObjectKey, StorageActor, StorageBackend, StorageContext, StorageError,
+    StorageKey, StorageResult, UploadBody, UploadPolicy, UploadSession, UploadSessionStatus,
+    UploadStrategy,
 };
 use pocopine_storage_gcs::GcsStorageBackend;
 use testcontainers::core::{wait::HttpWaitStrategy, ContainerPort, WaitFor};
@@ -154,6 +155,55 @@ async fn initiate(backend: &GcsStorageBackend, size: Option<u64>) -> StorageResu
             },
         )
         .await
+}
+
+fn large_policy() -> StorageResult<UploadPolicy> {
+    let mut policy = UploadPolicy::new("gcs")?
+        .max_bytes(32 * 1024 * 1024)
+        .preferred_chunk_size(1024 * 1024);
+    policy.expires_after = Duration::from_secs(60 * 60);
+    Ok(policy)
+}
+
+async fn initiate_large_checked(
+    backend: &GcsStorageBackend,
+    key: &str,
+    size: u64,
+    checksum: ChecksumPolicy,
+) -> StorageResult<UploadSession> {
+    let mut policy = large_policy()?;
+    policy.checksum = checksum;
+    backend
+        .initiate_upload(
+            &ctx(),
+            InitiateUpload {
+                scope: "files".to_string(),
+                storage_key: StorageKey::new(SafeObjectKey::parse(key)?),
+                file_name: "large.bin".to_string(),
+                size: Some(size),
+                content_type: Some("application/octet-stream".to_string()),
+                metadata: BTreeMap::new(),
+                requested_strategy: UploadStrategy::Auto,
+                policy,
+            },
+        )
+        .await
+}
+
+fn pattern_bytes(start: usize, len: usize) -> Bytes {
+    let mut buf = Vec::with_capacity(len);
+    for i in 0..len {
+        buf.push(((start + i) % 251) as u8);
+    }
+    Bytes::from(buf)
+}
+
+async fn object_exists(storage: &Storage, bucket: &str, key: &str) -> bool {
+    storage
+        .read_object(bucket_resource(bucket), key)
+        .send()
+        .await
+        .is_ok()
 }
 
 async fn object_bytes(storage: &Storage, bucket: &str, key: &str) -> Vec<u8> {
@@ -459,12 +509,15 @@ async fn duplicate_append_retry_after_staged_write_advances_metadata() -> Storag
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn inspect_truncates_rogue_staged_bytes_back_to_committed_offset() -> StorageResult<()> {
+async fn rogue_staged_object_does_not_promote_committed_offset() -> StorageResult<()> {
     let clients = gcs_clients().await;
     let bucket = create_bucket(&clients, "truncate").await;
     let backend =
         GcsStorageBackend::emulator(clients.storage.clone(), clients.endpoint.clone(), bucket)?;
     let session = initiate(&backend, Some(5)).await?;
+    // Native compose sessions buffer their tail inline in the metadata; the
+    // legacy `bytes.tmp` staging object is not part of the protocol, so a rogue
+    // one must never be mistaken for committed bytes.
     let bytes_key = session_object_key(&backend, &session, "bytes.tmp");
     clients
         .storage
@@ -479,10 +532,6 @@ async fn inspect_truncates_rogue_staged_bytes_back_to_committed_offset() -> Stor
 
     let inspected = backend.inspect_upload(&ctx(), session.id).await?;
     assert_eq!(inspected.next_offset, Some(0));
-    assert_eq!(
-        object_bytes(&clients.storage, backend.bucket(), &bytes_key).await,
-        b""
-    );
     Ok(())
 }
 
@@ -633,5 +682,394 @@ async fn initiate_rejects_policy_above_proxy_cap_for_streaming_upload() -> Stora
         rejected,
         Err(StorageError::PayloadTooLarge { limit: 8 })
     ));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn compose_upload_assembles_large_object_against_fake_gcs() -> StorageResult<()> {
+    let clients = gcs_clients().await;
+    let bucket = create_bucket(&clients, "compose").await;
+    let backend =
+        GcsStorageBackend::emulator(clients.storage.clone(), clients.endpoint.clone(), bucket)?;
+
+    // 4 MiB in 2 MiB chunks; with a 1 MiB component size this writes several
+    // component objects that are composed into the final object.
+    let chunk = 2 * 1024 * 1024usize;
+    let total = 2 * chunk;
+    let session = initiate_large_checked(
+        &backend,
+        "files/large.bin",
+        total as u64,
+        ChecksumPolicy::None,
+    )
+    .await?;
+
+    let mut offset = 0u64;
+    for index in 0..2 {
+        let updated = backend
+            .append_upload_bytes(
+                &ctx(),
+                session.id.clone(),
+                offset,
+                pattern_bytes(index * chunk, chunk),
+            )
+            .await?;
+        offset += chunk as u64;
+        assert_eq!(updated.next_offset, Some(offset));
+    }
+
+    let object = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id.clone(),
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(object.size, total as u64);
+    assert_eq!(
+        object_bytes(&clients.storage, backend.bucket(), "files/large.bin").await,
+        pattern_bytes(0, total).to_vec()
+    );
+    // Component objects are temporary and removed after completion.
+    let first_component = session_object_key(&backend, &session, "components/comp-00000");
+    assert!(!object_exists(&clients.storage, backend.bucket(), &first_component).await);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn compose_abort_removes_component_objects_against_fake_gcs() -> StorageResult<()> {
+    let clients = gcs_clients().await;
+    let bucket = create_bucket(&clients, "compose-abort").await;
+    let backend =
+        GcsStorageBackend::emulator(clients.storage.clone(), clients.endpoint.clone(), bucket)?;
+    let session = initiate_large_checked(
+        &backend,
+        "files/large.bin",
+        2 * 1024 * 1024,
+        ChecksumPolicy::None,
+    )
+    .await?;
+
+    // 2 MiB at a 1 MiB component size writes component objects.
+    backend
+        .append_upload_bytes(
+            &ctx(),
+            session.id.clone(),
+            0,
+            pattern_bytes(0, 2 * 1024 * 1024),
+        )
+        .await?;
+    let first_component = session_object_key(&backend, &session, "components/comp-00000");
+    assert!(object_exists(&clients.storage, backend.bucket(), &first_component).await);
+
+    backend.abort_upload(&ctx(), session.id.clone()).await?;
+
+    assert!(!object_exists(&clients.storage, backend.bucket(), &first_component).await);
+    assert!(!object_exists(&clients.storage, backend.bucket(), "files/large.bin").await);
+    let inspected = backend.inspect_upload(&ctx(), session.id).await;
+    assert!(matches!(
+        inspected,
+        Err(StorageError::UnknownUploadSession { .. })
+    ));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn compose_completion_is_idempotent_against_fake_gcs() -> StorageResult<()> {
+    let clients = gcs_clients().await;
+    let bucket = create_bucket(&clients, "compose-idem").await;
+    let backend =
+        GcsStorageBackend::emulator(clients.storage.clone(), clients.endpoint.clone(), bucket)?;
+    let total = 3 * 1024 * 1024usize;
+    let session = initiate_large_checked(
+        &backend,
+        "files/large.bin",
+        total as u64,
+        ChecksumPolicy::None,
+    )
+    .await?;
+    backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, pattern_bytes(0, total))
+        .await?;
+
+    let first = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id.clone(),
+                checksum: None,
+            },
+        )
+        .await?;
+    let second = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(first, second);
+    assert_eq!(first.size, total as u64);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn compose_upload_verifies_streaming_sha256_against_fake_gcs() -> StorageResult<()> {
+    let clients = gcs_clients().await;
+    let bucket = create_bucket(&clients, "compose-sha").await;
+    let backend =
+        GcsStorageBackend::emulator(clients.storage.clone(), clients.endpoint.clone(), bucket)?;
+    let total = 3 * 1024 * 1024usize;
+    let data = pattern_bytes(0, total);
+    let expected = ObjectChecksum {
+        algorithm: ChecksumAlgorithm::Sha256,
+        value: pocopine_crypto::sha256_hex(&data),
+    };
+    let session = initiate_large_checked(
+        &backend,
+        "files/checked.bin",
+        total as u64,
+        ChecksumPolicy::Required(ChecksumAlgorithm::Sha256),
+    )
+    .await?;
+    backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, data)
+        .await?;
+
+    let object = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: Some(expected.clone()),
+            },
+        )
+        .await?;
+    assert_eq!(object.checksum, Some(expected));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn compose_buffers_large_inline_tail_in_metadata_against_fake_gcs() -> StorageResult<()> {
+    let clients = gcs_clients().await;
+    let bucket = create_bucket(&clients, "compose-tail").await;
+    let backend =
+        GcsStorageBackend::emulator(clients.storage.clone(), clients.endpoint.clone(), bucket)?;
+    // 500 KiB stays below the 1 MiB component size, so it is buffered entirely
+    // in the inline (base64) tail — well over the 256 KiB non-tail metadata
+    // bound. inspect + complete must still read the session metadata.
+    let total = 500 * 1024usize;
+    let session = initiate_large_checked(
+        &backend,
+        "files/tail.bin",
+        total as u64,
+        ChecksumPolicy::None,
+    )
+    .await?;
+    backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, pattern_bytes(0, total))
+        .await?;
+
+    let inspected = backend.inspect_upload(&ctx(), session.id.clone()).await?;
+    assert_eq!(inspected.next_offset, Some(total as u64));
+
+    let object = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(object.size, total as u64);
+    assert_eq!(
+        object_bytes(&clients.storage, backend.bucket(), "files/tail.bin").await,
+        pattern_bytes(0, total).to_vec()
+    );
+    Ok(())
+}
+
+/// Initiate a server-mediated by-number multipart upload (the `upload_part`
+/// path). Component size for the 32 MiB cap is 1 MiB, so parts are <= 1 MiB.
+async fn initiate_multipart(
+    backend: &GcsStorageBackend,
+    key: &str,
+    size: u64,
+) -> StorageResult<UploadSession> {
+    let mut policy = large_policy()?;
+    policy.max_concurrent_parts = 4;
+    backend
+        .initiate_upload(
+            &ctx(),
+            InitiateUpload {
+                scope: "files".to_string(),
+                storage_key: StorageKey::new(SafeObjectKey::parse(key)?),
+                file_name: "bynum.bin".to_string(),
+                size: Some(size),
+                content_type: Some("application/octet-stream".to_string()),
+                metadata: BTreeMap::new(),
+                requested_strategy: UploadStrategy::Multipart,
+                policy,
+            },
+        )
+        .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn multipart_by_number_composes_parts_concurrently_against_fake_gcs() -> StorageResult<()> {
+    let clients = gcs_clients().await;
+    let bucket = create_bucket(&clients, "bynum").await;
+    let backend =
+        GcsStorageBackend::emulator(clients.storage.clone(), clients.endpoint.clone(), bucket)?;
+
+    // 1 MiB component size: two full parts plus a 512 KiB final part.
+    let part = 1024 * 1024usize;
+    let last = 512 * 1024usize;
+    let total = (2 * part + last) as u64;
+    let session = initiate_multipart(&backend, "files/bynum.bin", total).await?;
+    assert_eq!(session.strategy, UploadStrategy::Multipart);
+    assert!(session.plan.max_concurrent_parts >= 2);
+
+    let specs = [
+        (1u32, 0usize, part),
+        (2u32, part, part),
+        (3u32, 2 * part, last),
+    ];
+    let mut handles = Vec::new();
+    for (number, start, len) in specs.into_iter().rev() {
+        let backend = backend.clone();
+        let session_id = session.id.clone();
+        let bytes = pattern_bytes(start, len);
+        handles.push(tokio::spawn(async move {
+            backend
+                .upload_part(&ctx(), session_id, number, UploadBody::from_bytes(bytes))
+                .await
+        }));
+    }
+    for handle in handles {
+        handle.await.expect("join part task")?;
+    }
+
+    let object = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id.clone(),
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(object.size, total);
+    assert_eq!(
+        object_bytes(&clients.storage, backend.bucket(), "files/bynum.bin").await,
+        pattern_bytes(0, total as usize).to_vec()
+    );
+
+    // Idempotent re-complete returns the same object.
+    let again = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(again, object);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn multipart_by_number_rejects_missing_part_against_fake_gcs() -> StorageResult<()> {
+    let clients = gcs_clients().await;
+    let bucket = create_bucket(&clients, "bynum-gap").await;
+    let backend =
+        GcsStorageBackend::emulator(clients.storage.clone(), clients.endpoint.clone(), bucket)?;
+
+    let part = 1024 * 1024usize;
+    let total = (3 * part) as u64;
+    let session = initiate_multipart(&backend, "files/gap.bin", total).await?;
+    // Upload parts 1 and 3, leaving a gap at 2.
+    backend
+        .upload_part(
+            &ctx(),
+            session.id.clone(),
+            1,
+            UploadBody::from_bytes(pattern_bytes(0, part)),
+        )
+        .await?;
+    backend
+        .upload_part(
+            &ctx(),
+            session.id.clone(),
+            3,
+            UploadBody::from_bytes(pattern_bytes(2 * part, part)),
+        )
+        .await?;
+
+    let rejected = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id.clone(),
+                checksum: None,
+            },
+        )
+        .await;
+    assert!(
+        matches!(rejected, Err(StorageError::PolicyRejected { .. })),
+        "a missing part 2 must be rejected, got {rejected:?}"
+    );
+    assert!(!object_exists(&clients.storage, backend.bucket(), "files/gap.bin").await);
+
+    // The session stays Open; uploading the missing part lets it complete.
+    backend
+        .upload_part(
+            &ctx(),
+            session.id.clone(),
+            2,
+            UploadBody::from_bytes(pattern_bytes(part, part)),
+        )
+        .await?;
+    let object = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(object.size, total);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn multipart_by_number_rejects_wrong_part_length_against_fake_gcs() -> StorageResult<()> {
+    let clients = gcs_clients().await;
+    let bucket = create_bucket(&clients, "bynum-len").await;
+    let backend =
+        GcsStorageBackend::emulator(clients.storage.clone(), clients.endpoint.clone(), bucket)?;
+
+    // 1 MiB component size, declared 2 MiB => part 1 must be exactly 1 MiB.
+    let part = 1024 * 1024usize;
+    let session = initiate_multipart(&backend, "files/len.bin", (2 * part) as u64).await?;
+    let rejected = backend
+        .upload_part(
+            &ctx(),
+            session.id.clone(),
+            1,
+            UploadBody::from_bytes(pattern_bytes(0, part / 2)),
+        )
+        .await;
+    assert!(
+        matches!(rejected, Err(StorageError::PolicyRejected { .. })),
+        "an undersized non-final part must be rejected, got {rejected:?}"
+    );
     Ok(())
 }

--- a/crates/pocopine-storage-s3/Cargo.toml
+++ b/crates/pocopine-storage-s3/Cargo.toml
@@ -8,17 +8,34 @@ description = "S3-compatible backend adapter for pocopine-storage."
 
 [dependencies]
 aws-sdk-s3 = "1"
+# `PayloadSigningOverride::UnsignedPayload` + an interceptor let a streamed
+# `UploadPart` skip payload signing (the body is not known before signing).
+aws-runtime = "1"
+# `http-body-1-x` exposes `SdkBody::from_body_1_x`, used to wrap a streamed part
+# body (an axum `UploadBody`) into an S3 `ByteStream` without buffering.
+aws-smithy-runtime-api = "1"
+aws-smithy-types = { version = "1", features = ["http-body-1-x"] }
 bytes = "1"
+futures-util = { version = "0.3", default-features = false }
+http-body = "1"
+http-body-util = "0.1"
+pocopine-codec = { workspace = true }
 pocopine-storage = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-sha2 = "0.10"
 time = { version = "0.3", features = ["serde"] }
-tokio = { version = "1", default-features = false, features = ["sync"] }
+# `io-util` powers the streaming checksum read-back (`ByteStream::into_async_read`)
+# so checksum verification never buffers the whole object; `rt` lets the part
+# upload spawn a task that pumps the request body into the provider stream.
+tokio = { version = "1", default-features = false, features = ["io-util", "rt", "sync"] }
+# `ReceiverStream` bridges the `Send`-only request body to the `Send + Sync`
+# stream the S3 `ByteStream` body requires.
+tokio-stream = "0.1"
 tracing = { workspace = true }
 uuid = { version = "1", features = ["v4"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+pocopine-crypto = { workspace = true }
 testcontainers = "0.23"
 testcontainers-modules = { version = "0.11", features = ["minio"] }
 tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/crates/pocopine-storage-s3/src/state.rs
+++ b/crates/pocopine-storage-s3/src/state.rs
@@ -16,4 +16,94 @@ pub(crate) struct StoredUploadSession {
     pub(crate) object: Option<ObjectRef>,
     #[serde(default)]
     pub(crate) cleanup_pending: bool,
+    /// Transfer mechanism backing this session.
+    ///
+    /// Sessions written before native multipart support omit this field and
+    /// deserialize as [`NativeUploadState::LegacyProxy`], so in-flight uploads
+    /// created by an older build keep working on the staged-object rewrite path.
+    #[serde(default)]
+    pub(crate) native: NativeUploadState,
+}
+
+/// Backend transfer mechanism for an upload session.
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum NativeUploadState {
+    /// Legacy staged-object rewrite (download → extend → re-upload per append).
+    ///
+    /// Only used for sessions created before native multipart was introduced.
+    #[default]
+    LegacyProxy,
+    /// S3 native multipart upload: each flushed block is an `UploadPart`, the
+    /// final object is assembled by `CompleteMultipartUpload`, and only an
+    /// unflushed tail (smaller than one part) is ever staged in memory/`bytes.tmp`.
+    Multipart(S3MultipartState),
+}
+
+/// Provider-side multipart bookkeeping for one session.
+#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+pub(crate) struct S3MultipartState {
+    /// `UploadId` returned by `CreateMultipartUpload`.
+    ///
+    /// Created lazily on the first part flush so an initiated-but-abandoned
+    /// session leaves no provider-side multipart upload behind.
+    #[serde(default)]
+    pub(crate) upload_id: Option<String>,
+    /// Parts already uploaded to S3, in ascending part-number order.
+    #[serde(default)]
+    pub(crate) parts: Vec<S3CompletedPart>,
+    /// Next part number to assign (S3 part numbers are 1-based).
+    #[serde(default)]
+    pub(crate) next_part_number: i32,
+    /// Bytes received but not yet flushed to a part. Always smaller than one
+    /// part (the S3 5 MiB minimum), except just before completion when the final
+    /// remainder becomes the last part.
+    ///
+    /// Stored inline (base64) in the session metadata rather than a separate
+    /// object, so the tail and the part bookkeeping are persisted in a single
+    /// atomic `PutObject`. A crash can never leave the tail and metadata
+    /// describing different states (which would corrupt the object around a part
+    /// boundary on resume).
+    #[serde(
+        default,
+        with = "pocopine_codec::base64_bytes",
+        skip_serializing_if = "Vec::is_empty"
+    )]
+    pub(crate) pending_tail: Vec<u8>,
+}
+
+/// One uploaded multipart part.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub(crate) struct S3CompletedPart {
+    pub(crate) number: i32,
+    pub(crate) etag: String,
+    pub(crate) size: u64,
+}
+
+impl NativeUploadState {
+    pub(crate) fn multipart_mut(&mut self) -> Option<&mut S3MultipartState> {
+        match self {
+            NativeUploadState::Multipart(state) => Some(state),
+            NativeUploadState::LegacyProxy => None,
+        }
+    }
+
+    pub(crate) fn multipart(&self) -> Option<&S3MultipartState> {
+        match self {
+            NativeUploadState::Multipart(state) => Some(state),
+            NativeUploadState::LegacyProxy => None,
+        }
+    }
+}
+
+impl S3MultipartState {
+    /// Total bytes already committed to provider parts (excludes the pending tail).
+    pub(crate) fn flushed_len(&self) -> u64 {
+        self.parts.iter().map(|part| part.size).sum()
+    }
+
+    /// Total bytes accepted so far (flushed parts plus the buffered tail).
+    pub(crate) fn committed_len(&self) -> u64 {
+        self.flushed_len() + self.pending_tail.len() as u64
+    }
 }

--- a/crates/pocopine-storage-s3/src/storage.rs
+++ b/crates/pocopine-storage-s3/src/storage.rs
@@ -1,37 +1,133 @@
 use aws_sdk_s3::primitives::ByteStream;
+use aws_sdk_s3::types::{CompletedMultipartUpload, CompletedPart};
 use aws_sdk_s3::Client;
+use aws_smithy_types::body::SdkBody;
 use bytes::Bytes;
+use futures_util::TryStreamExt as _;
+use http_body::Frame;
+use http_body_util::StreamBody;
 use pocopine_storage::backend_common::{
     checked_new_offset, ensure_open, ensure_owner, ensure_size_limit,
-    ensure_upload_length_can_be_set, expires_at, refresh_expired, selected_strategy,
-    UploadSessionLockCleanup, UploadSessionLockRegistry,
+    ensure_upload_length_can_be_set, expires_at, refresh_expired, select_upload_mode,
+    UploadConcurrencyRegistry, UploadSessionLockCleanup, UploadSessionLockRegistry,
 };
-use pocopine_storage::checksum::{ensure_supported_checksum_policy, validate_complete_checksum};
+use pocopine_storage::checksum::{
+    checksum_algorithm_to_compute, ensure_supported_checksum_policy, precheck_checksum,
+    validate_complete_checksum, validate_complete_checksum_precomputed, StreamingChecksum,
+};
 use pocopine_storage::{
-    CompleteUpload, InitiateUpload, ObjectChecksum, ObjectRef, StorageBackend, StorageBoxFuture,
-    StorageContext, StorageError, StorageResult, TransferPlan, UploadSession, UploadSessionId,
-    UploadSessionStatus, UploadStrategy,
+    BackendCapabilities, ChecksumAlgorithm, ChecksumPolicy, CompleteUpload, InitiateUpload,
+    ObjectChecksum, ObjectRef, StorageBackend, StorageBoxFuture, StorageContext, StorageError,
+    StorageResult, TransferPlan, UploadBody, UploadSession, UploadSessionId, UploadSessionStatus,
+    UploadStrategy, UploadedPartStatus, UploadedPartView,
 };
+use time::OffsetDateTime;
+use tokio_stream::wrappers::ReceiverStream;
 use uuid::Uuid;
 
 use crate::layout::{S3KeyLayout, DEFAULT_INTERNAL_PREFIX};
-use crate::state::StoredUploadSession;
+use crate::state::{NativeUploadState, S3CompletedPart, S3MultipartState, StoredUploadSession};
 use crate::util::{
-    ensure_completable, is_get_object_not_found, is_put_precondition_failed, normalize_etag,
-    s3_error,
+    ensure_completable, is_get_object_not_found, is_head_object_not_found, is_no_such_upload,
+    is_precondition_failed, is_put_precondition_failed, normalize_etag, s3_error,
 };
 
 const DEFAULT_BACKEND_NAME: &str = "s3";
 const DEFAULT_MAX_PROXY_UPLOAD_BYTES: u64 = 64 * 1024 * 1024;
 
+/// S3 minimum part size. Every multipart part except the last must be at least
+/// this large, so sequential `PATCH` chunks smaller than this are coalesced in a
+/// bounded tail buffer until they reach it.
+const S3_MIN_PART_SIZE: u64 = 5 * 1024 * 1024;
+
+/// S3 maximum size of a single part (5 GiB).
+const S3_MAX_PART_SIZE: u64 = 5 * 1024 * 1024 * 1024;
+
+/// S3 maximum number of parts in one multipart upload.
+const S3_MAX_PARTS: u64 = 10_000;
+
+/// Read granularity for the streaming checksum read-back.
+const CHECKSUM_READ_CHUNK: usize = 256 * 1024;
+
+/// Object user-metadata key stamped at `CreateMultipartUpload` with the upload
+/// session id. It proves ownership when reconciling an existing key after S3
+/// reports `NoSuchUpload` (which can mean either "we already completed" or "the
+/// upload was aborted/expired"). Only an object carrying our session id is
+/// adopted on recovery.
+const SESSION_OWNER_META_KEY: &str = "pocopine-upload-session";
+
+/// Part size to coalesce to for a session whose maximum object size is
+/// `max_bytes`.
+///
+/// Scales up from the 5 MiB floor (rounded to a whole MiB) so the worst-case
+/// object stays within S3's 10,000-part limit, and never exceeds the 5 GiB
+/// per-part ceiling. For the default 64 MiB cap this is exactly 5 MiB.
+fn part_size_for(max_bytes: u64) -> u64 {
+    const MIB: u64 = 1024 * 1024;
+    let by_part_count = max_bytes.div_ceil(S3_MAX_PARTS).div_ceil(MIB) * MIB;
+    by_part_count.clamp(S3_MIN_PART_SIZE, S3_MAX_PART_SIZE)
+}
+
+/// Interceptor that forces SigV4 to sign a streamed `UploadPart` with an
+/// unsigned payload. The part body is produced lazily over a channel, so its
+/// hash cannot be computed before signing; without this the SDK pre-signs a
+/// hash that never matches the streamed bytes (`XAmzContentSHA256Mismatch`).
+#[derive(Debug, Clone)]
+struct UnsignedPayloadInterceptor;
+
+impl aws_smithy_runtime_api::client::interceptors::Intercept for UnsignedPayloadInterceptor {
+    fn name(&self) -> &'static str {
+        "PocopineUnsignedPayload"
+    }
+
+    fn modify_before_signing(
+        &self,
+        _context: &mut aws_smithy_runtime_api::client::interceptors::context::BeforeTransmitInterceptorContextMut<'_>,
+        _runtime_components: &aws_smithy_runtime_api::client::runtime_components::RuntimeComponents,
+        cfg: &mut aws_smithy_types::config_bag::ConfigBag,
+    ) -> Result<(), aws_smithy_runtime_api::box_error::BoxError> {
+        cfg.interceptor_state()
+            .store_put(aws_runtime::auth::PayloadSigningOverride::UnsignedPayload);
+        Ok(())
+    }
+}
+
+/// Adapt a streamed part body into an S3 `ByteStream` without buffering it: the
+/// bytes flow request → `UploadPart` one chunk at a time, so peak memory stays
+/// O(1) per part regardless of part size.
+///
+/// The inbound axum body stream is `Send` but not `Sync`, while the S3
+/// `ByteStream` body requires `Send + Sync`. A bounded channel bridges the two:
+/// a pump task forwards frames into the channel (blocking on backpressure when
+/// the channel is full, so only a few frames are ever in flight), and the
+/// `Sync` receiver side feeds the `ByteStream`.
+fn upload_body_to_byte_stream(body: UploadBody) -> ByteStream {
+    use futures_util::StreamExt as _;
+
+    let (tx, rx) = tokio::sync::mpsc::channel::<Result<Bytes, std::io::Error>>(4);
+    tokio::spawn(async move {
+        let mut stream = body.into_byte_stream();
+        while let Some(item) = stream.next().await {
+            if tx.send(item).await.is_err() {
+                // Receiver (the ByteStream) was dropped — stop pumping.
+                break;
+            }
+        }
+    });
+    let frames = ReceiverStream::new(rx).map_ok(Frame::data);
+    ByteStream::new(SdkBody::from_body_1_x(StreamBody::new(frames)))
+}
+
 /// Storage backend backed by an S3-compatible object store.
 ///
-/// The adapter stores temporary upload bytes as an internal object and rewrites
-/// that object on each sequential `PATCH`. That keeps the first S3 backend
-/// compatible with Pocopine's existing resumable upload protocol for bounded
-/// uploads, but it is not the high-throughput/direct multipart path. A later
-/// direct/multipart backend can add provider-side multipart uploads without
-/// changing the public `StorageBackend` contract.
+/// Uploads use S3 native multipart: each sequential `PATCH` is appended to a
+/// bounded tail buffer and, once the tail reaches [`S3_MIN_PART_SIZE`], flushed
+/// to a provider `UploadPart`. The final object is assembled by
+/// `CompleteMultipartUpload`. Peak memory is one part regardless of object size,
+/// and every byte is sent to S3 exactly once (no per-`PATCH` full-object
+/// rewrite). Sessions created by an older build deserialize as
+/// [`NativeUploadState::LegacyProxy`] and keep using the staged-object rewrite
+/// path until they drain.
 #[derive(Clone)]
 pub struct S3StorageBackend {
     name: &'static str,
@@ -39,6 +135,16 @@ pub struct S3StorageBackend {
     layout: S3KeyLayout,
     max_proxy_upload_bytes: u64,
     session_locks: UploadSessionLockRegistry,
+    part_concurrency: UploadConcurrencyRegistry,
+}
+
+struct HeadObjectInfo {
+    etag: Option<String>,
+    /// Value of the [`SESSION_OWNER_META_KEY`] user-metadata entry, if present.
+    owner_session: Option<String>,
+    /// Object size in bytes, used to adopt an already-completed object on retry
+    /// without re-listing the (consumed) multipart upload.
+    content_length: u64,
 }
 
 impl std::fmt::Debug for S3StorageBackend {
@@ -71,6 +177,7 @@ impl S3StorageBackend {
             layout: S3KeyLayout::new(bucket.into(), None, DEFAULT_INTERNAL_PREFIX.to_string())?,
             max_proxy_upload_bytes: DEFAULT_MAX_PROXY_UPLOAD_BYTES,
             session_locks: UploadSessionLockRegistry::new(),
+            part_concurrency: UploadConcurrencyRegistry::new(),
         })
     }
 
@@ -89,12 +196,7 @@ impl S3StorageBackend {
         Ok(self)
     }
 
-    /// Override the maximum size accepted by this sequential proxy backend.
-    ///
-    /// The default is 64 MiB because each append rewrites the staged object and
-    /// completion loads the staged bytes before the final S3 write. Larger
-    /// values are possible, but applications should prefer the future multipart
-    /// backend for large uploads.
+    /// Override the maximum upload size accepted by this backend.
     pub fn with_max_proxy_upload_bytes(mut self, max_bytes: u64) -> StorageResult<Self> {
         if max_bytes == 0 {
             return Err(StorageError::policy_rejected(
@@ -286,6 +388,60 @@ impl S3StorageBackend {
         }
     }
 
+    /// Write a zero-byte completed object for a multipart session, guarding
+    /// ownership by HEAD rather than the byte-match fast path of
+    /// [`Self::put_completed_object`] (which would wrongly adopt a *foreign*
+    /// empty object that happens to share the same — empty — bytes). Adopts our
+    /// own already-written object idempotently, rejects a foreign one, and
+    /// stamps the owner marker so a retry after a crash can adopt it.
+    async fn put_empty_owned_object(
+        &self,
+        object_key: &str,
+        session: &UploadSessionId,
+        content_type: Option<&str>,
+    ) -> StorageResult<Option<String>> {
+        match self.head_object(object_key).await? {
+            Some(info) if info.owner_session.as_deref() == Some(session.as_str()) => {
+                return Ok(info.etag);
+            }
+            Some(_) => {
+                return Err(StorageError::policy_rejected(format!(
+                    "S3 object key already exists: {object_key}"
+                )));
+            }
+            None => {}
+        }
+        let mut request = self
+            .client
+            .put_object()
+            .bucket(&self.layout.bucket)
+            .key(object_key)
+            .if_none_match("*")
+            .metadata(SESSION_OWNER_META_KEY, session.as_str())
+            .body(ByteStream::from(Bytes::new()));
+        if let Some(content_type) = content_type {
+            request = request.content_type(content_type);
+        }
+        match request.send().await {
+            Ok(output) => Ok(output.e_tag.map(normalize_etag)),
+            Err(err) if is_put_precondition_failed(&err) => {
+                // Lost the create race. The session lock is per-process, so a
+                // concurrent process completing this same empty upload may have
+                // won: re-HEAD and adopt idempotently when the object carries our
+                // session marker; otherwise it is a genuine foreign collision.
+                match self.head_object(object_key).await? {
+                    Some(info) if info.owner_session.as_deref() == Some(session.as_str()) => {
+                        Ok(info.etag)
+                    }
+                    _ => Err(StorageError::policy_rejected(format!(
+                        "S3 object key already exists: {object_key}"
+                    ))),
+                }
+            }
+            Err(err) => Err(s3_error("put empty object", err)),
+        }
+    }
+
     async fn delete_object(&self, key: &str) -> StorageResult<()> {
         self.client
             .delete_object()
@@ -297,29 +453,379 @@ impl S3StorageBackend {
         Ok(())
     }
 
-    async fn persist_expired_if_needed(
-        &self,
-        session: &UploadSessionId,
-        stored: &StoredUploadSession,
-    ) -> StorageResult<()> {
-        if stored.public.status == UploadSessionStatus::Expired {
-            self.write_session(session, stored).await?;
+    async fn head_object(&self, key: &str) -> StorageResult<Option<HeadObjectInfo>> {
+        match self
+            .client
+            .head_object()
+            .bucket(&self.layout.bucket)
+            .key(key)
+            .send()
+            .await
+        {
+            Ok(output) => {
+                let owner_session = output
+                    .metadata()
+                    .and_then(|metadata| metadata.get(SESSION_OWNER_META_KEY).cloned());
+                Ok(Some(HeadObjectInfo {
+                    etag: output.e_tag.map(normalize_etag),
+                    owner_session,
+                    content_length: output.content_length.unwrap_or(0).max(0) as u64,
+                }))
+            }
+            Err(err) if is_head_object_not_found(&err) => Ok(None),
+            Err(err) => Err(s3_error("head object", err)),
         }
+    }
+
+    // --- native multipart helpers --------------------------------------------
+
+    async fn create_multipart(
+        &self,
+        object_key: &str,
+        content_type: Option<&str>,
+        session: &UploadSessionId,
+    ) -> StorageResult<String> {
+        let mut request = self
+            .client
+            .create_multipart_upload()
+            .bucket(&self.layout.bucket)
+            .key(object_key)
+            // Stamp ownership so the final object can be attributed to this
+            // session when reconciling `NoSuchUpload` on a retry.
+            .metadata(SESSION_OWNER_META_KEY, session.as_str());
+        if let Some(content_type) = content_type {
+            request = request.content_type(content_type);
+        }
+        let output = request
+            .send()
+            .await
+            .map_err(|err| s3_error("create multipart upload", err))?;
+        output.upload_id().map(str::to_string).ok_or_else(|| {
+            StorageError::backend("S3 create multipart upload returned no upload id".to_string())
+        })
+    }
+
+    async fn upload_part(
+        &self,
+        object_key: &str,
+        upload_id: &str,
+        part_number: i32,
+        body: Bytes,
+    ) -> StorageResult<String> {
+        let output = self
+            .client
+            .upload_part()
+            .bucket(&self.layout.bucket)
+            .key(object_key)
+            .upload_id(upload_id)
+            .part_number(part_number)
+            .body(ByteStream::from(body))
+            .send()
+            .await
+            .map_err(|err| s3_error("upload part", err))?;
+        // Keep the ETag verbatim (quotes included) so CompleteMultipartUpload
+        // matches what S3 returned for the part.
+        output
+            .e_tag()
+            .map(str::to_string)
+            .ok_or_else(|| StorageError::backend("S3 upload part returned no etag".to_string()))
+    }
+
+    /// Assemble the final object from its parts.
+    ///
+    /// Uses `If-None-Match: *` so completion atomically refuses to overwrite an
+    /// existing destination key (no TOCTOU window) on real S3. Failure modes:
+    ///   - `412 PreconditionFailed`: the key exists but *our* multipart upload was
+    ///     not consumed, so the object was created by someone else — always
+    ///     reject, never adopt it.
+    ///   - `NoSuchUpload`: the upload id is gone. This is ambiguous — either a
+    ///     prior completion consumed it (object is ours) or it was aborted/expired
+    ///     (any object at the key is foreign). We disambiguate via the
+    ///     [`SESSION_OWNER_META_KEY`] marker stamped at create time: adopt the key
+    ///     only when it carries this session's id, otherwise the upload is gone.
+    async fn complete_multipart(
+        &self,
+        object_key: &str,
+        upload_id: &str,
+        parts: &[S3CompletedPart],
+        session: &UploadSessionId,
+    ) -> StorageResult<Option<String>> {
+        let completed_parts: Vec<CompletedPart> = parts
+            .iter()
+            .map(|part| {
+                CompletedPart::builder()
+                    .part_number(part.number)
+                    .e_tag(part.etag.clone())
+                    .build()
+            })
+            .collect();
+        let completed = CompletedMultipartUpload::builder()
+            .set_parts(Some(completed_parts))
+            .build();
+        match self
+            .client
+            .complete_multipart_upload()
+            .bucket(&self.layout.bucket)
+            .key(object_key)
+            .upload_id(upload_id)
+            .if_none_match("*")
+            .multipart_upload(completed)
+            .send()
+            .await
+        {
+            Ok(output) => Ok(output.e_tag().map(|etag| normalize_etag(etag.to_string()))),
+            Err(err) if is_precondition_failed(&err) => {
+                // A foreign object won the race; our upload is still active, so
+                // abort it to avoid leaking parts before reporting the collision.
+                let _ = self.abort_multipart(object_key, upload_id).await;
+                Err(StorageError::policy_rejected(format!(
+                    "S3 object key already exists: {object_key}"
+                )))
+            }
+            Err(err) if is_no_such_upload(&err) => {
+                match self.head_object(object_key).await? {
+                    // Adopt the existing object only if it was stamped by this
+                    // session; a foreign object (or none) means this upload was
+                    // aborted/expired and can no longer be completed.
+                    Some(info) if info.owner_session.as_deref() == Some(session.as_str()) => {
+                        Ok(info.etag)
+                    }
+                    _ => Err(StorageError::UploadClosed {
+                        session: session.to_string(),
+                    }),
+                }
+            }
+            Err(err) => Err(s3_error("complete multipart upload", err)),
+        }
+    }
+
+    async fn abort_multipart(&self, object_key: &str, upload_id: &str) -> StorageResult<()> {
+        match self
+            .client
+            .abort_multipart_upload()
+            .bucket(&self.layout.bucket)
+            .key(object_key)
+            .upload_id(upload_id)
+            .send()
+            .await
+        {
+            Ok(_) => Ok(()),
+            Err(err) if is_no_such_upload(&err) => Ok(()),
+            Err(err) => Err(s3_error("abort multipart upload", err)),
+        }
+    }
+
+    /// Stream one numbered part straight to S3 without buffering it.
+    ///
+    /// `content_length` is required: S3 `UploadPart` must know the part size, and
+    /// the server reads it from the request `Content-Length` rather than draining
+    /// the body to measure it. The ETag is recorded by S3 itself, so the
+    /// by-number completion path lists parts from the provider rather than
+    /// persisting per-part receipts in the session (which would race across
+    /// concurrent parts).
+    async fn upload_part_streaming(
+        &self,
+        object_key: &str,
+        upload_id: &str,
+        part_number: i32,
+        body: UploadBody,
+        content_length: u64,
+    ) -> StorageResult<()> {
+        self.client
+            .upload_part()
+            .bucket(&self.layout.bucket)
+            .key(object_key)
+            .upload_id(upload_id)
+            .part_number(part_number)
+            .content_length(content_length as i64)
+            .body(upload_body_to_byte_stream(body))
+            .customize()
+            // The default `WhenSupported` checksum would try to read the
+            // non-replayable streaming body to compute a CRC; only checksum when
+            // the operation actually requires it.
+            .config_override(
+                aws_sdk_s3::config::Builder::default().request_checksum_calculation(
+                    aws_sdk_s3::config::RequestChecksumCalculation::WhenRequired,
+                ),
+            )
+            .interceptor(UnsignedPayloadInterceptor)
+            .send()
+            .await
+            .map_err(|err| s3_error("upload part", err))?;
         Ok(())
     }
 
-    async fn cleanup_staged_bytes(
+    /// List the parts S3 has recorded for an in-progress multipart upload, in
+    /// ascending part-number order. Paginates across S3's 1,000-parts-per-page
+    /// limit so the full set (up to [`S3_MAX_PARTS`]) is returned.
+    async fn list_parts(
+        &self,
+        object_key: &str,
+        upload_id: &str,
+    ) -> StorageResult<Vec<S3CompletedPart>> {
+        let mut parts = Vec::new();
+        let mut marker: Option<String> = None;
+        loop {
+            let mut request = self
+                .client
+                .list_parts()
+                .bucket(&self.layout.bucket)
+                .key(object_key)
+                .upload_id(upload_id);
+            if let Some(marker) = &marker {
+                request = request.part_number_marker(marker);
+            }
+            let output = request
+                .send()
+                .await
+                .map_err(|err| s3_error("list parts", err))?;
+            for part in output.parts() {
+                let number = part.part_number().ok_or_else(|| {
+                    StorageError::backend("S3 list parts returned a part without a number")
+                })?;
+                let etag = part.e_tag().map(str::to_string).ok_or_else(|| {
+                    StorageError::backend("S3 list parts returned a part without an etag")
+                })?;
+                let size = part.size().unwrap_or(0).max(0) as u64;
+                parts.push(S3CompletedPart { number, etag, size });
+            }
+            if output.is_truncated() == Some(true) {
+                marker = output.next_part_number_marker().map(str::to_string);
+                if marker.is_none() {
+                    break;
+                }
+            } else {
+                break;
+            }
+        }
+        parts.sort_by_key(|part| part.number);
+        Ok(parts)
+    }
+
+    /// Resume helper: the multipart parts already committed for a by-number
+    /// upload, listed from S3 (the session tracks no per-part receipts).
+    ///
+    /// This is deliberately a standalone method rather than part of
+    /// [`StorageBackend::inspect_upload`]: `inspect_upload` is on the internal
+    /// routing/authorization path that every part `PUT` traverses, and listing
+    /// there would make an n-part upload O(n²). A client that wants to skip
+    /// already-uploaded parts on resume calls this explicitly.
+    pub async fn list_committed_parts(
+        &self,
+        ctx: &StorageContext,
+        session: UploadSessionId,
+    ) -> StorageResult<Vec<UploadedPartView>> {
+        let lock = self.session_locks.lock(&session);
+        let _cleanup = UploadSessionLockCleanup::new(&self.session_locks, &session);
+        let _guard = lock.lock().await;
+        let stored = self.read_session(&session).await?;
+        ensure_owner(&ctx.actor, &stored.owner)?;
+        let Some(upload_id) = stored
+            .native
+            .multipart()
+            .and_then(|state| state.upload_id.clone())
+        else {
+            return Ok(Vec::new());
+        };
+        let object_key = self.layout.object_key(stored.storage_key.key.as_str());
+        let parts = self.list_parts(&object_key, &upload_id).await?;
+        Ok(parts
+            .iter()
+            .map(|part| UploadedPartView {
+                number: part.number.max(0) as u32,
+                size: part.size,
+                status: UploadedPartStatus::Uploaded,
+                checksum: None,
+            })
+            .collect())
+    }
+
+    /// Verify the assembled object against the checksum policy by streaming it
+    /// back (only when a checksum is actually required/supplied — the default
+    /// `None` policy never reads the object). On mismatch the live object is
+    /// deleted so a bad upload is never observable; if that delete fails it is
+    /// surfaced, since a checksum-invalid live object is worse than the error.
+    async fn verify_object_checksum(
+        &self,
+        object_key: &str,
+        policy: &ChecksumPolicy,
+        requested: Option<ObjectChecksum>,
+    ) -> StorageResult<Option<ObjectChecksum>> {
+        match checksum_algorithm_to_compute(policy, requested.as_ref()) {
+            Some(algorithm) => {
+                let computed = self.stream_object_checksum(object_key, algorithm).await?;
+                match validate_complete_checksum_precomputed(policy, Some(computed), requested) {
+                    Ok(checksum) => Ok(checksum),
+                    Err(err) => {
+                        self.delete_object(object_key).await.map_err(|delete_err| {
+                            tracing::error!(
+                                target: "pocopine.log",
+                                event_name = "pocopine.storage.s3_invalid_object_cleanup_failed",
+                                object_key = %object_key,
+                                checksum_error = %err,
+                                delete_error = %delete_err,
+                            );
+                            delete_err
+                        })?;
+                        Err(err)
+                    }
+                }
+            }
+            None => validate_complete_checksum_precomputed(policy, None, requested),
+        }
+    }
+
+    /// Stream the stored object through `algorithm` without buffering it.
+    async fn stream_object_checksum(
+        &self,
+        key: &str,
+        algorithm: ChecksumAlgorithm,
+    ) -> StorageResult<ObjectChecksum> {
+        use tokio::io::AsyncReadExt as _;
+        let output = self
+            .client
+            .get_object()
+            .bucket(&self.layout.bucket)
+            .key(key)
+            .send()
+            .await
+            .map_err(|err| s3_error("get object for checksum", err))?;
+        let mut reader = output.body.into_async_read();
+        let mut hasher = StreamingChecksum::new(algorithm);
+        let mut buffer = vec![0u8; CHECKSUM_READ_CHUNK];
+        loop {
+            let read = reader
+                .read(&mut buffer)
+                .await
+                .map_err(|err| s3_error("read object body for checksum", err))?;
+            if read == 0 {
+                break;
+            }
+            hasher.update(&buffer[..read]);
+        }
+        Ok(hasher.finalize())
+    }
+
+    /// Create the provider multipart upload on first use and persist its id.
+    async fn ensure_upload_id(
         &self,
         session: &UploadSessionId,
         stored: &mut StoredUploadSession,
-    ) -> StorageResult<()> {
-        if !stored.cleanup_pending {
-            return Ok(());
+        object_key: &str,
+    ) -> StorageResult<String> {
+        if let Some(state) = stored.native.multipart() {
+            if let Some(upload_id) = &state.upload_id {
+                return Ok(upload_id.clone());
+            }
         }
-        self.delete_object(&self.layout.session_bytes_key(session))
+        let upload_id = self
+            .create_multipart(object_key, stored.public.content_type.as_deref(), session)
             .await?;
-        stored.cleanup_pending = false;
-        self.write_session(session, stored).await
+        if let Some(state) = stored.native.multipart_mut() {
+            state.upload_id = Some(upload_id.clone());
+        }
+        self.write_session(session, stored).await?;
+        Ok(upload_id)
     }
 
     fn ensure_requested_size_is_supported(&self, size: Option<u64>) -> StorageResult<()> {
@@ -353,11 +859,545 @@ impl S3StorageBackend {
             metadata,
         }
     }
+
+    async fn persist_expired_if_needed(
+        &self,
+        session: &UploadSessionId,
+        stored: &StoredUploadSession,
+    ) -> StorageResult<()> {
+        if stored.public.status == UploadSessionStatus::Expired {
+            self.write_session(session, stored).await?;
+        }
+        Ok(())
+    }
+
+    async fn cleanup_staged_bytes(
+        &self,
+        session: &UploadSessionId,
+        stored: &mut StoredUploadSession,
+    ) -> StorageResult<()> {
+        if !stored.cleanup_pending {
+            return Ok(());
+        }
+        self.delete_object(&self.layout.session_bytes_key(session))
+            .await?;
+        stored.cleanup_pending = false;
+        self.write_session(session, stored).await
+    }
+
+    // --- native multipart upload flow ----------------------------------------
+
+    async fn append_multipart(
+        &self,
+        session: &UploadSessionId,
+        mut stored: StoredUploadSession,
+        offset: u64,
+        bytes: Bytes,
+    ) -> StorageResult<UploadSession> {
+        // Copy the buffered tail to prepend to the incoming chunk. The copy
+        // (bounded by one part) leaves the tail durable in `stored` so the lazy
+        // `ensure_upload_id` write below still persists it; the tail is only
+        // replaced by the remainder in the single atomic write at the end.
+        let (flushed, tail) = {
+            let state = stored
+                .native
+                .multipart()
+                .expect("append_multipart called for a non-multipart session");
+            (state.flushed_len(), state.pending_tail.clone())
+        };
+        let expected = flushed + tail.len() as u64;
+        if expected != offset {
+            tracing::debug!(
+                target: "pocopine.log",
+                event_name = "pocopine.storage.offset_mismatch",
+                session = %session,
+                expected,
+                provided = offset,
+            );
+            return Err(StorageError::offset_mismatch(expected, offset));
+        }
+        let new_offset = checked_new_offset(offset, bytes.len())?;
+        ensure_size_limit(stored.max_bytes, stored.public.size, new_offset)?;
+        if bytes.is_empty() {
+            return Ok(stored.public);
+        }
+
+        let object_key = self.layout.object_key(stored.storage_key.key.as_str());
+
+        // Combine the buffered tail (bounded by one part) with the incoming
+        // chunk. When the tail is empty we slice the incoming `Bytes` directly,
+        // avoiding any copy.
+        let combined: Bytes = if tail.is_empty() {
+            bytes
+        } else {
+            let mut combined = tail;
+            combined.extend_from_slice(&bytes);
+            Bytes::from(combined)
+        };
+
+        // Flush every full-size part; the remainder becomes the new tail. Parts
+        // are uploaded to S3 first, then the resulting state (parts + remainder
+        // tail) is persisted in a single atomic write at the end. A crash before
+        // that write leaves the durable metadata unchanged, so the client simply
+        // re-sends from the old offset and we recompute the same parts (uploading
+        // a part is idempotent — the same part number overwrites).
+        //
+        // `part_size` is derived from the (fixed) session max so it is stable
+        // across appends and resumes, and large uploads stay under the part cap.
+        let part_size = part_size_for(stored.max_bytes) as usize;
+        let mut pos = 0usize;
+        while combined.len() - pos >= part_size {
+            let upload_id = self
+                .ensure_upload_id(session, &mut stored, &object_key)
+                .await?;
+            let number = stored
+                .native
+                .multipart()
+                .expect("multipart state")
+                .next_part_number;
+            let part = combined.slice(pos..pos + part_size);
+            let etag = self
+                .upload_part(&object_key, &upload_id, number, part)
+                .await?;
+            if let Some(state) = stored.native.multipart_mut() {
+                state.parts.push(S3CompletedPart {
+                    number,
+                    etag,
+                    size: part_size as u64,
+                });
+                state.next_part_number = number + 1;
+            }
+            pos += part_size;
+        }
+
+        if let Some(state) = stored.native.multipart_mut() {
+            state.pending_tail = combined.slice(pos..).to_vec();
+        }
+        stored.public.next_offset = Some(new_offset);
+        self.write_session(session, &stored).await?;
+        Ok(stored.public)
+    }
+
+    async fn complete_multipart_upload_flow(
+        &self,
+        session: &UploadSessionId,
+        mut stored: StoredUploadSession,
+        request: CompleteUpload,
+    ) -> StorageResult<ObjectRef> {
+        let total = stored.public.next_offset.unwrap_or(0);
+        if let Some(expected) = stored.public.size {
+            if total != expected {
+                return Err(StorageError::policy_rejected(format!(
+                    "upload is incomplete: expected {expected} bytes, got {total}"
+                )));
+            }
+        }
+        ensure_size_limit(stored.max_bytes, stored.public.size, total)?;
+        // Reject a missing-required or disallowed-algorithm checksum up front, so
+        // a config error never assembles (and then deletes) the object.
+        precheck_checksum(&stored.checksum_policy, request.checksum.as_ref())?;
+
+        let object_key = self.layout.object_key(stored.storage_key.key.as_str());
+        let has_upload_id = stored
+            .native
+            .multipart()
+            .expect("multipart state")
+            .upload_id
+            .is_some();
+
+        let (etag, checksum) = if !has_upload_id {
+            // Single direct-PUT path: the whole object fits in the buffered tail
+            // (or is empty). It is atomic — `put_completed_object` refuses to
+            // overwrite an existing key — and the checksum is validated before any
+            // state change, so a rejected checksum leaves the session open and
+            // resumable rather than stranded in `Completing`.
+            let tail = stored
+                .native
+                .multipart()
+                .expect("multipart state")
+                .pending_tail
+                .clone();
+            let checksum =
+                validate_complete_checksum(&stored.checksum_policy, &tail, request.checksum)?;
+            let etag = self
+                .put_completed_object(
+                    &object_key,
+                    Bytes::from(tail),
+                    stored.public.content_type.as_deref(),
+                )
+                .await?;
+            (etag, checksum)
+        } else {
+            // Multipart path.
+            // HEAD on every attempt (not just the first). This is the only
+            // overwrite guard that works on stores which ignore `If-None-Match`
+            // on `CompleteMultipartUpload`, and it distinguishes our own
+            // already-finalized object (adopt idempotently) from a foreign object
+            // that won the key (reject). The `If-None-Match: *` on completion is
+            // an additional atomic guard for the HEAD→complete window on real S3.
+            let existing_etag = match self.head_object(&object_key).await? {
+                Some(info) if info.owner_session.as_deref() == Some(session.as_str()) => {
+                    Some(info.etag)
+                }
+                Some(_) => {
+                    // Foreign object at the destination: abort our orphaned upload
+                    // (best effort) and reject rather than overwrite it.
+                    let _ = self.abort_multipart_session(&stored).await;
+                    return Err(StorageError::policy_rejected(format!(
+                        "S3 object key already exists: {object_key}"
+                    )));
+                }
+                None => None,
+            };
+
+            let etag = if let Some(etag) = existing_etag {
+                // A prior attempt already finalized this object; reuse it.
+                etag
+            } else {
+                if stored.public.status == UploadSessionStatus::Open
+                    || stored.public.next_offset != Some(total)
+                {
+                    stored.public.status = UploadSessionStatus::Completing;
+                    stored.public.next_offset = Some(total);
+                    self.write_session(session, &stored).await?;
+                }
+
+                // Flush the final remainder as the last part (exempt from the
+                // minimum-size rule), then assemble the object.
+                let tail = stored
+                    .native
+                    .multipart()
+                    .expect("multipart state")
+                    .pending_tail
+                    .clone();
+                if !tail.is_empty() {
+                    let tail_len = tail.len() as u64;
+                    let upload_id = stored
+                        .native
+                        .multipart()
+                        .and_then(|state| state.upload_id.clone())
+                        .expect("multipart upload id");
+                    let number = stored
+                        .native
+                        .multipart()
+                        .expect("multipart state")
+                        .next_part_number;
+                    let etag = self
+                        .upload_part(&object_key, &upload_id, number, Bytes::from(tail))
+                        .await?;
+                    if let Some(state) = stored.native.multipart_mut() {
+                        state.parts.push(S3CompletedPart {
+                            number,
+                            etag,
+                            size: tail_len,
+                        });
+                        state.next_part_number = number + 1;
+                        state.pending_tail = Vec::new();
+                    }
+                    self.write_session(session, &stored).await?;
+                }
+                let (upload_id, parts) = {
+                    let state = stored.native.multipart().expect("multipart state");
+                    (
+                        state.upload_id.clone().expect("multipart upload id"),
+                        state.parts.clone(),
+                    )
+                };
+                self.complete_multipart(&object_key, &upload_id, &parts, session)
+                    .await?
+            };
+
+            // Validate the checksum by streaming the finished object (only when a
+            // checksum was actually supplied; the default path never hashes).
+            //
+            // NOTE: multipart parts cannot be read before `CompleteMultipartUpload`,
+            // so verification necessarily happens after the object is assembled. A
+            // mismatch therefore deletes the (already-finalized) object and the
+            // session cannot be retried — the client must re-initiate. Phase 0
+            // accepts this; a later phase computes the checksum incrementally as
+            // parts stream so it can be verified before completion.
+            let checksum = self
+                .verify_object_checksum(&object_key, &stored.checksum_policy, request.checksum)
+                .await?;
+            (etag, checksum)
+        };
+
+        self.finalize_completed(session, stored, total, etag, checksum)
+            .await
+    }
+
+    /// Mark a session complete: record the resulting object, clear any buffered
+    /// tail, and persist. Native sessions buffer the tail inline in the metadata,
+    /// so there is no separate staged object to delete.
+    async fn finalize_completed(
+        &self,
+        session: &UploadSessionId,
+        mut stored: StoredUploadSession,
+        total: u64,
+        etag: Option<String>,
+        checksum: Option<ObjectChecksum>,
+    ) -> StorageResult<ObjectRef> {
+        let object = self.object_ref(&stored, total, etag, checksum);
+        stored.public.status = UploadSessionStatus::Complete;
+        stored.public.next_offset = Some(total);
+        stored.object = Some(object.clone());
+        if let Some(state) = stored.native.multipart_mut() {
+            state.pending_tail = Vec::new();
+        }
+        self.write_session(session, &stored).await?;
+        Ok(object)
+    }
+
+    /// Assemble a server-mediated multipart upload whose parts arrived by number
+    /// (the [`StorageBackend::upload_part`] path). Part receipts live on S3, not
+    /// in the session, so they are listed from the provider here rather than read
+    /// from local state — which is what makes concurrent, out-of-order part
+    /// uploads race-free (no per-part session write to clobber).
+    async fn complete_multipart_by_number_flow(
+        &self,
+        session: &UploadSessionId,
+        mut stored: StoredUploadSession,
+        request: CompleteUpload,
+    ) -> StorageResult<ObjectRef> {
+        // Reject a missing-required or disallowed-algorithm checksum up front.
+        precheck_checksum(&stored.checksum_policy, request.checksum.as_ref())?;
+        // A by-number upload must declare its length before completing. Parts
+        // arrive concurrently and `upload_part` releases the session lock before
+        // streaming, so without a declared total a `complete` racing an in-flight
+        // part would treat the currently-listed parts as the whole object and
+        // publish a truncated result. With a declared size, the `total != size`
+        // check below rejects a premature completion instead.
+        let expected_size = stored.public.size.ok_or_else(|| {
+            StorageError::policy_rejected(
+                "multipart upload requires a declared length before completion",
+            )
+        })?;
+        let object_key = self.layout.object_key(stored.storage_key.key.as_str());
+        let upload_id = stored
+            .native
+            .multipart()
+            .and_then(|state| state.upload_id.clone());
+
+        // No part was ever uploaded: the object is empty. Handle it exactly like
+        // the single direct-PUT path so a zero-byte upload still produces an
+        // object (CompleteMultipartUpload rejects zero parts, so it is avoided).
+        let Some(upload_id) = upload_id else {
+            if expected_size != 0 {
+                return Err(StorageError::policy_rejected(format!(
+                    "upload is incomplete: expected {expected_size} bytes, got 0"
+                )));
+            }
+            let checksum =
+                validate_complete_checksum(&stored.checksum_policy, &[], request.checksum)?;
+            let etag = self
+                .put_empty_owned_object(&object_key, session, stored.public.content_type.as_deref())
+                .await?;
+            return self
+                .finalize_completed(session, stored, 0, etag, checksum)
+                .await;
+        };
+
+        // Idempotent re-complete: a prior attempt may already have assembled our
+        // object. HEAD distinguishes our own finished object (adopt) from a
+        // foreign object that won the key (reject), and works even on stores that
+        // ignore `If-None-Match` on CompleteMultipartUpload.
+        match self.head_object(&object_key).await? {
+            Some(info) if info.owner_session.as_deref() == Some(session.as_str()) => {
+                // Already assembled by a prior attempt. The multipart upload id is
+                // consumed (ListParts would report `NoSuchUpload`), so adopt the
+                // object using its own size rather than re-listing parts.
+                let total = info.content_length;
+                let checksum = self
+                    .verify_object_checksum(&object_key, &stored.checksum_policy, request.checksum)
+                    .await?;
+                return self
+                    .finalize_completed(session, stored, total, info.etag, checksum)
+                    .await;
+            }
+            Some(_) => {
+                let _ = self.abort_multipart(&object_key, &upload_id).await;
+                return Err(StorageError::policy_rejected(format!(
+                    "S3 object key already exists: {object_key}"
+                )));
+            }
+            None => {}
+        }
+
+        let parts = self.list_parts(&object_key, &upload_id).await?;
+        // Reject gaps: `CompleteMultipartUpload` would otherwise concatenate
+        // whatever parts exist in number order, silently dropping a missing one
+        // (e.g. parts 1 and 3 with no 2) and publishing an object with corrupted
+        // offsets. `parts` is sorted ascending, so they must be exactly 1..=len.
+        for (index, part) in parts.iter().enumerate() {
+            let expected = index as i32 + 1;
+            if part.number != expected {
+                return Err(StorageError::policy_rejected(format!(
+                    "upload is incomplete: missing multipart part {expected}"
+                )));
+            }
+        }
+        // S3 requires every part except the last to be at least 5 MiB; otherwise
+        // `CompleteMultipartUpload` fails with `EntityTooSmall`. Validate before
+        // leaving `Open` (and before the size check, so this specific cause is
+        // reported) so a client that ignored `plan.min_part_size` can re-PUT the
+        // offending part — a `Completing` session refuses further parts.
+        if let Some((_last, leading)) = parts.split_last() {
+            for part in leading {
+                if part.size < S3_MIN_PART_SIZE {
+                    return Err(StorageError::policy_rejected(format!(
+                        "multipart part {} is {} bytes, below the {} byte minimum for a non-final part",
+                        part.number, part.size, S3_MIN_PART_SIZE
+                    )));
+                }
+            }
+        }
+
+        let total: u64 = parts.iter().map(|part| part.size).sum();
+        if total != expected_size {
+            // Rejects a `complete` that raced an in-flight part (S3 lists only
+            // 1..N so far) as well as a genuinely short upload.
+            return Err(StorageError::policy_rejected(format!(
+                "upload is incomplete: expected {expected_size} bytes, got {total}"
+            )));
+        }
+        ensure_size_limit(stored.max_bytes, stored.public.size, total)?;
+
+        let empty_mpu = parts.is_empty();
+        let etag = if empty_mpu {
+            // The upload was created but no part committed (every part failed), so
+            // the object is empty. Write the empty object (HEAD-guarded: rejects a
+            // foreign key, stamps ownership) but DON'T abort the MPU yet — the
+            // upload id is the only retry handle until the empty object is durably
+            // finalized below, so aborting first would strand the session if the
+            // PUT or checksum failed.
+            self.put_empty_owned_object(&object_key, session, stored.public.content_type.as_deref())
+                .await?
+        } else {
+            if stored.public.status == UploadSessionStatus::Open
+                || stored.public.next_offset != Some(total)
+            {
+                stored.public.status = UploadSessionStatus::Completing;
+                stored.public.next_offset = Some(total);
+                self.write_session(session, &stored).await?;
+            }
+            self.complete_multipart(&object_key, &upload_id, &parts, session)
+                .await?
+        };
+
+        let checksum = self
+            .verify_object_checksum(&object_key, &stored.checksum_policy, request.checksum)
+            .await?;
+        let object = self
+            .finalize_completed(session, stored, total, etag, checksum)
+            .await?;
+        if empty_mpu {
+            // The empty object is durable and the session is finalized; clean up
+            // the now-orphaned multipart upload best-effort (a leftover is swept
+            // by stale-upload cleanup and never re-adopted, since completion is
+            // idempotent via the finalized object).
+            let _ = self.abort_multipart(&object_key, &upload_id).await;
+        }
+        Ok(object)
+    }
+
+    async fn abort_multipart_session(&self, stored: &StoredUploadSession) -> StorageResult<()> {
+        if let Some(state) = stored.native.multipart() {
+            if let Some(upload_id) = &state.upload_id {
+                let object_key = self.layout.object_key(stored.storage_key.key.as_str());
+                self.abort_multipart(&object_key, upload_id).await?;
+            }
+        }
+        Ok(())
+    }
+
+    // --- legacy staged-object rewrite flow (pre-multipart sessions) -----------
+
+    async fn append_legacy(
+        &self,
+        session: &UploadSessionId,
+        mut stored: StoredUploadSession,
+        offset: u64,
+        bytes: Bytes,
+    ) -> StorageResult<UploadSession> {
+        let mut expected = stored.public.next_offset.unwrap_or(0);
+        let mut staged = self.reconcile_staged_bytes(session, expected).await?;
+        let staged_len = staged.len() as u64;
+        if staged_len > expected {
+            expected = staged_len;
+            stored.public.next_offset = Some(staged_len);
+            self.write_session(session, &stored).await?;
+        }
+        if expected != offset {
+            tracing::debug!(
+                target: "pocopine.log",
+                event_name = "pocopine.storage.offset_mismatch",
+                session = %session,
+                expected,
+                provided = offset,
+            );
+            return Err(StorageError::offset_mismatch(expected, offset));
+        }
+        let new_offset = checked_new_offset(offset, bytes.len())?;
+        ensure_size_limit(stored.max_bytes, stored.public.size, new_offset)?;
+        staged.extend_from_slice(&bytes);
+        self.put_staged_bytes(session, staged).await?;
+        stored.public.next_offset = Some(new_offset);
+        self.write_session(session, &stored).await?;
+        Ok(stored.public)
+    }
+
+    async fn complete_legacy(
+        &self,
+        session: &UploadSessionId,
+        mut stored: StoredUploadSession,
+        request: CompleteUpload,
+    ) -> StorageResult<ObjectRef> {
+        let trusted = stored.public.next_offset.unwrap_or(0);
+        let staged = self.reconcile_staged_bytes(session, trusted).await?;
+        let actual = staged.len() as u64;
+        if let Some(expected) = stored.public.size {
+            if actual != expected {
+                return Err(StorageError::policy_rejected(format!(
+                    "upload is incomplete: expected {expected} bytes, got {actual}"
+                )));
+            }
+        }
+        ensure_size_limit(stored.max_bytes, stored.public.size, actual)?;
+        let checksum =
+            validate_complete_checksum(&stored.checksum_policy, &staged, request.checksum)?;
+        let object_key = self.layout.object_key(stored.storage_key.key.as_str());
+        if stored.public.status == UploadSessionStatus::Open
+            || stored.public.next_offset != Some(actual)
+        {
+            stored.public.status = UploadSessionStatus::Completing;
+            stored.public.next_offset = Some(actual);
+            self.write_session(session, &stored).await?;
+        }
+        let staged = Bytes::from(staged);
+        let etag = self
+            .put_completed_object(&object_key, staged, stored.public.content_type.as_deref())
+            .await?;
+        let object = self.object_ref(&stored, actual, etag, checksum);
+        stored.public.status = UploadSessionStatus::Complete;
+        stored.public.next_offset = Some(actual);
+        stored.object = Some(object.clone());
+        stored.cleanup_pending = true;
+        self.write_session(session, &stored).await?;
+        self.cleanup_staged_bytes(session, &mut stored).await?;
+        Ok(object)
+    }
 }
 
 impl StorageBackend for S3StorageBackend {
     fn name(&self) -> &'static str {
         self.name
+    }
+
+    fn capabilities(&self) -> BackendCapabilities {
+        // Sequential proxy (the coalescing-tail path, the default) and
+        // server-mediated native multipart (the by-number `upload_part` path) are
+        // both backed by S3 multipart uploads.
+        BackendCapabilities::default().with_native_multipart()
     }
 
     fn initiate_upload<'a>(
@@ -366,9 +1406,52 @@ impl StorageBackend for S3StorageBackend {
         request: InitiateUpload,
     ) -> StorageBoxFuture<'a, UploadSession> {
         Box::pin(async move {
-            let strategy = selected_strategy(request.requested_strategy)?;
+            let strategy = select_upload_mode(request.requested_strategy, self.capabilities())?;
             ensure_supported_checksum_policy(&request.policy.checksum)?;
             self.ensure_requested_size_is_supported(request.size)?;
+            // By-number multipart requires the total length up front: parts are
+            // tracked only on S3 (not in the session), so without a declared size
+            // neither `set_upload_length` nor completion can reason about how much
+            // has been committed, and a deferred length could be set below
+            // already-uploaded parts and strand the session.
+            if strategy == UploadStrategy::Multipart && request.size.is_none() {
+                return Err(StorageError::policy_rejected(
+                    "multipart uploads require a declared length (size) at initiation",
+                ));
+            }
+            let max_bytes = request.policy.max_bytes.min(self.max_proxy_upload_bytes);
+            // The by-number multipart path advertises S3-aware part sizing and the
+            // policy's concurrency. It pins the part size (rather than allowing up
+            // to the 5 GiB provider ceiling): with every part bounded to
+            // `part_size` and the count bounded to `ceil(max_bytes / part_size)`,
+            // the worst-case stored bytes stay within one part of the budget
+            // without tracking a cumulative size across concurrent parts. The
+            // sequential path keeps the policy's chunk plan unchanged.
+            let (plan, session_part_size) = if strategy == UploadStrategy::Multipart {
+                let part_size = part_size_for(max_bytes);
+                let plan = TransferPlan {
+                    min_part_size: Some(S3_MIN_PART_SIZE.min(part_size)),
+                    preferred_part_size: Some(part_size),
+                    max_part_size: Some(part_size),
+                    max_parts: Some(max_bytes.div_ceil(part_size).max(1) as u32),
+                    max_concurrent_parts: request.policy.max_concurrent_parts.max(1),
+                    resumable: true,
+                };
+                // Keep the legacy `part_size` field in sync with the plan so a
+                // client reading only that field still sends parts at the S3 floor
+                // rather than `preferred_chunk_size` (which may be below 5 MiB).
+                (plan, Some(part_size))
+            } else {
+                let plan = TransferPlan {
+                    min_part_size: request.policy.min_part_size,
+                    preferred_part_size: request.policy.preferred_chunk_size,
+                    max_part_size: request.policy.max_part_size,
+                    max_parts: request.policy.max_parts,
+                    max_concurrent_parts: 1,
+                    resumable: true,
+                };
+                (plan, request.policy.preferred_chunk_size)
+            };
             let id = UploadSessionId::new(Uuid::new_v4().to_string())?;
             let session = UploadSession {
                 id: id.clone(),
@@ -380,15 +1463,8 @@ impl StorageBackend for S3StorageBackend {
                 strategy,
                 status: UploadSessionStatus::Open,
                 next_offset: Some(0),
-                part_size: request.policy.preferred_chunk_size,
-                plan: TransferPlan {
-                    min_part_size: request.policy.min_part_size,
-                    preferred_part_size: request.policy.preferred_chunk_size,
-                    max_part_size: request.policy.max_part_size,
-                    max_parts: request.policy.max_parts,
-                    max_concurrent_parts: 1,
-                    resumable: true,
-                },
+                part_size: session_part_size,
+                plan,
                 uploaded_parts: Vec::new(),
                 expires_at: expires_at(request.policy.expires_after),
             };
@@ -397,17 +1473,21 @@ impl StorageBackend for S3StorageBackend {
                 owner: ctx.actor.clone(),
                 storage_key: request.storage_key,
                 visibility: request.policy.visibility,
-                max_bytes: request.policy.max_bytes.min(self.max_proxy_upload_bytes),
+                max_bytes,
                 checksum_policy: request.policy.checksum,
                 request_metadata: request.metadata,
                 object: None,
                 cleanup_pending: false,
+                native: NativeUploadState::Multipart(S3MultipartState {
+                    upload_id: None,
+                    parts: Vec::new(),
+                    next_part_number: 1,
+                    pending_tail: Vec::new(),
+                }),
             };
+            // No staged `bytes.tmp` is created up front; native sessions only
+            // write a tail object once there are sub-part bytes to buffer.
             self.write_session(&id, &stored).await?;
-            if let Err(err) = self.put_staged_bytes(&id, Vec::new()).await {
-                let _ = self.delete_object(&self.layout.session_meta_key(&id)).await;
-                return Err(err);
-            }
             Ok(session)
         })
     }
@@ -423,7 +1503,17 @@ impl StorageBackend for S3StorageBackend {
             let _guard = lock.lock().await;
             let mut stored = self.read_session(&session).await?;
             ensure_owner(&ctx.actor, &stored.owner)?;
-            if stored.public.status == UploadSessionStatus::Open {
+            // Only legacy sessions reconcile here. `inspect_upload` is also on the
+            // internal routing/authorization path (`backend_for_session` calls it
+            // for every part `PUT`), so it must stay cheap: a by-number multipart
+            // session deliberately does NOT `ListParts` here, which would turn an
+            // n-part upload into O(n²) provider calls serialized on the session
+            // lock. Per-part resume listing is surfaced separately via
+            // `list_committed_parts` rather than on this hot path.
+            if stored.public.status == UploadSessionStatus::Open
+                && stored.native.multipart().is_none()
+            {
+                // Legacy sessions recover their offset from the staged object.
                 let staged = self
                     .reconcile_staged_bytes(&session, stored.public.next_offset.unwrap_or(0))
                     .await?;
@@ -451,14 +1541,21 @@ impl StorageBackend for S3StorageBackend {
             let mut stored = self.read_session(&session).await?;
             ensure_owner(&ctx.actor, &stored.owner)?;
             self.persist_expired_if_needed(&session, &stored).await?;
-            let committed_offset = stored.public.next_offset.unwrap_or(0);
-            let staged_len = self
-                .reconcile_staged_bytes(&session, committed_offset)
-                .await?
-                .len() as u64;
-            ensure_upload_length_can_be_set(stored.max_bytes, &stored.public, staged_len, size)?;
+            let committed_offset = match stored.native.multipart() {
+                Some(state) => state.committed_len(),
+                None => self
+                    .reconcile_staged_bytes(&session, stored.public.next_offset.unwrap_or(0))
+                    .await?
+                    .len() as u64,
+            };
+            ensure_upload_length_can_be_set(
+                stored.max_bytes,
+                &stored.public,
+                committed_offset,
+                size,
+            )?;
             stored.public.size = Some(size);
-            stored.public.next_offset = Some(staged_len);
+            stored.public.next_offset = Some(committed_offset);
             self.write_session(&session, &stored).await?;
             Ok(stored.public)
         })
@@ -475,7 +1572,7 @@ impl StorageBackend for S3StorageBackend {
             let lock = self.session_locks.lock(&session);
             let _cleanup = UploadSessionLockCleanup::new(&self.session_locks, &session);
             let _guard = lock.lock().await;
-            let mut stored = self.read_session(&session).await?;
+            let stored = self.read_session(&session).await?;
             ensure_owner(&ctx.actor, &stored.owner)?;
             self.persist_expired_if_needed(&session, &stored).await?;
             ensure_open(&stored.public)?;
@@ -484,31 +1581,117 @@ impl StorageBackend for S3StorageBackend {
                     "S3 backend currently supports sequential proxy uploads only",
                 ));
             }
-            let mut expected = stored.public.next_offset.unwrap_or(0);
-            let mut staged = self.reconcile_staged_bytes(&session, expected).await?;
-            let staged_len = staged.len() as u64;
-            if staged_len > expected {
-                expected = staged_len;
-                stored.public.next_offset = Some(staged_len);
-                self.write_session(&session, &stored).await?;
+            if stored.native.multipart().is_some() {
+                self.append_multipart(&session, stored, offset, bytes).await
+            } else {
+                self.append_legacy(&session, stored, offset, bytes).await
             }
-            if expected != offset {
-                tracing::debug!(
-                    target: "pocopine.log",
-                    event_name = "pocopine.storage.offset_mismatch",
-                    session = %session,
-                    expected,
-                    provided = offset,
-                );
-                return Err(StorageError::offset_mismatch(expected, offset));
+        })
+    }
+
+    fn upload_part<'a>(
+        &'a self,
+        ctx: &'a StorageContext,
+        session: UploadSessionId,
+        number: u32,
+        body: UploadBody,
+    ) -> StorageBoxFuture<'a, UploadSession> {
+        Box::pin(async move {
+            // Part numbers are 1-based. The HTTP route enforces this, but the
+            // trait method is directly callable, so reject zero before it reaches
+            // S3 `UploadPart` (which only accepts 1..=10000).
+            if number == 0 {
+                return Err(StorageError::policy_rejected(
+                    "multipart part number must be at least 1",
+                ));
             }
-            let new_offset = checked_new_offset(offset, bytes.len())?;
-            ensure_size_limit(stored.max_bytes, stored.public.size, new_offset)?;
-            staged.extend_from_slice(&bytes);
-            self.put_staged_bytes(&session, staged).await?;
-            stored.public.next_offset = Some(new_offset);
-            self.write_session(&session, &stored).await?;
-            Ok(stored.public)
+            // S3 `UploadPart` requires a known length; the server reads it from
+            // the request `Content-Length` rather than draining the stream.
+            let content_length = body.content_length().ok_or_else(|| {
+                StorageError::client("S3 part upload requires a Content-Length header")
+            })?;
+
+            // Resolve the upload id under the session lock (created lazily on the
+            // first part), then release the lock before streaming so sibling parts
+            // upload concurrently. Per-part receipts are not persisted — the
+            // by-number completion path lists them from S3 — so there is no
+            // session write to serialize while a part streams.
+            let (upload_id, object_key, public) = {
+                let lock = self.session_locks.lock(&session);
+                let _cleanup = UploadSessionLockCleanup::new(&self.session_locks, &session);
+                let _guard = lock.lock().await;
+                let mut stored = self.read_session(&session).await?;
+                ensure_owner(&ctx.actor, &stored.owner)?;
+                self.persist_expired_if_needed(&session, &stored).await?;
+                ensure_open(&stored.public)?;
+                if stored.public.strategy != UploadStrategy::Multipart {
+                    return Err(StorageError::unsupported(
+                        "S3 backend part upload requires the multipart strategy",
+                    ));
+                }
+                // Bound aggregate storage without cumulative cross-part state: a
+                // valid upload of `limit_bytes` is `ceil(limit_bytes / part_size)`
+                // parts of at most `part_size` each, so capping the part number
+                // and per-part size keeps the worst case within one part of the
+                // budget (completion still enforces the exact total). Prefer the
+                // declared size over the scope max so a client cannot upload extra
+                // parts beyond the object it declared (which would only fail, with
+                // unremovable parts, at completion).
+                let part_size = part_size_for(stored.max_bytes);
+                let limit_bytes = stored.public.size.unwrap_or(stored.max_bytes);
+                let max_parts = limit_bytes.div_ceil(part_size).max(1);
+                if u64::from(number) > max_parts {
+                    return Err(StorageError::policy_rejected(format!(
+                        "part number {number} exceeds the maximum of {max_parts} parts for this upload"
+                    )));
+                }
+                if content_length > part_size {
+                    return Err(StorageError::policy_rejected(format!(
+                        "part exceeds the maximum part size of {part_size} bytes for this upload"
+                    )));
+                }
+                let object_key = self.layout.object_key(stored.storage_key.key.as_str());
+                let upload_id = self
+                    .ensure_upload_id(&session, &mut stored, &object_key)
+                    .await?;
+                (upload_id, object_key, stored.public.clone())
+            };
+
+            // Enforce the scope's advertised concurrency server-side: a permit is
+            // held for the streaming duration so at most `max_concurrent_parts`
+            // parts of this session stream at once, regardless of how many part
+            // requests the client fires. Acquired after releasing the session
+            // lock so it bounds streams, not the cheap id lookup.
+            let max_concurrent = public.plan.max_concurrent_parts.max(1) as usize;
+            let _permit = self
+                .part_concurrency
+                .semaphore(&session, max_concurrent)
+                .acquire_owned()
+                .await
+                .map_err(|_| StorageError::UploadClosed {
+                    session: session.to_string(),
+                })?;
+            // The open check above ran before the permit wait; under saturated
+            // concurrency the wait can outlast the session's expiry. Re-check the
+            // captured deadline so an expired session can't still accept a part
+            // (no extra round-trip — `expires_at` is fixed at initiation). A
+            // concurrent abort is handled by S3 itself: the UploadPart then fails
+            // with `NoSuchUpload`.
+            if OffsetDateTime::now_utc() >= public.expires_at {
+                return Err(StorageError::UploadClosed {
+                    session: session.to_string(),
+                });
+            }
+
+            self.upload_part_streaming(
+                &object_key,
+                &upload_id,
+                number as i32,
+                body,
+                content_length,
+            )
+            .await?;
+            Ok(public)
         })
     }
 
@@ -527,47 +1710,34 @@ impl StorageBackend for S3StorageBackend {
                 let object = object.clone();
                 self.cleanup_staged_bytes(&request.session, &mut stored)
                     .await?;
+                // Terminal: the object is finalized, so the part-concurrency pool
+                // can go (in-flight permit holders keep their own Arc clone).
+                self.part_concurrency.forget(&request.session);
                 return Ok(object);
             }
             self.persist_expired_if_needed(&request.session, &stored)
                 .await?;
             ensure_completable(&stored.public)?;
-            let trusted = stored.public.next_offset.unwrap_or(0);
-            let staged = self
-                .reconcile_staged_bytes(&request.session, trusted)
-                .await?;
-            let actual = staged.len() as u64;
-            if let Some(expected) = stored.public.size {
-                if actual != expected {
-                    return Err(StorageError::policy_rejected(format!(
-                        "upload is incomplete: expected {expected} bytes, got {actual}"
-                    )));
+            let session = request.session.clone();
+            let result = if stored.native.multipart().is_some() {
+                if stored.public.strategy == UploadStrategy::Multipart {
+                    self.complete_multipart_by_number_flow(&session, stored, request)
+                        .await
+                } else {
+                    self.complete_multipart_upload_flow(&session, stored, request)
+                        .await
                 }
+            } else {
+                self.complete_legacy(&session, stored, request).await
+            };
+            // Only drop the concurrency pool once completion actually succeeds. A
+            // failed attempt (missing length, part gap, undersized/in-flight part)
+            // leaves the session `Open`, so the existing semaphore must survive or
+            // a later part would create a fresh one and bypass the limit.
+            if result.is_ok() {
+                self.part_concurrency.forget(&session);
             }
-            ensure_size_limit(stored.max_bytes, stored.public.size, actual)?;
-            let checksum =
-                validate_complete_checksum(&stored.checksum_policy, &staged, request.checksum)?;
-            let object_key = self.layout.object_key(stored.storage_key.key.as_str());
-            if stored.public.status == UploadSessionStatus::Open
-                || stored.public.next_offset != Some(actual)
-            {
-                stored.public.status = UploadSessionStatus::Completing;
-                stored.public.next_offset = Some(actual);
-                self.write_session(&request.session, &stored).await?;
-            }
-            let staged = Bytes::from(staged);
-            let etag = self
-                .put_completed_object(&object_key, staged, stored.public.content_type.as_deref())
-                .await?;
-            let object = self.object_ref(&stored, actual, etag, checksum);
-            stored.public.status = UploadSessionStatus::Complete;
-            stored.public.next_offset = Some(actual);
-            stored.object = Some(object.clone());
-            stored.cleanup_pending = true;
-            self.write_session(&request.session, &stored).await?;
-            self.cleanup_staged_bytes(&request.session, &mut stored)
-                .await?;
-            Ok(object)
+            result
         })
     }
 
@@ -583,6 +1753,24 @@ impl StorageBackend for S3StorageBackend {
             let known_session = match self.read_session(&session).await {
                 Ok(stored) => {
                     ensure_owner(&ctx.actor, &stored.owner)?;
+                    // Stop concurrent part uploads before aborting. `close()`
+                    // immediately fails every queued AND future `upload_part`
+                    // permit-acquire, so no part that has not already started
+                    // streaming can reach S3 after the abort. (Closing rather than
+                    // draining avoids racing Tokio's fair semaphore queue, where
+                    // waiters sit ahead of an `acquire_many` and would stream as
+                    // active parts release permits.) A part already mid-stream at
+                    // this instant is a narrow window whose orphaned provider part
+                    // is reclaimed by bucket-lifecycle / stale-upload cleanup.
+                    if stored.public.strategy == UploadStrategy::Multipart {
+                        let max = stored.public.plan.max_concurrent_parts.max(1);
+                        self.part_concurrency
+                            .semaphore(&session, max as usize)
+                            .close();
+                    }
+                    // Best-effort abort of the provider multipart upload before
+                    // dropping local state.
+                    self.abort_multipart_session(&stored).await?;
                     true
                 }
                 Err(StorageError::UnknownUploadSession { .. }) => false,
@@ -594,7 +1782,38 @@ impl StorageBackend for S3StorageBackend {
             if known_session {
                 self.delete_object(&meta_key).await?;
             }
+            self.part_concurrency.forget(&session);
             Ok(())
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{part_size_for, S3_MAX_PARTS, S3_MAX_PART_SIZE, S3_MIN_PART_SIZE};
+
+    #[test]
+    fn part_size_stays_at_floor_for_small_caps() {
+        // The default 64 MiB cap (and anything that fits in <=10k 5 MiB parts)
+        // uses the 5 MiB floor unchanged.
+        assert_eq!(part_size_for(64 * 1024 * 1024), S3_MIN_PART_SIZE);
+        assert_eq!(
+            part_size_for(S3_MIN_PART_SIZE * S3_MAX_PARTS),
+            S3_MIN_PART_SIZE
+        );
+    }
+
+    #[test]
+    fn part_size_scales_to_stay_under_part_cap() {
+        let max_bytes = 200 * 1024 * 1024 * 1024; // 200 GiB
+        let part = part_size_for(max_bytes);
+        assert!(part > S3_MIN_PART_SIZE);
+        assert!(part.is_multiple_of(1024 * 1024), "rounded to a whole MiB");
+        assert!(max_bytes.div_ceil(part) <= S3_MAX_PARTS);
+    }
+
+    #[test]
+    fn part_size_never_exceeds_provider_max() {
+        assert_eq!(part_size_for(u64::MAX), S3_MAX_PART_SIZE);
     }
 }

--- a/crates/pocopine-storage-s3/src/util.rs
+++ b/crates/pocopine-storage-s3/src/util.rs
@@ -1,5 +1,6 @@
-use aws_sdk_s3::error::SdkError;
+use aws_sdk_s3::error::{ProvideErrorMetadata, SdkError};
 use aws_sdk_s3::operation::get_object::GetObjectError;
+use aws_sdk_s3::operation::head_object::HeadObjectError;
 use aws_sdk_s3::operation::put_object::PutObjectError;
 use pocopine_storage::backend_common::ensure_open;
 use pocopine_storage::{StorageError, StorageResult, UploadSession, UploadSessionStatus};
@@ -21,10 +22,35 @@ pub(crate) fn is_get_object_not_found(err: &SdkError<GetObjectError>) -> bool {
         .is_some_and(GetObjectError::is_no_such_key)
 }
 
-pub(crate) fn is_put_precondition_failed(err: &SdkError<PutObjectError>) -> bool {
+pub(crate) fn is_head_object_not_found(err: &SdkError<HeadObjectError>) -> bool {
     err.as_service_error()
-        .and_then(|err| err.meta().code())
+        .is_some_and(HeadObjectError::is_not_found)
+}
+
+pub(crate) fn is_put_precondition_failed(err: &SdkError<PutObjectError>) -> bool {
+    is_precondition_failed(err)
+}
+
+/// True when an S3 operation failed its `If-None-Match: *` precondition because
+/// the destination key already exists (HTTP 412).
+pub(crate) fn is_precondition_failed<E>(err: &SdkError<E>) -> bool
+where
+    E: ProvideErrorMetadata,
+{
+    err.as_service_error()
+        .and_then(ProvideErrorMetadata::code)
         .is_some_and(|code| code == "PreconditionFailed")
+}
+
+/// True when an S3 multipart operation failed because the upload id is gone
+/// (already completed or aborted). Used to make completion/abort idempotent.
+pub(crate) fn is_no_such_upload<E>(err: &SdkError<E>) -> bool
+where
+    E: ProvideErrorMetadata,
+{
+    err.as_service_error()
+        .and_then(ProvideErrorMetadata::code)
+        .is_some_and(|code| code == "NoSuchUpload")
 }
 
 pub(crate) fn s3_error(operation: &'static str, err: impl std::fmt::Display) -> StorageError {

--- a/crates/pocopine-storage-s3/tests/minio.rs
+++ b/crates/pocopine-storage-s3/tests/minio.rs
@@ -15,8 +15,9 @@ use aws_sdk_s3::primitives::ByteStream;
 use aws_sdk_s3::Client;
 use bytes::Bytes;
 use pocopine_storage::{
-    CompleteUpload, InitiateUpload, SafeObjectKey, StorageBackend, StorageContext, StorageError,
-    StorageKey, StorageResult, UploadPolicy, UploadSession, UploadStrategy,
+    ChecksumAlgorithm, ChecksumPolicy, CompleteUpload, InitiateUpload, ObjectChecksum,
+    SafeObjectKey, StorageBackend, StorageContext, StorageError, StorageKey, StorageResult,
+    UploadBody, UploadPolicy, UploadSession, UploadStrategy, UploadedPartStatus,
 };
 use pocopine_storage_s3::S3StorageBackend;
 use testcontainers::runners::AsyncRunner;
@@ -112,6 +113,81 @@ async fn initiate(backend: &S3StorageBackend, size: Option<u64>) -> StorageResul
             },
         )
         .await
+}
+
+/// Policy that allows large uploads so tests can cross the S3 5 MiB part floor.
+fn large_policy() -> StorageResult<UploadPolicy> {
+    let mut policy = UploadPolicy::new("s3")?
+        .max_bytes(32 * 1024 * 1024)
+        .preferred_chunk_size(1024 * 1024);
+    policy.expires_after = Duration::from_secs(60 * 60);
+    Ok(policy)
+}
+
+async fn initiate_large(
+    backend: &S3StorageBackend,
+    size: Option<u64>,
+) -> StorageResult<UploadSession> {
+    backend
+        .initiate_upload(
+            &ctx(),
+            InitiateUpload {
+                scope: "files".to_string(),
+                storage_key: StorageKey::new(SafeObjectKey::parse("files/large.bin")?),
+                file_name: "large.bin".to_string(),
+                size,
+                content_type: Some("application/octet-stream".to_string()),
+                metadata: BTreeMap::new(),
+                requested_strategy: UploadStrategy::Auto,
+                policy: large_policy()?,
+            },
+        )
+        .await
+}
+
+async fn initiate_checked(
+    backend: &S3StorageBackend,
+    key: &str,
+    size: u64,
+    checksum: ChecksumPolicy,
+) -> StorageResult<UploadSession> {
+    let mut policy = large_policy()?;
+    policy.checksum = checksum;
+    backend
+        .initiate_upload(
+            &ctx(),
+            InitiateUpload {
+                scope: "files".to_string(),
+                storage_key: StorageKey::new(SafeObjectKey::parse(key)?),
+                file_name: "checked.bin".to_string(),
+                size: Some(size),
+                content_type: Some("application/octet-stream".to_string()),
+                metadata: BTreeMap::new(),
+                requested_strategy: UploadStrategy::Auto,
+                policy,
+            },
+        )
+        .await
+}
+
+/// Deterministic, position-dependent bytes so assembled-object comparisons catch
+/// any part ordering / offset bug.
+fn pattern_bytes(start: usize, len: usize) -> Bytes {
+    let mut buf = Vec::with_capacity(len);
+    for i in 0..len {
+        buf.push(((start + i) % 251) as u8);
+    }
+    Bytes::from(buf)
+}
+
+async fn object_exists(client: &Client, bucket: &str, key: &str) -> bool {
+    client
+        .head_object()
+        .bucket(bucket)
+        .key(key)
+        .send()
+        .await
+        .is_ok()
 }
 
 async fn object_bytes(client: &Client, bucket: &str, key: &str) -> Vec<u8> {
@@ -249,6 +325,255 @@ async fn changing_upload_length_uses_shared_invalid_value_error() -> StorageResu
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn multipart_upload_assembles_large_object_against_minio() -> StorageResult<()> {
+    let client = minio_client().await;
+    let bucket = create_bucket(&client, "multipart").await;
+    let backend = S3StorageBackend::new(client.clone(), bucket.clone())?;
+
+    // 6 MiB sent as 3 x 2 MiB chunks. This crosses the 5 MiB part floor: the
+    // first 5 MiB flush as one provider part, the trailing 1 MiB is the final
+    // part written at completion.
+    let chunk = 2 * 1024 * 1024usize;
+    let total = 3 * chunk;
+    let session = initiate_large(&backend, Some(total as u64)).await?;
+
+    let mut offset = 0u64;
+    for index in 0..3 {
+        let bytes = pattern_bytes(index * chunk, chunk);
+        let updated = backend
+            .append_upload_bytes(&ctx(), session.id.clone(), offset, bytes)
+            .await?;
+        offset += chunk as u64;
+        assert_eq!(updated.next_offset, Some(offset));
+    }
+
+    let object = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id.clone(),
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(object.size, total as u64);
+    // Bytes match exactly across the 5 MiB part boundary, proving the parts were
+    // uploaded and assembled in order (not rewritten as one staged object).
+    assert_eq!(
+        object_bytes(&client, &bucket, "files/large.bin").await,
+        pattern_bytes(0, total).to_vec()
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn aborting_multipart_upload_removes_provider_parts_against_minio() -> StorageResult<()> {
+    let client = minio_client().await;
+    let bucket = create_bucket(&client, "mp-abort").await;
+    let backend = S3StorageBackend::new(client.clone(), bucket.clone())?;
+    let session = initiate_large(&backend, None).await?;
+
+    // Push past the 5 MiB floor so a provider multipart upload actually exists.
+    backend
+        .append_upload_bytes(
+            &ctx(),
+            session.id.clone(),
+            0,
+            pattern_bytes(0, 6 * 1024 * 1024),
+        )
+        .await?;
+
+    // Aborting issues `AbortMultipartUpload` (so this returns `Ok` only if the
+    // provider accepted the abort) and drops local session state. (MinIO's
+    // `ListMultipartUploads` does not report in-progress uploads, so cleanup is
+    // verified via the observable effects below rather than by listing.)
+    backend.abort_upload(&ctx(), session.id.clone()).await?;
+
+    let inspected = backend.inspect_upload(&ctx(), session.id).await;
+    assert!(matches!(
+        inspected,
+        Err(StorageError::UnknownUploadSession { .. })
+    ));
+    // The aborted upload never produced a final object.
+    assert!(!object_exists(&client, &bucket, "files/large.bin").await);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn multipart_completion_is_idempotent_against_minio() -> StorageResult<()> {
+    let client = minio_client().await;
+    let bucket = create_bucket(&client, "mp-idem").await;
+    let backend = S3StorageBackend::new(client.clone(), bucket.clone())?;
+    let total = 6 * 1024 * 1024usize;
+    let session = initiate_large(&backend, Some(total as u64)).await?;
+
+    backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, pattern_bytes(0, total))
+        .await?;
+
+    let first = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id.clone(),
+                checksum: None,
+            },
+        )
+        .await?;
+    let second = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(first, second);
+    assert_eq!(first.size, total as u64);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn multipart_upload_verifies_streaming_sha256_against_minio() -> StorageResult<()> {
+    let client = minio_client().await;
+    let bucket = create_bucket(&client, "mp-sha").await;
+    let backend = S3StorageBackend::new(client.clone(), bucket.clone())?;
+    let total = 6 * 1024 * 1024usize;
+    let data = pattern_bytes(0, total);
+    let expected = ObjectChecksum {
+        algorithm: ChecksumAlgorithm::Sha256,
+        value: pocopine_crypto::sha256_hex(&data),
+    };
+
+    let session = initiate_checked(
+        &backend,
+        "files/checked.bin",
+        total as u64,
+        ChecksumPolicy::Required(ChecksumAlgorithm::Sha256),
+    )
+    .await?;
+    backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, data)
+        .await?;
+
+    // The checksum is verified by streaming the assembled object back through the
+    // multipart path (no full in-memory buffer).
+    let object = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: Some(expected.clone()),
+            },
+        )
+        .await?;
+    assert_eq!(object.checksum, Some(expected));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn multipart_missing_required_checksum_is_rejected_and_retryable() -> StorageResult<()> {
+    let client = minio_client().await;
+    let bucket = create_bucket(&client, "mp-reqsum").await;
+    let backend = S3StorageBackend::new(client.clone(), bucket.clone())?;
+    let total = 6 * 1024 * 1024usize;
+    let data = pattern_bytes(0, total);
+    let expected = ObjectChecksum {
+        algorithm: ChecksumAlgorithm::Sha256,
+        value: pocopine_crypto::sha256_hex(&data),
+    };
+
+    let session = initiate_checked(
+        &backend,
+        "files/reqsum.bin",
+        total as u64,
+        ChecksumPolicy::Required(ChecksumAlgorithm::Sha256),
+    )
+    .await?;
+    backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, data)
+        .await?;
+
+    // Missing the required checksum is rejected before the object is assembled,
+    // so the session stays open and a follow-up completion with the correct
+    // checksum still succeeds.
+    let rejected = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id.clone(),
+                checksum: None,
+            },
+        )
+        .await;
+    assert!(matches!(rejected, Err(StorageError::PolicyRejected { .. })));
+    assert!(!object_exists(&client, &bucket, "files/reqsum.bin").await);
+
+    let object = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: Some(expected.clone()),
+            },
+        )
+        .await?;
+    assert_eq!(object.checksum, Some(expected));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn single_part_upload_verifies_crc32c_against_minio() -> StorageResult<()> {
+    let client = minio_client().await;
+    let bucket = create_bucket(&client, "sp-crc").await;
+    let backend = S3StorageBackend::new(client.clone(), bucket.clone())?;
+    // Below the 5 MiB floor: completes via the single direct-PUT path.
+    let data = pattern_bytes(0, 4096);
+    let expected = ObjectChecksum {
+        algorithm: ChecksumAlgorithm::Crc32c,
+        value: pocopine_crypto::crc32c_hex(&data),
+    };
+
+    let session = initiate_checked(
+        &backend,
+        "files/crc.bin",
+        data.len() as u64,
+        ChecksumPolicy::Required(ChecksumAlgorithm::Crc32c),
+    )
+    .await?;
+    backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, data)
+        .await?;
+
+    let wrong = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id.clone(),
+                checksum: Some(ObjectChecksum {
+                    algorithm: ChecksumAlgorithm::Crc32c,
+                    value: "deadbeef".to_string(),
+                }),
+            },
+        )
+        .await;
+    assert!(matches!(wrong, Err(StorageError::PolicyRejected { .. })));
+
+    let object = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: Some(expected.clone()),
+            },
+        )
+        .await?;
+    assert_eq!(object.checksum, Some(expected));
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn complete_does_not_overwrite_existing_object_key() -> StorageResult<()> {
     let client = minio_client().await;
     let bucket = create_bucket(&client, "collision").await;
@@ -281,5 +606,342 @@ async fn complete_does_not_overwrite_existing_object_key() -> StorageResult<()> 
         object_bytes(&client, &bucket, "files/hello.txt").await,
         b"existing"
     );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn multipart_complete_does_not_overwrite_existing_object_key() -> StorageResult<()> {
+    let client = minio_client().await;
+    let bucket = create_bucket(&client, "mp-collision").await;
+    client
+        .put_object()
+        .bucket(&bucket)
+        .key("files/large.bin")
+        .body(ByteStream::from_static(b"existing"))
+        .send()
+        .await
+        .expect("seed existing object");
+
+    let backend = S3StorageBackend::new(client.clone(), bucket.clone())?;
+    let total = 6 * 1024 * 1024usize;
+    let session = initiate_large(&backend, Some(total as u64)).await?;
+    backend
+        .append_upload_bytes(&ctx(), session.id.clone(), 0, pattern_bytes(0, total))
+        .await?;
+
+    // The multipart completion path must also refuse to clobber an existing key
+    // (CompleteMultipartUpload would otherwise overwrite it).
+    let rejected = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await;
+    assert!(matches!(rejected, Err(StorageError::PolicyRejected { .. })));
+    assert_eq!(
+        object_bytes(&client, &bucket, "files/large.bin").await,
+        b"existing"
+    );
+    Ok(())
+}
+
+/// Initiate a server-mediated by-number multipart upload (the `upload_part`
+/// path) with concurrency advertised in the plan.
+async fn initiate_multipart(
+    backend: &S3StorageBackend,
+    key: &str,
+    size: Option<u64>,
+) -> StorageResult<UploadSession> {
+    let mut policy = UploadPolicy::new("s3")?
+        .max_bytes(32 * 1024 * 1024)
+        .preferred_chunk_size(1024 * 1024);
+    policy.expires_after = Duration::from_secs(60 * 60);
+    policy.max_concurrent_parts = 4;
+    backend
+        .initiate_upload(
+            &ctx(),
+            InitiateUpload {
+                scope: "files".to_string(),
+                storage_key: StorageKey::new(SafeObjectKey::parse(key)?),
+                file_name: "bynum.bin".to_string(),
+                size,
+                content_type: Some("application/octet-stream".to_string()),
+                metadata: BTreeMap::new(),
+                requested_strategy: UploadStrategy::Multipart,
+                policy,
+            },
+        )
+        .await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn multipart_by_number_uploads_parts_concurrently_against_minio() -> StorageResult<()> {
+    let client = minio_client().await;
+    let bucket = create_bucket(&client, "bynum").await;
+    let backend = S3StorageBackend::new(client.clone(), bucket.clone())?;
+
+    // Two 5 MiB parts (at the S3 floor) plus a 2 MiB final part.
+    let part = 5 * 1024 * 1024usize;
+    let last = 2 * 1024 * 1024usize;
+    let total = (2 * part + last) as u64;
+    let session = initiate_multipart(&backend, "files/bynum.bin", Some(total)).await?;
+    assert_eq!(session.strategy, UploadStrategy::Multipart);
+    assert!(
+        session.plan.max_concurrent_parts >= 2,
+        "plan should advertise multipart concurrency"
+    );
+
+    // Upload the parts concurrently and out of order; each part carries
+    // position-dependent bytes so any ordering bug shows up in the assembled
+    // object.
+    let specs = [
+        (1u32, 0usize, part),
+        (2u32, part, part),
+        (3u32, 2 * part, last),
+    ];
+    let mut handles = Vec::new();
+    for (number, start, len) in specs.into_iter().rev() {
+        let backend = backend.clone();
+        let session_id = session.id.clone();
+        let bytes = pattern_bytes(start, len);
+        handles.push(tokio::spawn(async move {
+            backend
+                .upload_part(&ctx(), session_id, number, UploadBody::from_bytes(bytes))
+                .await
+        }));
+    }
+    for handle in handles {
+        handle.await.expect("join part task")?;
+    }
+
+    let object = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id.clone(),
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(object.size, total);
+    assert_eq!(
+        object_bytes(&client, &bucket, "files/bynum.bin").await,
+        pattern_bytes(0, total as usize).to_vec()
+    );
+
+    // Completing again returns the same object (the parts were listed from S3,
+    // not re-uploaded).
+    let again = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(again, object);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn multipart_by_number_resumes_from_listed_parts_against_minio() -> StorageResult<()> {
+    let client = minio_client().await;
+    let bucket = create_bucket(&client, "bynum-resume").await;
+    let backend = S3StorageBackend::new(client.clone(), bucket.clone())?;
+
+    let part = 5 * 1024 * 1024usize;
+    let last = 2 * 1024 * 1024usize;
+    let total = (2 * part + last) as u64;
+    let session = initiate_multipart(&backend, "files/resume.bin", Some(total)).await?;
+
+    // Upload parts 1 and 3 only (a gap at 2). Re-upload part 1 to prove a part
+    // PUT is idempotent (S3 overwrites the same part number; no duplicate).
+    backend
+        .upload_part(
+            &ctx(),
+            session.id.clone(),
+            1,
+            UploadBody::from_bytes(pattern_bytes(0, part)),
+        )
+        .await?;
+    backend
+        .upload_part(
+            &ctx(),
+            session.id.clone(),
+            1,
+            UploadBody::from_bytes(pattern_bytes(0, part)),
+        )
+        .await?;
+    backend
+        .upload_part(
+            &ctx(),
+            session.id.clone(),
+            3,
+            UploadBody::from_bytes(pattern_bytes(2 * part, last)),
+        )
+        .await?;
+
+    // A fresh backend instance recovers which parts are committed by listing them
+    // from S3 (the session metadata tracks no part receipts). This resume listing
+    // is an explicit, off-the-hot-path call — not part of `inspect_upload`.
+    let reloaded = S3StorageBackend::new(client.clone(), bucket.clone())?;
+    let committed = reloaded
+        .list_committed_parts(&ctx(), session.id.clone())
+        .await?;
+    let mut numbers: Vec<u32> = committed.iter().map(|part| part.number).collect();
+    numbers.sort_unstable();
+    assert_eq!(numbers, vec![1, 3], "re-PUT of part 1 left no duplicate");
+    assert!(committed
+        .iter()
+        .all(|part| part.status == UploadedPartStatus::Uploaded));
+
+    // Fill the gap and complete.
+    reloaded
+        .upload_part(
+            &ctx(),
+            session.id.clone(),
+            2,
+            UploadBody::from_bytes(pattern_bytes(part, part)),
+        )
+        .await?;
+    let object = reloaded
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(object.size, total);
+    assert_eq!(
+        object_bytes(&client, &bucket, "files/resume.bin").await,
+        pattern_bytes(0, total as usize).to_vec()
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn multipart_by_number_rejects_part_gaps_against_minio() -> StorageResult<()> {
+    let client = minio_client().await;
+    let bucket = create_bucket(&client, "bynum-gap").await;
+    let backend = S3StorageBackend::new(client.clone(), bucket.clone())?;
+
+    let part = 5 * 1024 * 1024usize;
+    // The contiguity check runs before the byte-sum check, so a missing part 2 is
+    // rejected even though a declared length is present.
+    let session = initiate_multipart(&backend, "files/gap.bin", Some((3 * part) as u64)).await?;
+    backend
+        .upload_part(
+            &ctx(),
+            session.id.clone(),
+            1,
+            UploadBody::from_bytes(pattern_bytes(0, part)),
+        )
+        .await?;
+    backend
+        .upload_part(
+            &ctx(),
+            session.id.clone(),
+            3,
+            UploadBody::from_bytes(pattern_bytes(part, part)),
+        )
+        .await?;
+
+    let rejected = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id.clone(),
+                checksum: None,
+            },
+        )
+        .await;
+    assert!(
+        matches!(rejected, Err(StorageError::PolicyRejected { .. })),
+        "a gap at part 2 must be rejected, got {rejected:?}"
+    );
+    // Nothing was published.
+    assert!(!object_exists(&client, &bucket, "files/gap.bin").await);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn multipart_by_number_rejects_undersized_nonfinal_part_then_resumes() -> StorageResult<()> {
+    let client = minio_client().await;
+    let bucket = create_bucket(&client, "bynum-small").await;
+    let backend = S3StorageBackend::new(client.clone(), bucket.clone())?;
+
+    let part = 5 * 1024 * 1024usize;
+    let small = 1024 * 1024usize; // 1 MiB, below the 5 MiB non-final floor
+                                  // Declared length matches the eventual valid upload (part 1 = 5 MiB, part 2 =
+                                  // 1 MiB). The undersized-part check runs before the byte-sum check, so the
+                                  // first (undersized) attempt is rejected for the right reason.
+    let session =
+        initiate_multipart(&backend, "files/small.bin", Some((part + small) as u64)).await?;
+    // Part 1 (non-final) is undersized; part 2 is the last part (exempt).
+    backend
+        .upload_part(
+            &ctx(),
+            session.id.clone(),
+            1,
+            UploadBody::from_bytes(pattern_bytes(0, small)),
+        )
+        .await?;
+    backend
+        .upload_part(
+            &ctx(),
+            session.id.clone(),
+            2,
+            UploadBody::from_bytes(pattern_bytes(small, small)),
+        )
+        .await?;
+
+    let rejected = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id.clone(),
+                checksum: None,
+            },
+        )
+        .await;
+    assert!(
+        matches!(rejected, Err(StorageError::PolicyRejected { .. })),
+        "an undersized non-final part must be rejected before completion, got {rejected:?}"
+    );
+    assert!(!object_exists(&client, &bucket, "files/small.bin").await);
+
+    // The session stayed Open, so the client can replace part 1 with a valid one.
+    backend
+        .upload_part(
+            &ctx(),
+            session.id.clone(),
+            1,
+            UploadBody::from_bytes(pattern_bytes(0, part)),
+        )
+        .await?;
+    backend
+        .upload_part(
+            &ctx(),
+            session.id.clone(),
+            2,
+            UploadBody::from_bytes(pattern_bytes(part, small)),
+        )
+        .await?;
+    let object = backend
+        .complete_upload(
+            &ctx(),
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(object.size, (part + small) as u64);
     Ok(())
 }

--- a/crates/pocopine-storage/Cargo.toml
+++ b/crates/pocopine-storage/Cargo.toml
@@ -25,19 +25,38 @@ uuid = { version = "1", features = ["v4", "js"] }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 pocopine-server = { workspace = true }
-sha2 = "0.10"
+pocopine-crypto = { workspace = true }
+# `UploadBody` adapts the inbound axum request body into a provider-agnostic
+# byte stream (Stream trait + map_err) so part uploads forward to the provider
+# without buffering the whole part.
+futures-core = "0.3"
+futures-util = { version = "0.3", default-features = false }
 # Per-session async mutex (tokio::sync::Mutex) for the local-fs backend, plus
 # spawn_blocking to keep the std::fs I/O off the tokio worker threads.
 tokio = { version = "1", default-features = false, features = ["rt", "sync"] }
 tracing = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+criterion = { version = "0.5", features = ["async_tokio"] }
 http-body-util = "0.1"
 tempfile = "3"
 tokio = { version = "1", features = ["macros", "rt", "time"] }
 tower = { version = "0.5", features = ["util"] }
 
+# Upload hot-path throughput benchmark (in-memory backend; host only).
+[[bench]]
+name = "upload"
+harness = false
+
+# Provider-write amplification: legacy O(n^2) rewrite vs native O(n) strategies.
+[[bench]]
+name = "amplification"
+harness = false
+
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+# `FuturesUnordered` drives the bounded-concurrency multipart part uploads on
+# the single wasm task (`alloc` feature only — no std, keeps the bundle lean).
+futures-util = { version = "0.3", default-features = false, features = ["alloc"] }
 js-sys = { workspace = true }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }

--- a/crates/pocopine-storage/benches/amplification.rs
+++ b/crates/pocopine-storage/benches/amplification.rs
@@ -1,0 +1,191 @@
+//! Provider-write amplification: the legacy staged-object rewrite vs the native
+//! upload strategies introduced for #176.
+//!
+//! This models the bytes each strategy pushes to the object store for an upload
+//! delivered as a sequence of `PATCH` chunks, and moves those bytes through an
+//! in-memory sink so wall-clock time tracks the I/O volume. It is a Docker-free
+//! proxy for object-store write traffic, not a network benchmark — but the byte
+//! counts it reports are exact.
+//!
+//! Strategies:
+//! - `gcs_legacy_rewrite`: the OLD path (both S3 and GCS) — every `PATCH`
+//!   re-uploads the whole staged object, and completion writes it once more.
+//!   O(n^2) provider bytes.
+//! - `s3_native_multipart` (AWS baseline): coalesce to >=5 MiB parts; each byte
+//!   is uploaded exactly once via `UploadPart`. O(n).
+//! - `gcs_native_compose` (current GCS): each chunk is one component written
+//!   once; the final object is a server-side compose (no client re-upload). O(n).
+//! - `azure_native_blocks` (current Azure): sub-block chunks are coalesced and
+//!   each block's bytes are uploaded once via `Put Block`; `Put Block List` is a
+//!   metadata-only commit (no client re-upload). O(n).
+//!
+//! Run: `cargo bench -p pocopine-storage --bench amplification`.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+
+const CHUNK: usize = 1024 * 1024; // 1 MiB PATCH chunks
+const S3_PART: usize = 5 * 1024 * 1024; // S3 minimum part size
+const AZURE_BLOCK: usize = 1024 * 1024; // Azure block size for the default 64 MiB cap
+const MIB: f64 = 1024.0 * 1024.0;
+
+/// Counts bytes written and folds them so the compiler cannot elide the copy.
+#[derive(Default)]
+struct Sink {
+    written: u64,
+    fold: u64,
+}
+
+impl Sink {
+    #[inline]
+    fn write(&mut self, buf: &[u8]) {
+        self.written += buf.len() as u64;
+        let mut acc = 0u64;
+        for &byte in buf {
+            acc = acc.wrapping_add(byte as u64);
+        }
+        self.fold = self.fold.wrapping_add(acc);
+    }
+}
+
+/// Legacy: re-upload the whole staged object on every append, then once more on
+/// completion. Provider write bytes grow quadratically with object size.
+fn gcs_legacy_rewrite(total: usize, chunk: usize) -> Sink {
+    let mut sink = Sink::default();
+    let mut staged: Vec<u8> = Vec::with_capacity(total);
+    let mut offset = 0;
+    while offset < total {
+        let n = chunk.min(total - offset);
+        staged.resize(staged.len() + n, 0xA5);
+        sink.write(&staged); // put_staged rewrites the entire object
+        offset += n;
+    }
+    sink.write(&staged); // final completed-object write
+    sink
+}
+
+/// S3 native multipart: coalesce sub-part chunks into >=5 MiB parts, flushing
+/// each part's bytes to the provider exactly once via `UploadPart`.
+///
+/// Only the unflushed remainder is buffered (bounded by one part), tracked by
+/// length with no front-shifting, so the model reflects the real cost: every
+/// payload byte is written once. (The real backend additionally rewrites a small
+/// base64 tail in the session metadata per append; that churn is bounded by the
+/// part size and disappears once the client sends part-sized chunks, so it is
+/// not modeled here.)
+fn s3_native_multipart(total: usize, chunk: usize) -> Sink {
+    let mut sink = Sink::default();
+    let part = vec![0xA5u8; S3_PART];
+    let mut pending = 0usize;
+    let mut offset = 0;
+    while offset < total {
+        let n = chunk.min(total - offset);
+        pending += n;
+        while pending >= S3_PART {
+            sink.write(&part); // UploadPart: one full part, written once
+            pending -= S3_PART;
+        }
+        offset += n;
+    }
+    if pending > 0 {
+        sink.write(&part[..pending]); // final part
+    }
+    sink
+}
+
+/// GCS native compose: each chunk is one component, written once.
+fn gcs_native_compose(total: usize, chunk: usize) -> Sink {
+    let mut sink = Sink::default();
+    let block = vec![0xA5u8; chunk];
+    let mut offset = 0;
+    while offset < total {
+        let n = chunk.min(total - offset);
+        sink.write(&block[..n]); // component write
+        offset += n;
+    }
+    sink
+}
+
+/// Azure native block blob: coalesce sub-block chunks into fixed-size blocks,
+/// each uploaded once via `Put Block`. `Put Block List` commits the order
+/// server-side, so no payload is re-uploaded.
+fn azure_native_blocks(total: usize, chunk: usize) -> Sink {
+    let mut sink = Sink::default();
+    let block = vec![0xA5u8; AZURE_BLOCK];
+    let mut pending = 0usize;
+    let mut offset = 0;
+    while offset < total {
+        let n = chunk.min(total - offset);
+        pending += n;
+        while pending >= AZURE_BLOCK {
+            sink.write(&block); // Put Block: one full block, written once
+            pending -= AZURE_BLOCK;
+        }
+        offset += n;
+    }
+    if pending > 0 {
+        sink.write(&block[..pending]); // final block
+    }
+    sink
+}
+
+fn amplification(c: &mut Criterion) {
+    let totals = [4 * 1024 * 1024usize, 16 * 1024 * 1024, 64 * 1024 * 1024];
+
+    // Exact provider-write-byte report (the headline numbers).
+    eprintln!(
+        "\n=== provider write volume, {} KiB PATCH chunks ===",
+        CHUNK / 1024
+    );
+    eprintln!(
+        "{:>9}  {:>15}  {:>13}  {:>13}  {:>13}  {:>9}",
+        "upload", "legacy O(n^2)", "s3 O(n)", "gcs O(n)", "azure O(n)", "legacy x"
+    );
+    for &total in &totals {
+        let legacy = gcs_legacy_rewrite(total, CHUNK).written;
+        let s3 = s3_native_multipart(total, CHUNK).written;
+        let gcs = gcs_native_compose(total, CHUNK).written;
+        let azure = azure_native_blocks(total, CHUNK).written;
+        eprintln!(
+            "{:>5} MiB  {:>11.1} MiB  {:>9.1} MiB  {:>9.1} MiB  {:>9.1} MiB  {:>8.1}x",
+            total / 1024 / 1024,
+            legacy as f64 / MIB,
+            s3 as f64 / MIB,
+            gcs as f64 / MIB,
+            azure as f64 / MIB,
+            legacy as f64 / azure as f64,
+        );
+    }
+    eprintln!();
+
+    let mut group = c.benchmark_group("provider_write_cost");
+    for &total in &totals {
+        let mib = total / 1024 / 1024;
+        group.throughput(Throughput::Bytes(total as u64));
+        group.bench_with_input(
+            BenchmarkId::new("gcs_legacy_rewrite", mib),
+            &total,
+            |b, &t| b.iter(|| black_box(gcs_legacy_rewrite(t, CHUNK).fold)),
+        );
+        group.bench_with_input(
+            BenchmarkId::new("s3_native_multipart", mib),
+            &total,
+            |b, &t| b.iter(|| black_box(s3_native_multipart(t, CHUNK).fold)),
+        );
+        group.bench_with_input(
+            BenchmarkId::new("gcs_native_compose", mib),
+            &total,
+            |b, &t| b.iter(|| black_box(gcs_native_compose(t, CHUNK).fold)),
+        );
+        group.bench_with_input(
+            BenchmarkId::new("azure_native_blocks", mib),
+            &total,
+            |b, &t| b.iter(|| black_box(azure_native_blocks(t, CHUNK).fold)),
+        );
+    }
+    group.finish();
+}
+
+criterion_group!(benches, amplification);
+criterion_main!(benches);

--- a/crates/pocopine-storage/benches/upload.rs
+++ b/crates/pocopine-storage/benches/upload.rs
@@ -1,0 +1,82 @@
+//! Throughput benchmark for the upload hot path (initiate → N appends →
+//! complete) against the in-memory backend.
+//!
+//! This isolates the framework's per-chunk overhead (session bookkeeping,
+//! per-session locking, offset checks, append handling) from provider network
+//! I/O. The headline #176 win — bounded provider-write amplification for the S3
+//! and GCS native backends — is validated separately by their integration
+//! tests (part/component counts stay O(object_size / part_size), not O(n²)).
+//!
+//! Run with: `cargo bench -p pocopine-storage --bench upload`.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use bytes::Bytes;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use pocopine_storage::{
+    CompleteUpload, InitiateUpload, MemoryStorageBackend, SafeObjectKey, StorageBackend,
+    StorageContext, StorageKey, UploadPolicy, UploadStrategy,
+};
+use tokio::runtime::Builder;
+
+const TOTAL: usize = 16 * 1024 * 1024;
+
+async fn run_upload(total: usize, chunk: usize) {
+    let backend = MemoryStorageBackend::new();
+    let ctx = StorageContext::system("bench");
+    let policy = UploadPolicy::new("memory")
+        .expect("policy")
+        .max_bytes(total as u64);
+    let session = backend
+        .initiate_upload(
+            &ctx,
+            InitiateUpload {
+                scope: "files".to_string(),
+                storage_key: StorageKey::new(SafeObjectKey::parse("files/bench.bin").expect("key")),
+                file_name: "bench.bin".to_string(),
+                size: Some(total as u64),
+                content_type: Some("application/octet-stream".to_string()),
+                metadata: Default::default(),
+                requested_strategy: UploadStrategy::Auto,
+                policy,
+            },
+        )
+        .await
+        .expect("initiate");
+
+    let block = Bytes::from(vec![0u8; chunk]);
+    let mut offset = 0usize;
+    while offset < total {
+        let len = chunk.min(total - offset);
+        backend
+            .append_upload_bytes(&ctx, session.id.clone(), offset as u64, block.slice(0..len))
+            .await
+            .expect("append");
+        offset += len;
+    }
+    backend
+        .complete_upload(
+            &ctx,
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await
+        .expect("complete");
+}
+
+fn upload_throughput(c: &mut Criterion) {
+    let runtime = Builder::new_current_thread().build().expect("runtime");
+    let mut group = c.benchmark_group("memory_upload_16MiB");
+    group.throughput(Throughput::Bytes(TOTAL as u64));
+    for &chunk in &[64 * 1024usize, 256 * 1024, 1024 * 1024, 4 * 1024 * 1024] {
+        group.bench_with_input(BenchmarkId::from_parameter(chunk), &chunk, |b, &chunk| {
+            b.to_async(&runtime).iter(|| run_upload(TOTAL, chunk));
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, upload_throughput);
+criterion_main!(benches);

--- a/crates/pocopine-storage/src/backend_common.rs
+++ b/crates/pocopine-storage/src/backend_common.rs
@@ -3,12 +3,12 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex as StdMutex};
 
 use time::OffsetDateTime;
-use tokio::sync::Mutex as TokioMutex;
+use tokio::sync::{Mutex as TokioMutex, Semaphore};
 
 use crate::server::StorageActor;
 use crate::{
-    ObjectChecksum, ObjectRef, ObjectVisibility, StorageError, StorageKey, StorageResult,
-    UploadSession, UploadSessionId, UploadSessionStatus, UploadStrategy,
+    BackendCapabilities, ObjectChecksum, ObjectRef, ObjectVisibility, StorageError, StorageKey,
+    StorageResult, UploadSession, UploadSessionId, UploadSessionStatus, UploadStrategy,
 };
 
 const MAX_UPLOAD_EXPIRES_AFTER_SECS: u64 = 100 * 365 * 24 * 60 * 60;
@@ -54,6 +54,53 @@ impl UploadSessionLockRegistry {
     }
 }
 
+/// Per-session permit pool bounding how many part uploads stream concurrently
+/// for one upload session, enforcing the scope's advertised
+/// `max_concurrent_parts` server-side (the client limit is otherwise only a
+/// hint). Per-process, like [`UploadSessionLockRegistry`]: horizontally-scaled
+/// replicas each enforce the limit independently.
+#[derive(Clone, Default)]
+pub struct UploadConcurrencyRegistry {
+    permits: Arc<StdMutex<HashMap<String, Arc<Semaphore>>>>,
+}
+
+impl std::fmt::Debug for UploadConcurrencyRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UploadConcurrencyRegistry")
+            .finish_non_exhaustive()
+    }
+}
+
+impl UploadConcurrencyRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The session's permit pool, created on first use sized to `max_concurrent`
+    /// (clamped to at least one). All parts of a session share one pool, so the
+    /// size is fixed by the first caller — which is correct since every part of a
+    /// session carries the same advertised limit.
+    pub fn semaphore(&self, session: &UploadSessionId, max_concurrent: usize) -> Arc<Semaphore> {
+        let mut permits = self
+            .permits
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        permits
+            .entry(session.as_str().to_string())
+            .or_insert_with(|| Arc::new(Semaphore::new(max_concurrent.max(1))))
+            .clone()
+    }
+
+    /// Drop a finished session's permit pool (call on complete/abort).
+    pub fn forget(&self, session: &UploadSessionId) {
+        let mut permits = self
+            .permits
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        permits.remove(session.as_str());
+    }
+}
+
 pub struct UploadSessionLockCleanup<'a> {
     registry: &'a UploadSessionLockRegistry,
     session: UploadSessionId,
@@ -74,14 +121,54 @@ impl Drop for UploadSessionLockCleanup<'_> {
     }
 }
 
-pub fn selected_strategy(strategy: UploadStrategy) -> StorageResult<UploadStrategy> {
-    match strategy {
-        UploadStrategy::Auto | UploadStrategy::Sequential => Ok(UploadStrategy::Sequential),
-        UploadStrategy::SingleRequest | UploadStrategy::Multipart => {
-            Err(StorageError::unsupported(
-                "only sequential proxy uploads are implemented in pocopine-storage PR 1",
-            ))
+/// Negotiate a requested [`UploadStrategy`] against what the backend supports,
+/// returning the concrete strategy the session will run.
+///
+/// `Auto` resolves to the most capable server-mediated mode the backend
+/// advertises (sequential proxy today; native multipart once a backend opts in).
+/// A specific request that the backend cannot satisfy is rejected as
+/// unsupported. Backends advertise [`BackendCapabilities`] via
+/// `StorageBackend::capabilities()`, whose default is sequential-proxy-only — so
+/// this preserves the previous behavior for every backend until one opts into
+/// more.
+pub fn select_upload_mode(
+    requested: UploadStrategy,
+    caps: BackendCapabilities,
+) -> StorageResult<UploadStrategy> {
+    match requested {
+        UploadStrategy::Auto => {
+            if caps.sequential_proxy {
+                Ok(UploadStrategy::Sequential)
+            } else if caps.native_multipart {
+                Ok(UploadStrategy::Multipart)
+            } else if caps.single_request {
+                Ok(UploadStrategy::SingleRequest)
+            } else {
+                Err(StorageError::unsupported(
+                    "storage backend advertises no upload mode",
+                ))
+            }
         }
+        UploadStrategy::Sequential => caps
+            .sequential_proxy
+            .then_some(UploadStrategy::Sequential)
+            .ok_or_else(|| {
+                StorageError::unsupported(
+                    "storage backend does not support sequential proxy uploads",
+                )
+            }),
+        UploadStrategy::Multipart => caps
+            .native_multipart
+            .then_some(UploadStrategy::Multipart)
+            .ok_or_else(|| {
+                StorageError::unsupported("storage backend does not support multipart uploads")
+            }),
+        UploadStrategy::SingleRequest => caps
+            .single_request
+            .then_some(UploadStrategy::SingleRequest)
+            .ok_or_else(|| {
+                StorageError::unsupported("storage backend does not support single-request uploads")
+            }),
     }
 }
 
@@ -233,5 +320,60 @@ mod tests {
             let _guard = lock.try_lock().expect("session lock remains usable");
         }
         registry.drop_if_unused(&session);
+    }
+
+    #[test]
+    fn sequential_only_caps_preserve_legacy_behavior() {
+        // The default capabilities a backend advertises before opting into more.
+        let caps = BackendCapabilities::default();
+        assert_eq!(
+            select_upload_mode(UploadStrategy::Auto, caps).unwrap(),
+            UploadStrategy::Sequential
+        );
+        assert_eq!(
+            select_upload_mode(UploadStrategy::Sequential, caps).unwrap(),
+            UploadStrategy::Sequential
+        );
+        assert!(matches!(
+            select_upload_mode(UploadStrategy::Multipart, caps),
+            Err(StorageError::Unsupported { .. })
+        ));
+        assert!(matches!(
+            select_upload_mode(UploadStrategy::SingleRequest, caps),
+            Err(StorageError::Unsupported { .. })
+        ));
+    }
+
+    #[test]
+    fn capabilities_gate_each_strategy() {
+        let multipart = BackendCapabilities {
+            native_multipart: true,
+            ..BackendCapabilities::default()
+        };
+        assert_eq!(
+            select_upload_mode(UploadStrategy::Multipart, multipart).unwrap(),
+            UploadStrategy::Multipart
+        );
+        // Auto still prefers sequential proxy when both are available.
+        assert_eq!(
+            select_upload_mode(UploadStrategy::Auto, multipart).unwrap(),
+            UploadStrategy::Sequential
+        );
+
+        let single = BackendCapabilities {
+            single_request: true,
+            ..BackendCapabilities::default()
+        };
+        assert_eq!(
+            select_upload_mode(UploadStrategy::SingleRequest, single).unwrap(),
+            UploadStrategy::SingleRequest
+        );
+
+        // A backend with no modes rejects everything, including Auto.
+        let none = BackendCapabilities {
+            sequential_proxy: false,
+            ..BackendCapabilities::default()
+        };
+        assert!(select_upload_mode(UploadStrategy::Auto, none).is_err());
     }
 }

--- a/crates/pocopine-storage/src/checksum.rs
+++ b/crates/pocopine-storage/src/checksum.rs
@@ -1,45 +1,55 @@
-use sha2::{Digest, Sha256};
+use pocopine_crypto::{digest_hex, Algorithm, Hasher};
 
 use crate::{ChecksumAlgorithm, ChecksumPolicy, ObjectChecksum, StorageError, StorageResult};
 
-pub fn ensure_supported_checksum_policy(policy: &ChecksumPolicy) -> StorageResult<()> {
-    match policy {
-        ChecksumPolicy::None => Ok(()),
-        ChecksumPolicy::Optional(allowed) => {
-            for algorithm in allowed {
-                ensure_supported_checksum_algorithm(*algorithm)?;
-            }
-            Ok(())
+/// Incremental hasher for streaming upload bytes.
+///
+/// Native multipart/resumable backends never hold a whole object in memory, so
+/// they cannot call [`validate_complete_checksum`] (which takes the full
+/// buffer). They stream the stored object through this hasher and validate the
+/// result with [`validate_complete_checksum_precomputed`].
+pub struct StreamingChecksum {
+    algorithm: ChecksumAlgorithm,
+    hasher: Hasher,
+}
+
+impl StreamingChecksum {
+    pub fn new(algorithm: ChecksumAlgorithm) -> Self {
+        Self {
+            algorithm,
+            hasher: Hasher::new(crypto_algorithm(algorithm)),
         }
-        ChecksumPolicy::Required(algorithm) => ensure_supported_checksum_algorithm(*algorithm),
+    }
+
+    pub fn update(&mut self, chunk: &[u8]) {
+        self.hasher.update(chunk);
+    }
+
+    pub fn finalize(self) -> ObjectChecksum {
+        ObjectChecksum {
+            algorithm: self.algorithm,
+            value: self.hasher.finalize_hex(),
+        }
     }
 }
 
-pub fn validate_complete_checksum(
+/// Cheaply reject a checksum that can never validate, before any expensive
+/// finalize work (e.g. assembling a multipart object).
+///
+/// Catches a missing required checksum or a disallowed/ mismatched algorithm
+/// without hashing. The actual value comparison still happens later.
+pub fn precheck_checksum(
     policy: &ChecksumPolicy,
-    bytes: &[u8],
-    provided: Option<ObjectChecksum>,
-) -> StorageResult<Option<ObjectChecksum>> {
-    ensure_supported_checksum_policy(policy)?;
+    provided: Option<&ObjectChecksum>,
+) -> StorageResult<()> {
     match policy {
-        ChecksumPolicy::None => Ok(None),
-        ChecksumPolicy::Optional(allowed) => {
-            if let Some(checksum) = &provided {
-                if !allowed.contains(&checksum.algorithm) {
-                    return Err(StorageError::policy_rejected(
-                        "checksum algorithm is not allowed",
-                    ));
-                }
-                let computed = compute_checksum(checksum.algorithm, bytes)?;
-                if !checksum.value.eq_ignore_ascii_case(&computed.value) {
-                    return Err(StorageError::policy_rejected(
-                        "upload checksum does not match uploaded bytes",
-                    ));
-                }
-                return Ok(Some(computed));
-            }
-            Ok(None)
-        }
+        ChecksumPolicy::None => Ok(()),
+        ChecksumPolicy::Optional(allowed) => match provided {
+            Some(checksum) if !allowed.contains(&checksum.algorithm) => Err(
+                StorageError::policy_rejected("checksum algorithm is not allowed"),
+            ),
+            _ => Ok(()),
+        },
         ChecksumPolicy::Required(algorithm) => {
             let provided = provided.ok_or_else(|| {
                 StorageError::policy_rejected("required upload checksum is missing")
@@ -49,40 +59,145 @@ pub fn validate_complete_checksum(
                     "required upload checksum algorithm does not match policy",
                 ));
             }
-            let computed = compute_checksum(*algorithm, bytes)?;
-            if !provided.value.eq_ignore_ascii_case(&computed.value) {
+            Ok(())
+        }
+    }
+}
+
+/// The checksum algorithm a completed upload must hash, if any.
+///
+/// Returns `None` when no verification is needed (no policy, or an `Optional`
+/// policy with no client-supplied checksum), so a streaming backend can skip
+/// hashing entirely in the common case. Backends should stream-compute this
+/// algorithm and pass the result to [`validate_complete_checksum_precomputed`].
+pub fn checksum_algorithm_to_compute(
+    policy: &ChecksumPolicy,
+    provided: Option<&ObjectChecksum>,
+) -> Option<ChecksumAlgorithm> {
+    match policy {
+        ChecksumPolicy::None => None,
+        ChecksumPolicy::Optional(_) => provided.map(|checksum| checksum.algorithm),
+        ChecksumPolicy::Required(algorithm) => Some(*algorithm),
+    }
+}
+
+/// Validate a `provided` checksum against one the backend already computed while
+/// streaming, instead of re-hashing a full in-memory buffer.
+///
+/// `computed` is the checksum the backend streamed for the stored object (or
+/// `None` when [`checksum_algorithm_to_compute`] returned `None`).
+pub fn validate_complete_checksum_precomputed(
+    policy: &ChecksumPolicy,
+    computed: Option<ObjectChecksum>,
+    provided: Option<ObjectChecksum>,
+) -> StorageResult<Option<ObjectChecksum>> {
+    ensure_supported_checksum_policy(policy)?;
+    match policy {
+        ChecksumPolicy::None => Ok(None),
+        ChecksumPolicy::Optional(allowed) => match provided {
+            Some(checksum) => {
+                if !allowed.contains(&checksum.algorithm) {
+                    return Err(StorageError::policy_rejected(
+                        "checksum algorithm is not allowed",
+                    ));
+                }
+                verify_match(&checksum, expect_computed(checksum.algorithm, computed)?)
+            }
+            None => Ok(None),
+        },
+        ChecksumPolicy::Required(algorithm) => {
+            let provided = provided.ok_or_else(|| {
+                StorageError::policy_rejected("required upload checksum is missing")
+            })?;
+            if provided.algorithm != *algorithm {
                 return Err(StorageError::policy_rejected(
-                    "required upload checksum does not match uploaded bytes",
+                    "required upload checksum algorithm does not match policy",
                 ));
             }
-            Ok(Some(computed))
+            verify_match(&provided, expect_computed(*algorithm, computed)?)
         }
     }
 }
 
-fn ensure_supported_checksum_algorithm(algorithm: ChecksumAlgorithm) -> StorageResult<()> {
-    match algorithm {
-        ChecksumAlgorithm::Sha256 => Ok(()),
-        ChecksumAlgorithm::Crc32c | ChecksumAlgorithm::Md5 => Err(StorageError::unsupported(
-            "only sha256 checksum verification is implemented in pocopine-storage PR 1",
-        )),
-    }
+pub fn ensure_supported_checksum_policy(policy: &ChecksumPolicy) -> StorageResult<()> {
+    // Every `ChecksumAlgorithm` variant is now backed by `pocopine-crypto`, so
+    // there is nothing left to reject. Kept as a public hook so backends keep a
+    // single validation entry point if future algorithms are added.
+    let _ = policy;
+    Ok(())
 }
 
-fn compute_checksum(algorithm: ChecksumAlgorithm, bytes: &[u8]) -> StorageResult<ObjectChecksum> {
-    match algorithm {
-        ChecksumAlgorithm::Sha256 => {
-            let digest = Sha256::digest(bytes);
-            let mut value = String::with_capacity(digest.len() * 2);
-            for byte in digest {
-                use std::fmt::Write as _;
-                write!(&mut value, "{byte:02x}")
-                    .map_err(|err| StorageError::backend(format!("format checksum: {err}")))?;
+pub fn validate_complete_checksum(
+    policy: &ChecksumPolicy,
+    bytes: &[u8],
+    provided: Option<ObjectChecksum>,
+) -> StorageResult<Option<ObjectChecksum>> {
+    match policy {
+        ChecksumPolicy::None => Ok(None),
+        ChecksumPolicy::Optional(allowed) => match provided {
+            Some(checksum) => {
+                if !allowed.contains(&checksum.algorithm) {
+                    return Err(StorageError::policy_rejected(
+                        "checksum algorithm is not allowed",
+                    ));
+                }
+                verify_match(&checksum, compute_checksum(checksum.algorithm, bytes))
             }
-            Ok(ObjectChecksum { algorithm, value })
+            None => Ok(None),
+        },
+        ChecksumPolicy::Required(algorithm) => {
+            let provided = provided.ok_or_else(|| {
+                StorageError::policy_rejected("required upload checksum is missing")
+            })?;
+            if provided.algorithm != *algorithm {
+                return Err(StorageError::policy_rejected(
+                    "required upload checksum algorithm does not match policy",
+                ));
+            }
+            verify_match(&provided, compute_checksum(*algorithm, bytes))
         }
-        ChecksumAlgorithm::Crc32c | ChecksumAlgorithm::Md5 => Err(StorageError::unsupported(
-            "only sha256 checksum verification is implemented in pocopine-storage PR 1",
-        )),
+    }
+}
+
+/// Confirm a `computed` checksum matches what the client `provided`.
+fn verify_match(
+    provided: &ObjectChecksum,
+    computed: ObjectChecksum,
+) -> StorageResult<Option<ObjectChecksum>> {
+    if !provided.value.eq_ignore_ascii_case(&computed.value) {
+        return Err(StorageError::policy_rejected(
+            "upload checksum does not match uploaded bytes",
+        ));
+    }
+    Ok(Some(computed))
+}
+
+fn expect_computed(
+    algorithm: ChecksumAlgorithm,
+    computed: Option<ObjectChecksum>,
+) -> StorageResult<ObjectChecksum> {
+    let computed = computed.ok_or_else(|| {
+        StorageError::backend("checksum was not computed for the completed object".to_string())
+    })?;
+    if computed.algorithm != algorithm {
+        return Err(StorageError::backend(
+            "computed checksum algorithm does not match the requested algorithm".to_string(),
+        ));
+    }
+    Ok(computed)
+}
+
+fn compute_checksum(algorithm: ChecksumAlgorithm, bytes: &[u8]) -> ObjectChecksum {
+    ObjectChecksum {
+        algorithm,
+        value: digest_hex(crypto_algorithm(algorithm), bytes),
+    }
+}
+
+fn crypto_algorithm(algorithm: ChecksumAlgorithm) -> Algorithm {
+    match algorithm {
+        ChecksumAlgorithm::Sha256 => Algorithm::Sha256,
+        ChecksumAlgorithm::Crc32c => Algorithm::Crc32c,
+        ChecksumAlgorithm::Md5 => Algorithm::Md5,
     }
 }

--- a/crates/pocopine-storage/src/client.rs
+++ b/crates/pocopine-storage/src/client.rs
@@ -246,6 +246,7 @@ pub struct ResumableUploadBuilder;
 
 #[cfg(target_arch = "wasm32")]
 mod wasm {
+    use std::cell::Cell;
     #[cfg(any(test, feature = "test-utils"))]
     use std::cell::RefCell;
     use std::collections::BTreeMap;
@@ -254,6 +255,7 @@ mod wasm {
     use std::rc::Rc;
 
     use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
+    use futures_util::stream::{FuturesUnordered, StreamExt as _};
     use js_sys::Promise;
     use serde::de::DeserializeOwned;
     use wasm_bindgen::prelude::*;
@@ -265,12 +267,17 @@ mod wasm {
 
     use super::*;
     use crate::{
-        CompleteUploadRequest, InitiateUploadRequest, ObjectRef, StorageResponse, UploadPhase,
-        UploadProgress, UploadStrategy, STORAGE_PROTOCOL_V1,
+        plan_parts, CompleteUploadRequest, InitiateUploadRequest, ObjectRef, PartSpec,
+        StorageResponse, UploadPhase, UploadProgress, UploadStrategy, STORAGE_PROTOCOL_V1,
     };
 
     const DEFAULT_CHUNK_SIZE: u64 = 1024 * 1024;
     const TUS_PROTOCOL_VERSION: &str = "1.0.0";
+    /// Hard ceiling on in-flight multipart part uploads, regardless of what the
+    /// server's plan advertises. Browsers cap concurrent connections per origin
+    /// anyway; this just keeps a buggy/hostile plan from making us seed an
+    /// unbounded sliding window of fetches.
+    const MAX_CLIENT_CONCURRENT_PARTS: usize = 16;
 
     /// Test hook for the browser upload transport.
     #[doc(hidden)]
@@ -557,7 +564,7 @@ mod wasm {
         pub async fn send(self) -> StorageResult<ObjectRef> {
             self.emit(UploadPhase::Initiating, 0);
 
-            let mut session = match self.resume_session.clone() {
+            let session = match self.resume_session.clone() {
                 Some(session) => session,
                 None if self.auto_resume => {
                     if let Some(session) = self.load_resume_session().await? {
@@ -568,15 +575,26 @@ mod wasm {
                 }
                 None => self.initiate().await?,
             };
-            self.store_resume_session(&session);
 
-            if session.strategy != UploadStrategy::Sequential {
-                self.emit(UploadPhase::Failed, session.next_offset.unwrap_or(0));
-                return Err(StorageError::unsupported(
-                    "only sequential proxy uploads are implemented in pocopine-storage PR 1",
-                ));
+            // The server negotiated the strategy at initiate; the client drives the
+            // matching transport. SingleRequest/Auto are not client-driven. Each
+            // path owns its own resume-session persistence (only the sequential
+            // path is offset-resumable).
+            match session.strategy {
+                UploadStrategy::Sequential => self.send_sequential(session).await,
+                UploadStrategy::Multipart => self.send_multipart(session).await,
+                other => {
+                    self.emit(UploadPhase::Failed, session.next_offset.unwrap_or(0));
+                    Err(StorageError::unsupported(format!(
+                        "the browser client cannot drive the {other:?} upload strategy"
+                    )))
+                }
             }
+        }
 
+        /// Sequential proxy upload: ordered `PATCH` chunks coalesced server-side.
+        async fn send_sequential(&self, mut session: UploadSession) -> StorageResult<ObjectRef> {
+            self.store_resume_session(&session);
             let mut offset = self.inspect_offset(&session).await?;
             while offset < self.source.size {
                 self.emit(UploadPhase::Uploading, offset);
@@ -603,7 +621,9 @@ mod wasm {
                             break;
                         }
                         Err(err)
-                            if err.is_retryable_client_error() && attempts < self.retry_limit =>
+                            if err.is_retryable_client_error()
+                                && attempts < self.retry_limit
+                                && !self.is_aborted() =>
                         {
                             attempts += 1;
                             self.emit(UploadPhase::Retrying, offset);
@@ -618,10 +638,146 @@ mod wasm {
             }
 
             self.emit(UploadPhase::Completing, self.source.size);
-            let object = self.complete(&session).await?;
+            let object = self.complete_retrying(&session).await?;
             self.clear_resume_session();
             self.emit(UploadPhase::Complete, self.source.size);
             Ok(object)
+        }
+
+        /// Server-mediated multipart upload: parts (sized by the session plan) are
+        /// `PUT` to the by-number part endpoint with bounded concurrency, then the
+        /// upload is completed (the server assembles from the provider's parts).
+        async fn send_multipart(&self, session: UploadSession) -> StorageResult<ObjectRef> {
+            let parts = plan_parts(self.source.size, &session.plan)?;
+            // Clamp the server-advertised concurrency to a client ceiling so a
+            // buggy/hostile plan can't make us seed thousands of in-flight part
+            // fetches at once.
+            let concurrency = usize::from(session.plan.max_concurrent_parts.max(1))
+                .min(MAX_CLIENT_CONCURRENT_PARTS);
+            let total = self.source.size;
+            // Aggregate completed bytes, shared with the part futures so a
+            // per-part `Retrying` reports the true monotonic total (parts complete
+            // out of order, so a part's own offset could jump ahead then regress).
+            let uploaded = Rc::new(Cell::new(0u64));
+            let mut specs = parts.into_iter();
+            // Sliding window of in-flight parts, capped at the advertised
+            // concurrency. wasm is single-threaded, so these futures are `!Send`
+            // and run on this one task — no `spawn_local`.
+            let mut in_flight = FuturesUnordered::new();
+            for _ in 0..concurrency {
+                if let Some(spec) = specs.next() {
+                    in_flight.push(self.upload_part(&session, spec, uploaded.clone()));
+                }
+            }
+            while let Some(result) = in_flight.next().await {
+                match result {
+                    Ok(spec) => {
+                        uploaded.set(uploaded.get().saturating_add(spec.len));
+                        self.emit_part(UploadPhase::Uploading, uploaded.get(), spec.number);
+                        if let Some(spec) = specs.next() {
+                            in_flight.push(self.upload_part(&session, spec, uploaded.clone()));
+                        }
+                    }
+                    Err(err) => {
+                        self.emit(UploadPhase::Failed, uploaded.get());
+                        // Best-effort cleanup. Sibling part PUTs still in flight are
+                        // not individually cancelled, but the server's abort
+                        // reconciles them: a late part either hits the now-deleted
+                        // session (rejected) or lands a provider part the abort's
+                        // own cleanup removes (S3 NoSuchUpload, GCS component-range
+                        // delete, Azure uncommitted-block GC).
+                        let _ = self.abort(&session).await;
+                        return Err(err);
+                    }
+                }
+            }
+
+            self.emit(UploadPhase::Completing, total);
+            // Retry a transient failure on the final assemble (re-complete is
+            // idempotent server-side); on a terminal failure clean up the
+            // provider's multipart state rather than orphaning it.
+            match self.complete_retrying(&session).await {
+                Ok(object) => {
+                    self.clear_resume_session();
+                    self.emit(UploadPhase::Complete, total);
+                    Ok(object)
+                }
+                Err(err) => {
+                    self.emit(UploadPhase::Failed, total);
+                    let _ = self.abort(&session).await;
+                    Err(err)
+                }
+            }
+        }
+
+        /// Upload one part, retrying transient transport errors. Re-`PUT`ting the
+        /// same part number is idempotent server-side, so a retry is safe. Returns
+        /// the spec so the caller can advance progress.
+        async fn upload_part(
+            &self,
+            session: &UploadSession,
+            spec: PartSpec,
+            uploaded: Rc<Cell<u64>>,
+        ) -> StorageResult<PartSpec> {
+            let blob = self.slice(spec.offset, spec.offset + spec.len)?;
+            let mut attempts = 0;
+            loop {
+                match self.put_part(session, spec.number, blob.clone()).await {
+                    Ok(()) => return Ok(spec),
+                    Err(err)
+                        if err.is_retryable_client_error()
+                            && attempts < self.retry_limit
+                            && !self.is_aborted() =>
+                    {
+                        attempts += 1;
+                        // Report the aggregate completed bytes (monotonic), not this
+                        // part's offset, so progress never jumps ahead/regresses.
+                        self.emit_part(UploadPhase::Retrying, uploaded.get(), spec.number);
+                        retry_delay(self.retry_base_delay_ms, attempts).await?;
+                    }
+                    Err(err) => return Err(err),
+                }
+            }
+        }
+
+        async fn put_part(
+            &self,
+            session: &UploadSession,
+            number: u32,
+            blob: Blob,
+        ) -> StorageResult<()> {
+            // The server records the part on the provider and returns the session;
+            // we only need success — completion lists the parts server-side, so the
+            // client never reports per-part receipts on the proxy path. Check the
+            // status only rather than deserializing (and discarding) the session
+            // body, so the part path doesn't break if the server ever answers a
+            // part PUT with an empty/2xx body.
+            fetch_no_content(
+                BrowserStorageRequest::put_part(
+                    upload_url(&self.endpoint, session.id.as_str()),
+                    number,
+                    blob,
+                    self.with_credentials,
+                    self.abort_signal.clone(),
+                ),
+                "upload part",
+            )
+            .await
+        }
+
+        async fn abort(&self, session: &UploadSession) -> StorageResult<()> {
+            // Deliberately omit the caller's `AbortSignal`: this cleanup often runs
+            // *because* that signal fired (user cancel / timeout), and a
+            // pre-aborted signal makes `fetch` reject before sending — so the
+            // server would never receive the DELETE and the provider's multipart
+            // state would leak until expiry.
+            send_request(BrowserStorageRequest::delete(
+                upload_url(&self.endpoint, session.id.as_str()),
+                self.with_credentials,
+                None,
+            ))
+            .await
+            .map(|_| ())
         }
 
         async fn initiate(&self) -> StorageResult<UploadSession> {
@@ -671,7 +827,9 @@ mod wasm {
         ) -> StorageResult<UploadSession> {
             fetch_json(
                 BrowserStorageRequest::patch_blob(
-                    upload_bytes_url(&self.endpoint, session.id.as_str()),
+                    // Sequential append PATCHes the session resource directly
+                    // (TUS-shaped); the part number / offset rides in a header.
+                    upload_url(&self.endpoint, session.id.as_str()),
                     offset,
                     chunk,
                     self.with_credentials,
@@ -695,6 +853,28 @@ mod wasm {
             .await
         }
 
+        /// Complete, retrying transient transport errors. Re-completing is
+        /// idempotent server-side (the server lists the provider's parts and a
+        /// second assemble returns the same `ObjectRef`), so a retry is safe and
+        /// keeps a flaky final request from discarding a fully-uploaded object.
+        async fn complete_retrying(&self, session: &UploadSession) -> StorageResult<ObjectRef> {
+            let mut attempts = 0;
+            loop {
+                match self.complete(session).await {
+                    Ok(object) => return Ok(object),
+                    Err(err)
+                        if err.is_retryable_client_error()
+                            && attempts < self.retry_limit
+                            && !self.is_aborted() =>
+                    {
+                        attempts += 1;
+                        retry_delay(self.retry_base_delay_ms, attempts).await?;
+                    }
+                    Err(err) => return Err(err),
+                }
+            }
+        }
+
         fn chunk_size(&self, session: &UploadSession) -> u64 {
             session
                 .plan
@@ -712,14 +892,32 @@ mod wasm {
         }
 
         fn emit(&self, phase: UploadPhase, bytes_sent: u64) {
+            self.emit_progress(phase, bytes_sent, None);
+        }
+
+        fn emit_part(&self, phase: UploadPhase, bytes_sent: u64, number: u32) {
+            self.emit_progress(phase, bytes_sent, Some(number));
+        }
+
+        fn emit_progress(&self, phase: UploadPhase, bytes_sent: u64, current_part: Option<u32>) {
             if let Some(callback) = &self.progress {
                 callback(UploadProgress {
                     bytes_sent,
                     bytes_total: Some(self.source.size),
-                    current_part: None,
+                    current_part,
                     phase,
                 });
             }
+        }
+
+        /// True once the caller's `AbortSignal` has fired. Used to stop retrying
+        /// a transient transport error when the upload has been cancelled (a
+        /// cancelled `fetch` rejects as a retryable client error, so without this
+        /// guard the part/chunk loops would spin against a dead signal).
+        fn is_aborted(&self) -> bool {
+            self.abort_signal
+                .as_ref()
+                .is_some_and(web_sys::AbortSignal::aborted)
         }
 
         async fn load_resume_session(&self) -> StorageResult<Option<UploadSession>> {
@@ -1164,6 +1362,36 @@ mod wasm {
             }
         }
 
+        fn put_part(
+            url: String,
+            number: u32,
+            blob: Blob,
+            with_credentials: bool,
+            abort_signal: Option<AbortSignal>,
+        ) -> Self {
+            Self {
+                method: "PUT".to_string(),
+                url,
+                headers: vec![("Upload-Part".to_string(), number.to_string())],
+                json_body: None,
+                blob_body: Some(blob),
+                with_credentials,
+                abort_signal,
+            }
+        }
+
+        fn delete(url: String, with_credentials: bool, abort_signal: Option<AbortSignal>) -> Self {
+            Self {
+                method: "DELETE".to_string(),
+                url,
+                headers: Vec::new(),
+                json_body: None,
+                blob_body: None,
+                with_credentials,
+                abort_signal,
+            }
+        }
+
         fn tus_patch(
             url: String,
             offset: u64,
@@ -1228,6 +1456,31 @@ mod wasm {
             )));
         }
         result
+    }
+
+    /// Send a request that returns no body the client needs, surfacing the
+    /// structured `StorageError` from the envelope on failure. Used by the
+    /// multipart part path, where success is status-only and the server's
+    /// session body is intentionally discarded.
+    async fn fetch_no_content(
+        request: BrowserStorageRequest,
+        operation: &'static str,
+    ) -> StorageResult<()> {
+        let response = send_request(request).await?;
+        if (200..300).contains(&response.status) {
+            return Ok(());
+        }
+        // Non-2xx: prefer the structured error from the envelope (so the part
+        // retry loop sees the real variant), else a generic client error.
+        match serde_json::from_str::<StorageResponse<serde::de::IgnoredAny>>(&response.body) {
+            Ok(envelope) => Err(envelope.into_result().err().unwrap_or_else(|| {
+                StorageError::client(format!("{operation} failed with HTTP {}", response.status))
+            })),
+            Err(_) => Err(StorageError::client(format!(
+                "{operation} failed with HTTP {}",
+                response.status
+            ))),
+        }
     }
 
     fn ensure_tus_status(
@@ -1531,10 +1784,6 @@ mod wasm {
             endpoint.trim_end_matches('/'),
             percent_encode_path_segment(session)
         )
-    }
-
-    fn upload_bytes_url(endpoint: &str, session: &str) -> String {
-        format!("{}/bytes", upload_url(endpoint, session))
     }
 
     fn upload_complete_url(endpoint: &str, session: &str) -> String {

--- a/crates/pocopine-storage/src/lib.rs
+++ b/crates/pocopine-storage/src/lib.rs
@@ -34,15 +34,15 @@ pub use client::{BrowserStorageRequest, BrowserStorageResponse, BrowserStorageTr
 pub use client::{__reset_browser_transport_for_test, __set_browser_transport_for_test};
 pub use error::{StorageError, StorageResult};
 pub use protocol::{
-    AnonymousUploadBinding, ChecksumAlgorithm, ChecksumPolicy, CompleteUpload,
-    CompleteUploadRequest, InitiateUpload, InitiateUploadRequest, MetadataSchema, ObjectChecksum,
-    ObjectMetadata, ObjectOwnerRef, ObjectRef, ObjectVisibility, PrincipalRef, SafeObjectKey,
-    SignedRead, StorageBackendName, StorageKey, StorageResponse, TransferPlan, UploadIntent,
-    UploadPhase, UploadPolicy, UploadPolicyDescriptor, UploadProgress, UploadSession,
-    UploadSessionId, UploadSessionStatus, UploadStrategy, UploadTarget, UploadedPartStatus,
-    UploadedPartView, MAX_STORAGE_TOKEN_LEN, STORAGE_ANON_COOKIE, STORAGE_ENDPOINT_PREFIX,
-    STORAGE_PROTOCOL_V1, STORAGE_SCOPES_PREFIX, STORAGE_TUS_ENDPOINT_PREFIX, STORAGE_UPLOADS_PATH,
-    STORAGE_UPLOADS_PREFIX,
+    plan_parts, AnonymousUploadBinding, BackendCapabilities, ChecksumAlgorithm, ChecksumPolicy,
+    CompleteUpload, CompleteUploadRequest, InitiateUpload, InitiateUploadRequest, MetadataSchema,
+    ObjectChecksum, ObjectMetadata, ObjectOwnerRef, ObjectRef, ObjectVisibility, PartSpec,
+    PrincipalRef, SafeObjectKey, SignedRead, StorageBackendName, StorageKey, StorageResponse,
+    TransferPlan, UploadIntent, UploadPhase, UploadPolicy, UploadPolicyDescriptor, UploadProgress,
+    UploadSession, UploadSessionId, UploadSessionStatus, UploadStrategy, UploadTarget,
+    UploadedPartStatus, UploadedPartView, MAX_STORAGE_TOKEN_LEN, STORAGE_ANON_COOKIE,
+    STORAGE_ENDPOINT_PREFIX, STORAGE_PROTOCOL_V1, STORAGE_SCOPES_PREFIX,
+    STORAGE_TUS_ENDPOINT_PREFIX, STORAGE_UPLOADS_PATH, STORAGE_UPLOADS_PREFIX,
 };
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -56,5 +56,5 @@ pub use server::{
     storage_server_plugin, storage_tus_server_plugin, StorageActor, StorageBackend,
     StorageBoxFuture, StorageContext, StorageGuardFuture, StorageKeyFuture, StorageKeyResolver,
     StorageScope, StorageScopeBuilder, StorageScopeGuard, StorageServer, StorageServerBuilder,
-    StorageServerPlugin, StorageTusServerPlugin,
+    StorageServerPlugin, StorageTusServerPlugin, UploadBody, UploadByteStream,
 };

--- a/crates/pocopine-storage/src/local_fs.rs
+++ b/crates/pocopine-storage/src/local_fs.rs
@@ -10,7 +10,7 @@ use uuid::Uuid;
 
 use crate::backend_common::{
     checked_new_offset, ensure_open, ensure_owner, ensure_size_limit,
-    ensure_upload_length_can_be_set, expires_at, object_ref, refresh_expired, selected_strategy,
+    ensure_upload_length_can_be_set, expires_at, object_ref, refresh_expired, select_upload_mode,
 };
 use crate::checksum::{ensure_supported_checksum_policy, validate_complete_checksum};
 use crate::server::{StorageActor, StorageBackend, StorageBoxFuture, StorageContext};
@@ -307,7 +307,7 @@ impl LocalFsStorageBackend {
         request: InitiateUpload,
     ) -> StorageResult<UploadSession> {
         fs::create_dir_all(&self.root).map_err(|err| local_io_error("create storage root", err))?;
-        let strategy = selected_strategy(request.requested_strategy)?;
+        let strategy = select_upload_mode(request.requested_strategy, self.capabilities())?;
         ensure_supported_checksum_policy(&request.policy.checksum)?;
         let id = UploadSessionId::new(Uuid::new_v4().to_string())?;
         let session = UploadSession {

--- a/crates/pocopine-storage/src/memory.rs
+++ b/crates/pocopine-storage/src/memory.rs
@@ -6,7 +6,7 @@ use uuid::Uuid;
 
 use crate::backend_common::{
     checked_new_offset, ensure_open, ensure_owner, ensure_size_limit,
-    ensure_upload_length_can_be_set, expires_at, object_ref, refresh_expired, selected_strategy,
+    ensure_upload_length_can_be_set, expires_at, object_ref, refresh_expired, select_upload_mode,
 };
 use crate::checksum::{ensure_supported_checksum_policy, validate_complete_checksum};
 use crate::server::{StorageActor, StorageBackend, StorageBoxFuture, StorageContext};
@@ -104,7 +104,7 @@ impl StorageBackend for MemoryStorageBackend {
         request: InitiateUpload,
     ) -> StorageBoxFuture<'a, UploadSession> {
         Box::pin(async move {
-            let strategy = selected_strategy(request.requested_strategy)?;
+            let strategy = select_upload_mode(request.requested_strategy, self.capabilities())?;
             ensure_supported_checksum_policy(&request.policy.checksum)?;
             let id = UploadSessionId::new(Uuid::new_v4().to_string())?;
             let session = UploadSession {

--- a/crates/pocopine-storage/src/protocol.rs
+++ b/crates/pocopine-storage/src/protocol.rs
@@ -334,6 +334,71 @@ pub enum UploadStrategy {
     Multipart,
 }
 
+/// The upload mechanisms a storage backend supports, advertised so the server
+/// can negotiate a requested [`UploadStrategy`] against what the backend can
+/// actually do (see [`crate::backend_common::select_upload_mode`]).
+///
+/// Backends that do not override `StorageBackend::capabilities()` advertise the
+/// [`Default`] — sequential proxy only — so adding a new capability never
+/// silently changes an existing backend.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct BackendCapabilities {
+    /// Ordered `PATCH`-chunk proxy uploads streamed through the server.
+    pub sequential_proxy: bool,
+    /// Server-mediated provider-native multipart (parts assembled server-side).
+    pub native_multipart: bool,
+    /// The whole object accepted in a single request.
+    pub single_request: bool,
+    /// Signed direct-to-provider part URLs (the browser uploads bypass the
+    /// server). Opt-in per scope via the upload policy.
+    pub signed_direct: bool,
+}
+
+impl Default for BackendCapabilities {
+    fn default() -> Self {
+        Self {
+            sequential_proxy: true,
+            native_multipart: false,
+            single_request: false,
+            signed_direct: false,
+        }
+    }
+}
+
+impl BackendCapabilities {
+    /// A backend that only supports sequential proxy uploads (the default).
+    pub fn sequential_only() -> Self {
+        Self::default()
+    }
+
+    /// Advertise server-mediated native multipart (the by-number `upload_part`
+    /// path) in addition to whatever is already set. Builder helper so external
+    /// backend crates can opt into a capability without naming every field of
+    /// this `#[non_exhaustive]` struct.
+    pub fn with_native_multipart(mut self) -> Self {
+        self.native_multipart = true;
+        self
+    }
+
+    /// The strategies a client may request against a backend with these
+    /// capabilities, used to populate the scope descriptor so capability
+    /// discovery matches what `initiate_upload` actually accepts.
+    pub fn strategies(&self) -> Vec<UploadStrategy> {
+        let mut strategies = Vec::new();
+        if self.sequential_proxy {
+            strategies.push(UploadStrategy::Sequential);
+        }
+        if self.native_multipart {
+            strategies.push(UploadStrategy::Multipart);
+        }
+        if self.single_request {
+            strategies.push(UploadStrategy::SingleRequest);
+        }
+        strategies
+    }
+}
+
 /// Public upload session state.
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -490,14 +555,6 @@ impl UploadPolicy {
                 ));
             }
         }
-        if matches!(
-            self.checksum,
-            ChecksumPolicy::Required(ChecksumAlgorithm::Crc32c | ChecksumAlgorithm::Md5)
-        ) {
-            return Err(StorageError::unsupported(
-                "only sha256 checksum verification is implemented in pocopine-storage PR 1",
-            ));
-        }
         if let (Some(min), Some(preferred)) = (self.min_part_size, self.preferred_chunk_size) {
             if min > preferred {
                 return Err(StorageError::policy_rejected(
@@ -563,7 +620,11 @@ impl UploadPolicy {
     }
 
     #[cfg(not(target_arch = "wasm32"))]
-    pub(crate) fn descriptor(&self, scope: &str) -> UploadPolicyDescriptor {
+    pub(crate) fn descriptor(
+        &self,
+        scope: &str,
+        strategies: Vec<UploadStrategy>,
+    ) -> UploadPolicyDescriptor {
         UploadPolicyDescriptor {
             protocol: STORAGE_PROTOCOL_V1.to_string(),
             scope: scope.to_string(),
@@ -574,7 +635,7 @@ impl UploadPolicy {
             supports_progress: true,
             supports_abort: true,
             supports_batch: false,
-            strategies: vec![UploadStrategy::Sequential],
+            strategies,
             preferred_chunk_size: self.preferred_chunk_size,
             min_part_size: self.min_part_size,
             max_part_size: self.max_part_size,
@@ -765,6 +826,86 @@ pub struct TransferPlan {
     pub resumable: bool,
 }
 
+/// Absolute ceiling on the number of parts a multipart upload may plan, applied
+/// when the plan advertises no `max_parts`. Above every provider's real limit
+/// (S3 10k, GCS 32, Azure 50k) yet far below `u32::MAX`, so an untrusted or
+/// corrupted plan can never drive an unbounded allocation or overflow a part
+/// number.
+const MAX_MULTIPART_PARTS: u64 = 100_000;
+
+/// One planned multipart part: its 1-based number and byte range in the source.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PartSpec {
+    pub number: u32,
+    pub offset: u64,
+    pub len: u64,
+}
+
+/// The part size a client should use for a multipart upload under `plan`: the
+/// preferred size (or `max_part_size` as a fallback) clamped into `[min, max]`.
+/// The native backends advertise `preferred == max == part_size`, so this
+/// reproduces the exact part size the server's completion enforces.
+///
+/// Fails loud rather than guessing: a plan that advertises no part size at all
+/// is rejected, so a misconfigured backend surfaces immediately instead of the
+/// client silently slicing at some default and having every part rejected.
+fn multipart_part_size(plan: &TransferPlan) -> StorageResult<u64> {
+    let preferred = plan
+        .preferred_part_size
+        .or(plan.max_part_size)
+        .ok_or_else(|| {
+            StorageError::policy_rejected("multipart upload plan advertises no part size")
+        })?;
+    let min = plan.min_part_size.unwrap_or(1).max(1);
+    let max = plan.max_part_size.unwrap_or(u64::MAX).max(min);
+    Ok(preferred.max(1).clamp(min, max))
+}
+
+/// Lay out a multipart upload of `size` bytes against a session's
+/// [`TransferPlan`]: parts of `multipart_part_size(plan)` each, the last the
+/// remainder, numbered from 1. A zero-byte upload plans no parts (the server
+/// completes it as an empty object).
+///
+/// This is the shared, target-neutral sizing the browser client uses to drive
+/// the by-number part endpoint — kept here (not in the wasm client) so host
+/// tests cover it and it stays in lock-step with the backends' part layout.
+/// Rejects (rather than allocating/overflowing on) an upload that would need
+/// more parts than the plan's `max_parts` — or [`MAX_MULTIPART_PARTS`] when the
+/// plan sets none — so an untrusted plan can't drive an unbounded `Vec` or a
+/// part-number overflow.
+pub fn plan_parts(size: u64, plan: &TransferPlan) -> StorageResult<Vec<PartSpec>> {
+    if size == 0 {
+        return Ok(Vec::new());
+    }
+    let part_size = multipart_part_size(plan)?;
+    let count = size.div_ceil(part_size);
+    let max_parts = plan
+        .max_parts
+        .map_or(MAX_MULTIPART_PARTS, u64::from)
+        .min(MAX_MULTIPART_PARTS);
+    if count > max_parts {
+        return Err(StorageError::policy_rejected(format!(
+            "upload of {size} bytes needs {count} parts, exceeding the {max_parts}-part limit"
+        )));
+    }
+    // `count <= max_parts <= MAX_MULTIPART_PARTS`, so the capacity is bounded and
+    // the 1-based `number` (`u32`) cannot overflow.
+    let mut parts = Vec::with_capacity(count as usize);
+    let mut offset = 0u64;
+    let mut number = 1u32;
+    while offset < size {
+        let len = part_size.min(size - offset);
+        parts.push(PartSpec {
+            number,
+            offset,
+            len,
+        });
+        offset += len;
+        number += 1;
+    }
+    Ok(parts)
+}
+
 /// Browser-safe multipart part view.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct UploadedPartView {
@@ -894,4 +1035,126 @@ pub(crate) fn file_extension(file_name: &str) -> Option<&str> {
     file_name
         .rsplit_once('.')
         .and_then(|(_, extension)| (!extension.is_empty()).then_some(extension))
+}
+
+#[cfg(test)]
+mod plan_parts_tests {
+    use super::*;
+
+    fn plan(preferred: u64, min: u64, max: u64, max_parts: Option<u32>) -> TransferPlan {
+        TransferPlan {
+            min_part_size: Some(min),
+            preferred_part_size: Some(preferred),
+            max_part_size: Some(max),
+            max_parts,
+            max_concurrent_parts: 4,
+            resumable: true,
+        }
+    }
+
+    #[test]
+    fn empty_upload_plans_no_parts() {
+        assert!(plan_parts(0, &plan(5, 5, 5, Some(10))).unwrap().is_empty());
+    }
+
+    #[test]
+    fn exact_multiple_splits_into_equal_parts() {
+        let parts = plan_parts(15, &plan(5, 5, 5, Some(10))).unwrap();
+        assert_eq!(
+            parts,
+            vec![
+                PartSpec {
+                    number: 1,
+                    offset: 0,
+                    len: 5
+                },
+                PartSpec {
+                    number: 2,
+                    offset: 5,
+                    len: 5
+                },
+                PartSpec {
+                    number: 3,
+                    offset: 10,
+                    len: 5
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn remainder_is_the_last_part() {
+        let parts = plan_parts(12, &plan(5, 5, 5, Some(10))).unwrap();
+        assert_eq!(parts.len(), 3);
+        assert_eq!(
+            parts[2],
+            PartSpec {
+                number: 3,
+                offset: 10,
+                len: 2
+            }
+        );
+        // total length covers the whole object exactly, contiguously
+        assert_eq!(parts.iter().map(|p| p.len).sum::<u64>(), 12);
+        let mut next = 0;
+        for p in &parts {
+            assert_eq!(p.offset, next);
+            next += p.len;
+        }
+    }
+
+    #[test]
+    fn single_part_when_smaller_than_part_size() {
+        let parts = plan_parts(3, &plan(5, 5, 5, Some(10))).unwrap();
+        assert_eq!(
+            parts,
+            vec![PartSpec {
+                number: 1,
+                offset: 0,
+                len: 3
+            }]
+        );
+    }
+
+    #[test]
+    fn preferred_is_clamped_into_min_max() {
+        // preferred below min → clamps up to min (4)
+        assert_eq!(multipart_part_size(&plan(1, 4, 16, None)).unwrap(), 4);
+        // preferred above max → clamps down to max (8)
+        assert_eq!(multipart_part_size(&plan(64, 4, 8, None)).unwrap(), 8);
+    }
+
+    #[test]
+    fn exceeding_max_parts_is_rejected() {
+        // 100 bytes / 5-byte parts = 20 parts, over a 10-part cap
+        let err = plan_parts(100, &plan(5, 5, 5, Some(10))).unwrap_err();
+        assert!(matches!(err, StorageError::PolicyRejected { .. }));
+    }
+
+    #[test]
+    fn plan_with_no_part_size_is_rejected_not_guessed() {
+        let no_size = TransferPlan {
+            min_part_size: None,
+            preferred_part_size: None,
+            max_part_size: None,
+            max_parts: None,
+            max_concurrent_parts: 4,
+            resumable: true,
+        };
+        // A non-empty upload must fail loud rather than slice at a guessed size.
+        assert!(matches!(
+            plan_parts(10, &no_size),
+            Err(StorageError::PolicyRejected { .. })
+        ));
+        // An empty upload still needs no parts and never consults the size.
+        assert!(plan_parts(0, &no_size).unwrap().is_empty());
+    }
+
+    #[test]
+    fn unbounded_plan_is_capped_not_allocated() {
+        // No max_parts + a tiny part size against a huge size would otherwise try
+        // to allocate ~size parts; the absolute cap rejects it instead.
+        let err = plan_parts(u64::MAX, &plan(1, 1, 1, None)).unwrap_err();
+        assert!(matches!(err, StorageError::PolicyRejected { .. }));
+    }
 }

--- a/crates/pocopine-storage/src/server.rs
+++ b/crates/pocopine-storage/src/server.rs
@@ -2,21 +2,23 @@ use std::collections::{BTreeMap, HashMap};
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
+use std::task::{Context, Poll};
 
 use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
 use bytes::Bytes;
+use futures_core::Stream;
+use futures_util::TryStreamExt;
 use pocopine_core::{ServerError, ServerResult};
 use pocopine_server::auth::{Decision, DenyReason, Predicate, RequestContext};
 use pocopine_server::axum::body::{to_bytes, Body};
 use pocopine_server::axum::extract::{Path, State};
 use pocopine_server::axum::http::{
-    header::{CACHE_CONTROL, SET_COOKIE, VARY},
+    header::{CACHE_CONTROL, CONTENT_LENGTH, SET_COOKIE, VARY},
     HeaderMap, HeaderValue, Request, StatusCode,
 };
 use pocopine_server::axum::response::{IntoResponse, Json, Response};
-use pocopine_server::axum::routing::{get, head, options, patch, post};
+use pocopine_server::axum::routing::{get, head, options, post};
 use pocopine_server::{Server, ServerPlugin};
-use sha2::{Digest, Sha256};
 use uuid::Uuid;
 
 use crate::{
@@ -29,6 +31,9 @@ use crate::{
 
 const MAX_PROXY_PATCH_BYTES: u64 = 64 * 1024 * 1024;
 const MAX_JSON_CONTROL_BYTES: usize = 64 * 1024;
+/// Request header carrying the 1-based multipart part number on a part `PUT`,
+/// the multipart twin of the sequential path's `Upload-Offset`.
+const UPLOAD_PART_HEADER: &str = "Upload-Part";
 const STORAGE_COOKIE_PATH: &str = "/__pocopine/storage";
 const TUS_PROTOCOL_VERSION: &str = "1.0.0";
 const TUS_UPLOADS_ROUTE: &str = "/__pocopine/storage/tus/v1/:scope/uploads";
@@ -207,9 +212,116 @@ impl StorageKeyResolver for GeneratedStorageKeyResolver {
     }
 }
 
+/// A streaming request body for a multipart part upload.
+///
+/// Wraps the inbound axum [`Body`] together with the part's declared
+/// `Content-Length` so a backend can forward it straight to the provider's part
+/// API (`UploadPart` / resumable chunk / `Put Block`) without buffering the
+/// whole part in memory — peak memory stays O(1) per part regardless of part
+/// size. Consume it with [`UploadBody::into_byte_stream`].
+pub struct UploadBody {
+    inner: Body,
+    content_length: Option<u64>,
+}
+
+impl UploadBody {
+    /// Wrap an axum body with the part's declared length (from the request
+    /// `Content-Length`, when present).
+    pub fn new(inner: Body, content_length: Option<u64>) -> Self {
+        Self {
+            inner,
+            content_length,
+        }
+    }
+
+    /// Build an `UploadBody` from bytes already held in memory, with the content
+    /// length set to the buffer length. Convenient for tests and for callers that
+    /// drive `upload_part` directly without an HTTP request.
+    pub fn from_bytes(bytes: Bytes) -> Self {
+        let content_length = bytes.len() as u64;
+        Self {
+            inner: Body::from(bytes),
+            content_length: Some(content_length),
+        }
+    }
+
+    /// The part's declared length, if the client sent `Content-Length`.
+    ///
+    /// S3 `UploadPart` requires a known length, so a backend that maps parts
+    /// onto S3 should reject a part with no declared length rather than buffer
+    /// it to discover the size.
+    pub fn content_length(&self) -> Option<u64> {
+        self.content_length
+    }
+
+    /// Consume into a provider-agnostic byte stream that yields the part's
+    /// bytes without buffering. Feed it to `reqwest::Body::wrap_stream`, an S3
+    /// `ByteStream` (via `http_body`), or an Azure block body.
+    pub fn into_byte_stream(self) -> UploadByteStream {
+        let mapped = TryStreamExt::map_err(self.inner.into_data_stream(), std::io::Error::other);
+        UploadByteStream {
+            inner: Box::pin(mapped),
+        }
+    }
+
+    /// Collect the part into memory, rejecting once more than `max_bytes` have
+    /// arrived (defends against a body that exceeds its declared
+    /// `Content-Length`). For backends whose provider unit is a single bounded
+    /// object/block (GCS compose components, Azure blocks) rather than a true
+    /// streamed part (S3 `UploadPart`); peak memory is therefore one capped part
+    /// per concurrent upload, matching the sequential path's per-chunk profile.
+    pub async fn collect_capped(self, max_bytes: u64) -> StorageResult<Bytes> {
+        use futures_util::StreamExt as _;
+        let cap = usize::try_from(max_bytes).unwrap_or(usize::MAX);
+        let mut stream = self.into_byte_stream();
+        let mut buffer: Vec<u8> = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            let chunk =
+                chunk.map_err(|err| StorageError::client(format!("read part body: {err}")))?;
+            if buffer.len().saturating_add(chunk.len()) > cap {
+                return Err(StorageError::payload_too_large(max_bytes));
+            }
+            buffer.extend_from_slice(&chunk);
+        }
+        Ok(Bytes::from(buffer))
+    }
+}
+
+impl std::fmt::Debug for UploadBody {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UploadBody")
+            .field("content_length", &self.content_length)
+            .finish_non_exhaustive()
+    }
+}
+
+/// A `Send` byte stream of an [`UploadBody`]'s part data, yielding
+/// `Result<Bytes, std::io::Error>` items. Returned by
+/// [`UploadBody::into_byte_stream`] so backends can stream a part to the
+/// provider without depending on axum.
+pub struct UploadByteStream {
+    inner: Pin<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send>>,
+}
+
+impl Stream for UploadByteStream {
+    type Item = Result<Bytes, std::io::Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inner.as_mut().poll_next(cx)
+    }
+}
+
 /// Server-side backend contract for storage engines.
 pub trait StorageBackend: Send + Sync + 'static {
     fn name(&self) -> &'static str;
+
+    /// The upload mechanisms this backend supports. Drives strategy negotiation
+    /// in [`crate::backend_common::select_upload_mode`]. The default advertises
+    /// sequential proxy only, so a backend opts into more capabilities
+    /// explicitly.
+    fn capabilities(&self) -> crate::BackendCapabilities {
+        crate::BackendCapabilities::default()
+    }
 
     fn initiate_upload<'a>(
         &'a self,
@@ -237,6 +349,29 @@ pub trait StorageBackend: Send + Sync + 'static {
         offset: u64,
         bytes: Bytes,
     ) -> StorageBoxFuture<'a, UploadSession>;
+
+    /// Stream one numbered part straight to the provider's native multipart
+    /// primitive without buffering it (server-mediated multipart proxy).
+    ///
+    /// Parts may arrive out of order and concurrently; `number` is the 1-based
+    /// part index the client assigned. The default rejects the call as
+    /// unsupported, so only backends that advertise
+    /// [`BackendCapabilities::native_multipart`](crate::BackendCapabilities)
+    /// need to override it; sequential-only backends keep using
+    /// [`StorageBackend::append_upload_bytes`].
+    fn upload_part<'a>(
+        &'a self,
+        _ctx: &'a StorageContext,
+        _session: UploadSessionId,
+        _number: u32,
+        _body: UploadBody,
+    ) -> StorageBoxFuture<'a, UploadSession> {
+        Box::pin(async move {
+            Err(StorageError::unsupported(
+                "storage backend does not support multipart part uploads",
+            ))
+        })
+    }
 
     fn complete_upload<'a>(
         &'a self,
@@ -388,7 +523,14 @@ impl StorageServer {
             .authorize_read(ctx)
             .await
             .map_err(storage_auth_error)?;
-        Ok(scope_registration.policy.descriptor(scope))
+        // Advertise exactly the strategies the scope's backend can satisfy, so
+        // capability discovery matches what `initiate_upload` will accept (e.g.
+        // an S3-backed scope surfaces multipart, an in-memory one does not).
+        let strategies = self
+            .backend(scope_registration.policy.backend.as_str())
+            .map(|backend| backend.capabilities().strategies())
+            .unwrap_or_else(|_| crate::BackendCapabilities::default().strategies());
+        Ok(scope_registration.policy.descriptor(scope, strategies))
     }
 
     pub async fn initiate_upload(
@@ -407,14 +549,9 @@ impl StorageServer {
             .map_err(storage_auth_error)?;
         scope.policy.validate_initiate(&request)?;
 
-        if matches!(
-            request.requested_strategy,
-            UploadStrategy::SingleRequest | UploadStrategy::Multipart
-        ) {
-            return Err(StorageError::unsupported(
-                "only sequential proxy uploads are implemented in pocopine-storage PR 1",
-            ));
-        }
+        // Strategy is negotiated against the backend's advertised capabilities in
+        // its `initiate_upload` (via `select_upload_mode`); the server no longer
+        // hardcodes which strategies are supported.
 
         let intent = UploadIntent {
             scope: request.scope.clone(),
@@ -492,6 +629,23 @@ impl StorageServer {
         backend
             .append_upload_bytes(&ctx, session, offset, bytes)
             .await
+    }
+
+    pub async fn upload_part(
+        &self,
+        ctx: StorageContext,
+        session: UploadSessionId,
+        number: u32,
+        body: UploadBody,
+    ) -> StorageResult<UploadSession> {
+        require_bound_actor(&ctx)?;
+        let (backend, upload) = self.backend_for_session(&ctx, session.clone()).await?;
+        let scope = self.scope(&upload.scope)?;
+        scope
+            .authorize_write(ctx.clone())
+            .await
+            .map_err(storage_auth_error)?;
+        backend.upload_part(&ctx, session, number, body).await
     }
 
     pub async fn complete_upload(
@@ -752,14 +906,18 @@ impl ServerPlugin for StorageServerPlugin {
                 post(initiate_handler).with_state(storage.clone()),
             )
             .route(
+                // The session is the one mutable resource; the method (+ an
+                // `Upload-*` header) selects the operation:
+                //   PATCH + Upload-Offset → sequential append
+                //   PUT   + Upload-Part   → multipart part
+                //   GET → inspect · DELETE → abort
+                // `complete` is the lone action sub-path below.
                 "/__pocopine/storage/v1/uploads/:session",
                 get(inspect_handler)
+                    .patch(bytes_handler)
+                    .put(part_handler)
                     .delete(abort_handler)
                     .with_state(storage.clone()),
-            )
-            .route(
-                "/__pocopine/storage/v1/uploads/:session/bytes",
-                patch(bytes_handler).with_state(storage.clone()),
             )
             .route(
                 "/__pocopine/storage/v1/uploads/:session/complete",
@@ -882,6 +1040,79 @@ async fn bytes_handler(
             )
         }
         Err(err) => storage_response::<UploadSession>(Err(err), None),
+    }
+}
+
+async fn part_handler(
+    State(storage): State<StorageServer>,
+    Path(session): Path<String>,
+    request: Request<Body>,
+) -> Response {
+    match bytes_request(request, &storage).await {
+        Ok(request) => {
+            let set_cookie = request.set_cookie;
+            // The 1-based part number rides in the `Upload-Part` header — the
+            // multipart twin of the sequential path's `Upload-Offset`. A `PUT` to
+            // the session with no `Upload-Part` is not a valid part request.
+            let number = match request.headers.get(UPLOAD_PART_HEADER) {
+                Some(value) => match value
+                    .to_str()
+                    .ok()
+                    .and_then(|raw| parse_part_number(raw).ok())
+                {
+                    Some(number) => number,
+                    None => {
+                        return storage_response::<UploadSession>(
+                            Err(StorageError::invalid_value(UPLOAD_PART_HEADER, "<invalid>")),
+                            set_cookie,
+                        );
+                    }
+                },
+                None => {
+                    return storage_response::<UploadSession>(
+                        Err(StorageError::invalid_value(UPLOAD_PART_HEADER, "<missing>")),
+                        set_cookie,
+                    );
+                }
+            };
+            // Parse Content-Length up front: it is the only place the part's
+            // size is known without draining the stream, and S3 `UploadPart`
+            // needs it. A malformed header is rejected rather than ignored so a
+            // backend never silently streams an unbounded part.
+            let content_length = match request.headers.get(CONTENT_LENGTH) {
+                Some(value) => match value.to_str().ok().and_then(|raw| raw.parse::<u64>().ok()) {
+                    Some(parsed) => Some(parsed),
+                    None => {
+                        return storage_response::<UploadSession>(
+                            Err(StorageError::invalid_value("Content-Length", "<invalid>")),
+                            set_cookie,
+                        );
+                    }
+                },
+                None => None,
+            };
+            storage_response(
+                async {
+                    let session = UploadSessionId::new(session)?;
+                    let body = UploadBody::new(request.body, content_length);
+                    storage
+                        .upload_part(request.ctx, session, number, body)
+                        .await
+                }
+                .await,
+                set_cookie,
+            )
+        }
+        Err(err) => storage_response::<UploadSession>(Err(err), None),
+    }
+}
+
+/// Parse a 1-based multipart part number from the `Upload-Part` header value,
+/// rejecting non-numeric values and zero through the storage error envelope.
+fn parse_part_number(raw: &str) -> StorageResult<u32> {
+    match raw.parse::<u32>() {
+        Ok(number) if number >= 1 => Ok(number),
+        _ => Err(StorageError::invalid_value(UPLOAD_PART_HEADER, raw)),
     }
 }
 
@@ -1678,16 +1909,10 @@ fn apply_set_cookie(response: &mut Response, set_cookie: Option<String>) {
 /// cookies and replay them via the `Cookie` header. We hash with a domain
 /// separator so a leaked digest is not usable as a "blind hash" elsewhere.
 fn hash_anonymous_binding(raw: &str) -> String {
-    let mut hasher = Sha256::new();
+    let mut hasher = pocopine_crypto::Hasher::new(pocopine_crypto::Algorithm::Sha256);
     hasher.update(b"pocopine.storage.anon.v1\0");
     hasher.update(raw.as_bytes());
-    let digest = hasher.finalize();
-    let mut out = String::with_capacity(digest.len() * 2);
-    for byte in digest {
-        use std::fmt::Write as _;
-        let _ = write!(&mut out, "{byte:02x}");
-    }
-    out
+    hasher.finalize_hex()
 }
 
 fn require_bound_actor(ctx: &StorageContext) -> StorageResult<()> {

--- a/crates/pocopine-storage/tests/client_browser.rs
+++ b/crates/pocopine-storage/tests/client_browser.rs
@@ -380,6 +380,162 @@ async fn upload_client_local_storage_resume_is_opt_in() {
     pocopine_storage::__reset_browser_transport_for_test();
 }
 
+#[wasm_bindgen_test(async)]
+async fn multipart_upload_sends_parts_with_part_header_and_completes() {
+    pocopine_storage::__reset_browser_transport_for_test();
+    let fake = FakeStorageTransport::default();
+    fake.state.borrow_mut().multipart = true;
+    let state = fake.state.clone();
+    pocopine_storage::__set_browser_transport_for_test(fake);
+
+    let progress = Rc::new(RefCell::new(Vec::<UploadProgress>::new()));
+    let progress_for_callback = progress.clone();
+    let object = StorageClient::new()
+        .scope("avatars")
+        .upload_blob(blob("hello"), "photo.txt")
+        .strategy(UploadStrategy::Multipart)
+        .on_progress(move |event| progress_for_callback.borrow_mut().push(event))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(object.size, 5);
+    let state = state.borrow();
+    // initiate, three by-number part PUTs, then complete.
+    assert_eq!(
+        state
+            .requests
+            .iter()
+            .map(|request| request.method.as_str())
+            .collect::<Vec<_>>(),
+        ["POST", "PUT", "PUT", "PUT", "POST"]
+    );
+    // every part carried the Upload-Part header (no /parts/ sub-path, no offset).
+    assert!(state
+        .requests
+        .iter()
+        .filter(|request| request.method == "PUT")
+        .all(|request| header(request, "Upload-Part").is_some()));
+    // all three 1-based part numbers were uploaded (order-independent).
+    let mut numbers = state.part_numbers.clone();
+    numbers.sort_unstable();
+    assert_eq!(numbers, [1, 2, 3]);
+    // multipart progress reports the per-part index, and ends Complete.
+    assert!(progress
+        .borrow()
+        .iter()
+        .any(|event| event.current_part.is_some()));
+    assert_eq!(
+        progress.borrow().last().unwrap().phase,
+        UploadPhase::Complete
+    );
+    pocopine_storage::__reset_browser_transport_for_test();
+}
+
+#[wasm_bindgen_test(async)]
+async fn multipart_part_retries_transient_error_without_duplicate() {
+    pocopine_storage::__reset_browser_transport_for_test();
+    let fake = FakeStorageTransport::default();
+    {
+        let mut state = fake.state.borrow_mut();
+        state.multipart = true;
+        state.part_error_once = true;
+    }
+    let state = fake.state.clone();
+    pocopine_storage::__set_browser_transport_for_test(fake);
+
+    let object = StorageClient::new()
+        .scope("avatars")
+        .upload_blob(blob("hello"), "photo.txt")
+        .strategy(UploadStrategy::Multipart)
+        .retry_limit(1)
+        .retry_base_delay_ms(0)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(object.size, 5);
+    let state = state.borrow();
+    // One part PUT failed transiently and was retried, so there are four PUTs
+    // but still exactly three distinct recorded parts (no phantom/duplicate).
+    let put_count = state
+        .requests
+        .iter()
+        .filter(|request| request.method == "PUT")
+        .count();
+    assert_eq!(put_count, 4);
+    let mut numbers = state.part_numbers.clone();
+    numbers.sort_unstable();
+    assert_eq!(numbers, [1, 2, 3]);
+    pocopine_storage::__reset_browser_transport_for_test();
+}
+
+#[wasm_bindgen_test(async)]
+async fn multipart_terminal_part_failure_aborts_and_errors() {
+    pocopine_storage::__reset_browser_transport_for_test();
+    let fake = FakeStorageTransport::default();
+    {
+        let mut state = fake.state.borrow_mut();
+        state.multipart = true;
+        state.part_error_once = true;
+    }
+    let state = fake.state.clone();
+    pocopine_storage::__set_browser_transport_for_test(fake);
+
+    // retry_limit 0 → the first part error is terminal; the client must clean up
+    // the provider's multipart state with a DELETE rather than orphaning it.
+    let err = StorageClient::new()
+        .scope("avatars")
+        .upload_blob(blob("hello"), "photo.txt")
+        .strategy(UploadStrategy::Multipart)
+        .retry_limit(0)
+        .send()
+        .await
+        .unwrap_err();
+
+    assert!(matches!(err, StorageError::Client { .. }));
+    let state = state.borrow();
+    assert!(
+        state
+            .requests
+            .iter()
+            .any(|request| request.method == "DELETE"),
+        "a terminal part failure must trigger best-effort cleanup"
+    );
+    pocopine_storage::__reset_browser_transport_for_test();
+}
+
+#[wasm_bindgen_test(async)]
+async fn multipart_zero_byte_upload_plans_no_parts() {
+    pocopine_storage::__reset_browser_transport_for_test();
+    let fake = FakeStorageTransport::default();
+    fake.state.borrow_mut().multipart = true;
+    let state = fake.state.clone();
+    pocopine_storage::__set_browser_transport_for_test(fake);
+
+    let object = StorageClient::new()
+        .scope("avatars")
+        .upload_blob(blob(""), "photo.txt")
+        .strategy(UploadStrategy::Multipart)
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(object.size, 0);
+    let state = state.borrow();
+    // An empty object has no parts: initiate then complete, no PUTs.
+    assert_eq!(
+        state
+            .requests
+            .iter()
+            .map(|request| request.method.as_str())
+            .collect::<Vec<_>>(),
+        ["POST", "POST"]
+    );
+    assert!(state.part_numbers.is_empty());
+    pocopine_storage::__reset_browser_transport_for_test();
+}
+
 #[derive(Clone, Default)]
 struct FakeStorageTransport {
     state: Rc<RefCell<FakeState>>,
@@ -392,6 +548,9 @@ struct FakeState {
     patch_offsets: Vec<u64>,
     mismatch_once: bool,
     client_error_once: bool,
+    multipart: bool,
+    part_error_once: bool,
+    part_numbers: Vec<u32>,
     tus_offset: u64,
     tus_patch_offsets: Vec<u64>,
     tus_conflict_once: bool,
@@ -428,12 +587,47 @@ impl BrowserStorageTransport for FakeStorageTransport {
             match (request.method.as_str(), request.url.as_str()) {
                 ("POST", "/__pocopine/storage/v1/uploads") => {
                     state.offset = 0;
-                    Ok(json_response(Ok(session(state.offset))))
+                    if state.multipart {
+                        Ok(json_response(Ok(multipart_session())))
+                    } else {
+                        Ok(json_response(Ok(session(state.offset))))
+                    }
+                }
+                ("PUT", "/__pocopine/storage/v1/uploads/session-1") => {
+                    let number = request
+                        .headers
+                        .iter()
+                        .find(|(name, _)| name.eq_ignore_ascii_case("Upload-Part"))
+                        .and_then(|(_, value)| value.parse::<u32>().ok())
+                        .unwrap();
+                    // Fail before recording so a transient part error never leaves a
+                    // phantom part — a retried PUT records the number exactly once.
+                    if state.part_error_once {
+                        state.part_error_once = false;
+                        return Err(StorageError::client("temporary part transport failure"));
+                    }
+                    state.part_numbers.push(number);
+                    let size = request
+                        .blob_body
+                        .as_ref()
+                        .map(|blob| blob.size() as u64)
+                        .unwrap_or(0);
+                    state.offset += size;
+                    // upload_part returns the (refreshed) session
+                    Ok(json_response(Ok(multipart_session())))
+                }
+                ("DELETE", "/__pocopine/storage/v1/uploads/session-1") => {
+                    // Best-effort multipart cleanup; the body is ignored client-side.
+                    Ok(BrowserStorageResponse {
+                        status: 204,
+                        headers: Vec::new(),
+                        body: String::new(),
+                    })
                 }
                 ("GET", "/__pocopine/storage/v1/uploads/session-1") => {
                     Ok(json_response(Ok(session(state.offset))))
                 }
-                ("PATCH", "/__pocopine/storage/v1/uploads/session-1/bytes") => {
+                ("PATCH", "/__pocopine/storage/v1/uploads/session-1") => {
                     let provided = request
                         .headers
                         .iter()
@@ -551,6 +745,32 @@ fn session(offset: u64) -> UploadSession {
             max_part_size: None,
             max_parts: None,
             max_concurrent_parts: 1,
+            resumable: true,
+        },
+        uploaded_parts: Vec::new(),
+        expires_at: OffsetDateTime::UNIX_EPOCH + time::Duration::days(1),
+    }
+}
+
+fn multipart_session() -> UploadSession {
+    UploadSession {
+        id: UploadSessionId::new("session-1").unwrap(),
+        scope: "avatars".to_string(),
+        file_name: "photo.txt".to_string(),
+        size: Some(5),
+        content_type: None,
+        metadata: Default::default(),
+        strategy: UploadStrategy::Multipart,
+        status: UploadSessionStatus::Open,
+        next_offset: Some(0),
+        part_size: Some(2),
+        // 2-byte parts over a 5-byte object → 3 parts; concurrency 2.
+        plan: TransferPlan {
+            min_part_size: Some(2),
+            preferred_part_size: Some(2),
+            max_part_size: Some(2),
+            max_parts: Some(3),
+            max_concurrent_parts: 2,
             resumable: true,
         },
         uploaded_parts: Vec::new(),

--- a/crates/pocopine-storage/tests/storage_host.rs
+++ b/crates/pocopine-storage/tests/storage_host.rs
@@ -1070,12 +1070,15 @@ async fn optional_sha256_checksum_is_verified_when_present() -> StorageResult<()
 }
 
 #[test]
-fn required_unsupported_checksum_algorithms_fail_configuration() -> StorageResult<()> {
-    let mut checksum_policy = policy("memory")?;
-    checksum_policy.checksum = ChecksumPolicy::Required(ChecksumAlgorithm::Md5);
-    let builder = StorageServer::builder().backend("memory", MemoryStorageBackend::new())?;
-    let rejected = builder.public_scope("avatars", checksum_policy);
-    assert!(matches!(rejected, Err(StorageError::Unsupported { .. })));
+fn md5_and_crc32c_checksum_policies_are_now_supported() -> StorageResult<()> {
+    // pocopine-crypto backs all three algorithms, so configuring a scope with a
+    // required MD5 or CRC32C checksum no longer fails as unsupported.
+    for algorithm in [ChecksumAlgorithm::Md5, ChecksumAlgorithm::Crc32c] {
+        let mut checksum_policy = policy("memory")?;
+        checksum_policy.checksum = ChecksumPolicy::Required(algorithm);
+        let builder = StorageServer::builder().backend("memory", MemoryStorageBackend::new())?;
+        assert!(builder.public_scope("avatars", checksum_policy).is_ok());
+    }
     Ok(())
 }
 
@@ -1582,7 +1585,7 @@ where
             Request::builder()
                 .method("PATCH")
                 .uri(format!(
-                    "/__pocopine/storage/v1/uploads/{}/bytes",
+                    "/__pocopine/storage/v1/uploads/{}",
                     session.as_str()
                 ))
                 .header("Upload-Offset", offset.to_string())

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,10 @@ looks the way it does — the code itself tells you *what*.
 - [`browser-storage.md`](./browser-storage.md) — typed `localStorage`
   helpers for small browser preferences, plus the auth-token and SSR
   boundaries.
+- [`storage-uploads.md`](./storage-uploads.md) — object-storage upload
+  architecture (#176): the server-mediated, proxy-like path that streams
+  bytes once into S3/GCS/Azure native multipart, capability negotiation,
+  race-free completion, concurrency fencing, and the crash-recovery model.
 - [`pine-stylekit.md`](./pine-stylekit.md) — the Pocopine-native
   utility-CSS compiler (RFC 092): Tailwind-shaped class grammar,
   `@theme` tokens, the generated utility catalog, diagnostics, and the

--- a/docs/storage-uploads.md
+++ b/docs/storage-uploads.md
@@ -1,0 +1,289 @@
+# Object storage uploads
+
+How `pocopine-storage` moves bytes from a browser into S3, GCS, or Azure
+Blob Storage: a **server-mediated, proxy-like** upload path that streams
+each byte to the provider exactly once, with O(1) server memory per
+in-flight part. This is the architecture reference for the upload
+runtime (issue #176). For the small typed-`localStorage` helper, see
+[`browser-storage.md`](./browser-storage.md) instead — different feature,
+same crate name prefix.
+
+## Why proxy-like
+
+The server is the credential boundary: provider keys never reach the
+browser. So the bytes flow *through* the server. The risk in that design
+is the server itself — a naive proxy buffers or rewrites the object and
+falls over under load. The whole upload runtime is built to avoid that:
+
+- **Stream, don't buffer.** A part is forwarded to the provider as it
+  arrives; the server never holds a whole object (or, on S3, even a whole
+  part) in memory.
+- **Write each byte once.** No "download the staged object, append, re-up­
+  load" rewrite loop (which is O(n²) in bytes for an n-chunk upload).
+- **Let the provider assemble.** Parts are committed with the provider's
+  native multipart primitive (`CompleteMultipartUpload` / `ComposeObject`
+  / `Put Block List`), never reassembled by the server.
+
+## Layers
+
+```text
+  browser UploadClient                         ← Phase 4 (roadmap)
+        │  HTTP, bytes stream through the server
+        ▼
+  axum routes (server.rs)                       ← per-request plumbing
+     POST   /uploads                 initiate
+     PATCH  /uploads/:s              sequential chunk   (Upload-Offset header)
+     PUT    /uploads/:s              multipart part     (Upload-Part header)  ← Phase 2
+     POST   /uploads/:s/complete     assemble
+     GET/DELETE /uploads/:s          inspect / abort
+        ▼
+  StorageServer                                 ← auth, scope policy, ownership
+     require_bound_actor · authorize_write · scope policy
+        ▼
+  StorageBackend trait                          ← one impl per provider
+     capabilities() · initiate · append_upload_bytes(Bytes)
+     upload_part(UploadBody) · complete · abort
+        ▼
+  S3 / GCS / Azure                              ← native multipart assembly
+     (memory + local-fs backends for tests/dev)
+```
+
+Everything above `StorageBackend` is provider-neutral. Each backend
+crate (`pocopine-storage-s3`, `-gcs`, `-azure`) maps the contract onto
+one provider; shared session bookkeeping lives in
+`pocopine-storage/src/backend_common.rs`.
+
+## Two transports
+
+A scope's backend advertises which transports it can serve, and the
+client's requested [`UploadStrategy`] is negotiated against that.
+
+| Strategy | Route | How the server handles bytes |
+|----------|-------|------------------------------|
+| `Sequential` | `PATCH …/uploads/:s` + `Upload-Offset` | Ordered chunks; the server coalesces them into a **bounded tail** and flushes provider-sized parts. One chunk in flight. |
+| `Multipart` | `PUT …/uploads/:s` + `Upload-Part: n` | Parts addressed **by number**, uploaded **concurrently**; each streams straight to a provider part. |
+| `SingleRequest` / `Auto` | — | `Auto` resolves to the most capable advertised mode; `SingleRequest` is reserved. |
+
+Both transports converge on the same native provider assembly at
+`complete`. `Sequential` is the default and exists so an upload works
+even when the client can't or won't do multipart; `Multipart` is the
+fast path for large files.
+
+### Capability negotiation
+
+```rust
+pub struct BackendCapabilities {
+    pub sequential_proxy: bool,   // PATCH-chunk proxy (default true)
+    pub native_multipart: bool,   // by-number part route
+    pub single_request: bool,
+    pub signed_direct: bool,      // Phase 3 (roadmap)
+}
+```
+
+A backend opts in by overriding `StorageBackend::capabilities()`:
+
+```rust
+fn capabilities(&self) -> BackendCapabilities {
+    BackendCapabilities::default().with_native_multipart()
+}
+```
+
+`backend_common::select_upload_mode(requested, caps)` resolves the
+session's concrete strategy: `Auto` picks the best advertised mode, a
+specific request that the backend can't satisfy is rejected as
+`Unsupported`. The default capabilities are sequential-proxy-only, so a
+backend that does nothing keeps working exactly as before. The
+`/scopes/:scope` descriptor derives its advertised `strategies` from the
+backend's capabilities, so client-side discovery matches what `initiate`
+will actually accept.
+
+## The streaming part path
+
+A multipart part must reach the provider without the server buffering
+the whole thing. The request body is wrapped, not collected:
+
+```rust
+pub struct UploadBody { /* axum Body + declared Content-Length */ }
+
+impl UploadBody {
+    pub fn content_length(&self) -> Option<u64>;
+    pub fn into_byte_stream(self) -> UploadByteStream;        // Stream<Result<Bytes, io::Error>>
+    pub async fn collect_capped(self, max: u64) -> StorageResult<Bytes>;
+}
+```
+
+The part handler (`PUT …/uploads/:session`, part number in the `Upload-Part`
+header) never calls `to_bytes`; it builds an `UploadBody` from the live axum
+body and hands it to:
+
+```rust
+fn upload_part(&self, ctx, session, number: u32, body: UploadBody)
+    -> StorageBoxFuture<UploadSession>;
+```
+
+`upload_part` defaults to `Unsupported`, so only backends that advertise
+`native_multipart` implement it. How the body reaches the provider
+depends on the provider's part API:
+
+- **S3 — true streaming.** The part streams to `UploadPart` with O(1)
+  memory. The inbound axum body is `Send` but not `Sync`, while the S3
+  `ByteStream` body requires `Send + Sync`, so a bounded channel bridges
+  the two (a pump task forwards frames, blocking on backpressure). The
+  body is produced lazily, so its hash can't be precomputed; the part is
+  signed with `UnsignedPayload` (and request checksums set to
+  `WhenRequired`) to avoid an `x-amz-content-sha256` mismatch.
+- **GCS / Azure — bounded collect.** A GCS *compose component* and an
+  Azure *block* are written as one bounded object/block per part, which
+  their SDKs don't stream a single shot without a seekable source. So the
+  part is collected with `collect_capped(part_size)` — peak memory is one
+  part per concurrent upload, the same profile as the sequential path's
+  per-chunk buffer. S3 is the only backend that streams a part with no
+  buffering.
+
+### Provider mapping
+
+| | S3 | GCS | Azure |
+|---|----|----|-------|
+| Part unit | `UploadPart` (part number) | component object | `Put Block` (block id) |
+| Assembly | `CompleteMultipartUpload` | `ComposeObject` | `Put Block List` |
+| Part discovery | `ListParts` | probe component keys | `GetBlockList` (uncommitted) |
+| Provider limit | 10 000 parts, 5 MiB floor | 32 compose sources | 50 000 blocks |
+| Per-part memory | O(1) streamed | one component | one block |
+
+The part/component/block **size is pinned by the server** at `initiate`
+(advertised as `min == preferred == max` in the [`TransferPlan`]) and the
+part count is capped to the provider's assembly limit, so a valid upload
+always assembles in a single provider operation.
+
+## Completion is race-free
+
+Parts arrive concurrently and out of order. The design that makes this
+safe: **the server does not track parts in session state.** Per-part
+receipts live on the provider, so concurrent parts never contend on a
+shared session record.
+
+```mermaid
+flowchart TD
+    Init([initiate Multipart + declared size]) --> Parts
+    subgraph Parts["upload_part · concurrent, by number"]
+      P1["PUT parts/1 → provider part 1"]
+      P2["PUT parts/2 → provider part 2"]
+      P3["PUT parts/N → provider part N"]
+    end
+    Parts --> C([POST complete])
+    C --> Probe["list / probe provider parts"]
+    Probe -->|gap or missing| Reject["reject: incomplete"]
+    Probe -->|all present| Assemble["assemble natively<br/>(complete / compose / commit)"]
+    Assemble --> Verify["stream checksum (if required)"]
+    Verify --> Done([ObjectRef])
+```
+
+At completion the backend lists what the provider actually holds (S3
+`ListParts`, GCS component-key probes, Azure `GetBlockList`) and
+assembles from that. Several invariants make the result trustworthy:
+
+- **Declared length required.** A multipart session must declare its size
+  at `initiate`. Parts stream without the session lock, so a `complete`
+  racing an in-flight part would otherwise assemble a truncated object;
+  the declared total catches that (`total != size → incomplete`).
+- **Exact per-part length.** Parts `1..N-1` must be exactly the pinned
+  part size and part `N` the remainder, enforced in `upload_part`. The
+  assembled object's size then equals the declared total by
+  construction — no need to trust provider metadata sizes (some emulators
+  report them as zero).
+- **Contiguity.** A gap (parts 1 and 3, no 2) is rejected as incomplete
+  rather than silently concatenated.
+- **No overwrite + ownership.** Assembly uses `If-None-Match: *` (or the
+  provider equivalent) so it never clobbers an existing key, and stamps an
+  ownership marker (`pocopine-upload-session`) in the object's custom
+  metadata.
+- **Idempotent re-complete.** If our own marked object already exists, a
+  retry adopts it; a foreign object at the key is rejected.
+- **Checksum before observable.** When a checksum policy is set, the
+  assembled object is streamed and verified; a mismatch deletes it.
+
+## Concurrency and fencing
+
+`max_concurrent_parts` (from the scope policy) is enforced **server-side**
+by a per-session semaphore in
+`backend_common::UploadConcurrencyRegistry`, not left as a client hint.
+A part acquires a permit for the duration of its provider write; excess
+parts wait. Because the permit wait can outlast the session's expiry, the
+captured `expires_at` is re-checked after the permit is granted.
+
+For GCS and Azure, the part write also re-reads the session and
+re-validates `Open` **while holding the session lock**, so a part can't
+land a component/block after a concurrent `complete` or `abort` has
+cleaned up. The slow client→server transfer happens *before* the lock, so
+this fence doesn't serialize the upload — only the bounded provider write.
+
+## Failure and recovery
+
+The session moves `Open → Completing → Complete`, and the runtime is built
+to survive a crash at any point:
+
+```mermaid
+flowchart TD
+    Open -->|complete starts| Completing["Completing<br/>(fenced: abort refused)"]
+    Completing -->|assembled + verified| Complete
+    Completing -->|pre-commit error,<br/>object absent/foreign| Open
+    Completing -->|post-commit checksum mismatch,<br/>parts already consumed| Aborted
+    Complete -->|re-complete| Complete
+```
+
+- The session is persisted as `Completing` **before** the object is
+  published, so a concurrent `abort` is refused and a crash leaves a
+  recoverable session (a retry adopts the owner-marked object).
+- A **pre-commit** failure (a missing part, a foreign object winning the
+  key) reopens the session to `Open` — but only when the destination is
+  definitively absent or foreign, never on an indeterminate lookup, so a
+  retry can't change bytes a prior completion already published.
+- A **post-commit** checksum mismatch is terminal: the parts are already
+  consumed by the commit and can't be re-assembled, so the invalid object
+  is deleted and the session is marked `Aborted` (the client must
+  re-initiate). The concurrency pool is released on this terminal path
+  too, not just on success.
+- `abort` closes the concurrency pool (so queued/late parts fail instead
+  of writing after cleanup) and removes provider state (S3 `Abort­Multi­
+  partUpload`; GCS deletes the component range, tolerating gaps; Azure
+  relies on uncommitted-block GC).
+
+Legacy sessions created before native multipart deserialize as a
+`LegacyProxy` variant and keep using the staged-object rewrite path until
+they drain — additive `#[serde(default)]` fields, no migration.
+
+## Memory profile
+
+| Path | Peak server memory |
+|------|--------------------|
+| S3 multipart | O(1) — the part streams through a bounded channel |
+| GCS / Azure multipart | one part per concurrent upload (`part_size × max_concurrent`) |
+| Sequential (any backend) | one coalescing tail (≤ one provider part) |
+| Legacy rewrite (draining only) | O(object size) — the path this work replaced |
+
+For a 64 MiB upload the old sequential rewrite did ~63 full-object
+re-uploads (O(n²) bandwidth); the native paths send each byte to the
+provider exactly once.
+
+## Source map
+
+- `pocopine-storage/src/protocol.rs` — `UploadStrategy`,
+  `BackendCapabilities`, `TransferPlan`, `UploadSession`, `UploadPolicy`.
+- `pocopine-storage/src/server.rs` — routes, `StorageServer`,
+  `StorageBackend` trait, `UploadBody` / `UploadByteStream`.
+- `pocopine-storage/src/backend_common.rs` — `select_upload_mode`,
+  `UploadSessionLockRegistry`, `UploadConcurrencyRegistry`, shared
+  size/owner/open guards.
+- `pocopine-storage-{s3,gcs,azure}/src/storage.rs` — per-provider
+  `initiate` / `append_upload_bytes` / `upload_part` / `complete` /
+  `abort`, plus native helpers and emulator-backed integration tests.
+
+## Roadmap
+
+- **Signed direct-to-provider** (`UploadPolicy.allow_signed_direct`): the
+  server issues short-lived signed part URLs and the browser uploads
+  straight to the provider, bypassing the proxy. Opt-in per scope;
+  everything else (complete, abort, validation) is unchanged.
+- **Browser client + Pine UI**: a `send_multipart` branch in the browser
+  `UploadClient` that drives the part endpoints with bounded concurrency,
+  per-part progress, and retry, plus the Pine upload component retarget.

--- a/examples/file-browser/src/components/upload_panel/FileBrowserUploadPanel.poco
+++ b/examples/file-browser/src/components/upload_panel/FileBrowserUploadPanel.poco
@@ -2,7 +2,6 @@
   <pine-upload-root scope="files"
                     auto-resume
                     multiple
-                    chunk-size="1048576"
                     max-size-bytes="536870912"
                     class="block"
                     @pp:upload:complete="upload_complete"

--- a/examples/file-browser/src/lib.rs
+++ b/examples/file-browser/src/lib.rs
@@ -452,7 +452,7 @@ pub fn main() {
     ];
     pine::register_all();
     App::new()
-        .plugin(pocopine_storage::upload_plugin())
+        .plugin(pocopine_storage::storage_plugin())
         .store::<FileBrowserStore>()
         .register::<PineIcon>()
         .register::<FileBrowserApp>()


### PR DESCRIPTION
Implements GitHub issue #176 end to end: a **server-mediated, proxy-like** object-storage upload runtime that streams each byte to the provider exactly once with bounded server memory, replacing the old O(n²) staged-object rewrite. Spans S3, GCS, and Azure Blob Storage.

This unifies the work previously split as the Phase 0 draft (#183), which this supersedes.

## Why

Provider credentials live on the server, so bytes flow *through* it. A naive proxy buffers or rewrites the object and falls over under load. This runtime instead: streams (never holds a whole object — or, on S3, even a whole part — in memory), writes each byte once, and lets the provider assemble parts natively.

A 64 MiB upload previously did ~63 full-object re-uploads (O(n²) bandwidth). The native paths send each byte once.

## What's in it (phased)

- **Phase 0 — kill the O(n²) rewrite.** Native sequential uploads: each TUS `PATCH` chunk is coalesced into a bounded tail and flushed to a provider part (S3 multipart / GCS compose / Azure block blob). Adds the shared `pocopine-crypto` and `pocopine-codec` crates.
- **Phase 1 — capability negotiation.** `BackendCapabilities` + `select_upload_mode`; the scope descriptor advertises exactly what the backend can serve.
- **Phase 2 — server-mediated streaming multipart.** `UploadBody`/`UploadByteStream` + the `upload_part` trait method + `PUT …/uploads/:session` part route (`Upload-Part` header). Parts are addressed **by number** and uploaded **concurrently**, each streamed to the provider's native part primitive.

## Per-backend

| | S3 | GCS | Azure |
|---|----|----|-------|
| Part unit | `UploadPart` | compose component | `Put Block` |
| Assembly | `CompleteMultipartUpload` | `ComposeObject` | `Put Block List` |
| Part memory | **O(1) streamed** | one component | one block |

S3 streams each part with no buffering (channel-bridged `ByteStream` + unsigned-payload signing). GCS/Azure collect one bounded part per concurrent upload (their SDKs write a whole component/block per part).

## Correctness highlights

- **Race-free completion** — parts live on the provider, not in session state, so concurrent out-of-order parts never contend; completion lists/probes provider state and assembles.
- Declared-length required for multipart; **exact per-part length** so the assembled size equals the declared total; gap rejection; no-overwrite (`If-None-Match`) + ownership marker; idempotent re-complete; checksum verified before the object is observable.
- Server-side `max_concurrent_parts` enforcement via a per-session semaphore; lock-held write fence on GCS/Azure; `Open → Completing → Complete/Aborted` crash-recovery model (pre-commit reopen vs post-commit terminal abort).
- Legacy in-flight sessions deserialize as `LegacyProxy` and keep the old path until drained — additive `#[serde(default)]`, no migration.

## Testing

Emulator-backed integration suites, all green:

- core: 5 unit + 39 host
- S3 (MinIO): 9 unit + 16
- GCS (fake-gcs): 7 unit + 21
- Azure (Azurite): 14 unit + 21

Host + wasm clippy clean, `cargo fmt` clean. Every checkpoint was reviewed with Codex (`codex exec review`) to a clean verdict.

## Docs

`docs/storage-uploads.md` — full architecture article (layers, transports, streaming part path, per-provider mapping, race-free completion, concurrency fencing, crash-recovery state model, memory profile, roadmap).

## Not in scope (roadmap)

- **Phase 3** — signed direct-to-provider (opt-in `UploadPolicy.allow_signed_direct`); the browser uploads straight to the provider via short-lived signed part URLs, bypassing the proxy.
- **Phase 4** — browser `UploadClient` multipart branch + Pine upload component retarget.

Closes #176.
