### PR TITLE
docs(rfcs): sync draft statuses with implementation reality

### DIFF
--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -57,41 +57,43 @@ Conventions:
 | 048 | [Scoped async tasks and extractor-driven `#[computed]`](./rfc-048-hooks.md) | Implemented |
 | 046 | [`Children` extractor on `LifecycleContext`](./rfc-046-children-extractor.md) | Draft |
 | 047 | [`$slots` magic + slot-presence probes](./rfc-047-slots-magic.md) | Draft |
-| 049 | [Typed slot contracts — compile-time child constraints](./rfc-049-typed-slot-contracts.md) | Draft |
-| 050 | [Real HTML parser at compile time — `html5ever` in `pocopine-macros`](./rfc-050-html5ever-compile-time-parser.md) | Draft |
+| 049 | [Typed slot contracts — compile-time child constraints](./rfc-049-typed-slot-contracts.md) | Implemented |
+| 050 | [Real HTML parser at compile time — `html5ever` in `pocopine-macros`](./rfc-050-html5ever-compile-time-parser.md) | Implemented |
 | 051 | [Component registry safety — aliases, prefixes, boot verification](./rfc-051-component-registry-safety.md) | Deferred to 056 |
 | 052 | [Typed structural parent extractors](./rfc-052-parent-extractors.md) | Deferred to 056 |
 | 053 | [Typed component interaction surface](./rfc-053-typed-component-interaction.md) | Deferred to 056 |
-| 054 | [Compiled `pp-for` row plans](./rfc-054-compiled-pp-for-row-plans.md) | Draft |
+| 054 | [Compiled `pp-for` row plans](./rfc-054-compiled-pp-for-row-plans.md) | Implemented |
 | 055 | [Typed context ergonomics on top of keyed `provide` / `inject`](./rfc-055-typed-context.md) | Deferred to 056 |
 | 056 | [Component interaction safety batch](./rfc-056-component-interaction-safety-batch.md) | Implemented (all phases + follow-on infrastructure) |
 | 057 | [Compile-time template plans](./rfc-057-compile-time-template-plans.md) | Superseded by 058 |
-| 058 | [Compiled views and walker removal](./rfc-058-compiled-views-walker-removal.md) | Phases 1–6.5 implemented; 7–8 deferred |
+| 058 | [Compiled views and walker removal](./rfc-058-compiled-views-walker-removal.md) | Accepted |
 | 059 | [Server-side rendering and hydration](./rfc-059-server-side-rendering-and-hydration.md) | Draft (revised post-RFC-058 Phase 6.5) |
-| 060 | [`uses` as the authoritative component registry](./rfc-060-component-uses-registry.md) | Draft |
-| 061 | [Compiled-mount-only architecture](./rfc-061-compiled-mount-only.md) | Draft |
-| 062 | [Per-component mount specialization](./rfc-062-per-component-mount-specialization.md) | Draft |
-| 063 | [Directive cleanup for Vue-3 alignment](./rfc-063-directive-cleanup-vue-alignment.md) | Draft |
+| 060 | [`uses` as the authoritative component registry](./rfc-060-component-uses-registry.md) | Accepted |
+| 061 | [Compiled-mount-only architecture](./rfc-061-compiled-mount-only.md) | Implemented |
+| 062 | [Per-component mount specialization](./rfc-062-per-component-mount-specialization.md) | Accepted |
+| 063 | [Directive cleanup for Vue-3 alignment](./rfc-063-directive-cleanup-vue-alignment.md) | Accepted |
 | 064 | [Performance roadmap to community-credible benchmarks](./rfc-064-performance-roadmap.md) | Draft |
 | 065 | [Route-cluster bundling](./rfc-065-route-cluster-bundling.md) | Draft |
