### PR TITLE
fix(storage): give host-only benches a wasm32 main (unblocks clippy-wasm)

### DIFF
--- a/crates/pocopine-storage/benches/amplification.rs
+++ b/crates/pocopine-storage/benches/amplification.rs
@@ -21,171 +21,181 @@
 //!
 //! Run: `cargo bench -p pocopine-storage --bench amplification`.
 
-#![cfg(not(target_arch = "wasm32"))]
+// The criterion bench harness is host-only. Gating it off wasm32 would leave
+// this `harness = false` bench binary with no `main` (E0601), so the body lives
+// in a host-only module and wasm32 gets an empty `main` instead — keeps
+// `clippy --all-targets --target wasm32-unknown-unknown` green.
+#[cfg(not(target_arch = "wasm32"))]
+mod bench {
+    use criterion::{black_box, criterion_group, BenchmarkId, Criterion, Throughput};
 
-use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+    const CHUNK: usize = 1024 * 1024; // 1 MiB PATCH chunks
+    const S3_PART: usize = 5 * 1024 * 1024; // S3 minimum part size
+    const AZURE_BLOCK: usize = 1024 * 1024; // Azure block size for the default 64 MiB cap
+    const MIB: f64 = 1024.0 * 1024.0;
 
-const CHUNK: usize = 1024 * 1024; // 1 MiB PATCH chunks
-const S3_PART: usize = 5 * 1024 * 1024; // S3 minimum part size
-const AZURE_BLOCK: usize = 1024 * 1024; // Azure block size for the default 64 MiB cap
-const MIB: f64 = 1024.0 * 1024.0;
+    /// Counts bytes written and folds them so the compiler cannot elide the copy.
+    #[derive(Default)]
+    struct Sink {
+        written: u64,
+        fold: u64,
+    }
 
-/// Counts bytes written and folds them so the compiler cannot elide the copy.
-#[derive(Default)]
-struct Sink {
-    written: u64,
-    fold: u64,
-}
-
-impl Sink {
-    #[inline]
-    fn write(&mut self, buf: &[u8]) {
-        self.written += buf.len() as u64;
-        let mut acc = 0u64;
-        for &byte in buf {
-            acc = acc.wrapping_add(byte as u64);
+    impl Sink {
+        #[inline]
+        fn write(&mut self, buf: &[u8]) {
+            self.written += buf.len() as u64;
+            let mut acc = 0u64;
+            for &byte in buf {
+                acc = acc.wrapping_add(byte as u64);
+            }
+            self.fold = self.fold.wrapping_add(acc);
         }
-        self.fold = self.fold.wrapping_add(acc);
     }
-}
 
-/// Legacy: re-upload the whole staged object on every append, then once more on
-/// completion. Provider write bytes grow quadratically with object size.
-fn gcs_legacy_rewrite(total: usize, chunk: usize) -> Sink {
-    let mut sink = Sink::default();
-    let mut staged: Vec<u8> = Vec::with_capacity(total);
-    let mut offset = 0;
-    while offset < total {
-        let n = chunk.min(total - offset);
-        staged.resize(staged.len() + n, 0xA5);
-        sink.write(&staged); // put_staged rewrites the entire object
-        offset += n;
-    }
-    sink.write(&staged); // final completed-object write
-    sink
-}
-
-/// S3 native multipart: coalesce sub-part chunks into >=5 MiB parts, flushing
-/// each part's bytes to the provider exactly once via `UploadPart`.
-///
-/// Only the unflushed remainder is buffered (bounded by one part), tracked by
-/// length with no front-shifting, so the model reflects the real cost: every
-/// payload byte is written once. (The real backend additionally rewrites a small
-/// base64 tail in the session metadata per append; that churn is bounded by the
-/// part size and disappears once the client sends part-sized chunks, so it is
-/// not modeled here.)
-fn s3_native_multipart(total: usize, chunk: usize) -> Sink {
-    let mut sink = Sink::default();
-    let part = vec![0xA5u8; S3_PART];
-    let mut pending = 0usize;
-    let mut offset = 0;
-    while offset < total {
-        let n = chunk.min(total - offset);
-        pending += n;
-        while pending >= S3_PART {
-            sink.write(&part); // UploadPart: one full part, written once
-            pending -= S3_PART;
+    /// Legacy: re-upload the whole staged object on every append, then once more on
+    /// completion. Provider write bytes grow quadratically with object size.
+    fn gcs_legacy_rewrite(total: usize, chunk: usize) -> Sink {
+        let mut sink = Sink::default();
+        let mut staged: Vec<u8> = Vec::with_capacity(total);
+        let mut offset = 0;
+        while offset < total {
+            let n = chunk.min(total - offset);
+            staged.resize(staged.len() + n, 0xA5);
+            sink.write(&staged); // put_staged rewrites the entire object
+            offset += n;
         }
-        offset += n;
+        sink.write(&staged); // final completed-object write
+        sink
     }
-    if pending > 0 {
-        sink.write(&part[..pending]); // final part
-    }
-    sink
-}
 
-/// GCS native compose: each chunk is one component, written once.
-fn gcs_native_compose(total: usize, chunk: usize) -> Sink {
-    let mut sink = Sink::default();
-    let block = vec![0xA5u8; chunk];
-    let mut offset = 0;
-    while offset < total {
-        let n = chunk.min(total - offset);
-        sink.write(&block[..n]); // component write
-        offset += n;
-    }
-    sink
-}
-
-/// Azure native block blob: coalesce sub-block chunks into fixed-size blocks,
-/// each uploaded once via `Put Block`. `Put Block List` commits the order
-/// server-side, so no payload is re-uploaded.
-fn azure_native_blocks(total: usize, chunk: usize) -> Sink {
-    let mut sink = Sink::default();
-    let block = vec![0xA5u8; AZURE_BLOCK];
-    let mut pending = 0usize;
-    let mut offset = 0;
-    while offset < total {
-        let n = chunk.min(total - offset);
-        pending += n;
-        while pending >= AZURE_BLOCK {
-            sink.write(&block); // Put Block: one full block, written once
-            pending -= AZURE_BLOCK;
+    /// S3 native multipart: coalesce sub-part chunks into >=5 MiB parts, flushing
+    /// each part's bytes to the provider exactly once via `UploadPart`.
+    ///
+    /// Only the unflushed remainder is buffered (bounded by one part), tracked by
+    /// length with no front-shifting, so the model reflects the real cost: every
+    /// payload byte is written once. (The real backend additionally rewrites a small
+    /// base64 tail in the session metadata per append; that churn is bounded by the
+    /// part size and disappears once the client sends part-sized chunks, so it is
+    /// not modeled here.)
+    fn s3_native_multipart(total: usize, chunk: usize) -> Sink {
+        let mut sink = Sink::default();
+        let part = vec![0xA5u8; S3_PART];
+        let mut pending = 0usize;
+        let mut offset = 0;
+        while offset < total {
+            let n = chunk.min(total - offset);
+            pending += n;
+            while pending >= S3_PART {
+                sink.write(&part); // UploadPart: one full part, written once
+                pending -= S3_PART;
+            }
+            offset += n;
         }
-        offset += n;
+        if pending > 0 {
+            sink.write(&part[..pending]); // final part
+        }
+        sink
     }
-    if pending > 0 {
-        sink.write(&block[..pending]); // final block
+
+    /// GCS native compose: each chunk is one component, written once.
+    fn gcs_native_compose(total: usize, chunk: usize) -> Sink {
+        let mut sink = Sink::default();
+        let block = vec![0xA5u8; chunk];
+        let mut offset = 0;
+        while offset < total {
+            let n = chunk.min(total - offset);
+            sink.write(&block[..n]); // component write
+            offset += n;
+        }
+        sink
     }
-    sink
-}
 
-fn amplification(c: &mut Criterion) {
-    let totals = [4 * 1024 * 1024usize, 16 * 1024 * 1024, 64 * 1024 * 1024];
+    /// Azure native block blob: coalesce sub-block chunks into fixed-size blocks,
+    /// each uploaded once via `Put Block`. `Put Block List` commits the order
+    /// server-side, so no payload is re-uploaded.
+    fn azure_native_blocks(total: usize, chunk: usize) -> Sink {
+        let mut sink = Sink::default();
+        let block = vec![0xA5u8; AZURE_BLOCK];
+        let mut pending = 0usize;
+        let mut offset = 0;
+        while offset < total {
+            let n = chunk.min(total - offset);
+            pending += n;
+            while pending >= AZURE_BLOCK {
+                sink.write(&block); // Put Block: one full block, written once
+                pending -= AZURE_BLOCK;
+            }
+            offset += n;
+        }
+        if pending > 0 {
+            sink.write(&block[..pending]); // final block
+        }
+        sink
+    }
 
-    // Exact provider-write-byte report (the headline numbers).
-    eprintln!(
-        "\n=== provider write volume, {} KiB PATCH chunks ===",
-        CHUNK / 1024
-    );
-    eprintln!(
-        "{:>9}  {:>15}  {:>13}  {:>13}  {:>13}  {:>9}",
-        "upload", "legacy O(n^2)", "s3 O(n)", "gcs O(n)", "azure O(n)", "legacy x"
-    );
-    for &total in &totals {
-        let legacy = gcs_legacy_rewrite(total, CHUNK).written;
-        let s3 = s3_native_multipart(total, CHUNK).written;
-        let gcs = gcs_native_compose(total, CHUNK).written;
-        let azure = azure_native_blocks(total, CHUNK).written;
+    fn amplification(c: &mut Criterion) {
+        let totals = [4 * 1024 * 1024usize, 16 * 1024 * 1024, 64 * 1024 * 1024];
+
+        // Exact provider-write-byte report (the headline numbers).
         eprintln!(
-            "{:>5} MiB  {:>11.1} MiB  {:>9.1} MiB  {:>9.1} MiB  {:>9.1} MiB  {:>8.1}x",
-            total / 1024 / 1024,
-            legacy as f64 / MIB,
-            s3 as f64 / MIB,
-            gcs as f64 / MIB,
-            azure as f64 / MIB,
-            legacy as f64 / azure as f64,
+            "\n=== provider write volume, {} KiB PATCH chunks ===",
+            CHUNK / 1024
         );
-    }
-    eprintln!();
+        eprintln!(
+            "{:>9}  {:>15}  {:>13}  {:>13}  {:>13}  {:>9}",
+            "upload", "legacy O(n^2)", "s3 O(n)", "gcs O(n)", "azure O(n)", "legacy x"
+        );
+        for &total in &totals {
+            let legacy = gcs_legacy_rewrite(total, CHUNK).written;
+            let s3 = s3_native_multipart(total, CHUNK).written;
+            let gcs = gcs_native_compose(total, CHUNK).written;
+            let azure = azure_native_blocks(total, CHUNK).written;
+            eprintln!(
+                "{:>5} MiB  {:>11.1} MiB  {:>9.1} MiB  {:>9.1} MiB  {:>9.1} MiB  {:>8.1}x",
+                total / 1024 / 1024,
+                legacy as f64 / MIB,
+                s3 as f64 / MIB,
+                gcs as f64 / MIB,
+                azure as f64 / MIB,
+                legacy as f64 / azure as f64,
+            );
+        }
+        eprintln!();
 
-    let mut group = c.benchmark_group("provider_write_cost");
-    for &total in &totals {
-        let mib = total / 1024 / 1024;
-        group.throughput(Throughput::Bytes(total as u64));
-        group.bench_with_input(
-            BenchmarkId::new("gcs_legacy_rewrite", mib),
-            &total,
-            |b, &t| b.iter(|| black_box(gcs_legacy_rewrite(t, CHUNK).fold)),
-        );
-        group.bench_with_input(
-            BenchmarkId::new("s3_native_multipart", mib),
-            &total,
-            |b, &t| b.iter(|| black_box(s3_native_multipart(t, CHUNK).fold)),
-        );
-        group.bench_with_input(
-            BenchmarkId::new("gcs_native_compose", mib),
-            &total,
-            |b, &t| b.iter(|| black_box(gcs_native_compose(t, CHUNK).fold)),
-        );
-        group.bench_with_input(
-            BenchmarkId::new("azure_native_blocks", mib),
-            &total,
-            |b, &t| b.iter(|| black_box(azure_native_blocks(t, CHUNK).fold)),
-        );
+        let mut group = c.benchmark_group("provider_write_cost");
+        for &total in &totals {
+            let mib = total / 1024 / 1024;
+            group.throughput(Throughput::Bytes(total as u64));
+            group.bench_with_input(
+                BenchmarkId::new("gcs_legacy_rewrite", mib),
+                &total,
+                |b, &t| b.iter(|| black_box(gcs_legacy_rewrite(t, CHUNK).fold)),
+            );
+            group.bench_with_input(
+                BenchmarkId::new("s3_native_multipart", mib),
+                &total,
+                |b, &t| b.iter(|| black_box(s3_native_multipart(t, CHUNK).fold)),
+            );
+            group.bench_with_input(
+                BenchmarkId::new("gcs_native_compose", mib),
+                &total,
+                |b, &t| b.iter(|| black_box(gcs_native_compose(t, CHUNK).fold)),
+            );
+            group.bench_with_input(
+                BenchmarkId::new("azure_native_blocks", mib),
+                &total,
+                |b, &t| b.iter(|| black_box(azure_native_blocks(t, CHUNK).fold)),
+            );
+        }
+        group.finish();
     }
-    group.finish();
+
+    criterion_group!(benches, amplification);
 }
 
-criterion_group!(benches, amplification);
-criterion_main!(benches);
+#[cfg(not(target_arch = "wasm32"))]
+criterion::criterion_main!(bench::benches);
+
+#[cfg(target_arch = "wasm32")]
+fn main() {}

--- a/crates/pocopine-storage/benches/upload.rs
+++ b/crates/pocopine-storage/benches/upload.rs
@@ -9,74 +9,86 @@
 //!
 //! Run with: `cargo bench -p pocopine-storage --bench upload`.
 
-#![cfg(not(target_arch = "wasm32"))]
+// The criterion + tokio bench harness is host-only. Gating it off wasm32 would
+// leave this `harness = false` bench binary with no `main` (E0601), so the body
+// lives in a host-only module and wasm32 gets an empty `main` instead — keeps
+// `clippy --all-targets --target wasm32-unknown-unknown` green.
+#[cfg(not(target_arch = "wasm32"))]
+mod bench {
+    use bytes::Bytes;
+    use criterion::{criterion_group, BenchmarkId, Criterion, Throughput};
+    use pocopine_storage::{
+        CompleteUpload, InitiateUpload, MemoryStorageBackend, SafeObjectKey, StorageBackend,
+        StorageContext, StorageKey, UploadPolicy, UploadStrategy,
+    };
+    use tokio::runtime::Builder;
 
-use bytes::Bytes;
-use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
-use pocopine_storage::{
-    CompleteUpload, InitiateUpload, MemoryStorageBackend, SafeObjectKey, StorageBackend,
-    StorageContext, StorageKey, UploadPolicy, UploadStrategy,
-};
-use tokio::runtime::Builder;
+    const TOTAL: usize = 16 * 1024 * 1024;
 
-const TOTAL: usize = 16 * 1024 * 1024;
-
-async fn run_upload(total: usize, chunk: usize) {
-    let backend = MemoryStorageBackend::new();
-    let ctx = StorageContext::system("bench");
-    let policy = UploadPolicy::new("memory")
-        .expect("policy")
-        .max_bytes(total as u64);
-    let session = backend
-        .initiate_upload(
-            &ctx,
-            InitiateUpload {
-                scope: "files".to_string(),
-                storage_key: StorageKey::new(SafeObjectKey::parse("files/bench.bin").expect("key")),
-                file_name: "bench.bin".to_string(),
-                size: Some(total as u64),
-                content_type: Some("application/octet-stream".to_string()),
-                metadata: Default::default(),
-                requested_strategy: UploadStrategy::Auto,
-                policy,
-            },
-        )
-        .await
-        .expect("initiate");
-
-    let block = Bytes::from(vec![0u8; chunk]);
-    let mut offset = 0usize;
-    while offset < total {
-        let len = chunk.min(total - offset);
-        backend
-            .append_upload_bytes(&ctx, session.id.clone(), offset as u64, block.slice(0..len))
+    async fn run_upload(total: usize, chunk: usize) {
+        let backend = MemoryStorageBackend::new();
+        let ctx = StorageContext::system("bench");
+        let policy = UploadPolicy::new("memory")
+            .expect("policy")
+            .max_bytes(total as u64);
+        let session = backend
+            .initiate_upload(
+                &ctx,
+                InitiateUpload {
+                    scope: "files".to_string(),
+                    storage_key: StorageKey::new(
+                        SafeObjectKey::parse("files/bench.bin").expect("key"),
+                    ),
+                    file_name: "bench.bin".to_string(),
+                    size: Some(total as u64),
+                    content_type: Some("application/octet-stream".to_string()),
+                    metadata: Default::default(),
+                    requested_strategy: UploadStrategy::Auto,
+                    policy,
+                },
+            )
             .await
-            .expect("append");
-        offset += len;
+            .expect("initiate");
+
+        let block = Bytes::from(vec![0u8; chunk]);
+        let mut offset = 0usize;
+        while offset < total {
+            let len = chunk.min(total - offset);
+            backend
+                .append_upload_bytes(&ctx, session.id.clone(), offset as u64, block.slice(0..len))
+                .await
+                .expect("append");
+            offset += len;
+        }
+        backend
+            .complete_upload(
+                &ctx,
+                CompleteUpload {
+                    session: session.id,
+                    checksum: None,
+                },
+            )
+            .await
+            .expect("complete");
     }
-    backend
-        .complete_upload(
-            &ctx,
-            CompleteUpload {
-                session: session.id,
-                checksum: None,
-            },
-        )
-        .await
-        .expect("complete");
+
+    fn upload_throughput(c: &mut Criterion) {
+        let runtime = Builder::new_current_thread().build().expect("runtime");
+        let mut group = c.benchmark_group("memory_upload_16MiB");
+        group.throughput(Throughput::Bytes(TOTAL as u64));
+        for &chunk in &[64 * 1024usize, 256 * 1024, 1024 * 1024, 4 * 1024 * 1024] {
+            group.bench_with_input(BenchmarkId::from_parameter(chunk), &chunk, |b, &chunk| {
+                b.to_async(&runtime).iter(|| run_upload(TOTAL, chunk));
+            });
+        }
+        group.finish();
+    }
+
+    criterion_group!(benches, upload_throughput);
 }
 
-fn upload_throughput(c: &mut Criterion) {
-    let runtime = Builder::new_current_thread().build().expect("runtime");
-    let mut group = c.benchmark_group("memory_upload_16MiB");
-    group.throughput(Throughput::Bytes(TOTAL as u64));
-    for &chunk in &[64 * 1024usize, 256 * 1024, 1024 * 1024, 4 * 1024 * 1024] {
-        group.bench_with_input(BenchmarkId::from_parameter(chunk), &chunk, |b, &chunk| {
-            b.to_async(&runtime).iter(|| run_upload(TOTAL, chunk));
-        });
-    }
-    group.finish();
-}
+#[cfg(not(target_arch = "wasm32"))]
+criterion::criterion_main!(bench::benches);
 
-criterion_group!(benches, upload_throughput);
-criterion_main!(benches);
+#[cfg(target_arch = "wasm32")]
+fn main() {}


### PR DESCRIPTION
## Problem

`clippy (wasm32)` is **red on `main`** — both `pocopine-storage` benches fail to compile for `wasm32-unknown-unknown`:

```
error[E0601]: `main` function not found in crate `upload`
error[E0601]: `main` function not found in crate `amplification`
```

Both benches are `harness = false`, so each is a plain binary that needs its own `main` (supplied by `criterion_main!`). The crate-level `#![cfg(not(target_arch = "wasm32"))]` emptied the entire crate on wasm32 → no `main` → E0601. `cargo clippy --all-targets` builds benches, so the wasm32 job fails.

Pre-existing (introduced with the benches in `e71bed8c`); surfaced by the CI on #191, but unrelated to that PR's contents.

## Fix

Move each bench body into a host-only `mod bench` and give wasm32 an empty `main`:

```rust
#[cfg(not(target_arch = "wasm32"))]
mod bench { /* uses + criterion_group! */ }

#[cfg(not(target_arch = "wasm32"))]
criterion::criterion_main!(bench::benches);

#[cfg(target_arch = "wasm32")]
fn main() {}
```

The host bench is behaviorally unchanged (same `criterion_group`/`criterion_main`); only the wasm32 target gains a stub `main`.

## Verification

- `cargo clippy -p pocopine-storage --target wasm32-unknown-unknown --all-targets` → **PASS** (was E0601 ×2)
- `cargo clippy -p pocopine-storage --all-targets` (host) → PASS
- `cargo fmt --check` → clean
- `cargo bench --bench amplification` still runs and reports the same headline numbers