### PR TITLE
perf(storage): drop legacy O(n²) staged-rewrite upload path

### DIFF
--- a/crates/pocopine-storage-azure/src/layout.rs
+++ b/crates/pocopine-storage-azure/src/layout.rs
@@ -68,10 +68,6 @@ impl AzureKeyLayout {
     pub(crate) fn session_meta_key(&self, session: &UploadSessionId) -> String {
         format!("{}/{}/session.json", self.internal_prefix, session.as_str())
     }
-
-    pub(crate) fn session_bytes_key(&self, session: &UploadSessionId) -> String {
-        format!("{}/{}/bytes.tmp", self.internal_prefix, session.as_str())
-    }
 }
 
 fn container_name_from_url(url: &Url) -> StorageResult<String> {
@@ -179,10 +175,6 @@ mod tests {
         assert_eq!(
             layout.session_meta_key(&session),
             "tenant-a/__pocopine/storage/sessions/session-1/session.json"
-        );
-        assert_eq!(
-            layout.session_bytes_key(&session),
-            "tenant-a/__pocopine/storage/sessions/session-1/bytes.tmp"
         );
         assert_eq!(layout.container_name, "pocopine");
     }

--- a/crates/pocopine-storage-azure/src/state.rs
+++ b/crates/pocopine-storage-azure/src/state.rs
@@ -17,11 +17,7 @@ pub(crate) struct StoredUploadSession {
     pub(crate) object: Option<ObjectRef>,
     #[serde(default)]
     pub(crate) completion_object_key: Option<String>,
-    #[serde(default)]
-    pub(crate) cleanup_pending: bool,
-    /// Transfer mechanism. Sessions written before native block-blob support
-    /// omit this field and deserialize as [`NativeUploadState::LegacyProxy`], so
-    /// in-flight uploads from an older build keep the staged-object rewrite path.
+    /// Transfer mechanism backing this session.
     #[serde(default)]
     pub(crate) native: NativeUploadState,
     #[serde(skip)]
@@ -29,16 +25,22 @@ pub(crate) struct StoredUploadSession {
 }
 
 /// Backend transfer mechanism for an upload session.
-#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+///
+/// Modeled as an enum so additional transfer modes (e.g. signed direct-to-
+/// provider uploads) can be added without changing the session schema.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum NativeUploadState {
-    /// Legacy staged-object rewrite (download → extend → re-upload per append).
-    #[default]
-    LegacyProxy,
     /// Native block blob: sub-block `PATCH` chunks are coalesced into a bounded
     /// tail and flushed as blocks (`Put Block`); completion assembles them with
     /// `Put Block List`. No bytes are re-written.
     Block(AzureBlockState),
+}
+
+impl Default for NativeUploadState {
+    fn default() -> Self {
+        NativeUploadState::Block(AzureBlockState::default())
+    }
 }
 
 /// Block-blob bookkeeping for one session. Block ids are derived from the index
@@ -65,14 +67,12 @@ impl NativeUploadState {
     pub(crate) fn block(&self) -> Option<&AzureBlockState> {
         match self {
             NativeUploadState::Block(state) => Some(state),
-            NativeUploadState::LegacyProxy => None,
         }
     }
 
     pub(crate) fn block_mut(&mut self) -> Option<&mut AzureBlockState> {
         match self {
             NativeUploadState::Block(state) => Some(state),
-            NativeUploadState::LegacyProxy => None,
         }
     }
 }
@@ -87,25 +87,11 @@ pub(crate) struct AzureObjectAttrs {
 pub(crate) struct AzureObjectBytes {
     pub(crate) bytes: Vec<u8>,
     pub(crate) etag: Option<String>,
-    pub(crate) version_id: Option<String>,
-    pub(crate) truncated: bool,
-}
-
-impl AzureObjectBytes {
-    pub(crate) fn empty() -> Self {
-        Self {
-            bytes: Vec::new(),
-            etag: None,
-            version_id: None,
-            truncated: false,
-        }
-    }
 }
 
 pub(crate) struct AzureObjectMetadata {
     pub(crate) size: Option<u64>,
     pub(crate) etag: Option<String>,
-    pub(crate) version_id: Option<String>,
 }
 
 pub(crate) struct AzureObjectWrite {
@@ -175,7 +161,6 @@ mod tests {
             request_metadata: BTreeMap::new(),
             object: None,
             completion_object_key: None,
-            cleanup_pending: false,
             native: NativeUploadState::default(),
             meta_etag: None,
         };
@@ -184,8 +169,6 @@ mod tests {
         let decoded = decode_session_object(AzureObjectBytes {
             bytes,
             etag: Some("\"etag-1\"".to_string()),
-            version_id: Some("version-1".to_string()),
-            truncated: false,
         })
         .unwrap();
 

--- a/crates/pocopine-storage-azure/src/storage.rs
+++ b/crates/pocopine-storage-azure/src/storage.rs
@@ -19,7 +19,7 @@ use pocopine_storage::backend_common::{
 };
 use pocopine_storage::checksum::{
     checksum_algorithm_to_compute, ensure_supported_checksum_policy, precheck_checksum,
-    validate_complete_checksum, validate_complete_checksum_precomputed, StreamingChecksum,
+    validate_complete_checksum_precomputed, StreamingChecksum,
 };
 use pocopine_storage::{
     BackendCapabilities, ChecksumAlgorithm, CompleteUpload, InitiateUpload, ObjectChecksum,
@@ -36,7 +36,7 @@ use crate::state::{
     AzureObjectMetadata, AzureObjectWrite, NativeUploadState, StoredUploadSession,
 };
 use crate::util::{
-    azure_error, bytes_match_at, ensure_completable, is_azure_already_exists, is_azure_not_found,
+    azure_error, ensure_completable, is_azure_already_exists, is_azure_not_found,
     is_azure_precondition_failed, map_session_write_error, usize_from_u64,
 };
 
@@ -163,10 +163,11 @@ impl AzureBlobStorageBackend {
         Ok(self)
     }
 
-    /// Override the maximum size accepted by this sequential proxy backend.
+    /// Override the maximum object size accepted by this backend.
     ///
-    /// The default is 64 MiB because each append rewrites the staged blob and
-    /// completion loads the staged bytes before the final Azure write.
+    /// The cap also sizes the per-session block width (`block_size_for`) so the
+    /// committed block count stays within Azure's per-blob limit. The default is
+    /// 64 MiB.
     pub fn with_max_proxy_upload_bytes(mut self, max_bytes: u64) -> StorageResult<Self> {
         if max_bytes == 0 {
             return Err(StorageError::policy_rejected(
@@ -301,84 +302,6 @@ impl AzureBlobStorageBackend {
         Ok(())
     }
 
-    async fn get_staged_bytes(
-        &self,
-        session: &UploadSessionId,
-        read_limit: u64,
-    ) -> StorageResult<AzureObjectBytes> {
-        let key = self.layout.session_bytes_key(session);
-        match self.get_object_bytes_with_limit(&key, read_limit).await {
-            Ok(bytes) => Ok(bytes),
-            Err(StorageError::UnknownUploadSession { .. }) => Ok(AzureObjectBytes::empty()),
-            Err(err) => Err(err),
-        }
-    }
-
-    async fn reconcile_staged_bytes(
-        &self,
-        session: &UploadSessionId,
-        trusted_len: u64,
-    ) -> StorageResult<Vec<u8>> {
-        let read_limit = trusted_len
-            .checked_add(1)
-            .ok_or_else(|| StorageError::policy_rejected("upload byte offset overflowed"))?;
-        let mut staged = self.get_staged_bytes(session, read_limit).await?;
-        let actual = staged.bytes.len() as u64;
-        if actual > trusted_len {
-            tracing::warn!(
-                target: "pocopine.log",
-                event_name = "pocopine.storage.azure_staged_bytes_truncated",
-                session = %session,
-                actual,
-                trusted = trusted_len,
-            );
-            staged.bytes.truncate(usize_from_u64(trusted_len)?);
-            self.put_staged_bytes(
-                session,
-                Bytes::from(staged.bytes.clone()),
-                staged.etag.map(BlobWritePrecondition::IfMatch),
-            )
-            .await?;
-            return Ok(staged.bytes);
-        }
-        if actual == trusted_len {
-            return Ok(staged.bytes);
-        }
-        Err(StorageError::backend(format!(
-            "Azure staged upload blob is shorter than committed metadata: expected {trusted_len} bytes, got {actual}"
-        )))
-    }
-
-    async fn ensure_staged_not_shorter_than_metadata(
-        &self,
-        session: &UploadSessionId,
-        trusted_len: u64,
-    ) -> StorageResult<()> {
-        let read_limit = trusted_len
-            .checked_add(1)
-            .ok_or_else(|| StorageError::policy_rejected("upload byte offset overflowed"))?;
-        let staged = self.get_staged_bytes(session, read_limit).await?;
-        let actual = staged.bytes.len() as u64;
-        if actual < trusted_len {
-            return Err(StorageError::backend(format!(
-                "Azure staged upload blob is shorter than committed metadata: expected {trusted_len} bytes, got {actual}"
-            )));
-        }
-        Ok(())
-    }
-
-    async fn put_staged_bytes(
-        &self,
-        session: &UploadSessionId,
-        bytes: Bytes,
-        precondition: Option<BlobWritePrecondition>,
-    ) -> StorageResult<AzureObjectWrite> {
-        let key = self.layout.session_bytes_key(session);
-        self.put_object_bytes(&key, bytes, Some("application/octet-stream"), precondition)
-            .await
-            .map_err(map_session_write_error)
-    }
-
     async fn get_object_bytes_with_limit(
         &self,
         key: &str,
@@ -399,8 +322,6 @@ impl AzureBlobStorageBackend {
             return Ok(AzureObjectBytes {
                 bytes: Vec::new(),
                 etag: metadata.etag,
-                version_id: metadata.version_id,
-                truncated: false,
             });
         }
         let probe_limit = max_bytes
@@ -433,23 +354,18 @@ impl AzureBlobStorageBackend {
         let collect_limit = usize_from_u64(probe_limit)?;
         let mut body = response.body;
         let mut bytes = Vec::with_capacity(usize_from_u64(read_len.min(probe_limit))?);
-        let mut body_exceeded_limit = false;
         while let Some(chunk) = body.next().await {
             let chunk = chunk.map_err(|err| azure_error("read blob body", err))?;
             let remaining = collect_limit.saturating_sub(bytes.len());
             if chunk.len() > remaining {
                 bytes.extend_from_slice(&chunk[..remaining]);
-                body_exceeded_limit = true;
                 break;
             }
             bytes.extend_from_slice(&chunk);
             if bytes.len() == collect_limit {
-                body_exceeded_limit = true;
                 break;
             }
         }
-        let truncated =
-            metadata.size.map(|size| size > max_bytes).unwrap_or(false) || body_exceeded_limit;
         if bytes.len() > usize_from_u64(max_bytes)? {
             bytes.truncate(usize_from_u64(max_bytes)?);
         }
@@ -460,8 +376,6 @@ impl AzureBlobStorageBackend {
                 .etag
                 .map(|etag| etag.to_string())
                 .or(metadata.etag),
-            version_id: response.properties.version_id.or(metadata.version_id),
-            truncated,
         })
     }
 
@@ -485,14 +399,7 @@ impl AzureBlobStorageBackend {
             .etag()
             .map_err(|err| azure_error("read blob etag", err))?
             .map(|etag| etag.to_string());
-        let version_id = response
-            .version_id()
-            .map_err(|err| azure_error("read blob version id", err))?;
-        Ok(AzureObjectMetadata {
-            size,
-            etag,
-            version_id,
-        })
+        Ok(AzureObjectMetadata { size, etag })
     }
 
     async fn put_object_bytes(
@@ -535,72 +442,6 @@ impl AzureBlobStorageBackend {
         })
     }
 
-    async fn put_completed_object(
-        &self,
-        key: &str,
-        bytes: Bytes,
-        content_type: Option<&str>,
-    ) -> StorageResult<AzureObjectWrite> {
-        match self.compare_existing_completed_object(key, &bytes).await {
-            Ok(Some(existing)) => return Ok(existing),
-            Ok(None) => {
-                return Err(StorageError::policy_rejected(format!(
-                    "Azure blob key already exists with different bytes: {key}"
-                )));
-            }
-            Err(StorageError::UnknownUploadSession { .. }) => {}
-            Err(err) => return Err(err),
-        }
-        match self
-            .put_object_bytes(
-                key,
-                bytes.clone(),
-                content_type,
-                Some(BlobWritePrecondition::IfNotExists),
-            )
-            .await
-        {
-            Ok(written) => Ok(written),
-            Err(StorageError::Conflict { .. }) => {
-                match self.compare_existing_completed_object(key, &bytes).await {
-                    Ok(Some(existing)) => Ok(existing),
-                    Ok(None) | Err(StorageError::UnknownUploadSession { .. }) => {
-                        Err(StorageError::policy_rejected(format!(
-                            "Azure blob key already exists: {key}"
-                        )))
-                    }
-                    Err(err) => Err(err),
-                }
-            }
-            Err(err) => Err(err),
-        }
-    }
-
-    async fn compare_existing_completed_object(
-        &self,
-        key: &str,
-        bytes: &Bytes,
-    ) -> StorageResult<Option<AzureObjectWrite>> {
-        let metadata = self.get_object_metadata(key).await?;
-        if let Some(size) = metadata.size {
-            if size != bytes.len() as u64 {
-                return Ok(None);
-            }
-        }
-        let metadata_etag = metadata.etag.clone();
-        let metadata_version_id = metadata.version_id.clone();
-        let existing = self
-            .download_object_bytes_with_limit(key, bytes.len() as u64, metadata)
-            .await?;
-        if existing.truncated || existing.bytes.as_slice() != bytes.as_ref() {
-            return Ok(None);
-        }
-        Ok(Some(AzureObjectWrite {
-            etag: existing.etag.or(metadata_etag),
-            version_id: existing.version_id.or(metadata_version_id),
-        }))
-    }
-
     async fn delete_object(&self, key: &str) -> StorageResult<()> {
         let options = BlobClientDeleteOptions {
             delete_snapshots: Some(DeleteSnapshotsOptionType::Include),
@@ -636,60 +477,6 @@ impl AzureBlobStorageBackend {
             self.write_session(session, stored).await?;
         }
         Ok(())
-    }
-
-    async fn cleanup_staged_bytes(
-        &self,
-        session: &UploadSessionId,
-        stored: &mut StoredUploadSession,
-    ) -> StorageResult<()> {
-        if !stored.cleanup_pending {
-            return Ok(());
-        }
-        self.delete_object_if_exists(&self.layout.session_bytes_key(session))
-            .await?;
-        stored.cleanup_pending = false;
-        self.write_session(session, stored).await
-    }
-
-    async fn cleanup_staged_bytes_best_effort(
-        &self,
-        session: &UploadSessionId,
-        stored: &mut StoredUploadSession,
-    ) {
-        if let Err(err) = self.cleanup_staged_bytes(session, stored).await {
-            tracing::warn!(
-                target: "pocopine.log",
-                event_name = "pocopine.storage.azure_cleanup_pending",
-                session = %session,
-                error = %err,
-            );
-        }
-    }
-
-    async fn rollback_completion_after_error(
-        &self,
-        session: &UploadSessionId,
-        stored: &mut StoredUploadSession,
-        error: StorageError,
-    ) -> StorageError {
-        stored.public.status = UploadSessionStatus::Open;
-        stored.completion_object_key = None;
-        match self.write_session(session, stored).await {
-            Ok(()) => error,
-            Err(rollback_error) => {
-                tracing::error!(
-                    target: "pocopine.log",
-                    event_name = "pocopine.storage.azure_completion_rollback_failed",
-                    session = %session,
-                    original_error = %error,
-                    rollback_error = %rollback_error,
-                );
-                StorageError::backend(format!(
-                    "Azure complete upload failed ({error}); rollback failed ({rollback_error})"
-                ))
-            }
-        }
     }
 
     fn ensure_requested_size_is_supported(&self, size: Option<u64>) -> StorageResult<()> {
@@ -1361,134 +1148,6 @@ impl AzureBlobStorageBackend {
         self.write_session(session, &mut stored).await?;
         Ok(object)
     }
-
-    // --- legacy staged-object rewrite flow (pre-block sessions) ---------------
-
-    async fn append_legacy(
-        &self,
-        session: &UploadSessionId,
-        mut stored: StoredUploadSession,
-        offset: u64,
-        bytes: Bytes,
-    ) -> StorageResult<UploadSession> {
-        let expected = stored.public.next_offset.unwrap_or(0);
-        let new_offset = checked_new_offset(offset, bytes.len())?;
-        let read_limit = expected
-            .max(new_offset)
-            .checked_add(1)
-            .ok_or_else(|| StorageError::policy_rejected("upload byte offset overflowed"))?;
-        let mut staged_object = self.get_staged_bytes(session, read_limit).await?;
-        let staged_len = staged_object.bytes.len() as u64;
-        if expected != offset {
-            if new_offset == expected
-                && bytes_match_at(&staged_object.bytes, offset, bytes.as_ref())?
-            {
-                return Ok(stored.public);
-            }
-            tracing::debug!(
-                target: "pocopine.log",
-                event_name = "pocopine.storage.offset_mismatch",
-                session = %session,
-                expected,
-                provided = offset,
-            );
-            return Err(StorageError::offset_mismatch(expected, offset));
-        }
-        if staged_len > expected {
-            if staged_len == new_offset
-                && bytes_match_at(&staged_object.bytes, expected, bytes.as_ref())?
-            {
-                stored.public.next_offset = Some(new_offset);
-                self.write_session(session, &mut stored).await?;
-                return Ok(stored.public);
-            }
-            tracing::warn!(
-                target: "pocopine.log",
-                event_name = "pocopine.storage.azure_staged_bytes_truncated",
-                session = %session,
-                actual = staged_len,
-                trusted = expected,
-            );
-            staged_object.bytes.truncate(usize_from_u64(expected)?);
-            let written = self
-                .put_staged_bytes(
-                    session,
-                    Bytes::from(staged_object.bytes.clone()),
-                    staged_object
-                        .etag
-                        .clone()
-                        .map(BlobWritePrecondition::IfMatch),
-                )
-                .await?;
-            staged_object.etag = written.etag;
-        } else if staged_len < expected {
-            return Err(StorageError::backend(format!(
-                "Azure staged upload blob is shorter than committed metadata: expected {expected} bytes, got {staged_len}"
-            )));
-        }
-        ensure_size_limit(stored.max_bytes, stored.public.size, new_offset)?;
-        staged_object.bytes.extend_from_slice(&bytes);
-        self.put_staged_bytes(
-            session,
-            Bytes::from(staged_object.bytes),
-            staged_object.etag.map(BlobWritePrecondition::IfMatch),
-        )
-        .await?;
-        stored.public.next_offset = Some(new_offset);
-        self.write_session(session, &mut stored).await?;
-        Ok(stored.public)
-    }
-
-    async fn complete_legacy(
-        &self,
-        session: &UploadSessionId,
-        mut stored: StoredUploadSession,
-        provided_checksum: Option<ObjectChecksum>,
-    ) -> StorageResult<ObjectRef> {
-        let trusted = stored.public.next_offset.unwrap_or(0);
-        let staged = self.reconcile_staged_bytes(session, trusted).await?;
-        let actual = staged.len() as u64;
-        if let Some(expected) = stored.public.size {
-            if actual != expected {
-                return Err(StorageError::policy_rejected(format!(
-                    "upload is incomplete: expected {expected} bytes, got {actual}"
-                )));
-            }
-        }
-        ensure_size_limit(stored.max_bytes, stored.public.size, actual)?;
-        let checksum =
-            validate_complete_checksum(&stored.checksum_policy, &staged, provided_checksum)?;
-        let object_key = self.layout.object_key(stored.storage_key.key.as_str());
-        if stored.public.status == UploadSessionStatus::Open
-            || stored.public.next_offset != Some(actual)
-            || stored.completion_object_key.as_deref() != Some(object_key.as_str())
-        {
-            stored.public.status = UploadSessionStatus::Completing;
-            stored.public.next_offset = Some(actual);
-            stored.completion_object_key = Some(object_key.clone());
-            self.write_session(session, &mut stored).await?;
-        }
-        let staged = Bytes::from(staged);
-        let written = match self
-            .put_completed_object(&object_key, staged, stored.public.content_type.as_deref())
-            .await
-        {
-            Ok(written) => written,
-            Err(err) => {
-                return Err(self
-                    .rollback_completion_after_error(session, &mut stored, err)
-                    .await);
-            }
-        };
-        let object = self.object_ref(&stored, actual, written, checksum);
-        stored.public.status = UploadSessionStatus::Complete;
-        stored.public.next_offset = Some(actual);
-        stored.object = Some(object.clone());
-        stored.cleanup_pending = true;
-        self.write_session(session, &mut stored).await?;
-        self.cleanup_staged_bytes(session, &mut stored).await?;
-        Ok(object)
-    }
 }
 
 impl StorageBackend for AzureBlobStorageBackend {
@@ -1574,7 +1233,6 @@ impl StorageBackend for AzureBlobStorageBackend {
                 request_metadata: request.metadata,
                 object: None,
                 completion_object_key: None,
-                cleanup_pending: false,
                 native: NativeUploadState::Block(Default::default()),
                 meta_etag: None,
             };
@@ -1596,16 +1254,8 @@ impl StorageBackend for AzureBlobStorageBackend {
             let _guard = lock.lock().await;
             let stored = self.read_session(&session).await?;
             ensure_owner(&ctx.actor, &stored.owner)?;
-            // Native block sessions keep an authoritative offset in the metadata;
-            // only the legacy staged-object path reconciles against storage.
-            if stored.public.status == UploadSessionStatus::Open && stored.native.block().is_none()
-            {
-                self.ensure_staged_not_shorter_than_metadata(
-                    &session,
-                    stored.public.next_offset.unwrap_or(0),
-                )
-                .await?;
-            }
+            // Native block sessions keep an authoritative offset in the session
+            // metadata, so no provider round-trip is needed to report progress.
             Ok(stored.public)
         })
     }
@@ -1626,10 +1276,6 @@ impl StorageBackend for AzureBlobStorageBackend {
             self.persist_expired_if_needed(&session, &mut stored)
                 .await?;
             let committed_offset = stored.public.next_offset.unwrap_or(0);
-            if stored.native.block().is_none() {
-                self.ensure_staged_not_shorter_than_metadata(&session, committed_offset)
-                    .await?;
-            }
             ensure_upload_length_can_be_set(
                 stored.max_bytes,
                 &stored.public,
@@ -1663,11 +1309,7 @@ impl StorageBackend for AzureBlobStorageBackend {
                     "Azure backend currently supports sequential proxy uploads only",
                 ));
             }
-            if stored.native.block().is_some() {
-                self.append_block(&session, stored, offset, bytes).await
-            } else {
-                self.append_legacy(&session, stored, offset, bytes).await
-            }
+            self.append_block(&session, stored, offset, bytes).await
         })
     }
 
@@ -1793,8 +1435,6 @@ impl StorageBackend for AzureBlobStorageBackend {
             ensure_owner(&ctx.actor, &stored.owner)?;
             if let Some(object) = &stored.object {
                 let object = object.clone();
-                self.cleanup_staged_bytes_best_effort(&request.session, &mut stored)
-                    .await;
                 self.part_concurrency.forget(&request.session);
                 return Ok(object);
             }
@@ -1802,16 +1442,11 @@ impl StorageBackend for AzureBlobStorageBackend {
                 .await?;
             ensure_completable(&stored.public)?;
             let session = request.session.clone();
-            let result = if stored.native.block().is_some() {
-                if stored.public.strategy == UploadStrategy::Multipart {
-                    self.complete_block_by_number(&session, stored, request.checksum)
-                        .await
-                } else {
-                    self.complete_block(&session, stored, request.checksum)
-                        .await
-                }
+            let result = if stored.public.strategy == UploadStrategy::Multipart {
+                self.complete_block_by_number(&session, stored, request.checksum)
+                    .await
             } else {
-                self.complete_legacy(&session, stored, request.checksum)
+                self.complete_block(&session, stored, request.checksum)
                     .await
             };
             // Drop the concurrency pool only on success; a failed attempt leaves
@@ -1862,15 +1497,12 @@ impl StorageBackend for AzureBlobStorageBackend {
                 }
             }
             let meta_key = self.layout.session_meta_key(&session);
-            let bytes_key = self.layout.session_bytes_key(&session);
-            let bytes_deleted = self.delete_object_if_exists(&bytes_key).await;
             let meta_deleted = match read_session {
                 AbortSessionRead::Known(_) | AbortSessionRead::Corrupt => {
                     self.delete_object_if_exists(&meta_key).await
                 }
                 AbortSessionRead::Missing => Ok(()),
             };
-            bytes_deleted?;
             meta_deleted?;
             self.part_concurrency.forget(&session);
             Ok(())

--- a/crates/pocopine-storage-azure/src/util.rs
+++ b/crates/pocopine-storage-azure/src/util.rs
@@ -17,16 +17,6 @@ pub(crate) fn usize_from_u64(value: u64) -> StorageResult<usize> {
         .map_err(|_| StorageError::policy_rejected("upload byte count exceeds host capacity"))
 }
 
-pub(crate) fn bytes_match_at(staged: &[u8], offset: u64, bytes: &[u8]) -> StorageResult<bool> {
-    let start = usize_from_u64(offset)?;
-    let end = start
-        .checked_add(bytes.len())
-        .ok_or_else(|| StorageError::policy_rejected("upload byte offset overflowed"))?;
-    Ok(staged
-        .get(start..end)
-        .is_some_and(|existing| existing == bytes))
-}
-
 pub(crate) fn map_session_write_error(error: StorageError) -> StorageError {
     match error {
         StorageError::Conflict { .. } | StorageError::PolicyRejected { .. } => {

--- a/crates/pocopine-storage-gcs/src/layout.rs
+++ b/crates/pocopine-storage-gcs/src/layout.rs
@@ -79,10 +79,6 @@ impl GcsKeyLayout {
         format!("{}/{}/session.json", self.internal_prefix, session.as_str())
     }
 
-    pub(crate) fn session_bytes_key(&self, session: &UploadSessionId) -> String {
-        format!("{}/{}/bytes.tmp", self.internal_prefix, session.as_str())
-    }
-
     /// Key for one native-compose component object.
     pub(crate) fn session_component_key(&self, session: &UploadSessionId, index: u32) -> String {
         format!(
@@ -139,10 +135,6 @@ mod tests {
         assert_eq!(
             layout.session_meta_key(&session),
             "tenant-a/__pocopine/storage/sessions/session-1/session.json"
-        );
-        assert_eq!(
-            layout.session_bytes_key(&session),
-            "tenant-a/__pocopine/storage/sessions/session-1/bytes.tmp"
         );
         assert_eq!(layout.bucket_resource(), "projects/_/buckets/bucket");
     }

--- a/crates/pocopine-storage-gcs/src/lib.rs
+++ b/crates/pocopine-storage-gcs/src/lib.rs
@@ -3,12 +3,13 @@
 //! This crate implements Pocopine's current bounded sequential proxy upload
 //! contract using the official `google-cloud-storage` clients. Completed
 //! objects are written by `SafeObjectKey`, while upload-session metadata and
-//! staging bytes live under an internal prefix in the same bucket.
+//! component objects live under an internal prefix in the same bucket.
 //!
-//! The adapter rewrites the staged object on each append and keeps only
-//! in-process per-session locks, so route a given upload session to one server
-//! replica or wait for a future provider-side multipart backend before using it
-//! for large or horizontally written uploads.
+//! The adapter flushes each block once as a component object and assembles the
+//! final object with a single `ComposeObject`; only an unflushed tail is
+//! buffered inline in the session metadata. It keeps only in-process per-session
+//! locks, so route a given upload session to one server replica before using it
+//! for horizontally written uploads.
 
 mod control;
 mod layout;

--- a/crates/pocopine-storage-gcs/src/state.rs
+++ b/crates/pocopine-storage-gcs/src/state.rs
@@ -17,11 +17,7 @@ pub(crate) struct StoredUploadSession {
     pub(crate) object: Option<ObjectRef>,
     #[serde(default)]
     pub(crate) completion_object_key: Option<String>,
-    #[serde(default)]
-    pub(crate) cleanup_pending: bool,
-    /// Transfer mechanism. Sessions written before native compose support omit
-    /// this field and deserialize as [`NativeUploadState::LegacyProxy`], so
-    /// in-flight uploads from an older build keep the staged-object rewrite path.
+    /// Transfer mechanism backing this session.
     #[serde(default)]
     pub(crate) native: NativeUploadState,
     #[serde(skip)]
@@ -29,17 +25,23 @@ pub(crate) struct StoredUploadSession {
 }
 
 /// Backend transfer mechanism for an upload session.
-#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+///
+/// Modeled as an enum so additional transfer modes (e.g. signed direct-to-
+/// provider uploads) can be added without changing the session schema.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum NativeUploadState {
-    /// Legacy staged-object rewrite (download → extend → re-upload per append).
-    #[default]
-    LegacyProxy,
     /// Native compose: each flushed block is written once as a component object
     /// and the final object is assembled with a single `ComposeObject`. Only an
     /// unflushed tail (smaller than one component) is buffered, inline in this
     /// metadata so the tail and bookkeeping persist in one atomic write.
     Compose(GcsComposeState),
+}
+
+impl Default for NativeUploadState {
+    fn default() -> Self {
+        NativeUploadState::Compose(GcsComposeState::default())
+    }
 }
 
 /// Compose bookkeeping for one session.
@@ -74,14 +76,12 @@ impl NativeUploadState {
     pub(crate) fn compose(&self) -> Option<&GcsComposeState> {
         match self {
             NativeUploadState::Compose(state) => Some(state),
-            NativeUploadState::LegacyProxy => None,
         }
     }
 
     pub(crate) fn compose_mut(&mut self) -> Option<&mut GcsComposeState> {
         match self {
             NativeUploadState::Compose(state) => Some(state),
-            NativeUploadState::LegacyProxy => None,
         }
     }
 }
@@ -102,18 +102,6 @@ pub(crate) struct GcsObjectBytes {
     pub(crate) generation: Option<String>,
     pub(crate) generation_match: Option<i64>,
     pub(crate) truncated: bool,
-}
-
-impl GcsObjectBytes {
-    pub(crate) fn empty() -> Self {
-        Self {
-            bytes: Vec::new(),
-            etag: None,
-            generation: None,
-            generation_match: None,
-            truncated: false,
-        }
-    }
 }
 
 pub(crate) struct GcsObjectMetadata {

--- a/crates/pocopine-storage-gcs/src/storage.rs
+++ b/crates/pocopine-storage-gcs/src/storage.rs
@@ -25,7 +25,7 @@ use crate::state::{
     GcsObjectMetadata, GcsObjectWrite, NativeUploadState, StoredUploadSession,
 };
 use crate::util::{
-    bytes_match_at, ensure_completable, gcs_error, is_gcs_not_found, is_gcs_precondition_failed,
+    ensure_completable, gcs_error, is_gcs_not_found, is_gcs_precondition_failed,
     map_session_write_error, non_empty, positive_generation, usize_from_u64,
 };
 
@@ -166,8 +166,9 @@ impl GcsStorageBackend {
 
     /// Override the maximum size accepted by this sequential proxy backend.
     ///
-    /// The default is 64 MiB because each append rewrites the staged object and
-    /// completion loads the staged bytes before the final GCS write.
+    /// The default is 64 MiB: appends flush full-size component objects (each
+    /// written once) and completion assembles them with a single `ComposeObject`,
+    /// so the cap bounds component count and the inline tail buffered per session.
     pub fn with_max_proxy_upload_bytes(mut self, max_bytes: u64) -> StorageResult<Self> {
         if max_bytes == 0 {
             return Err(StorageError::policy_rejected(
@@ -292,72 +293,6 @@ impl GcsStorageBackend {
             .map_err(map_session_write_error)?;
         stored.meta_generation = written.generation_match;
         Ok(())
-    }
-
-    async fn get_staged_bytes(
-        &self,
-        session: &UploadSessionId,
-        read_limit: u64,
-    ) -> StorageResult<GcsObjectBytes> {
-        let key = self.layout.session_bytes_key(session);
-        match self.get_object_bytes_with_limit(&key, read_limit).await {
-            Ok(bytes) => Ok(bytes),
-            Err(StorageError::UnknownUploadSession { .. }) => Ok(GcsObjectBytes::empty()),
-            Err(err) => Err(err),
-        }
-    }
-
-    async fn reconcile_staged_bytes(
-        &self,
-        session: &UploadSessionId,
-        trusted_len: u64,
-    ) -> StorageResult<Vec<u8>> {
-        let read_limit = trusted_len
-            .checked_add(1)
-            .ok_or_else(|| StorageError::policy_rejected("upload byte offset overflowed"))?;
-        let mut staged = self.get_staged_bytes(session, read_limit).await?;
-        let actual = staged.bytes.len() as u64;
-        if actual > trusted_len {
-            tracing::warn!(
-                target: "pocopine.log",
-                event_name = "pocopine.storage.gcs_staged_bytes_truncated",
-                session = %session,
-                actual,
-                trusted = trusted_len,
-            );
-            staged.bytes.truncate(usize_from_u64(trusted_len)?);
-            self.put_staged_bytes(
-                session,
-                Bytes::from(staged.bytes.clone()),
-                staged.generation_match,
-            )
-            .await?;
-            return Ok(staged.bytes);
-        }
-        if actual == trusted_len {
-            return Ok(staged.bytes);
-        }
-        Err(StorageError::backend(format!(
-            "GCS staged upload object is shorter than committed metadata: expected {trusted_len} bytes, got {actual}"
-        )))
-    }
-
-    async fn put_staged_bytes(
-        &self,
-        session: &UploadSessionId,
-        bytes: Bytes,
-        if_generation_match: Option<i64>,
-    ) -> StorageResult<()> {
-        let key = self.layout.session_bytes_key(session);
-        self.put_object_bytes(
-            &key,
-            bytes,
-            Some("application/octet-stream"),
-            if_generation_match,
-        )
-        .await
-        .map_err(map_session_write_error)
-        .map(|_| ())
     }
 
     async fn get_object_bytes_with_limit(
@@ -761,20 +696,6 @@ impl GcsStorageBackend {
             self.write_session(session, stored).await?;
         }
         Ok(())
-    }
-
-    async fn cleanup_staged_bytes(
-        &self,
-        session: &UploadSessionId,
-        stored: &mut StoredUploadSession,
-    ) -> StorageResult<()> {
-        if !stored.cleanup_pending {
-            return Ok(());
-        }
-        self.delete_object_if_exists(&self.layout.session_bytes_key(session))
-            .await?;
-        stored.cleanup_pending = false;
-        self.write_session(session, stored).await
     }
 
     fn ensure_requested_size_is_supported(&self, size: Option<u64>) -> StorageResult<()> {
@@ -1373,131 +1294,6 @@ impl GcsStorageBackend {
         self.delete_component_chain(session).await;
         Ok(object)
     }
-
-    // --- legacy staged-object rewrite flow (pre-compose sessions) -------------
-
-    async fn append_legacy(
-        &self,
-        session: &UploadSessionId,
-        mut stored: StoredUploadSession,
-        offset: u64,
-        bytes: Bytes,
-    ) -> StorageResult<UploadSession> {
-        let expected = stored.public.next_offset.unwrap_or(0);
-        let new_offset = checked_new_offset(offset, bytes.len())?;
-        let read_limit = expected
-            .max(new_offset)
-            .checked_add(1)
-            .ok_or_else(|| StorageError::policy_rejected("upload byte offset overflowed"))?;
-        let mut staged_object = self.get_staged_bytes(session, read_limit).await?;
-        let staged_len = staged_object.bytes.len() as u64;
-        if expected != offset {
-            if new_offset == expected
-                && bytes_match_at(&staged_object.bytes, offset, bytes.as_ref())?
-            {
-                return Ok(stored.public);
-            }
-            tracing::debug!(
-                target: "pocopine.log",
-                event_name = "pocopine.storage.offset_mismatch",
-                session = %session,
-                expected,
-                provided = offset,
-            );
-            return Err(StorageError::offset_mismatch(expected, offset));
-        }
-        if staged_len > expected {
-            if staged_len == new_offset
-                && bytes_match_at(&staged_object.bytes, expected, bytes.as_ref())?
-            {
-                stored.public.next_offset = Some(new_offset);
-                self.write_session(session, &mut stored).await?;
-                return Ok(stored.public);
-            }
-            tracing::warn!(
-                target: "pocopine.log",
-                event_name = "pocopine.storage.gcs_staged_bytes_truncated",
-                session = %session,
-                actual = staged_len,
-                trusted = expected,
-            );
-            staged_object.bytes.truncate(usize_from_u64(expected)?);
-            self.put_staged_bytes(
-                session,
-                Bytes::from(staged_object.bytes.clone()),
-                staged_object.generation_match,
-            )
-            .await?;
-        } else if staged_len < expected {
-            return Err(StorageError::backend(format!(
-                "GCS staged upload object is shorter than committed metadata: expected {expected} bytes, got {staged_len}"
-            )));
-        }
-        ensure_size_limit(stored.max_bytes, stored.public.size, new_offset)?;
-        staged_object.bytes.extend_from_slice(&bytes);
-        self.put_staged_bytes(
-            session,
-            Bytes::from(staged_object.bytes),
-            staged_object.generation_match,
-        )
-        .await?;
-        stored.public.next_offset = Some(new_offset);
-        self.write_session(session, &mut stored).await?;
-        Ok(stored.public)
-    }
-
-    async fn complete_legacy(
-        &self,
-        session: &UploadSessionId,
-        mut stored: StoredUploadSession,
-        provided_checksum: Option<ObjectChecksum>,
-    ) -> StorageResult<ObjectRef> {
-        let trusted = stored.public.next_offset.unwrap_or(0);
-        let staged = self.reconcile_staged_bytes(session, trusted).await?;
-        let actual = staged.len() as u64;
-        if let Some(expected) = stored.public.size {
-            if actual != expected {
-                return Err(StorageError::policy_rejected(format!(
-                    "upload is incomplete: expected {expected} bytes, got {actual}"
-                )));
-            }
-        }
-        ensure_size_limit(stored.max_bytes, stored.public.size, actual)?;
-        let checksum =
-            validate_complete_checksum(&stored.checksum_policy, &staged, provided_checksum)?;
-        let object_key = self.layout.object_key(stored.storage_key.key.as_str());
-        if stored.public.status == UploadSessionStatus::Open
-            || stored.public.next_offset != Some(actual)
-            || stored.completion_object_key.as_deref() != Some(object_key.as_str())
-        {
-            stored.public.status = UploadSessionStatus::Completing;
-            stored.public.next_offset = Some(actual);
-            stored.completion_object_key = Some(object_key.clone());
-            self.write_session(session, &mut stored).await?;
-        }
-        let staged = Bytes::from(staged);
-        let written = match self
-            .put_completed_object(&object_key, staged, stored.public.content_type.as_deref())
-            .await
-        {
-            Ok(written) => written,
-            Err(err @ StorageError::PolicyRejected { .. }) => {
-                stored.public.status = UploadSessionStatus::Open;
-                stored.completion_object_key = None;
-                let _ = self.write_session(session, &mut stored).await;
-                return Err(err);
-            }
-            Err(err) => return Err(err),
-        };
-        let object = self.object_ref(&stored, actual, written, checksum);
-        stored.public.status = UploadSessionStatus::Complete;
-        stored.public.next_offset = Some(actual);
-        stored.object = Some(object.clone());
-        stored.cleanup_pending = true;
-        self.write_session(session, &mut stored).await?;
-        self.cleanup_staged_bytes(session, &mut stored).await?;
-        Ok(object)
-    }
 }
 
 impl StorageBackend for GcsStorageBackend {
@@ -1586,12 +1382,11 @@ impl StorageBackend for GcsStorageBackend {
                 request_metadata: request.metadata,
                 object: None,
                 completion_object_key: None,
-                cleanup_pending: false,
                 native: NativeUploadState::Compose(Default::default()),
                 meta_generation: None,
             };
-            // Native sessions buffer their tail inline in the metadata, so no
-            // separate staged `bytes.tmp` object is created up front.
+            // The session buffers its tail inline in the metadata, so no
+            // separate staging object is created up front.
             self.create_session(&id, &mut stored).await?;
             Ok(session)
         })
@@ -1606,22 +1401,11 @@ impl StorageBackend for GcsStorageBackend {
             let lock = self.session_locks.lock(&session);
             let _cleanup = UploadSessionLockCleanup::new(&self.session_locks, &session);
             let _guard = lock.lock().await;
-            let mut stored = self.read_session(&session).await?;
+            let stored = self.read_session(&session).await?;
             ensure_owner(&ctx.actor, &stored.owner)?;
-            // Native sessions keep an authoritative offset in the metadata; only
-            // the legacy staged-object path needs reconciliation against storage.
-            if stored.public.status == UploadSessionStatus::Open
-                && stored.native.compose().is_none()
-            {
-                let staged = self
-                    .reconcile_staged_bytes(&session, stored.public.next_offset.unwrap_or(0))
-                    .await?;
-                let staged_len = staged.len() as u64;
-                if stored.public.next_offset != Some(staged_len) {
-                    stored.public.next_offset = Some(staged_len);
-                    self.write_session(&session, &mut stored).await?;
-                }
-            }
+            // Native compose sessions keep an authoritative offset in the
+            // metadata (flushed components plus the inline tail), so `inspect`
+            // needs no provider round-trip to reconcile.
             Ok(stored.public)
         })
     }
@@ -1641,15 +1425,10 @@ impl StorageBackend for GcsStorageBackend {
             ensure_owner(&ctx.actor, &stored.owner)?;
             self.persist_expired_if_needed(&session, &mut stored)
                 .await?;
-            let committed_offset = match stored.native.compose() {
-                Some(state) => state.committed_len(),
-                None => {
-                    let staged = self
-                        .reconcile_staged_bytes(&session, stored.public.next_offset.unwrap_or(0))
-                        .await?;
-                    staged.len() as u64
-                }
-            };
+            let committed_offset = stored
+                .native
+                .compose()
+                .map_or(0, |state| state.committed_len());
             ensure_upload_length_can_be_set(
                 stored.max_bytes,
                 &stored.public,
@@ -1683,11 +1462,7 @@ impl StorageBackend for GcsStorageBackend {
                     "GCS backend currently supports sequential proxy uploads only",
                 ));
             }
-            if stored.native.compose().is_some() {
-                self.append_compose(&session, stored, offset, bytes).await
-            } else {
-                self.append_legacy(&session, stored, offset, bytes).await
-            }
+            self.append_compose(&session, stored, offset, bytes).await
         })
     }
 
@@ -1812,8 +1587,6 @@ impl StorageBackend for GcsStorageBackend {
             ensure_owner(&ctx.actor, &stored.owner)?;
             if let Some(object) = &stored.object {
                 let object = object.clone();
-                self.cleanup_staged_bytes(&request.session, &mut stored)
-                    .await?;
                 self.part_concurrency.forget(&request.session);
                 return Ok(object);
             }
@@ -1821,16 +1594,11 @@ impl StorageBackend for GcsStorageBackend {
                 .await?;
             ensure_completable(&stored.public)?;
             let session = request.session.clone();
-            let result = if stored.native.compose().is_some() {
-                if stored.public.strategy == UploadStrategy::Multipart {
-                    self.complete_compose_by_number(&session, stored, request.checksum)
-                        .await
-                } else {
-                    self.complete_compose(&session, stored, request.checksum)
-                        .await
-                }
+            let result = if stored.public.strategy == UploadStrategy::Multipart {
+                self.complete_compose_by_number(&session, stored, request.checksum)
+                    .await
             } else {
-                self.complete_legacy(&session, stored, request.checksum)
+                self.complete_compose(&session, stored, request.checksum)
                     .await
             };
             // Drop the concurrency pool only once completion succeeds; a failed
@@ -1894,15 +1662,12 @@ impl StorageBackend for GcsStorageBackend {
                 }
             }
             let meta_key = self.layout.session_meta_key(&session);
-            let bytes_key = self.layout.session_bytes_key(&session);
-            let bytes_deleted = self.delete_object_if_exists(&bytes_key).await;
             let meta_deleted = match read_session {
                 AbortSessionRead::Known(_) | AbortSessionRead::Corrupt => {
                     self.delete_object_if_exists(&meta_key).await
                 }
                 AbortSessionRead::Missing => Ok(()),
             };
-            bytes_deleted?;
             meta_deleted?;
             self.part_concurrency.forget(&session);
             Ok(())

--- a/crates/pocopine-storage-gcs/src/util.rs
+++ b/crates/pocopine-storage-gcs/src/util.rs
@@ -31,16 +31,6 @@ pub(crate) fn usize_from_u64(value: u64) -> StorageResult<usize> {
         .map_err(|_| StorageError::policy_rejected("upload byte count exceeds host capacity"))
 }
 
-pub(crate) fn bytes_match_at(staged: &[u8], offset: u64, bytes: &[u8]) -> StorageResult<bool> {
-    let start = usize_from_u64(offset)?;
-    let end = start
-        .checked_add(bytes.len())
-        .ok_or_else(|| StorageError::policy_rejected("upload byte offset overflowed"))?;
-    Ok(staged
-        .get(start..end)
-        .is_some_and(|existing| existing == bytes))
-}
-
 pub(crate) fn map_session_write_error(error: StorageError) -> StorageError {
     match error {
         StorageError::PolicyRejected { .. } => {

--- a/crates/pocopine-storage-gcs/tests/fake_gcs.rs
+++ b/crates/pocopine-storage-gcs/tests/fake_gcs.rs
@@ -481,12 +481,16 @@ async fn complete_does_not_overwrite_existing_object_key() -> StorageResult<()> 
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn duplicate_append_retry_after_staged_write_advances_metadata() -> StorageResult<()> {
+async fn append_ignores_rogue_staged_object_and_advances_metadata() -> StorageResult<()> {
     let clients = gcs_clients().await;
     let bucket = create_bucket(&clients, "retry").await;
     let backend =
         GcsStorageBackend::emulator(clients.storage.clone(), clients.endpoint.clone(), bucket)?;
     let session = initiate(&backend, Some(5)).await?;
+    // Native compose buffers the tail inline in the session metadata; a stray
+    // `bytes.tmp` object is not part of the protocol, so the append must write
+    // its bytes as usual and advance the offset to the appended length without
+    // ever consulting the rogue object.
     let bytes_key = session_object_key(&backend, &session, "bytes.tmp");
     clients
         .storage
@@ -497,7 +501,7 @@ async fn duplicate_append_retry_after_staged_write_advances_metadata() -> Storag
         )
         .send_unbuffered()
         .await
-        .expect("seed staged retry bytes");
+        .expect("seed rogue staged bytes");
 
     let updated = backend
         .append_upload_bytes(&ctx(), session.id.clone(), 0, Bytes::from_static(b"hello"))

--- a/crates/pocopine-storage-s3/src/layout.rs
+++ b/crates/pocopine-storage-s3/src/layout.rs
@@ -57,10 +57,6 @@ impl S3KeyLayout {
     pub(crate) fn session_meta_key(&self, session: &UploadSessionId) -> String {
         format!("{}/{}/session.json", self.internal_prefix, session.as_str())
     }
-
-    pub(crate) fn session_bytes_key(&self, session: &UploadSessionId) -> String {
-        format!("{}/{}/bytes.tmp", self.internal_prefix, session.as_str())
-    }
 }
 
 fn normalize_object_prefix(prefix: String) -> StorageResult<Option<String>> {
@@ -109,10 +105,6 @@ mod tests {
         assert_eq!(
             layout.session_meta_key(&session),
             "tenant-a/__pocopine/storage/sessions/session-1/session.json"
-        );
-        assert_eq!(
-            layout.session_bytes_key(&session),
-            "tenant-a/__pocopine/storage/sessions/session-1/bytes.tmp"
         );
     }
 

--- a/crates/pocopine-storage-s3/src/state.rs
+++ b/crates/pocopine-storage-s3/src/state.rs
@@ -14,30 +14,28 @@ pub(crate) struct StoredUploadSession {
     pub(crate) checksum_policy: ChecksumPolicy,
     pub(crate) request_metadata: BTreeMap<String, String>,
     pub(crate) object: Option<ObjectRef>,
-    #[serde(default)]
-    pub(crate) cleanup_pending: bool,
     /// Transfer mechanism backing this session.
-    ///
-    /// Sessions written before native multipart support omit this field and
-    /// deserialize as [`NativeUploadState::LegacyProxy`], so in-flight uploads
-    /// created by an older build keep working on the staged-object rewrite path.
     #[serde(default)]
     pub(crate) native: NativeUploadState,
 }
 
 /// Backend transfer mechanism for an upload session.
-#[derive(Clone, Debug, Default, serde::Serialize, serde::Deserialize)]
+///
+/// Modeled as an enum so additional transfer modes (e.g. signed direct-to-
+/// provider uploads) can be added without changing the session schema.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum NativeUploadState {
-    /// Legacy staged-object rewrite (download → extend → re-upload per append).
-    ///
-    /// Only used for sessions created before native multipart was introduced.
-    #[default]
-    LegacyProxy,
     /// S3 native multipart upload: each flushed block is an `UploadPart`, the
     /// final object is assembled by `CompleteMultipartUpload`, and only an
-    /// unflushed tail (smaller than one part) is ever staged in memory/`bytes.tmp`.
+    /// unflushed tail (smaller than one part) is ever buffered in memory.
     Multipart(S3MultipartState),
+}
+
+impl Default for NativeUploadState {
+    fn default() -> Self {
+        NativeUploadState::Multipart(S3MultipartState::default())
+    }
 }
 
 /// Provider-side multipart bookkeeping for one session.
@@ -84,14 +82,12 @@ impl NativeUploadState {
     pub(crate) fn multipart_mut(&mut self) -> Option<&mut S3MultipartState> {
         match self {
             NativeUploadState::Multipart(state) => Some(state),
-            NativeUploadState::LegacyProxy => None,
         }
     }
 
     pub(crate) fn multipart(&self) -> Option<&S3MultipartState> {
         match self {
             NativeUploadState::Multipart(state) => Some(state),
-            NativeUploadState::LegacyProxy => None,
         }
     }
 }

--- a/crates/pocopine-storage-s3/src/storage.rs
+++ b/crates/pocopine-storage-s3/src/storage.rs
@@ -126,9 +126,7 @@ fn upload_body_to_byte_stream(body: UploadBody) -> ByteStream {
 /// to a provider `UploadPart`. The final object is assembled by
 /// `CompleteMultipartUpload`. Peak memory is one part regardless of object size,
 /// and every byte is sent to S3 exactly once (no per-`PATCH` full-object
-/// rewrite). Sessions created by an older build deserialize as
-/// [`NativeUploadState::LegacyProxy`] and keep using the staged-object rewrite
-/// path until they drain.
+/// rewrite).
 #[derive(Clone)]
 pub struct S3StorageBackend {
     name: &'static str,
@@ -248,51 +246,6 @@ impl S3StorageBackend {
         let bytes = serde_json::to_vec_pretty(stored)
             .map_err(|err| StorageError::backend(format!("encode s3 upload metadata: {err}")))?;
         self.put_object_bytes(&key, bytes, Some("application/json"))
-            .await
-            .map(|_| ())
-    }
-
-    async fn get_staged_bytes(&self, session: &UploadSessionId) -> StorageResult<Vec<u8>> {
-        let key = self.layout.session_bytes_key(session);
-        match self.get_object_bytes(&key).await {
-            Ok(bytes) => Ok(bytes),
-            Err(StorageError::UnknownUploadSession { .. }) => Ok(Vec::new()),
-            Err(err) => Err(err),
-        }
-    }
-
-    async fn reconcile_staged_bytes(
-        &self,
-        session: &UploadSessionId,
-        trusted_len: u64,
-    ) -> StorageResult<Vec<u8>> {
-        let staged = self.get_staged_bytes(session).await?;
-        let actual = staged.len() as u64;
-        if actual > trusted_len {
-            tracing::warn!(
-                target: "pocopine.log",
-                event_name = "pocopine.storage.s3_staged_bytes_ahead",
-                session = %session,
-                actual,
-                trusted = trusted_len,
-            );
-            return Ok(staged);
-        }
-        if actual == trusted_len {
-            return Ok(staged);
-        }
-        Err(StorageError::backend(format!(
-            "S3 staged upload object is shorter than committed metadata: expected {trusted_len} bytes, got {actual}"
-        )))
-    }
-
-    async fn put_staged_bytes(
-        &self,
-        session: &UploadSessionId,
-        bytes: Vec<u8>,
-    ) -> StorageResult<()> {
-        let key = self.layout.session_bytes_key(session);
-        self.put_object_bytes(&key, bytes, Some("application/octet-stream"))
             .await
             .map(|_| ())
     }
@@ -904,20 +857,6 @@ impl S3StorageBackend {
         Ok(())
     }
 
-    async fn cleanup_staged_bytes(
-        &self,
-        session: &UploadSessionId,
-        stored: &mut StoredUploadSession,
-    ) -> StorageResult<()> {
-        if !stored.cleanup_pending {
-            return Ok(());
-        }
-        self.delete_object(&self.layout.session_bytes_key(session))
-            .await?;
-        stored.cleanup_pending = false;
-        self.write_session(session, stored).await
-    }
-
     // --- native multipart upload flow ----------------------------------------
 
     async fn append_multipart(
@@ -1342,83 +1281,6 @@ impl S3StorageBackend {
         }
         Ok(())
     }
-
-    // --- legacy staged-object rewrite flow (pre-multipart sessions) -----------
-
-    async fn append_legacy(
-        &self,
-        session: &UploadSessionId,
-        mut stored: StoredUploadSession,
-        offset: u64,
-        bytes: Bytes,
-    ) -> StorageResult<UploadSession> {
-        let mut expected = stored.public.next_offset.unwrap_or(0);
-        let mut staged = self.reconcile_staged_bytes(session, expected).await?;
-        let staged_len = staged.len() as u64;
-        if staged_len > expected {
-            expected = staged_len;
-            stored.public.next_offset = Some(staged_len);
-            self.write_session(session, &stored).await?;
-        }
-        if expected != offset {
-            tracing::debug!(
-                target: "pocopine.log",
-                event_name = "pocopine.storage.offset_mismatch",
-                session = %session,
-                expected,
-                provided = offset,
-            );
-            return Err(StorageError::offset_mismatch(expected, offset));
-        }
-        let new_offset = checked_new_offset(offset, bytes.len())?;
-        ensure_size_limit(stored.max_bytes, stored.public.size, new_offset)?;
-        staged.extend_from_slice(&bytes);
-        self.put_staged_bytes(session, staged).await?;
-        stored.public.next_offset = Some(new_offset);
-        self.write_session(session, &stored).await?;
-        Ok(stored.public)
-    }
-
-    async fn complete_legacy(
-        &self,
-        session: &UploadSessionId,
-        mut stored: StoredUploadSession,
-        request: CompleteUpload,
-    ) -> StorageResult<ObjectRef> {
-        let trusted = stored.public.next_offset.unwrap_or(0);
-        let staged = self.reconcile_staged_bytes(session, trusted).await?;
-        let actual = staged.len() as u64;
-        if let Some(expected) = stored.public.size {
-            if actual != expected {
-                return Err(StorageError::policy_rejected(format!(
-                    "upload is incomplete: expected {expected} bytes, got {actual}"
-                )));
-            }
-        }
-        ensure_size_limit(stored.max_bytes, stored.public.size, actual)?;
-        let checksum =
-            validate_complete_checksum(&stored.checksum_policy, &staged, request.checksum)?;
-        let object_key = self.layout.object_key(stored.storage_key.key.as_str());
-        if stored.public.status == UploadSessionStatus::Open
-            || stored.public.next_offset != Some(actual)
-        {
-            stored.public.status = UploadSessionStatus::Completing;
-            stored.public.next_offset = Some(actual);
-            self.write_session(session, &stored).await?;
-        }
-        let staged = Bytes::from(staged);
-        let etag = self
-            .put_completed_object(&object_key, staged, stored.public.content_type.as_deref())
-            .await?;
-        let object = self.object_ref(&stored, actual, etag, checksum);
-        stored.public.status = UploadSessionStatus::Complete;
-        stored.public.next_offset = Some(actual);
-        stored.object = Some(object.clone());
-        stored.cleanup_pending = true;
-        self.write_session(session, &stored).await?;
-        self.cleanup_staged_bytes(session, &mut stored).await?;
-        Ok(object)
-    }
 }
 
 impl StorageBackend for S3StorageBackend {
@@ -1510,7 +1372,6 @@ impl StorageBackend for S3StorageBackend {
                 checksum_policy: request.policy.checksum,
                 request_metadata: request.metadata,
                 object: None,
-                cleanup_pending: false,
                 native: NativeUploadState::Multipart(S3MultipartState {
                     upload_id: None,
                     parts: Vec::new(),
@@ -1534,28 +1395,16 @@ impl StorageBackend for S3StorageBackend {
             let lock = self.session_locks.lock(&session);
             let _cleanup = UploadSessionLockCleanup::new(&self.session_locks, &session);
             let _guard = lock.lock().await;
-            let mut stored = self.read_session(&session).await?;
+            let stored = self.read_session(&session).await?;
             ensure_owner(&ctx.actor, &stored.owner)?;
-            // Only legacy sessions reconcile here. `inspect_upload` is also on the
-            // internal routing/authorization path (`backend_for_session` calls it
-            // for every part `PUT`), so it must stay cheap: a by-number multipart
-            // session deliberately does NOT `ListParts` here, which would turn an
-            // n-part upload into O(n²) provider calls serialized on the session
-            // lock. Per-part resume listing is surfaced separately via
-            // `list_committed_parts` rather than on this hot path.
-            if stored.public.status == UploadSessionStatus::Open
-                && stored.native.multipart().is_none()
-            {
-                // Legacy sessions recover their offset from the staged object.
-                let staged = self
-                    .reconcile_staged_bytes(&session, stored.public.next_offset.unwrap_or(0))
-                    .await?;
-                let staged_len = staged.len() as u64;
-                if stored.public.next_offset != Some(staged_len) {
-                    stored.public.next_offset = Some(staged_len);
-                    self.write_session(&session, &stored).await?;
-                }
-            }
+            // `inspect_upload` is on the internal routing/authorization path
+            // (`backend_for_session` calls it for every part `PUT`), so it must
+            // stay cheap: a by-number multipart session deliberately does NOT
+            // `ListParts` here, which would turn an n-part upload into O(n²)
+            // provider calls serialized on the session lock. The sequential
+            // tail offset is tracked in the session metadata, so no provider
+            // round-trip is needed; per-part resume listing is surfaced
+            // separately via `list_committed_parts`.
             Ok(stored.public)
         })
     }
@@ -1574,13 +1423,10 @@ impl StorageBackend for S3StorageBackend {
             let mut stored = self.read_session(&session).await?;
             ensure_owner(&ctx.actor, &stored.owner)?;
             self.persist_expired_if_needed(&session, &stored).await?;
-            let committed_offset = match stored.native.multipart() {
-                Some(state) => state.committed_len(),
-                None => self
-                    .reconcile_staged_bytes(&session, stored.public.next_offset.unwrap_or(0))
-                    .await?
-                    .len() as u64,
-            };
+            let committed_offset = stored
+                .native
+                .multipart()
+                .map_or(0, |state| state.committed_len());
             ensure_upload_length_can_be_set(
                 stored.max_bytes,
                 &stored.public,
@@ -1614,11 +1460,7 @@ impl StorageBackend for S3StorageBackend {
                     "S3 backend currently supports sequential proxy uploads only",
                 ));
             }
-            if stored.native.multipart().is_some() {
-                self.append_multipart(&session, stored, offset, bytes).await
-            } else {
-                self.append_legacy(&session, stored, offset, bytes).await
-            }
+            self.append_multipart(&session, stored, offset, bytes).await
         })
     }
 
@@ -1737,12 +1579,10 @@ impl StorageBackend for S3StorageBackend {
             let lock = self.session_locks.lock(&request.session);
             let _cleanup = UploadSessionLockCleanup::new(&self.session_locks, &request.session);
             let _guard = lock.lock().await;
-            let mut stored = self.read_session(&request.session).await?;
+            let stored = self.read_session(&request.session).await?;
             ensure_owner(&ctx.actor, &stored.owner)?;
             if let Some(object) = &stored.object {
                 let object = object.clone();
-                self.cleanup_staged_bytes(&request.session, &mut stored)
-                    .await?;
                 // Terminal: the object is finalized, so the part-concurrency pool
                 // can go (in-flight permit holders keep their own Arc clone).
                 self.part_concurrency.forget(&request.session);
@@ -1752,16 +1592,12 @@ impl StorageBackend for S3StorageBackend {
                 .await?;
             ensure_completable(&stored.public)?;
             let session = request.session.clone();
-            let result = if stored.native.multipart().is_some() {
-                if stored.public.strategy == UploadStrategy::Multipart {
-                    self.complete_multipart_by_number_flow(&session, stored, request)
-                        .await
-                } else {
-                    self.complete_multipart_upload_flow(&session, stored, request)
-                        .await
-                }
+            let result = if stored.public.strategy == UploadStrategy::Multipart {
+                self.complete_multipart_by_number_flow(&session, stored, request)
+                    .await
             } else {
-                self.complete_legacy(&session, stored, request).await
+                self.complete_multipart_upload_flow(&session, stored, request)
+                    .await
             };
             // Only drop the concurrency pool once completion actually succeeds. A
             // failed attempt (missing length, part gap, undersized/in-flight part)
@@ -1810,8 +1646,6 @@ impl StorageBackend for S3StorageBackend {
                 Err(err) => return Err(err),
             };
             let meta_key = self.layout.session_meta_key(&session);
-            let bytes_key = self.layout.session_bytes_key(&session);
-            self.delete_object(&bytes_key).await?;
             if known_session {
                 self.delete_object(&meta_key).await?;
             }


### PR DESCRIPTION
## What

Removes the legacy **staged-object rewrite** upload path (`append_legacy` / `complete_legacy`) from the S3, GCS, and Azure backends. The native upload path — which coalesces each sequential `PATCH` into a bounded tail and flushes provider-sized parts once — is now the only sequential transport.

## Why

The legacy path re-uploaded the entire staged object on every chunk: **O(n²)** provider write bytes for an n-chunk upload. The native path writes each byte to the provider exactly once: **O(n)**. The legacy code only existed to drain sessions serialized before native uploads landed; with native confirmed O(n) and resumable, it's dead weight.

```mermaid
flowchart LR
    subgraph legacy["legacy staged-rewrite — O(n²)"]
      A1[PATCH chunk] --> A2[GET whole staged object]
      A2 --> A3[append in memory]
      A3 --> A4[PUT whole object back]
    end
    subgraph native["native coalescing tail — O(n)"]
      B1[PATCH chunk] --> B2[append to bounded tail]
      B2 --> B3{tail ≥ part size?}
      B3 -->|yes| B4[flush ONE part once<br/>UploadPart / component / Put Block]
      B3 -->|no| B5[buffer inline in metadata]
    end
```

## Empirical confirmation (`benches/amplification.rs`)

| upload | legacy O(n²) | native O(n) | amplification |
|-------:|-------------:|------------:|--------------:|
| 4 MiB  | 14.0 MiB     | 4.0 MiB     | 3.5× |
| 16 MiB | 152.0 MiB    | 16.0 MiB    | 9.5× |
| 64 MiB | 2144.0 MiB   | 64.0 MiB    | 33.5× |

## Changes

- Drop the `NativeUploadState::LegacyProxy` variant. The enum stays (forward-looking for a future signed-direct transfer mode); `Default` is now a manual impl returning the native variant.
- Remove `append_legacy` / `complete_legacy`, the staged-bytes helpers (`get`/`put`/`reconcile`/`cleanup_staged_bytes`), the `cleanup_pending` field, and the now-dead `session_bytes_key` layout key.
- Collapse the legacy branches in `inspect_upload` / `set_upload_length` / `append_upload_bytes` / `complete_upload` / `abort_upload`.
- Native-path state verified-and-kept: `completion_object_key`, `meta_generation`.

**−940 / +99** across 13 files.

## ⚠️ Breaking change

A session created by a **pre-native-multipart** binary can no longer resume — it deserializes to an empty native state and returns a clean **offset-mismatch** error on the next `PATCH`, so the client re-initiates. No corruption; **completed** old sessions still read back unchanged. Only relevant if a live, in-flight upload spanned that exact binary upgrade.

## Verification

| check | result |
|---|---|
| `cargo build` (4 crates) | clean |
| `clippy --all-targets` | zero warnings |
| `rustfmt --check` | clean |
| unit tests | s3 **12**, gcs **7**, azure **14** ✅ |
| MinIO integration suite | **16/16** ✅ |
| fake-gcs integration suite | **21/21** ✅ |
| Azurite integration suite | **21/21** ✅ |

Resumability validated end-to-end: `sequential_upload_resumes_and_completes_against_{minio,fake_gcs,azurite}` all pass.