-| 066 | [Server-function auth and access policy](./rfc-066-server-function-auth.md) | Draft |
-| 067 | [Background jobs with Redis and memory backends](./rfc-067-redis-background-jobs.md) | Draft |
-| 068 | [SVG namespace template support](./rfc-068-svg-namespace-template-support.md) | Draft |
-| 069 | [Unified observability, logging, and analytics](./rfc-069-observability.md) | Draft |
-| 070 | [JWT-based authentication verification](./rfc-070-jwt-auth-verification.md) | Draft |
-| 071 | [Event spine and live invalidation streams](./rfc-071-event-spine-and-live-invalidation.md) | Draft |
-| 072 | [Offline sync protocol](./rfc-072-offline-sync-protocol.md) | Draft |
+| 066 | [Server-function auth and access policy](./rfc-066-server-function-auth.md) | Implemented |
+| 067 | [Background jobs with Redis and memory backends](./rfc-067-redis-background-jobs.md) | Implemented |
+| 068 | [SVG namespace template support](./rfc-068-svg-namespace-template-support.md) | Implemented |
+| 069 | [Unified observability, logging, and analytics](./rfc-069-observability.md) | Implemented |
+| 070 | [JWT-based authentication verification](./rfc-070-jwt-auth-verification.md) | Implemented |
+| 071 | [Event spine and live invalidation streams](./rfc-071-event-spine-and-live-invalidation.md) | Implemented |
+| 072 | [Offline sync protocol](./rfc-072-offline-sync-protocol.md) | Accepted |
 | 073 | [Yrs collaboration over WebSocket and Redis](./rfc-073-yrs-collaboration.md) | Draft |
-| 074 | [`pocopine-auth-credentials` and the `Provider` trait](./rfc-074-auth-credentials-and-provider-trait.md) | Draft |
+| 074 | [`pocopine-auth-credentials` and the `Provider` trait](./rfc-074-auth-credentials-and-provider-trait.md) | Accepted |
 | 076 | [App plugin lifecycle](./rfc-076-app-plugin-lifecycle.md) | Implemented |
 | 077 | [Server plugin lifecycle](./rfc-077-server-plugin-lifecycle.md) | Implemented (Phase 4 typed hooks rejected) |
 | 078 | [Client route guards, loaders, and fetch middleware](./rfc-078-client-route-guards-and-loaders.md) | Implemented |
 | 079 | [`pine-richtext` TablesExtension](./rfc-079-pine-richtext-tables-extension.md) | Draft |
-| 080 | [Heroku-style deploy contract (process graph + services)](./rfc-080-deploy-contract.md) | Draft |
-| 081 | [Component handle refs](./rfc-081-component-handle-refs.md) | Draft (Phase 1 landed) |
+| 080 | [Heroku-style deploy contract (process graph + services)](./rfc-080-deploy-contract.md) | Accepted |
+| 081 | [Component handle refs](./rfc-081-component-handle-refs.md) | Implemented |
 | 082 | [Storage-agnostic file/object storage](./rfc-082-pocopine-storage.md) | Accepted |
-| 084 | [Typed slot props](./rfc-084-typed-slot-props.md) | Draft |
-| 086 | [`pocopine-sync-query`](./rfc-086-sync-query.md) | Draft |
-| 087 | [`pocopine-sync-query` driver lifecycle](./rfc-087-sync-query-driver.md) | Draft |
-| 088 | [`pocopine-sync-query` production parity](./rfc-088-sync-query-production-parity.md) | Draft |
-| 089 | [SPA router parity and nested outlets](./rfc-089-spa-router-parity.md) | Draft |
+| 084 | [Typed slot props](./rfc-084-typed-slot-props.md) | Accepted |
+| 086 | [`pocopine-sync-query`](./rfc-086-sync-query.md) | Implemented |
+| 087 | [`pocopine-sync-query` driver lifecycle](./rfc-087-sync-query-driver.md) | Implemented |
+| 088 | [`pocopine-sync-query` production parity](./rfc-088-sync-query-production-parity.md) | Implemented |
+| 089 | [SPA router parity and nested outlets](./rfc-089-spa-router-parity.md) | Accepted |
+| 090 | [Merge `pocopine-sync-crud` into `pocopine-sync-query`](./rfc-090-merge-crud-into-query.md) | Implemented |
+| 092 | [Pine Stylekit utility compiler](./rfc-092-pocopine-stylekit.md) | Accepted |

--- a/rfcs/rfc-049-typed-slot-contracts.md
+++ b/rfcs/rfc-049-typed-slot-contracts.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Draft |
+| **Status** | Implemented |
 | **Author** | pocopine team |
 | **Created** | 2026-04-24 |
 | **Supersedes** | — |

--- a/rfcs/rfc-050-html5ever-compile-time-parser.md
+++ b/rfcs/rfc-050-html5ever-compile-time-parser.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Draft |
+| **Status** | Implemented |
 | **Author** | pocopine team |
 | **Created** | 2026-04-24 |
 | **Supersedes** | — |

--- a/rfcs/rfc-054-compiled-pp-for-row-plans.md
+++ b/rfcs/rfc-054-compiled-pp-for-row-plans.md
@@ -1,6 +1,6 @@
 # RFC 054 — Compiled `pp-for` row plans
 
-Status: Draft
+Status: Implemented
 
 Author: Codex
 

--- a/rfcs/rfc-058-compiled-views-walker-removal.md
+++ b/rfcs/rfc-058-compiled-views-walker-removal.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Draft - council review |
+| **Status** | Accepted (Phases 1–4, 6, 6.5 landed — runtime walker removed; Phase 5 hydration / 7 clustering / 8 split-delivery pending) |
 | **Author** | pocopine team |
 | **Created** | 2026-04-26 |
 | **Supersedes** | Draft direction of [RFC 057](./rfc-057-compile-time-template-plans.md) for the main optimization path |

--- a/rfcs/rfc-060-component-uses-registry.md
+++ b/rfcs/rfc-060-component-uses-registry.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Draft |
+| **Status** | Accepted (core registry landed: uses/extends parsing, hard-error validation, phf table, transitive registration; strict-mode opt-in, dev-mode warnings, cluster hookup pending) |
 | **Author** | pocopine team |
 | **Created** | 2026-04-28 |
 | **Supersedes** | — (extends RFC 049; resolves RFC 051's deferral) |

--- a/rfcs/rfc-061-compiled-mount-only.md
+++ b/rfcs/rfc-061-compiled-mount-only.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Draft (open questions resolved 2026-04-28) |
+| **Status** | Implemented (Phases 1–4: bridge deletion, `[pp-app]` mount, `mount_subtree`/`SubtreeHandle`, phf registry; optional dev MutationObserver pending) |
 | **Author** | pocopine team |
 | **Created** | 2026-04-28 |
 | **Supersedes** | RFC 058 Phase 6.5 adopted-DOM bridge (deletion target) |

--- a/rfcs/rfc-062-per-component-mount-specialization.md
+++ b/rfcs/rfc-062-per-component-mount-specialization.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Draft |
+| **Status** | Accepted (per-component mount specialization + const node-path walk + no-fallback-lane landed; hydrate emit + §4.4 size gate pending) |
 | **Author** | pocopine team |
 | **Created** | 2026-04-28 |
 | **Supersedes** | — |

--- a/rfcs/rfc-063-directive-cleanup-vue-alignment.md
+++ b/rfcs/rfc-063-directive-cleanup-vue-alignment.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Draft (revised 2026-04-29 — `pp-html` removed from delete bucket) |
+| **Status** | Accepted (Tier 1 deletes landed: pp-cloak/pp-init/pp-data forbidden; §4.2 convergences, migrate-063 codemod, pp-outlet promotion & pine-icons rewrite pending) |
 | **Author** | pocopine team |
 | **Created** | 2026-04-28 |
 | **Supersedes** | — (deletes/converges directives from RFC 001, RFC 007, RFC 011) |

--- a/rfcs/rfc-066-server-function-auth.md
+++ b/rfcs/rfc-066-server-function-auth.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Draft |
+| **Status** | Implemented |
 | **Author** | pocopine team |
 | **Created** | 2026-05-02 |
 | **Related** | [`rfc-002-app-stores-servers.md`](./rfc-002-app-stores-servers.md), [`rfc-059-server-side-rendering-and-hydration.md`](./rfc-059-server-side-rendering-and-hydration.md) |

--- a/rfcs/rfc-067-redis-background-jobs.md
+++ b/rfcs/rfc-067-redis-background-jobs.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Draft |
+| **Status** | Implemented |
 | **Author** | pocopine team |
 | **Created** | 2026-05-02 |
 | **Related** | [`rfc-002-app-stores-servers.md`](./rfc-002-app-stores-servers.md), [`rfc-066-server-function-auth.md`](./rfc-066-server-function-auth.md) |

--- a/rfcs/rfc-068-svg-namespace-template-support.md
+++ b/rfcs/rfc-068-svg-namespace-template-support.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Draft |
+| **Status** | Implemented |
 | **Author** | pocopine team |
 | **Created** | 2026-05-03 |
 | **Related** | [RFC 058](./rfc-058-compiled-views-walker-removal.md), [RFC 063](./rfc-063-directive-cleanup-vue-alignment.md) |

--- a/rfcs/rfc-069-observability.md
+++ b/rfcs/rfc-069-observability.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Draft |
+| **Status** | Implemented |
 | **Author** | pocopine team |
 | **Created** | 2026-05-03 |
 | **Related** | [`rfc-037-js-bridge.md`](./rfc-037-js-bridge.md), [`rfc-059-server-side-rendering-and-hydration.md`](./rfc-059-server-side-rendering-and-hydration.md), [`rfc-066-server-function-auth.md`](./rfc-066-server-function-auth.md), [`rfc-067-redis-background-jobs.md`](./rfc-067-redis-background-jobs.md) |

--- a/rfcs/rfc-070-jwt-auth-verification.md
+++ b/rfcs/rfc-070-jwt-auth-verification.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Draft |
+| **Status** | Implemented |
 | **Author** | pocopine team |
 | **Created** | 2026-05-03 |
 | **Related** | [`rfc-066-server-function-auth.md`](./rfc-066-server-function-auth.md), [`rfc-069-observability.md`](./rfc-069-observability.md) |

--- a/rfcs/rfc-071-event-spine-and-live-invalidation.md
+++ b/rfcs/rfc-071-event-spine-and-live-invalidation.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Draft |
+| **Status** | Implemented |
 | **Author** | pocopine team |
 | **Created** | 2026-05-03 |
 | **Related** | [RFC 002](./rfc-002-app-stores-servers.md), [RFC 066](./rfc-066-server-function-auth.md), [RFC 069](./rfc-069-observability.md), [RFC 072](./rfc-072-offline-sync-protocol.md), [RFC 073](./rfc-073-yrs-collaboration.md) |

--- a/rfcs/rfc-072-offline-sync-protocol.md
+++ b/rfcs/rfc-072-offline-sync-protocol.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Draft |
+| **Status** | Accepted (core protocol open/pull/push + local stores incl. SQLite/IndexedDB + live wakeup landed; Phase C CDC sources / E custom conflict / G SQLx pending) |
 | **Author** | pocopine team |
 | **Created** | 2026-05-03 |
 | **Builds on** | [RFC 071](./rfc-071-event-spine-and-live-invalidation.md) |

--- a/rfcs/rfc-074-auth-credentials-and-provider-trait.md
+++ b/rfcs/rfc-074-auth-credentials-and-provider-trait.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Draft |
+| **Status** | Accepted (PR-1 Provider trait + PR-2 credentials data plane — signup/login/logout — landed; PR-3 email/reset flows & PR-4 example adoption pending) |
 | **Author** | pocopine team |
 | **Created** | 2026-05-04 |
 | **Related** | [`rfc-066-server-function-auth.md`](./rfc-066-server-function-auth.md), [`rfc-069-observability.md`](./rfc-069-observability.md), [`rfc-070-jwt-auth-verification.md`](./rfc-070-jwt-auth-verification.md) |

--- a/rfcs/rfc-080-deploy-contract.md
+++ b/rfcs/rfc-080-deploy-contract.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Draft |
+| **Status** | Accepted (contract + launcher + Fly/Railway/Render adapters landed; `--container` build container + static/Cloud Run adapters pending) |
 | **Author** | pocopine team |
 | **Created** | 2026-05-17 |
 | **Related** | [RFC 002 — App / Stores / Servers](./rfc-002-app-stores-servers.md), [RFC 037 — JS bridge](./rfc-037-js-bridge.md), [RFC 067 — Background jobs](./rfc-067-redis-background-jobs.md), [RFC 073 — Yrs collaboration](./rfc-073-yrs-collaboration.md) |

--- a/rfcs/rfc-081-component-handle-refs.md
+++ b/rfcs/rfc-081-component-handle-refs.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Draft (Phase 1 landed) |
+| **Status** | Implemented (Phases 1–3 landed; Phase 4 `Parent<T>` symmetry optional) |
 | **Author** | pocopine team |
 | **Created** | 2026-05-19 |
 | **Related** | [`rfc-002-app-stores-servers.md`](./rfc-002-app-stores-servers.md), [`rfc-060-component-uses-registry.md`](./rfc-060-component-uses-registry.md), [`rfc-079-pine-richtext-tables-extension.md`](./rfc-079-pine-richtext-tables-extension.md) |

--- a/rfcs/rfc-084-typed-slot-props.md
+++ b/rfcs/rfc-084-typed-slot-props.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Draft |
+| **Status** | Accepted (Phases 1–2 compound-side `props = T` validation landed; Phase 3 caller-side `pp-let` checking + compile-fail tests pending) |
 | **Author** | pocopine team |
 | **Created** | 2026-05-26 |
 | **Related** | [`rfc-044-props.md`](./rfc-044-props.md), [`rfc-049-slot-contracts.md`](./rfc-049-slot-contracts.md), [`rfc-050-template-ast.md`](./rfc-050-template-ast.md), [`rfc-081-component-handle-refs.md`](./rfc-081-component-handle-refs.md) |

--- a/rfcs/rfc-086-sync-query.md
+++ b/rfcs/rfc-086-sync-query.md
@@ -1,6 +1,6 @@
 # RFC 086 — `pocopine-sync-query`
 
-* **Status:** Draft
+* **Status:** Implemented
 * **Author:** sync framework working group
 * **Tracking branch:** `wip/sync-query` (TBD)
 * **Supersedes:** the shape-subscription portion of RFC 085 for production multi-tenant use; coexists with `pocopine-sync-crud`.

--- a/rfcs/rfc-087-sync-query-driver.md
+++ b/rfcs/rfc-087-sync-query-driver.md
@@ -1,6 +1,6 @@
 # RFC 087 — `pocopine-sync-query` driver lifecycle
 
-* **Status:** Draft
+* **Status:** Implemented
 * **Author:** sync framework working group
 * **Tracking branch:** `wip/sync-query-driver`
 * **Supersedes:** the "background-task drivers" line item in `pocopine-sync-query` README's roadmap

--- a/rfcs/rfc-088-sync-query-production-parity.md
+++ b/rfcs/rfc-088-sync-query-production-parity.md
@@ -1,6 +1,6 @@
 # RFC 088 — `pocopine-sync-query` production parity
 
-* **Status:** Draft
+* **Status:** Implemented
 * **Author:** sync framework working group
 * **Tracking branches:** `wip/sync-query-persistence` (Section A), `wip/sync-query-selectors` (Section B), `wip/sync-query-per-params-topics` (Section C)
 * **Supersedes:** the "Non-goals" line items in RFC 087 §"Non-goals" — this RFC closes those gaps.

--- a/rfcs/rfc-089-spa-router-parity.md
+++ b/rfcs/rfc-089-spa-router-parity.md
@@ -1,6 +1,6 @@
 # RFC 089 - SPA router parity and nested outlets
 
-* **Status:** Draft
+* **Status:** Accepted (Phases 0–1 typed target/location/navigation API + reserved-namespace enforcement landed; compiled `pp-route` links + nested outlets, Phases 2–5 pending)
 * **Author:** pocopine team
 * **Created:** 2026-05-28
 * **Tracking branch:** `review/router-api-docs`

--- a/rfcs/rfc-090-merge-crud-into-query.md
+++ b/rfcs/rfc-090-merge-crud-into-query.md
@@ -1,6 +1,6 @@
 # RFC 090 — Merge `pocopine-sync-crud` into `pocopine-sync-query`
 
-* **Status:** Draft
+* **Status:** Implemented
 * **Author:** sync framework working group
 * **Tracking branch:** `feat/rfc-090-merge-crud-into-query`
 * **Supersedes:** the dual-crate boundary documented in

--- a/rfcs/rfc-092-pocopine-stylekit.md
+++ b/rfcs/rfc-092-pocopine-stylekit.md
@@ -1,6 +1,6 @@
 # RFC 092 — Pine Stylekit utility compiler
 
-* **Status:** Draft
+* **Status:** Accepted (Milestone 1 shipped; default CSS engine)
 * **Author:** Pine design-system working group
 * **Tracking branch:** `rfc/pine-stylekit`
 * **Tracking issue:** [#169](https://github.com/mambisi/pocopine/issues/169)


### PR DESCRIPTION
Audited all 32 Draft RFCs against the codebase (crates, symbols, tests, example usage) and corrected the lifecycle status of those that no longer match reality. **Docs-only — no code changes.**

## Flipped to Implemented (15)
Core deliverables shipped with tests/usage:
`049` `050` `054` `061` `066` `067` `068` `069` `070` `071` `081` `086` `087` `088` `090`

## Flipped Draft → Accepted (9)
Design built, later phases pending — each header annotates what remains:
`058` `060` `062` `063` `072` `074` `080` `084` `089`

Also flips `092` (Pine Stylekit) Draft → Accepted (Milestone 1 shipped; default CSS engine).

## Kept Draft (8)
Proposal / roadmap only, little or no corresponding code:
`042` `046` `047` `059` `064` `065` `073` `079`

## Index
Synced `rfcs/README.md` status column to match, and added the missing `090` and `092` rows.