### PR TITLE
RFC-093: Pocopine Agenkit — Pocopine-native generative-AI runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6878,8 +6878,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "pocopine-agenkit"
+version = "0.1.1"
+dependencies = [
+ "axum 0.7.9",
+ "futures",
+ "http-body-util",
+ "pocopine-agenkit-core",
+ "pocopine-auth",
+ "pocopine-core",
+ "pocopine-observe",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.3",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "pocopine-agenkit-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6907,6 +6907,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pocopine-agenkit-oai"
+version = "0.1.1"
+dependencies = [
+ "futures",
+ "pocopine-agenkit",
+ "pocopine-agenkit-core",
+ "reqwest 0.12.28",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "wiremock",
+]
+
+[[package]]
 name = "pocopine-analytics"
 version = "0.1.1"
 dependencies = [
@@ -8209,12 +8225,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls 0.26.4",
+ "tokio-util",
  "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots 1.0.7",
 ]
@@ -8257,7 +8275,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -8916,7 +8934,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
  "xxhash-rust",
 ]
@@ -11185,6 +11203,19 @@ dependencies = [
  "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6878,6 +6878,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "pocopine-agenkit-core"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "pocopine-analytics"
 version = "0.1.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/pine-motion",
     "crates/pine-richtext",
     "crates/pocopine",
+    "crates/pocopine-agenkit-core",
     "crates/pocopine-analytics",
     "crates/pocopine-assets",
     "crates/pocopine-auth",
@@ -100,6 +101,7 @@ repository = "https://github.com/mambisi/pocopine"
 # `default-features = false` opt-outs actually take effect. Users
 # of `pocopine` get devtools on by default via its own `default`
 # feature, which forwards `pocopine-core/devtools`.
+pocopine-agenkit-core = { path = "crates/pocopine-agenkit-core", version = "0.1.0" }
 pocopine-analytics = { path = "crates/pocopine-analytics", version = "0.1.0" }
 pocopine-assets = { path = "crates/pocopine-assets", version = "0.1.0" }
 pocopine-auth = { path = "crates/pocopine-auth", version = "0.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/pocopine",
     "crates/pocopine-agenkit",
     "crates/pocopine-agenkit-core",
+    "crates/pocopine-agenkit-oai",
     "crates/pocopine-analytics",
     "crates/pocopine-assets",
     "crates/pocopine-auth",
@@ -104,6 +105,7 @@ repository = "https://github.com/mambisi/pocopine"
 # feature, which forwards `pocopine-core/devtools`.
 pocopine-agenkit = { path = "crates/pocopine-agenkit", version = "0.1.0" }
 pocopine-agenkit-core = { path = "crates/pocopine-agenkit-core", version = "0.1.0" }
+pocopine-agenkit-oai = { path = "crates/pocopine-agenkit-oai", version = "0.1.0" }
 pocopine-analytics = { path = "crates/pocopine-analytics", version = "0.1.0" }
 pocopine-assets = { path = "crates/pocopine-assets", version = "0.1.0" }
 pocopine-auth = { path = "crates/pocopine-auth", version = "0.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "crates/pine-motion",
     "crates/pine-richtext",
     "crates/pocopine",
+    "crates/pocopine-agenkit",
     "crates/pocopine-agenkit-core",
     "crates/pocopine-analytics",
     "crates/pocopine-assets",
@@ -101,6 +102,7 @@ repository = "https://github.com/mambisi/pocopine"
 # `default-features = false` opt-outs actually take effect. Users
 # of `pocopine` get devtools on by default via its own `default`
 # feature, which forwards `pocopine-core/devtools`.
+pocopine-agenkit = { path = "crates/pocopine-agenkit", version = "0.1.0" }
 pocopine-agenkit-core = { path = "crates/pocopine-agenkit-core", version = "0.1.0" }
 pocopine-analytics = { path = "crates/pocopine-analytics", version = "0.1.0" }
 pocopine-assets = { path = "crates/pocopine-assets", version = "0.1.0" }

--- a/crates/pocopine-agenkit-core/Cargo.toml
+++ b/crates/pocopine-agenkit-core/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "pocopine-agenkit-core"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Dependency-light, wasm-friendly contract and payload types for Pocopine Agenkit. Defines model/provider refs, content/messages, tool/retriever/embedder descriptors, flow + orchestration types, trace/stream payloads, and AgenkitError. Stays observe-neutral so generated clients, tests, and tooling share the same types."
+
+# RFC-093 — intentionally dependency-light and wasm-friendly (no provider
+# SDKs, no tracing, no server runtime, no pocopine-observe). `serde` carries
+# the payload types; `serde_json::Value` carries opaque tool args / structured
+# output / JSON-schema metadata. Both compile cleanly for wasm32.
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/pocopine-agenkit-core/src/agent.rs
+++ b/crates/pocopine-agenkit-core/src/agent.rs
@@ -1,0 +1,100 @@
+//! Agent descriptor (RFC-093 Phase 1.4, §D4, §D7).
+//!
+//! An [`AiAgentDescriptor`] is the framework-visible description of a typed
+//! runnable AI unit: its id, model alias, system prompt, tool allowlist,
+//! schemas, and limits. The runnable `AiAgent` trait lives in the facade.
+
+use crate::{ModelRef, SchemaRef};
+
+/// The framework-visible description of a typed agent.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct AiAgentDescriptor {
+    /// Stable agent id.
+    pub id: String,
+    /// The model alias the agent runs on; `None` inherits the flow default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<ModelRef>,
+    /// The agent's system prompt/instructions.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub system: Option<String>,
+    /// The ids of the tools the agent may call.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tool_ids: Vec<String>,
+    /// Typed input schema.
+    pub input: SchemaRef,
+    /// Typed output schema.
+    pub output: SchemaRef,
+    /// Maximum output tokens, if bounded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u32>,
+}
+
+impl AiAgentDescriptor {
+    /// A new agent descriptor with empty schemas and no tools.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            model: None,
+            system: None,
+            tool_ids: Vec::new(),
+            input: SchemaRef::default(),
+            output: SchemaRef::default(),
+            max_tokens: None,
+        }
+    }
+
+    /// Set the model alias.
+    pub fn model(mut self, model: ModelRef) -> Self {
+        self.model = Some(model);
+        self
+    }
+
+    /// Set the system prompt.
+    pub fn system(mut self, system: impl Into<String>) -> Self {
+        self.system = Some(system.into());
+        self
+    }
+
+    /// Allow a tool.
+    pub fn tool(mut self, id: impl Into<String>) -> Self {
+        self.tool_ids.push(id.into());
+        self
+    }
+
+    /// Set the input schema.
+    pub fn input(mut self, input: SchemaRef) -> Self {
+        self.input = input;
+        self
+    }
+
+    /// Set the output schema.
+    pub fn output(mut self, output: SchemaRef) -> Self {
+        self.output = output;
+        self
+    }
+
+    /// Cap output tokens.
+    pub fn max_tokens(mut self, max_tokens: u32) -> Self {
+        self.max_tokens = Some(max_tokens);
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn descriptor_round_trips_and_omits_defaults() {
+        let agent = AiAgentDescriptor::new("fast_researcher")
+            .model(ModelRef::new("local/fast"))
+            .system("Find likely answers quickly, then cite evidence.")
+            .tool("search_docs")
+            .max_tokens(700);
+        let json = serde_json::to_string(&agent).unwrap();
+        assert!(json.contains(r#""model":"local/fast""#));
+        assert!(json.contains(r#""max_tokens":700"#));
+        let back: AiAgentDescriptor = serde_json::from_str(&json).unwrap();
+        assert_eq!(agent, back);
+    }
+}

--- a/crates/pocopine-agenkit-core/src/content.rs
+++ b/crates/pocopine-agenkit-core/src/content.rs
@@ -1,0 +1,237 @@
+//! Content and messaging payloads (RFC-093 Phase 1.2).
+//!
+//! A [`Message`] pairs a [`Role`] with [`Content`], a sequence of
+//! [`ContentPart`]s. Parts are multimodal: text, a media attachment, or an
+//! opaque JSON value (structured tool output). These are the client-safe
+//! shapes carried between flows, providers, and threads.
+
+use crate::Role;
+
+/// One piece of a multimodal message.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ContentPart {
+    /// Plain text.
+    Text {
+        /// The text body.
+        text: String,
+    },
+    /// A media attachment (image, audio, document, ...).
+    Media(MediaPart),
+    /// An opaque JSON value, e.g. a structured tool result.
+    Json {
+        /// The JSON payload.
+        value: serde_json::Value,
+    },
+}
+
+impl ContentPart {
+    /// A text part.
+    pub fn text(text: impl Into<String>) -> Self {
+        Self::Text { text: text.into() }
+    }
+
+    /// The text of this part, if it is a [`ContentPart::Text`].
+    pub fn as_text(&self) -> Option<&str> {
+        match self {
+            Self::Text { text } => Some(text),
+            _ => None,
+        }
+    }
+}
+
+/// A media attachment. References by `url` or carries inline `data_base64`;
+/// the framework never stores raw provider payloads here by default (§D10).
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct MediaPart {
+    /// IANA media type, e.g. `image/png`.
+    pub media_type: String,
+    /// External URL for the media, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    /// Inline base64 data, if any (encoded via `pocopine-codec` upstream).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data_base64: Option<String>,
+    /// Optional display name.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+}
+
+/// An ordered list of [`ContentPart`]s.
+#[derive(Clone, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
+pub struct Content {
+    /// The parts, in order.
+    pub parts: Vec<ContentPart>,
+}
+
+impl Content {
+    /// Content with a single text part.
+    pub fn text(text: impl Into<String>) -> Self {
+        Self {
+            parts: vec![ContentPart::text(text)],
+        }
+    }
+
+    /// Content from an explicit list of parts.
+    pub fn from_parts(parts: Vec<ContentPart>) -> Self {
+        Self { parts }
+    }
+
+    /// True when there are no parts.
+    pub fn is_empty(&self) -> bool {
+        self.parts.is_empty()
+    }
+
+    /// Append a text part.
+    pub fn push_text(&mut self, text: impl Into<String>) {
+        self.parts.push(ContentPart::text(text));
+    }
+
+    /// Concatenate all text parts (media/json parts are skipped).
+    pub fn as_text(&self) -> String {
+        self.parts
+            .iter()
+            .filter_map(ContentPart::as_text)
+            .collect::<Vec<_>>()
+            .join("")
+    }
+}
+
+impl From<&str> for Content {
+    fn from(value: &str) -> Self {
+        Self::text(value)
+    }
+}
+
+impl From<String> for Content {
+    fn from(value: String) -> Self {
+        Self::text(value)
+    }
+}
+
+/// A single message in a conversation/generation request.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct Message {
+    /// Who authored the message.
+    pub role: Role,
+    /// The message body.
+    pub content: Content,
+    /// Tool calls this (assistant) message requested. Carries the protocol
+    /// linkage providers like OpenAI require between a tool request and its
+    /// result.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tool_calls: Vec<crate::ToolCall>,
+    /// The id of the [`crate::ToolCall`] a `tool`-role message answers.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+}
+
+impl Message {
+    /// A message with an explicit role and content.
+    pub fn new(role: Role, content: impl Into<Content>) -> Self {
+        Self {
+            role,
+            content: content.into(),
+            tool_calls: Vec::new(),
+            tool_call_id: None,
+        }
+    }
+
+    /// An `assistant` message that requested the given tool calls, preserving
+    /// any text the model emitted alongside them (some models narrate before a
+    /// call; dropping it loses that context on the next turn). Pass an empty
+    /// content for a pure tool-call turn.
+    pub fn assistant_tool_calls(
+        content: impl Into<Content>,
+        tool_calls: Vec<crate::ToolCall>,
+    ) -> Self {
+        Self {
+            role: Role::Assistant,
+            content: content.into(),
+            tool_calls,
+            tool_call_id: None,
+        }
+    }
+
+    /// A `tool` result message answering the call with `tool_call_id`.
+    pub fn tool_result(tool_call_id: impl Into<String>, content: impl Into<Content>) -> Self {
+        Self {
+            role: Role::Tool,
+            content: content.into(),
+            tool_calls: Vec::new(),
+            tool_call_id: Some(tool_call_id.into()),
+        }
+    }
+
+    /// A `system` message.
+    pub fn system(content: impl Into<Content>) -> Self {
+        Self::new(Role::System, content)
+    }
+
+    /// A `user` message.
+    pub fn user(content: impl Into<Content>) -> Self {
+        Self::new(Role::User, content)
+    }
+
+    /// An `assistant` message.
+    pub fn assistant(content: impl Into<Content>) -> Self {
+        Self::new(Role::Assistant, content)
+    }
+
+    /// The concatenated text of the message body.
+    pub fn text(&self) -> String {
+        self.content.as_text()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn text_content_round_trips() {
+        let content = Content::text("hello");
+        let json = serde_json::to_string(&content).unwrap();
+        assert_eq!(json, r#"[{"type":"text","text":"hello"}]"#);
+        let back: Content = serde_json::from_str(&json).unwrap();
+        assert_eq!(content, back);
+        assert_eq!(back.as_text(), "hello");
+    }
+
+    #[test]
+    fn media_part_omits_none_fields() {
+        let part = ContentPart::Media(MediaPart {
+            media_type: "image/png".to_string(),
+            url: Some("https://x/y.png".to_string()),
+            data_base64: None,
+            name: None,
+        });
+        let json = serde_json::to_string(&part).unwrap();
+        assert!(json.contains(r#""type":"media""#));
+        assert!(json.contains(r#""media_type":"image/png""#));
+        assert!(!json.contains("data_base64"));
+        assert_eq!(serde_json::from_str::<ContentPart>(&json).unwrap(), part);
+    }
+
+    #[test]
+    fn message_constructors_set_role_and_text() {
+        let msg = Message::user("how do uploads work?");
+        assert_eq!(msg.role, Role::User);
+        assert_eq!(msg.text(), "how do uploads work?");
+        let back: Message = serde_json::from_str(&serde_json::to_string(&msg).unwrap()).unwrap();
+        assert_eq!(msg, back);
+    }
+
+    #[test]
+    fn as_text_joins_text_parts_and_skips_others() {
+        let content = Content::from_parts(vec![
+            ContentPart::text("a"),
+            ContentPart::Json {
+                value: serde_json::json!({"k": 1}),
+            },
+            ContentPart::text("b"),
+        ]);
+        assert_eq!(content.as_text(), "ab");
+    }
+}

--- a/crates/pocopine-agenkit-core/src/embed.rs
+++ b/crates/pocopine-agenkit-core/src/embed.rs
@@ -1,0 +1,99 @@
+//! Embedding payloads (RFC-093 Phase 1.3, §D5).
+//!
+//! An embedder turns text/multimodal content into vectors. Descriptors expose
+//! model/provider *aliases* and dimensions, never provider credentials (§D5).
+
+use crate::ModelRef;
+
+/// The framework-visible description of a registered embedder.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct EmbedderDescriptor {
+    /// Stable embedder id.
+    pub id: String,
+    /// The model alias used to embed (e.g. `"local/embed"`).
+    pub model: ModelRef,
+    /// Output vector dimensionality.
+    pub dimensions: u32,
+}
+
+impl EmbedderDescriptor {
+    /// An embedder descriptor.
+    pub fn new(id: impl Into<String>, model: ModelRef, dimensions: u32) -> Self {
+        Self {
+            id: id.into(),
+            model,
+            dimensions,
+        }
+    }
+}
+
+/// A single embedding vector.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
+pub struct Embedding {
+    /// The vector components.
+    pub vector: Vec<f32>,
+}
+
+impl Embedding {
+    /// Wrap a vector.
+    pub fn new(vector: Vec<f32>) -> Self {
+        Self { vector }
+    }
+
+    /// The vector dimensionality.
+    pub fn dimensions(&self) -> usize {
+        self.vector.len()
+    }
+}
+
+/// A batch of embeddings produced from a batch of inputs.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct EmbeddingBatch {
+    /// One embedding per input, in input order.
+    pub embeddings: Vec<Embedding>,
+    /// The shared dimensionality of every embedding in the batch.
+    pub dimensions: u32,
+}
+
+impl EmbeddingBatch {
+    /// Build a batch, stamping the shared dimensionality.
+    pub fn new(embeddings: Vec<Embedding>, dimensions: u32) -> Self {
+        Self {
+            embeddings,
+            dimensions,
+        }
+    }
+
+    /// Number of embeddings in the batch.
+    pub fn len(&self) -> usize {
+        self.embeddings.len()
+    }
+
+    /// Whether the batch is empty.
+    pub fn is_empty(&self) -> bool {
+        self.embeddings.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn batch_round_trips_and_reports_dimensions() {
+        let batch = EmbeddingBatch::new(vec![Embedding::new(vec![0.1, 0.2, 0.3])], 3);
+        assert_eq!(batch.len(), 1);
+        assert_eq!(batch.embeddings[0].dimensions(), 3);
+        let back: EmbeddingBatch =
+            serde_json::from_str(&serde_json::to_string(&batch).unwrap()).unwrap();
+        assert_eq!(batch, back);
+    }
+
+    #[test]
+    fn descriptor_carries_alias_not_credentials() {
+        let descriptor = EmbedderDescriptor::new("local", ModelRef::new("local/embed"), 384);
+        let json = serde_json::to_string(&descriptor).unwrap();
+        assert!(json.contains(r#""model":"local/embed""#));
+    }
+}

--- a/crates/pocopine-agenkit-core/src/enums.rs
+++ b/crates/pocopine-agenkit-core/src/enums.rs
@@ -1,0 +1,206 @@
+//! Payload-free leaf enums (RFC-093 Phase 1.1).
+//!
+//! These carry no other Agenkit types, so everything downstream can embed
+//! them freely. All serialize `snake_case` for stable, inspectable payloads.
+
+/// Who authored a [`crate::Message`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Role {
+    /// System / developer instructions.
+    System,
+    /// End-user input.
+    User,
+    /// Model output.
+    Assistant,
+    /// A tool result fed back to the model.
+    Tool,
+}
+
+/// The kind of work a flow [`step`](crate::StepId) performs.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StepKind {
+    /// A model generation call.
+    Generation,
+    /// A tool invocation.
+    Tool,
+    /// A retrieval/RAG lookup.
+    Retrieval,
+    /// An embedding call.
+    Embedding,
+    /// A reducer / fan-in checker.
+    Reducer,
+    /// A typed agent run.
+    Agent,
+    /// A parallel fan-out group.
+    Parallel,
+    /// Arbitrary traced app work wrapped in `ctx.step(...)`.
+    Custom,
+}
+
+/// The lifecycle status of a step or branch.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StepStatus {
+    /// Started but not finished.
+    Started,
+    /// Finished successfully.
+    Completed,
+    /// Finished with an error.
+    Failed,
+    /// Aborted (flow cancelled or a losing parallel branch).
+    Cancelled,
+}
+
+/// Whether a tool may mutate state. Read-only is the safe default (§D5).
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolSideEffectPolicy {
+    /// The tool only reads; safe to retry and run speculatively.
+    #[default]
+    ReadOnly,
+    /// The tool mutates state; must be marked explicitly.
+    SideEffecting,
+}
+
+/// The category of a framework-mediated resource a flow declares (§D6).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ResourceKind {
+    /// A registered tool.
+    Tool,
+    /// A registered retriever.
+    Retriever,
+    /// A registered embedder.
+    Embedder,
+    /// A typed agent.
+    Agent,
+    /// An agent thread.
+    Thread,
+    /// An app state handle.
+    State,
+    /// A provider alias.
+    Provider,
+    /// A model alias.
+    Model,
+}
+
+/// How a reducer reached its decision (§D7).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReducerKind {
+    /// A model acted as judge.
+    ModelJudge,
+    /// A deterministic Rust function.
+    Deterministic,
+    /// A voting / majority strategy.
+    Vote,
+    /// A schema validator.
+    SchemaValidator,
+    /// A product-specific check (e.g. a debugger evidence check).
+    Custom,
+}
+
+/// How much of a flow's progress a client may observe (§D8).
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum StreamMode {
+    /// No progress stream; only the final typed result.
+    #[default]
+    FinalOnly,
+    /// User-visible output deltas plus the final result.
+    OutputDeltas,
+    /// Redacted step/tool/parallel/reducer status plus the final result.
+    Progress,
+    /// Progress plus safe trace refs for local debugging; never raw secrets
+    /// or hidden reasoning.
+    DebugSafe,
+}
+
+/// Promise-like join policy for a parallel branch group (§D8).
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum ParallelJoin {
+    /// Require every branch to succeed.
+    All,
+    /// Wait for every branch and return successes plus failures.
+    #[default]
+    AllSettled,
+    /// Return the first success and cancel the rest.
+    FirstSuccess,
+    /// Return once at least `n` branches succeed, cancelling the rest.
+    Quorum(u32),
+}
+
+/// What to do when branches fail (§D7).
+#[derive(
+    Clone, Copy, Debug, Default, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum BranchFailurePolicy {
+    /// Abort the group on the first failure.
+    FailFast,
+    /// Collect partial results and continue.
+    #[default]
+    CollectPartial,
+    /// Require at least `n` successful branches or fail the group.
+    MinSuccess(u32),
+}
+
+/// How long agent-thread state is retained (§D10).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ThreadRetention {
+    /// Dropped at the end of the run.
+    Ephemeral,
+    /// Kept for the session.
+    Session,
+    /// Persisted durably (future durable store).
+    Durable,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn enums_serialize_snake_case() {
+        assert_eq!(
+            serde_json::to_string(&Role::Assistant).unwrap(),
+            "\"assistant\""
+        );
+        assert_eq!(
+            serde_json::to_string(&StepKind::Retrieval).unwrap(),
+            "\"retrieval\""
+        );
+        assert_eq!(
+            serde_json::to_string(&ToolSideEffectPolicy::SideEffecting).unwrap(),
+            "\"side_effecting\""
+        );
+    }
+
+    #[test]
+    fn parallel_join_data_variant_round_trips() {
+        let join = ParallelJoin::Quorum(2);
+        let json = serde_json::to_string(&join).unwrap();
+        assert_eq!(json, "{\"quorum\":2}");
+        assert_eq!(serde_json::from_str::<ParallelJoin>(&json).unwrap(), join);
+    }
+
+    #[test]
+    fn safe_defaults() {
+        assert_eq!(
+            ToolSideEffectPolicy::default(),
+            ToolSideEffectPolicy::ReadOnly
+        );
+        assert_eq!(StreamMode::default(), StreamMode::FinalOnly);
+        assert_eq!(ParallelJoin::default(), ParallelJoin::AllSettled);
+    }
+}

--- a/crates/pocopine-agenkit-core/src/error.rs
+++ b/crates/pocopine-agenkit-core/src/error.rs
@@ -1,0 +1,190 @@
+//! The unified error type for Agenkit (RFC-093 §D13, §D15 DC-2).
+//!
+//! Modelled as a manual enum + `Display` + `std::error::Error` + helper
+//! constructors + `impl From`, matching the workspace convention
+//! (`JobError`/`SyncError`/`StorageError`); no `thiserror`. The variants
+//! distinguish the failure classes a flow runtime must tell apart so callers,
+//! traces, and the server boundary can react differently.
+
+use std::fmt;
+
+/// Convenient `Result` alias for Agenkit APIs.
+pub type AgenkitResult<T> = Result<T, AgenkitError>;
+
+/// Every way an Agenkit operation can fail.
+///
+/// Serializable so it can ride trace payloads and be asserted in tests; the
+/// facade maps it to `pocopine_server::ServerError` before it crosses the
+/// client boundary (provider internals never leak).
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum AgenkitError {
+    /// A model provider call failed (network, provider error, bad response).
+    Provider { message: String },
+    /// Structured output or a tool argument failed schema validation.
+    Validation { message: String },
+    /// A tool was rejected by policy: not allowlisted, side-effect not
+    /// permitted, or principal not authorized.
+    ToolPolicy { message: String },
+    /// A per-flow/per-step budget was exhausted (tokens, time, cost, depth).
+    BudgetExhausted { message: String },
+    /// The operation was cancelled (flow cancelled, losing parallel branch).
+    Cancelled,
+    /// A reducer could not accept any candidate, or branches disagreed beyond
+    /// the configured success policy.
+    ReducerDisagreement { message: String },
+    /// Misconfiguration: unknown provider/model alias, missing registration,
+    /// or an invalid builder.
+    Config { message: String },
+    /// A referenced resource (flow, agent, thread, tool, retriever) was not
+    /// found in the registry.
+    NotFound { message: String },
+    /// Serialization/deserialization of a payload failed.
+    Json { message: String },
+    /// A runtime invariant broke (e.g. a parallel branch panicked). Never a
+    /// caller mistake; indicates a bug in app or framework code.
+    Internal { message: String },
+}
+
+impl AgenkitError {
+    /// A model provider failure.
+    pub fn provider(message: impl Into<String>) -> Self {
+        Self::Provider {
+            message: message.into(),
+        }
+    }
+
+    /// A schema/validation failure.
+    pub fn validation(message: impl Into<String>) -> Self {
+        Self::Validation {
+            message: message.into(),
+        }
+    }
+
+    /// A tool policy rejection.
+    pub fn tool_policy(message: impl Into<String>) -> Self {
+        Self::ToolPolicy {
+            message: message.into(),
+        }
+    }
+
+    /// A budget-exhaustion failure.
+    pub fn budget_exhausted(message: impl Into<String>) -> Self {
+        Self::BudgetExhausted {
+            message: message.into(),
+        }
+    }
+
+    /// A reducer disagreement / no-acceptable-candidate failure.
+    pub fn reducer_disagreement(message: impl Into<String>) -> Self {
+        Self::ReducerDisagreement {
+            message: message.into(),
+        }
+    }
+
+    /// A configuration failure.
+    pub fn config(message: impl Into<String>) -> Self {
+        Self::Config {
+            message: message.into(),
+        }
+    }
+
+    /// A registry lookup miss.
+    pub fn not_found(message: impl Into<String>) -> Self {
+        Self::NotFound {
+            message: message.into(),
+        }
+    }
+
+    /// A broken runtime invariant (e.g. a panicked parallel branch).
+    pub fn internal(message: impl Into<String>) -> Self {
+        Self::Internal {
+            message: message.into(),
+        }
+    }
+
+    /// The stable snake_case discriminant, useful for trace fields and tests.
+    pub fn kind(&self) -> &'static str {
+        match self {
+            Self::Provider { .. } => "provider",
+            Self::Validation { .. } => "validation",
+            Self::ToolPolicy { .. } => "tool_policy",
+            Self::BudgetExhausted { .. } => "budget_exhausted",
+            Self::Cancelled => "cancelled",
+            Self::ReducerDisagreement { .. } => "reducer_disagreement",
+            Self::Config { .. } => "config",
+            Self::NotFound { .. } => "not_found",
+            Self::Json { .. } => "json",
+            Self::Internal { .. } => "internal",
+        }
+    }
+
+    /// Whether a retry could plausibly succeed (transient provider failures).
+    /// Validation, policy, and config errors are not retryable.
+    pub fn is_retryable(&self) -> bool {
+        matches!(self, Self::Provider { .. })
+    }
+}
+
+impl fmt::Display for AgenkitError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Provider { message } => write!(f, "provider error: {message}"),
+            Self::Validation { message } => write!(f, "validation error: {message}"),
+            Self::ToolPolicy { message } => write!(f, "tool policy error: {message}"),
+            Self::BudgetExhausted { message } => write!(f, "budget exhausted: {message}"),
+            Self::Cancelled => f.write_str("operation cancelled"),
+            Self::ReducerDisagreement { message } => {
+                write!(f, "reducer disagreement: {message}")
+            }
+            Self::Config { message } => write!(f, "configuration error: {message}"),
+            Self::NotFound { message } => write!(f, "not found: {message}"),
+            Self::Json { message } => write!(f, "serialization error: {message}"),
+            Self::Internal { message } => write!(f, "internal error: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for AgenkitError {}
+
+impl From<serde_json::Error> for AgenkitError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::Json {
+            message: err.to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn constructors_set_kind() {
+        assert_eq!(AgenkitError::provider("x").kind(), "provider");
+        assert_eq!(AgenkitError::validation("x").kind(), "validation");
+        assert_eq!(AgenkitError::Cancelled.kind(), "cancelled");
+    }
+
+    #[test]
+    fn only_provider_errors_are_retryable() {
+        assert!(AgenkitError::provider("timeout").is_retryable());
+        assert!(!AgenkitError::validation("bad").is_retryable());
+        assert!(!AgenkitError::Cancelled.is_retryable());
+    }
+
+    #[test]
+    fn serde_round_trip_is_tagged() {
+        let err = AgenkitError::tool_policy("not allowlisted");
+        let json = serde_json::to_string(&err).unwrap();
+        assert!(json.contains("\"kind\":\"tool_policy\""));
+        let back: AgenkitError = serde_json::from_str(&json).unwrap();
+        assert_eq!(err, back);
+    }
+
+    #[test]
+    fn json_error_maps_through_from() {
+        let err: AgenkitError = serde_json::from_str::<i32>("not json").unwrap_err().into();
+        assert_eq!(err.kind(), "json");
+    }
+}

--- a/crates/pocopine-agenkit-core/src/events.rs
+++ b/crates/pocopine-agenkit-core/src/events.rs
@@ -1,0 +1,79 @@
+//! Stable AI event-name constants (RFC-093 §D12).
+//!
+//! These are the names the facade stamps onto `pocopine_observe::ObservedEvent`
+//! via `emit_tracing`. They are part of the public contract: dashboards and
+//! the future debugger key off them, so they must stay stable.
+
+// Flow lifecycle.
+/// A public flow began.
+pub const AI_FLOW_STARTED: &str = "ai_flow_started";
+/// A public flow completed successfully.
+pub const AI_FLOW_COMPLETED: &str = "ai_flow_completed";
+/// A public flow failed.
+pub const AI_FLOW_FAILED: &str = "ai_flow_failed";
+
+// Flow context diagnostics.
+/// A framework-mediated resource was used but not declared in the manifest.
+pub const AI_CONTEXT_GAP: &str = "ai_context_gap";
+/// A flow's context manifest version changed between runs.
+pub const AI_CONTEXT_MANIFEST_CHANGED: &str = "ai_context_manifest_changed";
+
+// Step orchestration.
+/// A flow step began.
+pub const AI_STEP_STARTED: &str = "ai_step_started";
+/// A flow step completed.
+pub const AI_STEP_COMPLETED: &str = "ai_step_completed";
+/// A flow step failed.
+pub const AI_STEP_FAILED: &str = "ai_step_failed";
+
+// Parallel and reducer steps.
+/// A parallel fan-out group began.
+pub const AI_PARALLEL_STARTED: &str = "ai_parallel_started";
+/// A parallel fan-out group completed.
+pub const AI_PARALLEL_COMPLETED: &str = "ai_parallel_completed";
+/// A reducer/fan-in step began.
+pub const AI_REDUCER_STARTED: &str = "ai_reducer_started";
+/// A reducer/fan-in step completed.
+pub const AI_REDUCER_COMPLETED: &str = "ai_reducer_completed";
+
+// Model calls.
+/// A model request was sent.
+pub const AI_MODEL_REQUEST: &str = "ai_model_request";
+/// A model response was received.
+pub const AI_MODEL_RESPONSE: &str = "ai_model_response";
+/// A model call failed.
+pub const AI_MODEL_FAILED: &str = "ai_model_failed";
+
+// Tool calls.
+/// A tool invocation began.
+pub const AI_TOOL_STARTED: &str = "ai_tool_started";
+/// A tool invocation completed.
+pub const AI_TOOL_COMPLETED: &str = "ai_tool_completed";
+/// A tool invocation failed.
+pub const AI_TOOL_FAILED: &str = "ai_tool_failed";
+
+// Retrieval calls.
+/// A retrieval call began.
+pub const AI_RETRIEVAL_STARTED: &str = "ai_retrieval_started";
+/// A retrieval call completed.
+pub const AI_RETRIEVAL_COMPLETED: &str = "ai_retrieval_completed";
+/// A retrieval call failed.
+pub const AI_RETRIEVAL_FAILED: &str = "ai_retrieval_failed";
+
+// Embedding calls.
+/// An embedding call began.
+pub const AI_EMBEDDING_STARTED: &str = "ai_embedding_started";
+/// An embedding call completed.
+pub const AI_EMBEDDING_COMPLETED: &str = "ai_embedding_completed";
+/// An embedding call failed.
+pub const AI_EMBEDDING_FAILED: &str = "ai_embedding_failed";
+
+// Agent thread lifecycle.
+/// An agent thread was created.
+pub const AI_THREAD_CREATED: &str = "ai_thread_created";
+/// An agent thread was resumed.
+pub const AI_THREAD_RESUMED: &str = "ai_thread_resumed";
+/// An agent thread was checkpointed.
+pub const AI_THREAD_CHECKPOINTED: &str = "ai_thread_checkpointed";
+/// An agent thread was deleted.
+pub const AI_THREAD_DELETED: &str = "ai_thread_deleted";

--- a/crates/pocopine-agenkit-core/src/flow.rs
+++ b/crates/pocopine-agenkit-core/src/flow.rs
@@ -1,0 +1,129 @@
+//! Flow descriptors (RFC-093 Phase 1.4, §D4, §D6).
+//!
+//! A [`FlowDescriptor`] is the app-callable unit's contract: typed input/output
+//! schemas, the declared context manifest, the public stream mode, and whether
+//! the flow is exposed as a server function.
+
+use crate::{ContextManifest, ResourceKind, SchemaRef, StreamMode};
+
+/// The schema of a flow's typed input.
+pub type FlowInputSchema = SchemaRef;
+/// The schema of a flow's typed output.
+pub type FlowOutputSchema = SchemaRef;
+
+/// The framework-visible contract of a registered flow.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct FlowDescriptor {
+    /// Stable flow id.
+    pub id: String,
+    /// Whether the flow is exposed as a public server function (§D9).
+    #[serde(default)]
+    pub public: bool,
+    /// Typed input schema.
+    pub input: FlowInputSchema,
+    /// Typed output schema.
+    pub output: FlowOutputSchema,
+    /// The public streaming mode for this flow (§D8).
+    #[serde(default)]
+    pub stream_mode: StreamMode,
+    /// The declared context manifest (§D6).
+    #[serde(default)]
+    pub manifest: ContextManifest,
+}
+
+impl FlowDescriptor {
+    /// A private flow descriptor with empty schemas and manifest.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            public: false,
+            input: SchemaRef::default(),
+            output: SchemaRef::default(),
+            stream_mode: StreamMode::FinalOnly,
+            manifest: ContextManifest::new(),
+        }
+    }
+
+    /// Set the input schema.
+    pub fn input(mut self, input: FlowInputSchema) -> Self {
+        self.input = input;
+        self
+    }
+
+    /// Set the output schema.
+    pub fn output(mut self, output: FlowOutputSchema) -> Self {
+        self.output = output;
+        self
+    }
+
+    /// Mark the flow public (exposed as a server function).
+    pub fn public(mut self) -> Self {
+        self.public = true;
+        self
+    }
+
+    /// Set the public stream mode.
+    pub fn stream_mode(mut self, mode: StreamMode) -> Self {
+        self.stream_mode = mode;
+        self
+    }
+
+    /// Declare a tool dependency in the manifest.
+    pub fn uses_tool(mut self, id: impl Into<String>) -> Self {
+        self.manifest.declare(ResourceKind::Tool, id);
+        self
+    }
+
+    /// Declare a retriever dependency in the manifest.
+    pub fn uses_retriever(mut self, id: impl Into<String>) -> Self {
+        self.manifest.declare(ResourceKind::Retriever, id);
+        self
+    }
+
+    /// Declare an embedder dependency in the manifest.
+    pub fn uses_embedder(mut self, id: impl Into<String>) -> Self {
+        self.manifest.declare(ResourceKind::Embedder, id);
+        self
+    }
+
+    /// Declare an agent dependency in the manifest.
+    pub fn uses_agent(mut self, id: impl Into<String>) -> Self {
+        self.manifest.declare(ResourceKind::Agent, id);
+        self
+    }
+
+    /// Declare an app-state dependency in the manifest.
+    pub fn uses_state(mut self, key: impl Into<String>) -> Self {
+        self.manifest.declare(ResourceKind::State, key);
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builder_declares_manifest_resources() {
+        let flow = FlowDescriptor::new("answer_question")
+            .public()
+            .input(SchemaRef::named("QuestionInput"))
+            .output(SchemaRef::named("Answer"))
+            .stream_mode(StreamMode::Progress)
+            .uses_retriever("project_docs")
+            .uses_agent("docs_first")
+            .uses_tool("search_docs");
+
+        assert!(flow.public);
+        assert_eq!(flow.stream_mode, StreamMode::Progress);
+        assert!(
+            flow.manifest
+                .contains(ResourceKind::Retriever, "project_docs")
+        );
+        assert!(flow.manifest.contains(ResourceKind::Agent, "docs_first"));
+
+        let back: FlowDescriptor =
+            serde_json::from_str(&serde_json::to_string(&flow).unwrap()).unwrap();
+        assert_eq!(flow, back);
+    }
+}

--- a/crates/pocopine-agenkit-core/src/id.rs
+++ b/crates/pocopine-agenkit-core/src/id.rs
@@ -1,0 +1,182 @@
+//! Identifier newtypes (RFC-093 Phase 1.1).
+//!
+//! Core only *carries* ids as transparent string newtypes; the facade mints
+//! them (via `pocopine-crypto`/`pocopine-codec`) so this crate stays
+//! dependency-light. [`ModelRef`] is special: it is a `"provider/model"`
+//! alias, never a raw provider id (§D10).
+
+/// Declare a transparent `String` newtype id with the standard surface.
+macro_rules! string_id {
+    ($(#[$meta:meta])* $name:ident) => {
+        $(#[$meta])*
+        #[derive(
+            Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord,
+            serde::Serialize, serde::Deserialize,
+        )]
+        #[serde(transparent)]
+        pub struct $name(String);
+
+        impl $name {
+            /// Wrap a value as this id.
+            pub fn new(value: impl Into<String>) -> Self {
+                Self(value.into())
+            }
+
+            /// Borrow the underlying string.
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+
+            /// Consume into the owned string.
+            pub fn into_string(self) -> String {
+                self.0
+            }
+        }
+
+        impl std::fmt::Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(&self.0)
+            }
+        }
+
+        impl From<String> for $name {
+            fn from(value: String) -> Self {
+                Self(value)
+            }
+        }
+
+        impl From<&str> for $name {
+            fn from(value: &str) -> Self {
+                Self(value.to_owned())
+            }
+        }
+
+        impl AsRef<str> for $name {
+            fn as_ref(&self) -> &str {
+                &self.0
+            }
+        }
+    };
+}
+
+string_id!(
+    /// A provider alias (e.g. `"local"`, `"openai"`). Never a credential.
+    ProviderRef
+);
+string_id!(
+    /// A single flow/agent invocation id.
+    RunId
+);
+string_id!(
+    /// A correlation id stamped onto every trace event in one run tree.
+    TraceId
+);
+string_id!(
+    /// An opaque session id (chat/debugger continuity).
+    SessionId
+);
+string_id!(
+    /// An opaque agent-thread id. Never a provider-backed thread id (§D10).
+    AgentThreadId
+);
+string_id!(
+    /// Groups the branches of one `ctx.parallel(...)` fan-out.
+    ParallelGroupId
+);
+string_id!(
+    /// Identifies one step within a flow's trace tree.
+    StepId
+);
+
+/// A model alias of the shape `"provider/model"` (e.g. `"local/default"`).
+///
+/// The server allowlists aliases per app/flow before resolving them to a
+/// host-side provider; clients never send raw provider ids (§D10).
+#[derive(
+    Clone,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Hash,
+    PartialOrd,
+    Ord,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+#[serde(transparent)]
+pub struct ModelRef(String);
+
+impl ModelRef {
+    /// Wrap a `"provider/model"` alias.
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(value.into())
+    }
+
+    /// Borrow the full alias string.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// The provider-alias portion (before the first `/`), if the ref is
+    /// namespaced.
+    pub fn provider(&self) -> Option<&str> {
+        self.0.split_once('/').map(|(provider, _)| provider)
+    }
+
+    /// The model portion (after the first `/`), or the whole string when the
+    /// ref is not namespaced.
+    pub fn model(&self) -> &str {
+        self.0
+            .split_once('/')
+            .map_or(self.0.as_str(), |(_, model)| model)
+    }
+}
+
+impl std::fmt::Display for ModelRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<&str> for ModelRef {
+    fn from(value: &str) -> Self {
+        Self(value.to_owned())
+    }
+}
+
+impl From<String> for ModelRef {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn string_id_round_trips_transparently() {
+        let id = StepId::new("step-1");
+        let json = serde_json::to_string(&id).unwrap();
+        assert_eq!(json, "\"step-1\"");
+        let back: StepId = serde_json::from_str(&json).unwrap();
+        assert_eq!(id, back);
+        assert_eq!(id.as_str(), "step-1");
+    }
+
+    #[test]
+    fn model_ref_splits_provider_and_model() {
+        let m = ModelRef::new("local/default");
+        assert_eq!(m.provider(), Some("local"));
+        assert_eq!(m.model(), "default");
+        assert_eq!(m.as_str(), "local/default");
+    }
+
+    #[test]
+    fn model_ref_without_namespace_returns_whole_as_model() {
+        let m = ModelRef::new("default");
+        assert_eq!(m.provider(), None);
+        assert_eq!(m.model(), "default");
+    }
+}

--- a/crates/pocopine-agenkit-core/src/lib.rs
+++ b/crates/pocopine-agenkit-core/src/lib.rs
@@ -1,0 +1,75 @@
+//! `pocopine-agenkit-core` — stable, dependency-light contracts for
+//! [Pocopine Agenkit](../../rfcs/rfc-093-pocopine-agenkit.md), the
+//! Pocopine-native generative-AI runtime.
+//!
+//! This crate holds the shared payload and descriptor types that flow
+//! between the runtime facade ([`pocopine-agenkit`]), generated clients,
+//! tests, and future tooling: model/provider refs, content/messages,
+//! tool/retriever/embedder descriptors, flow + orchestration types,
+//! trace/stream payloads, usage/cost metadata, and `AgenkitError`.
+//!
+//! Design rules (RFC-093 §D2, §D10, §D12):
+//!
+//! * **Dependency-light and wasm-friendly.** No provider SDKs, no async
+//!   runtime, no `tracing`, no server dependency. The same client-safe
+//!   payloads must compile for `wasm32-unknown-unknown`.
+//! * **Observe-neutral.** Core defines neutral [`TraceEvent`]/[`TraceSpan`]
+//!   payloads and stable event-name constants; the facade owns the mapping
+//!   onto `pocopine_observe::ObservedEvent` + `emit_tracing`. Core never
+//!   depends on `pocopine-observe`.
+//! * **No secret-bearing client config.** Payloads carry model/provider
+//!   *aliases* and schema metadata, never provider credentials.
+//!
+//! Normal apps depend on the [`pocopine-agenkit`] facade, which re-exports
+//! the stable surface of this crate. Internal tests, generated clients, and
+//! future tooling can import this crate directly for the payload types.
+//!
+//! [`pocopine-agenkit`]: https://docs.rs/pocopine-agenkit
+//! [`TraceEvent`]: crate
+//! [`TraceSpan`]: crate
+//!
+//! # Status
+//!
+//! Phase 1 in progress: identifiers, leaf enums, and the error type are in
+//! place (see the RFC's Implementation Plan for the remaining checkpoints).
+#![forbid(unsafe_code)]
+
+pub mod agent;
+pub mod content;
+pub mod embed;
+pub mod enums;
+pub mod error;
+pub mod events;
+pub mod flow;
+pub mod id;
+pub mod manifest;
+pub mod reduce;
+pub mod retrieval;
+pub mod schema;
+pub mod stream;
+pub mod thread;
+pub mod tool;
+pub mod trace;
+
+pub use agent::AiAgentDescriptor;
+pub use content::{Content, ContentPart, MediaPart, Message};
+pub use embed::{EmbedderDescriptor, Embedding, EmbeddingBatch};
+pub use enums::{
+    BranchFailurePolicy, ParallelJoin, ReducerKind, ResourceKind, Role, StepKind, StepStatus,
+    StreamMode, ThreadRetention, ToolSideEffectPolicy,
+};
+pub use error::{AgenkitError, AgenkitResult};
+pub use flow::{FlowDescriptor, FlowInputSchema, FlowOutputSchema};
+pub use id::{
+    AgentThreadId, ModelRef, ParallelGroupId, ProviderRef, RunId, SessionId, StepId, TraceId,
+};
+pub use manifest::{ContextGapDiagnostic, ContextManifest, DeclaredResource};
+pub use reduce::ReducerDecision;
+pub use retrieval::{
+    Citation, RetrievalHit, RetrievalQuery, RetrievalSet, RetrieverDescriptor, SourceRef,
+};
+pub use schema::SchemaRef;
+pub use stream::FlowStreamEvent;
+pub use thread::{AgentThreadDescriptor, ThreadCheckpoint, ThreadMessage};
+pub use tool::{ToolCall, ToolDescriptor, ToolResult};
+pub use trace::{CostEstimate, TraceEvent, TraceSpan, Usage};

--- a/crates/pocopine-agenkit-core/src/manifest.rs
+++ b/crates/pocopine-agenkit-core/src/manifest.rs
@@ -1,0 +1,151 @@
+//! Flow context manifests and gap diagnostics (RFC-093 Phase 1.4, §D6).
+//!
+//! A [`ContextManifest`] documents the framework-mediated resources a flow
+//! declares it will use. It is documentation and trace metadata, not an
+//! enforcement policy: the facade compares actual framework-mediated access
+//! against the manifest and emits advisory [`ContextGapDiagnostic`]s.
+//!
+//! Core does not hash the manifest itself (that would pull a crypto
+//! dependency). It exposes [`ContextManifest::canonical_string`]; the facade
+//! hashes that via `pocopine-crypto` and stamps the result back as `version`.
+
+use crate::ResourceKind;
+
+/// One declared framework-mediated resource.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct DeclaredResource {
+    /// The resource category.
+    pub kind: ResourceKind,
+    /// The resource id (tool id, retriever id, state key, model alias, ...).
+    pub id: String,
+}
+
+impl DeclaredResource {
+    /// A declared resource.
+    pub fn new(kind: ResourceKind, id: impl Into<String>) -> Self {
+        Self {
+            kind,
+            id: id.into(),
+        }
+    }
+}
+
+/// The set of resources a flow declares it uses.
+#[derive(Clone, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ContextManifest {
+    /// The declared resources.
+    #[serde(default)]
+    pub resources: Vec<DeclaredResource>,
+    /// A stable version/hash stamped by the facade (§D6). `None` until set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+}
+
+impl ContextManifest {
+    /// An empty manifest.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Declare a resource (idempotent: duplicates are ignored).
+    pub fn declare(&mut self, kind: ResourceKind, id: impl Into<String>) {
+        let resource = DeclaredResource::new(kind, id);
+        if !self.resources.contains(&resource) {
+            self.resources.push(resource);
+        }
+    }
+
+    /// Whether a resource of the given kind and id was declared.
+    pub fn contains(&self, kind: ResourceKind, id: &str) -> bool {
+        self.resources.iter().any(|r| r.kind == kind && r.id == id)
+    }
+
+    /// A deterministic, order-independent string the facade hashes to produce
+    /// [`ContextManifest::version`]. Sorted so the hash is stable regardless
+    /// of declaration order.
+    pub fn canonical_string(&self) -> String {
+        let mut lines: Vec<String> = self
+            .resources
+            .iter()
+            .map(|r| {
+                format!(
+                    "{}:{}",
+                    serde_json::to_string(&r.kind).unwrap_or_default(),
+                    r.id
+                )
+            })
+            .collect();
+        lines.sort();
+        lines.join("\n")
+    }
+
+    /// Set the facade-computed version/hash.
+    pub fn with_version(mut self, version: impl Into<String>) -> Self {
+        self.version = Some(version.into());
+        self
+    }
+}
+
+/// An advisory diagnostic: a framework-mediated resource was accessed but not
+/// declared in the flow's manifest (§D6). Emitted to `pocopine.trace`, never
+/// an error.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ContextGapDiagnostic {
+    /// The flow that accessed the undeclared resource.
+    pub flow_id: String,
+    /// The undeclared resource's category.
+    pub resource_kind: ResourceKind,
+    /// The undeclared resource's id.
+    pub resource_id: String,
+    /// A human-readable explanation.
+    pub message: String,
+}
+
+impl ContextGapDiagnostic {
+    /// Build a gap diagnostic.
+    pub fn new(
+        flow_id: impl Into<String>,
+        resource_kind: ResourceKind,
+        resource_id: impl Into<String>,
+    ) -> Self {
+        let resource_id = resource_id.into();
+        let flow_id = flow_id.into();
+        let message = format!(
+            "flow `{flow_id}` used an undeclared {resource_kind:?} `{resource_id}`; \
+             add it to the flow's context manifest for reliable replay"
+        );
+        Self {
+            flow_id,
+            resource_kind,
+            resource_id,
+            message,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn declare_is_idempotent_and_queryable() {
+        let mut manifest = ContextManifest::new();
+        manifest.declare(ResourceKind::Tool, "search_docs");
+        manifest.declare(ResourceKind::Tool, "search_docs");
+        manifest.declare(ResourceKind::Retriever, "project_docs");
+        assert_eq!(manifest.resources.len(), 2);
+        assert!(manifest.contains(ResourceKind::Tool, "search_docs"));
+        assert!(!manifest.contains(ResourceKind::Tool, "project_docs"));
+    }
+
+    #[test]
+    fn canonical_string_is_order_independent() {
+        let mut a = ContextManifest::new();
+        a.declare(ResourceKind::Tool, "t");
+        a.declare(ResourceKind::Retriever, "r");
+        let mut b = ContextManifest::new();
+        b.declare(ResourceKind::Retriever, "r");
+        b.declare(ResourceKind::Tool, "t");
+        assert_eq!(a.canonical_string(), b.canonical_string());
+    }
+}

--- a/crates/pocopine-agenkit-core/src/reduce.rs
+++ b/crates/pocopine-agenkit-core/src/reduce.rs
@@ -1,0 +1,71 @@
+//! Reducer decisions (RFC-093 Phase 1.4, §D7).
+//!
+//! A reducer combines parallel branch outputs and records *why* a candidate
+//! was accepted, rejected, or merged. For evidence-driven products (e.g. the
+//! debugger) the reason should reference concrete evidence, not model claims.
+
+use crate::ReducerKind;
+
+/// The outcome of a reducer/fan-in step.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ReducerDecision {
+    /// How the decision was made.
+    pub kind: ReducerKind,
+    /// Whether the reducer accepted a final answer.
+    pub accepted: bool,
+    /// Why the answer was accepted, rejected, or merged.
+    pub reason: String,
+    /// The index of the chosen candidate branch, when a single one was picked.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub chosen_index: Option<u32>,
+    /// How many candidate branches the reducer considered.
+    #[serde(default)]
+    pub candidates: u32,
+}
+
+impl ReducerDecision {
+    /// An accepting decision that chose a candidate by index.
+    pub fn accept(kind: ReducerKind, reason: impl Into<String>, chosen_index: u32) -> Self {
+        Self {
+            kind,
+            accepted: true,
+            reason: reason.into(),
+            chosen_index: Some(chosen_index),
+            candidates: 0,
+        }
+    }
+
+    /// A rejecting decision (no candidate was acceptable).
+    pub fn reject(kind: ReducerKind, reason: impl Into<String>) -> Self {
+        Self {
+            kind,
+            accepted: false,
+            reason: reason.into(),
+            chosen_index: None,
+            candidates: 0,
+        }
+    }
+
+    /// Record how many candidates were considered.
+    pub fn with_candidates(mut self, candidates: u32) -> Self {
+        self.candidates = candidates;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decision_round_trips() {
+        let decision =
+            ReducerDecision::accept(ReducerKind::ModelJudge, "claim supported by trace", 1)
+                .with_candidates(3);
+        assert!(decision.accepted);
+        assert_eq!(decision.chosen_index, Some(1));
+        let back: ReducerDecision =
+            serde_json::from_str(&serde_json::to_string(&decision).unwrap()).unwrap();
+        assert_eq!(decision, back);
+    }
+}

--- a/crates/pocopine-agenkit-core/src/retrieval.rs
+++ b/crates/pocopine-agenkit-core/src/retrieval.rs
@@ -1,0 +1,215 @@
+//! Retrieval / RAG payloads (RFC-093 Phase 1.3, §D5).
+//!
+//! A retriever is a read-oriented context source. Descriptors declare source
+//! kinds and auth requirements; hits carry citations and source refs so
+//! reducers and traces can cite evidence without storing raw document bodies
+//! by default (§D5, §D12).
+
+use crate::{Content, SchemaRef};
+
+/// A reference to a retrieval source (a document, trace, log, row, ...).
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct SourceRef {
+    /// Stable id of the source within its kind.
+    pub id: String,
+    /// The source kind (e.g. `"doc"`, `"trace"`, `"build_log"`).
+    pub kind: String,
+    /// Optional URI/locator for the source.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub uri: Option<String>,
+}
+
+impl SourceRef {
+    /// A source ref of the given kind.
+    pub fn new(kind: impl Into<String>, id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            kind: kind.into(),
+            uri: None,
+        }
+    }
+
+    /// Attach a URI/locator.
+    pub fn with_uri(mut self, uri: impl Into<String>) -> Self {
+        self.uri = Some(uri.into());
+        self
+    }
+}
+
+/// A citation backing a claim, pointing at a [`SourceRef`].
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct Citation {
+    /// The cited source.
+    pub source: SourceRef,
+    /// An optional supporting snippet.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub snippet: Option<String>,
+}
+
+/// The framework-visible description of a registered retriever.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct RetrieverDescriptor {
+    /// Stable retriever id.
+    pub id: String,
+    /// What the retriever searches.
+    pub description: String,
+    /// Schema of the retriever's typed query. Carries a JSON-schema body only
+    /// when the host runtime derives it (e.g. for the retriever-as-tool
+    /// adapter's `parameters`); metadata only, never a value or credential.
+    #[serde(default)]
+    pub query: SchemaRef,
+    /// The source kinds it can return.
+    #[serde(default)]
+    pub source_kinds: Vec<String>,
+    /// Whether retrieval requires an authenticated principal.
+    #[serde(default)]
+    pub requires_auth: bool,
+}
+
+impl RetrieverDescriptor {
+    /// A retriever descriptor.
+    pub fn new(id: impl Into<String>, description: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            description: description.into(),
+            query: SchemaRef::default(),
+            source_kinds: Vec::new(),
+            requires_auth: false,
+        }
+    }
+
+    /// Set the query schema.
+    pub fn with_query(mut self, query: SchemaRef) -> Self {
+        self.query = query;
+        self
+    }
+
+    /// Declare the source kinds returned.
+    pub fn with_source_kinds<I, S>(mut self, kinds: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.source_kinds = kinds.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Require an authenticated principal for retrieval.
+    pub fn requires_auth(mut self) -> Self {
+        self.requires_auth = true;
+        self
+    }
+}
+
+/// A retrieval request.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct RetrievalQuery {
+    /// Free-text query.
+    pub text: String,
+    /// How many hits to return at most.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub top_k: Option<u32>,
+    /// Opaque filter object (tenant, kind, time range, ...).
+    #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
+    pub filters: serde_json::Value,
+}
+
+impl RetrievalQuery {
+    /// A query with just free text.
+    pub fn new(text: impl Into<String>) -> Self {
+        Self {
+            text: text.into(),
+            top_k: None,
+            filters: serde_json::Value::Null,
+        }
+    }
+
+    /// Limit the number of hits.
+    pub fn top_k(mut self, k: u32) -> Self {
+        self.top_k = Some(k);
+        self
+    }
+
+    /// Attach a filter object.
+    pub fn with_filters(mut self, filters: serde_json::Value) -> Self {
+        self.filters = filters;
+        self
+    }
+}
+
+/// One retrieved hit with its score and provenance.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct RetrievalHit {
+    /// Where the hit came from.
+    pub source: SourceRef,
+    /// Relevance score, higher is better (semantics are retriever-defined).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub score: Option<f64>,
+    /// The retrieved content.
+    pub content: Content,
+    /// An optional citation derived from the hit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub citation: Option<Citation>,
+}
+
+/// An ordered set of retrieval hits.
+#[derive(Clone, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(transparent)]
+pub struct RetrievalSet {
+    /// The hits, best-first by convention.
+    pub hits: Vec<RetrievalHit>,
+}
+
+impl RetrievalSet {
+    /// Build a set from hits.
+    pub fn new(hits: Vec<RetrievalHit>) -> Self {
+        Self { hits }
+    }
+
+    /// Number of hits.
+    pub fn len(&self) -> usize {
+        self.hits.len()
+    }
+
+    /// Whether the set is empty.
+    pub fn is_empty(&self) -> bool {
+        self.hits.is_empty()
+    }
+
+    /// The source refs of every hit, for trace/citation metadata.
+    pub fn source_refs(&self) -> Vec<&SourceRef> {
+        self.hits.iter().map(|hit| &hit.source).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn query_omits_defaults_and_round_trips() {
+        let query = RetrievalQuery::new("how do uploads work?").top_k(5);
+        let json = serde_json::to_string(&query).unwrap();
+        assert!(!json.contains("filters"));
+        assert!(json.contains(r#""top_k":5"#));
+        assert_eq!(
+            serde_json::from_str::<RetrievalQuery>(&json).unwrap(),
+            query
+        );
+    }
+
+    #[test]
+    fn set_reports_sources() {
+        let set = RetrievalSet::new(vec![RetrievalHit {
+            source: SourceRef::new("doc", "uploads.md").with_uri("docs/uploads.md"),
+            score: Some(0.91),
+            content: Content::text("uploads use presigned URLs"),
+            citation: None,
+        }]);
+        assert_eq!(set.len(), 1);
+        assert_eq!(set.source_refs()[0].id, "uploads.md");
+        let back: RetrievalSet =
+            serde_json::from_str(&serde_json::to_string(&set).unwrap()).unwrap();
+        assert_eq!(set, back);
+    }
+}

--- a/crates/pocopine-agenkit-core/src/schema.rs
+++ b/crates/pocopine-agenkit-core/src/schema.rs
@@ -1,0 +1,44 @@
+//! Schema descriptors shared by tools, flows, and agents (RFC-093 Phase 1.3).
+//!
+//! A [`SchemaRef`] names a typed payload and optionally carries its JSON
+//! schema. It is metadata only — it never carries values or credentials, so
+//! it is safe to ship to generated clients.
+
+/// A reference to a typed input/output schema.
+#[derive(Clone, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct SchemaRef {
+    /// Stable schema name (typically the Rust type name).
+    pub name: String,
+    /// Optional JSON-schema description of the shape.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub json_schema: Option<serde_json::Value>,
+}
+
+impl SchemaRef {
+    /// A named schema with no JSON-schema body.
+    pub fn named(name: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            json_schema: None,
+        }
+    }
+
+    /// Attach a JSON-schema body.
+    pub fn with_json_schema(mut self, json_schema: serde_json::Value) -> Self {
+        self.json_schema = Some(json_schema);
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn named_schema_round_trips_without_body() {
+        let schema = SchemaRef::named("Summary");
+        let json = serde_json::to_string(&schema).unwrap();
+        assert_eq!(json, r#"{"name":"Summary"}"#);
+        assert_eq!(serde_json::from_str::<SchemaRef>(&json).unwrap(), schema);
+    }
+}

--- a/crates/pocopine-agenkit-core/src/stream.rs
+++ b/crates/pocopine-agenkit-core/src/stream.rs
@@ -1,0 +1,224 @@
+//! Public, client-safe stream events (RFC-093 Phase 1.4, §D8).
+//!
+//! [`FlowStreamEvent`]s are the *only* shapes a browser client receives for a
+//! streaming flow. By construction they carry redacted, allowlisted data —
+//! ids, kinds, counts, durations, and user-visible output deltas — never raw
+//! model thoughts, reasoning tokens, prompts, tool arguments, or provider
+//! payloads. The facade applies a final redaction chokepoint before the wire
+//! (§D10), but these types only model client-safe fields to begin with.
+
+use crate::{ParallelGroupId, ParallelJoin, StepId, StepKind};
+
+/// A single public progress event for a streaming flow.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum FlowStreamEvent {
+    /// The flow began.
+    FlowStarted {
+        /// The run id.
+        run_id: String,
+        /// The trace id for local correlation.
+        trace_id: String,
+    },
+    /// The flow finished successfully.
+    FlowCompleted {
+        /// The run id.
+        run_id: String,
+    },
+    /// The flow failed (public error kind only, never provider internals).
+    FlowFailed {
+        /// The run id.
+        run_id: String,
+        /// The public error kind (`AgenkitError::kind`).
+        error_kind: String,
+        /// The trace id for local correlation.
+        trace_id: String,
+    },
+    /// A step began.
+    StepStarted {
+        /// The step id.
+        step_id: StepId,
+        /// The kind of work.
+        kind: StepKind,
+        /// A safe step name.
+        name: String,
+        /// The parent step, if nested.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        parent_step_id: Option<StepId>,
+    },
+    /// A redacted progress note for a step.
+    StepProgress {
+        /// The step id.
+        step_id: StepId,
+        /// A safe, human-readable progress message.
+        message: String,
+    },
+    /// A step completed.
+    StepCompleted {
+        /// The step id.
+        step_id: StepId,
+    },
+    /// A step failed (public error kind only).
+    StepFailed {
+        /// The step id.
+        step_id: StepId,
+        /// The public error kind.
+        error_kind: String,
+    },
+    /// A user-visible output fragment.
+    OutputDelta {
+        /// The output text fragment (user-visible by definition).
+        text: String,
+    },
+    /// An incremental partial structured-output object: a best-effort parse of
+    /// the JSON generated so far, so clients can render a progressively
+    /// completing object (the structured analogue of `OutputDelta`).
+    ObjectDelta {
+        /// The partial output object parsed from the stream so far.
+        partial: serde_json::Value,
+    },
+    /// The user-visible output is complete.
+    OutputCompleted,
+    /// A tool invocation began (no raw args).
+    ToolStarted {
+        /// The step id.
+        step_id: StepId,
+        /// The tool id.
+        tool_id: String,
+    },
+    /// A tool invocation completed (no raw result).
+    ToolCompleted {
+        /// The step id.
+        step_id: StepId,
+        /// The tool id.
+        tool_id: String,
+    },
+    /// A tool invocation failed (public error kind only).
+    ToolFailed {
+        /// The step id.
+        step_id: StepId,
+        /// The tool id.
+        tool_id: String,
+        /// The public error kind.
+        error_kind: String,
+    },
+    /// A parallel fan-out group began.
+    ParallelStarted {
+        /// The parallel group id.
+        group_id: ParallelGroupId,
+        /// How many branches were launched.
+        branch_count: u32,
+        /// The join policy.
+        join: ParallelJoin,
+    },
+    /// A branch of a parallel group began.
+    BranchStarted {
+        /// The parallel group id.
+        group_id: ParallelGroupId,
+        /// The branch's step id.
+        step_id: StepId,
+        /// A safe branch name.
+        name: String,
+    },
+    /// A branch completed.
+    BranchCompleted {
+        /// The parallel group id.
+        group_id: ParallelGroupId,
+        /// The branch's step id.
+        step_id: StepId,
+    },
+    /// A branch failed (public error kind only).
+    BranchFailed {
+        /// The parallel group id.
+        group_id: ParallelGroupId,
+        /// The branch's step id.
+        step_id: StepId,
+        /// The public error kind.
+        error_kind: String,
+    },
+    /// A parallel group finished.
+    ParallelCompleted {
+        /// The parallel group id.
+        group_id: ParallelGroupId,
+        /// How many branches succeeded.
+        success_count: u32,
+    },
+    /// A reducer began.
+    ReducerStarted {
+        /// The reducer step id.
+        step_id: StepId,
+    },
+    /// A reducer reached a decision (metadata only).
+    ReducerDecision {
+        /// The reducer step id.
+        step_id: StepId,
+        /// Whether a final answer was accepted.
+        accepted: bool,
+    },
+    /// A reducer completed.
+    ReducerCompleted {
+        /// The reducer step id.
+        step_id: StepId,
+    },
+    /// An optional aggregate usage update.
+    UsageUpdate {
+        /// Aggregate input tokens so far.
+        input_tokens: u64,
+        /// Aggregate output tokens so far.
+        output_tokens: u64,
+    },
+    /// A public error (kind + trace id, never provider internals).
+    Error {
+        /// The public error kind.
+        error_kind: String,
+        /// The trace id for local correlation.
+        trace_id: String,
+    },
+    /// Forward-compatibility fallback: an event tag this build does not know.
+    /// Never constructed by the server; produced on the decode side (e.g. a
+    /// cached wasm client reading a newer server's stream) so unknown events
+    /// are skipped instead of failing the whole stream.
+    #[serde(other)]
+    Unknown,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn events_are_tagged_and_round_trip() {
+        let started = FlowStreamEvent::ParallelStarted {
+            group_id: ParallelGroupId::new("candidate_answers"),
+            branch_count: 3,
+            join: ParallelJoin::AllSettled,
+        };
+        let json = serde_json::to_string(&started).unwrap();
+        assert!(json.contains(r#""event":"parallel_started""#));
+        assert_eq!(
+            serde_json::from_str::<FlowStreamEvent>(&json).unwrap(),
+            started
+        );
+
+        let delta = FlowStreamEvent::OutputDelta {
+            text: "Uploads use ".to_string(),
+        };
+        let json = serde_json::to_string(&delta).unwrap();
+        assert!(json.contains(r#""event":"output_delta""#));
+    }
+
+    #[test]
+    fn unit_variant_serializes_as_tag_only() {
+        let json = serde_json::to_string(&FlowStreamEvent::OutputCompleted).unwrap();
+        assert_eq!(json, r#"{"event":"output_completed"}"#);
+    }
+
+    #[test]
+    fn unknown_event_tag_decodes_to_unknown_instead_of_failing() {
+        // A stale client must skip events a newer server added, not error the
+        // whole stream mid-flight.
+        let event: FlowStreamEvent =
+            serde_json::from_str(r#"{"event":"added_in_a_future_version"}"#).unwrap();
+        assert_eq!(event, FlowStreamEvent::Unknown);
+    }
+}

--- a/crates/pocopine-agenkit-core/src/thread.rs
+++ b/crates/pocopine-agenkit-core/src/thread.rs
@@ -1,0 +1,109 @@
+//! Agent thread descriptors and messages (RFC-093 Phase 1.4, §D4, §D10).
+//!
+//! A thread is optional conversation/session state. Ids exposed to clients are
+//! opaque Pocopine ids, never provider-backed thread ids; messages and
+//! checkpoints are privacy-labeled, and raw prompts/tool args/provider
+//! payloads are not stored unless capture policy enables it (§D10).
+
+use crate::{AgentThreadId, Content, Role, ThreadRetention};
+
+/// The framework-visible description of an agent thread.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct AgentThreadDescriptor {
+    /// The opaque thread id.
+    pub id: AgentThreadId,
+    /// The agent this thread belongs to.
+    pub agent_id: String,
+    /// How long the thread is retained.
+    pub retention: ThreadRetention,
+}
+
+impl AgentThreadDescriptor {
+    /// A thread descriptor.
+    pub fn new(id: AgentThreadId, agent_id: impl Into<String>, retention: ThreadRetention) -> Self {
+        Self {
+            id,
+            agent_id: agent_id.into(),
+            retention,
+        }
+    }
+}
+
+/// One stored message in a thread's history.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ThreadMessage {
+    /// Who authored the message.
+    pub role: Role,
+    /// The (privacy-labeled) message body.
+    pub content: Content,
+    /// Wall-clock timestamp in epoch millis, when known. Supplied by the host
+    /// (core has no clock).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ts_ms: Option<u64>,
+}
+
+impl ThreadMessage {
+    /// A thread message.
+    pub fn new(role: Role, content: impl Into<Content>) -> Self {
+        Self {
+            role,
+            content: content.into(),
+            ts_ms: None,
+        }
+    }
+
+    /// Stamp a timestamp.
+    pub fn at(mut self, ts_ms: u64) -> Self {
+        self.ts_ms = Some(ts_ms);
+        self
+    }
+}
+
+/// A resumable checkpoint within a thread.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ThreadCheckpoint {
+    /// Opaque checkpoint id.
+    pub id: String,
+    /// An optional safe summary of the thread state at this checkpoint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+}
+
+impl ThreadCheckpoint {
+    /// A checkpoint with an optional summary.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            summary: None,
+        }
+    }
+
+    /// Attach a safe summary.
+    pub fn with_summary(mut self, summary: impl Into<String>) -> Self {
+        self.summary = Some(summary.into());
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn thread_descriptor_and_message_round_trip() {
+        let descriptor = AgentThreadDescriptor::new(
+            AgentThreadId::new("th-1"),
+            "debugger_agent",
+            ThreadRetention::Session,
+        );
+        let back: AgentThreadDescriptor =
+            serde_json::from_str(&serde_json::to_string(&descriptor).unwrap()).unwrap();
+        assert_eq!(descriptor, back);
+
+        let msg = ThreadMessage::new(Role::User, "why did the upload fail?").at(1_700_000_000_000);
+        assert_eq!(msg.ts_ms, Some(1_700_000_000_000));
+        let back: ThreadMessage =
+            serde_json::from_str(&serde_json::to_string(&msg).unwrap()).unwrap();
+        assert_eq!(msg, back);
+    }
+}

--- a/crates/pocopine-agenkit-core/src/tool.rs
+++ b/crates/pocopine-agenkit-core/src/tool.rs
@@ -1,0 +1,138 @@
+//! Tool descriptors and call/result payloads (RFC-093 Phase 1.3, §D5).
+//!
+//! A tool is an action a flow or agent may invoke with typed input and typed
+//! output. The descriptor declares its side-effect policy and schemas; it
+//! carries no implementation and no credentials.
+
+use crate::{SchemaRef, ToolSideEffectPolicy};
+
+/// The framework-visible description of a registered tool.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ToolDescriptor {
+    /// Stable tool id (the model calls the tool by this id).
+    pub id: String,
+    /// Human/model-readable description of what the tool does.
+    pub description: String,
+    /// Whether the tool may mutate state (§D5). Read-only is the default.
+    #[serde(default)]
+    pub side_effect: ToolSideEffectPolicy,
+    /// Schema of the tool's typed input.
+    pub input: SchemaRef,
+    /// Schema of the tool's typed output.
+    pub output: SchemaRef,
+}
+
+impl ToolDescriptor {
+    /// A read-only tool descriptor.
+    pub fn new(id: impl Into<String>, description: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            description: description.into(),
+            side_effect: ToolSideEffectPolicy::ReadOnly,
+            input: SchemaRef::default(),
+            output: SchemaRef::default(),
+        }
+    }
+
+    /// Mark the tool as side-effecting (§D5).
+    pub fn side_effecting(mut self) -> Self {
+        self.side_effect = ToolSideEffectPolicy::SideEffecting;
+        self
+    }
+
+    /// Set the input schema.
+    pub fn with_input(mut self, input: SchemaRef) -> Self {
+        self.input = input;
+        self
+    }
+
+    /// Set the output schema.
+    pub fn with_output(mut self, output: SchemaRef) -> Self {
+        self.output = output;
+        self
+    }
+}
+
+/// A model-requested tool invocation with opaque, schema-validated args.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ToolCall {
+    /// Unique id for this call (correlates the result).
+    pub id: String,
+    /// The tool to invoke.
+    pub tool_id: String,
+    /// The arguments, validated against the tool's input schema before use.
+    pub args: serde_json::Value,
+}
+
+impl ToolCall {
+    /// A tool call.
+    pub fn new(id: impl Into<String>, tool_id: impl Into<String>, args: serde_json::Value) -> Self {
+        Self {
+            id: id.into(),
+            tool_id: tool_id.into(),
+            args,
+        }
+    }
+}
+
+/// The result of a tool invocation, validated before crossing a boundary.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct ToolResult {
+    /// The id of the [`ToolCall`] this answers.
+    pub call_id: String,
+    /// The typed output payload.
+    pub output: serde_json::Value,
+    /// Whether the tool reported an error.
+    #[serde(default)]
+    pub is_error: bool,
+}
+
+impl ToolResult {
+    /// A successful tool result.
+    pub fn ok(call_id: impl Into<String>, output: serde_json::Value) -> Self {
+        Self {
+            call_id: call_id.into(),
+            output,
+            is_error: false,
+        }
+    }
+
+    /// A failed tool result carrying an error payload.
+    pub fn error(call_id: impl Into<String>, output: serde_json::Value) -> Self {
+        Self {
+            call_id: call_id.into(),
+            output,
+            is_error: true,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn descriptor_defaults_read_only_and_round_trips() {
+        let tool = ToolDescriptor::new("search_docs", "Search project docs")
+            .with_input(SchemaRef::named("SearchDocs"))
+            .with_output(SchemaRef::named("Vec<SearchHit>"));
+        assert_eq!(tool.side_effect, ToolSideEffectPolicy::ReadOnly);
+        let back: ToolDescriptor =
+            serde_json::from_str(&serde_json::to_string(&tool).unwrap()).unwrap();
+        assert_eq!(tool, back);
+    }
+
+    #[test]
+    fn side_effecting_builder_flips_policy() {
+        let tool = ToolDescriptor::new("delete_doc", "Delete a doc").side_effecting();
+        assert_eq!(tool.side_effect, ToolSideEffectPolicy::SideEffecting);
+    }
+
+    #[test]
+    fn call_and_result_correlate_by_id() {
+        let call = ToolCall::new("c1", "search_docs", serde_json::json!({"query": "x"}));
+        let result = ToolResult::ok(&call.id, serde_json::json!([]));
+        assert_eq!(result.call_id, call.id);
+        assert!(!result.is_error);
+    }
+}

--- a/crates/pocopine-agenkit-core/src/trace.rs
+++ b/crates/pocopine-agenkit-core/src/trace.rs
@@ -1,0 +1,340 @@
+//! Neutral trace payloads (RFC-093 Phase 1.4, §D12, §D15 DC-1/DC-1a).
+//!
+//! Core defines these provider-neutral structures; the facade maps them onto
+//! `pocopine_observe::ObservedEvent` + `emit_tracing`, so this crate never
+//! depends on `pocopine-observe`. Because observe has no span hierarchy, the
+//! parent/child shape is carried by explicit `step_id` / `parent_step_id` /
+//! `parallel_group_id` fields (§D15 DC-1a).
+
+use std::collections::BTreeMap;
+
+use crate::{
+    AgenkitError, ModelRef, ParallelGroupId, RunId, StepId, StepKind, StepStatus, TraceId,
+};
+
+/// Token usage for a model call or an aggregate.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct Usage {
+    /// Prompt/input tokens.
+    pub input_tokens: u64,
+    /// Completion/output tokens.
+    pub output_tokens: u64,
+}
+
+impl Usage {
+    /// Usage from input/output token counts.
+    pub fn new(input_tokens: u64, output_tokens: u64) -> Self {
+        Self {
+            input_tokens,
+            output_tokens,
+        }
+    }
+
+    /// Total tokens (input + output).
+    pub fn total(&self) -> u64 {
+        self.input_tokens.saturating_add(self.output_tokens)
+    }
+
+    /// Sum two usage records.
+    pub fn merge(self, other: Self) -> Self {
+        Self {
+            input_tokens: self.input_tokens.saturating_add(other.input_tokens),
+            output_tokens: self.output_tokens.saturating_add(other.output_tokens),
+        }
+    }
+}
+
+/// An estimated monetary cost for a call or aggregate.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct CostEstimate {
+    /// ISO 4217 currency code (e.g. `"USD"`).
+    pub currency: String,
+    /// The estimated amount in `currency`.
+    pub amount: f64,
+}
+
+impl CostEstimate {
+    /// A cost estimate.
+    pub fn new(currency: impl Into<String>, amount: f64) -> Self {
+        Self {
+            currency: currency.into(),
+            amount,
+        }
+    }
+}
+
+/// A single neutral trace event. The facade translates it to an
+/// `ObservedEvent` with the matching event-name constant and `pocopine.trace`
+/// target.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct TraceEvent {
+    /// Stable event name (see [`crate::events`]).
+    pub name: String,
+    /// The run this event belongs to.
+    pub run_id: RunId,
+    /// The correlation id shared by every event in one run tree.
+    pub trace_id: TraceId,
+    /// The step this event describes, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub step_id: Option<StepId>,
+    /// The parent step, conveying tree structure (§D15 DC-1a).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_step_id: Option<StepId>,
+    /// The parallel group this step belongs to, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parallel_group_id: Option<ParallelGroupId>,
+    /// What kind of work the step performs.
+    pub kind: StepKind,
+    /// The step's lifecycle status.
+    pub status: StepStatus,
+    /// The model alias involved, if this is a model event.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<ModelRef>,
+    /// Redacted, privacy-safe metadata fields (ids, counts, durations).
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub fields: BTreeMap<String, serde_json::Value>,
+    /// Token usage, when available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub usage: Option<Usage>,
+    /// Cost estimate, when available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cost: Option<CostEstimate>,
+    /// The error, for failure events.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<AgenkitError>,
+    /// The context-manifest version of the flow, when available.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub manifest_version: Option<String>,
+}
+
+impl TraceEvent {
+    /// A new event with the required correlation fields.
+    pub fn new(
+        name: impl Into<String>,
+        run_id: RunId,
+        trace_id: TraceId,
+        kind: StepKind,
+        status: StepStatus,
+    ) -> Self {
+        Self {
+            name: name.into(),
+            run_id,
+            trace_id,
+            step_id: None,
+            parent_step_id: None,
+            parallel_group_id: None,
+            kind,
+            status,
+            model: None,
+            fields: BTreeMap::new(),
+            usage: None,
+            cost: None,
+            error: None,
+            manifest_version: None,
+        }
+    }
+
+    /// Set the step id.
+    pub fn with_step(mut self, step_id: StepId) -> Self {
+        self.step_id = Some(step_id);
+        self
+    }
+
+    /// Set the parent step id.
+    pub fn with_parent(mut self, parent_step_id: StepId) -> Self {
+        self.parent_step_id = Some(parent_step_id);
+        self
+    }
+
+    /// Set the parallel group id.
+    pub fn with_parallel_group(mut self, group: ParallelGroupId) -> Self {
+        self.parallel_group_id = Some(group);
+        self
+    }
+
+    /// Set the model alias.
+    pub fn with_model(mut self, model: ModelRef) -> Self {
+        self.model = Some(model);
+        self
+    }
+
+    /// Attach a redacted metadata field.
+    pub fn with_field(
+        mut self,
+        key: impl Into<String>,
+        value: impl Into<serde_json::Value>,
+    ) -> Self {
+        self.fields.insert(key.into(), value.into());
+        self
+    }
+
+    /// Attach token usage.
+    pub fn with_usage(mut self, usage: Usage) -> Self {
+        self.usage = Some(usage);
+        self
+    }
+
+    /// Attach an error.
+    pub fn with_error(mut self, error: AgenkitError) -> Self {
+        self.error = Some(error);
+        self
+    }
+
+    /// Attach the context-manifest version.
+    pub fn with_manifest_version(mut self, version: impl Into<String>) -> Self {
+        self.manifest_version = Some(version.into());
+        self
+    }
+}
+
+/// A structural node in a trace tree, used for replay and assembling a flow's
+/// step hierarchy from emitted events.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct TraceSpan {
+    /// This step's id.
+    pub step_id: StepId,
+    /// The parent step, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent_step_id: Option<StepId>,
+    /// The parallel group this step belongs to, if any.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parallel_group_id: Option<ParallelGroupId>,
+    /// What kind of work the step performs.
+    pub kind: StepKind,
+    /// A human-readable step name.
+    pub name: String,
+    /// The step's final status.
+    pub status: StepStatus,
+    /// Wall-clock duration, if measured.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
+    /// Nested child spans.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub children: Vec<TraceSpan>,
+}
+
+impl TraceSpan {
+    /// A new leaf span.
+    pub fn new(
+        step_id: StepId,
+        kind: StepKind,
+        name: impl Into<String>,
+        status: StepStatus,
+    ) -> Self {
+        Self {
+            step_id,
+            parent_step_id: None,
+            parallel_group_id: None,
+            kind,
+            name: name.into(),
+            status,
+            duration_ms: None,
+            children: Vec::new(),
+        }
+    }
+
+    /// Set the parent step id.
+    pub fn with_parent(mut self, parent: StepId) -> Self {
+        self.parent_step_id = Some(parent);
+        self
+    }
+
+    /// Set the parallel group id.
+    pub fn with_parallel_group(mut self, group: ParallelGroupId) -> Self {
+        self.parallel_group_id = Some(group);
+        self
+    }
+
+    /// Append a child span.
+    pub fn push_child(mut self, child: TraceSpan) -> Self {
+        self.children.push(child);
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn usage_totals_and_merges() {
+        let a = Usage::new(10, 5);
+        let b = Usage::new(3, 7);
+        assert_eq!(a.total(), 15);
+        assert_eq!(a.merge(b), Usage::new(13, 12));
+    }
+
+    /// Exit-gate proof: a nested-parallel trace tree round-trips with the
+    /// structural fields intact and no secret fields present (§D15 DC-1a).
+    #[test]
+    fn nested_parallel_trace_tree_round_trips() {
+        let group = ParallelGroupId::new("candidate_answers");
+        let root = TraceSpan::new(
+            StepId::new("flow"),
+            StepKind::Custom,
+            "answer_with_review",
+            StepStatus::Completed,
+        )
+        .push_child(
+            TraceSpan::new(
+                StepId::new("p"),
+                StepKind::Parallel,
+                "candidate_answers",
+                StepStatus::Completed,
+            )
+            .push_child(
+                TraceSpan::new(
+                    StepId::new("b1"),
+                    StepKind::Agent,
+                    "fast_researcher",
+                    StepStatus::Completed,
+                )
+                .with_parent(StepId::new("p"))
+                .with_parallel_group(group.clone()),
+            )
+            .push_child(
+                TraceSpan::new(
+                    StepId::new("b2"),
+                    StepKind::Agent,
+                    "strict_reviewer",
+                    StepStatus::Completed,
+                )
+                .with_parent(StepId::new("p"))
+                .with_parallel_group(group.clone()),
+            )
+            .push_child(
+                TraceSpan::new(
+                    StepId::new("b3"),
+                    StepKind::Agent,
+                    "docs_first",
+                    StepStatus::Completed,
+                )
+                .with_parent(StepId::new("p"))
+                .with_parallel_group(group.clone()),
+            ),
+        )
+        .push_child(TraceSpan::new(
+            StepId::new("r"),
+            StepKind::Reducer,
+            "judge_and_merge",
+            StepStatus::Completed,
+        ));
+
+        let json = serde_json::to_string(&root).unwrap();
+        let back: TraceSpan = serde_json::from_str(&json).unwrap();
+        assert_eq!(root, back);
+
+        // The three parallel branches share one group id and point at parent `p`.
+        let parallel = &back.children[0];
+        assert_eq!(parallel.children.len(), 3);
+        for branch in &parallel.children {
+            assert_eq!(branch.parent_step_id.as_ref().unwrap().as_str(), "p");
+            assert_eq!(branch.parallel_group_id.as_ref().unwrap(), &group);
+        }
+
+        let lower = json.to_lowercase();
+        for needle in ["api_key", "authorization", "secret", "bearer", "password"] {
+            assert!(!lower.contains(needle), "trace tree leaked {needle:?}");
+        }
+    }
+}

--- a/crates/pocopine-agenkit-core/tests/no_secrets.rs
+++ b/crates/pocopine-agenkit-core/tests/no_secrets.rs
@@ -1,0 +1,75 @@
+//! Invariant: client-safe contract payloads never carry credential-shaped
+//! fields (RFC-093 §D10). This is the seed of the Phase 3 secret-boundary
+//! suite — it runs against the descriptor/payload types as they are added.
+
+use pocopine_agenkit_core::{
+    Content, EmbedderDescriptor, ModelRef, RetrievalHit, RetrievalQuery, RetrievalSet,
+    RetrieverDescriptor, SchemaRef, SourceRef, ToolCall, ToolDescriptor, ToolResult,
+};
+
+/// Substrings that must never appear as field names in a serialized payload.
+const FORBIDDEN: &[&str] = &[
+    "api_key",
+    "apikey",
+    "authorization",
+    "secret",
+    "bearer",
+    "password",
+    "access_token",
+    "refresh_token",
+    "private_key",
+    "credential",
+];
+
+fn assert_no_secret_fields(label: &str, json: &str) {
+    let lower = json.to_lowercase();
+    for needle in FORBIDDEN {
+        assert!(
+            !lower.contains(needle),
+            "{label} serialized payload contains forbidden substring {needle:?}: {json}"
+        );
+    }
+}
+
+#[test]
+fn capability_descriptors_have_no_credential_fields() {
+    let tool = ToolDescriptor::new("search_docs", "Search project docs")
+        .with_input(SchemaRef::named("SearchDocs"))
+        .with_output(SchemaRef::named("Vec<SearchHit>"))
+        .side_effecting();
+    assert_no_secret_fields("ToolDescriptor", &serde_json::to_string(&tool).unwrap());
+
+    let retriever = RetrieverDescriptor::new("project_docs", "Search docs")
+        .with_source_kinds(["doc"])
+        .requires_auth();
+    assert_no_secret_fields(
+        "RetrieverDescriptor",
+        &serde_json::to_string(&retriever).unwrap(),
+    );
+
+    let embedder = EmbedderDescriptor::new("local", ModelRef::new("local/embed"), 384);
+    assert_no_secret_fields(
+        "EmbedderDescriptor",
+        &serde_json::to_string(&embedder).unwrap(),
+    );
+}
+
+#[test]
+fn call_result_and_hits_have_no_credential_fields() {
+    let call = ToolCall::new("c1", "search_docs", serde_json::json!({"query": "uploads"}));
+    assert_no_secret_fields("ToolCall", &serde_json::to_string(&call).unwrap());
+
+    let result = ToolResult::ok("c1", serde_json::json!([{"title": "Uploads"}]));
+    assert_no_secret_fields("ToolResult", &serde_json::to_string(&result).unwrap());
+
+    let query = RetrievalQuery::new("uploads").top_k(5);
+    assert_no_secret_fields("RetrievalQuery", &serde_json::to_string(&query).unwrap());
+
+    let set = RetrievalSet::new(vec![RetrievalHit {
+        source: SourceRef::new("doc", "uploads.md"),
+        score: Some(0.9),
+        content: Content::text("uploads use presigned URLs"),
+        citation: None,
+    }]);
+    assert_no_secret_fields("RetrievalSet", &serde_json::to_string(&set).unwrap());
+}

--- a/crates/pocopine-agenkit-oai/Cargo.toml
+++ b/crates/pocopine-agenkit-oai/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "pocopine-agenkit-oai"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "OpenAI-compatible provider for Pocopine Agenkit. Implements the Agenkit Provider trait against any /v1/chat/completions endpoint (OpenAI, OpenRouter, Together, Groq, Ollama, vLLM, ...). Server-only credentials."
+
+# Host-only: depends on the host-side pocopine-agenkit runtime + reqwest, which
+# do not build for wasm32. The browser never calls a provider directly (§D10).
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+pocopine-agenkit = { workspace = true }
+pocopine-agenkit-core = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+# `stream` for SSE streaming (response.bytes_stream()).
+reqwest = { version = "0.12", default-features = false, features = [
+    "json",
+    "stream",
+    "rustls-tls-webpki-roots",
+] }
+futures = "0.3"
+# Stream the SSE response off a spawned reader task.
+tokio = { version = "1", features = ["rt", "sync"] }
+tokio-stream = "0.1"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
+wiremock = "0.6"
+# A structured-output type for the partial-object streaming test.
+schemars = "0.8"

--- a/crates/pocopine-agenkit-oai/src/lib.rs
+++ b/crates/pocopine-agenkit-oai/src/lib.rs
@@ -1,0 +1,426 @@
+//! OpenAI-compatible provider for [Pocopine Agenkit](../../rfcs/rfc-093-pocopine-agenkit.md).
+//!
+//! Implements the Agenkit `Provider` trait against any
+//! `/v1/chat/completions` endpoint — OpenAI itself, or compatible gateways
+//! (OpenRouter, Together, Groq, Fireworks, Ollama, vLLM, LM Studio, ...) — by
+//! pointing [`OpenAiProvider::with_base_url`] at the target.
+//!
+//! ```no_run
+//! use pocopine_agenkit::server::Agenkit;
+//! use pocopine_agenkit_oai::OpenAiProvider;
+//! use pocopine_agenkit_core::ModelRef;
+//!
+//! let agenkit = Agenkit::builder()
+//!     // Credentials are read from OPENAI_API_KEY — server-only (§D10).
+//!     .provider(OpenAiProvider::from_env("openai").expect("OPENAI_API_KEY"))
+//!     .default_model(ModelRef::new("openai/gpt-4o-mini"))
+//!     .build()
+//!     .unwrap();
+//! # let _ = agenkit;
+//! ```
+//!
+//! Supports the full Agenkit contract: text + native **SSE streaming**,
+//! schema-constrained **structured output** (strict `json_schema`), function
+//! tools, and usage. Provider credentials live only in the `Authorization`
+//! header and are never echoed in errors (§D10).
+#![cfg(not(target_arch = "wasm32"))]
+#![forbid(unsafe_code)]
+
+mod wire;
+
+use std::collections::BTreeMap;
+
+use futures::StreamExt;
+use pocopine_agenkit::server::{
+    BoxFuture, BoxStream, GenerateRequest, GenerateResponse, Provider, ProviderCapabilities,
+    StreamChunk,
+};
+use pocopine_agenkit_core::{AgenkitError, AgenkitResult, ToolCall};
+use serde::Deserialize;
+use tokio::sync::mpsc::UnboundedSender;
+use tokio_stream::wrappers::UnboundedReceiverStream;
+
+use wire::{ChatRequest, ChatResponse, StreamEvent};
+
+/// The default OpenAI API base URL.
+pub const DEFAULT_BASE_URL: &str = "https://api.openai.com/v1";
+
+/// A provider backed by an OpenAI-compatible `/v1/chat/completions` endpoint.
+#[derive(Clone)]
+pub struct OpenAiProvider {
+    alias: String,
+    api_key: String,
+    base_url: String,
+    organization: Option<String>,
+    /// Use native strict `json_schema` structured output (vs `json_object`).
+    strict_schema: bool,
+    http: reqwest::Client,
+}
+
+impl OpenAiProvider {
+    /// A provider serving `alias`, authenticating with `api_key`, against the
+    /// default OpenAI base URL.
+    pub fn new(alias: impl Into<String>, api_key: impl Into<String>) -> Self {
+        Self {
+            alias: alias.into(),
+            api_key: api_key.into(),
+            base_url: DEFAULT_BASE_URL.to_string(),
+            organization: None,
+            strict_schema: true,
+            // A connect timeout only: an unreachable endpoint fails fast, but
+            // a long-lived SSE stream is never cut by a total-request timeout.
+            // Use `with_http_client` for finer control.
+            http: reqwest::Client::builder()
+                .connect_timeout(std::time::Duration::from_secs(15))
+                .build()
+                .unwrap_or_default(),
+        }
+    }
+
+    /// Build from the environment: `OPENAI_API_KEY` (required) and optionally
+    /// `OPENAI_BASE_URL`. Credentials never enter app code or client bundles.
+    pub fn from_env(alias: impl Into<String>) -> AgenkitResult<Self> {
+        let api_key = std::env::var("OPENAI_API_KEY")
+            .map_err(|_| AgenkitError::config("OPENAI_API_KEY is not set"))?;
+        let mut provider = Self::new(alias, api_key);
+        if let Ok(base_url) = std::env::var("OPENAI_BASE_URL") {
+            provider.base_url = base_url;
+        }
+        Ok(provider)
+    }
+
+    /// Point at a compatible endpoint (e.g. `https://openrouter.ai/api/v1`).
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = base_url.into();
+        self
+    }
+
+    /// Set the `OpenAI-Organization` header.
+    pub fn with_organization(mut self, organization: impl Into<String>) -> Self {
+        self.organization = Some(organization.into());
+        self
+    }
+
+    /// Toggle native strict `json_schema` structured output. Disable for
+    /// endpoints/models that don't support it (falls back to `json_object`).
+    pub fn with_strict_schema(mut self, strict: bool) -> Self {
+        self.strict_schema = strict;
+        self
+    }
+
+    /// Use a pre-configured `reqwest::Client` (timeouts, proxy, ...).
+    pub fn with_http_client(mut self, http: reqwest::Client) -> Self {
+        self.http = http;
+        self
+    }
+
+    fn endpoint(&self) -> String {
+        format!("{}/chat/completions", self.base_url.trim_end_matches('/'))
+    }
+
+    fn post(&self, wire: &ChatRequest) -> reqwest::RequestBuilder {
+        let mut builder = self
+            .http
+            .post(self.endpoint())
+            .bearer_auth(&self.api_key)
+            .json(wire);
+        if let Some(organization) = &self.organization {
+            builder = builder.header("OpenAI-Organization", organization);
+        }
+        builder
+    }
+
+    async fn chat(&self, request: GenerateRequest) -> AgenkitResult<GenerateResponse> {
+        let wire = ChatRequest::from_agenkit(&request, false, self.strict_schema);
+        let response = self
+            .post(&wire)
+            .send()
+            .await
+            .map_err(|err| AgenkitError::provider(format!("request failed: {err}")))?;
+        let status = response.status();
+        let body = response.text().await.map_err(|err| {
+            AgenkitError::provider(format!("reading response body failed: {err}"))
+        })?;
+        if !status.is_success() {
+            return Err(AgenkitError::provider(openai_error_message(
+                status.as_u16(),
+                &body,
+            )));
+        }
+        serde_json::from_str::<ChatResponse>(&body)
+            .map_err(|err| AgenkitError::provider(format!("invalid response shape: {err}")))?
+            .into_agenkit()
+    }
+
+    /// Read the SSE stream into `tx`, forwarding text deltas and accumulating
+    /// tool-call fragments by index.
+    async fn stream_into(
+        &self,
+        request: GenerateRequest,
+        tx: UnboundedSender<AgenkitResult<StreamChunk>>,
+    ) -> AgenkitResult<()> {
+        let wire = ChatRequest::from_agenkit(&request, true, self.strict_schema);
+        let response = self
+            .post(&wire)
+            .send()
+            .await
+            .map_err(|err| AgenkitError::provider(format!("request failed: {err}")))?;
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            return Err(AgenkitError::provider(openai_error_message(
+                status.as_u16(),
+                &body,
+            )));
+        }
+
+        // Buffer raw bytes and only decode whole `\n`-terminated lines. `\n`
+        // (0x0A) never appears inside a multi-byte UTF-8 sequence, so a line cut
+        // at a newline is always valid UTF-8 — decoding per network chunk with
+        // `from_utf8_lossy` would instead corrupt any codepoint split across two
+        // chunks into replacement characters.
+        let mut bytes = response.bytes_stream();
+        let mut buffer: Vec<u8> = Vec::new();
+        let mut tools: BTreeMap<u32, ToolAccumulator> = BTreeMap::new();
+
+        while let Some(chunk) = bytes.next().await {
+            let chunk = chunk
+                .map_err(|err| AgenkitError::provider(format!("stream read failed: {err}")))?;
+            buffer.extend_from_slice(&chunk);
+
+            while let Some(newline) = buffer.iter().position(|&b| b == b'\n') {
+                let done = apply_sse_line(&buffer[..newline], &mut tools, &tx);
+                buffer.drain(..=newline);
+                if done {
+                    emit_tool_calls(tools, &tx);
+                    return Ok(());
+                }
+            }
+        }
+
+        // Flush a final line that arrived without a trailing newline (a gateway
+        // that closes the body right after the last `data:` and omits `[DONE]`).
+        if !buffer.is_empty() {
+            apply_sse_line(&buffer, &mut tools, &tx);
+        }
+        emit_tool_calls(tools, &tx);
+        Ok(())
+    }
+}
+
+/// Parse one SSE line and apply it to the accumulators. Returns `true` when the
+/// terminal `data: [DONE]` sentinel was seen. Keep-alive/comment/undecodable
+/// lines are ignored.
+fn apply_sse_line(
+    line: &[u8],
+    tools: &mut BTreeMap<u32, ToolAccumulator>,
+    tx: &UnboundedSender<AgenkitResult<StreamChunk>>,
+) -> bool {
+    let Ok(text) = std::str::from_utf8(line) else {
+        return false;
+    };
+    let Some(data) = text.trim().strip_prefix("data:") else {
+        return false;
+    };
+    let data = data.trim();
+    if data.is_empty() {
+        return false;
+    }
+    if data == "[DONE]" {
+        return true;
+    }
+    // Ignore unparseable keep-alive / comment lines.
+    let Ok(event) = serde_json::from_str::<StreamEvent>(data) else {
+        return false;
+    };
+    for choice in event.choices {
+        if let Some(content) = choice.delta.content
+            && !content.is_empty()
+        {
+            let _ = tx.send(Ok(StreamChunk::Text(content)));
+        }
+        for delta in choice.delta.tool_calls {
+            let acc = tools.entry(delta.index).or_default();
+            if let Some(id) = delta.id {
+                acc.id = id;
+            }
+            if let Some(function) = delta.function {
+                if let Some(name) = function.name {
+                    acc.name = name;
+                }
+                if let Some(arguments) = function.arguments {
+                    acc.arguments.push_str(&arguments);
+                }
+            }
+        }
+    }
+    if let Some(usage) = event.usage {
+        let _ = tx.send(Ok(StreamChunk::Usage(usage.into_usage())));
+    }
+    false
+}
+
+impl Provider for OpenAiProvider {
+    fn id(&self) -> &str {
+        &self.alias
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities::all()
+    }
+
+    fn generate<'a>(
+        &'a self,
+        request: GenerateRequest,
+    ) -> BoxFuture<'a, AgenkitResult<GenerateResponse>> {
+        Box::pin(self.chat(request))
+    }
+
+    fn generate_stream<'a>(
+        &'a self,
+        request: GenerateRequest,
+    ) -> BoxStream<'a, AgenkitResult<StreamChunk>> {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let provider = self.clone();
+        let forward = tx.clone();
+        tokio::spawn(async move {
+            if let Err(error) = provider.stream_into(request, forward.clone()).await {
+                let _ = forward.send(Err(error));
+            }
+        });
+        Box::pin(UnboundedReceiverStream::new(rx))
+    }
+}
+
+#[derive(Default)]
+struct ToolAccumulator {
+    id: String,
+    name: String,
+    arguments: String,
+}
+
+fn emit_tool_calls(
+    tools: BTreeMap<u32, ToolAccumulator>,
+    tx: &UnboundedSender<AgenkitResult<StreamChunk>>,
+) {
+    for (_, acc) in tools {
+        // Empty (zero-argument tool) or truncated args default to `{}`, not
+        // `null` — a struct-typed tool input deserializes from `{}` but not from
+        // `null`, so `null` would turn a valid no-arg call into a cryptic
+        // "expected object" validation error downstream.
+        let args = if acc.arguments.trim().is_empty() {
+            serde_json::json!({})
+        } else {
+            serde_json::from_str(&acc.arguments).unwrap_or_else(|_| serde_json::json!({}))
+        };
+        let _ = tx.send(Ok(StreamChunk::ToolCall(ToolCall::new(
+            acc.id, acc.name, args,
+        ))));
+    }
+}
+
+/// Build a client-safe error string from an OpenAI error body. Deliberately
+/// surfaces only the stable status/type — never the free-form message, which
+/// can echo a masked key on a 401 (§D10).
+fn openai_error_message(status: u16, body: &str) -> String {
+    #[derive(Deserialize)]
+    struct ErrorBody {
+        error: ErrorDetail,
+    }
+    #[derive(Deserialize)]
+    struct ErrorDetail {
+        #[serde(rename = "type", default)]
+        kind: Option<String>,
+    }
+
+    match serde_json::from_str::<ErrorBody>(body) {
+        Ok(parsed) => format!(
+            "OpenAI API error {status} (type={})",
+            parsed.error.kind.as_deref().unwrap_or("unknown")
+        ),
+        Err(_) => format!("OpenAI API error {status}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_body_does_not_echo_the_message() {
+        let body = r#"{"error":{"message":"Incorrect API key provided: sk-proj-LEAK","type":"invalid_request_error","code":"invalid_api_key"}}"#;
+        let rendered = openai_error_message(401, body);
+        assert!(rendered.contains("type=invalid_request_error"));
+        assert!(!rendered.contains("sk-proj-LEAK"));
+    }
+
+    fn drain_text(
+        rx: &mut tokio::sync::mpsc::UnboundedReceiver<AgenkitResult<StreamChunk>>,
+    ) -> String {
+        let mut text = String::new();
+        while let Ok(Ok(StreamChunk::Text(fragment))) = rx.try_recv() {
+            text.push_str(&fragment);
+        }
+        text
+    }
+
+    #[test]
+    fn buffered_lines_reassemble_a_codepoint_split_across_chunks() {
+        // Two SSE `data:` events whose JSON content carries multi-byte chars
+        // ("café", "naïve 🚀"), fed as a byte stream that is re-sliced at
+        // arbitrary boundaries — including in the middle of a multi-byte char.
+        let sse = concat!(
+            "data: {\"choices\":[{\"delta\":{\"content\":\"café \"}}]}\n",
+            "data: {\"choices\":[{\"delta\":{\"content\":\"naïve 🚀\"}}]}\n",
+            "data: [DONE]\n",
+        )
+        .as_bytes();
+
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut tools = BTreeMap::new();
+        let mut buffer: Vec<u8> = Vec::new();
+        // Drive the exact buffering loop from `stream_into`, chunking every 3
+        // bytes so multi-byte sequences straddle chunk boundaries.
+        let mut done = false;
+        for chunk in sse.chunks(3) {
+            buffer.extend_from_slice(chunk);
+            while let Some(newline) = buffer.iter().position(|&b| b == b'\n') {
+                if apply_sse_line(&buffer[..newline], &mut tools, &tx) {
+                    done = true;
+                }
+                buffer.drain(..=newline);
+            }
+        }
+        assert!(done, "should have seen [DONE]");
+        assert_eq!(drain_text(&mut rx), "café naïve 🚀");
+    }
+
+    #[test]
+    fn trailing_line_without_newline_is_flushed() {
+        // A final `data:` event with no terminating newline and no `[DONE]`.
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut tools = BTreeMap::new();
+        let line = br#"data: {"choices":[{"delta":{"content":"last"}}]}"#;
+        apply_sse_line(line, &mut tools, &tx);
+        assert_eq!(drain_text(&mut rx), "last");
+    }
+
+    #[test]
+    fn empty_tool_arguments_default_to_object_not_null() {
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut tools = BTreeMap::new();
+        tools.insert(
+            0,
+            ToolAccumulator {
+                id: "call_1".to_string(),
+                name: "now".to_string(),
+                arguments: String::new(), // a zero-argument tool call
+            },
+        );
+        emit_tool_calls(tools, &tx);
+        let Ok(StreamChunk::ToolCall(call)) = rx.try_recv().unwrap() else {
+            panic!("expected a tool call");
+        };
+        assert_eq!(call.args, serde_json::json!({}));
+    }
+}

--- a/crates/pocopine-agenkit-oai/src/wire.rs
+++ b/crates/pocopine-agenkit-oai/src/wire.rs
@@ -1,0 +1,664 @@
+//! OpenAI Chat Completions wire types and the mapping to/from Agenkit's
+//! neutral request/response.
+
+use pocopine_agenkit::server::{FinishReason, GenerateRequest, GenerateResponse};
+use pocopine_agenkit_core::{AgenkitError, AgenkitResult, Content, Message, Role, ToolCall, Usage};
+use serde::{Deserialize, Serialize};
+
+// ---- request ----------------------------------------------------------------
+
+#[derive(Serialize)]
+pub(crate) struct ChatRequest {
+    pub(crate) model: String,
+    pub(crate) messages: Vec<WireMessage>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(crate) tools: Vec<WireTool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) response_format: Option<ResponseFormat>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) max_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) stream: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) stream_options: Option<StreamOptions>,
+}
+
+#[derive(Serialize)]
+pub(crate) struct StreamOptions {
+    pub(crate) include_usage: bool,
+}
+
+impl ChatRequest {
+    /// Map a neutral request. `stream` toggles SSE; `strict_schema` selects
+    /// native `json_schema` structured output (vs `json_object`).
+    pub(crate) fn from_agenkit(
+        request: &GenerateRequest,
+        stream: bool,
+        strict_schema: bool,
+    ) -> Self {
+        let structured = request.json_schema.is_some();
+
+        let mut messages = Vec::new();
+        // `json_object` mode requires the word "json" in the conversation, so
+        // fold a structured instruction into the system turn either way.
+        let mut system = request.system.clone();
+        if structured {
+            let note = "Respond with a single valid JSON object.";
+            system = Some(match system {
+                Some(existing) => format!("{existing}\n{note}"),
+                None => note.to_string(),
+            });
+        }
+        if let Some(system) = system {
+            messages.push(WireMessage::text("system", system));
+        }
+        messages.extend(request.messages.iter().map(WireMessage::from_message));
+
+        let has_tools = !request.tools.is_empty();
+        Self {
+            model: request.model.model().to_string(),
+            messages,
+            tools: request
+                .tools
+                .iter()
+                .map(WireTool::from_descriptor)
+                .collect(),
+            response_format: response_format(
+                request.json_schema.as_ref(),
+                strict_schema,
+                has_tools,
+            ),
+            max_tokens: request.max_tokens,
+            stream: stream.then_some(true),
+            stream_options: stream.then_some(StreamOptions {
+                include_usage: true,
+            }),
+        }
+    }
+}
+
+fn response_format(
+    schema: Option<&serde_json::Value>,
+    strict_schema: bool,
+    has_tools: bool,
+) -> Option<ResponseFormat> {
+    let schema = schema?;
+    // Native strict `json_schema` only when asked, the schema is one OpenAI's
+    // strict subset can express, AND no tools are offered — strict structured
+    // output forces the model to emit the schema, which suppresses tool calls
+    // (the agent loop sends both). In every other case fall back to JSON-object
+    // mode (the model still returns a JSON object; the runtime validates it).
+    if strict_schema && !has_tools && is_strict_compatible(schema) {
+        let mut strict = schema.clone();
+        make_strict(&mut strict);
+        Some(ResponseFormat::JsonSchema {
+            json_schema: JsonSchemaSpec {
+                name: "agenkit_output".to_string(),
+                strict: true,
+                schema: strict,
+            },
+        })
+    } else {
+        Some(ResponseFormat::JsonObject)
+    }
+}
+
+/// Whether a derived schema is one OpenAI strict `json_schema` mode can express:
+/// a concrete root object (not a bare `$ref`/marker) with no
+/// strict-incompatible construct anywhere. Anything else degrades to
+/// `json_object`.
+fn is_strict_compatible(schema: &serde_json::Value) -> bool {
+    schema.get("properties").is_some() && !contains_strict_incompatible(schema)
+}
+
+/// True if any node carries a construct OpenAI strict mode rejects with a hard
+/// 400: a schema-valued `additionalProperties` (an open map like
+/// `HashMap<String, T>`), an `allOf`/`oneOf` combinator (strict supports only
+/// `anyOf`), or a draft-07 `definitions` block (strict expects `$defs`).
+/// schemars 0.8 emits these routinely — a doc-commented nested field wraps its
+/// `$ref` in `allOf`, a data-carrying enum becomes `oneOf` — so they must
+/// degrade to `json_object` instead of failing the request at the provider.
+fn contains_strict_incompatible(schema: &serde_json::Value) -> bool {
+    match schema {
+        serde_json::Value::Object(map) => {
+            matches!(map.get("additionalProperties"), Some(v) if v.is_object())
+                || map.contains_key("allOf")
+                || map.contains_key("oneOf")
+                || map.contains_key("definitions")
+                || map.values().any(contains_strict_incompatible)
+        }
+        serde_json::Value::Array(items) => items.iter().any(contains_strict_incompatible),
+        _ => false,
+    }
+}
+
+/// Best-effort transform of a derived JSON Schema into OpenAI's strict subset:
+/// every object gets `additionalProperties: false` and *all* properties listed
+/// in `required` (strict mode requires this) — but a property that `schemars`
+/// left optional (an `Option<T>` field, absent from the original `required`) is
+/// made nullable so it can still be omitted in spirit. `$schema`/`format` (which
+/// strict mode rejects) are dropped. Applied recursively through `properties`,
+/// `$defs`, `items`, and `anyOf`/`allOf`/`oneOf`.
+pub(crate) fn make_strict(schema: &mut serde_json::Value) {
+    let serde_json::Value::Object(map) = schema else {
+        return;
+    };
+    map.remove("$schema");
+    map.remove("format");
+
+    if map.get("properties").map(|p| p.is_object()) == Some(true) {
+        // Capture which keys were optional before we overwrite `required`.
+        let originally_required: std::collections::HashSet<String> = map
+            .get("required")
+            .and_then(|r| r.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let Some(serde_json::Value::Object(properties)) = map.get_mut("properties") else {
+            unreachable!("checked is_object above");
+        };
+        let keys: Vec<serde_json::Value> = properties
+            .keys()
+            .cloned()
+            .map(serde_json::Value::String)
+            .collect();
+        for (key, value) in properties.iter_mut() {
+            make_strict(value);
+            if !originally_required.contains(key) {
+                make_nullable(value);
+            }
+        }
+        map.insert(
+            "additionalProperties".to_string(),
+            serde_json::Value::Bool(false),
+        );
+        map.insert("required".to_string(), serde_json::Value::Array(keys));
+    }
+    for defs_key in ["$defs", "definitions"] {
+        if let Some(serde_json::Value::Object(defs)) = map.get_mut(defs_key) {
+            for value in defs.values_mut() {
+                make_strict(value);
+            }
+        }
+    }
+    if let Some(items) = map.get_mut("items") {
+        make_strict(items);
+    }
+    for combinator in ["anyOf", "allOf", "oneOf"] {
+        if let Some(serde_json::Value::Array(variants)) = map.get_mut(combinator) {
+            for value in variants.iter_mut() {
+                make_strict(value);
+            }
+        }
+    }
+}
+
+/// Allow `null` for an (originally-optional) property's type, so a strict schema
+/// that lists it as `required` still lets the model omit it by emitting `null`.
+fn make_nullable(schema: &mut serde_json::Value) {
+    let serde_json::Value::Object(map) = schema else {
+        return;
+    };
+    match map.get_mut("type") {
+        Some(serde_json::Value::String(ty)) => {
+            if ty != "null" {
+                let ty = ty.clone();
+                map.insert(
+                    "type".to_string(),
+                    serde_json::Value::Array(vec![
+                        serde_json::Value::String(ty),
+                        serde_json::Value::String("null".to_string()),
+                    ]),
+                );
+            }
+        }
+        Some(serde_json::Value::Array(types)) => {
+            if !types.iter().any(|v| v == "null") {
+                types.push(serde_json::Value::String("null".to_string()));
+            }
+        }
+        // No scalar `type` (e.g. a `$ref` or `anyOf` optional): leave as-is —
+        // adding null would require rewriting the combinator; the field is still
+        // `required`, which is the strict-mode default.
+        _ => {}
+    }
+}
+
+#[derive(Serialize)]
+pub(crate) struct WireMessage {
+    pub(crate) role: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) content: Option<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(crate) tool_calls: Vec<WireToolCall>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) tool_call_id: Option<String>,
+}
+
+impl WireMessage {
+    pub(crate) fn text(role: &'static str, content: impl Into<String>) -> Self {
+        Self {
+            role,
+            content: Some(content.into()),
+            tool_calls: Vec::new(),
+            tool_call_id: None,
+        }
+    }
+
+    pub(crate) fn from_message(message: &Message) -> Self {
+        let role = match message.role {
+            Role::System => "system",
+            Role::User => "user",
+            Role::Assistant => "assistant",
+            Role::Tool => "tool",
+        };
+        let tool_calls = message
+            .tool_calls
+            .iter()
+            .map(WireToolCall::from_tool_call)
+            .collect();
+        let content = if message.content.is_empty() && !message.tool_calls.is_empty() {
+            None
+        } else {
+            Some(message.content.as_text())
+        };
+        Self {
+            role,
+            content,
+            tool_calls,
+            tool_call_id: message.tool_call_id.clone(),
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub(crate) struct WireToolCall {
+    pub(crate) id: String,
+    #[serde(rename = "type")]
+    pub(crate) kind: &'static str,
+    pub(crate) function: WireFunctionCall,
+}
+
+impl WireToolCall {
+    fn from_tool_call(call: &ToolCall) -> Self {
+        Self {
+            id: call.id.clone(),
+            kind: "function",
+            function: WireFunctionCall {
+                name: call.tool_id.clone(),
+                arguments: serde_json::to_string(&call.args).unwrap_or_else(|_| "{}".to_string()),
+            },
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub(crate) struct WireFunctionCall {
+    pub(crate) name: String,
+    pub(crate) arguments: String,
+}
+
+#[derive(Serialize)]
+pub(crate) struct WireTool {
+    #[serde(rename = "type")]
+    pub(crate) kind: &'static str,
+    pub(crate) function: WireFunctionDef,
+}
+
+impl WireTool {
+    fn from_descriptor(descriptor: &pocopine_agenkit_core::ToolDescriptor) -> Self {
+        let parameters = descriptor
+            .input
+            .json_schema
+            .clone()
+            .unwrap_or_else(|| serde_json::json!({ "type": "object" }));
+        Self {
+            kind: "function",
+            function: WireFunctionDef {
+                name: descriptor.id.clone(),
+                description: descriptor.description.clone(),
+                parameters,
+            },
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub(crate) struct WireFunctionDef {
+    pub(crate) name: String,
+    pub(crate) description: String,
+    pub(crate) parameters: serde_json::Value,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum ResponseFormat {
+    JsonObject,
+    JsonSchema { json_schema: JsonSchemaSpec },
+}
+
+#[derive(Serialize)]
+pub(crate) struct JsonSchemaSpec {
+    pub(crate) name: String,
+    pub(crate) strict: bool,
+    pub(crate) schema: serde_json::Value,
+}
+
+// ---- non-streaming response -------------------------------------------------
+
+#[derive(Deserialize)]
+pub(crate) struct ChatResponse {
+    #[serde(default)]
+    pub(crate) choices: Vec<Choice>,
+    #[serde(default)]
+    pub(crate) usage: Option<WireUsage>,
+}
+
+impl ChatResponse {
+    pub(crate) fn into_agenkit(self) -> AgenkitResult<GenerateResponse> {
+        let choice = self
+            .choices
+            .into_iter()
+            .next()
+            .ok_or_else(|| AgenkitError::provider("OpenAI response contained no choices"))?;
+
+        let content = Content::text(choice.message.content.unwrap_or_default());
+        let tool_calls = choice
+            .message
+            .tool_calls
+            .into_iter()
+            .map(ResponseToolCall::into_call)
+            .collect();
+        let finish_reason = finish_reason(choice.finish_reason.as_deref());
+        let usage = self.usage.map(WireUsage::into_usage);
+
+        Ok(GenerateResponse {
+            content,
+            tool_calls,
+            usage,
+            finish_reason,
+        })
+    }
+}
+
+#[derive(Deserialize)]
+pub(crate) struct Choice {
+    pub(crate) message: ChoiceMessage,
+    #[serde(default)]
+    pub(crate) finish_reason: Option<String>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct ChoiceMessage {
+    #[serde(default)]
+    pub(crate) content: Option<String>,
+    #[serde(default)]
+    pub(crate) tool_calls: Vec<ResponseToolCall>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct ResponseToolCall {
+    pub(crate) id: String,
+    pub(crate) function: ResponseFunction,
+}
+
+impl ResponseToolCall {
+    fn into_call(self) -> ToolCall {
+        let args =
+            serde_json::from_str(&self.function.arguments).unwrap_or(serde_json::Value::Null);
+        ToolCall::new(self.id, self.function.name, args)
+    }
+}
+
+#[derive(Deserialize)]
+pub(crate) struct ResponseFunction {
+    pub(crate) name: String,
+    pub(crate) arguments: String,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct WireUsage {
+    #[serde(default)]
+    pub(crate) prompt_tokens: u64,
+    #[serde(default)]
+    pub(crate) completion_tokens: u64,
+}
+
+impl WireUsage {
+    pub(crate) fn into_usage(self) -> Usage {
+        Usage::new(self.prompt_tokens, self.completion_tokens)
+    }
+}
+
+pub(crate) fn finish_reason(raw: Option<&str>) -> FinishReason {
+    match raw {
+        Some("length") => FinishReason::Length,
+        Some("tool_calls") => FinishReason::ToolCalls,
+        _ => FinishReason::Stop,
+    }
+}
+
+// ---- streaming response -----------------------------------------------------
+
+/// One SSE `data:` chunk from a streaming completion.
+#[derive(Deserialize)]
+pub(crate) struct StreamEvent {
+    #[serde(default)]
+    pub(crate) choices: Vec<StreamChoice>,
+    #[serde(default)]
+    pub(crate) usage: Option<WireUsage>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct StreamChoice {
+    #[serde(default)]
+    pub(crate) delta: StreamDelta,
+}
+
+#[derive(Deserialize, Default)]
+pub(crate) struct StreamDelta {
+    #[serde(default)]
+    pub(crate) content: Option<String>,
+    #[serde(default)]
+    pub(crate) tool_calls: Vec<StreamToolCallDelta>,
+}
+
+/// A partial tool call: `id`/`name` arrive once, `arguments` in fragments,
+/// correlated by `index`.
+#[derive(Deserialize)]
+pub(crate) struct StreamToolCallDelta {
+    #[serde(default)]
+    pub(crate) index: u32,
+    #[serde(default)]
+    pub(crate) id: Option<String>,
+    #[serde(default)]
+    pub(crate) function: Option<StreamFunctionDelta>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct StreamFunctionDelta {
+    #[serde(default)]
+    pub(crate) name: Option<String>,
+    #[serde(default)]
+    pub(crate) arguments: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn make_strict_locks_objects_down() {
+        let mut schema = serde_json::json!({
+            "$schema": "https://json-schema.org/draft-07/schema#",
+            "type": "object",
+            "properties": {
+                "title": {"type": "string"},
+                "count": {"type": "integer", "format": "uint32"}
+            }
+        });
+        make_strict(&mut schema);
+        assert_eq!(schema["additionalProperties"], serde_json::json!(false));
+        let required = schema["required"].as_array().unwrap();
+        assert_eq!(required.len(), 2);
+        assert!(required.contains(&serde_json::json!("title")));
+        assert!(required.contains(&serde_json::json!("count")));
+        assert!(schema.get("$schema").is_none());
+        assert!(schema["properties"]["count"].get("format").is_none());
+    }
+
+    #[test]
+    fn tool_descriptor_schema_becomes_function_parameters() {
+        use pocopine_agenkit_core::{SchemaRef, ToolDescriptor};
+        // The runtime derives this from the tool's `Input` type; it must land in
+        // the function's `parameters` so the model sees the argument shape.
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"]
+        });
+        let descriptor = ToolDescriptor::new("search_docs", "Search project docs")
+            .with_input(SchemaRef::named("SearchInput").with_json_schema(schema.clone()));
+
+        let wire = WireTool::from_descriptor(&descriptor);
+        assert_eq!(wire.function.name, "search_docs");
+        assert_eq!(wire.function.parameters, schema);
+    }
+
+    #[test]
+    fn tool_without_a_schema_falls_back_to_an_object() {
+        use pocopine_agenkit_core::ToolDescriptor;
+        let descriptor = ToolDescriptor::new("noop", "Does nothing");
+        let wire = WireTool::from_descriptor(&descriptor);
+        assert_eq!(
+            wire.function.parameters,
+            serde_json::json!({"type": "object"})
+        );
+    }
+
+    #[test]
+    fn real_schema_selects_json_schema_mode_only_when_strict() {
+        let schema = serde_json::json!({"type": "object", "properties": {"x": {"type": "string"}}});
+        assert!(matches!(
+            response_format(Some(&schema), true, false),
+            Some(ResponseFormat::JsonSchema { .. })
+        ));
+        assert!(matches!(
+            response_format(Some(&schema), false, false),
+            Some(ResponseFormat::JsonObject)
+        ));
+        // A marker schema (no properties) always uses json_object.
+        let marker = serde_json::json!({"type": "object"});
+        assert!(matches!(
+            response_format(Some(&marker), true, false),
+            Some(ResponseFormat::JsonObject)
+        ));
+    }
+
+    #[test]
+    fn tools_force_json_object_over_strict_schema() {
+        // Strict json_schema would suppress tool calling, so a request that
+        // carries tools degrades to json_object even with a real schema.
+        let schema = serde_json::json!({"type": "object", "properties": {"x": {"type": "string"}}});
+        assert!(matches!(
+            response_format(Some(&schema), true, true),
+            Some(ResponseFormat::JsonObject)
+        ));
+    }
+
+    #[test]
+    fn open_map_schema_falls_back_to_json_object() {
+        // A HashMap<String, u32> field -> open `additionalProperties`, which
+        // strict mode can't express; degrade instead of sending an invalid schema.
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "counts": {"type": "object", "additionalProperties": {"type": "integer"}}
+            }
+        });
+        assert!(matches!(
+            response_format(Some(&schema), true, false),
+            Some(ResponseFormat::JsonObject)
+        ));
+    }
+
+    #[test]
+    fn all_of_wrapped_ref_falls_back_to_json_object() {
+        // schemars 0.8 wraps a doc-commented nested struct field in
+        // `allOf: [{$ref}]`; strict mode rejects `allOf` with a 400, so the
+        // request must degrade instead.
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "nested": {
+                    "allOf": [{"$ref": "#/definitions/Nested"}],
+                    "description": "doc comment"
+                }
+            },
+            "definitions": {
+                "Nested": {"type": "object", "properties": {"x": {"type": "string"}}}
+            }
+        });
+        assert!(matches!(
+            response_format(Some(&schema), true, false),
+            Some(ResponseFormat::JsonObject)
+        ));
+    }
+
+    #[test]
+    fn one_of_enum_falls_back_to_json_object() {
+        // A data-carrying enum derives to `oneOf`, which strict mode rejects
+        // (only `anyOf` is supported); degrade instead of a provider 400.
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "kind": {"oneOf": [
+                    {"type": "object", "properties": {"a": {"type": "string"}}},
+                    {"type": "object", "properties": {"b": {"type": "integer"}}}
+                ]}
+            }
+        });
+        assert!(matches!(
+            response_format(Some(&schema), true, false),
+            Some(ResponseFormat::JsonObject)
+        ));
+    }
+
+    #[test]
+    fn ref_root_schema_falls_back_to_json_object() {
+        // A newtype/enum root serializes as a bare `$ref`; make_strict can't lock
+        // it, so it must degrade rather than send an under-constrained root.
+        let schema = serde_json::json!({"$ref": "#/$defs/T", "$defs": {"T": {"type": "string"}}});
+        assert!(matches!(
+            response_format(Some(&schema), true, false),
+            Some(ResponseFormat::JsonObject)
+        ));
+    }
+
+    #[test]
+    fn optional_fields_become_nullable_and_required() {
+        // schemars leaves an Option<T> field out of `required`; strict mode wants
+        // every field required, so it must be made nullable to stay omittable.
+        let mut schema = serde_json::json!({
+            "type": "object",
+            "properties": {
+                "title": {"type": "string"},
+                "note": {"type": "string"}
+            },
+            "required": ["title"]
+        });
+        make_strict(&mut schema);
+        let required = schema["required"].as_array().unwrap();
+        assert_eq!(required.len(), 2, "all fields required under strict mode");
+        // The required field keeps its scalar type; the optional one is nullable.
+        assert_eq!(schema["properties"]["title"]["type"], "string");
+        assert_eq!(
+            schema["properties"]["note"]["type"],
+            serde_json::json!(["string", "null"])
+        );
+    }
+}

--- a/crates/pocopine-agenkit-oai/tests/wire.rs
+++ b/crates/pocopine-agenkit-oai/tests/wire.rs
@@ -1,0 +1,320 @@
+#![cfg(not(target_arch = "wasm32"))]
+//! Integration tests for the OpenAI-compatible provider, driven against a
+//! `wiremock` server (no real API calls / credentials).
+
+use futures::StreamExt;
+use pocopine_agenkit::server::{
+    Agenkit, AiFlowContext, Flow, GenerateRequest, Provider, StreamChunk,
+};
+use pocopine_agenkit_core::{AgenkitResult, FlowStreamEvent, Message, ModelRef};
+use pocopine_agenkit_oai::OpenAiProvider;
+use serde::Deserialize;
+use serde_json::json;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+fn provider(server: &MockServer) -> OpenAiProvider {
+    OpenAiProvider::new("openai", "test-key").with_base_url(format!("{}/v1", server.uri()))
+}
+
+/// Build one SSE `data:` line carrying a content delta (JSON-escaped via serde).
+fn sse_content_chunk(content: &str) -> String {
+    let body = json!({ "choices": [{ "delta": { "content": content } }] });
+    format!("data: {}\n\n", serde_json::to_string(&body).unwrap())
+}
+
+fn text_request(prompt: &str) -> GenerateRequest {
+    GenerateRequest {
+        model: ModelRef::new("openai/gpt-4o-mini"),
+        messages: vec![Message::user(prompt)],
+        ..GenerateRequest::default()
+    }
+}
+
+#[tokio::test]
+async fn maps_text_completion_and_sends_bearer_auth() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .and(header("authorization", "Bearer test-key"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "choices": [{
+                "message": {"role": "assistant", "content": "uploads use presigned URLs"},
+                "finish_reason": "stop"
+            }],
+            "usage": {"prompt_tokens": 7, "completion_tokens": 5}
+        })))
+        .mount(&server)
+        .await;
+
+    let response = provider(&server)
+        .generate(text_request("how do uploads work?"))
+        .await
+        .unwrap();
+    assert_eq!(response.text_output(), "uploads use presigned URLs");
+    assert_eq!(response.usage.unwrap().total(), 12);
+}
+
+#[tokio::test]
+async fn structured_request_sets_response_format_and_strips_namespace() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(|req: &Request| {
+            #[derive(Deserialize)]
+            struct Body {
+                model: String,
+                response_format: Option<serde_json::Value>,
+            }
+            let body: Body = serde_json::from_slice(&req.body).unwrap();
+            // The provider namespace is stripped and structured mode is set.
+            assert_eq!(body.model, "gpt-4o-mini");
+            assert_eq!(body.response_format, Some(json!({"type": "json_object"})));
+            ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{"message": {"content": "{\"title\":\"Uploads\"}"}, "finish_reason": "stop"}]
+            }))
+        })
+        .mount(&server)
+        .await;
+
+    let request = GenerateRequest {
+        json_schema: Some(json!({"type": "object"})),
+        ..text_request("summarize")
+    };
+    let response = provider(&server).generate(request).await.unwrap();
+    assert_eq!(response.text_output(), "{\"title\":\"Uploads\"}");
+}
+
+#[tokio::test]
+async fn maps_tool_calls_from_the_response() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "choices": [{
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "search_docs", "arguments": "{\"query\":\"uploads\"}"}
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        })))
+        .mount(&server)
+        .await;
+
+    let response = provider(&server)
+        .generate(text_request("find docs"))
+        .await
+        .unwrap();
+    assert_eq!(response.tool_calls.len(), 1);
+    assert_eq!(response.tool_calls[0].tool_id, "search_docs");
+    assert_eq!(response.tool_calls[0].args, json!({"query": "uploads"}));
+}
+
+#[tokio::test]
+async fn http_error_maps_to_provider_error_without_leaking_message() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+            "error": {
+                "message": "Incorrect API key provided: sk-proj-LEAK",
+                "type": "invalid_request_error",
+                "code": "invalid_api_key"
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let error = provider(&server)
+        .generate(text_request("hi"))
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), "provider");
+    let rendered = error.to_string();
+    assert!(rendered.contains("401"));
+    assert!(
+        !rendered.contains("sk-proj-LEAK"),
+        "error leaked the key: {rendered}"
+    );
+}
+
+#[tokio::test]
+async fn integrates_as_an_agenkit_provider() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "choices": [{"message": {"content": "hello from gpt"}, "finish_reason": "stop"}]
+        })))
+        .mount(&server)
+        .await;
+
+    let agenkit = Agenkit::builder()
+        .provider(provider(&server))
+        .default_model(ModelRef::new("openai/gpt-4o-mini"))
+        .build()
+        .unwrap();
+
+    let answer = agenkit.ai().prompt("hi").generate_text().await.unwrap();
+    assert_eq!(answer, "hello from gpt");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn streams_text_deltas_and_usage_from_sse() {
+    let server = MockServer::start().await;
+    let sse = concat!(
+        "data: {\"choices\":[{\"delta\":{\"content\":\"uploads \"}}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{\"content\":\"use presigned URLs\"}}]}\n\n",
+        "data: {\"choices\":[],\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":2}}\n\n",
+        "data: [DONE]\n\n",
+    );
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(sse),
+        )
+        .mount(&server)
+        .await;
+
+    let client = provider(&server);
+    let mut stream = client.generate_stream(text_request("how do uploads work?"));
+    let mut text = String::new();
+    let mut usage = None;
+    let mut delta_count = 0;
+    while let Some(chunk) = stream.next().await {
+        match chunk.unwrap() {
+            StreamChunk::Text(fragment) => {
+                delta_count += 1;
+                text.push_str(&fragment);
+            }
+            StreamChunk::Usage(reported) => usage = Some(reported),
+            StreamChunk::ToolCall(_) => {}
+        }
+    }
+    assert_eq!(text, "uploads use presigned URLs");
+    assert!(
+        delta_count >= 2,
+        "expected incremental deltas, got {delta_count}"
+    );
+    assert_eq!(usage.unwrap().total(), 5);
+}
+
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+struct Summary {
+    title: String,
+    words: u32,
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn streams_structured_object_deltas_across_sse_chunks() {
+    let server = MockServer::start().await;
+    // The model streams the JSON object split across SSE chunks mid-token; the
+    // facade parses each accumulated prefix into a partial object (ObjectDelta).
+    // Reassembled: {"title":"Object storage","words":12}
+    let sse = format!(
+        "{}{}{}data: [DONE]\n\n",
+        sse_content_chunk("{\"title\":\"Obj"),
+        sse_content_chunk("ect storage\",\""),
+        sse_content_chunk("words\":12}"),
+    );
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(sse),
+        )
+        .mount(&server)
+        .await;
+
+    async fn summarize(_input: (), ctx: AiFlowContext) -> AgenkitResult<Summary> {
+        ctx.ai()
+            .prompt("summarize")
+            .schema::<Summary>()
+            .stream_structured()
+            .await
+    }
+
+    let agenkit = Agenkit::builder()
+        .provider(provider(&server))
+        .default_model(ModelRef::new("openai/gpt-4o-mini"))
+        .flow(Flow::new("summarize", summarize).public())
+        .build()
+        .unwrap();
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let value = agenkit
+        .run_flow_streaming("summarize", serde_json::Value::Null, tx)
+        .await
+        .unwrap();
+    let result: Summary = serde_json::from_value(value).unwrap();
+    assert_eq!(
+        result,
+        Summary {
+            title: "Object storage".to_string(),
+            words: 12
+        }
+    );
+
+    let mut partials = Vec::new();
+    while let Ok(event) = rx.try_recv() {
+        if let FlowStreamEvent::ObjectDelta { partial } = event {
+            partials.push(partial);
+        }
+    }
+    // The SSE arrives in several chunks, so the client sees the object
+    // progressively complete and converge to the validated result.
+    assert!(
+        partials.len() > 1,
+        "expected incremental partials, got {partials:?}"
+    );
+    assert!(
+        partials[0].get("words").is_none(),
+        "trailing field should arrive after the title: {:?}",
+        partials[0]
+    );
+    let converged: Summary = serde_json::from_value(partials.last().unwrap().clone()).unwrap();
+    assert_eq!(converged, result);
+}
+
+#[tokio::test]
+async fn real_schema_uses_strict_json_schema_mode() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(|req: &Request| {
+            let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap();
+            let format = &body["response_format"];
+            assert_eq!(format["type"], "json_schema");
+            assert_eq!(format["json_schema"]["strict"], true);
+            // The strict transform locked the schema down.
+            assert_eq!(
+                format["json_schema"]["schema"]["additionalProperties"],
+                false
+            );
+            assert_eq!(
+                format["json_schema"]["schema"]["required"],
+                json!(["title"])
+            );
+            ResponseTemplate::new(200).set_body_json(
+                json!({"choices": [{"message": {"content": "{\"title\":\"Uploads\"}"}}]}),
+            )
+        })
+        .mount(&server)
+        .await;
+
+    let request = GenerateRequest {
+        json_schema: Some(json!({"type": "object", "properties": {"title": {"type": "string"}}})),
+        ..text_request("summarize")
+    };
+    let response = provider(&server).generate(request).await.unwrap();
+    assert_eq!(response.text_output(), "{\"title\":\"Uploads\"}");
+}

--- a/crates/pocopine-agenkit/Cargo.toml
+++ b/crates/pocopine-agenkit/Cargo.toml
@@ -1,0 +1,47 @@
+[package]
+name = "pocopine-agenkit"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Pocopine Agenkit runtime facade — the unified generative-AI app surface: Agenkit/Ai builders, providers, flows, tools/retrievers/embedders, agents, threads, parallel orchestration, and trace emission. App authors depend on this crate; it re-exports the stable contracts from pocopine-agenkit-core."
+
+[dependencies]
+pocopine-agenkit-core = { workspace = true }
+
+# The runtime is host-side; its dependencies are gated so the workspace
+# `wasm32-unknown-unknown` build keeps compiling this crate as an (empty)
+# library. Modelled on crates/pocopine-sync-query. More land per checkpoint:
+#   * Phase 3    pocopine-auth + pocopine-server (server-fn + principal adapter)
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# Public flows map AgenkitError -> ServerError at the client boundary (§D9/§D10).
+pocopine-core = { workspace = true }
+# Tools/retrieval run under the caller principal threaded in by the in-facade
+# adapter (§D5/§D10, §D15 DC-5) — no #[server] macro change.
+pocopine-auth = { workspace = true }
+# AI events ride the existing observability stack: TraceEvent -> ObservedEvent
+# -> emit_tracing. No parallel telemetry runtime (§D12).
+pocopine-observe = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+# Provider runtime + bounded parallel branches (JoinSet/abort) + timeouts.
+tokio = { version = "1", features = ["macros", "rt", "time", "sync"] }
+# Type-driven JSON Schemas for robust structured output (§D10).
+schemars = "0.8"
+# The public AI-flow streaming route (SSE) + Provider::generate_stream, matching
+# pocopine-server/live (§D8).
+axum = "0.7"
+futures = "0.3"
+tokio-stream = "0.1"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+# `multi_thread` so parallel-branch cancellation tests actually race.
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "time", "sync"] }
+# Tests/examples derive JsonSchema on their structured-output types.
+schemars = "0.8"
+# Capture emitted `pocopine.trace` events in flow/parallel trace-tree tests.
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["registry", "std"] }
+# Drive the SSE route in-process (oneshot) and collect its body.
+tower = { version = "0.5", features = ["util"] }
+http-body-util = "0.1"

--- a/crates/pocopine-agenkit/examples/summarize.rs
+++ b/crates/pocopine-agenkit/examples/summarize.rs
@@ -1,0 +1,106 @@
+//! The canonical Agenkit example (RFC-093): configure the runtime once, then
+//! call a public flow with the same shape as any other Pocopine server work.
+//!
+//! Run with: `cargo run -p pocopine-agenkit --example summarize`
+//!
+//! A real app swaps `MockProvider` for a hosted provider (server-only
+//! credentials) and exposes `summarize` through a `#[server]` function that
+//! calls `agenkit().run_public_flow("summarize", input)`.
+//!
+//! The runtime is host-only (the browser calls flows through generated
+//! `#[server]` helpers, never the runtime directly — §D10), so the example
+//! body is gated off `wasm32`; the workspace's wasm build keeps a no-op `main`.
+
+#[cfg(not(target_arch = "wasm32"))]
+mod host {
+    use pocopine_agenkit::prelude::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize, schemars::JsonSchema)]
+    struct SummarizeInput {
+        prompt: String,
+    }
+
+    #[derive(Serialize, Deserialize, Debug, schemars::JsonSchema)]
+    struct Summary {
+        title: String,
+        words: u32,
+    }
+
+    /// A registered tool the model could call (shown for completeness).
+    struct WordCount;
+
+    #[derive(Deserialize, schemars::JsonSchema)]
+    struct WordCountInput {
+        text: String,
+    }
+
+    impl AiTool for WordCount {
+        const ID: &'static str = "word_count";
+        type Input = WordCountInput;
+        type Output = u32;
+
+        fn descriptor() -> ToolDescriptor {
+            ToolDescriptor::new("word_count", "Count the words in a string")
+        }
+
+        fn call(
+            &self,
+            input: WordCountInput,
+            _ctx: AiToolContext,
+        ) -> BoxFuture<'_, AgenkitResult<u32>> {
+            Box::pin(async move { Ok(input.text.split_whitespace().count() as u32) })
+        }
+    }
+
+    /// The app-callable flow: typed input, typed structured output, one trace tree.
+    async fn summarize(input: SummarizeInput, ctx: AiFlowContext) -> AgenkitResult<Summary> {
+        ctx.ai()
+            .system("Summarize the prompt as a title and a word count.")
+            .prompt(input.prompt)
+            .schema::<Summary>()
+            .generate_structured()
+            .await
+    }
+
+    /// Configure AI once (§D3).
+    fn agenkit() -> Agenkit {
+        Agenkit::builder()
+            .provider(
+                MockProvider::new("local")
+                    .default_structured(serde_json::json!({"title": "Uploads", "words": 12})),
+            )
+            .default_model(ModelRef::new("local/default"))
+            .tool(WordCount)
+            .flow(
+                Flow::new("summarize", summarize)
+                    .public()
+                    .uses_tool("word_count"),
+            )
+            .build()
+            .expect("valid runtime")
+    }
+
+    pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
+        let summary: Summary = agenkit()
+            .run_public_flow(
+                "summarize",
+                SummarizeInput {
+                    prompt: "How do uploads work?".to_string(),
+                },
+            )
+            .await?;
+        println!("summary: {summary:?}");
+        Ok(())
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    host::run().await
+}
+
+/// The runtime does not build for `wasm32`; keep the example target compiling.
+#[cfg(target_arch = "wasm32")]
+fn main() {}

--- a/crates/pocopine-agenkit/src/client.rs
+++ b/crates/pocopine-agenkit/src/client.rs
@@ -1,0 +1,12 @@
+//! Client-side surface (RFC-093 §D9, §D10).
+//!
+//! What a browser/client touches: the typed flow-call contract and the public
+//! stream-event vocabulary. Provider credentials and the runtime never live
+//! here — the client calls public flows through generated `#[server]` helpers
+//! and consumes redacted [`FlowStreamEvent`]s.
+//!
+//! This module compiles on every target. Its substance (the typed call helper
+//! and the stream consumer) lands in Phase 3; for now it re-exposes the
+//! client-safe stream vocabulary from [`crate::shared`].
+
+pub use crate::shared::{FlowStreamEvent, StreamMode};

--- a/crates/pocopine-agenkit/src/lib.rs
+++ b/crates/pocopine-agenkit/src/lib.rs
@@ -37,6 +37,10 @@ pub mod shared;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod server;
 
+/// The curated host-side authoring prelude (`use pocopine_agenkit::prelude::*`).
+#[cfg(not(target_arch = "wasm32"))]
+pub mod prelude;
+
 /// Re-exported so apps can derive `JsonSchema` on structured-output types
 /// without depending on `schemars` directly.
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/pocopine-agenkit/src/lib.rs
+++ b/crates/pocopine-agenkit/src/lib.rs
@@ -1,0 +1,43 @@
+//! `pocopine-agenkit` — the unified runtime facade for
+//! [Pocopine Agenkit](../../rfcs/rfc-093-pocopine-agenkit.md), the
+//! Pocopine-native generative-AI runtime.
+//!
+//! This is the crate app authors depend on. It owns the runtime surface —
+//! `Agenkit`/`Ai` builders, provider traits and registry, flow registry,
+//! tool/retriever/embedder execution, agents and threads, parallel
+//! orchestration, trace recording, redaction policy, and server-function
+//! helpers — and re-exports the stable contracts from
+//! [`pocopine_agenkit_core`].
+//!
+//! The runtime maps the neutral [`pocopine_agenkit_core`] trace payloads
+//! onto `pocopine_observe::ObservedEvent` + `emit_tracing`, so AI events
+//! ride the existing Pocopine observability stack rather than a parallel
+//! telemetry runtime (RFC-093 §D12).
+//!
+//! # Module layout
+//!
+//! - [`shared`] — the contract vocabulary both sides exchange (compiles on
+//!   every target).
+//! - [`client`] — the client-side surface (typed flow call + stream consumer);
+//!   compiles on every target.
+//! - [`server`] — the host-side runtime; gated to non-wasm targets so the
+//!   workspace `wasm32-unknown-unknown` build keeps compiling this crate.
+//!   Larger server submodules are split into files under `server/`.
+//!
+//! Browser clients call public flows through generated `#[server]` helpers,
+//! never the [`server`] runtime directly (§D10).
+//!
+//! A curated `prelude` and root re-exports land as the final checkpoint of
+//! Phase 2, once the surface stabilises (RFC-093 §D14).
+#![forbid(unsafe_code)]
+
+pub mod client;
+pub mod shared;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub mod server;
+
+/// Re-exported so apps can derive `JsonSchema` on structured-output types
+/// without depending on `schemars` directly.
+#[cfg(not(target_arch = "wasm32"))]
+pub use schemars;

--- a/crates/pocopine-agenkit/src/prelude.rs
+++ b/crates/pocopine-agenkit/src/prelude.rs
@@ -1,0 +1,23 @@
+//! The curated authoring prelude (RFC-093 §D14).
+//!
+//! `use pocopine_agenkit::prelude::*;` brings the everyday surface into scope:
+//! the runtime entry points, the typed author traits, the flow context, and
+//! the core payload types most flows touch. It is host-only — the browser
+//! talks to flows through generated `#[server]` helpers, not this runtime.
+
+pub use crate::server::{
+    Agenkit, AgenkitBuilder, AgentThreadHandle, Ai, AiAgent, AiAgentBuilder, AiEmbedder,
+    AiFlowContext, AiRetriever, AiTool, AiToolContext, BoxFuture, EmbedContext, Flow, MockProvider,
+    Provider, RetrievalContext,
+};
+
+pub use pocopine_agenkit_core::{
+    AgenkitError, AgenkitResult, Content, ContentPart, EmbedderDescriptor, FlowStreamEvent,
+    Message, ModelRef, ParallelJoin, RetrievalQuery, RetrievalSet, RetrieverDescriptor, Role,
+    SchemaRef, StreamMode, ToolDescriptor,
+};
+
+/// `schemars::JsonSchema` — derive it on structured-output types so the runtime
+/// can constrain and validate generation. Also reachable as
+/// `pocopine_agenkit::schemars` for the crate path.
+pub use schemars::JsonSchema;

--- a/crates/pocopine-agenkit/src/server/agenkit.rs
+++ b/crates/pocopine-agenkit/src/server/agenkit.rs
@@ -1,0 +1,405 @@
+//! The `Agenkit` facade and its builder (RFC-093 Phase 2.2, §D3).
+//!
+//! `Agenkit` is the one canonical entry point. Apps configure it once and then
+//! call [`Agenkit::ai`] (and, in later checkpoints, registered flows/agents)
+//! from server functions, jobs, and evals.
+
+use std::any::Any;
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use pocopine_agenkit_core::{
+    AgenkitError, AgenkitResult, FlowStreamEvent, ModelRef, RunId, StepKind, StepStatus, TraceId,
+    events,
+};
+use pocopine_auth::Principal;
+use serde::{Serialize, de::DeserializeOwned};
+use std::future::Future;
+use tokio::sync::mpsc::UnboundedSender;
+
+tokio::task_local! {
+    /// The caller principal in scope for the current request (set by the
+    /// in-facade adapter, §D15 DC-5). `run_flow` picks this up automatically.
+    pub(crate) static CURRENT_PRINCIPAL: Principal;
+}
+
+/// Run `future` with `principal` in scope so any `run_public_flow` / `run_flow`
+/// call within it executes under that identity. This is the seam an axum
+/// middleware uses after reading `Principal` from request extensions (§D15 DC-5).
+pub async fn with_principal<F: Future>(principal: Principal, future: F) -> F::Output {
+    CURRENT_PRINCIPAL.scope(principal, future).await
+}
+
+fn current_principal() -> Principal {
+    CURRENT_PRINCIPAL
+        .try_with(Clone::clone)
+        .unwrap_or_else(|_| Principal::anonymous())
+}
+
+use super::context::{AiContext, AppState};
+use super::embed::{AiEmbedder, EmbedderRegistry};
+use super::flow::{AiFlowContext, FlowHandler, FlowRegistry};
+use super::generate::Ai;
+use super::provider::{Provider, ProviderRegistry};
+use super::retrieval::{AiRetriever, RetrieverRegistry};
+use super::run::RunState;
+use super::thread::{AgentThreadStore, InMemoryThreadStore};
+use super::tool::{AiTool, ToolRegistry};
+
+/// Shared, immutable runtime state behind an [`Agenkit`] handle.
+pub(crate) struct AgenkitInner {
+    pub(crate) providers: ProviderRegistry,
+    pub(crate) default_model: Option<ModelRef>,
+    pub(crate) tools: ToolRegistry,
+    pub(crate) retrievers: RetrieverRegistry,
+    pub(crate) embedders: EmbedderRegistry,
+    pub(crate) flows: FlowRegistry,
+    pub(crate) state: Arc<AppState>,
+    pub(crate) thread_store: Arc<dyn AgentThreadStore>,
+    /// When set, only these model aliases may be resolved (§D10). Enforced
+    /// before any provider call.
+    pub(crate) model_allowlist: Option<HashSet<String>>,
+    pub(crate) run_seq: AtomicU64,
+}
+
+impl AgenkitInner {
+    /// Reject a model alias that is not allowlisted, before any provider call.
+    pub(crate) fn check_model_allowed(&self, model: &ModelRef) -> AgenkitResult<()> {
+        if let Some(allow) = &self.model_allowlist
+            && !allow.contains(model.as_str())
+        {
+            return Err(AgenkitError::config(format!(
+                "model alias `{}` is not allowlisted",
+                model.as_str()
+            )));
+        }
+        Ok(())
+    }
+}
+
+/// The unified Agenkit runtime handle. Cheap to clone (`Arc` inside).
+#[derive(Clone)]
+pub struct Agenkit {
+    pub(crate) inner: Arc<AgenkitInner>,
+}
+
+impl Agenkit {
+    /// Start configuring a runtime.
+    pub fn builder() -> AgenkitBuilder {
+        AgenkitBuilder::default()
+    }
+
+    /// Begin a generation request.
+    pub fn ai(&self) -> Ai {
+        Ai::new(self.inner.clone())
+    }
+
+    /// The configured default model alias, if any.
+    pub fn default_model(&self) -> Option<&ModelRef> {
+        self.inner.default_model.as_ref()
+    }
+
+    /// The tool registry.
+    pub fn tools(&self) -> &ToolRegistry {
+        &self.inner.tools
+    }
+
+    /// The retriever registry.
+    pub fn retrievers(&self) -> &RetrieverRegistry {
+        &self.inner.retrievers
+    }
+
+    /// The embedder registry.
+    pub fn embedders(&self) -> &EmbedderRegistry {
+        &self.inner.embedders
+    }
+
+    /// A fresh execution context over the runtime's app state.
+    pub fn context(&self) -> AiContext {
+        AiContext::new(self.inner.state.clone())
+    }
+
+    /// Whether a flow id is registered.
+    pub fn has_flow(&self, id: &str) -> bool {
+        self.inner.flows.contains(id)
+    }
+
+    /// Run a registered flow over JSON input under a fresh trace tree.
+    ///
+    /// Emits `ai_flow_started` / `ai_flow_completed` / `ai_flow_failed`; the
+    /// flow body emits its own step/retrieval/model events under the same
+    /// `trace_id`.
+    pub async fn run_flow(
+        &self,
+        id: &str,
+        input: serde_json::Value,
+    ) -> AgenkitResult<serde_json::Value> {
+        self.run_flow_inner(id, input, None, None).await
+    }
+
+    /// Run a flow explicitly under `principal` (the in-facade adapter path).
+    pub async fn run_flow_as(
+        &self,
+        principal: Principal,
+        id: &str,
+        input: serde_json::Value,
+    ) -> AgenkitResult<serde_json::Value> {
+        self.run_flow_inner(id, input, Some(principal), None).await
+    }
+
+    /// Run a flow while streaming public [`FlowStreamEvent`]s into `sink`.
+    ///
+    /// The sink carries client-safe events by construction (§D8); the Phase 3.3
+    /// route applies the redaction chokepoint before the wire. Provider
+    /// credentials, raw prompts, and tool args never reach this channel.
+    pub async fn run_flow_streaming(
+        &self,
+        id: &str,
+        input: serde_json::Value,
+        sink: UnboundedSender<FlowStreamEvent>,
+    ) -> AgenkitResult<serde_json::Value> {
+        self.run_flow_inner(id, input, None, Some(sink)).await
+    }
+
+    async fn run_flow_inner(
+        &self,
+        id: &str,
+        input: serde_json::Value,
+        principal: Option<Principal>,
+        sink: Option<UnboundedSender<FlowStreamEvent>>,
+    ) -> AgenkitResult<serde_json::Value> {
+        let handler: Arc<dyn FlowHandler> = self
+            .inner
+            .flows
+            .get(id)
+            .ok_or_else(|| AgenkitError::not_found(format!("flow `{id}` is not registered")))?;
+
+        // Identity: an explicit principal wins; otherwise pick up the
+        // task-local set by the adapter; otherwise anonymous (§D15 DC-5).
+        let principal = principal.unwrap_or_else(current_principal);
+        let seq = self.inner.run_seq.fetch_add(1, Ordering::Relaxed);
+        let run_id = RunId::new(format!("run-{seq}"));
+        let trace_id = TraceId::new(format!("trace-{seq}"));
+        let run = RunState::new(
+            self.inner.clone(),
+            run_id.clone(),
+            trace_id.clone(),
+            principal,
+            sink,
+        );
+        let descriptor = handler.descriptor();
+        let ctx = AiFlowContext::new(run.clone(), id.to_string(), descriptor.manifest.clone());
+
+        run.emit(
+            run.event(
+                events::AI_FLOW_STARTED,
+                StepKind::Custom,
+                StepStatus::Started,
+            )
+            .with_field("flow_id", id),
+        );
+        run.stream(FlowStreamEvent::FlowStarted {
+            run_id: run_id.as_str().to_string(),
+            trace_id: trace_id.as_str().to_string(),
+        });
+
+        let result = handler.run_json(input, ctx).await;
+        match &result {
+            Ok(value) => {
+                // Surface the final typed result as user-visible output BEFORE
+                // the lifecycle `completed`, so clients keyed on `FlowCompleted`
+                // as end-of-stream still receive the result (no-op when not
+                // streaming, since the sink is absent). Skip it when the flow
+                // already streamed its output via `stream_text`, to avoid
+                // duplicating the result.
+                if !run.output_was_streamed() {
+                    run.stream(FlowStreamEvent::OutputDelta {
+                        text: value.to_string(),
+                    });
+                }
+                run.stream(FlowStreamEvent::OutputCompleted);
+                run.emit(
+                    run.event(
+                        events::AI_FLOW_COMPLETED,
+                        StepKind::Custom,
+                        StepStatus::Completed,
+                    )
+                    .with_field("flow_id", id),
+                );
+                run.stream(FlowStreamEvent::FlowCompleted {
+                    run_id: run_id.as_str().to_string(),
+                });
+            }
+            Err(error) => {
+                run.emit(
+                    run.event(events::AI_FLOW_FAILED, StepKind::Custom, StepStatus::Failed)
+                        .with_field("flow_id", id)
+                        .with_error(error.clone()),
+                );
+                run.stream(FlowStreamEvent::FlowFailed {
+                    run_id: run_id.as_str().to_string(),
+                    error_kind: error.kind().to_string(),
+                    trace_id: trace_id.as_str().to_string(),
+                });
+            }
+        }
+        result
+    }
+
+    /// Typed convenience over [`Agenkit::run_flow`].
+    pub async fn run_flow_typed<I, O>(&self, id: &str, input: I) -> AgenkitResult<O>
+    where
+        I: Serialize,
+        O: DeserializeOwned,
+    {
+        let input = serde_json::to_value(input)
+            .map_err(|err| AgenkitError::validation(format!("flow `{id}` input: {err}")))?;
+        let output = self.run_flow(id, input).await?;
+        serde_json::from_value(output)
+            .map_err(|err| AgenkitError::validation(format!("flow `{id}` output: {err}")))
+    }
+}
+
+/// Builder for [`Agenkit`].
+#[derive(Default)]
+pub struct AgenkitBuilder {
+    providers: ProviderRegistry,
+    default_model: Option<ModelRef>,
+    tools: ToolRegistry,
+    retrievers: RetrieverRegistry,
+    embedders: EmbedderRegistry,
+    flows: FlowRegistry,
+    state: AppState,
+    thread_store: Option<Arc<dyn AgentThreadStore>>,
+    model_allowlist: HashSet<String>,
+}
+
+impl AgenkitBuilder {
+    /// Register a provider (consumed and boxed).
+    pub fn provider<P: Provider>(mut self, provider: P) -> Self {
+        self.providers.register(Arc::new(provider));
+        self
+    }
+
+    /// Register an already-shared provider.
+    pub fn provider_arc(mut self, provider: Arc<dyn Provider>) -> Self {
+        self.providers.register(provider);
+        self
+    }
+
+    /// Set the default model alias used when an [`Ai`] request omits one.
+    pub fn default_model(mut self, model: impl Into<ModelRef>) -> Self {
+        self.default_model = Some(model.into());
+        self
+    }
+
+    /// Register a typed tool.
+    pub fn tool<T: AiTool>(mut self, tool: T) -> Self {
+        self.tools.register(tool);
+        self
+    }
+
+    /// Register a typed retriever.
+    pub fn retriever<R: AiRetriever>(mut self, retriever: R) -> Self {
+        self.retrievers.register(retriever);
+        self
+    }
+
+    /// Register a typed embedder.
+    pub fn embedder<E: AiEmbedder>(mut self, embedder: E) -> Self {
+        self.embedders.register(embedder);
+        self
+    }
+
+    /// Provide a framework-mediated app resource under `key` (§D6).
+    pub fn state<T: Any + Send + Sync>(mut self, key: impl Into<String>, value: T) -> Self {
+        self.state.insert(key, value);
+        self
+    }
+
+    /// Provide an already-shared app resource under `key`.
+    pub fn state_arc<T: Any + Send + Sync>(
+        mut self,
+        key: impl Into<String>,
+        value: Arc<T>,
+    ) -> Self {
+        self.state.insert_arc(key, value);
+        self
+    }
+
+    /// Register a flow.
+    pub fn flow<H: FlowHandler>(mut self, flow: H) -> Self {
+        self.flows.register(flow);
+        self
+    }
+
+    /// Provide a custom agent-thread store (defaults to an in-memory store).
+    pub fn thread_store<S: AgentThreadStore>(mut self, store: S) -> Self {
+        self.thread_store = Some(Arc::new(store));
+        self
+    }
+
+    /// Allowlist a model alias. Once any alias is allowlisted, only allowlisted
+    /// aliases may be resolved — rejected before any provider call (§D10).
+    pub fn allow_model(mut self, alias: impl Into<String>) -> Self {
+        self.model_allowlist.insert(alias.into());
+        self
+    }
+
+    /// Allowlist several model aliases.
+    pub fn allow_models<I, S>(mut self, aliases: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.model_allowlist
+            .extend(aliases.into_iter().map(Into::into));
+        self
+    }
+
+    /// Finalize the runtime. Fails if no provider was registered.
+    pub fn build(self) -> AgenkitResult<Agenkit> {
+        if self.providers.is_empty() {
+            return Err(AgenkitError::config(
+                "Agenkit requires at least one provider",
+            ));
+        }
+        Ok(Agenkit {
+            inner: Arc::new(AgenkitInner {
+                providers: self.providers,
+                default_model: self.default_model,
+                tools: self.tools,
+                retrievers: self.retrievers,
+                embedders: self.embedders,
+                flows: self.flows,
+                state: Arc::new(self.state),
+                thread_store: self
+                    .thread_store
+                    .unwrap_or_else(|| Arc::new(InMemoryThreadStore::new())),
+                model_allowlist: (!self.model_allowlist.is_empty()).then_some(self.model_allowlist),
+                run_seq: AtomicU64::new(0),
+            }),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::provider::MockProvider;
+    use super::*;
+
+    #[test]
+    fn build_requires_a_provider() {
+        assert!(Agenkit::builder().build().is_err());
+        let ok = Agenkit::builder()
+            .provider(MockProvider::new("local"))
+            .default_model(ModelRef::new("local/default"))
+            .build();
+        assert!(ok.is_ok());
+        assert_eq!(
+            ok.unwrap().default_model().unwrap().as_str(),
+            "local/default"
+        );
+    }
+}

--- a/crates/pocopine-agenkit/src/server/agent.rs
+++ b/crates/pocopine-agenkit/src/server/agent.rs
@@ -1,0 +1,350 @@
+//! Typed agents (RFC-093 Phase 2.6, §D4, §D7).
+//!
+//! An [`AiAgent`] is a typed runnable AI unit: a model alias, a system prompt,
+//! an optional tool allowlist, and typed input/output. [`AgentRun`] executes a
+//! bounded model+tool loop, validating structured output, and is `'static` so
+//! it can also run as a parallel branch (Phase 2.6b).
+
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use pocopine_agenkit_core::{
+    AgenkitError, AgenkitResult, Message, ModelRef, Role, StepId, StepKind, StepStatus,
+    ThreadMessage, ToolDescriptor, events,
+};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use super::context::AiContext;
+use super::provider::GenerateRequest;
+use super::run::RunState;
+use super::thread::AgentThreadHandle;
+
+/// A typed, author-facing agent.
+pub trait AiAgent: Send + Sync + 'static {
+    /// Stable agent id.
+    const ID: &'static str;
+
+    /// Typed input (serialized into the agent's prompt).
+    type Input: Serialize + Send + 'static;
+    /// Typed, type-validated output (deserialized into `Self::Output`; schema
+    /// keyword constraints like `range`/`length` are not re-checked). Derives
+    /// `schemars::JsonSchema` so the agent's generation is schema-constrained
+    /// where the provider supports it.
+    type Output: Serialize + DeserializeOwned + schemars::JsonSchema + Send + 'static;
+
+    /// Configure the agent's model, system prompt, tools, and limits.
+    fn configure(builder: AiAgentBuilder<Self>) -> AiAgentBuilder<Self>
+    where
+        Self: Sized;
+}
+
+/// Configuration for an [`AiAgent`].
+pub struct AiAgentBuilder<A: ?Sized> {
+    model: Option<ModelRef>,
+    system: Option<String>,
+    tool_ids: Vec<String>,
+    max_tokens: Option<u32>,
+    max_steps: u32,
+    _marker: PhantomData<fn() -> A>,
+}
+
+impl<A: ?Sized> Default for AiAgentBuilder<A> {
+    fn default() -> Self {
+        Self {
+            model: None,
+            system: None,
+            tool_ids: Vec::new(),
+            max_tokens: None,
+            max_steps: 4,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<A: ?Sized> AiAgentBuilder<A> {
+    /// Set the agent's model alias (defaults to the runtime default).
+    pub fn model(mut self, model: impl Into<ModelRef>) -> Self {
+        self.model = Some(model.into());
+        self
+    }
+
+    /// Set the agent's system prompt.
+    pub fn system(mut self, system: impl Into<String>) -> Self {
+        self.system = Some(system.into());
+        self
+    }
+
+    /// Allow the agent to call a tool (by registry id).
+    pub fn tool(mut self, id: impl Into<String>) -> Self {
+        self.tool_ids.push(id.into());
+        self
+    }
+
+    /// Allow the agent to call several tools (by registry id).
+    pub fn tools<I, S>(mut self, ids: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.tool_ids.extend(ids.into_iter().map(Into::into));
+        self
+    }
+
+    /// Cap output tokens per model call.
+    pub fn max_tokens(mut self, max_tokens: u32) -> Self {
+        self.max_tokens = Some(max_tokens);
+        self
+    }
+
+    /// Bound the model+tool loop (default 4).
+    pub fn max_steps(mut self, max_steps: u32) -> Self {
+        self.max_steps = max_steps;
+        self
+    }
+}
+
+/// A configured, runnable agent invocation. `'static`, so it can also be a
+/// parallel branch.
+pub struct AgentRun<A: AiAgent> {
+    run: Arc<RunState>,
+    parent_step: Option<StepId>,
+    input: Option<A::Input>,
+    thread: Option<AgentThreadHandle>,
+}
+
+impl<A: AiAgent> AgentRun<A> {
+    pub(crate) fn new(run: Arc<RunState>, parent_step: Option<StepId>) -> Self {
+        Self {
+            run,
+            parent_step,
+            input: None,
+            thread: None,
+        }
+    }
+
+    /// Set the agent input.
+    pub fn input(mut self, input: A::Input) -> Self {
+        self.input = Some(input);
+        self
+    }
+
+    /// Attach an existing thread (the run appends to its history).
+    pub fn thread(mut self, thread: AgentThreadHandle) -> Self {
+        self.thread = Some(thread);
+        self
+    }
+
+    /// Execute the agent's model+tool loop and return validated output.
+    pub async fn run(self) -> AgenkitResult<A::Output> {
+        // Destructure up front so `input` can move out without partially
+        // moving `self` (which the borrows below would reject).
+        let Self {
+            run,
+            parent_step,
+            input,
+            thread,
+        } = self;
+
+        let config = A::configure(AiAgentBuilder::default());
+        let model = config
+            .model
+            .clone()
+            .or_else(|| run.inner.default_model.clone())
+            .ok_or_else(|| AgenkitError::config(format!("agent `{}` has no model", A::ID)))?;
+        run.inner.check_model_allowed(&model)?;
+        let provider = run.inner.providers.resolve(&model)?;
+        let input = input
+            .ok_or_else(|| AgenkitError::config(format!("agent `{}` requires input", A::ID)))?;
+
+        let agent_step = run.next_step_id();
+        let mut started = run
+            .event(
+                events::AI_STEP_STARTED,
+                StepKind::Agent,
+                StepStatus::Started,
+            )
+            .with_step(agent_step.clone())
+            .with_model(model.clone())
+            .with_field("agent_id", A::ID);
+        if let Some(parent) = &parent_step {
+            started = started.with_parent(parent.clone());
+        }
+        run.emit(started);
+
+        let result = run_loop::<A>(
+            &run,
+            &config,
+            &model,
+            &provider,
+            &input,
+            &agent_step,
+            thread.as_ref(),
+        )
+        .await;
+        match &result {
+            Ok(_) => run.emit(
+                run.event(
+                    events::AI_STEP_COMPLETED,
+                    StepKind::Agent,
+                    StepStatus::Completed,
+                )
+                .with_step(agent_step.clone())
+                .with_field("agent_id", A::ID),
+            ),
+            Err(error) => run.emit(
+                run.event(events::AI_STEP_FAILED, StepKind::Agent, StepStatus::Failed)
+                    .with_step(agent_step.clone())
+                    .with_field("agent_id", A::ID)
+                    .with_error(error.clone()),
+            ),
+        }
+
+        let output = result?;
+        if let Some(thread) = &thread {
+            let input_text = serde_json::to_string(&input).unwrap_or_default();
+            let output_text = serde_json::to_string(&output).unwrap_or_default();
+            thread
+                .store
+                .append(
+                    &thread.id,
+                    vec![
+                        ThreadMessage::new(Role::User, input_text),
+                        ThreadMessage::new(Role::Assistant, output_text),
+                    ],
+                )
+                .await?;
+        }
+        Ok(output)
+    }
+}
+
+/// The bounded model+tool loop, factored out so it borrows the run state
+/// rather than a partially-moved `AgentRun`.
+async fn run_loop<A: AiAgent>(
+    run: &Arc<RunState>,
+    config: &AiAgentBuilder<A>,
+    model: &ModelRef,
+    provider: &Arc<dyn super::provider::Provider>,
+    input: &A::Input,
+    agent_step: &StepId,
+    thread: Option<&AgentThreadHandle>,
+) -> AgenkitResult<A::Output> {
+    let ctx = AiContext::with_principal(run.inner.state.clone(), run.principal.clone());
+    let tools: Vec<ToolDescriptor> = config
+        .tool_ids
+        .iter()
+        .filter_map(|id| run.inner.tools.get(id).map(|tool| tool.descriptor()))
+        .collect();
+    let schema = super::schema::json_schema_for::<A::Output>();
+
+    let mut messages = Vec::new();
+    if let Some(thread) = thread {
+        for message in thread.history().await? {
+            messages.push(Message::new(message.role, message.content));
+        }
+    }
+    messages.push(Message::user(
+        serde_json::to_string(input).unwrap_or_default(),
+    ));
+
+    for _ in 0..config.max_steps {
+        let request = GenerateRequest {
+            model: model.clone(),
+            system: config.system.clone(),
+            messages: messages.clone(),
+            tools: tools.clone(),
+            json_schema: Some(schema.clone()),
+            max_tokens: config.max_tokens,
+        };
+
+        let model_step = run.next_step_id();
+        run.emit(
+            run.event(
+                events::AI_MODEL_REQUEST,
+                StepKind::Generation,
+                StepStatus::Started,
+            )
+            .with_step(model_step.clone())
+            .with_parent(agent_step.clone())
+            .with_model(model.clone()),
+        );
+        let response = provider.generate(request).await?;
+        let mut completed = run
+            .event(
+                events::AI_MODEL_RESPONSE,
+                StepKind::Generation,
+                StepStatus::Completed,
+            )
+            .with_step(model_step)
+            .with_parent(agent_step.clone())
+            .with_model(model.clone());
+        if let Some(usage) = response.usage {
+            completed = completed.with_usage(usage);
+        }
+        run.emit(completed);
+
+        if response.tool_calls.is_empty() {
+            let value = response
+                .structured_value()
+                .cloned()
+                .or_else(|| serde_json::from_str(&response.text_output()).ok())
+                .ok_or_else(|| {
+                    AgenkitError::validation(format!("agent `{}` returned no JSON", A::ID))
+                })?;
+            return serde_json::from_value(value).map_err(|err| {
+                AgenkitError::validation(format!("agent `{}` output: {err}", A::ID))
+            });
+        }
+
+        // Record the assistant's tool-request turn so the next request carries
+        // the protocol linkage real providers (OpenAI, ...) require — keeping
+        // any text the model emitted alongside the calls.
+        messages.push(Message::assistant_tool_calls(
+            response.content.clone(),
+            response.tool_calls.clone(),
+        ));
+
+        for call in &response.tool_calls {
+            // Enforce the agent's explicit tool allowlist (§D5/§D10).
+            if !config.tool_ids.iter().any(|id| id == &call.tool_id) {
+                return Err(AgenkitError::tool_policy(format!(
+                    "agent `{}` called non-allowlisted tool `{}`",
+                    A::ID,
+                    call.tool_id
+                )));
+            }
+            let tool = run.inner.tools.get(&call.tool_id).ok_or_else(|| {
+                AgenkitError::tool_policy(format!("tool `{}` is not registered", call.tool_id))
+            })?;
+            let tool_step = run.next_step_id();
+            run.emit(
+                run.event(events::AI_TOOL_STARTED, StepKind::Tool, StepStatus::Started)
+                    .with_step(tool_step.clone())
+                    .with_parent(agent_step.clone())
+                    .with_field("tool_id", call.tool_id.clone()),
+            );
+            let output = tool.call_json(call.args.clone(), ctx.clone()).await?;
+            run.emit(
+                run.event(
+                    events::AI_TOOL_COMPLETED,
+                    StepKind::Tool,
+                    StepStatus::Completed,
+                )
+                .with_step(tool_step)
+                .with_parent(agent_step.clone())
+                .with_field("tool_id", call.tool_id.clone()),
+            );
+            messages.push(Message::tool_result(
+                call.id.clone(),
+                serde_json::to_string(&output).unwrap_or_default(),
+            ));
+        }
+    }
+
+    Err(AgenkitError::budget_exhausted(format!(
+        "agent `{}` exceeded its {}-step loop",
+        A::ID,
+        config.max_steps
+    )))
+}

--- a/crates/pocopine-agenkit/src/server/bridge.rs
+++ b/crates/pocopine-agenkit/src/server/bridge.rs
@@ -1,0 +1,132 @@
+//! Public-flow → server-function bridge (RFC-093 Phase 3.1, §D9, §D10).
+//!
+//! An app exposes a public flow by writing a `#[server]` function that calls
+//! [`Agenkit::run_public_flow`]. The macro generates the typed wasm client and
+//! the route; this bridge maps [`AgenkitError`] to `pocopine_core::ServerError`
+//! at the boundary, dropping provider internals so they never cross to the
+//! client. Only flows marked `.public()` are callable here.
+
+use pocopine_agenkit_core::{AgenkitError, StreamMode};
+use pocopine_auth::Principal;
+use pocopine_core::ServerError;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use super::agenkit::Agenkit;
+
+/// Map an [`AgenkitError`] to a client-safe [`ServerError`].
+///
+/// Validation and tool-policy errors carry their (Agenkit-internal) message;
+/// everything that could quote provider internals (provider, config, budget,
+/// cancellation, reducer) collapses to the error *kind* only (§D10).
+pub fn to_server_error(error: &AgenkitError) -> ServerError {
+    match error {
+        AgenkitError::Validation { message } => {
+            ServerError::bad_request(format!("invalid input: {message}"))
+        }
+        AgenkitError::ToolPolicy { message } => {
+            ServerError::forbidden(format!("tool policy: {message}"))
+        }
+        AgenkitError::NotFound { .. } => ServerError::bad_request("unknown AI flow"),
+        AgenkitError::Json { .. } => ServerError::bad_request("invalid AI payload"),
+        // Provider / Config / BudgetExhausted / Cancelled / ReducerDisagreement:
+        // never leak internals — surface the stable kind only.
+        other => ServerError::App(format!("ai error ({})", other.kind())),
+    }
+}
+
+impl Agenkit {
+    /// Whether a registered flow is public (callable from the client boundary).
+    pub fn flow_is_public(&self, id: &str) -> bool {
+        self.inner
+            .flows
+            .get(id)
+            .map(|handler| handler.descriptor().public)
+            .unwrap_or(false)
+    }
+
+    /// The stream-visibility cap the flow author declared via
+    /// `Flow::stream_mode` (§D8). Defaults to [`StreamMode::FinalOnly`]: a
+    /// flow opts *into* exposing progress events; clients can request less
+    /// visibility than the cap, never more.
+    pub fn flow_stream_mode(&self, id: &str) -> StreamMode {
+        self.inner
+            .flows
+            .get(id)
+            .map(|handler| handler.descriptor().stream_mode)
+            .unwrap_or_default()
+    }
+
+    /// Call a public flow from a `#[server]` function.
+    ///
+    /// Returns a `ServerError` for non-public/unknown flows and maps any
+    /// `AgenkitError` to a client-safe `ServerError`. Provider credentials,
+    /// raw prompts, and provider error details never cross this boundary.
+    pub async fn run_public_flow<I, O>(&self, id: &str, input: I) -> Result<O, ServerError>
+    where
+        I: Serialize,
+        O: DeserializeOwned,
+    {
+        if !self.flow_is_public(id) {
+            // Do not reveal whether a private flow exists.
+            return Err(ServerError::bad_request("unknown AI flow"));
+        }
+        self.run_flow_typed::<I, O>(id, input)
+            .await
+            .map_err(|error| to_server_error(&error))
+    }
+
+    /// Call a public flow under an explicit caller `principal` (§D15 DC-5).
+    ///
+    /// Tools and retrieval inside the flow run under `principal`. Use this when
+    /// the principal is threaded in explicitly rather than via a scope.
+    pub async fn run_public_flow_as<I, O>(
+        &self,
+        principal: Principal,
+        id: &str,
+        input: I,
+    ) -> Result<O, ServerError>
+    where
+        I: Serialize,
+        O: DeserializeOwned,
+    {
+        if !self.flow_is_public(id) {
+            return Err(ServerError::bad_request("unknown AI flow"));
+        }
+        let input = serde_json::to_value(input)
+            .map_err(|err| ServerError::bad_request(format!("invalid input: {err}")))?;
+        let output = self
+            .run_flow_as(principal, id, input)
+            .await
+            .map_err(|err| to_server_error(&err))?;
+        serde_json::from_value(output)
+            .map_err(|err| to_server_error(&AgenkitError::validation(err.to_string())))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_errors_do_not_leak_details() {
+        let error = AgenkitError::provider("503 from secret-host:8443 with bearer abc");
+        let mapped = to_server_error(&error);
+        let rendered = mapped.to_string();
+        assert!(rendered.contains("ai error (provider)"));
+        assert!(!rendered.contains("secret-host"));
+        assert!(!rendered.contains("bearer"));
+    }
+
+    #[test]
+    fn validation_maps_to_bad_request() {
+        let mapped = to_server_error(&AgenkitError::validation("missing field `q`"));
+        assert!(matches!(mapped, ServerError::BadRequest(_)));
+    }
+
+    #[test]
+    fn tool_policy_maps_to_forbidden() {
+        let mapped = to_server_error(&AgenkitError::tool_policy("not allowlisted"));
+        assert!(matches!(mapped, ServerError::Forbidden(_)));
+    }
+}

--- a/crates/pocopine-agenkit/src/server/context.rs
+++ b/crates/pocopine-agenkit/src/server/context.rs
@@ -1,0 +1,112 @@
+//! Execution context and app state for tools, retrievers, and embedders
+//! (RFC-093 Phase 2.4, §D5).
+//!
+//! [`AiContext`] is the owned, cheaply-cloneable handle passed into tool /
+//! retriever / embedder calls. It exposes framework-mediated app state so
+//! those reads are visible to traces (§D6). The caller principal is threaded
+//! in by the Phase 3.2 adapter.
+
+use std::any::Any;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use pocopine_agenkit_core::{AgenkitError, AgenkitResult};
+use pocopine_auth::Principal;
+
+/// A type-erased registry of app resources keyed by name. Tools/retrievers
+/// reach app services (a doc index, a db pool handle, ...) through here so the
+/// access is declared and traceable, rather than via hidden globals (§D6).
+#[derive(Default, Clone)]
+pub struct AppState {
+    entries: HashMap<String, Arc<dyn Any + Send + Sync>>,
+}
+
+impl AppState {
+    /// An empty state map.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Insert a value under `key`.
+    pub fn insert<T: Any + Send + Sync>(&mut self, key: impl Into<String>, value: T) {
+        self.entries.insert(key.into(), Arc::new(value));
+    }
+
+    /// Insert an already-shared value under `key`.
+    pub fn insert_arc<T: Any + Send + Sync>(&mut self, key: impl Into<String>, value: Arc<T>) {
+        self.entries.insert(key.into(), value);
+    }
+
+    /// Fetch and downcast the value stored under `key`.
+    pub fn get<T: Any + Send + Sync>(&self, key: &str) -> Option<Arc<T>> {
+        self.entries.get(key).cloned()?.downcast::<T>().ok()
+    }
+}
+
+/// The owned context handed to tool / retriever / embedder calls. Carries the
+/// caller [`Principal`] so reads/writes run under the request's identity (§D5).
+#[derive(Clone)]
+pub struct AiContext {
+    state: Arc<AppState>,
+    principal: Principal,
+}
+
+impl AiContext {
+    /// Build an anonymous context over the given app state.
+    pub(crate) fn new(state: Arc<AppState>) -> Self {
+        Self::with_principal(state, Principal::anonymous())
+    }
+
+    /// Build a context bound to the caller principal.
+    pub(crate) fn with_principal(state: Arc<AppState>, principal: Principal) -> Self {
+        Self { state, principal }
+    }
+
+    /// Fetch a framework-mediated app resource by key, downcast to `T`.
+    pub fn state<T: Any + Send + Sync>(&self, key: &str) -> AgenkitResult<Arc<T>> {
+        self.state.get::<T>(key).ok_or_else(|| {
+            AgenkitError::not_found(format!("app state `{key}` not found (or wrong type)"))
+        })
+    }
+
+    /// The caller principal a tool/retriever runs under. Anonymous unless the
+    /// flow was invoked with a principal (§D5/§D10).
+    pub fn principal(&self) -> &Principal {
+        &self.principal
+    }
+}
+
+/// Context for a tool call.
+pub type AiToolContext = AiContext;
+/// Context for a retrieval call.
+pub type RetrievalContext = AiContext;
+/// Context for an embedding call.
+pub type EmbedContext = AiContext;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Debug)]
+    struct DocIndex {
+        docs: Vec<&'static str>,
+    }
+
+    #[test]
+    fn state_round_trips_typed_resource() {
+        let mut state = AppState::new();
+        state.insert(
+            "doc_index",
+            DocIndex {
+                docs: vec!["a", "b"],
+            },
+        );
+        let ctx = AiContext::new(Arc::new(state));
+        let index = ctx.state::<DocIndex>("doc_index").unwrap();
+        assert_eq!(index.docs.len(), 2);
+        assert_eq!(
+            ctx.state::<DocIndex>("missing").unwrap_err().kind(),
+            "not_found"
+        );
+    }
+}

--- a/crates/pocopine-agenkit/src/server/embed.rs
+++ b/crates/pocopine-agenkit/src/server/embed.rs
@@ -1,0 +1,153 @@
+//! Embedders: typed [`AiEmbedder`] trait, object-safe [`DynEmbedder`] erasure,
+//! and the [`EmbedderRegistry`] (RFC-093 Phase 2.4, §D5).
+//!
+//! Embedders expose model/provider *aliases* and dimensions, never provider
+//! credentials (§D5). The runtime erases the typed trait to dispatch on
+//! `serde_json::Value`.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use pocopine_agenkit_core::{AgenkitError, AgenkitResult, EmbedderDescriptor, EmbeddingBatch};
+use serde::de::DeserializeOwned;
+
+use super::context::EmbedContext;
+use super::provider::BoxFuture;
+
+/// A typed, author-facing embedder.
+pub trait AiEmbedder: Send + Sync + 'static {
+    /// Stable embedder id.
+    const ID: &'static str;
+
+    /// Typed input, deserialized when driven generically.
+    type Input: DeserializeOwned + Send + 'static;
+
+    /// The framework-visible descriptor.
+    fn descriptor() -> EmbedderDescriptor;
+
+    /// Produce embeddings for `input`.
+    fn embed(
+        &self,
+        input: Self::Input,
+        ctx: EmbedContext,
+    ) -> BoxFuture<'_, AgenkitResult<EmbeddingBatch>>;
+}
+
+/// Object-safe erased embedder. Stored as `Arc<dyn DynEmbedder>`.
+pub trait DynEmbedder: Send + Sync + 'static {
+    /// The embedder id.
+    fn id(&self) -> &'static str;
+    /// The descriptor.
+    fn descriptor(&self) -> EmbedderDescriptor;
+    /// Validate + dispatch a JSON-encoded input.
+    fn embed_json<'a>(
+        &'a self,
+        input: serde_json::Value,
+        ctx: EmbedContext,
+    ) -> BoxFuture<'a, AgenkitResult<EmbeddingBatch>>;
+}
+
+impl<E: AiEmbedder> DynEmbedder for E {
+    fn id(&self) -> &'static str {
+        E::ID
+    }
+
+    fn descriptor(&self) -> EmbedderDescriptor {
+        E::descriptor()
+    }
+
+    fn embed_json<'a>(
+        &'a self,
+        input: serde_json::Value,
+        ctx: EmbedContext,
+    ) -> BoxFuture<'a, AgenkitResult<EmbeddingBatch>> {
+        Box::pin(async move {
+            let input: E::Input = serde_json::from_value(input).map_err(|err| {
+                AgenkitError::validation(format!("embedder `{}` input: {err}", E::ID))
+            })?;
+            E::embed(self, input, ctx).await
+        })
+    }
+}
+
+/// A registry of embedders keyed by id.
+#[derive(Default, Clone)]
+pub struct EmbedderRegistry {
+    embedders: HashMap<&'static str, Arc<dyn DynEmbedder>>,
+}
+
+impl EmbedderRegistry {
+    /// An empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a typed embedder.
+    pub fn register<E: AiEmbedder>(&mut self, embedder: E) {
+        self.embedders.insert(E::ID, Arc::new(embedder));
+    }
+
+    /// Look up an embedder by id.
+    pub fn get(&self, id: &str) -> Option<Arc<dyn DynEmbedder>> {
+        self.embedders.get(id).cloned()
+    }
+
+    /// Whether an embedder id is registered.
+    pub fn contains(&self, id: &str) -> bool {
+        self.embedders.contains_key(id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::context::{AiContext, AppState};
+    use super::*;
+    use pocopine_agenkit_core::{Embedding, ModelRef};
+    use serde::Deserialize;
+
+    #[derive(Deserialize)]
+    struct EmbedInput {
+        text: String,
+    }
+
+    struct LocalEmbedder;
+
+    impl AiEmbedder for LocalEmbedder {
+        const ID: &'static str = "local";
+        type Input = EmbedInput;
+
+        fn descriptor() -> EmbedderDescriptor {
+            EmbedderDescriptor::new("local", ModelRef::new("local/embed"), 3)
+        }
+
+        fn embed(
+            &self,
+            input: EmbedInput,
+            _ctx: EmbedContext,
+        ) -> BoxFuture<'_, AgenkitResult<EmbeddingBatch>> {
+            Box::pin(async move {
+                let value = input.text.len() as f32;
+                Ok(EmbeddingBatch::new(
+                    vec![Embedding::new(vec![value, value, value])],
+                    3,
+                ))
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn registry_embeds_typed_input() {
+        let mut registry = EmbedderRegistry::new();
+        registry.register(LocalEmbedder);
+        let embedder = registry.get("local").unwrap();
+        let batch = embedder
+            .embed_json(
+                serde_json::json!({"text": "abc"}),
+                AiContext::new(Arc::new(AppState::new())),
+            )
+            .await
+            .unwrap();
+        assert_eq!(batch.dimensions, 3);
+        assert_eq!(batch.embeddings[0].vector, vec![3.0, 3.0, 3.0]);
+    }
+}

--- a/crates/pocopine-agenkit/src/server/flow.rs
+++ b/crates/pocopine-agenkit/src/server/flow.rs
@@ -1,0 +1,417 @@
+//! Flows and the flow context (RFC-093 Phase 2.5, §D4, §D6, §D7).
+//!
+//! A [`Flow`] is the app-callable unit: typed input/output, a declared context
+//! manifest, and a body that runs generation, retrieval, custom steps, and
+//! (later) agents/parallel branches under one trace tree. [`AiFlowContext`] is
+//! handed to the body; it exposes `ai()`, `step(...)`, and `retrieve::<R>()`,
+//! recording framework-mediated access against the manifest and emitting
+//! advisory `ai_context_gap` diagnostics for undeclared access (§D6).
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use pocopine_agenkit_core::{
+    AgenkitError, AgenkitResult, ContextGapDiagnostic, ContextManifest, FlowDescriptor,
+    ResourceKind, RetrievalSet, RunId, StepId, StepKind, StepStatus, StreamMode, TraceId, events,
+};
+use schemars::JsonSchema;
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use super::agent::{AgentRun, AiAgent};
+use super::context::AiContext;
+use super::generate::Ai;
+use super::parallel::ParallelBuilder;
+use super::provider::BoxFuture;
+use super::reduce::ReduceBuilder;
+use super::retrieval::AiRetriever;
+use super::run::RunState;
+use super::schema::schema_ref_for;
+use super::thread::ThreadBuilder;
+
+/// An object-safe registered flow: validates JSON input, runs the typed body,
+/// and serializes the typed output.
+pub trait FlowHandler: Send + Sync + 'static {
+    /// The flow id.
+    fn id(&self) -> &str;
+    /// The flow descriptor (schemas + manifest + stream mode).
+    fn descriptor(&self) -> FlowDescriptor;
+    /// Run the flow over JSON input within `ctx`.
+    fn run_json<'a>(
+        &'a self,
+        input: serde_json::Value,
+        ctx: AiFlowContext,
+    ) -> BoxFuture<'a, AgenkitResult<serde_json::Value>>;
+}
+
+/// A typed flow: `id` + a body `Fn(Input, AiFlowContext) -> Future<Output>`.
+pub struct Flow<I, O, F> {
+    descriptor: FlowDescriptor,
+    handler: F,
+    _marker: PhantomData<fn(I) -> O>,
+}
+
+impl<I, O, F, Fut> Flow<I, O, F>
+where
+    I: DeserializeOwned + JsonSchema + Send + 'static,
+    O: Serialize + JsonSchema + Send + 'static,
+    F: Fn(I, AiFlowContext) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = AgenkitResult<O>> + Send + 'static,
+{
+    /// Register a flow body under `id`. The input/output JSON schemas are
+    /// derived from `I`/`O` via `schemars`, so the public server contract and
+    /// context manifest carry the real shapes.
+    pub fn new(id: impl Into<String>, handler: F) -> Self {
+        let descriptor = FlowDescriptor::new(id)
+            .input(schema_ref_for::<I>())
+            .output(schema_ref_for::<O>());
+        Self {
+            descriptor,
+            handler,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Mark the flow public (exposed as a server function).
+    pub fn public(mut self) -> Self {
+        self.descriptor = self.descriptor.public();
+        self
+    }
+
+    /// Set the public stream mode.
+    pub fn stream_mode(mut self, mode: StreamMode) -> Self {
+        self.descriptor = self.descriptor.stream_mode(mode);
+        self
+    }
+
+    /// Declare a tool dependency.
+    pub fn uses_tool(mut self, id: impl Into<String>) -> Self {
+        self.descriptor = self.descriptor.uses_tool(id);
+        self
+    }
+
+    /// Declare a retriever dependency.
+    pub fn uses_retriever(mut self, id: impl Into<String>) -> Self {
+        self.descriptor = self.descriptor.uses_retriever(id);
+        self
+    }
+
+    /// Declare an agent dependency.
+    pub fn uses_agent(mut self, id: impl Into<String>) -> Self {
+        self.descriptor = self.descriptor.uses_agent(id);
+        self
+    }
+
+    /// Declare an app-state dependency.
+    pub fn uses_state(mut self, key: impl Into<String>) -> Self {
+        self.descriptor = self.descriptor.uses_state(key);
+        self
+    }
+}
+
+impl<I, O, F, Fut> FlowHandler for Flow<I, O, F>
+where
+    I: DeserializeOwned + Send + 'static,
+    O: Serialize + Send + 'static,
+    F: Fn(I, AiFlowContext) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = AgenkitResult<O>> + Send + 'static,
+{
+    fn id(&self) -> &str {
+        &self.descriptor.id
+    }
+
+    fn descriptor(&self) -> FlowDescriptor {
+        self.descriptor.clone()
+    }
+
+    fn run_json<'a>(
+        &'a self,
+        input: serde_json::Value,
+        ctx: AiFlowContext,
+    ) -> BoxFuture<'a, AgenkitResult<serde_json::Value>> {
+        Box::pin(async move {
+            let input: I = serde_json::from_value(input).map_err(|err| {
+                AgenkitError::validation(format!("flow `{}` input: {err}", self.descriptor.id))
+            })?;
+            let output = (self.handler)(input, ctx).await?;
+            serde_json::to_value(output).map_err(|err| {
+                AgenkitError::validation(format!("flow `{}` output: {err}", self.descriptor.id))
+            })
+        })
+    }
+}
+
+/// A registry of flows keyed by id.
+#[derive(Default, Clone)]
+pub struct FlowRegistry {
+    flows: HashMap<String, Arc<dyn FlowHandler>>,
+}
+
+impl FlowRegistry {
+    /// An empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a flow.
+    pub fn register<H: FlowHandler>(&mut self, flow: H) {
+        self.flows.insert(flow.id().to_string(), Arc::new(flow));
+    }
+
+    /// Look up a flow by id.
+    pub fn get(&self, id: &str) -> Option<Arc<dyn FlowHandler>> {
+        self.flows.get(id).cloned()
+    }
+
+    /// Whether a flow id is registered.
+    pub fn contains(&self, id: &str) -> bool {
+        self.flows.contains_key(id)
+    }
+}
+
+/// The context handed to a flow body. Cheap to clone (`Arc` inside).
+#[derive(Clone)]
+pub struct AiFlowContext {
+    run: Arc<RunState>,
+    flow_id: String,
+    manifest: ContextManifest,
+    parent_step: Option<StepId>,
+}
+
+impl AiFlowContext {
+    pub(crate) fn new(run: Arc<RunState>, flow_id: String, manifest: ContextManifest) -> Self {
+        Self {
+            run,
+            flow_id,
+            manifest,
+            parent_step: None,
+        }
+    }
+
+    /// The run id for this invocation.
+    pub fn run_id(&self) -> &RunId {
+        &self.run.run_id
+    }
+
+    /// The trace id for this invocation.
+    pub fn trace_id(&self) -> &TraceId {
+        &self.run.trace_id
+    }
+
+    pub(crate) fn run_state(&self) -> &Arc<RunState> {
+        &self.run
+    }
+
+    /// A traced generation request bound to this run.
+    pub fn ai(&self) -> Ai {
+        Ai::new(self.run.inner.clone()).with_tracer(self.run.clone(), self.parent_step.clone())
+    }
+
+    /// Begin a typed agent run under this flow's trace tree.
+    pub fn agent<A: AiAgent>(&self) -> AgentRun<A> {
+        AgentRun::new(self.run.clone(), self.parent_step.clone())
+    }
+
+    /// Open or create thread state for agent `A`.
+    pub fn thread<A: AiAgent>(&self) -> ThreadBuilder {
+        ThreadBuilder::new(self.run.clone(), A::ID)
+    }
+
+    /// Reduce parallel candidates into one typed result (§D7).
+    pub fn reduce<C>(&self, name: impl Into<String>, candidates: Vec<C>) -> ReduceBuilder<'_, C> {
+        ReduceBuilder::new(self, name, candidates)
+    }
+
+    /// Begin a bounded parallel fan-out group (§D7).
+    pub fn parallel<T: Send + 'static>(&self, group: impl Into<String>) -> ParallelBuilder<'_, T> {
+        ParallelBuilder::new(self, group)
+    }
+
+    /// Fetch a framework-mediated app resource by key (§D6). Prefer declaring
+    /// it via `Flow::uses_state(...)` so the access is traceable.
+    pub fn state<T: std::any::Any + Send + Sync>(
+        &self,
+        key: &str,
+    ) -> pocopine_agenkit_core::AgenkitResult<Arc<T>> {
+        self.record_access(ResourceKind::State, key);
+        self.exec_context().state(key)
+    }
+
+    /// The caller principal this flow runs under (anonymous unless invoked with
+    /// one via `run_public_flow_as` / a principal scope) (§D5/§D10).
+    pub fn principal(&self) -> &pocopine_auth::Principal {
+        &self.run.principal
+    }
+
+    /// An execution context over the runtime's app state, bound to the caller
+    /// principal so tools/retrieval run under the request identity.
+    fn exec_context(&self) -> AiContext {
+        AiContext::with_principal(self.run.inner.state.clone(), self.run.principal.clone())
+    }
+
+    /// Record framework-mediated access; emit an advisory gap diagnostic when
+    /// the resource was not declared in the flow's manifest (§D6).
+    fn record_access(&self, kind: ResourceKind, id: &str) {
+        if !self.manifest.contains(kind, id) {
+            let diagnostic = ContextGapDiagnostic::new(self.flow_id.clone(), kind, id);
+            self.run.emit(
+                self.run
+                    .event(
+                        events::AI_CONTEXT_GAP,
+                        StepKind::Custom,
+                        StepStatus::Completed,
+                    )
+                    .with_field("flow_id", self.flow_id.clone())
+                    .with_field("resource_id", diagnostic.resource_id)
+                    .with_field("message", diagnostic.message),
+            );
+        }
+    }
+
+    /// Wrap custom app work in a traced step under this flow's trace tree.
+    pub async fn step<T, Fut>(&self, name: &str, work: Fut) -> AgenkitResult<T>
+    where
+        Fut: Future<Output = AgenkitResult<T>>,
+    {
+        let step_id = self.run.next_step_id();
+        let mut started = self
+            .run
+            .event(
+                events::AI_STEP_STARTED,
+                StepKind::Custom,
+                StepStatus::Started,
+            )
+            .with_step(step_id.clone())
+            .with_field("name", name);
+        if let Some(parent) = &self.parent_step {
+            started = started.with_parent(parent.clone());
+        }
+        self.run.emit(started);
+
+        let result = work.await;
+        match &result {
+            Ok(_) => self.run.emit(
+                self.run
+                    .event(
+                        events::AI_STEP_COMPLETED,
+                        StepKind::Custom,
+                        StepStatus::Completed,
+                    )
+                    .with_step(step_id)
+                    .with_field("name", name),
+            ),
+            Err(error) => self.run.emit(
+                self.run
+                    .event(events::AI_STEP_FAILED, StepKind::Custom, StepStatus::Failed)
+                    .with_step(step_id)
+                    .with_field("name", name)
+                    .with_error(error.clone()),
+            ),
+        }
+        result
+    }
+
+    /// Begin a deterministic retrieval against retriever `R`.
+    pub fn retrieve<R: AiRetriever>(&self) -> RetrieveBuilder<'_, R>
+    where
+        R::Query: Serialize,
+    {
+        RetrieveBuilder {
+            ctx: self,
+            query: None,
+            top_k: None,
+            _marker: PhantomData,
+        }
+    }
+}
+
+/// Builder for a deterministic retrieval (`ctx.retrieve::<R>()`).
+pub struct RetrieveBuilder<'a, R: AiRetriever> {
+    ctx: &'a AiFlowContext,
+    query: Option<R::Query>,
+    top_k: Option<u32>,
+    _marker: PhantomData<R>,
+}
+
+impl<'a, R: AiRetriever> RetrieveBuilder<'a, R>
+where
+    R::Query: Serialize,
+{
+    /// Set the typed query.
+    pub fn query(mut self, query: R::Query) -> Self {
+        self.query = Some(query);
+        self
+    }
+
+    /// Limit the number of hits (best-effort: merged into the query object).
+    pub fn top_k(mut self, k: u32) -> Self {
+        self.top_k = Some(k);
+        self
+    }
+
+    /// Execute the retrieval, emitting `ai_retrieval_*` trace events.
+    pub async fn run(self) -> AgenkitResult<RetrievalSet> {
+        let retriever = self.ctx.run.inner.retrievers.get(R::ID).ok_or_else(|| {
+            AgenkitError::not_found(format!("retriever `{}` is not registered", R::ID))
+        })?;
+        self.ctx.record_access(ResourceKind::Retriever, R::ID);
+
+        let query = self.query.ok_or_else(|| {
+            AgenkitError::config(format!("retriever `{}` requires a query", R::ID))
+        })?;
+        let mut value = serde_json::to_value(query).map_err(|err| {
+            AgenkitError::validation(format!("retriever `{}` query: {err}", R::ID))
+        })?;
+        if let (Some(k), Some(object)) = (self.top_k, value.as_object_mut()) {
+            object
+                .entry("top_k")
+                .or_insert_with(|| serde_json::json!(k));
+        }
+
+        let step_id = self.ctx.run.next_step_id();
+        self.ctx.run.emit(
+            self.ctx
+                .run
+                .event(
+                    events::AI_RETRIEVAL_STARTED,
+                    StepKind::Retrieval,
+                    StepStatus::Started,
+                )
+                .with_step(step_id.clone())
+                .with_field("retriever_id", R::ID),
+        );
+
+        let result = retriever
+            .retrieve_json(value, self.ctx.exec_context())
+            .await;
+        match &result {
+            Ok(set) => self.ctx.run.emit(
+                self.ctx
+                    .run
+                    .event(
+                        events::AI_RETRIEVAL_COMPLETED,
+                        StepKind::Retrieval,
+                        StepStatus::Completed,
+                    )
+                    .with_step(step_id)
+                    .with_field("retriever_id", R::ID)
+                    .with_field("hit_count", set.len() as u64),
+            ),
+            Err(error) => self.ctx.run.emit(
+                self.ctx
+                    .run
+                    .event(
+                        events::AI_RETRIEVAL_FAILED,
+                        StepKind::Retrieval,
+                        StepStatus::Failed,
+                    )
+                    .with_step(step_id)
+                    .with_field("retriever_id", R::ID)
+                    .with_error(error.clone()),
+            ),
+        }
+        result
+    }
+}

--- a/crates/pocopine-agenkit/src/server/generate.rs
+++ b/crates/pocopine-agenkit/src/server/generate.rs
@@ -1,0 +1,490 @@
+//! The `Ai` generation builder (RFC-093 Phase 2.2, §D3).
+//!
+//! `agenkit.ai().system(..).prompt(..).generate_text()` for text, or
+//! `.schema::<T>().generate_structured()` for typed structured output. Model
+//! output is untrusted: structured output is validated by deserializing into
+//! `T`, and a non-JSON / shape-mismatched response surfaces as
+//! [`AgenkitError::Validation`] (§D10).
+
+use std::marker::PhantomData;
+use std::sync::Arc;
+
+use futures::StreamExt;
+use pocopine_agenkit_core::{
+    AgenkitError, AgenkitResult, Content, FlowStreamEvent, Message, ModelRef, Role, StepId,
+    StepKind, StepStatus, Usage, events,
+};
+use schemars::JsonSchema;
+use serde::de::DeserializeOwned;
+
+use super::agenkit::AgenkitInner;
+use super::provider::{FinishReason, GenerateRequest, GenerateResponse, StreamChunk};
+use super::run::RunState;
+use super::schema::json_schema_for;
+
+/// A pending generation request bound to a runtime.
+pub struct Ai {
+    inner: Arc<AgenkitInner>,
+    model: Option<ModelRef>,
+    system: Option<String>,
+    messages: Vec<Message>,
+    max_tokens: Option<u32>,
+    tracer: Option<Arc<RunState>>,
+    parent_step: Option<StepId>,
+}
+
+impl Ai {
+    pub(crate) fn new(inner: Arc<AgenkitInner>) -> Self {
+        Self {
+            inner,
+            model: None,
+            system: None,
+            messages: Vec::new(),
+            max_tokens: None,
+            tracer: None,
+            parent_step: None,
+        }
+    }
+
+    /// Bind this request to a run so model calls emit `ai_model_*` trace events.
+    pub(crate) fn with_tracer(mut self, run: Arc<RunState>, parent_step: Option<StepId>) -> Self {
+        self.tracer = Some(run);
+        self.parent_step = parent_step;
+        self
+    }
+
+    /// Override the model alias for this request.
+    pub fn model(mut self, model: impl Into<ModelRef>) -> Self {
+        self.model = Some(model.into());
+        self
+    }
+
+    /// Set the system prompt.
+    pub fn system(mut self, system: impl Into<String>) -> Self {
+        self.system = Some(system.into());
+        self
+    }
+
+    /// Append a user prompt message.
+    pub fn prompt(mut self, prompt: impl Into<String>) -> Self {
+        self.messages.push(Message::new(Role::User, prompt.into()));
+        self
+    }
+
+    /// Append an arbitrary message.
+    pub fn message(mut self, message: Message) -> Self {
+        self.messages.push(message);
+        self
+    }
+
+    /// Cap output tokens.
+    pub fn max_tokens(mut self, max_tokens: u32) -> Self {
+        self.max_tokens = Some(max_tokens);
+        self
+    }
+
+    /// Switch to typed structured output for `T`.
+    ///
+    /// `T` must derive `schemars::JsonSchema` so the runtime can constrain the
+    /// model (strict schema where the provider supports it). The result is
+    /// *type*-validated (deserialized into `T`); schema keyword constraints
+    /// like `range`/`length`/`regex` are not re-checked runtime-side.
+    pub fn schema<T: DeserializeOwned + JsonSchema>(self) -> AiStructured<T> {
+        AiStructured {
+            ai: self,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Resolve the effective model: explicit override, else the runtime default.
+    fn resolve_model(&self) -> AgenkitResult<ModelRef> {
+        self.model
+            .clone()
+            .or_else(|| self.inner.default_model.clone())
+            .ok_or_else(|| {
+                AgenkitError::config("no model specified and no default model configured")
+            })
+    }
+
+    fn build_request(
+        &self,
+        json_schema: Option<serde_json::Value>,
+    ) -> AgenkitResult<GenerateRequest> {
+        Ok(GenerateRequest {
+            model: self.resolve_model()?,
+            system: self.system.clone(),
+            messages: self.messages.clone(),
+            tools: Vec::new(),
+            json_schema,
+            max_tokens: self.max_tokens,
+        })
+    }
+
+    async fn run(&self, json_schema: Option<serde_json::Value>) -> AgenkitResult<GenerateResponse> {
+        let request = self.build_request(json_schema)?;
+        self.inner.check_model_allowed(&request.model)?;
+        let provider = self.inner.providers.resolve(&request.model)?;
+        let model = request.model.clone();
+
+        let Some(run) = &self.tracer else {
+            return provider.generate(request).await;
+        };
+
+        let step_id = run.next_step_id();
+        let mut started = run
+            .event(
+                events::AI_MODEL_REQUEST,
+                StepKind::Generation,
+                StepStatus::Started,
+            )
+            .with_step(step_id.clone())
+            .with_model(model.clone());
+        if let Some(parent) = &self.parent_step {
+            started = started.with_parent(parent.clone());
+        }
+        run.emit(started);
+
+        let result = provider.generate(request).await;
+        match &result {
+            Ok(response) => {
+                let mut completed = run
+                    .event(
+                        events::AI_MODEL_RESPONSE,
+                        StepKind::Generation,
+                        StepStatus::Completed,
+                    )
+                    .with_step(step_id)
+                    .with_model(model);
+                if let Some(usage) = response.usage {
+                    completed = completed.with_usage(usage);
+                }
+                run.emit(completed);
+            }
+            Err(error) => run.emit(
+                run.event(
+                    events::AI_MODEL_FAILED,
+                    StepKind::Generation,
+                    StepStatus::Failed,
+                )
+                .with_step(step_id)
+                .with_model(model)
+                .with_error(error.clone()),
+            ),
+        }
+        result
+    }
+
+    /// Generate plain text.
+    pub async fn generate_text(self) -> AgenkitResult<String> {
+        Ok(self.run(None).await?.text_output())
+    }
+
+    /// Generate text plus its token usage.
+    pub async fn generate_text_with_usage(self) -> AgenkitResult<(String, Option<Usage>)> {
+        let response = self.run(None).await?;
+        Ok((response.text_output(), response.usage))
+    }
+
+    /// Generate text, streaming each fragment to the flow's client stream as a
+    /// user-visible `OutputDelta` while accumulating the full text.
+    ///
+    /// Uses the provider's native streaming when available; otherwise the
+    /// runtime's one-shot fallback delivers the result as a single delta. The
+    /// returned string is always the complete output.
+    pub async fn stream_text(self) -> AgenkitResult<String> {
+        Ok(self.run_streamed(None, false).await?.display_text())
+    }
+
+    /// Run a streamed generation: emit `ai_model_*` traces, consume the
+    /// provider stream, forward output to the run's client stream (text deltas,
+    /// or partial structured objects when `structured`), and assemble the final
+    /// response.
+    async fn run_streamed(
+        &self,
+        json_schema: Option<serde_json::Value>,
+        structured: bool,
+    ) -> AgenkitResult<GenerateResponse> {
+        let request = self.build_request(json_schema)?;
+        self.inner.check_model_allowed(&request.model)?;
+        let provider = self.inner.providers.resolve(&request.model)?;
+        let model = request.model.clone();
+
+        let model_step = self.tracer.as_ref().map(|run| {
+            let step_id = run.next_step_id();
+            let mut started = run
+                .event(
+                    events::AI_MODEL_REQUEST,
+                    StepKind::Generation,
+                    StepStatus::Started,
+                )
+                .with_step(step_id.clone())
+                .with_model(model.clone())
+                .with_field("streaming", true);
+            if let Some(parent) = &self.parent_step {
+                started = started.with_parent(parent.clone());
+            }
+            run.emit(started);
+            step_id
+        });
+
+        let mut stream = provider.generate_stream(request);
+        let mut text = String::new();
+        let mut tool_calls = Vec::new();
+        let mut usage = None;
+        let mut failure = None;
+        let mut last_partial: Option<serde_json::Value> = None;
+        while let Some(chunk) = stream.next().await {
+            match chunk {
+                Ok(StreamChunk::Text(delta)) => {
+                    text.push_str(&delta);
+                    if let Some(run) = &self.tracer {
+                        run.mark_output_streamed();
+                        if structured {
+                            // Re-parse only when the delta carries a structural
+                            // or string-boundary char — i.e. when a field can
+                            // start, advance, or complete. Re-parsing the whole
+                            // buffer on every token would be O(n^2) over a large
+                            // structured response; pure mid-value token growth is
+                            // folded into the next structural delta.
+                            let advances = delta.bytes().any(|b| {
+                                matches!(b, b'{' | b'}' | b'[' | b']' | b':' | b',' | b'"')
+                            });
+                            if advances {
+                                // Emit a Genkit-style partial object whenever the
+                                // best-effort parse of the JSON-so-far advances.
+                                if let Some(partial) =
+                                    super::partial_json::parse_partial_json(&text)
+                                    && last_partial.as_ref() != Some(&partial)
+                                {
+                                    run.stream(FlowStreamEvent::ObjectDelta {
+                                        partial: partial.clone(),
+                                    });
+                                    last_partial = Some(partial);
+                                }
+                            }
+                        } else {
+                            run.stream(FlowStreamEvent::OutputDelta {
+                                text: delta.clone(),
+                            });
+                        }
+                    }
+                }
+                Ok(StreamChunk::ToolCall(call)) => tool_calls.push(call),
+                Ok(StreamChunk::Usage(reported)) => usage = Some(reported),
+                Err(error) => {
+                    failure = Some(error);
+                    break;
+                }
+            }
+        }
+        drop(stream);
+
+        let result = match failure {
+            Some(error) => Err(error),
+            None => {
+                let finish_reason = if tool_calls.is_empty() {
+                    FinishReason::Stop
+                } else {
+                    FinishReason::ToolCalls
+                };
+                Ok(GenerateResponse {
+                    content: Content::text(text),
+                    tool_calls,
+                    usage,
+                    finish_reason,
+                })
+            }
+        };
+
+        if let (Some(run), Some(step_id)) = (&self.tracer, model_step) {
+            match &result {
+                Ok(response) => {
+                    let mut completed = run
+                        .event(
+                            events::AI_MODEL_RESPONSE,
+                            StepKind::Generation,
+                            StepStatus::Completed,
+                        )
+                        .with_step(step_id)
+                        .with_model(model);
+                    if let Some(usage) = response.usage {
+                        completed = completed.with_usage(usage);
+                    }
+                    run.emit(completed);
+                }
+                Err(error) => run.emit(
+                    run.event(
+                        events::AI_MODEL_FAILED,
+                        StepKind::Generation,
+                        StepStatus::Failed,
+                    )
+                    .with_step(step_id)
+                    .with_model(model)
+                    .with_error(error.clone()),
+                ),
+            }
+        }
+        result
+    }
+}
+
+/// An [`Ai`] request bound to a structured output type `T`.
+pub struct AiStructured<T> {
+    ai: Ai,
+    _marker: PhantomData<T>,
+}
+
+impl<T: DeserializeOwned + JsonSchema> AiStructured<T> {
+    /// Override the model alias.
+    pub fn model(mut self, model: impl Into<ModelRef>) -> Self {
+        self.ai = self.ai.model(model);
+        self
+    }
+
+    /// Set the system prompt.
+    pub fn system(mut self, system: impl Into<String>) -> Self {
+        self.ai = self.ai.system(system);
+        self
+    }
+
+    /// Append a user prompt message.
+    pub fn prompt(mut self, prompt: impl Into<String>) -> Self {
+        self.ai = self.ai.prompt(prompt);
+        self
+    }
+
+    /// Generate and validate typed structured output.
+    pub async fn generate_structured(self) -> AgenkitResult<T> {
+        // The real JSON Schema for `T` — providers that support it constrain
+        // generation; others fall back to JSON mode + a prompt instruction.
+        let schema = json_schema_for::<T>();
+        let response = self.ai.run(Some(schema)).await?;
+
+        let value = response
+            .structured_value()
+            .cloned()
+            .or_else(|| serde_json::from_str(&response.text_output()).ok())
+            .ok_or_else(|| {
+                AgenkitError::validation("model did not return JSON for a structured request")
+            })?;
+
+        serde_json::from_value(value).map_err(|err| {
+            AgenkitError::validation(format!("structured output did not match schema: {err}"))
+        })
+    }
+
+    /// Generate structured output while streaming Genkit-style partial objects
+    /// to the flow's client stream (`ObjectDelta`), then validate and return the
+    /// complete `T`.
+    ///
+    /// Each `ObjectDelta` is a best-effort parse of the JSON generated so far,
+    /// so a client can render a progressively-completing object. Uses native
+    /// streaming when the provider supports it; otherwise the result arrives as
+    /// a single partial.
+    pub async fn stream_structured(self) -> AgenkitResult<T> {
+        let schema = json_schema_for::<T>();
+        let response = self.ai.run_streamed(Some(schema), true).await?;
+
+        let value = response
+            .structured_value()
+            .cloned()
+            .or_else(|| serde_json::from_str(&response.display_text()).ok())
+            .ok_or_else(|| {
+                AgenkitError::validation("model did not return JSON for a structured request")
+            })?;
+
+        serde_json::from_value(value).map_err(|err| {
+            AgenkitError::validation(format!("structured output did not match schema: {err}"))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::agenkit::Agenkit;
+    use super::super::provider::MockProvider;
+    use pocopine_agenkit_core::ModelRef;
+    use serde::Deserialize;
+
+    fn runtime(provider: MockProvider) -> Agenkit {
+        Agenkit::builder()
+            .provider(provider)
+            .default_model(ModelRef::new("local/default"))
+            .build()
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn generate_text_uses_default_model() {
+        let agenkit = runtime(
+            MockProvider::new("local").on_prompt_text("uploads", "uploads use presigned URLs"),
+        );
+        let answer = agenkit
+            .ai()
+            .prompt("how do uploads work?")
+            .generate_text()
+            .await
+            .unwrap();
+        assert_eq!(answer, "uploads use presigned URLs");
+    }
+
+    #[derive(Debug, Deserialize, PartialEq, schemars::JsonSchema)]
+    struct Summary {
+        title: String,
+        words: u32,
+    }
+
+    #[tokio::test]
+    async fn generate_structured_validates_into_type() {
+        let agenkit = runtime(
+            MockProvider::new("local")
+                .default_structured(serde_json::json!({"title": "Uploads", "words": 12})),
+        );
+        let summary: Summary = agenkit
+            .ai()
+            .prompt("summarize the uploads doc")
+            .schema::<Summary>()
+            .generate_structured()
+            .await
+            .unwrap();
+        assert_eq!(
+            summary,
+            Summary {
+                title: "Uploads".to_string(),
+                words: 12
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn structured_shape_mismatch_is_validation_error() {
+        let agenkit =
+            runtime(MockProvider::new("local").default_structured(serde_json::json!({"title": 7})));
+        let result = agenkit
+            .ai()
+            .prompt("x")
+            .schema::<Summary>()
+            .generate_structured()
+            .await;
+        assert_eq!(result.unwrap_err().kind(), "validation");
+    }
+
+    #[tokio::test]
+    async fn missing_model_is_config_error() {
+        let agenkit = Agenkit::builder()
+            .provider(MockProvider::new("local"))
+            .build()
+            .unwrap();
+        let result = agenkit.ai().prompt("x").generate_text().await;
+        assert_eq!(result.unwrap_err().kind(), "config");
+    }
+
+    #[test]
+    fn structured_output_derives_a_real_schema() {
+        // The runtime sends a real JSON Schema (not a marker), so a capable
+        // provider can constrain generation.
+        let schema = super::json_schema_for::<Summary>();
+        assert_eq!(schema["properties"]["title"]["type"], "string");
+        assert!(schema["properties"].get("words").is_some());
+    }
+}

--- a/crates/pocopine-agenkit/src/server/mod.rs
+++ b/crates/pocopine-agenkit/src/server/mod.rs
@@ -8,6 +8,7 @@
 
 pub mod agenkit;
 pub mod agent;
+pub mod bridge;
 pub mod context;
 pub mod embed;
 pub mod flow;
@@ -20,11 +21,13 @@ pub mod reduce;
 pub mod retrieval;
 pub mod run;
 mod schema;
+pub mod stream_route;
 pub mod thread;
 pub mod tool;
 
-pub use agenkit::{with_principal, Agenkit, AgenkitBuilder};
+pub use agenkit::{Agenkit, AgenkitBuilder, with_principal};
 pub use agent::{AgentRun, AiAgent, AiAgentBuilder};
+pub use bridge::to_server_error;
 pub use context::{AiContext, AiToolContext, AppState, EmbedContext, RetrievalContext};
 pub use embed::{AiEmbedder, DynEmbedder, EmbedderRegistry};
 pub use flow::{AiFlowContext, Flow, FlowHandler, FlowRegistry, RetrieveBuilder};
@@ -36,6 +39,7 @@ pub use provider::{
     ProviderCapabilities, ProviderRegistry, StreamChunk,
 };
 pub use reduce::ReduceBuilder;
-pub use retrieval::{retriever_as_tool, AiRetriever, DynRetriever, RetrieverRegistry};
+pub use retrieval::{AiRetriever, DynRetriever, RetrieverRegistry, retriever_as_tool};
+pub use stream_route::{AI_FLOW_STREAM_PATH, ai_flow_stream_router, stream_filter};
 pub use thread::{AgentThreadHandle, AgentThreadStore, InMemoryThreadStore, ThreadBuilder};
 pub use tool::{AiTool, DynTool, ToolRegistry};

--- a/crates/pocopine-agenkit/src/server/mod.rs
+++ b/crates/pocopine-agenkit/src/server/mod.rs
@@ -6,20 +6,36 @@
 //! This whole module is gated to non-wasm targets (see `lib.rs`); the browser
 //! talks to it only through generated `#[server]` helpers (§D10).
 
+pub mod agenkit;
+pub mod agent;
 pub mod context;
 pub mod embed;
+pub mod flow;
+pub mod generate;
 pub mod observe;
+pub mod parallel;
+mod partial_json;
 pub mod provider;
+pub mod reduce;
 pub mod retrieval;
+pub mod run;
 mod schema;
+pub mod thread;
 pub mod tool;
 
+pub use agenkit::{with_principal, Agenkit, AgenkitBuilder};
+pub use agent::{AgentRun, AiAgent, AiAgentBuilder};
 pub use context::{AiContext, AiToolContext, AppState, EmbedContext, RetrievalContext};
 pub use embed::{AiEmbedder, DynEmbedder, EmbedderRegistry};
+pub use flow::{AiFlowContext, Flow, FlowHandler, FlowRegistry, RetrieveBuilder};
+pub use generate::{Ai, AiStructured};
 pub use observe::{emit_trace_event, to_observed_event};
+pub use parallel::ParallelBuilder;
 pub use provider::{
     BoxFuture, BoxStream, FinishReason, GenerateRequest, GenerateResponse, MockProvider, Provider,
     ProviderCapabilities, ProviderRegistry, StreamChunk,
 };
+pub use reduce::ReduceBuilder;
 pub use retrieval::{retriever_as_tool, AiRetriever, DynRetriever, RetrieverRegistry};
+pub use thread::{AgentThreadHandle, AgentThreadStore, InMemoryThreadStore, ThreadBuilder};
 pub use tool::{AiTool, DynTool, ToolRegistry};

--- a/crates/pocopine-agenkit/src/server/mod.rs
+++ b/crates/pocopine-agenkit/src/server/mod.rs
@@ -1,0 +1,16 @@
+//! Host-side runtime (RFC-093 §D2). Everything server-side lives here: the
+//! `Agenkit`/`Ai` builders, providers, and — across later checkpoints —
+//! tools/retrievers/embedders, flows, agents, threads, parallel orchestration,
+//! trace emission, the server-function bridge, and the streaming route.
+//!
+//! This whole module is gated to non-wasm targets (see `lib.rs`); the browser
+//! talks to it only through generated `#[server]` helpers (§D10).
+
+pub mod observe;
+pub mod provider;
+
+pub use observe::{emit_trace_event, to_observed_event};
+pub use provider::{
+    BoxFuture, BoxStream, FinishReason, GenerateRequest, GenerateResponse, MockProvider, Provider,
+    ProviderCapabilities, ProviderRegistry, StreamChunk,
+};

--- a/crates/pocopine-agenkit/src/server/mod.rs
+++ b/crates/pocopine-agenkit/src/server/mod.rs
@@ -6,11 +6,20 @@
 //! This whole module is gated to non-wasm targets (see `lib.rs`); the browser
 //! talks to it only through generated `#[server]` helpers (§D10).
 
+pub mod context;
+pub mod embed;
 pub mod observe;
 pub mod provider;
+pub mod retrieval;
+mod schema;
+pub mod tool;
 
+pub use context::{AiContext, AiToolContext, AppState, EmbedContext, RetrievalContext};
+pub use embed::{AiEmbedder, DynEmbedder, EmbedderRegistry};
 pub use observe::{emit_trace_event, to_observed_event};
 pub use provider::{
     BoxFuture, BoxStream, FinishReason, GenerateRequest, GenerateResponse, MockProvider, Provider,
     ProviderCapabilities, ProviderRegistry, StreamChunk,
 };
+pub use retrieval::{retriever_as_tool, AiRetriever, DynRetriever, RetrieverRegistry};
+pub use tool::{AiTool, DynTool, ToolRegistry};

--- a/crates/pocopine-agenkit/src/server/observe.rs
+++ b/crates/pocopine-agenkit/src/server/observe.rs
@@ -1,0 +1,209 @@
+//! Trace-mapping layer: core [`TraceEvent`] -> `pocopine_observe::ObservedEvent`
+//! -> `emit_tracing` (RFC-093 Phase 2.3, §D12, §D15 DC-1).
+//!
+//! This is the single place the runtime touches observability. Core stays
+//! observe-neutral; every AI event family is mapped here, with explicit
+//! per-field [`FieldPrivacy`] so default redaction (`public_only`) strips
+//! anything sensitive. Operational ids, kinds, counts, and durations are
+//! `Public`; an error *kind* is `Public` but the error *message* is
+//! `Sensitive` (it may quote provider internals).
+
+use pocopine_agenkit_core::{StepKind, StepStatus, TraceEvent};
+use pocopine_observe::{
+    FieldPrivacy, FieldValue, ObserveContext, ObservedEvent, RedactionPolicy, emit_tracing,
+};
+
+fn step_kind_str(kind: StepKind) -> &'static str {
+    match kind {
+        StepKind::Generation => "generation",
+        StepKind::Tool => "tool",
+        StepKind::Retrieval => "retrieval",
+        StepKind::Embedding => "embedding",
+        StepKind::Reducer => "reducer",
+        StepKind::Agent => "agent",
+        StepKind::Parallel => "parallel",
+        StepKind::Custom => "custom",
+    }
+}
+
+fn step_status_str(status: StepStatus) -> &'static str {
+    match status {
+        StepStatus::Started => "started",
+        StepStatus::Completed => "completed",
+        StepStatus::Failed => "failed",
+        StepStatus::Cancelled => "cancelled",
+    }
+}
+
+/// Convert an opaque trace field value to an observability field value.
+/// Non-scalars are stringified so they remain inspectable but typed.
+fn field_value(value: &serde_json::Value) -> FieldValue {
+    match value {
+        serde_json::Value::Bool(b) => FieldValue::from(*b),
+        serde_json::Value::Number(n) => n
+            .as_u64()
+            .map(FieldValue::from)
+            .or_else(|| n.as_i64().map(FieldValue::from))
+            .or_else(|| n.as_f64().map(FieldValue::from))
+            .unwrap_or_else(|| FieldValue::from(n.to_string())),
+        serde_json::Value::String(s) => FieldValue::from(s.clone()),
+        other => FieldValue::from(other.to_string()),
+    }
+}
+
+/// Map a neutral [`TraceEvent`] to a privacy-labeled [`ObservedEvent`] on the
+/// `pocopine.trace` target. Pure (no emission) so it is unit-testable.
+pub fn to_observed_event(event: &TraceEvent) -> ObservedEvent {
+    let mut observed = ObservedEvent::trace(event.name.clone())
+        .context(ObserveContext::default().with_trace_id(event.trace_id.as_str()))
+        .field("run_id", event.run_id.as_str(), FieldPrivacy::Public)
+        .field("kind", step_kind_str(event.kind), FieldPrivacy::Public)
+        .field(
+            "status",
+            step_status_str(event.status),
+            FieldPrivacy::Public,
+        );
+
+    if let Some(step_id) = &event.step_id {
+        observed = observed.field("step_id", step_id.as_str(), FieldPrivacy::Public);
+    }
+    if let Some(parent) = &event.parent_step_id {
+        observed = observed.field("parent_step_id", parent.as_str(), FieldPrivacy::Public);
+    }
+    if let Some(group) = &event.parallel_group_id {
+        observed = observed.field("parallel_group_id", group.as_str(), FieldPrivacy::Public);
+    }
+    if let Some(model) = &event.model {
+        observed = observed.field("model", model.as_str(), FieldPrivacy::Public);
+    }
+    if let Some(usage) = &event.usage {
+        observed = observed
+            .field("input_tokens", usage.input_tokens, FieldPrivacy::Public)
+            .field("output_tokens", usage.output_tokens, FieldPrivacy::Public)
+            .field("total_tokens", usage.total(), FieldPrivacy::Public);
+    }
+    if let Some(cost) = &event.cost {
+        observed = observed
+            .field("cost_amount", cost.amount, FieldPrivacy::Public)
+            .field("cost_currency", cost.currency.clone(), FieldPrivacy::Public);
+    }
+    if let Some(error) = &event.error {
+        // The kind is safe; the message may quote provider internals.
+        observed = observed
+            .field("error_kind", error.kind(), FieldPrivacy::Public)
+            .field("error_message", error.to_string(), FieldPrivacy::Sensitive);
+    }
+    if let Some(version) = &event.manifest_version {
+        observed = observed.field("manifest_version", version.clone(), FieldPrivacy::Public);
+    }
+    for (key, value) in &event.fields {
+        let privacy = if PUBLIC_FIELD_KEYS.contains(&key.as_str()) {
+            FieldPrivacy::Public
+        } else {
+            FieldPrivacy::Sensitive
+        };
+        observed = observed.field(key.clone(), field_value(value), privacy);
+    }
+
+    observed
+}
+
+/// Freeform `TraceEvent::fields` keys that are structural (ids, names, counts,
+/// flags) and safe under `public_only` redaction. Any key NOT listed here —
+/// including freeform messages and anything a future provider adapter stuffs
+/// into the open map — defaults to `Sensitive` and is stripped from public
+/// trace projections (§D10).
+const PUBLIC_FIELD_KEYS: &[&str] = &[
+    "accepted",
+    "agent_id",
+    "branch",
+    "branch_count",
+    "candidates",
+    "flow_id",
+    "group",
+    "hit_count",
+    "name",
+    "reducer_kind",
+    "resource_id",
+    "retriever_id",
+    "streaming",
+    "success_count",
+    "thread_id",
+    "tool_id",
+];
+
+/// Map, redact, and emit a [`TraceEvent`] through
+/// `pocopine_observe::emit_tracing`.
+///
+/// This is the runtime's only emission entry point. `emit_tracing` itself does
+/// not redact, so the §D10 contract — Sensitive fields (e.g. the raw error
+/// message) stripped under the default `public_only` policy — is enforced HERE,
+/// before anything reaches a tracing subscriber that may export off-host.
+pub fn emit_trace_event(event: &TraceEvent) {
+    emit_tracing(&to_observed_event(event).redacted(RedactionPolicy::default()));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pocopine_agenkit_core::{AgenkitError, ParallelGroupId, RunId, StepId, TraceId, Usage};
+    use pocopine_observe::RedactionPolicy;
+
+    fn sample_event() -> TraceEvent {
+        TraceEvent::new(
+            pocopine_agenkit_core::events::AI_STEP_FAILED,
+            RunId::new("run-1"),
+            TraceId::new("trace-1"),
+            StepKind::Agent,
+            StepStatus::Failed,
+        )
+        .with_step(StepId::new("b1"))
+        .with_parent(StepId::new("p"))
+        .with_parallel_group(ParallelGroupId::new("candidate_answers"))
+        .with_usage(Usage::new(10, 5))
+        .with_error(AgenkitError::provider("upstream 503 from secret-host"))
+    }
+
+    #[test]
+    fn maps_structural_fields_as_public() {
+        let observed = to_observed_event(&sample_event());
+        assert_eq!(observed.context.trace_id.as_deref(), Some("trace-1"));
+        assert!(observed.fields.contains_key("step_id"));
+        assert!(observed.fields.contains_key("parent_step_id"));
+        assert!(observed.fields.contains_key("parallel_group_id"));
+        assert!(observed.fields.contains_key("total_tokens"));
+        assert!(observed.fields.contains_key("error_kind"));
+    }
+
+    #[test]
+    fn error_message_is_sensitive_and_stripped_by_default() {
+        let observed = to_observed_event(&sample_event());
+        // The raw message is present but labeled Sensitive...
+        assert!(observed.fields.contains_key("error_message"));
+        // ...and stripped by the default public-only redaction, while the
+        // safe error_kind and structural fields survive.
+        let redacted = observed.redacted(RedactionPolicy::public_only());
+        assert!(!redacted.fields.contains_key("error_message"));
+        assert!(redacted.fields.contains_key("error_kind"));
+        assert!(redacted.fields.contains_key("parallel_group_id"));
+    }
+
+    #[test]
+    fn unlisted_freeform_fields_are_sensitive_by_default() {
+        // A key outside the structural allowlist (e.g. a freeform message or a
+        // future provider-adapter field) must not survive public_only.
+        let event = sample_event()
+            .with_field("message", "advisory text")
+            .with_field("x_provider_debug", "Bearer sk-PLANTED-not-for-clients")
+            .with_field("flow_id", "summarize");
+        let redacted = to_observed_event(&event).redacted(RedactionPolicy::public_only());
+        assert!(!redacted.fields.contains_key("message"));
+        assert!(!redacted.fields.contains_key("x_provider_debug"));
+        assert!(redacted.fields.contains_key("flow_id"));
+    }
+
+    #[test]
+    fn emit_does_not_panic_without_subscriber() {
+        emit_trace_event(&sample_event());
+    }
+}

--- a/crates/pocopine-agenkit/src/server/parallel.rs
+++ b/crates/pocopine-agenkit/src/server/parallel.rs
@@ -1,0 +1,310 @@
+//! Bounded parallel fan-out with real in-flight cancellation (RFC-093 Phase
+//! 2.6b, §D7, §D8, §D15 DC-7).
+//!
+//! `ctx.parallel(name)` runs branches concurrently on a `tokio::task::JoinSet`
+//! with a [`ParallelJoin`] policy. Unlike `pocopine-jobs` (drop/nack), losing
+//! branches are *aborted in flight* via `JoinSet::abort_all` on
+//! `FirstSuccess`/`Quorum`. Concurrency, timeout, and min-success are bounded.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use pocopine_agenkit_core::{
+    AgenkitError, AgenkitResult, FlowStreamEvent, ParallelGroupId, ParallelJoin, StepId, StepKind,
+    StepStatus, events,
+};
+use tokio::sync::Semaphore;
+use tokio::task::JoinSet;
+
+use super::flow::AiFlowContext;
+
+type BranchFuture<T> = Pin<Box<dyn Future<Output = AgenkitResult<T>> + Send + 'static>>;
+
+/// Builder for a parallel branch group (`ctx.parallel(...)`).
+pub struct ParallelBuilder<'a, T> {
+    ctx: &'a AiFlowContext,
+    group: String,
+    join: ParallelJoin,
+    min_success: Option<u32>,
+    max_concurrency: Option<usize>,
+    timeout: Option<Duration>,
+    branches: Vec<(String, BranchFuture<T>)>,
+}
+
+impl<'a, T: Send + 'static> ParallelBuilder<'a, T> {
+    pub(crate) fn new(ctx: &'a AiFlowContext, group: impl Into<String>) -> Self {
+        Self {
+            ctx,
+            group: group.into(),
+            join: ParallelJoin::AllSettled,
+            min_success: None,
+            max_concurrency: None,
+            timeout: None,
+            branches: Vec::new(),
+        }
+    }
+
+    /// Set the join policy (default `AllSettled`).
+    pub fn join(mut self, join: ParallelJoin) -> Self {
+        self.join = join;
+        self
+    }
+
+    /// Require at least `n` branches to succeed.
+    pub fn min_success(mut self, n: u32) -> Self {
+        self.min_success = Some(n);
+        self
+    }
+
+    /// Cap how many branches run at once.
+    pub fn max_concurrency(mut self, n: usize) -> Self {
+        self.max_concurrency = Some(n.max(1));
+        self
+    }
+
+    /// Per-branch timeout (a timed-out branch is a failure).
+    pub fn timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = Some(timeout);
+        self
+    }
+
+    /// Add an auto-named branch.
+    pub fn branch<F>(mut self, future: F) -> Self
+    where
+        F: Future<Output = AgenkitResult<T>> + Send + 'static,
+    {
+        let name = format!("branch-{}", self.branches.len());
+        self.branches.push((name, Box::pin(future)));
+        self
+    }
+
+    /// Add a named branch.
+    pub fn named_branch<F>(mut self, name: impl Into<String>, future: F) -> Self
+    where
+        F: Future<Output = AgenkitResult<T>> + Send + 'static,
+    {
+        self.branches.push((name.into(), Box::pin(future)));
+        self
+    }
+
+    /// Run the branches, returning the successful outputs per the join policy.
+    pub async fn run(self) -> AgenkitResult<Vec<T>> {
+        let run = self.ctx.run_state().clone();
+        let group_id = ParallelGroupId::new(self.group.clone());
+        let group_step = run.next_step_id();
+        let branch_count = self.branches.len() as u32;
+
+        run.emit(
+            run.event(
+                events::AI_PARALLEL_STARTED,
+                StepKind::Parallel,
+                StepStatus::Started,
+            )
+            .with_step(group_step.clone())
+            .with_parallel_group(group_id.clone())
+            .with_field("group", self.group.clone())
+            .with_field("branch_count", branch_count as u64),
+        );
+        run.stream(FlowStreamEvent::ParallelStarted {
+            group_id: group_id.clone(),
+            branch_count,
+            join: self.join,
+        });
+
+        let permits = self
+            .max_concurrency
+            .unwrap_or_else(|| self.branches.len().max(1));
+        let semaphore = Arc::new(Semaphore::new(permits));
+        let timeout = self.timeout;
+
+        let mut set: JoinSet<(usize, AgenkitResult<T>)> = JoinSet::new();
+        let mut branch_steps: Vec<StepId> = Vec::with_capacity(self.branches.len());
+        let mut branch_names: Vec<String> = Vec::with_capacity(self.branches.len());
+        let mut task_branch: HashMap<tokio::task::Id, usize> =
+            HashMap::with_capacity(self.branches.len());
+
+        for (index, (name, future)) in self.branches.into_iter().enumerate() {
+            let branch_step = run.next_step_id();
+            run.emit(
+                run.event(
+                    events::AI_STEP_STARTED,
+                    StepKind::Agent,
+                    StepStatus::Started,
+                )
+                .with_step(branch_step.clone())
+                .with_parent(group_step.clone())
+                .with_parallel_group(group_id.clone())
+                .with_field("branch", name.clone()),
+            );
+            run.stream(FlowStreamEvent::BranchStarted {
+                group_id: group_id.clone(),
+                step_id: branch_step.clone(),
+                name: name.clone(),
+            });
+            branch_steps.push(branch_step);
+            branch_names.push(name);
+
+            let semaphore = semaphore.clone();
+            let handle = set.spawn(async move {
+                let _permit = semaphore
+                    .acquire_owned()
+                    .await
+                    .expect("semaphore is never closed");
+                let result = match timeout {
+                    Some(duration) => match tokio::time::timeout(duration, future).await {
+                        Ok(result) => result,
+                        Err(_) => Err(AgenkitError::budget_exhausted("branch exceeded timeout")),
+                    },
+                    None => future.await,
+                };
+                (index, result)
+            });
+            task_branch.insert(handle.id(), index);
+        }
+
+        let target = match self.join {
+            ParallelJoin::FirstSuccess => 1,
+            ParallelJoin::Quorum(n) => n.max(1),
+            ParallelJoin::All | ParallelJoin::AllSettled => branch_count.max(1),
+        };
+        // An early-exit join must still satisfy `.min_success(m)`: keep racing
+        // until the floor is met instead of aborting the losers and then
+        // failing the min-success gate with certainty.
+        let target = target.max(self.min_success.unwrap_or(0));
+
+        let mut successes: Vec<T> = Vec::new();
+        let mut success_count: u32 = 0;
+        let mut first_error: Option<AgenkitError> = None;
+
+        while let Some(joined) = set.join_next().await {
+            let (index, result) = match joined {
+                Ok(pair) => pair,
+                // An aborted loser (cancelled by `abort_all`) is expected and
+                // carries no branch outcome — skip it.
+                Err(join_error) if join_error.is_cancelled() => continue,
+                // A panicked branch is a branch FAILURE, not a no-op: surface
+                // it through the normal failure path so `All` aborts the group
+                // and `AllSettled` records it instead of returning partial Ok.
+                Err(join_error) => {
+                    let Some(index) = task_branch.get(&join_error.id()).copied() else {
+                        continue;
+                    };
+                    (
+                        index,
+                        Err(AgenkitError::internal(format!(
+                            "parallel branch `{}` panicked",
+                            branch_names[index]
+                        ))),
+                    )
+                }
+            };
+            let step_id = branch_steps[index].clone();
+            let name = branch_names[index].clone();
+            match result {
+                Ok(value) => {
+                    run.emit(
+                        run.event(
+                            events::AI_STEP_COMPLETED,
+                            StepKind::Agent,
+                            StepStatus::Completed,
+                        )
+                        .with_step(step_id.clone())
+                        .with_parallel_group(group_id.clone())
+                        .with_field("branch", name),
+                    );
+                    run.stream(FlowStreamEvent::BranchCompleted {
+                        group_id: group_id.clone(),
+                        step_id,
+                    });
+                    successes.push(value);
+                    success_count += 1;
+                    if success_count >= target
+                        && matches!(
+                            self.join,
+                            ParallelJoin::FirstSuccess | ParallelJoin::Quorum(_)
+                        )
+                    {
+                        // Cancel the losing branches in flight (§D15 DC-7).
+                        set.abort_all();
+                        break;
+                    }
+                }
+                Err(error) => {
+                    run.emit(
+                        run.event(events::AI_STEP_FAILED, StepKind::Agent, StepStatus::Failed)
+                            .with_step(step_id.clone())
+                            .with_parallel_group(group_id.clone())
+                            .with_field("branch", name)
+                            .with_error(error.clone()),
+                    );
+                    run.stream(FlowStreamEvent::BranchFailed {
+                        group_id: group_id.clone(),
+                        step_id,
+                        error_kind: error.kind().to_string(),
+                    });
+                    if first_error.is_none() {
+                        first_error = Some(error);
+                    }
+                    if matches!(self.join, ParallelJoin::All) {
+                        set.abort_all();
+                        break;
+                    }
+                }
+            }
+        }
+
+        run.emit(
+            run.event(
+                events::AI_PARALLEL_COMPLETED,
+                StepKind::Parallel,
+                StepStatus::Completed,
+            )
+            .with_step(group_step)
+            .with_parallel_group(group_id.clone())
+            .with_field("group", self.group.clone())
+            .with_field("success_count", success_count as u64),
+        );
+        run.stream(FlowStreamEvent::ParallelCompleted {
+            group_id,
+            success_count,
+        });
+
+        // Policy gates.
+        if matches!(self.join, ParallelJoin::All)
+            && let Some(error) = first_error
+        {
+            return Err(error);
+        }
+        // A quorum that can never be reached (e.g. n > branch_count) must fail,
+        // not silently return fewer than `n` successes.
+        if let ParallelJoin::Quorum(n) = self.join
+            && success_count < n
+        {
+            return Err(AgenkitError::reducer_disagreement(format!(
+                "parallel group `{}` reached {success_count} of the required quorum {n}",
+                self.group
+            )));
+        }
+        if let Some(min) = self.min_success
+            && success_count < min
+        {
+            return Err(AgenkitError::reducer_disagreement(format!(
+                "parallel group `{}` had {success_count} successes, need {min}",
+                self.group
+            )));
+        }
+        if success_count == 0 {
+            return Err(first_error.unwrap_or_else(|| {
+                AgenkitError::reducer_disagreement(format!(
+                    "parallel group `{}` produced no successful branch",
+                    self.group
+                ))
+            }));
+        }
+
+        Ok(successes)
+    }
+}

--- a/crates/pocopine-agenkit/src/server/partial_json.rs
+++ b/crates/pocopine-agenkit/src/server/partial_json.rs
@@ -1,0 +1,304 @@
+//! Best-effort partial-JSON parsing for streaming structured output (§D8).
+//!
+//! As a model streams the JSON of a structured result, this parses the prefix
+//! accumulated so far into the most complete value it can represent — closing
+//! incomplete value strings, dropping incomplete keys / dangling `key:` pairs /
+//! partial keywords / trailing commas, and closing open containers. It is the
+//! mechanism behind `ObjectDelta` (the Genkit-style partial object). Leaf
+//! decoding defers to `serde_json`, so escapes and UTF-8 are handled correctly.
+
+use serde_json::{Map, Value};
+
+/// Parse a possibly-truncated JSON prefix into the most complete value it can
+/// represent, or `None` if there is no parseable value yet.
+pub(crate) fn parse_partial_json(input: &str) -> Option<Value> {
+    let mut parser = Partial {
+        bytes: input.as_bytes(),
+        pos: 0,
+    };
+    parser.skip_ws();
+    parser.value()
+}
+
+struct Partial<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl Partial<'_> {
+    fn peek(&self) -> Option<u8> {
+        self.bytes.get(self.pos).copied()
+    }
+
+    fn skip_ws(&mut self) {
+        while matches!(self.peek(), Some(b' ' | b'\t' | b'\n' | b'\r')) {
+            self.pos += 1;
+        }
+    }
+
+    fn value(&mut self) -> Option<Value> {
+        self.skip_ws();
+        match self.peek()? {
+            b'{' => self.object(),
+            b'[' => self.array(),
+            b'"' => self.string(true).map(Value::String),
+            b'-' | b'0'..=b'9' => self.number(),
+            b't' | b'f' => self.keyword("true", "false"),
+            b'n' => self.keyword("null", "null"),
+            _ => None,
+        }
+    }
+
+    fn object(&mut self) -> Option<Value> {
+        self.pos += 1; // consume '{'
+        let mut map = Map::new();
+        loop {
+            self.skip_ws();
+            match self.peek() {
+                None => break,
+                Some(b'}') => {
+                    self.pos += 1;
+                    break;
+                }
+                Some(b',') => {
+                    self.pos += 1;
+                }
+                Some(b'"') => {
+                    // A key must be fully terminated; a truncated key ends the object.
+                    let Some(key) = self.string(false) else {
+                        break;
+                    };
+                    self.skip_ws();
+                    if self.peek() != Some(b':') {
+                        break; // dangling key, no colon yet
+                    }
+                    self.pos += 1;
+                    // An incomplete value drops the pair (keeps prior pairs).
+                    let Some(value) = self.value() else {
+                        break;
+                    };
+                    map.insert(key, value);
+                    self.skip_ws();
+                    match self.peek() {
+                        Some(b',') => self.pos += 1,
+                        Some(b'}') => {
+                            self.pos += 1;
+                            break;
+                        }
+                        _ => break,
+                    }
+                }
+                _ => break,
+            }
+        }
+        Some(Value::Object(map))
+    }
+
+    fn array(&mut self) -> Option<Value> {
+        self.pos += 1; // consume '['
+        let mut items = Vec::new();
+        loop {
+            self.skip_ws();
+            match self.peek() {
+                None => break,
+                Some(b']') => {
+                    self.pos += 1;
+                    break;
+                }
+                Some(b',') => {
+                    self.pos += 1;
+                }
+                _ => {
+                    let Some(value) = self.value() else {
+                        break;
+                    };
+                    items.push(value);
+                    self.skip_ws();
+                    match self.peek() {
+                        Some(b',') => self.pos += 1,
+                        Some(b']') => {
+                            self.pos += 1;
+                            break;
+                        }
+                        _ => break,
+                    }
+                }
+            }
+        }
+        Some(Value::Array(items))
+    }
+
+    /// Read a string starting at the current `"`. Leaf-decode via `serde_json`.
+    /// A truncated string yields its best-effort prefix when `allow_partial`,
+    /// else `None` (used to drop incomplete keys).
+    fn string(&mut self, allow_partial: bool) -> Option<String> {
+        let start = self.pos; // at opening quote
+        let mut scan = self.pos + 1;
+        let mut escaped = false;
+        let mut closed = false;
+        while let Some(c) = self.bytes.get(scan).copied() {
+            if escaped {
+                escaped = false;
+            } else if c == b'\\' {
+                escaped = true;
+            } else if c == b'"' {
+                closed = true;
+                break;
+            }
+            scan += 1;
+        }
+
+        if closed {
+            // bytes[start..=scan] is a complete JSON string literal.
+            let literal = std::str::from_utf8(&self.bytes[start..=scan]).ok()?;
+            let value: String = serde_json::from_str(literal).ok()?;
+            self.pos = scan + 1;
+            return Some(value);
+        }
+
+        // Truncated: no closing quote. Return the longest decodable prefix.
+        self.pos = self.bytes.len();
+        if !allow_partial {
+            return None;
+        }
+        let raw = std::str::from_utf8(&self.bytes[start + 1..]).ok()?;
+        Some(close_partial_string(raw))
+    }
+
+    fn number(&mut self) -> Option<Value> {
+        let start = self.pos;
+        while matches!(
+            self.peek(),
+            Some(b'-' | b'+' | b'.' | b'e' | b'E' | b'0'..=b'9')
+        ) {
+            self.pos += 1;
+        }
+        let raw = std::str::from_utf8(&self.bytes[start..self.pos]).ok()?;
+        // A partial/invalid number (e.g. "-", "1.") is dropped.
+        serde_json::from_str::<Value>(raw).ok()
+    }
+
+    fn keyword(&mut self, a: &str, b: &str) -> Option<Value> {
+        let rest = &self.bytes[self.pos..];
+        for keyword in [a, b] {
+            if rest.starts_with(keyword.as_bytes()) {
+                self.pos += keyword.len();
+                return serde_json::from_str(keyword).ok();
+            }
+        }
+        None // partial keyword prefix
+    }
+}
+
+/// Close a truncated JSON string body into its longest decodable prefix.
+///
+/// `raw` is the (still-escaped) content of an unterminated string. Streamed
+/// JSON is valid except at the truncation point, so the only undecodable part
+/// is a trailing fragment — a dangling `\`, an incomplete `\uXXXX`, or a lone
+/// surrogate half (`\uD83D` with its pair not yet streamed). Re-quote and parse
+/// the body, dropping one trailing char at a time until it decodes. This is
+/// robust where ad-hoc escape-trimming was not: it never mistakes an escaped
+/// backslash (`\\u…`) for a unicode escape, and never collapses a split
+/// surrogate to an empty string.
+fn close_partial_string(raw: &str) -> String {
+    let mut end = raw.len();
+    while end > 0 {
+        if raw.is_char_boundary(end)
+            && let Ok(value) = serde_json::from_str::<String>(&format!("\"{}\"", &raw[..end]))
+        {
+            return value;
+        }
+        end -= 1;
+    }
+    String::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn parse(input: &str) -> Value {
+        parse_partial_json(input).unwrap()
+    }
+
+    #[test]
+    fn closes_incomplete_value_string() {
+        assert_eq!(parse(r#"{"title":"Up"#), json!({"title": "Up"}));
+        assert_eq!(
+            parse(r#"{"title":"uploads use "#),
+            json!({"title": "uploads use "})
+        );
+    }
+
+    #[test]
+    fn keeps_prior_pairs_and_drops_incomplete_tail() {
+        assert_eq!(
+            parse(r#"{"title":"Uploads","words":1"#),
+            json!({"title": "Uploads", "words": 1})
+        );
+        assert_eq!(parse(r#"{"title":"Uploads","#), json!({"title": "Uploads"}));
+        // dangling key / colon -> drop the incomplete pair
+        assert_eq!(
+            parse(r#"{"title":"Uploads","words":"#),
+            json!({"title": "Uploads"})
+        );
+        assert_eq!(
+            parse(r#"{"title":"Uploads","wo"#),
+            json!({"title": "Uploads"})
+        );
+    }
+
+    #[test]
+    fn drops_incomplete_keyword_value() {
+        assert_eq!(parse(r#"{"ok":tr"#), json!({}));
+        assert_eq!(parse(r#"{"ok":true"#), json!({"ok": true}));
+        assert_eq!(parse(r#"{"v":null"#), json!({"v": null}));
+    }
+
+    #[test]
+    fn nested_and_arrays() {
+        assert_eq!(parse(r#"{"a":[1,2"#), json!({"a": [1, 2]}));
+        assert_eq!(parse("[1,2,"), json!([1, 2]));
+        assert_eq!(parse(r#"{"a":{"b":"c"#), json!({"a": {"b": "c"}}));
+    }
+
+    #[test]
+    fn empty_and_opening_brace() {
+        assert_eq!(parse("{"), json!({}));
+        assert_eq!(parse("  {  "), json!({}));
+        assert!(parse_partial_json("").is_none());
+        assert!(parse_partial_json("   ").is_none());
+    }
+
+    #[test]
+    fn complete_json_passes_through() {
+        assert_eq!(
+            parse(r#"{"title":"Uploads","words":12}"#),
+            json!({"title": "Uploads", "words": 12})
+        );
+    }
+
+    #[test]
+    fn unicode_and_escapes_in_strings() {
+        assert_eq!(parse(r#"{"s":"a\"b"#), json!({"s": "a\"b"}));
+        assert_eq!(parse(r#"{"s":"café"#), json!({"s": "café"}));
+    }
+
+    #[test]
+    fn truncated_surrogate_keeps_the_prefix() {
+        // A split surrogate pair (high half streamed, low half not yet) must not
+        // collapse the whole value to "" — keep the decodable prefix.
+        assert_eq!(parse(r#"{"title":"Hi \uD83D"#), json!({"title": "Hi "}));
+        // A truncated `\uXX` escape likewise drops only the incomplete escape.
+        assert_eq!(parse(r#"{"s":"abc\u00"#), json!({"s": "abc"}));
+    }
+
+    #[test]
+    fn escaped_backslash_before_u_is_not_a_unicode_escape() {
+        // `\\u` is an escaped backslash + literal `u`, NOT a (truncated) unicode
+        // escape; it must decode rather than corrupt the value to "".
+        assert_eq!(parse(r#"{"path":"a\\u"#), json!({"path": "a\\u"}));
+        assert_eq!(parse(r#"{"path":"C:\\users"#), json!({"path": "C:\\users"}));
+    }
+}

--- a/crates/pocopine-agenkit/src/server/provider.rs
+++ b/crates/pocopine-agenkit/src/server/provider.rs
@@ -1,0 +1,555 @@
+//! Provider trait, request/response types, registry, and a deterministic mock
+//! (RFC-093 Phase 2.1, §D15 DC-4).
+//!
+//! A [`Provider`] resolves a model alias to actual generation. The trait is
+//! object-safe via boxed-future return types (mirroring
+//! `pocopine_sync_query::source::Source`), so the registry stores
+//! `Arc<dyn Provider>` directly with no separate `Dyn` shim. Provider
+//! credentials live behind the implementation — they never appear in these
+//! payloads (§D10).
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use futures::{Stream, StreamExt};
+use pocopine_agenkit_core::{
+    AgenkitError, AgenkitResult, Content, ContentPart, Message, ModelRef, ToolCall, ToolDescriptor,
+    Usage,
+};
+
+/// A boxed, `Send` future — the object-safe return shape for async trait
+/// methods across the runtime (§D15 DC-4).
+pub type BoxFuture<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+/// A boxed, `Send` stream — the object-safe return shape for streaming
+/// generation.
+pub type BoxStream<'a, T> = Pin<Box<dyn Stream<Item = T> + Send + 'a>>;
+
+/// What a provider supports beyond basic generation. The runtime uses native
+/// support when present and degrades gracefully otherwise (§D13).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ProviderCapabilities {
+    /// Native incremental streaming (otherwise a one-shot fallback is used).
+    pub streaming: bool,
+    /// Native schema-constrained structured output (otherwise JSON-mode +
+    /// prompt instruction is used).
+    pub json_schema: bool,
+    /// Native tool/function calling.
+    pub tools: bool,
+}
+
+impl ProviderCapabilities {
+    /// A provider that supports everything.
+    pub fn all() -> Self {
+        Self {
+            streaming: true,
+            json_schema: true,
+            tools: true,
+        }
+    }
+}
+
+/// One incremental piece of a streamed generation.
+#[derive(Clone, Debug, PartialEq)]
+pub enum StreamChunk {
+    /// A user-visible text fragment.
+    Text(String),
+    /// A fully-assembled tool call (the provider accumulates any partials).
+    ToolCall(ToolCall),
+    /// Token usage, typically delivered once near the end.
+    Usage(Usage),
+}
+
+/// Why a generation stopped.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FinishReason {
+    /// The model stopped naturally.
+    #[default]
+    Stop,
+    /// The output was truncated by a token limit.
+    Length,
+    /// The model requested tool calls.
+    ToolCalls,
+}
+
+/// A model generation request assembled by the [`crate::Ai`] builder.
+#[derive(Clone, Debug, Default)]
+pub struct GenerateRequest {
+    /// The resolved model alias.
+    pub model: ModelRef,
+    /// Optional system prompt.
+    pub system: Option<String>,
+    /// The conversation/messages.
+    pub messages: Vec<Message>,
+    /// Tools the model may call.
+    pub tools: Vec<ToolDescriptor>,
+    /// When set, the model must return JSON matching this schema (structured
+    /// output). The runtime validates the result before returning it.
+    pub json_schema: Option<serde_json::Value>,
+    /// Optional output token cap.
+    pub max_tokens: Option<u32>,
+}
+
+impl GenerateRequest {
+    /// The concatenated text of every user message — the effective prompt.
+    pub fn prompt_text(&self) -> String {
+        self.messages
+            .iter()
+            .filter(|m| matches!(m.role, pocopine_agenkit_core::Role::User))
+            .map(|m| m.content.as_text())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    /// The text of the most recent message (a user prompt, or a tool result on
+    /// a follow-up turn). The mock provider matches rules against this so a tool
+    /// rule fires on the prompt turn and a later rule can fire on the tool
+    /// result turn, rather than the prompt rule re-firing forever.
+    pub fn last_message_text(&self) -> String {
+        self.messages
+            .last()
+            .map(|m| m.content.as_text())
+            .unwrap_or_default()
+    }
+}
+
+/// A model generation response.
+#[derive(Clone, Debug)]
+pub struct GenerateResponse {
+    /// The generated content.
+    pub content: Content,
+    /// Any tool calls the model requested.
+    pub tool_calls: Vec<ToolCall>,
+    /// Token usage, when the provider reports it.
+    pub usage: Option<Usage>,
+    /// Why generation stopped.
+    pub finish_reason: FinishReason,
+}
+
+impl GenerateResponse {
+    /// A plain text response.
+    pub fn text(text: impl Into<String>) -> Self {
+        Self {
+            content: Content::text(text),
+            tool_calls: Vec::new(),
+            usage: None,
+            finish_reason: FinishReason::Stop,
+        }
+    }
+
+    /// A structured response carrying a JSON value.
+    pub fn structured(value: serde_json::Value) -> Self {
+        Self {
+            content: Content::from_parts(vec![ContentPart::Json { value }]),
+            tool_calls: Vec::new(),
+            usage: None,
+            finish_reason: FinishReason::Stop,
+        }
+    }
+
+    /// Attach usage.
+    pub fn with_usage(mut self, usage: Usage) -> Self {
+        self.usage = Some(usage);
+        self
+    }
+
+    /// The response text (concatenated text parts).
+    pub fn text_output(&self) -> String {
+        self.content.as_text()
+    }
+
+    /// A textual rendering of the response: text parts if any, else a
+    /// structured JSON value rendered as text. Used to accumulate streamed
+    /// output and to parse structured results.
+    pub fn display_text(&self) -> String {
+        let text = self.content.as_text();
+        if !text.is_empty() {
+            return text;
+        }
+        self.structured_value()
+            .map(|value| value.to_string())
+            .unwrap_or_default()
+    }
+
+    /// The first JSON content part, if the response is structured.
+    pub fn structured_value(&self) -> Option<&serde_json::Value> {
+        self.content.parts.iter().find_map(|part| match part {
+            ContentPart::Json { value } => Some(value),
+            _ => None,
+        })
+    }
+}
+
+/// A model provider. Object-safe; stored as `Arc<dyn Provider>`.
+pub trait Provider: Send + Sync + 'static {
+    /// The provider alias this implementation serves (e.g. `"local"`).
+    fn id(&self) -> &str;
+
+    /// What this provider supports. Defaults to nothing beyond `generate`, so
+    /// the runtime uses fallbacks; real providers override.
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities::default()
+    }
+
+    /// Generate a response for `request`.
+    fn generate<'a>(
+        &'a self,
+        request: GenerateRequest,
+    ) -> BoxFuture<'a, AgenkitResult<GenerateResponse>>;
+
+    /// Stream a generation as incremental [`StreamChunk`]s.
+    ///
+    /// The default is a one-shot fallback over [`Provider::generate`], so a
+    /// non-streaming provider still satisfies the streaming contract (the whole
+    /// result arrives as a single text chunk). Providers that stream natively
+    /// override this.
+    fn generate_stream<'a>(
+        &'a self,
+        request: GenerateRequest,
+    ) -> BoxStream<'a, AgenkitResult<StreamChunk>> {
+        default_stream(self.generate(request))
+    }
+}
+
+/// Turn a one-shot generation future into a [`StreamChunk`] stream.
+fn default_stream<'a>(
+    future: BoxFuture<'a, AgenkitResult<GenerateResponse>>,
+) -> BoxStream<'a, AgenkitResult<StreamChunk>> {
+    Box::pin(futures::stream::once(future).flat_map(|result| {
+        let chunks = match result {
+            Ok(response) => response_to_chunks(response),
+            Err(error) => vec![Err(error)],
+        };
+        futures::stream::iter(chunks)
+    }))
+}
+
+/// Decompose a finished response into the chunks a streaming consumer expects.
+pub(crate) fn response_to_chunks(response: GenerateResponse) -> Vec<AgenkitResult<StreamChunk>> {
+    let mut chunks = Vec::new();
+    let text = response.display_text();
+    if !text.is_empty() {
+        chunks.push(Ok(StreamChunk::Text(text)));
+    }
+    for call in response.tool_calls {
+        chunks.push(Ok(StreamChunk::ToolCall(call)));
+    }
+    if let Some(usage) = response.usage {
+        chunks.push(Ok(StreamChunk::Usage(usage)));
+    }
+    chunks
+}
+
+/// A registry of providers keyed by alias.
+#[derive(Clone, Default)]
+pub struct ProviderRegistry {
+    providers: HashMap<String, Arc<dyn Provider>>,
+}
+
+impl ProviderRegistry {
+    /// An empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a provider under its [`Provider::id`].
+    pub fn register(&mut self, provider: Arc<dyn Provider>) {
+        self.providers.insert(provider.id().to_string(), provider);
+    }
+
+    /// Resolve the provider for a model alias (`"provider/model"`). Falls back
+    /// to the single registered provider when the alias is not namespaced.
+    pub fn resolve(&self, model: &ModelRef) -> AgenkitResult<Arc<dyn Provider>> {
+        if let Some(provider_alias) = model.provider() {
+            return self.providers.get(provider_alias).cloned().ok_or_else(|| {
+                AgenkitError::config(format!(
+                    "no provider registered for alias `{provider_alias}`"
+                ))
+            });
+        }
+        if self.providers.len() == 1 {
+            return Ok(self.providers.values().next().cloned().expect("len == 1"));
+        }
+        Err(AgenkitError::config(format!(
+            "model alias `{}` has no provider namespace and there is not exactly one provider",
+            model.as_str()
+        )))
+    }
+
+    /// Whether any providers are registered.
+    pub fn is_empty(&self) -> bool {
+        self.providers.is_empty()
+    }
+}
+
+/// A deterministic in-memory provider for tests and examples (§D13 "local
+/// provider first"). Matching is by substring of the prompt, in rule order;
+/// the first match wins, otherwise a default is returned.
+#[derive(Clone, Default)]
+pub struct MockProvider {
+    id: String,
+    rules: Vec<MockRule>,
+    default_text: Option<String>,
+    default_structured: Option<serde_json::Value>,
+    delay_ms: u64,
+}
+
+#[derive(Clone)]
+struct MockRule {
+    needle: String,
+    response: MockResponse,
+}
+
+#[derive(Clone)]
+enum MockResponse {
+    Text(String),
+    Structured(serde_json::Value),
+    Tool {
+        tool_id: String,
+        args: serde_json::Value,
+    },
+}
+
+impl MockProvider {
+    /// A mock provider serving the given alias.
+    pub fn new(id: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            ..Self::default()
+        }
+    }
+
+    /// Return `text` when the prompt contains `needle`.
+    pub fn on_prompt_text(mut self, needle: impl Into<String>, text: impl Into<String>) -> Self {
+        self.rules.push(MockRule {
+            needle: needle.into(),
+            response: MockResponse::Text(text.into()),
+        });
+        self
+    }
+
+    /// Return structured `value` when the prompt contains `needle`.
+    pub fn on_prompt_structured(
+        mut self,
+        needle: impl Into<String>,
+        value: serde_json::Value,
+    ) -> Self {
+        self.rules.push(MockRule {
+            needle: needle.into(),
+            response: MockResponse::Structured(value),
+        });
+        self
+    }
+
+    /// Request a tool call when the prompt contains `needle`.
+    pub fn on_prompt_tool(
+        mut self,
+        needle: impl Into<String>,
+        tool_id: impl Into<String>,
+        args: serde_json::Value,
+    ) -> Self {
+        self.rules.push(MockRule {
+            needle: needle.into(),
+            response: MockResponse::Tool {
+                tool_id: tool_id.into(),
+                args,
+            },
+        });
+        self
+    }
+
+    /// The default text when no rule matches.
+    pub fn default_text(mut self, text: impl Into<String>) -> Self {
+        self.default_text = Some(text.into());
+        self
+    }
+
+    /// The default structured value when no rule matches a structured request.
+    pub fn default_structured(mut self, value: serde_json::Value) -> Self {
+        self.default_structured = Some(value);
+        self
+    }
+
+    /// Delay each generation by `ms` (for cancellation/latency tests).
+    pub fn with_delay_ms(mut self, ms: u64) -> Self {
+        self.delay_ms = ms;
+        self
+    }
+
+    fn respond(&self, request: &GenerateRequest) -> AgenkitResult<GenerateResponse> {
+        let prompt = request.prompt_text();
+        let latest = request.last_message_text();
+        let usage = Usage::new((prompt.len() / 4) as u64, 8);
+
+        if let Some(rule) = self.rules.iter().find(|r| latest.contains(&r.needle)) {
+            return Ok(match &rule.response {
+                MockResponse::Text(text) => GenerateResponse::text(text.clone()).with_usage(usage),
+                MockResponse::Structured(value) => {
+                    GenerateResponse::structured(value.clone()).with_usage(usage)
+                }
+                MockResponse::Tool { tool_id, args } => GenerateResponse {
+                    content: Content::default(),
+                    tool_calls: vec![ToolCall::new(
+                        format!("call-{tool_id}"),
+                        tool_id.clone(),
+                        args.clone(),
+                    )],
+                    usage: Some(usage),
+                    finish_reason: FinishReason::ToolCalls,
+                },
+            });
+        }
+
+        if request.json_schema.is_some() {
+            let value = self
+                .default_structured
+                .clone()
+                .ok_or_else(|| AgenkitError::provider("mock: no structured response configured"))?;
+            return Ok(GenerateResponse::structured(value).with_usage(usage));
+        }
+
+        let text = self
+            .default_text
+            .clone()
+            .unwrap_or_else(|| format!("mock response for: {prompt}"));
+        Ok(GenerateResponse::text(text).with_usage(usage))
+    }
+}
+
+impl Provider for MockProvider {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        // The mock simulates streaming and tools, but not native JSON-schema
+        // structured output (it returns canned values).
+        ProviderCapabilities {
+            streaming: true,
+            json_schema: false,
+            tools: true,
+        }
+    }
+
+    fn generate<'a>(
+        &'a self,
+        request: GenerateRequest,
+    ) -> BoxFuture<'a, AgenkitResult<GenerateResponse>> {
+        Box::pin(async move {
+            if self.delay_ms > 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(self.delay_ms)).await;
+            }
+            self.respond(&request)
+        })
+    }
+
+    fn generate_stream<'a>(
+        &'a self,
+        request: GenerateRequest,
+    ) -> BoxStream<'a, AgenkitResult<StreamChunk>> {
+        // Simulate incremental streaming by splitting the displayable response
+        // (text, or the serialized JSON of a structured value) into word-sized
+        // deltas — so partial-object streaming has prefixes to parse. Tool calls
+        // and usage follow whole, so a text+tool_calls response keeps its tool
+        // calls (parity with the non-streaming path / `response_to_chunks`).
+        let chunks = match self.respond(&request) {
+            Ok(response) => {
+                let text = response.display_text();
+                if text.is_empty() {
+                    response_to_chunks(response)
+                } else {
+                    let mut chunks: Vec<AgenkitResult<StreamChunk>> = text
+                        .split_inclusive(' ')
+                        .map(|word| Ok(StreamChunk::Text(word.to_string())))
+                        .collect();
+                    for call in response.tool_calls {
+                        chunks.push(Ok(StreamChunk::ToolCall(call)));
+                    }
+                    if let Some(usage) = response.usage {
+                        chunks.push(Ok(StreamChunk::Usage(usage)));
+                    }
+                    chunks
+                }
+            }
+            Err(error) => vec![Err(error)],
+        };
+        Box::pin(futures::stream::iter(chunks))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pocopine_agenkit_core::Role;
+
+    fn request(prompt: &str, structured: bool) -> GenerateRequest {
+        GenerateRequest {
+            model: ModelRef::new("local/default"),
+            messages: vec![Message::new(Role::User, prompt)],
+            json_schema: structured.then(|| serde_json::json!({"type": "object"})),
+            ..GenerateRequest::default()
+        }
+    }
+
+    #[tokio::test]
+    async fn mock_matches_rules_then_defaults() {
+        let provider = MockProvider::new("local")
+            .on_prompt_text("uploads", "uploads use presigned URLs")
+            .default_text("idk");
+        let response = provider
+            .generate(request("how do uploads work?", false))
+            .await
+            .unwrap();
+        assert_eq!(response.text_output(), "uploads use presigned URLs");
+
+        let response = provider
+            .generate(request("something else", false))
+            .await
+            .unwrap();
+        assert_eq!(response.text_output(), "idk");
+    }
+
+    #[tokio::test]
+    async fn mock_returns_structured_value() {
+        let provider =
+            MockProvider::new("local").default_structured(serde_json::json!({"answer": "42"}));
+        let response = provider.generate(request("q", true)).await.unwrap();
+        assert_eq!(
+            response.structured_value().unwrap(),
+            &serde_json::json!({"answer": "42"})
+        );
+    }
+
+    #[tokio::test]
+    async fn stream_forwards_tool_calls() {
+        use futures::StreamExt;
+        // A tool response must reach a streaming consumer as a ToolCall chunk
+        // (not be dropped on the streaming path).
+        let provider = MockProvider::new("local").on_prompt_tool(
+            "search",
+            "search_docs",
+            serde_json::json!({"q": "uploads"}),
+        );
+        let mut stream = provider.generate_stream(request("please search docs", false));
+        let mut tool_ids = Vec::new();
+        while let Some(chunk) = stream.next().await {
+            if let Ok(StreamChunk::ToolCall(call)) = chunk {
+                tool_ids.push(call.tool_id);
+            }
+        }
+        assert_eq!(tool_ids, vec!["search_docs".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn registry_resolves_by_namespace() {
+        let mut registry = ProviderRegistry::new();
+        registry.register(Arc::new(MockProvider::new("local")));
+        assert!(registry.resolve(&ModelRef::new("local/default")).is_ok());
+        assert!(registry.resolve(&ModelRef::new("openai/gpt")).is_err());
+        // Unnamespaced resolves because there is exactly one provider.
+        assert!(registry.resolve(&ModelRef::new("default")).is_ok());
+    }
+}

--- a/crates/pocopine-agenkit/src/server/reduce.rs
+++ b/crates/pocopine-agenkit/src/server/reduce.rs
@@ -1,0 +1,155 @@
+//! Reducers / fan-in checkers (RFC-093 Phase 2.6, §D7).
+//!
+//! `ctx.reduce(name, candidates)` combines parallel branch outputs into one
+//! typed result, either via a model judge (`.schema::<O>()`) or a
+//! deterministic Rust fold (`.fold(...)`). Each records a [`ReducerDecision`]
+//! and emits `ai_reducer_*` trace events.
+
+use pocopine_agenkit_core::{
+    AgenkitResult, FlowStreamEvent, ReducerDecision, ReducerKind, StepId, StepKind, StepStatus,
+    events,
+};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+use super::flow::AiFlowContext;
+
+/// Builder returned by `ctx.reduce(...)`.
+pub struct ReduceBuilder<'a, C> {
+    ctx: &'a AiFlowContext,
+    name: String,
+    candidates: Vec<C>,
+    system: Option<String>,
+}
+
+impl<'a, C> ReduceBuilder<'a, C> {
+    pub(crate) fn new(ctx: &'a AiFlowContext, name: impl Into<String>, candidates: Vec<C>) -> Self {
+        Self {
+            ctx,
+            name: name.into(),
+            candidates,
+            system: None,
+        }
+    }
+
+    /// Set the judge's system prompt (model-judge mode).
+    pub fn system(mut self, system: impl Into<String>) -> Self {
+        self.system = Some(system.into());
+        self
+    }
+
+    fn emit_started(&self, kind: ReducerKind) -> StepId {
+        let run = self.ctx.run_state();
+        let step_id = run.next_step_id();
+        run.emit(
+            run.event(
+                events::AI_REDUCER_STARTED,
+                StepKind::Reducer,
+                StepStatus::Started,
+            )
+            .with_step(step_id.clone())
+            .with_field("name", self.name.clone())
+            .with_field("reducer_kind", format!("{kind:?}"))
+            .with_field("candidates", self.candidates.len() as u64),
+        );
+        run.stream(FlowStreamEvent::ReducerStarted {
+            step_id: step_id.clone(),
+        });
+        step_id
+    }
+
+    fn emit_decision(&self, step_id: StepId, decision: &ReducerDecision) {
+        let run = self.ctx.run_state();
+        run.emit(
+            run.event(
+                events::AI_REDUCER_COMPLETED,
+                StepKind::Reducer,
+                StepStatus::Completed,
+            )
+            .with_step(step_id.clone())
+            .with_field("name", self.name.clone())
+            .with_field("accepted", decision.accepted)
+            .with_field("reason", decision.reason.clone()),
+        );
+        run.stream(FlowStreamEvent::ReducerDecision {
+            step_id: step_id.clone(),
+            accepted: decision.accepted,
+        });
+        run.stream(FlowStreamEvent::ReducerCompleted { step_id });
+    }
+}
+
+impl<C: Serialize> ReduceBuilder<'_, C> {
+    /// Reduce via a model judge, validating the merged answer into `O`.
+    pub async fn schema<O: DeserializeOwned + schemars::JsonSchema>(self) -> AgenkitResult<O> {
+        let step_id = self.emit_started(ReducerKind::ModelJudge);
+        let candidates_json = serde_json::to_string(&self.candidates).unwrap_or_default();
+        let prompt = format!(
+            "Candidate answers (JSON array):\n{candidates_json}\n\nReturn the single best, \
+             evidence-supported final answer."
+        );
+        let system = self.system.clone().unwrap_or_else(|| {
+            "You are a strict judge. Keep only claims supported by evidence.".to_string()
+        });
+        let result = self
+            .ctx
+            .ai()
+            .system(system)
+            .prompt(prompt)
+            .schema::<O>()
+            .generate_structured()
+            .await;
+
+        let decision = match &result {
+            Ok(_) => ReducerDecision::accept(ReducerKind::ModelJudge, "judge merged candidates", 0)
+                .with_candidates(self.candidates.len() as u32),
+            // Use the stable error KIND, not the message: the reason is written
+            // to a Public trace field and a provider message could quote
+            // host/credential internals (§D10/§D12).
+            Err(error) => ReducerDecision::reject(ReducerKind::ModelJudge, error.kind()),
+        };
+        self.emit_decision(step_id, &decision);
+        result
+    }
+
+    /// Reduce deterministically with a Rust function.
+    pub async fn fold<O, F>(self, reducer: F) -> AgenkitResult<O>
+    where
+        F: FnOnce(Vec<C>) -> AgenkitResult<O>,
+    {
+        let step_id = self.emit_started(ReducerKind::Deterministic);
+        // Move candidates out via destructure so the closure can consume them
+        // without partially moving `self` (the decision emit needs ctx + name).
+        let ReduceBuilder {
+            ctx,
+            name,
+            candidates,
+            ..
+        } = self;
+        let count = candidates.len() as u32;
+        let result = reducer(candidates);
+        let decision = match &result {
+            Ok(_) => ReducerDecision::accept(ReducerKind::Deterministic, "deterministic fold", 0)
+                .with_candidates(count),
+            Err(error) => ReducerDecision::reject(ReducerKind::Deterministic, error.kind()),
+        };
+        let run = ctx.run_state();
+        run.emit(
+            run.event(
+                events::AI_REDUCER_COMPLETED,
+                StepKind::Reducer,
+                StepStatus::Completed,
+            )
+            .with_step(step_id.clone())
+            .with_field("name", name)
+            .with_field("accepted", decision.accepted)
+            .with_field("reason", decision.reason),
+        );
+        run.stream(FlowStreamEvent::ReducerDecision {
+            step_id: step_id.clone(),
+            accepted: decision.accepted,
+        });
+        run.stream(FlowStreamEvent::ReducerCompleted { step_id });
+        result
+    }
+}

--- a/crates/pocopine-agenkit/src/server/retrieval.rs
+++ b/crates/pocopine-agenkit/src/server/retrieval.rs
@@ -1,0 +1,248 @@
+//! Retrievers: typed [`AiRetriever`] trait, object-safe [`DynRetriever`]
+//! erasure, the [`RetrieverRegistry`], and the retriever-as-tool adapter
+//! (RFC-093 Phase 2.4, §D5).
+//!
+//! Flows call retrievers directly for deterministic context loading; the
+//! adapter wraps a retriever as a [`DynTool`] so an agent can decide when to
+//! search. Retrieval is read-only by default.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use pocopine_agenkit_core::{AgenkitError, AgenkitResult, RetrievalSet, RetrieverDescriptor};
+use schemars::JsonSchema;
+use serde::de::DeserializeOwned;
+
+use super::context::RetrievalContext;
+use super::provider::BoxFuture;
+use super::schema::schema_ref_for;
+use super::tool::DynTool;
+
+/// A typed, author-facing retriever. Returns the concrete [`RetrievalSet`] so
+/// hits carry citations/source refs for traces and reducers (§D5, §D12).
+pub trait AiRetriever: Send + Sync + 'static {
+    /// Stable retriever id.
+    const ID: &'static str;
+
+    /// Typed query, deserialized when the retriever is driven as a tool. The
+    /// `JsonSchema` derive becomes the `parameters` schema when this retriever
+    /// is exposed as a tool, so the model sees the query shape (§D5).
+    type Query: DeserializeOwned + JsonSchema + Send + 'static;
+
+    /// The framework-visible descriptor. Authors supply id/description/source
+    /// kinds; the runtime fills the query schema from [`Self::Query`] unless the
+    /// descriptor already carries one (see the [`DynRetriever`] erasure).
+    fn descriptor() -> RetrieverDescriptor;
+
+    /// Run the retrieval.
+    fn retrieve(
+        &self,
+        query: Self::Query,
+        ctx: RetrievalContext,
+    ) -> BoxFuture<'_, AgenkitResult<RetrievalSet>>;
+
+    /// Wrap this retriever as a tool, so an agent can call it (§D5). Requires a
+    /// default-constructible retriever (the common stateless case).
+    fn as_tool() -> Arc<dyn DynTool>
+    where
+        Self: Default,
+    {
+        let retriever: Arc<dyn DynRetriever> = Arc::new(Self::default());
+        retriever_as_tool(retriever)
+    }
+}
+
+/// Object-safe erased retriever. Stored as `Arc<dyn DynRetriever>`.
+pub trait DynRetriever: Send + Sync + 'static {
+    /// The retriever id.
+    fn id(&self) -> &'static str;
+    /// The descriptor.
+    fn descriptor(&self) -> RetrieverDescriptor;
+    /// Validate + dispatch a JSON-encoded query.
+    fn retrieve_json<'a>(
+        &'a self,
+        query: serde_json::Value,
+        ctx: RetrievalContext,
+    ) -> BoxFuture<'a, AgenkitResult<RetrievalSet>>;
+}
+
+impl<R: AiRetriever> DynRetriever for R {
+    fn id(&self) -> &'static str {
+        R::ID
+    }
+
+    fn descriptor(&self) -> RetrieverDescriptor {
+        // Author supplies id/description/source kinds; the runtime fills the
+        // typed query schema (the model's `parameters` when used as a tool)
+        // from `schemars`, unless the author already attached one.
+        let mut descriptor = R::descriptor();
+        if descriptor.query.json_schema.is_none() {
+            descriptor.query = schema_ref_for::<R::Query>();
+        }
+        descriptor
+    }
+
+    fn retrieve_json<'a>(
+        &'a self,
+        query: serde_json::Value,
+        ctx: RetrievalContext,
+    ) -> BoxFuture<'a, AgenkitResult<RetrievalSet>> {
+        Box::pin(async move {
+            let query: R::Query = serde_json::from_value(query).map_err(|err| {
+                AgenkitError::validation(format!("retriever `{}` query: {err}", R::ID))
+            })?;
+            R::retrieve(self, query, ctx).await
+        })
+    }
+}
+
+/// A registry of retrievers keyed by id.
+#[derive(Default, Clone)]
+pub struct RetrieverRegistry {
+    retrievers: HashMap<&'static str, Arc<dyn DynRetriever>>,
+}
+
+impl RetrieverRegistry {
+    /// An empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a typed retriever.
+    pub fn register<R: AiRetriever>(&mut self, retriever: R) {
+        self.retrievers.insert(R::ID, Arc::new(retriever));
+    }
+
+    /// Look up a retriever by id.
+    pub fn get(&self, id: &str) -> Option<Arc<dyn DynRetriever>> {
+        self.retrievers.get(id).cloned()
+    }
+
+    /// Whether a retriever id is registered.
+    pub fn contains(&self, id: &str) -> bool {
+        self.retrievers.contains_key(id)
+    }
+}
+
+/// Wrap an erased retriever as a [`DynTool`] for agent-controlled search.
+pub fn retriever_as_tool(retriever: Arc<dyn DynRetriever>) -> Arc<dyn DynTool> {
+    Arc::new(RetrieverTool { retriever })
+}
+
+struct RetrieverTool {
+    retriever: Arc<dyn DynRetriever>,
+}
+
+impl DynTool for RetrieverTool {
+    fn id(&self) -> &'static str {
+        self.retriever.id()
+    }
+
+    fn descriptor(&self) -> pocopine_agenkit_core::ToolDescriptor {
+        let descriptor = self.retriever.descriptor();
+        // Read-only by construction: retrieval never mutates state. The
+        // retriever's query schema becomes the tool's input `parameters`, so an
+        // agent sees the query shape — same wiring as a native tool (§D5).
+        pocopine_agenkit_core::ToolDescriptor::new(descriptor.id, descriptor.description)
+            .with_input(descriptor.query)
+    }
+
+    fn call_json<'a>(
+        &'a self,
+        args: serde_json::Value,
+        ctx: RetrievalContext,
+    ) -> BoxFuture<'a, AgenkitResult<serde_json::Value>> {
+        let retriever = self.retriever.clone();
+        Box::pin(async move {
+            let set = retriever.retrieve_json(args, ctx).await?;
+            serde_json::to_value(set).map_err(AgenkitError::from)
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::context::{AiContext, AppState};
+    use super::*;
+    use pocopine_agenkit_core::{Content, RetrievalHit, SourceRef};
+    use serde::Deserialize;
+
+    #[derive(Default)]
+    struct ProjectDocs;
+
+    #[derive(Deserialize, schemars::JsonSchema)]
+    struct ProjectDocsQuery {
+        question: String,
+    }
+
+    impl AiRetriever for ProjectDocs {
+        const ID: &'static str = "project_docs";
+        type Query = ProjectDocsQuery;
+
+        fn descriptor() -> RetrieverDescriptor {
+            RetrieverDescriptor::new("project_docs", "Search project docs")
+                .with_source_kinds(["doc"])
+        }
+
+        fn retrieve(
+            &self,
+            query: ProjectDocsQuery,
+            _ctx: RetrievalContext,
+        ) -> BoxFuture<'_, AgenkitResult<RetrievalSet>> {
+            Box::pin(async move {
+                Ok(RetrievalSet::new(vec![RetrievalHit {
+                    source: SourceRef::new("doc", "uploads.md"),
+                    score: Some(0.9),
+                    content: Content::text(format!("answer to: {}", query.question)),
+                    citation: None,
+                }]))
+            })
+        }
+    }
+
+    fn ctx() -> AiContext {
+        AiContext::new(Arc::new(AppState::new()))
+    }
+
+    #[tokio::test]
+    async fn registry_retrieves_typed_query() {
+        let mut registry = RetrieverRegistry::new();
+        registry.register(ProjectDocs);
+        let retriever = registry.get("project_docs").unwrap();
+        let set = retriever
+            .retrieve_json(serde_json::json!({"question": "uploads?"}), ctx())
+            .await
+            .unwrap();
+        assert_eq!(set.len(), 1);
+        assert_eq!(set.hits[0].source.id, "uploads.md");
+    }
+
+    #[tokio::test]
+    async fn retriever_as_tool_dispatches_and_serializes() {
+        let tool = ProjectDocs::as_tool();
+        assert_eq!(tool.id(), "project_docs");
+        let value = tool
+            .call_json(serde_json::json!({"question": "uploads?"}), ctx())
+            .await
+            .unwrap();
+        // The serialized RetrievalSet is a JSON array of hits.
+        assert!(value.is_array());
+        assert_eq!(value[0]["source"]["id"], "uploads.md");
+    }
+
+    #[test]
+    fn retriever_as_tool_exposes_the_query_schema_as_parameters() {
+        // Same wiring as a native tool: the typed query becomes the tool's
+        // input `parameters`, so an agent sees the query shape.
+        let descriptor = ProjectDocs::as_tool().descriptor();
+        let input = descriptor.input.json_schema.expect("query schema derived");
+        assert_eq!(input["properties"]["question"]["type"], "string");
+    }
+
+    #[test]
+    fn retriever_descriptor_carries_the_derived_query_schema() {
+        let descriptor = DynRetriever::descriptor(&ProjectDocs);
+        let query = descriptor.query.json_schema.expect("query schema derived");
+        assert_eq!(query["properties"]["question"]["type"], "string");
+    }
+}

--- a/crates/pocopine-agenkit/src/server/run.rs
+++ b/crates/pocopine-agenkit/src/server/run.rs
@@ -1,0 +1,99 @@
+//! Per-invocation run state and the tracer (RFC-093 Phase 2.5).
+//!
+//! A [`RunState`] carries the `run_id`/`trace_id` shared by every event in one
+//! flow invocation, a monotonic step-id counter, and the handle back to the
+//! runtime. It is the single source the flow context, generation builder, and
+//! (later) parallel/agent execution use to emit trace events.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+
+use pocopine_agenkit_core::{
+    FlowStreamEvent, RunId, StepId, StepKind, StepStatus, TraceEvent, TraceId,
+};
+use pocopine_auth::Principal;
+use tokio::sync::mpsc::UnboundedSender;
+
+use super::agenkit::AgenkitInner;
+use super::observe::emit_trace_event;
+
+/// Shared state for one flow/agent invocation.
+pub(crate) struct RunState {
+    pub(crate) inner: Arc<AgenkitInner>,
+    pub(crate) run_id: RunId,
+    pub(crate) trace_id: TraceId,
+    /// The caller principal this run executes under (anonymous by default).
+    pub(crate) principal: Principal,
+    /// Public client-stream sink, present only for streaming runs. The Phase
+    /// 3.3 route's redaction chokepoint sits between this and the wire.
+    stream: Option<UnboundedSender<FlowStreamEvent>>,
+    /// Set once the flow has streamed user-visible output deltas, so the
+    /// runtime does not re-emit the final result as a duplicate delta.
+    output_streamed: AtomicBool,
+    step_seq: AtomicU64,
+}
+
+impl RunState {
+    /// Start a run.
+    pub(crate) fn new(
+        inner: Arc<AgenkitInner>,
+        run_id: RunId,
+        trace_id: TraceId,
+        principal: Principal,
+        stream: Option<UnboundedSender<FlowStreamEvent>>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            inner,
+            run_id,
+            trace_id,
+            principal,
+            stream,
+            output_streamed: AtomicBool::new(false),
+            step_seq: AtomicU64::new(0),
+        })
+    }
+
+    /// Mark that user-visible output has been streamed as deltas.
+    pub(crate) fn mark_output_streamed(&self) {
+        self.output_streamed.store(true, Ordering::Relaxed);
+    }
+
+    /// Whether the flow already streamed its output as deltas.
+    pub(crate) fn output_was_streamed(&self) -> bool {
+        self.output_streamed.load(Ordering::Relaxed)
+    }
+
+    /// Allocate the next unique step id within this run.
+    pub(crate) fn next_step_id(&self) -> StepId {
+        StepId::new(format!(
+            "s{}",
+            self.step_seq.fetch_add(1, Ordering::Relaxed)
+        ))
+    }
+
+    /// Build a trace event stamped with this run's correlation ids.
+    pub(crate) fn event(&self, name: &str, kind: StepKind, status: StepStatus) -> TraceEvent {
+        TraceEvent::new(
+            name.to_string(),
+            self.run_id.clone(),
+            self.trace_id.clone(),
+            kind,
+            status,
+        )
+    }
+
+    /// Map + emit a trace event through the observe layer.
+    pub(crate) fn emit(&self, event: TraceEvent) {
+        emit_trace_event(&event);
+    }
+
+    /// Emit a public, client-safe stream event, if this run is streaming.
+    /// These shapes are client-safe by construction (§D8); the Phase 3.3 route
+    /// applies the final redaction chokepoint before the wire.
+    pub(crate) fn stream(&self, event: FlowStreamEvent) {
+        if let Some(sink) = &self.stream {
+            // A closed receiver just means the client disconnected; ignore.
+            let _ = sink.send(event);
+        }
+    }
+}

--- a/crates/pocopine-agenkit/src/server/schema.rs
+++ b/crates/pocopine-agenkit/src/server/schema.rs
@@ -1,0 +1,94 @@
+//! Schema derivation for the descriptor layer (RFC-093 §D5).
+//!
+//! One place that turns a Rust type into a JSON Schema (and a [`SchemaRef`])
+//! via [`schemars`]. Structured output, tool input/output, flow input/output,
+//! and agent output all route through here, so the model and generated clients
+//! see real, consistent schemas — while `pocopine-agenkit-core` stays
+//! `schemars`-free and wasm-friendly (DC-1).
+
+use pocopine_agenkit_core::SchemaRef;
+use schemars::JsonSchema;
+
+/// The JSON Schema for `T`, derived via `schemars`. Providers that support
+/// schema-constrained output use it directly; others fall back to JSON mode,
+/// and it doubles as the `parameters` schema for function-calling tools.
+pub(crate) fn json_schema_for<T: JsonSchema>() -> serde_json::Value {
+    serde_json::to_value(schemars::schema_for!(T))
+        .unwrap_or_else(|_| serde_json::json!({ "type": "object" }))
+}
+
+/// A [`SchemaRef`] for `T`: the schemars `title` (falling back to the short
+/// Rust type name) plus the derived JSON Schema body. Used to fill descriptor
+/// input/output schemas at registration without burdening authors.
+pub(crate) fn schema_ref_for<T: JsonSchema>() -> SchemaRef {
+    let json = json_schema_for::<T>();
+    let name = json
+        .get("title")
+        .and_then(|title| title.as_str())
+        .map(str::to_string)
+        .unwrap_or_else(short_type_name::<T>);
+    SchemaRef {
+        name,
+        json_schema: Some(json),
+    }
+}
+
+/// A display name from `std::any::type_name` with module paths stripped but the
+/// generic structure kept — a stable-enough name when a type carries no schemars
+/// `title` (a container like `Vec<_>`). Keeping the generic args distinguishes
+/// `Vec<A>` from `Vec<B>`, which a bare last-segment ("Vec") would collide.
+fn short_type_name<T>() -> String {
+    let full = std::any::type_name::<T>();
+    let mut out = String::with_capacity(full.len());
+    let mut segment = String::new();
+    for ch in full.chars() {
+        if ch.is_alphanumeric() || ch == '_' || ch == ':' {
+            segment.push(ch);
+        } else {
+            // End of a `a::b::C` path run — keep only its last segment, then the
+            // structural char (`<`, `>`, `,`, space, ...) verbatim.
+            out.push_str(segment.rsplit("::").next().unwrap_or(&segment));
+            segment.clear();
+            out.push(ch);
+        }
+    }
+    out.push_str(segment.rsplit("::").next().unwrap_or(&segment));
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Serialize, Deserialize, JsonSchema)]
+    struct SearchInput {
+        query: String,
+    }
+
+    #[test]
+    fn schema_ref_carries_title_and_body() {
+        let schema = schema_ref_for::<SearchInput>();
+        assert_eq!(schema.name, "SearchInput");
+        let body = schema.json_schema.unwrap();
+        assert_eq!(body["properties"]["query"]["type"], "string");
+    }
+
+    #[test]
+    fn untitled_types_fall_back_to_the_short_type_name() {
+        // schemars titles named structs (and even primitives — `u32` -> "uint32"),
+        // so the fallback only fires for anonymous shapes like containers. The
+        // generic args are kept so distinct containers get distinct names.
+        assert_eq!(short_type_name::<Vec<String>>(), "Vec<String>");
+        assert_ne!(
+            short_type_name::<Vec<String>>(),
+            short_type_name::<Vec<u32>>(),
+            "distinct container types must not collide to one name"
+        );
+
+        // A primitive still yields a real name + body (its schemars title).
+        let schema = schema_ref_for::<u32>();
+        assert!(!schema.name.is_empty());
+        assert!(schema.json_schema.is_some());
+    }
+}

--- a/crates/pocopine-agenkit/src/server/stream_route.rs
+++ b/crates/pocopine-agenkit/src/server/stream_route.rs
@@ -1,0 +1,244 @@
+//! The public AI-flow streaming route (RFC-093 Phase 3.3, §D8, §D10).
+//!
+//! An SSE route (matching `pocopine-server`/`pocopine-live`, axum 0.7) that
+//! runs a flow streaming and forwards [`FlowStreamEvent`]s to the client. Every
+//! event passes through [`stream_filter`] — the single redaction chokepoint —
+//! as the last transform before the wire. The flow runs under the caller
+//! [`Principal`] read from request extensions (§D15 DC-5).
+
+use std::convert::Infallible;
+
+use axum::extract::{Path, Query, State};
+use axum::http::StatusCode;
+use axum::response::sse::{Event as SseEvent, KeepAlive, Sse};
+use axum::response::{IntoResponse, Response};
+use axum::routing::post;
+use axum::{Extension, Json, Router};
+use futures::StreamExt;
+use pocopine_agenkit_core::{FlowStreamEvent, StreamMode};
+use pocopine_auth::Principal;
+use tokio_stream::wrappers::UnboundedReceiverStream;
+
+use super::agenkit::{Agenkit, with_principal};
+
+/// The route path; `:id` is the flow id.
+pub const AI_FLOW_STREAM_PATH: &str = "/__pocopine/agenkit/v1/flow/:id/stream";
+
+/// The redaction chokepoint (§D8/§D10).
+///
+/// Every [`FlowStreamEvent`] variant is client-safe by construction — it can
+/// only carry ids, kinds, counts, error *kinds*, and user-visible output, never
+/// raw prompts, tool args, hidden reasoning, or provider payloads. This gate
+/// additionally enforces the [`StreamMode`] visibility contract: it is the one
+/// place that decides what crosses to the wire.
+pub fn stream_filter(event: &FlowStreamEvent, mode: StreamMode) -> bool {
+    use FlowStreamEvent::*;
+    enum Visibility {
+        /// Run lifecycle: crosses in every mode.
+        Lifecycle,
+        /// User-visible output: crosses in every mode (FinalOnly would stream
+        /// nothing useful without the final result).
+        Output,
+        /// The redacted step/tool/parallel/reducer tree: Progress+ only.
+        Progress,
+    }
+    // Classify every variant EXPLICITLY: a new FlowStreamEvent variant must
+    // not compile until someone decides its wire visibility here (§D10).
+    let visibility = match event {
+        FlowStarted { .. }
+        | FlowCompleted { .. }
+        | FlowFailed { .. }
+        | Error { .. }
+        | OutputCompleted => Visibility::Lifecycle,
+        OutputDelta { .. } | ObjectDelta { .. } => Visibility::Output,
+        StepStarted { .. }
+        | StepProgress { .. }
+        | StepCompleted { .. }
+        | StepFailed { .. }
+        | ToolStarted { .. }
+        | ToolCompleted { .. }
+        | ToolFailed { .. }
+        | ParallelStarted { .. }
+        | BranchStarted { .. }
+        | BranchCompleted { .. }
+        | BranchFailed { .. }
+        | ParallelCompleted { .. }
+        | ReducerStarted { .. }
+        | ReducerDecision { .. }
+        | ReducerCompleted { .. }
+        | UsageUpdate { .. } => Visibility::Progress,
+        // The decode-side fallback; the server never constructs it. Drop
+        // defensively rather than forwarding an empty shell.
+        Unknown => return false,
+    };
+    match mode {
+        StreamMode::FinalOnly | StreamMode::OutputDeltas => {
+            !matches!(visibility, Visibility::Progress)
+        }
+        StreamMode::Progress | StreamMode::DebugSafe => true,
+    }
+}
+
+/// Visibility rank for clamping; higher exposes strictly more.
+fn mode_rank(mode: StreamMode) -> u8 {
+    match mode {
+        StreamMode::FinalOnly => 0,
+        StreamMode::OutputDeltas => 1,
+        StreamMode::Progress => 2,
+        StreamMode::DebugSafe => 3,
+    }
+}
+
+/// Clamp the client-requested mode to the author-declared cap (§D8): the
+/// query string can lower visibility, never raise it above `Flow::stream_mode`.
+fn clamp_mode(requested: StreamMode, declared: StreamMode) -> StreamMode {
+    if mode_rank(requested) <= mode_rank(declared) {
+        requested
+    } else {
+        declared
+    }
+}
+
+fn parse_mode(raw: Option<&str>) -> StreamMode {
+    match raw {
+        Some("final") => StreamMode::FinalOnly,
+        Some("output") => StreamMode::OutputDeltas,
+        Some("debug") => StreamMode::DebugSafe,
+        // A streaming subscription defaults to redacted progress.
+        _ => StreamMode::Progress,
+    }
+}
+
+fn to_sse(event: &FlowStreamEvent) -> SseEvent {
+    // The JSON carries the tagged `event` discriminant; clients dispatch on it.
+    let data = serde_json::to_string(event).unwrap_or_else(|_| "{}".to_string());
+    SseEvent::default().data(data)
+}
+
+/// Query string for the stream route.
+#[derive(serde::Deserialize)]
+struct StreamQuery {
+    mode: Option<String>,
+}
+
+async fn stream_handler(
+    State(agenkit): State<Agenkit>,
+    Path(id): Path<String>,
+    Query(query): Query<StreamQuery>,
+    principal: Option<Extension<Principal>>,
+    Json(input): Json<serde_json::Value>,
+) -> Response {
+    // Same authorization boundary as the non-streaming bridge: only public
+    // flows are reachable, and a private flow is indistinguishable from an
+    // unknown one (§D9/§D10).
+    if !agenkit.flow_is_public(&id) {
+        return (StatusCode::NOT_FOUND, "unknown AI flow").into_response();
+    }
+
+    // The client can request *less* visibility than the flow author declared,
+    // never more (§D8).
+    let mode = clamp_mode(
+        parse_mode(query.mode.as_deref()),
+        agenkit.flow_stream_mode(&id),
+    );
+    let principal = principal
+        .map(|ext| ext.0)
+        .unwrap_or_else(Principal::anonymous);
+
+    let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+
+    // Run the flow under the caller principal; the task-local seam lets
+    // `run_flow_streaming` pick it up (§D15 DC-5). The run emits the final
+    // result (OutputDelta/OutputCompleted) before FlowCompleted, and FlowFailed
+    // on error — so the handler only forwards the channel.
+    tokio::spawn(with_principal(principal, async move {
+        let _ = agenkit.run_flow_streaming(&id, input, tx).await;
+    }));
+
+    let stream = UnboundedReceiverStream::new(rx).filter_map(move |event| async move {
+        stream_filter(&event, mode).then(|| Ok::<SseEvent, Infallible>(to_sse(&event)))
+    });
+
+    Sse::new(stream)
+        .keep_alive(KeepAlive::default())
+        .into_response()
+}
+
+/// Build the AI-flow streaming router. Mount it alongside the app's other
+/// routes (and `Server::with_auth(...)` so the principal is populated).
+pub fn ai_flow_stream_router(agenkit: Agenkit) -> Router {
+    Router::new()
+        .route(AI_FLOW_STREAM_PATH, post(stream_handler))
+        .with_state(agenkit)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pocopine_agenkit_core::{ParallelGroupId, StepId};
+
+    fn lifecycle_event() -> FlowStreamEvent {
+        FlowStreamEvent::FlowCompleted {
+            run_id: "run-0".to_string(),
+        }
+    }
+
+    fn progress_event() -> FlowStreamEvent {
+        FlowStreamEvent::BranchStarted {
+            group_id: ParallelGroupId::new("g"),
+            step_id: StepId::new("s1"),
+            name: "b0".to_string(),
+        }
+    }
+
+    #[test]
+    fn final_only_drops_progress_keeps_lifecycle() {
+        assert!(stream_filter(&lifecycle_event(), StreamMode::FinalOnly));
+        assert!(!stream_filter(&progress_event(), StreamMode::FinalOnly));
+    }
+
+    #[test]
+    fn output_deltas_passes_output_not_progress() {
+        let delta = FlowStreamEvent::OutputDelta {
+            text: "hi".to_string(),
+        };
+        assert!(stream_filter(&delta, StreamMode::OutputDeltas));
+        assert!(!stream_filter(&progress_event(), StreamMode::OutputDeltas));
+    }
+
+    #[test]
+    fn progress_passes_the_tree() {
+        assert!(stream_filter(&progress_event(), StreamMode::Progress));
+        assert!(stream_filter(&progress_event(), StreamMode::DebugSafe));
+    }
+
+    #[test]
+    fn unknown_never_crosses_the_wire() {
+        assert!(!stream_filter(
+            &FlowStreamEvent::Unknown,
+            StreamMode::DebugSafe
+        ));
+        assert!(!stream_filter(
+            &FlowStreamEvent::Unknown,
+            StreamMode::FinalOnly
+        ));
+    }
+
+    #[test]
+    fn requested_mode_is_clamped_to_the_declared_cap() {
+        // A client cannot escalate above the author's declared visibility...
+        assert_eq!(
+            clamp_mode(StreamMode::DebugSafe, StreamMode::FinalOnly),
+            StreamMode::FinalOnly
+        );
+        assert_eq!(
+            clamp_mode(StreamMode::Progress, StreamMode::OutputDeltas),
+            StreamMode::OutputDeltas
+        );
+        // ...but can always request less.
+        assert_eq!(
+            clamp_mode(StreamMode::FinalOnly, StreamMode::DebugSafe),
+            StreamMode::FinalOnly
+        );
+    }
+}

--- a/crates/pocopine-agenkit/src/server/thread.rs
+++ b/crates/pocopine-agenkit/src/server/thread.rs
@@ -1,0 +1,196 @@
+//! Agent thread state (RFC-093 Phase 2.6, §D4, §D10).
+//!
+//! Thread state is opt-in. The [`AgentThreadStore`] trait is behind a runtime
+//! seam so v1 ships an in-memory store while a future durable store can drop
+//! in. Thread ids exposed to callers are opaque Pocopine ids; provider-backed
+//! ids (if any) never leak (§D10).
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
+
+use pocopine_agenkit_core::{
+    AgenkitResult, AgentThreadId, StepKind, StepStatus, ThreadMessage, ThreadRetention, events,
+};
+
+use super::provider::BoxFuture;
+use super::run::RunState;
+
+/// Durable-or-not storage for agent threads.
+pub trait AgentThreadStore: Send + Sync + 'static {
+    /// Create a new thread for `agent_id`, returning its opaque id.
+    fn create(
+        &self,
+        agent_id: &str,
+        retention: ThreadRetention,
+    ) -> BoxFuture<'_, AgenkitResult<AgentThreadId>>;
+
+    /// Load a thread's message history, or `None` if it does not exist.
+    fn load(&self, id: &AgentThreadId) -> BoxFuture<'_, AgenkitResult<Option<Vec<ThreadMessage>>>>;
+
+    /// Append messages to a thread.
+    fn append(
+        &self,
+        id: &AgentThreadId,
+        messages: Vec<ThreadMessage>,
+    ) -> BoxFuture<'_, AgenkitResult<()>>;
+
+    /// Delete a thread and its state.
+    fn delete(&self, id: &AgentThreadId) -> BoxFuture<'_, AgenkitResult<()>>;
+}
+
+/// The default in-memory thread store (tests, examples, single-process apps).
+#[derive(Default)]
+pub struct InMemoryThreadStore {
+    threads: Mutex<HashMap<String, Vec<ThreadMessage>>>,
+    seq: AtomicU64,
+}
+
+impl InMemoryThreadStore {
+    /// An empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl AgentThreadStore for InMemoryThreadStore {
+    fn create(
+        &self,
+        agent_id: &str,
+        _retention: ThreadRetention,
+    ) -> BoxFuture<'_, AgenkitResult<AgentThreadId>> {
+        let seq = self.seq.fetch_add(1, Ordering::Relaxed);
+        let id = AgentThreadId::new(format!("th-{agent_id}-{seq}"));
+        self.threads
+            .lock()
+            .unwrap()
+            .insert(id.as_str().to_string(), Vec::new());
+        Box::pin(async move { Ok(id) })
+    }
+
+    fn load(&self, id: &AgentThreadId) -> BoxFuture<'_, AgenkitResult<Option<Vec<ThreadMessage>>>> {
+        let result = self.threads.lock().unwrap().get(id.as_str()).cloned();
+        Box::pin(async move { Ok(result) })
+    }
+
+    fn append(
+        &self,
+        id: &AgentThreadId,
+        messages: Vec<ThreadMessage>,
+    ) -> BoxFuture<'_, AgenkitResult<()>> {
+        self.threads
+            .lock()
+            .unwrap()
+            .entry(id.as_str().to_string())
+            .or_default()
+            .extend(messages);
+        Box::pin(async move { Ok(()) })
+    }
+
+    fn delete(&self, id: &AgentThreadId) -> BoxFuture<'_, AgenkitResult<()>> {
+        self.threads.lock().unwrap().remove(id.as_str());
+        Box::pin(async move { Ok(()) })
+    }
+}
+
+/// A handle to a thread within a flow run: its id plus the store to reach it.
+#[derive(Clone)]
+pub struct AgentThreadHandle {
+    pub(crate) id: AgentThreadId,
+    pub(crate) store: Arc<dyn AgentThreadStore>,
+}
+
+impl AgentThreadHandle {
+    /// The opaque thread id.
+    pub fn id(&self) -> &AgentThreadId {
+        &self.id
+    }
+
+    /// Load the current message history.
+    pub async fn history(&self) -> AgenkitResult<Vec<ThreadMessage>> {
+        Ok(self.store.load(&self.id).await?.unwrap_or_default())
+    }
+}
+
+/// Builder returned by `ctx.thread::<A>()`.
+pub struct ThreadBuilder {
+    run: Arc<RunState>,
+    // `A::ID` is a `&'static str` declared once on the agent — carry it by
+    // reference, never an owned/cloned `String`.
+    agent_id: &'static str,
+}
+
+impl ThreadBuilder {
+    pub(crate) fn new(run: Arc<RunState>, agent_id: &'static str) -> Self {
+        Self { run, agent_id }
+    }
+
+    /// Create a fresh thread for the agent.
+    pub async fn create(&self) -> AgenkitResult<AgentThreadHandle> {
+        let store = self.run.inner.thread_store.clone();
+        let id = store
+            .create(self.agent_id, ThreadRetention::Session)
+            .await?;
+        self.run.emit(
+            self.run
+                .event(
+                    events::AI_THREAD_CREATED,
+                    StepKind::Custom,
+                    StepStatus::Completed,
+                )
+                .with_field("thread_id", id.as_str())
+                .with_field("agent_id", self.agent_id),
+        );
+        Ok(AgentThreadHandle { id, store })
+    }
+
+    /// Resume the thread with `id` if it exists, otherwise create a new one.
+    pub async fn resume_or_create(
+        &self,
+        id: Option<AgentThreadId>,
+    ) -> AgenkitResult<AgentThreadHandle> {
+        let store = self.run.inner.thread_store.clone();
+        if let Some(id) = id
+            && store.load(&id).await?.is_some()
+        {
+            self.run.emit(
+                self.run
+                    .event(
+                        events::AI_THREAD_RESUMED,
+                        StepKind::Custom,
+                        StepStatus::Completed,
+                    )
+                    .with_field("thread_id", id.as_str())
+                    .with_field("agent_id", self.agent_id),
+            );
+            return Ok(AgentThreadHandle { id, store });
+        }
+        self.create().await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pocopine_agenkit_core::Role;
+
+    #[tokio::test]
+    async fn in_memory_store_round_trips() {
+        let store = InMemoryThreadStore::new();
+        let id = store
+            .create("debugger", ThreadRetention::Session)
+            .await
+            .unwrap();
+        store
+            .append(
+                &id,
+                vec![ThreadMessage::new(Role::User, "why did it fail?")],
+            )
+            .await
+            .unwrap();
+        let history = store.load(&id).await.unwrap().unwrap();
+        assert_eq!(history.len(), 1);
+        store.delete(&id).await.unwrap();
+        assert!(store.load(&id).await.unwrap().is_none());
+    }
+}

--- a/crates/pocopine-agenkit/src/server/tool.rs
+++ b/crates/pocopine-agenkit/src/server/tool.rs
@@ -1,0 +1,213 @@
+//! Tools: typed [`AiTool`] trait, object-safe [`DynTool`] erasure, and the
+//! [`ToolRegistry`] (RFC-093 Phase 2.4, §D5).
+//!
+//! Authors implement the typed [`AiTool`]; the runtime erases it to a
+//! [`DynTool`] that dispatches on `serde_json::Value`, validating input before
+//! execution and output before it crosses a model/client boundary (§D5).
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use pocopine_agenkit_core::{AgenkitError, AgenkitResult, ToolDescriptor};
+use schemars::JsonSchema;
+use serde::{Serialize, de::DeserializeOwned};
+
+use super::context::AiToolContext;
+use super::provider::BoxFuture;
+use super::schema::schema_ref_for;
+
+/// A typed, author-facing tool.
+pub trait AiTool: Send + Sync + 'static {
+    /// Stable tool id (the model calls the tool by this id).
+    const ID: &'static str;
+
+    /// Typed input, deserialized from the model's tool-call arguments. The
+    /// `JsonSchema` derive becomes the function-calling `parameters` schema, so
+    /// the model sees the real argument shape (§D5).
+    type Input: DeserializeOwned + JsonSchema + Send + 'static;
+    /// Typed output, serialized back to the model/flow.
+    type Output: Serialize + JsonSchema + Send + 'static;
+
+    /// The framework-visible descriptor. Authors supply the id, description, and
+    /// side-effect policy; the runtime fills the input/output JSON schemas from
+    /// [`Self::Input`]/[`Self::Output`] unless the descriptor already carries
+    /// them (see the [`DynTool`] erasure).
+    fn descriptor() -> ToolDescriptor;
+
+    /// Execute the tool.
+    fn call(
+        &self,
+        input: Self::Input,
+        ctx: AiToolContext,
+    ) -> BoxFuture<'_, AgenkitResult<Self::Output>>;
+}
+
+/// Object-safe erased tool. Stored as `Arc<dyn DynTool>`.
+pub trait DynTool: Send + Sync + 'static {
+    /// The tool id.
+    fn id(&self) -> &'static str;
+    /// The descriptor.
+    fn descriptor(&self) -> ToolDescriptor;
+    /// Validate + dispatch a JSON-encoded call.
+    fn call_json<'a>(
+        &'a self,
+        args: serde_json::Value,
+        ctx: AiToolContext,
+    ) -> BoxFuture<'a, AgenkitResult<serde_json::Value>>;
+}
+
+impl<T: AiTool> DynTool for T {
+    fn id(&self) -> &'static str {
+        T::ID
+    }
+
+    fn descriptor(&self) -> ToolDescriptor {
+        // Author supplies id/description/policy; the runtime fills the typed
+        // input/output schemas (the model's `parameters`) from `schemars`,
+        // unless the author already attached them.
+        let mut descriptor = T::descriptor();
+        if descriptor.input.json_schema.is_none() {
+            descriptor.input = schema_ref_for::<T::Input>();
+        }
+        if descriptor.output.json_schema.is_none() {
+            descriptor.output = schema_ref_for::<T::Output>();
+        }
+        descriptor
+    }
+
+    fn call_json<'a>(
+        &'a self,
+        args: serde_json::Value,
+        ctx: AiToolContext,
+    ) -> BoxFuture<'a, AgenkitResult<serde_json::Value>> {
+        Box::pin(async move {
+            let input: T::Input = serde_json::from_value(args).map_err(|err| {
+                AgenkitError::validation(format!("tool `{}` input: {err}", T::ID))
+            })?;
+            let output = T::call(self, input, ctx).await?;
+            serde_json::to_value(output)
+                .map_err(|err| AgenkitError::validation(format!("tool `{}` output: {err}", T::ID)))
+        })
+    }
+}
+
+/// A registry of tools keyed by id.
+#[derive(Default, Clone)]
+pub struct ToolRegistry {
+    tools: HashMap<&'static str, Arc<dyn DynTool>>,
+}
+
+impl ToolRegistry {
+    /// An empty registry.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Register a typed tool.
+    pub fn register<T: AiTool>(&mut self, tool: T) {
+        self.tools.insert(T::ID, Arc::new(tool));
+    }
+
+    /// Register an already-erased tool (e.g. a retriever-as-tool adapter).
+    pub fn register_dyn(&mut self, tool: Arc<dyn DynTool>) {
+        self.tools.insert(tool.id(), tool);
+    }
+
+    /// Look up a tool by id.
+    pub fn get(&self, id: &str) -> Option<Arc<dyn DynTool>> {
+        self.tools.get(id).cloned()
+    }
+
+    /// Whether a tool id is registered.
+    pub fn contains(&self, id: &str) -> bool {
+        self.tools.contains_key(id)
+    }
+
+    /// The descriptors of all registered tools.
+    pub fn descriptors(&self) -> Vec<ToolDescriptor> {
+        self.tools.values().map(|tool| tool.descriptor()).collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::context::{AiContext, AppState};
+    use super::*;
+    use serde::Deserialize;
+
+    #[derive(Deserialize, JsonSchema)]
+    struct SearchInput {
+        query: String,
+    }
+
+    #[derive(Serialize, JsonSchema)]
+    struct SearchHit {
+        title: String,
+    }
+
+    struct SearchDocs;
+
+    impl AiTool for SearchDocs {
+        const ID: &'static str = "search_docs";
+        type Input = SearchInput;
+        type Output = Vec<SearchHit>;
+
+        fn descriptor() -> ToolDescriptor {
+            ToolDescriptor::new("search_docs", "Search project docs")
+        }
+
+        fn call(
+            &self,
+            input: SearchInput,
+            _ctx: AiToolContext,
+        ) -> BoxFuture<'_, AgenkitResult<Vec<SearchHit>>> {
+            Box::pin(async move {
+                Ok(vec![SearchHit {
+                    title: format!("hit for {}", input.query),
+                }])
+            })
+        }
+    }
+
+    fn ctx() -> AiContext {
+        AiContext::new(std::sync::Arc::new(AppState::new()))
+    }
+
+    #[tokio::test]
+    async fn registry_dispatches_and_validates() {
+        let mut registry = ToolRegistry::new();
+        registry.register(SearchDocs);
+        let tool = registry.get("search_docs").unwrap();
+
+        let output = tool
+            .call_json(serde_json::json!({"query": "uploads"}), ctx())
+            .await
+            .unwrap();
+        assert_eq!(output, serde_json::json!([{"title": "hit for uploads"}]));
+    }
+
+    #[test]
+    fn descriptor_carries_a_derived_parameter_schema() {
+        // The author's `descriptor()` names only id/description; the runtime
+        // fills the real input schema so a provider sees the argument shape.
+        let mut registry = ToolRegistry::new();
+        registry.register(SearchDocs);
+        let descriptor = registry.get("search_docs").unwrap().descriptor();
+
+        let input = descriptor.input.json_schema.expect("input schema derived");
+        assert_eq!(input["properties"]["query"]["type"], "string");
+        assert!(descriptor.output.json_schema.is_some());
+    }
+
+    #[tokio::test]
+    async fn invalid_input_is_validation_error() {
+        let mut registry = ToolRegistry::new();
+        registry.register(SearchDocs);
+        let tool = registry.get("search_docs").unwrap();
+        let err = tool
+            .call_json(serde_json::json!({"wrong": 1}), ctx())
+            .await
+            .unwrap_err();
+        assert_eq!(err.kind(), "validation");
+    }
+}

--- a/crates/pocopine-agenkit/src/shared.rs
+++ b/crates/pocopine-agenkit/src/shared.rs
@@ -1,0 +1,12 @@
+//! Vocabulary shared by the [`client`](crate::client) and
+//! [`server`](crate::server) modules (RFC-093 §D2).
+//!
+//! These are the stable, client-safe contract types both sides exchange — the
+//! public stream events/modes and the error surface. They compile on every
+//! target. Larger or churning contract types stay in `pocopine-agenkit-core`;
+//! this module is the curated subset the facade itself trades across the
+//! client/server boundary.
+
+pub use pocopine_agenkit_core::{
+    AgenkitError, AgenkitResult, FlowStreamEvent, RunId, StreamMode, TraceId,
+};

--- a/crates/pocopine-agenkit/tests/agent_thread_reduce.rs
+++ b/crates/pocopine-agenkit/tests/agent_thread_reduce.rs
@@ -1,0 +1,194 @@
+#![cfg(not(target_arch = "wasm32"))]
+//! Phase 2.6a: typed agents (with a tool-call loop), thread persistence, and
+//! reducers (deterministic fold + model judge).
+
+mod common;
+
+use common::{block_on, capture};
+use pocopine_agenkit::server::{
+    Agenkit, AiAgent, AiAgentBuilder, AiFlowContext, AiTool, AiToolContext, BoxFuture, Flow,
+    MockProvider,
+};
+use pocopine_agenkit_core::{AgenkitResult, ModelRef, ToolDescriptor};
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, schemars::JsonSchema)]
+struct LookupIn {
+    term: String,
+}
+
+#[derive(Serialize, schemars::JsonSchema)]
+struct LookupOut {
+    fact: String,
+}
+
+struct Lookup;
+
+impl AiTool for Lookup {
+    const ID: &'static str = "lookup";
+    type Input = LookupIn;
+    type Output = LookupOut;
+
+    fn descriptor() -> ToolDescriptor {
+        ToolDescriptor::new("lookup", "Look up a fact about a term")
+    }
+
+    fn call(
+        &self,
+        input: LookupIn,
+        _ctx: AiToolContext,
+    ) -> BoxFuture<'_, AgenkitResult<LookupOut>> {
+        Box::pin(async move {
+            Ok(LookupOut {
+                fact: format!("{} use presigned URLs", input.term),
+            })
+        })
+    }
+}
+
+#[derive(Serialize, Deserialize, schemars::JsonSchema)]
+struct Question {
+    question: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, schemars::JsonSchema)]
+struct AgentAnswer {
+    answer: String,
+}
+
+struct Researcher;
+
+impl AiAgent for Researcher {
+    const ID: &'static str = "researcher";
+    type Input = Question;
+    type Output = AgentAnswer;
+
+    fn configure(builder: AiAgentBuilder<Self>) -> AiAgentBuilder<Self> {
+        builder
+            .system("Use the lookup tool, then answer.")
+            .tools(["lookup"])
+            .max_steps(3)
+    }
+}
+
+async fn research_flow(input: Question, ctx: AiFlowContext) -> AgenkitResult<AgentAnswer> {
+    ctx.agent::<Researcher>().input(input).run().await
+}
+
+async fn threaded_flow(input: Question, ctx: AiFlowContext) -> AgenkitResult<usize> {
+    let thread = ctx.thread::<Researcher>().create().await?;
+    ctx.agent::<Researcher>()
+        .thread(thread.clone())
+        .input(input)
+        .run()
+        .await?;
+    Ok(thread.history().await?.len())
+}
+
+async fn reduce_fold_flow(_input: (), ctx: AiFlowContext) -> AgenkitResult<u32> {
+    let candidates = vec![1_u32, 5, 3];
+    ctx.reduce("pick_max", candidates)
+        .fold(|values| Ok(values.into_iter().max().unwrap_or(0)))
+        .await
+}
+
+async fn judge_flow(_input: (), ctx: AiFlowContext) -> AgenkitResult<AgentAnswer> {
+    let candidates = vec!["candidate a".to_string(), "candidate b".to_string()];
+    ctx.reduce("judge", candidates)
+        .system("Pick the best.")
+        .schema::<AgentAnswer>()
+        .await
+}
+
+fn runtime() -> Agenkit {
+    Agenkit::builder()
+        .provider(
+            MockProvider::new("local")
+                .on_prompt_structured(
+                    "fact",
+                    serde_json::json!({"answer": "uploads use presigned URLs"}),
+                )
+                .on_prompt_tool("uploads", "lookup", serde_json::json!({"term": "uploads"}))
+                .default_structured(serde_json::json!({"answer": "best"})),
+        )
+        .default_model(ModelRef::new("local/default"))
+        .tool(Lookup)
+        .flow(
+            Flow::new("research", research_flow)
+                .uses_tool("lookup")
+                .uses_agent("researcher"),
+        )
+        .flow(Flow::new("threaded", threaded_flow))
+        .flow(Flow::new("reduce_fold", reduce_fold_flow))
+        .flow(Flow::new("judge", judge_flow))
+        .build()
+        .unwrap()
+}
+
+#[test]
+fn agent_runs_tool_loop_then_answers() {
+    let trace = capture(|| {
+        let answer: AgentAnswer = block_on(runtime().run_flow_typed(
+            "research",
+            Question {
+                question: "how do uploads work?".to_string(),
+            },
+        ))
+        .unwrap();
+        assert_eq!(
+            answer,
+            AgentAnswer {
+                answer: "uploads use presigned URLs".to_string()
+            }
+        );
+    });
+
+    for name in [
+        "ai_tool_started",
+        "ai_tool_completed",
+        "ai_step_completed",
+        "ai_model_request",
+    ] {
+        assert!(
+            trace.contains(name),
+            "missing `{name}`; got {:?}",
+            trace.names()
+        );
+    }
+    // Two model calls: the tool-requesting call and the final structured call.
+    assert!(trace.count("ai_model_request") >= 2);
+}
+
+#[test]
+fn threaded_agent_persists_exchange() {
+    let count: usize = block_on(runtime().run_flow_typed(
+        "threaded",
+        Question {
+            question: "how do uploads work?".to_string(),
+        },
+    ))
+    .unwrap();
+    // The run appends one user + one assistant message to the thread.
+    assert_eq!(count, 2);
+}
+
+#[test]
+fn deterministic_reduce_folds_candidates() {
+    let trace = capture(|| {
+        let max: u32 = block_on(runtime().run_flow_typed("reduce_fold", ())).unwrap();
+        assert_eq!(max, 5);
+    });
+    assert!(trace.contains("ai_reducer_started"));
+    assert!(trace.contains("ai_reducer_completed"));
+}
+
+#[test]
+fn model_judge_reduce_returns_typed_answer() {
+    let answer: AgentAnswer = block_on(runtime().run_flow_typed("judge", ())).unwrap();
+    assert_eq!(
+        answer,
+        AgentAnswer {
+            answer: "best".to_string()
+        }
+    );
+}

--- a/crates/pocopine-agenkit/tests/common/mod.rs
+++ b/crates/pocopine-agenkit/tests/common/mod.rs
@@ -1,0 +1,90 @@
+//! Shared test support: capture emitted `pocopine.trace` event names.
+//!
+//! `emit_tracing` records the AI event name in the `event_name` tracing field
+//! (see `pocopine-observe`). This installs a thread-local subscriber that
+//! collects those names so flow/parallel tests can assert the trace tree.
+//!
+//! Shared across integration-test binaries; not every binary uses every
+//! helper, so dead-code is expected here.
+#![allow(dead_code)]
+
+use std::fmt::Debug;
+use std::sync::{Arc, Mutex};
+
+use tracing::Subscriber;
+use tracing::field::{Field, Visit};
+use tracing_subscriber::layer::{Context, Layer};
+use tracing_subscriber::prelude::*;
+
+/// Collects the `event_name` of every emitted trace event.
+#[derive(Clone, Default)]
+pub struct TraceCapture {
+    events: Arc<Mutex<Vec<String>>>,
+}
+
+impl TraceCapture {
+    /// Every captured event name, in emission order.
+    pub fn names(&self) -> Vec<String> {
+        self.events.lock().unwrap().clone()
+    }
+
+    /// Whether an event with this name was emitted.
+    pub fn contains(&self, name: &str) -> bool {
+        self.events.lock().unwrap().iter().any(|n| n == name)
+    }
+
+    /// How many times an event name was emitted.
+    pub fn count(&self, name: &str) -> usize {
+        self.events
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|n| n.as_str() == name)
+            .count()
+    }
+}
+
+struct EventNameVisitor<'a>(&'a mut Option<String>);
+
+impl Visit for EventNameVisitor<'_> {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == "event_name" {
+            *self.0 = Some(value.to_string());
+        }
+    }
+
+    fn record_debug(&mut self, field: &Field, value: &dyn Debug) {
+        if field.name() == "event_name" && self.0.is_none() {
+            *self.0 = Some(format!("{value:?}").trim_matches('"').to_string());
+        }
+    }
+}
+
+impl<S: Subscriber> Layer<S> for TraceCapture {
+    fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
+        let mut name = None;
+        event.record(&mut EventNameVisitor(&mut name));
+        if let Some(name) = name {
+            self.events.lock().unwrap().push(name);
+        }
+    }
+}
+
+/// Run `f` with a trace-capturing subscriber installed on the current thread,
+/// returning the captured event names. `f` should drive a current-thread
+/// runtime so all emissions happen on this thread.
+pub fn capture<F: FnOnce()>(f: F) -> TraceCapture {
+    let capture = TraceCapture::default();
+    let subscriber = tracing_subscriber::registry().with(capture.clone());
+    tracing::subscriber::with_default(subscriber, f);
+    capture
+}
+
+/// Build a current-thread runtime and block on `future`.
+pub fn block_on<F: std::future::Future>(future: F) -> F::Output {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap()
+        .block_on(future)
+}

--- a/crates/pocopine-agenkit/tests/flow_trace.rs
+++ b/crates/pocopine-agenkit/tests/flow_trace.rs
@@ -1,0 +1,169 @@
+#![cfg(not(target_arch = "wasm32"))]
+//! Phase 2.5 exit gate: a registered flow runs `ctx.retrieve` + `ctx.step` +
+//! `ctx.ai()` and emits a correlated trace tree through `pocopine.trace`.
+
+mod common;
+
+use common::{block_on, capture};
+use pocopine_agenkit::server::{
+    Agenkit, AiFlowContext, AiRetriever, BoxFuture, Flow, MockProvider, RetrievalContext,
+};
+use pocopine_agenkit_core::{
+    AgenkitError, AgenkitResult, Content, ModelRef, RetrievalHit, RetrievalSet,
+    RetrieverDescriptor, SourceRef,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, schemars::JsonSchema)]
+struct QuestionInput {
+    question: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, schemars::JsonSchema)]
+struct Answer {
+    text: String,
+}
+
+#[derive(Serialize, Deserialize, schemars::JsonSchema)]
+struct DocsQuery {
+    question: String,
+}
+
+#[derive(Default)]
+struct ProjectDocs;
+
+impl AiRetriever for ProjectDocs {
+    const ID: &'static str = "project_docs";
+    type Query = DocsQuery;
+
+    fn descriptor() -> RetrieverDescriptor {
+        RetrieverDescriptor::new("project_docs", "Search project docs").with_source_kinds(["doc"])
+    }
+
+    fn retrieve(
+        &self,
+        query: DocsQuery,
+        _ctx: RetrievalContext,
+    ) -> BoxFuture<'_, AgenkitResult<RetrievalSet>> {
+        Box::pin(async move {
+            Ok(RetrievalSet::new(vec![RetrievalHit {
+                source: SourceRef::new("doc", "uploads.md"),
+                score: Some(0.9),
+                content: Content::text(format!("uploads use presigned URLs ({})", query.question)),
+                citation: None,
+            }]))
+        })
+    }
+}
+
+async fn answer_question(input: QuestionInput, ctx: AiFlowContext) -> AgenkitResult<Answer> {
+    let docs = ctx
+        .retrieve::<ProjectDocs>()
+        .query(DocsQuery {
+            question: input.question,
+        })
+        .top_k(3)
+        .run()
+        .await?;
+
+    let context = ctx
+        .step("assemble_context", async move {
+            Ok::<_, AgenkitError>(
+                docs.hits
+                    .iter()
+                    .map(|hit| hit.content.as_text())
+                    .collect::<Vec<_>>()
+                    .join(" "),
+            )
+        })
+        .await?;
+
+    ctx.ai()
+        .system("Answer using the retrieved docs.")
+        .prompt(context)
+        .schema::<Answer>()
+        .generate_structured()
+        .await
+}
+
+fn runtime() -> Agenkit {
+    Agenkit::builder()
+        .provider(
+            MockProvider::new("local")
+                .default_structured(serde_json::json!({"text": "uploads use presigned URLs"})),
+        )
+        .default_model(ModelRef::new("local/default"))
+        .retriever(ProjectDocs)
+        .flow(
+            Flow::new("answer_question", answer_question)
+                .public()
+                .uses_retriever("project_docs"),
+        )
+        .build()
+        .unwrap()
+}
+
+#[test]
+fn flow_runs_and_emits_correlated_trace_tree() {
+    let trace = capture(|| {
+        let answer: Answer = block_on(runtime().run_flow_typed(
+            "answer_question",
+            QuestionInput {
+                question: "how do uploads work?".to_string(),
+            },
+        ))
+        .unwrap();
+        assert_eq!(
+            answer,
+            Answer {
+                text: "uploads use presigned URLs".to_string()
+            }
+        );
+    });
+
+    for name in [
+        "ai_flow_started",
+        "ai_retrieval_started",
+        "ai_retrieval_completed",
+        "ai_step_started",
+        "ai_step_completed",
+        "ai_model_request",
+        "ai_model_response",
+        "ai_flow_completed",
+    ] {
+        assert!(
+            trace.contains(name),
+            "missing trace event `{name}`; got {:?}",
+            trace.names()
+        );
+    }
+}
+
+#[test]
+fn undeclared_retriever_emits_advisory_context_gap() {
+    let agenkit = Agenkit::builder()
+        .provider(MockProvider::new("local").default_structured(serde_json::json!({"text": "x"})))
+        .default_model(ModelRef::new("local/default"))
+        .retriever(ProjectDocs)
+        // NOTE: flow does NOT declare `.uses_retriever("project_docs")`.
+        .flow(Flow::new("answer_question", answer_question))
+        .build()
+        .unwrap();
+
+    let trace = capture(|| {
+        let _: Answer = block_on(agenkit.run_flow_typed(
+            "answer_question",
+            QuestionInput {
+                question: "q".to_string(),
+            },
+        ))
+        .unwrap();
+    });
+
+    // The flow still runs (advisory only), but a context-gap event is emitted.
+    assert!(
+        trace.contains("ai_context_gap"),
+        "expected ai_context_gap; got {:?}",
+        trace.names()
+    );
+}

--- a/crates/pocopine-agenkit/tests/parallel_stream.rs
+++ b/crates/pocopine-agenkit/tests/parallel_stream.rs
@@ -1,0 +1,263 @@
+#![cfg(not(target_arch = "wasm32"))]
+//! Phase 2.6b: parallel fan-out + reducer (`answer_with_review`), real
+//! in-flight cancellation on `FirstSuccess`, and public stream emission.
+
+mod common;
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+use common::block_on;
+use pocopine_agenkit::server::{
+    Agenkit, AiAgent, AiAgentBuilder, AiFlowContext, Flow, MockProvider,
+};
+use pocopine_agenkit_core::{AgenkitResult, FlowStreamEvent, ModelRef, ParallelJoin};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, schemars::JsonSchema)]
+struct Question {
+    q: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, schemars::JsonSchema)]
+struct CandidateAnswer {
+    claim: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, schemars::JsonSchema)]
+struct FinalAnswer {
+    answer: String,
+}
+
+struct Researcher;
+
+impl AiAgent for Researcher {
+    const ID: &'static str = "researcher";
+    type Input = Question;
+    type Output = CandidateAnswer;
+
+    fn configure(builder: AiAgentBuilder<Self>) -> AiAgentBuilder<Self> {
+        builder.system("Answer concisely.")
+    }
+}
+
+async fn answer_with_review(input: Question, ctx: AiFlowContext) -> AgenkitResult<FinalAnswer> {
+    let candidates = ctx
+        .parallel::<CandidateAnswer>("candidate_answers")
+        .join(ParallelJoin::AllSettled)
+        .min_success(2)
+        .max_concurrency(3)
+        .branch(
+            ctx.agent::<Researcher>()
+                .input(Question {
+                    q: format!("{}#1", input.q),
+                })
+                .run(),
+        )
+        .branch(
+            ctx.agent::<Researcher>()
+                .input(Question {
+                    q: format!("{}#2", input.q),
+                })
+                .run(),
+        )
+        .branch(
+            ctx.agent::<Researcher>()
+                .input(Question {
+                    q: format!("{}#3", input.q),
+                })
+                .run(),
+        )
+        .run()
+        .await?;
+
+    ctx.reduce("judge_and_merge", candidates)
+        .system("Keep only claims supported by evidence.")
+        .schema::<FinalAnswer>()
+        .await
+}
+
+async fn race(_input: (), ctx: AiFlowContext) -> AgenkitResult<i32> {
+    let loser_done = ctx.state::<AtomicBool>("loser_done")?;
+    let winners = ctx
+        .parallel::<i32>("race")
+        .join(ParallelJoin::FirstSuccess)
+        // Fast branch wins immediately.
+        .branch(async { Ok(1) })
+        // Slow branch must be aborted before it can set the flag.
+        .branch({
+            let loser_done = loser_done.clone();
+            async move {
+                tokio::time::sleep(Duration::from_millis(400)).await;
+                loser_done.store(true, Ordering::SeqCst);
+                Ok(2)
+            }
+        })
+        .run()
+        .await?;
+    Ok(winners[0])
+}
+
+async fn strict_with_panic(_input: (), ctx: AiFlowContext) -> AgenkitResult<Vec<i32>> {
+    ctx.parallel::<i32>("strict")
+        .join(ParallelJoin::All)
+        .branch(async { Ok(1) })
+        .branch(async { panic!("branch blew up") })
+        .branch(async { Ok(3) })
+        .run()
+        .await
+}
+
+async fn settled_with_panic(_input: (), ctx: AiFlowContext) -> AgenkitResult<Vec<i32>> {
+    ctx.parallel::<i32>("settled")
+        .join(ParallelJoin::AllSettled)
+        .branch(async { Ok(1) })
+        .branch(async { panic!("branch blew up") })
+        .branch(async { Ok(3) })
+        .run()
+        .await
+}
+
+fn runtime() -> (Agenkit, Arc<AtomicBool>) {
+    let loser_done = Arc::new(AtomicBool::new(false));
+    let agenkit = Agenkit::builder()
+        .provider(
+            MockProvider::new("local")
+                .on_prompt_structured("Candidate answers", serde_json::json!({"answer": "merged"}))
+                .default_structured(serde_json::json!({"claim": "c"})),
+        )
+        .default_model(ModelRef::new("local/default"))
+        .state_arc("loser_done", loser_done.clone())
+        .flow(Flow::new("answer_with_review", answer_with_review).uses_agent("researcher"))
+        .flow(Flow::new("race", race).uses_state("loser_done"))
+        .flow(Flow::new("strict_with_panic", strict_with_panic))
+        .flow(Flow::new("settled_with_panic", settled_with_panic))
+        .build()
+        .unwrap();
+    (agenkit, loser_done)
+}
+
+#[test]
+fn answer_with_review_fans_out_then_reduces() {
+    let (agenkit, _) = runtime();
+    let answer: FinalAnswer = block_on(agenkit.run_flow_typed(
+        "answer_with_review",
+        Question {
+            q: "how do uploads work?".to_string(),
+        },
+    ))
+    .unwrap();
+    // Three agent branches (AllSettled, min_success 2) reduced by a model judge.
+    assert_eq!(
+        answer,
+        FinalAnswer {
+            answer: "merged".to_string()
+        }
+    );
+}
+
+#[test]
+fn first_success_aborts_losing_branch_in_flight() {
+    let (agenkit, loser_done) = runtime();
+    let winner: i32 = block_on(agenkit.run_flow_typed("race", ())).unwrap();
+    assert_eq!(winner, 1);
+    // The slow branch was aborted mid-sleep, so it never reached the store.
+    assert!(
+        !loser_done.load(Ordering::SeqCst),
+        "losing branch was not cancelled in flight"
+    );
+}
+
+#[test]
+fn all_join_fails_when_a_branch_panics() {
+    // A panicked branch is a branch failure, not a silent skip: `All` must
+    // refuse to return a partial result set.
+    let (agenkit, _) = runtime();
+    let result: Result<Vec<i32>, _> = block_on(agenkit.run_flow_typed("strict_with_panic", ()));
+    let error = result.expect_err("All join must fail on a panicked branch");
+    assert_eq!(error.kind(), "internal", "error: {error}");
+}
+
+#[test]
+fn all_settled_join_records_a_panicked_branch_but_keeps_survivors() {
+    let (agenkit, _) = runtime();
+    let mut survivors: Vec<i32> =
+        block_on(agenkit.run_flow_typed("settled_with_panic", ())).unwrap();
+    // Settled results arrive in completion order; only membership matters.
+    survivors.sort_unstable();
+    assert_eq!(survivors, vec![1, 3]);
+}
+
+#[test]
+fn streaming_emits_public_flow_events() {
+    let (agenkit, _) = runtime();
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let answer: FinalAnswer = block_on(async {
+        let value = agenkit
+            .run_flow_streaming(
+                "answer_with_review",
+                serde_json::json!({"q": "how do uploads work?"}),
+                tx,
+            )
+            .await
+            .unwrap();
+        serde_json::from_value(value).unwrap()
+    });
+    assert_eq!(
+        answer,
+        FinalAnswer {
+            answer: "merged".to_string()
+        }
+    );
+
+    let mut events = Vec::new();
+    while let Ok(event) = rx.try_recv() {
+        events.push(event);
+    }
+
+    // The public stream reconstructs the trace tree for clients: flow ->
+    // parallel(group) -> 3 branches -> reducer -> flow complete.
+    let has = |pred: fn(&FlowStreamEvent) -> bool| events.iter().any(pred);
+    assert!(has(|e| matches!(e, FlowStreamEvent::FlowStarted { .. })));
+    assert!(has(|e| matches!(
+        e,
+        FlowStreamEvent::ParallelStarted { .. }
+    )));
+    assert!(has(|e| matches!(
+        e,
+        FlowStreamEvent::ParallelCompleted { .. }
+    )));
+    assert!(has(|e| matches!(e, FlowStreamEvent::ReducerStarted { .. })));
+    assert!(has(|e| matches!(
+        e,
+        FlowStreamEvent::ReducerCompleted { .. }
+    )));
+    assert!(has(|e| matches!(e, FlowStreamEvent::FlowCompleted { .. })));
+    assert_eq!(
+        events
+            .iter()
+            .filter(|e| matches!(e, FlowStreamEvent::BranchStarted { .. }))
+            .count(),
+        3,
+        "expected three parallel branches"
+    );
+
+    // No public stream event may carry a raw prompt, tool args, or provider
+    // payload (§D8/§D10). Serialize every event and scan for the seeded marker.
+    for event in &events {
+        let json = serde_json::to_string(event).unwrap().to_lowercase();
+        for needle in [
+            "how do uploads work",
+            "system",
+            "prompt",
+            "api_key",
+            "candidate answers",
+        ] {
+            assert!(
+                !json.contains(needle),
+                "stream event leaked `{needle}`: {json}"
+            );
+        }
+    }
+}

--- a/crates/pocopine-agenkit/tests/principal.rs
+++ b/crates/pocopine-agenkit/tests/principal.rs
@@ -1,0 +1,76 @@
+#![cfg(not(target_arch = "wasm32"))]
+//! Phase 3.2: the in-facade principal adapter threads the caller identity into
+//! a flow, its tools/retrieval, and parallel branches.
+
+mod common;
+
+use common::block_on;
+use pocopine_agenkit::server::{Agenkit, AiFlowContext, Flow, MockProvider, with_principal};
+use pocopine_agenkit_core::{AgenkitResult, ModelRef};
+use pocopine_auth::{AuthUser, Principal};
+
+fn whoami_principal(ctx: &AiFlowContext) -> String {
+    ctx.principal()
+        .user()
+        .map(|u| u.id.clone())
+        .unwrap_or_else(|| "anon".to_string())
+}
+
+async fn whoami(_input: (), ctx: AiFlowContext) -> AgenkitResult<String> {
+    Ok(whoami_principal(&ctx))
+}
+
+async fn whoami_in_branch(_input: (), ctx: AiFlowContext) -> AgenkitResult<String> {
+    let branch_ctx = ctx.clone();
+    let results = ctx
+        .parallel::<String>("who")
+        .branch(async move { Ok(whoami_principal(&branch_ctx)) })
+        .run()
+        .await?;
+    Ok(results[0].clone())
+}
+
+fn runtime() -> Agenkit {
+    Agenkit::builder()
+        .provider(MockProvider::new("local"))
+        .default_model(ModelRef::new("local/default"))
+        .flow(Flow::new("whoami", whoami).public())
+        .flow(Flow::new("whoami_in_branch", whoami_in_branch).public())
+        .build()
+        .unwrap()
+}
+
+fn alice() -> Principal {
+    Principal::from_user(AuthUser::new("alice"))
+}
+
+#[test]
+fn explicit_principal_flows_into_the_flow() {
+    let agenkit = runtime();
+    let id: String = block_on(agenkit.run_public_flow_as(alice(), "whoami", ())).unwrap();
+    assert_eq!(id, "alice");
+}
+
+#[test]
+fn anonymous_when_no_principal() {
+    let agenkit = runtime();
+    let id: String = block_on(agenkit.run_public_flow("whoami", ())).unwrap();
+    assert_eq!(id, "anon");
+}
+
+#[test]
+fn scoped_principal_is_picked_up_by_run_flow() {
+    let agenkit = runtime();
+    let id: String = block_on(with_principal(alice(), async {
+        agenkit.run_flow_typed::<(), String>("whoami", ()).await
+    }))
+    .unwrap();
+    assert_eq!(id, "alice");
+}
+
+#[test]
+fn principal_flows_into_a_parallel_branch() {
+    let agenkit = runtime();
+    let id: String = block_on(agenkit.run_public_flow_as(alice(), "whoami_in_branch", ())).unwrap();
+    assert_eq!(id, "alice");
+}

--- a/crates/pocopine-agenkit/tests/secret_boundary.rs
+++ b/crates/pocopine-agenkit/tests/secret_boundary.rs
@@ -1,0 +1,204 @@
+#![cfg(not(target_arch = "wasm32"))]
+//! Phase 3.4: the secret-boundary suite (§D10). A provider whose internals
+//! quote a planted secret must never let that secret cross to the client —
+//! not via the returned `ServerError`, not via the public stream — and a
+//! non-allowlisted model alias must be rejected *before* any provider call.
+
+mod common;
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use common::block_on;
+use pocopine_agenkit::server::{
+    Agenkit, AiFlowContext, BoxFuture, Flow, GenerateRequest, GenerateResponse, Provider,
+};
+use pocopine_agenkit_core::{AgenkitError, AgenkitResult, FlowStreamEvent, ModelRef};
+
+/// A value that must never appear on a client-facing surface.
+const PLANTED_SECRET: &str = "sk-live-PLANTED-SECRET-do-not-leak";
+
+/// A provider whose error quotes provider internals (host + credential).
+struct SecretLeakProvider;
+
+impl Provider for SecretLeakProvider {
+    fn id(&self) -> &str {
+        "local"
+    }
+
+    fn generate<'a>(
+        &'a self,
+        _request: GenerateRequest,
+    ) -> BoxFuture<'a, AgenkitResult<GenerateResponse>> {
+        Box::pin(async {
+            Err(AgenkitError::provider(format!(
+                "401 from api.provider.test using {PLANTED_SECRET}"
+            )))
+        })
+    }
+}
+
+/// A provider that records whether `generate` was ever called.
+struct RecordingProvider {
+    called: Arc<AtomicBool>,
+}
+
+impl Provider for RecordingProvider {
+    fn id(&self) -> &str {
+        "local"
+    }
+
+    fn generate<'a>(
+        &'a self,
+        _request: GenerateRequest,
+    ) -> BoxFuture<'a, AgenkitResult<GenerateResponse>> {
+        self.called.store(true, Ordering::SeqCst);
+        Box::pin(async { Ok(GenerateResponse::text("ok")) })
+    }
+}
+
+async fn ask(_input: (), ctx: AiFlowContext) -> AgenkitResult<String> {
+    ctx.ai().prompt("hello").generate_text().await
+}
+
+async fn ask_denied_model(_input: (), ctx: AiFlowContext) -> AgenkitResult<String> {
+    ctx.ai()
+        .model("local/denied")
+        .prompt("hello")
+        .generate_text()
+        .await
+}
+
+#[test]
+fn provider_error_does_not_leak_through_server_error() {
+    let agenkit = Agenkit::builder()
+        .provider(SecretLeakProvider)
+        .default_model(ModelRef::new("local/default"))
+        .flow(Flow::new("ask", ask).public())
+        .build()
+        .unwrap();
+
+    let error = block_on(agenkit.run_public_flow::<(), String>("ask", ())).unwrap_err();
+    let rendered = error.to_string();
+    assert!(
+        !rendered.contains(PLANTED_SECRET),
+        "ServerError leaked the secret: {rendered}"
+    );
+    assert!(
+        !rendered.contains("api.provider.test"),
+        "ServerError leaked the host: {rendered}"
+    );
+    // Only the stable kind crosses.
+    assert!(
+        rendered.contains("ai error (provider)"),
+        "unexpected error: {rendered}"
+    );
+}
+
+#[test]
+fn provider_error_does_not_leak_through_the_stream() {
+    let agenkit = Agenkit::builder()
+        .provider(SecretLeakProvider)
+        .default_model(ModelRef::new("local/default"))
+        .flow(Flow::new("ask", ask).public())
+        .build()
+        .unwrap();
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let _ = block_on(agenkit.run_flow_streaming("ask", serde_json::Value::Null, tx));
+
+    let mut joined = String::new();
+    let mut saw_failure = false;
+    while let Ok(event) = rx.try_recv() {
+        if matches!(event, FlowStreamEvent::FlowFailed { .. }) {
+            saw_failure = true;
+        }
+        joined.push_str(&serde_json::to_string(&event).unwrap());
+    }
+    assert!(saw_failure, "expected a flow_failed event");
+    assert!(
+        !joined.contains(PLANTED_SECRET),
+        "stream leaked the secret: {joined}"
+    );
+    assert!(
+        !joined.contains("api.provider.test"),
+        "stream leaked the host: {joined}"
+    );
+}
+
+#[test]
+fn non_allowlisted_alias_is_rejected_before_any_provider_call() {
+    let called = Arc::new(AtomicBool::new(false));
+    let agenkit = Agenkit::builder()
+        .provider(RecordingProvider {
+            called: called.clone(),
+        })
+        .allow_model("local/allowed")
+        .flow(Flow::new("ask_denied_model", ask_denied_model).public())
+        .build()
+        .unwrap();
+
+    let error =
+        block_on(agenkit.run_public_flow::<(), String>("ask_denied_model", ())).unwrap_err();
+    assert!(
+        !called.load(Ordering::SeqCst),
+        "the provider was called despite a non-allowlisted model alias"
+    );
+    // The boundary returns a generic error, not provider internals.
+    assert!(
+        error.to_string().starts_with("server error"),
+        "unexpected: {error}"
+    );
+}
+
+#[test]
+fn private_flows_are_not_callable_from_the_boundary() {
+    let agenkit = Agenkit::builder()
+        .provider(RecordingProvider {
+            called: Arc::new(AtomicBool::new(false)),
+        })
+        .default_model(ModelRef::new("local/default"))
+        // NOTE: no `.public()`.
+        .flow(Flow::new("ask", ask))
+        .build()
+        .unwrap();
+
+    let error = block_on(agenkit.run_public_flow::<(), String>("ask", ())).unwrap_err();
+    // Indistinguishable from an unknown flow.
+    assert!(error.to_string().contains("unknown AI flow"));
+}
+
+/// Representative of the wasm-artifact scan: client-facing payloads (the only
+/// types that reach a browser, all from `pocopine-agenkit-core`) carry no
+/// credential-shaped fields. The full corpus lives in core's `tests/no_secrets`.
+#[test]
+fn client_facing_stream_events_have_no_credential_fields() {
+    let events = [
+        FlowStreamEvent::FlowStarted {
+            run_id: "r".into(),
+            trace_id: "t".into(),
+        },
+        FlowStreamEvent::FlowFailed {
+            run_id: "r".into(),
+            error_kind: "provider".into(),
+            trace_id: "t".into(),
+        },
+        FlowStreamEvent::OutputDelta { text: "hi".into() },
+    ];
+    for event in &events {
+        let json = serde_json::to_string(event).unwrap().to_lowercase();
+        for needle in [
+            "api_key",
+            "authorization",
+            "bearer",
+            "secret",
+            "password",
+            "prompt",
+        ] {
+            assert!(
+                !json.contains(needle),
+                "stream event carries `{needle}`: {json}"
+            );
+        }
+    }
+}

--- a/crates/pocopine-agenkit/tests/stream_route.rs
+++ b/crates/pocopine-agenkit/tests/stream_route.rs
@@ -1,0 +1,72 @@
+#![cfg(not(target_arch = "wasm32"))]
+//! Phase 3.3: the AI-flow SSE route streams redacted FlowStreamEvents and the
+//! final result, driven in-process via tower's `oneshot`.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use http_body_util::BodyExt;
+use pocopine_agenkit::server::{Agenkit, AiFlowContext, Flow, MockProvider, ai_flow_stream_router};
+use pocopine_agenkit_core::{AgenkitResult, ModelRef};
+use tower::ServiceExt;
+
+async fn echo(_input: serde_json::Value, _ctx: AiFlowContext) -> AgenkitResult<serde_json::Value> {
+    Ok(serde_json::json!({"ok": true, "secret_field_api_key": "should-not-be-in-stream"}))
+}
+
+fn runtime() -> Agenkit {
+    Agenkit::builder()
+        .provider(MockProvider::new("local"))
+        .default_model(ModelRef::new("local/default"))
+        .flow(Flow::new("echo", echo).public())
+        .build()
+        .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn stream_route_emits_sse_events_and_result() {
+    let app = ai_flow_stream_router(runtime());
+    let request = Request::builder()
+        .method("POST")
+        .uri("/__pocopine/agenkit/v1/flow/echo/stream?mode=progress")
+        .header("content-type", "application/json")
+        .body(Body::from("{}"))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get("content-type").unwrap(),
+        "text/event-stream",
+        "expected an SSE response"
+    );
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let text = String::from_utf8_lossy(&body);
+
+    // The public stream carries lifecycle + the final output.
+    assert!(text.contains("flow_started"), "body: {text}");
+    assert!(text.contains("flow_completed"), "body: {text}");
+    assert!(text.contains("output_completed"), "body: {text}");
+    // The final result is surfaced as user-visible output.
+    assert!(text.contains("\\\"ok\\\":true"), "body: {text}");
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn final_only_mode_omits_step_progress() {
+    let app = ai_flow_stream_router(runtime());
+    let request = Request::builder()
+        .method("POST")
+        .uri("/__pocopine/agenkit/v1/flow/echo/stream?mode=final")
+        .header("content-type", "application/json")
+        .body(Body::from("{}"))
+        .unwrap();
+
+    let response = app.oneshot(request).await.unwrap();
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let text = String::from_utf8_lossy(&body);
+
+    assert!(text.contains("flow_completed"));
+    // No model/step/tool progress events in FinalOnly mode.
+    assert!(!text.contains("ai_model"), "body: {text}");
+    assert!(!text.contains("step_started"), "body: {text}");
+}

--- a/crates/pocopine-agenkit/tests/streaming.rs
+++ b/crates/pocopine-agenkit/tests/streaming.rs
@@ -1,0 +1,173 @@
+#![cfg(not(target_arch = "wasm32"))]
+//! Streaming: `ctx.ai().stream_text()` forwards incremental OutputDeltas to the
+//! client stream, and the runtime does not duplicate the final result.
+
+mod common;
+
+use common::block_on;
+use pocopine_agenkit::server::{Agenkit, AiFlowContext, Flow, MockProvider};
+use pocopine_agenkit_core::{AgenkitResult, FlowStreamEvent, ModelRef};
+
+const ANSWER: &str = "uploads use presigned URLs for direct browser upload";
+
+async fn chat(_input: (), ctx: AiFlowContext) -> AgenkitResult<String> {
+    ctx.ai().prompt("how do uploads work?").stream_text().await
+}
+
+fn runtime() -> Agenkit {
+    Agenkit::builder()
+        .provider(MockProvider::new("local").on_prompt_text("uploads", ANSWER))
+        .default_model(ModelRef::new("local/default"))
+        .flow(Flow::new("chat", chat).public())
+        .build()
+        .unwrap()
+}
+
+#[test]
+fn flow_streams_incremental_output_deltas() {
+    let agenkit = runtime();
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let result: String = block_on(async {
+        let value = agenkit
+            .run_flow_streaming("chat", serde_json::Value::Null, tx)
+            .await
+            .unwrap();
+        serde_json::from_value(value).unwrap()
+    });
+    assert_eq!(result, ANSWER);
+
+    let mut deltas = Vec::new();
+    let mut completions = 0;
+    while let Ok(event) = rx.try_recv() {
+        match event {
+            FlowStreamEvent::OutputDelta { text } => deltas.push(text),
+            FlowStreamEvent::OutputCompleted => completions += 1,
+            _ => {}
+        }
+    }
+
+    // The mock streams word-by-word, so the client sees many deltas (not one
+    // buffered result), and they reassemble to the full answer with no
+    // duplication from the runtime's final-result emission.
+    assert!(
+        deltas.len() > 3,
+        "expected incremental deltas, got {deltas:?}"
+    );
+    assert_eq!(deltas.concat(), ANSWER);
+    assert_eq!(completions, 1);
+}
+
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+struct Summary {
+    title: String,
+    words: u32,
+}
+
+async fn summarize(_input: (), ctx: AiFlowContext) -> AgenkitResult<Summary> {
+    ctx.ai()
+        .prompt("summarize the uploads doc")
+        .schema::<Summary>()
+        .stream_structured()
+        .await
+}
+
+#[test]
+fn structured_flow_streams_partial_objects() {
+    // The mock streams the serialized JSON word-by-word, so the client sees the
+    // object completing field-by-field (Genkit-style partial objects).
+    let agenkit = Agenkit::builder()
+        .provider(MockProvider::new("local").default_structured(
+            serde_json::json!({"title": "Object storage uploads", "words": 12}),
+        ))
+        .default_model(ModelRef::new("local/default"))
+        .flow(Flow::new("summarize", summarize).public())
+        .build()
+        .unwrap();
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let result: Summary = block_on(async {
+        let value = agenkit
+            .run_flow_streaming("summarize", serde_json::Value::Null, tx)
+            .await
+            .unwrap();
+        serde_json::from_value(value).unwrap()
+    });
+    assert_eq!(
+        result,
+        Summary {
+            title: "Object storage uploads".to_string(),
+            words: 12
+        }
+    );
+
+    let mut partials = Vec::new();
+    let mut text_deltas = 0;
+    while let Ok(event) = rx.try_recv() {
+        match event {
+            FlowStreamEvent::ObjectDelta { partial } => partials.push(partial),
+            FlowStreamEvent::OutputDelta { .. } => text_deltas += 1,
+            _ => {}
+        }
+    }
+
+    // Structured streaming emits partial *objects*, never raw text deltas, and
+    // the runtime does not duplicate the final result as a text delta.
+    assert_eq!(
+        text_deltas, 0,
+        "structured streaming must not emit text deltas"
+    );
+    assert!(
+        partials.len() > 1,
+        "expected incremental partials, got {partials:?}"
+    );
+
+    // Every partial is a JSON object, growing toward the full result: an early
+    // partial has the (still-completing) title but not yet the trailing field.
+    assert!(partials.iter().all(serde_json::Value::is_object));
+    assert!(
+        partials[0].get("words").is_none(),
+        "first partial should arrive before the trailing field: {:?}",
+        partials[0]
+    );
+    let first_title = partials[0]["title"].as_str().unwrap();
+    assert!(
+        "Object storage uploads".starts_with(first_title.trim_end()),
+        "first partial title {first_title:?} should be a prefix of the final title"
+    );
+
+    // The last partial converges to exactly the validated result.
+    let converged: Summary = serde_json::from_value(partials.last().unwrap().clone()).unwrap();
+    assert_eq!(converged, result);
+}
+
+#[test]
+fn non_streaming_flow_still_emits_the_result_once() {
+    async fn computed(_input: (), _ctx: AiFlowContext) -> AgenkitResult<String> {
+        // Returns a value without streaming it.
+        Ok("computed".to_string())
+    }
+    let agenkit = Agenkit::builder()
+        .provider(MockProvider::new("local"))
+        .default_model(ModelRef::new("local/default"))
+        .flow(Flow::new("computed", computed).public())
+        .build()
+        .unwrap();
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let _: String = block_on(async {
+        let value = agenkit
+            .run_flow_streaming("computed", serde_json::Value::Null, tx)
+            .await
+            .unwrap();
+        serde_json::from_value(value).unwrap()
+    });
+
+    let deltas: Vec<_> = std::iter::from_fn(|| rx.try_recv().ok())
+        .filter_map(|e| match e {
+            FlowStreamEvent::OutputDelta { text } => Some(text),
+            _ => None,
+        })
+        .collect();
+    // Exactly one final-result delta for a flow that didn't stream.
+    assert_eq!(deltas, vec!["\"computed\"".to_string()]);
+}

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -97,3 +97,4 @@ Conventions:
 | 089 | [SPA router parity and nested outlets](./rfc-089-spa-router-parity.md) | Accepted |
 | 090 | [Merge `pocopine-sync-crud` into `pocopine-sync-query`](./rfc-090-merge-crud-into-query.md) | Implemented |
 | 092 | [Pine Stylekit utility compiler](./rfc-092-pocopine-stylekit.md) | Accepted |
+| 093 | [Pocopine Agenkit plan](./rfc-093-pocopine-agenkit.md) | Draft |

--- a/rfcs/rfc-093-pocopine-agenkit.md
+++ b/rfcs/rfc-093-pocopine-agenkit.md
@@ -1,0 +1,1323 @@
+# RFC 093 - Pocopine Agenkit plan
+
+* **Status:** Draft
+* **Author:** Pocopine AI working group
+* **Tracking branch:** `pocopine-agenkit`
+* **Related:** [RFC 002 (application framework, stores, server functions)](./rfc-002-app-stores-servers.md),
+  [RFC 066 (server-function auth and access policy)](./rfc-066-server-function-auth.md),
+  [RFC 069 (observability, logging, and analytics)](./rfc-069-observability.md),
+  [RFC 076 (app plugin lifecycle)](./rfc-076-app-plugin-lifecycle.md),
+  [RFC 077 (server plugin lifecycle)](./rfc-077-server-plugin-lifecycle.md)
+* **References:** [Google Genkit](https://github.com/genkit-ai/genkit),
+  [Rig](https://github.com/0xPlaygrounds/rig),
+  [LangChain agents](https://docs.langchain.com/oss/python/langchain/agents),
+  [OpenAI Agents SDK](https://openai.github.io/openai-agents-python/agents/),
+  [LlamaIndex agents](https://developers.llamaindex.ai/python/framework/module_guides/deploying/agents/),
+  [Semantic Kernel Agent Framework](https://learn.microsoft.com/en-us/semantic-kernel/frameworks/agent/)
+
+## Summary
+
+Add **Pocopine Agenkit**: a Pocopine-native generative-AI kit for
+building AI features, AI server functions, local prompt/flow tooling,
+and future focused products such as an agent-powered Pocopine debugger.
+
+This RFC now scopes the first implementation to exactly two crates:
+
+* `pocopine-agenkit-core`;
+* `pocopine-agenkit`.
+
+The goal is one Pocopine platform surface: app flows, server functions,
+tools, model calls, traces, analytics, evals, and future debugging
+products all compose through the same framework-owned contracts.
+
+The target is not "an LLM client crate." The target is the Pocopine
+equivalent of a batteries-included AI app stack:
+
+* typed model/provider abstraction;
+* prompts, tools, agents, threads, and flows;
+* structured output and schema validation;
+* RAG hooks without binding the framework to one vector database;
+* server-function integration so apps call AI flows like normal
+  Pocopine app functions;
+* local traces, evals, and replayable run records;
+* server-only provider credentials.
+
+Google Genkit is the primary product and code/API reference: unified
+providers, flows, tools, prompts, structured output, RAG, a local
+developer UI, and production monitoring. Pocopine should learn from
+Genkit's code organization and authoring ergonomics where they fit, but
+not inherit a separate telemetry platform. Rig is the Rust
+provider/reference crate to evaluate behind Pocopine-owned traits.
+
+## Motivation
+
+Pocopine already has the hard parts of a full-stack Rust app framework:
+typed components, server functions, auth policy, jobs, storage,
+observability, deploy adapters, sync, and VS Code integration. AI app
+features should use those surfaces instead of becoming detached ad hoc
+Node scripts or one-off provider calls inside server handlers.
+
+A Pocopine app should be able to configure AI once:
+
+```rust
+use pocopine_agenkit::prelude::*;
+
+pub fn agenkit() -> Agenkit {
+    Agenkit::builder()
+        .default_model(ModelRef::new("local/default"))
+        .provider(local_provider())
+        .tool(search_docs)
+        .flow(summarize_doc)
+        .build()
+}
+```
+
+and then call an AI flow with the same operational shape as other
+Pocopine server work: auth, tracing, typed payloads, local dev
+diagnostics, deployability, and replayable errors.
+
+The second motivation is product focus. A general coding-agent harness
+is not the first Pocopine product. Pocopine can already use reusable
+skill packs, and many agent shells can consume skill-like context. The
+first Agenkit work should create the AI runtime contracts that later
+products can depend on, especially a possible **Pocopine Debugger** that
+uses Pocopine traces, server-function metadata, build output, and RFC
+context to help diagnose application failures.
+
+## Decisions
+
+### D1 - Working Name
+
+The product name is **Pocopine Agenkit** (spelling resolved), matching the
+branch and the crate names `pocopine-agenkit-core` / `pocopine-agenkit`. The
+earlier draft alternatives (`Agentkit`, `Genkit for Pocopine`) are dropped.
+
+### D2 - Two-Crate Scope
+
+Use Pocopine infrastructure crate names, not `pine-*`, because the
+feature is server/tooling infrastructure rather than a browser-runtime
+component library.
+
+The first implementation has exactly two crates. Keeping the first
+slice narrow avoids committing to an agent harness, product UI, proc
+macros, or provider crate names before the core contracts are proven.
+
+| Layer | Crate | Reason |
+|-------|-------|--------|
+| 0 | `pocopine-agenkit-core` | Stable shared contracts: content parts, messages, model refs, schema descriptors, tool descriptors, flow descriptors, run ids, trace events, usage/cost metadata, errors, and client-safe payload structs. This crate must stay dependency-light and wasm-friendly so generated clients, tests, and tooling can use the same types. |
+| 1 | `pocopine-agenkit` | The unified runtime facade app authors depend on. It owns `Agenkit`, `Ai`, provider traits, provider registry, flow registry, tool execution, trace recording, server-function helpers, redaction policy, and public re-exports from core. |
+
+Dependency direction:
+
+```text
+pocopine-agenkit-core
+  <- pocopine-agenkit
+```
+
+The facade crate re-exports the stable authoring surface:
+
+```rust
+use pocopine_agenkit::prelude::*;
+```
+
+Normal apps should depend on `pocopine-agenkit`, not directly on
+`pocopine-agenkit-core`. Internal tests, generated clients, and future
+tooling can import core when they need stable payload types without the
+runtime.
+
+Deferred crates are explicitly out of this RFC: proc macros, provider
+adapter crates, a code-agent runtime, a debugger product crate, and a
+commercial UI. They should depend on the two crates above once the
+runtime proves the trait shape.
+
+### D3 - Unified API Surface
+
+The user-facing API must have one canonical entry point: `Agenkit`.
+Apps configure it once and then call `ai()` or registered flow handles
+from server functions, jobs, evals, and future debugger products.
+
+Generation:
+
+```rust
+let answer = agenkit
+    .ai()
+    .model(ModelRef::new("local/default"))
+    .system("Answer using the project's docs.")
+    .prompt("How do uploads work?")
+    .generate_text()
+    .await?;
+```
+
+Structured output:
+
+```rust
+let summary: Summary = agenkit
+    .ai()
+    .prompt(input.prompt())
+    .schema::<Summary>()
+    .generate_structured()
+    .await?;
+```
+
+Manual tool registration:
+
+```rust
+async fn search_docs(input: SearchDocs, ctx: AiToolContext) -> AgenkitResult<Vec<SearchHit>> {
+    ctx.state::<DocIndex>("doc_index")?.search(input.query).await
+}
+```
+
+Manual flow registration:
+
+```rust
+async fn summarize_doc(input: SummarizeDoc, ctx: AiFlowContext) -> AgenkitResult<Summary> {
+    ctx.ai()
+        .prompt(input.prompt())
+        .schema::<Summary>()
+        .generate_structured()
+        .await
+}
+```
+
+The same underlying flow descriptor should power all entry points:
+
+* app server calls;
+* server jobs;
+* eval dataset runs;
+* debugger-assisted diagnosis;
+* trace replay.
+
+### D4 - App Authoring Concepts
+
+Agenkit exposes six authoring concepts through that unified facade:
+
+| Concept | Pocopine surface | Purpose |
+|---------|------------------|---------|
+| Model | `ModelRef`, provider config, runtime registry | Select the provider/model without wiring app code to vendor clients. |
+| Prompt | typed prompt templates plus runtime variables | Keep prompt text inspectable, reusable, and testable. |
+| Tool | manual `Tool` registration | Let models call app-owned functions with typed args and auth policy. |
+| Agent | typed `AiAgent` registration | A runnable AI decision unit with instructions, tools, input/output schemas, limits, and optional memory/session policy. |
+| Thread | `AgentThread` and thread stores | Optional conversation/session state for an agent across turns. |
+| Flow | manual `Flow` registration | The app-callable unit for generation, RAG, tools, and multi-step workflows. |
+
+Flows are the bridge to Pocopine apps. A flow can be exposed as a
+server function, but not every flow must be public. Private flows can
+back jobs, tools, evals, and internal automation.
+
+`AiAgent` is not the same thing as a flow. A flow is the typed
+orchestration and app boundary: auth policy, server-function exposure,
+stream contract, trace lifetime, and final input/output shape. An
+`AiAgent` is a typed runnable unit inside a flow or future product: it
+can choose tool calls, produce structured output, participate in
+parallel branches, and later carry memory/session behavior if the
+runtime needs it.
+
+`AgentThread` is not the same thing as an agent or a flow. A thread is
+optional conversation/session state: message history, safe attachments,
+checkpoints, resumable ids, and retention policy. Stateless one-shot
+agents do not need a thread. Chat-like products, debugger sessions, and
+longer investigations can attach a thread to an agent run.
+
+The separation is:
+
+| Layer | Owns | Strength |
+|-------|------|----------|
+| `Flow` | App operation, auth, public schema, streaming contract, trace lifetime, orchestration. | Reliable server-function boundary and production behavior. |
+| `AiAgent` | AI behavior: instructions, model alias, tools, structured output, guardrails, limits. | Reusable typed AI role that can run sequentially, in parallel, or inside products. |
+| `AgentThread` | Conversation/session state across turns. | Continuity for debugger/chat sessions without forcing every flow to become stateful. |
+
+Proc macros such as `#[ai_tool]` and `#[ai_flow]` are future authoring
+sugar. Manual registration must work first.
+
+### D5 - Tool And Retrieval Traits
+
+Tools and retrieval need clear separate contracts.
+
+A **tool** is an action an agent or flow may invoke with typed input and
+typed output. Tools can be read-only or side-effecting, so they need an
+explicit policy boundary.
+
+A **retriever** is a read-oriented context source used for RAG,
+debugging evidence, docs lookup, trace lookup, search, or ranking.
+Retrievers can be exposed as tools when an agent should decide when to
+search, but retrieval is not inherently a tool. Keeping retrieval
+separate lets flows perform deterministic context loading, eval replay,
+and debugger evidence collection without routing every lookup through a
+model tool call.
+
+An **embedder** is an optional provider-backed or local capability that
+turns text or multimodal content into vectors. Agenkit should support
+embedding-powered retrieval without binding the framework to one vector
+database.
+
+Typed tool shape:
+
+```rust
+pub trait AiTool: Send + Sync + 'static {
+    const ID: &'static str;
+
+    type Input: Send + 'static;
+    type Output: Send + 'static;
+
+    fn descriptor() -> ToolDescriptor;
+
+    async fn call(
+        &self,
+        input: Self::Input,
+        ctx: AiToolContext<'_>,
+    ) -> AgenkitResult<Self::Output>;
+}
+```
+
+Typed retriever shape:
+
+```rust
+pub trait AiRetriever: Send + Sync + 'static {
+    const ID: &'static str;
+
+    type Query: Send + 'static;
+    type Hit: Send + 'static;
+
+    fn descriptor() -> RetrieverDescriptor;
+
+    async fn retrieve(
+        &self,
+        query: Self::Query,
+        ctx: RetrievalContext<'_>,
+    ) -> AgenkitResult<RetrievalSet<Self::Hit>>;
+}
+```
+
+Typed embedder shape:
+
+```rust
+pub trait AiEmbedder: Send + Sync + 'static {
+    const ID: &'static str;
+
+    type Input: Send + 'static;
+
+    fn descriptor() -> EmbedderDescriptor;
+
+    async fn embed(
+        &self,
+        input: Self::Input,
+        ctx: EmbedContext<'_>,
+    ) -> AgenkitResult<EmbeddingBatch>;
+}
+```
+
+These traits are author-facing typed APIs. The runtime can erase them
+into object-safe registry entries such as `DynTool`, `DynRetriever`,
+and `DynEmbedder` for storage, JSON schema validation, tracing, and
+agent tool-call dispatch.
+
+Example registration:
+
+```rust
+pub fn agenkit() -> Agenkit {
+    Agenkit::builder()
+        .tool(SearchDocs)
+        .retriever(ProjectDocs)
+        .embedder(LocalEmbedder)
+        .flow(answer_question)
+        .build()
+}
+```
+
+Example deterministic retrieval inside a flow:
+
+```rust
+let docs = ctx
+    .retrieve::<ProjectDocs>()
+    .query(ProjectDocsQuery::new(&input.question))
+    .top_k(5)
+    .run()
+    .await?;
+```
+
+Example agent-controlled retrieval:
+
+```rust
+impl AiAgent for DocsFirst {
+    const ID: &'static str = "docs_first";
+
+    type Input = QuestionInput;
+    type Output = CandidateAnswer;
+
+    fn configure(agent: AiAgentBuilder<Self>) -> AiAgentBuilder<Self> {
+        agent
+            .system("Search project docs before answering.")
+            .tools([ProjectDocs::as_tool()])
+    }
+}
+```
+
+Rules:
+
+* `pocopine-agenkit-core` defines shared descriptors and payloads:
+  `ToolDescriptor`, `ToolCall`, `ToolResult`,
+  `ToolSideEffectPolicy`, `RetrieverDescriptor`, `RetrievalQuery`,
+  `RetrievalHit`, `RetrievalSet`, `SourceRef`, `Citation`,
+  `EmbedderDescriptor`, `Embedding`, and `EmbeddingBatch`.
+* `pocopine-agenkit` owns typed traits and runtime registries:
+  `AiTool`, `AiRetriever`, `AiEmbedder`, `ToolRegistry`,
+  `RetrieverRegistry`, and `EmbedderRegistry`.
+* Tool input is validated before execution and tool output is validated
+  before it is sent back to a model or client boundary.
+* Tools run under the current flow principal, explicit tool allowlist,
+  budget, timeout, and side-effect policy.
+* Tool descriptors declare side effects and framework-mediated state or
+  resource dependencies. Tool implementations should use
+  `AiToolContext` for app resources so those reads/writes are visible
+  to traces.
+* Side-effecting tools must be marked explicitly. Read-only is the safe
+  default.
+* Retrieval is read-only by default and must respect auth, tenancy, and
+  per-flow source allowlists.
+* Retriever descriptors declare source kinds, auth requirements, and
+  framework-mediated resource dependencies.
+* Retrieval hits carry citations/source refs and privacy labels.
+  Traces should record source ids, scores, and redacted metadata, not
+  raw document bodies by default.
+* Retrievers can be wrapped as tools through an adapter, but flows can
+  call retrievers directly when retrieval should be deterministic.
+* Embedders expose model/provider aliases and dimensions, not provider
+  credentials.
+
+### D6 - Flow Context Best Practices And Diagnostics
+
+Flows should be written as if they were pure at the app boundary and
+declared-effectful inside the runtime. This is a best-practice and
+diagnostics model, not a hard safety guarantee. Rust code can still
+call a global database pool, read a file, or use a network client
+directly. What Agenkit can do is make the safe path obvious, traceable,
+and documented, then warn when framework-mediated context access was
+not declared.
+
+The rule:
+
+```text
+flow output = input + declared context + declared AI effects
+```
+
+Declared context includes registered tools, retrievers, embedders,
+agent threads, app state handles, environment aliases, and model
+aliases. Anything outside that set is an undeclared dependency and
+should not be invisible to traces when it goes through Agenkit APIs.
+
+Flow descriptors can carry a context manifest:
+
+```rust
+Flow::new("answer_question", answer_question)
+    .input::<QuestionInput>()
+    .output::<Answer>()
+    .uses_retriever::<ProjectDocs>()
+    .uses_agent::<DocsFirst>()
+    .uses_tool::<SearchDocs>()
+```
+
+This manifest is documentation and trace metadata, not an enforcement
+policy. Agenkit can compare framework-mediated context access against
+the manifest and emit advisory diagnostics when something is missing,
+but it should not expose a `context_policy(...)` API or pretend to
+make arbitrary Rust code pure.
+
+Correct deterministic retrieval:
+
+```rust
+let docs = ctx
+    .retrieve::<ProjectDocs>()
+    .query(ProjectDocsQuery::new(&input.question))
+    .top_k(5)
+    .run()
+    .await?;
+```
+
+Avoid hidden context loads:
+
+```rust
+// Bad for traceability: hidden dependency on DocIndex that does not
+// appear in the flow descriptor unless it was explicitly declared.
+let docs = ctx.state::<DocIndex>()?.search(&input.question).await?;
+```
+
+If a flow really needs app state, it should be declared:
+
+```rust
+Flow::new("debug_failure", debug_failure)
+    .input::<DebugInput>()
+    .output::<DebugReport>()
+    .uses_state::<TraceStore>("trace_store")
+    .uses_retriever::<BuildLogs>()
+    .uses_agent::<DebuggerAgent>()
+```
+
+Rules:
+
+* `pocopine-agenkit-core` defines `ContextManifest`,
+  `DeclaredResource`, `ResourceKind`, and `ContextGapDiagnostic`.
+* `pocopine-agenkit` records framework-mediated context access: state,
+  retrievers, tools, agents, threads, embedders, providers, and model
+  aliases.
+* Runtime diagnostics are advisory. They should be emitted as typed
+  diagnostics and `pocopine.trace` events, not only logs.
+* Generated clients and public flow schemas should include the public
+  input/output schema, but not secret-bearing resource config.
+* Flow traces should record the context manifest hash or version, so a
+  replay can detect that the flow's resource set changed.
+* Direct app code can still bypass the framework by using globals or
+  direct DB clients. The docs, examples, and skills should state this
+  plainly: if a flow loads hidden context outside Agenkit APIs, traces
+  and replay become less reliable.
+* Future proc macros and lints can improve detection, but the first
+  implementation should not overpromise enforcement.
+* Pocopine Debugger should flag flows with missing manifests or context
+  gap diagnostics as lower-confidence because replay and root-cause
+  analysis are weaker.
+
+### D7 - Multi-Step, AiAgent, And Parallel Flow Orchestration
+
+Multi-step generation is traced flow orchestration, not a separate
+agent harness. A public flow still has one typed input and one typed
+output, but internally it can run retrieval, model calls, tool calls,
+validation, ranking, and reducer steps under one trace tree.
+
+Model calls and tool calls are traced automatically. Custom app work is
+included in the same trace by wrapping it in an explicit step:
+
+```rust
+async fn answer_question(input: QuestionInput, ctx: AiFlowContext) -> AgenkitResult<Answer> {
+    let docs = ctx
+        .retrieve::<ProjectDocs>()
+        .query(ProjectDocsQuery::new(&input.question))
+        .top_k(5)
+        .run()
+        .await?;
+
+    let draft: DraftAnswer = ctx
+        .ai()
+        .system("Answer using the retrieved project docs.")
+        .docs(docs)
+        .prompt(&input.question)
+        .schema::<DraftAnswer>()
+        .generate_structured()
+        .await?;
+
+    let answer: Answer = ctx
+        .ai()
+        .system("Verify the draft and return the final answer.")
+        .input(draft)
+        .schema::<Answer>()
+        .generate_structured()
+        .await?;
+
+    Ok(answer)
+}
+```
+
+Parallel agents use the same flow runtime. An `AiAgent` in v1 is not a
+separate process or external harness. It is a typed runnable AI unit
+containing a stable id, model alias, system prompt, optional tool
+allowlist, input/output schemas, limits, redaction/capture policy, and
+future memory/session policy.
+
+This matches the common shape in other frameworks while staying
+Pocopine-native:
+
+* LangChain describes an agent as a model calling tools in a loop, with
+  the harness providing model, prompt, tools, and middleware.
+* The OpenAI Agents SDK describes an agent as a model configured with
+  instructions, tools, handoffs, guardrails, structured outputs, and
+  runtime behavior.
+* LlamaIndex describes an agent as a system using an LLM, memory, and
+  tools to handle user input.
+* Semantic Kernel separates `Agent`, `AgentThread`, and orchestration
+  patterns such as concurrent, sequential, handoff, and group chat.
+
+The Rust-first API should be type-driven:
+
+```rust
+struct FastResearcher;
+
+impl AiAgent for FastResearcher {
+    const ID: &'static str = "fast_researcher";
+
+    type Input = QuestionInput;
+    type Output = CandidateAnswer;
+
+    fn configure(agent: AiAgentBuilder<Self>) -> AiAgentBuilder<Self> {
+        agent
+            .model(ModelRef::new("local/fast"))
+            .system("Find likely answers quickly, then cite evidence.")
+            .tools([search_docs])
+            .max_tokens(700)
+    }
+}
+```
+
+Prefer `ctx.agent::<FastResearcher>()` over string-based lookup. The
+typed form lets the compiler carry the agent id, input schema, output
+schema, and policy. A dynamic lookup such as
+`ctx.agent_by_id("fast_researcher")` can exist later for CLI, config,
+debugger UI, or eval runners, but it should not be the main app
+authoring API.
+
+Agent threads are explicit:
+
+```rust
+let answer = ctx
+    .agent::<DebuggerAgent>()
+    .thread(existing_thread)
+    .input(next_question)
+    .run()
+    .await?;
+```
+
+A threaded run appends safe messages/checkpoints to the thread. A
+threadless run uses only the supplied input, flow context, tools, and
+provider state. This keeps one-shot server flows cheap and predictable
+while giving debugger/chat products durable context.
+
+Fan-out/fan-in flows run several agents concurrently and then combine
+their outputs through a reducer:
+
+```rust
+async fn answer_with_review(
+    input: QuestionInput,
+    ctx: AiFlowContext,
+) -> AgenkitResult<FinalAnswer> {
+    let candidates = ctx
+        .parallel("candidate_answers")
+        .branch(ctx.agent::<FastResearcher>().input(input.clone()))
+        .branch(ctx.agent::<StrictReviewer>().input(input.clone()))
+        .branch(ctx.agent::<DocsFirst>().input(input.clone()))
+        .run()
+        .await?;
+
+    let checked: FinalAnswer = ctx
+        .reduce("judge_and_merge", candidates)
+        .system("Keep only claims supported by evidence.")
+        .schema::<FinalAnswer>()
+        .await?;
+
+    Ok(checked)
+}
+```
+
+Trace shape:
+
+```text
+flow: answer_with_review
+  parallel group: candidate_answers
+    step: fast_researcher
+    step: strict_reviewer
+    step: docs_first
+  step: judge_and_merge
+  step: validate_final_answer
+```
+
+A debugger-style flow can combine all three layers:
+
+```rust
+async fn debug_failure(input: DebugInput, ctx: AiFlowContext) -> AgenkitResult<DebugReport> {
+    let thread = ctx
+        .thread::<DebuggerAgent>()
+        .resume_or_create(input.session_id)
+        .await?;
+
+    let trace = ctx
+        .retrieve::<TraceStore>()
+        .query(TraceQuery::new(input.trace_id))
+        .run()
+        .await?;
+
+    let findings = ctx
+        .parallel("diagnosis_candidates")
+        .join(ParallelJoin::AllSettled)
+        .min_success(2)
+        .branch(ctx.agent::<TraceReviewer>().input(trace.clone()))
+        .branch(ctx.agent::<LogReviewer>().input(input.logs.clone()))
+        .branch(ctx.agent::<CodeReviewer>().input(input.files.clone()))
+        .run()
+        .await?;
+
+    ctx.agent::<DebuggerAgent>()
+        .thread(thread)
+        .input(findings)
+        .run()
+        .await
+}
+```
+
+Rules:
+
+* `pocopine-agenkit-core` defines shared orchestration types:
+  `StepId`, `StepKind`, `StepStatus`, `ParallelGroupId`,
+  `AiAgentDescriptor`, `AgentThreadId`, `AgentThreadDescriptor`,
+  `ThreadMessage`, `ThreadCheckpoint`, `ReducerKind`, and the trace
+  payloads that describe parent/child step relationships.
+* `pocopine-agenkit` owns the `AiAgent` trait, `AiAgentBuilder`,
+  `AgentThreadStore`, and execution APIs such as `ctx.step(...)`,
+  `ctx.parallel(...)`, `ctx.agent::<T>()`, `ctx.thread::<T>()`, and
+  `ctx.reduce(...)`.
+* Typed agent calls erase into branch plans for parallel execution, so
+  different agent types can run in the same group while preserving each
+  agent's descriptor, input schema, output schema, and policy.
+* Thread state is opt-in. Flows can attach an existing thread, create a
+  new thread, or run agents without any thread.
+* Thread storage must be behind a runtime trait so v1 can start with an
+  in-memory or local store while future debugger products can use
+  durable storage.
+* Parallel groups must be bounded by explicit max concurrency, timeout,
+  token, and cost budgets. A cancelled flow cancels unfinished child
+  steps.
+* Branch failures are policy-driven: fail fast, collect partial results,
+  or require a minimum number of successful candidates.
+* Reducers can be model judges, deterministic Rust functions, scoring
+  rubrics, voting strategies, schema validators, or product-specific
+  checks.
+* Reducers must produce typed outputs and record why an answer was
+  accepted, rejected, or merged. For Pocopine Debugger, a reducer should
+  prefer concrete evidence such as traces, logs, tests, file paths, and
+  generated client contracts over unsupported model claims.
+* Each branch still uses model aliases, provider allowlists, tool
+  allowlists, auth policy, and redaction settings from the parent flow.
+  Parallel execution must not create a bypass around the server-only
+  secret boundary.
+
+The first implementation should stay lightweight. Durable DAGs,
+long-running resumability, distributed queues, and retry schedulers can
+layer on `pocopine-jobs` later if a real product needs them.
+
+### D8 - User-Facing Streams And Parallel Join Policies
+
+Streaming to users is a separate public contract from internal traces.
+The runtime may record detailed trace metadata for debugging and evals,
+but a browser client should only receive typed, redacted, allowlisted
+events.
+
+Do not stream raw model thoughts, hidden chain-of-thought, provider
+reasoning tokens, raw prompts, raw tool arguments, or raw provider
+payloads to clients. If a product wants to show that the system is
+"thinking," it should stream explicit progress events and optional
+model-generated reasoning summaries that were requested for display,
+redacted, and marked as user-visible output.
+
+User-facing stream events should be shaped as `FlowStreamEvent` values:
+
+| Event | Purpose |
+|-------|---------|
+| `flow_started` / `flow_completed` / `flow_failed` | Public flow lifecycle. |
+| `step_started` / `step_progress` / `step_completed` / `step_failed` | Redacted step status for retrieval, generation, validation, reducers, and custom app work. |
+| `output_delta` / `output_completed` | User-visible answer text or structured output fragments. |
+| `tool_started` / `tool_completed` / `tool_failed` | Redacted tool status; no raw args by default. |
+| `parallel_started` / `branch_started` / `branch_completed` / `branch_failed` / `parallel_completed` | Public progress for fan-out/fan-in flows. |
+| `reducer_started` / `reducer_decision` / `reducer_completed` | Redacted checker/merge progress and final decision metadata. |
+| `usage_update` | Optional aggregate usage/cost metadata when enabled. |
+| `error` | Public error kind and trace id, not provider internals. |
+
+Public streaming modes should be explicit:
+
+| Mode | Client sees |
+|------|-------------|
+| `FinalOnly` | No progress stream; only the final typed result. |
+| `OutputDeltas` | User-visible output deltas plus final typed result. |
+| `Progress` | Redacted step/tool/parallel/reducer status plus final typed result. |
+| `DebugSafe` | Progress plus safe trace refs for local debugging; never raw secrets or hidden reasoning. |
+
+Parallel groups need Promise-like join policies, but the default should
+match the product goal:
+
+| Policy | Behavior | Good for |
+|--------|----------|----------|
+| `All` | Require every branch to succeed; fail or cancel on policy. | Required independent checks. |
+| `AllSettled` | Wait for every branch and return successes plus failures. | Agent review where the reducer should see disagreements and failures. |
+| `FirstSuccess` | Return the first successful branch and cancel the rest. | Latency races across equivalent providers/models. |
+| `Quorum(n)` | Return when at least `n` branches succeed, optionally cancelling the rest. | Voting or majority-style checks. |
+
+For parallel agents that combine answers, prefer `AllSettled` with a
+minimum-success requirement and a reducer. `FirstSuccess` is useful for
+latency, but it is the wrong default for quality checking because it
+throws away disagreement. `All` is useful when every branch is required,
+but it is too brittle for exploratory multi-agent review unless every
+agent is mandatory.
+
+Example:
+
+```rust
+let candidates = ctx
+    .parallel("candidate_answers")
+    .join(ParallelJoin::AllSettled)
+    .min_success(2)
+    .max_concurrency(3)
+    .branch(ctx.agent::<FastResearcher>().input(input.clone()))
+    .branch(ctx.agent::<StrictReviewer>().input(input.clone()))
+    .branch(ctx.agent::<DocsFirst>().input(input.clone()))
+    .run()
+    .await?;
+```
+
+### D9 - Server-Function Integration
+
+AI calls should feel like Firebase/Genkit-style callable app functions,
+but through Pocopine's existing server-function and auth contracts.
+
+Rules:
+
+* Public flows expose typed input/output through generated client
+  helpers.
+* Auth policy is declared at the flow/server-function boundary, not in
+  arbitrary prompt code.
+* Provider keys never enter browser bundles.
+* Flow invocations produce trace ids that can be correlated with
+  `pocopine-observe` events.
+* Streaming is an explicit mode, not a hidden return-type special case.
+* Public streams use `FlowStreamEvent` and stream Pocopine events, not
+  raw provider streams.
+* Public flow clients see a single typed flow contract even when the
+  server runs multiple internal steps or parallel branches.
+
+### D10 - Secret Boundary And Client Security
+
+Provider credentials are server-only. A Pocopine browser client must
+never receive an AI provider API key, provider bearer token, OAuth
+refresh token, service-account document, signing secret, or provider
+request header. The browser calls typed Pocopine flow endpoints; the
+server validates auth, resolves configured model/provider aliases, and
+performs provider calls from host-side credentials.
+
+Rules:
+
+* `pocopine-agenkit-core` may define `ProviderRef`, `ModelRef`, schema
+  metadata, tool descriptors, and client-safe payload shapes, but it
+  must not define a client-serializable secret-bearing provider config.
+* `pocopine-agenkit` loads provider credentials only from host-side
+  sources: environment variables, deploy/runtime secret stores, dev
+  `.env` loaded by the server process, or explicit host runtime config.
+* Generated client helpers expose public flow names, typed input/output
+  schemas, trace ids, and safe model aliases only. They must not expose
+  provider base headers, raw provider config, or credential presence.
+* Client-supplied model/provider choices are aliases, not raw provider
+  ids. The server allowlists aliases per app or per flow before use.
+* Public flows run under Pocopine auth policy. Tools execute under the
+  current app principal and only from the flow's explicit tool allowlist.
+* Retrieval executes under the current app principal and only from the
+  flow's explicit source allowlist.
+* Parallel branches inherit the parent flow's auth, model alias
+  allowlist, tool allowlist, budget, and redaction policy.
+* Model output is untrusted. Structured output is schema-validated, tool
+  calls are validated before execution, and provider/tool errors are
+  mapped to Pocopine errors before they cross the client boundary.
+* Streaming flows stream Pocopine events, not raw provider streams.
+  Provider chunks are translated server-side so provider headers,
+  request ids, and vendor-specific debug payloads cannot leak.
+* Hidden reasoning, provider reasoning tokens, and raw chain-of-thought
+  are never part of client stream events. User-visible reasoning
+  summaries must be explicit outputs with their own capture/redaction
+  policy.
+* Agent thread state follows the same privacy model as traces. Thread
+  messages, attachments, checkpoints, and summaries must be
+  privacy-labeled; raw prompts, tool args, provider payloads, and
+  secrets are not stored unless explicitly enabled by capture policy.
+* Thread ids exposed to clients are opaque Pocopine ids, not provider
+  thread ids. Provider-backed thread ids, if any, stay in host runtime
+  state.
+* Traces and logs redact secrets by default: API keys, Authorization
+  headers, cookies, service-account material, `.env` values, provider
+  request headers, and configured redaction fields. Prompt and output
+  capture must be configurable separately from operational metadata.
+
+This makes the security boundary visible in the type system: client
+types can describe *what* flow to call and *what* data shape to send,
+but only host runtime types can describe *how* to authenticate with an
+AI provider.
+
+### D11 - Product Focus And Deferred Agent Surfaces
+
+This RFC does not define a general coding-agent harness. It defines the
+AI app runtime that future focused products can use.
+
+The strongest first product candidate is **Pocopine Debugger**: an
+agent-powered debugging assistant that consumes Pocopine traces,
+server-function metadata, generated clients, build/test output,
+observability events, and project RFCs. Its job would be to diagnose
+Pocopine-specific failures, not to compete with every generic coding
+agent shell.
+
+That product can be designed after `pocopine-agenkit-core` and
+`pocopine-agenkit` prove:
+
+* flows can be registered and invoked safely;
+* traces are privacy-labeled and redacted;
+* provider credentials remain server-only;
+* tools run under explicit app policy;
+* run records are structured enough for replay and diagnosis.
+
+Future products may include a debugger UI, VS Code integration, skill
+loading, eval runners, or a stdio process. None of those should add new
+AI contracts until the core runtime cannot express the need.
+
+### D12 - Unified Pocopine Observability Platform
+
+Agenkit uses Pocopine observability as the platform layer. It must not
+grow a parallel Genkit-style telemetry runtime, separate trace exporter,
+or AI-only dashboard contract.
+
+The split stays the same as the rest of Pocopine:
+
+| Crate | Agenkit responsibility |
+|-------|------------------------|
+| `pocopine-observe` | Stable AI event schema, context, privacy labels, redaction metadata, trace ids, session ids, and fixed tracing targets. |
+| `pocopine-logging` | Browser/server subscribers, local dev logs, JSON logs, and OTLP export through existing logging setup. |
+| `pocopine-analytics` | Redacted telemetry fan-out for production dashboards, usage/cost summaries, eval summaries, and product analytics. |
+
+Runtime code emits `tracing` spans/events or typed `ObservedEvent`s.
+It does not install global subscribers, own vendor exporters, or bypass
+the existing analytics sinks. App entrypoints and deployment adapters
+keep deciding where events go.
+
+AI-specific event families should use the existing targets and privacy
+model:
+
+| Event family | Target/class | Notes |
+|--------------|--------------|-------|
+| Flow lifecycle | `pocopine.trace` | `ai_flow_started`, `ai_flow_completed`, `ai_flow_failed`; includes flow id, trace id, model alias, duration, and privacy-labeled metadata. |
+| Flow context diagnostics | `pocopine.trace` | `ai_context_gap`, `ai_context_manifest_changed`; records flow id, resource kind, resource id, and manifest version/hash. |
+| Step orchestration | `pocopine.trace` | `ai_step_started`, `ai_step_completed`, `ai_step_failed`; records step id, parent step id, step kind, duration, and redacted input/output refs. |
+| Parallel and reducer steps | `pocopine.trace` | `ai_parallel_started`, `ai_parallel_completed`, `ai_reducer_started`, `ai_reducer_completed`; records branch count, join policy, success policy, reducer kind, and redacted decision metadata. |
+| Model calls | `pocopine.trace` | `ai_model_request`, `ai_model_response`, `ai_model_failed`; records provider alias, model alias, token/cost metadata when available, and redacted error kind. |
+| Tool calls | `pocopine.trace` | `ai_tool_started`, `ai_tool_completed`, `ai_tool_failed`; records tool id, duration, auth principal context, and validated argument schema id, not raw args by default. |
+| Retrieval calls | `pocopine.trace` | `ai_retrieval_started`, `ai_retrieval_completed`, `ai_retrieval_failed`; records retriever id, source ids, hit count, scores when available, and redacted metadata. |
+| Embedding calls | `pocopine.trace` | `ai_embedding_started`, `ai_embedding_completed`, `ai_embedding_failed`; records embedder alias, input count, dimensions, duration, and redacted error kind. |
+| Agent thread lifecycle | `pocopine.trace` | `ai_thread_created`, `ai_thread_resumed`, `ai_thread_checkpointed`, `ai_thread_deleted`; records opaque thread id, agent id, retention class, and redacted checkpoint metadata. |
+| Public stream events | client stream | Redacted `FlowStreamEvent` values derived from the runtime, not raw trace events or raw provider streams. |
+| Evals | `pocopine.analytics` | Dataset/case summaries, pass/fail scores, cost/token aggregates, and stable eval ids. |
+| Operational failures | `pocopine.log` | Configuration, provider, streaming, validation, and secret-boundary failures with redacted fields. |
+| Usage/cost summaries | `pocopine.metric` or `pocopine.analytics` | Aggregated token counts, latency, model mix, and queue depth. |
+
+GenAI semantic conventions can inform field names where they map cleanly,
+but Pocopine's `ObservedEvent`, privacy labels, redaction rules, and
+targets are authoritative. Prompt and output capture must be explicitly
+configured and privacy-labeled; operational traces should remain useful
+without storing raw prompts, raw outputs, tool arguments, provider
+headers, request bodies, or secrets.
+
+The trace model must capture:
+
+* model/provider aliases, not raw provider credentials;
+* context manifest version/hash when available;
+* token/cost metadata when available;
+* tool calls and validated tool results;
+* retrieval source refs, hit counts, score metadata, and citations;
+* embedding dimensions and batch metadata;
+* flow step timing;
+* parallel group timing, join policy, branch status, and reducer
+  decisions;
+* optional agent thread ids and checkpoint refs;
+* structured-output validation errors;
+* auth/user context at the boundary, without logging secrets;
+* replay handles for local evals and future debugger inspection.
+
+Evals are deferred past the first core slice, but the run record should
+not block them. A future dataset runner should be able to run a flow
+over a dataset and emit per-case results later without changing the
+flow API or adding an eval-only telemetry path.
+
+### D13 - Recommended Improvements Before Implementation
+
+These improvements should be designed before writing the first runtime
+APIs. They keep the implementation small while avoiding obvious
+dead-ends.
+
+* Budget model: define per-flow and per-step limits for timeout,
+  concurrency, tokens, retries, and estimated cost. Parallel agents
+  become expensive quickly without this.
+* Cancellation model: define how cancellation propagates through nested
+  steps, provider streams, tool calls, and parallel branches.
+* Stream visibility model: define which event classes are client-safe,
+  which are trace-only, and which require explicit prompt/output capture
+  consent.
+* Parallel join model: define `All`, `AllSettled`, `FirstSuccess`, and
+  `Quorum(n)` semantics, including cancellation and failure handling.
+* Retrieval model: define score semantics, source refs, citations,
+  source allowlists, auth filtering, and deterministic replay of
+  retrieval outputs.
+* Flow context guidance: document the best-practice rule that AI flows
+  should load context through declared Agenkit APIs, and clearly explain
+  the debugging/replay cost of hidden DB/file/network reads.
+* Declared-context model: define how flow descriptors declare tools,
+  retrievers, embedders, agents, threads, state handles, provider
+  aliases, and model aliases.
+* Static lint model: future proc macros or lints should flag direct
+  global/database access inside AI flow bodies when possible.
+* Evidence model: structured outputs should be able to carry citations,
+  source refs, trace refs, test refs, or file refs so reducers can check
+  claims instead of merely ranking prose.
+* Replay model: traces should store enough safe metadata and output refs
+  to reproduce a flow with a mock provider, without storing provider
+  credentials or raw sensitive prompts by default.
+* Thread storage model: define in-memory/local/durable thread stores,
+  retention policy, deletion behavior, and how provider-backed thread
+  ids are hidden behind opaque Pocopine ids.
+* Capture policy: prompt/output capture should be configured separately
+  from operational metadata at flow, step, and branch level.
+* Deterministic verification hooks: reducers should be able to call Rust
+  validators, schema checks, tests, or Pocopine debugger checks before
+  accepting a final answer.
+* Local provider first: use a deterministic local/mock provider in tests
+  and examples before committing to hosted provider adapters.
+* Typed errors: distinguish provider failure, schema failure, tool
+  policy failure, budget exhaustion, cancellation, and reducer
+  disagreement in `AgenkitError`.
+
+### D14 - Why One Facade Instead Of Many App APIs
+
+The implementation has two crates, but the app authoring API must stay
+unified. The facade exists for five reasons:
+
+* Provider churn should not leak into app code. Apps choose
+  `ModelRef`s and provider config, not provider crate internals.
+* Debugger products, evals, server functions, and jobs need the same
+  flow descriptors. Separate APIs would split tracing and replay.
+* Observability needs one platform contract. Separate AI telemetry would
+  duplicate `pocopine-observe`, weaken redaction guarantees, and make
+  future debugger traces drift from production traces.
+* Future proc macros need stable core descriptors to generate
+  predictable runtime registration.
+* Future UI or editor work should layer on the open runtime contracts,
+  not fork the core app API.
+
+### D15 - Resolved Implementation Decisions
+
+These decisions were frozen in Phase 0 after grounding the design in the
+current framework (cited crates are the integration surfaces Agenkit reuses).
+
+* **DC-1 - Core stays observe-neutral.** `pocopine-agenkit-core` defines
+  neutral `TraceEvent`/`TraceSpan` payloads plus stable `&'static str`
+  event-name constants and must **not** depend on `pocopine-observe`. The
+  facade owns the mapping `TraceEvent -> pocopine_observe::ObservedEvent`
+  followed by `emit_tracing`. Rationale: `pocopine-observe` is consumed only
+  by facade-tier crates (`pocopine-logging`, `pocopine-analytics`) today;
+  keeping core free of it preserves "dependency-light + wasm-friendly" and
+  keeps generated clients from transitively pulling `tracing`.
+* **DC-1a - Trace trees are fields, not spans.** `pocopine-observe` has no
+  span parent/child hierarchy: parent/child is conveyed only by a shared
+  `trace_id` in `ObserveContext` plus explicit fields. `TraceEvent`/
+  `TraceSpan` therefore carry explicit `step_id` / `parent_step_id` /
+  `parallel_group_id`, which the facade copies into `ObservedEvent` fields.
+* **DC-2 - `AgenkitError`/`AgenkitResult` live in core**, modelled as a
+  manual enum + `Display` + `impl std::error::Error` + helper constructors +
+  `impl From` (no `thiserror`, matching `JobError`/`SyncError`/`StorageError`).
+  Host-only variants are gated `#[cfg(not(target_arch = "wasm32"))]`. Variants
+  distinguish provider, schema/validation, tool-policy, budget-exhaustion,
+  cancellation, and reducer-disagreement failures (§D13).
+* **DC-3 - `prelude` and root re-exports are facade-only and deferred.** No
+  `prelude` exists elsewhere in the workspace; it is a sanctioned new
+  convention. Per the workspace's "defer umbrella re-exports until the API is
+  stable" rule, the facade does not re-export core while the surface churns;
+  the curated `prelude` lands as the final checkpoint of each phase.
+* **DC-4 - Async contract traits use native `async fn in trait`** with
+  `#[allow(async_fn_in_trait)]` plus a boxed-future typedef
+  (`Pin<Box<dyn Future<Output = AgenkitResult<...>> + Send + 'a>>`) for
+  object-safe `DynTool`/`DynRetriever`/`DynEmbedder`/`DynProvider` erasure,
+  mirroring `pocopine_sync_query::source::Source`. The `async-trait` macro is
+  not used for public contract traits. Registries are
+  `HashMap<String, Arc<dyn DynX>>`, mirroring `SyncServerBuilder` /
+  `StorageServerBuilder` / `Server::new`.
+* **DC-5 - Public flows reuse the `#[server]` path; principal access is an
+  in-facade adapter.** Exposing a public flow as a `#[server]` function gives
+  the typed wasm client for free (the macro emits
+  `pocopine::fetch::call::<Args, R>`); no separate Rust client codegen is
+  added. Because `#[server]` hands `RequestContext`/`Principal` only to guards,
+  not handler bodies, tools/retrieval obtain the caller principal through a
+  thin adapter in `pocopine-agenkit` that reads `Principal` from request
+  extensions and threads it through `AiFlowContext`. The shared
+  `pocopine-macros` `#[server]` macro is **not** modified (macro work is
+  deferred, §Deferred Follow-Ups).
+* **DC-6 - Streaming ships in v1.** `StreamMode::{FinalOnly, OutputDeltas,
+  Progress, DebugSafe}` are all honored. There is no server-function
+  streaming today (only `pocopine-live`'s SSE), so the streaming route is
+  net-new: it reuses `pocopine-live`'s SSE primitives (replay cursor via
+  `last_event_id`, keep-alive, structured event enum) with AI-flow semantics,
+  and applies a single per-event redaction chokepoint as the last transform
+  before the wire so raw thoughts/reasoning tokens/prompts/tool args/provider
+  payloads can never leak (§D8, §D10).
+* **DC-7 - In-flight parallel cancellation is net-new.** `pocopine-jobs`
+  cancellation is drop/nack/requeue and does not abort running work; parallel
+  `ParallelJoin::{FirstSuccess, Quorum}` require real sibling cancellation via
+  `tokio::task::JoinSet` + `abort()`. Only the budget *shapes*
+  (`RetryPolicy`, `Duration` timeouts) are borrowed from `pocopine-jobs`.
+
+## Non-Goals
+
+* No browser-side provider calls in v1. Secrets stay on the server.
+* No client-side provider credential storage. LocalStorage,
+  sessionStorage, IndexedDB, browser cookies, generated JS bundles, and
+  wasm custom sections must never contain provider API keys or provider
+  bearer tokens.
+* No provider zoo in the first slice. Prove the Pocopine API first.
+* No `pocopine-agenkit-code`, JSONL stdio protocol, VS Code panel, or
+  generic coding-agent harness in this RFC.
+* No proc-macro crate in the first slice. Manual registration must work
+  before authoring sugar.
+* No mandatory thread state for every agent run. Stateless agent calls
+  must remain the default for one-shot flows.
+* No production durable thread database in the first slice. Define the
+  trait and prove it with in-memory/local stores first.
+* No claim that Agenkit can prevent arbitrary Rust code from using
+  globals, direct database clients, filesystem APIs, or network clients.
+  The first slice records framework-mediated context access and emits
+  advisory diagnostics only; later macros/lints can improve detection.
+* No commercial-only runtime contract. Future debugger or UI products
+  must layer on the same open core/facade contracts.
+* No direct copy of Genkit, Pi, or Rig APIs. They are references; the
+  Pocopine surface must fit Pocopine's server functions, auth,
+  observability, and deployment model.
+* No hand-rolled encoding/crypto helpers. If trace ids, signatures,
+  base64 payloads, or percent-encoded fields are needed, use
+  `pocopine-crypto` and `pocopine-codec`.
+
+## Implementation Plan
+
+### Phase 0 - Scaffolding And API Freeze
+
+**Checkpoint 0.1** - land the two empty crates wired into the workspace plus
+the frozen decisions, with no runtime logic:
+
+* create `pocopine-agenkit-core` (dependency-light, wasm-friendly) and
+  `pocopine-agenkit` (host-side facade depending on core), inheriting the
+  `[workspace.package]` fields and registered in the root `[workspace]
+  members` + `[workspace.dependencies]`;
+* model the facade's host-only dependency target-split on
+  `crates/pocopine-sync-query/Cargo.toml`: core is serde-only; the facade
+  gates `tokio`, `pocopine-observe`, `pocopine-auth`, `pocopine-server` under
+  `[target.'cfg(not(target_arch = "wasm32"))'.dependencies]` as the
+  checkpoints that need them arrive, so the workspace wasm build keeps
+  compiling the facade as an (empty) library;
+* freeze the §D15 decisions (DC-1..DC-7), the resolved name (§D1), the
+  secret-boundary test plan, the context-manifest/diagnostics model, the
+  typed tool/retriever/embedder trait shapes, the multi-step/parallel trace
+  schema, the public stream-event schema and visibility rules (§D8), and the
+  optional `AgentThread` storage/retention contract;
+* provider strategy: a deterministic local/mock provider first; Rig stays a
+  reference to evaluate behind Pocopine traits in a deferred adapter crate.
+
+Exit gate: `cargo build` and `cargo build --target wasm32-unknown-unknown`
+both pass on the two crates, `cargo fmt --all --check` is clean, and an app
+author can read this RFC and know which crate to use, which API to call, and
+which future products are intentionally out of scope.
+
+### Phase 1 - `pocopine-agenkit-core`
+
+Add only shared contracts, built bottom-up along the type dependency graph.
+Each checkpoint is a reviewable commit; serde round-trip tests and the
+"no credential-shaped field" corpus accumulate per checkpoint.
+
+* **Checkpoint 1.1 - identity, leaf enums, error** (roots the whole graph;
+  blocks everything else): `ModelRef`, `ProviderRef`, `RunId`, `TraceId`,
+  `SessionId`, `AgentThreadId`, `ParallelGroupId`, `StepId`; payload-free
+  enums `Role`, `StepKind`, `StepStatus`, `ToolSideEffectPolicy`,
+  `ResourceKind`, `ReducerKind`, `StreamMode`, `ParallelJoin`,
+  `BranchFailurePolicy`, `ThreadRetention`; `AgenkitError`/`AgenkitResult`
+  (§D15 DC-2). Core only *carries* ids; the facade mints them (via
+  `pocopine-crypto`/`pocopine-codec`) to keep core dependency-light.
+* **Checkpoint 1.2 - content/messaging** (depends on `Role`):
+  `Content`, `ContentPart`, `Message`, multimodal attachments.
+* **Checkpoint 1.3 - capability descriptors/payloads** (three independent
+  families, can be authored in parallel): `ToolDescriptor`, `ToolCall`,
+  `ToolResult`; `RetrieverDescriptor`, `RetrievalQuery`, `RetrievalHit`,
+  `RetrievalSet`, `SourceRef`, `Citation`; `EmbedderDescriptor`, `Embedding`,
+  `EmbeddingBatch`. First home for the "no credential field" invariant tests.
+* **Checkpoint 1.4 - flow, manifest, orchestration, trace/stream** (most
+  schema-sensitive, lands last): `FlowDescriptor`, `FlowInputSchema`,
+  `FlowOutputSchema`; `ContextManifest`, `DeclaredResource`,
+  `ContextGapDiagnostic`; `AiAgentDescriptor`, `AgentThreadDescriptor`,
+  `ThreadMessage`, `ThreadCheckpoint`, `ReducerDecision`; `FlowStreamEvent`,
+  `TraceEvent`, `TraceSpan`, `Usage`, `CostEstimate`; stable event-name
+  constants for the AI event families. `TraceEvent`/`TraceSpan` carry explicit
+  `step_id`/`parent_step_id`/`parallel_group_id` (§D15 DC-1a).
+
+Rules:
+
+* no provider SDKs;
+* no secret-bearing provider config structs that serialize to client
+  payloads;
+* no proc macros;
+* no stdio implementation or agent harness;
+* no server runtime dependency; no `pocopine-observe` dependency (§D15 DC-1);
+* serde round-trip tests for every public payload;
+* tests proving public payloads do not contain credential fields;
+* stable event names and trace payload structs for the first AI event
+  families;
+* wasm-friendly by default where practical.
+
+Exit gate: `pocopine-agenkit-core` can serialize and deserialize the
+same client-safe payloads used by runtime tests and future generated
+clients; a round-trip test for a nested-parallel `TraceEvent` proves
+`parent_step_id`/`parallel_group_id` survive and no secret fields exist.
+
+### Phase 2 - `pocopine-agenkit`
+
+Add the runtime facade. The deterministic mock provider is the critical path
+and lands first; nothing downstream is testable without it. The trace-mapping
+layer lands early (2.3) so every later checkpoint traces through one tested
+mapper.
+
+* **Checkpoint 2.1 - provider trait + mock provider + registry** (first):
+  `Provider` trait + `DynProvider` shim (§D15 DC-4), `ProviderRegistry`, and a
+  deterministic `MockProvider` (canned text + structured JSON keyed by input,
+  for reproducible tests and replay).
+* **Checkpoint 2.2 - `Agenkit::builder()` + `Ai` generation**:
+  fluent builder + `.build()`; `Ai` with `generate_text` and
+  `generate_structured` (structured runs the schema-validation hook — model
+  output is untrusted, §D10).
+* **Checkpoint 2.3 - trace-mapping layer + observe integration**: the facade's
+  `TraceEvent -> ObservedEvent` + `emit_tracing` mapping (§D15 DC-1), one
+  function per event family, copying `step_id`/`parent_step_id`/
+  `parallel_group_id` into `ObservedEvent` fields with the right
+  `FieldPrivacy`; default `RedactionPolicy::public_only`, raw
+  prompts/args/outputs `Sensitive` and stripped unless capture policy opts in.
+* **Checkpoint 2.4 - tool/retriever/embedder** typed traits (§D15 DC-4),
+  `DynTool`/`DynRetriever`/`DynEmbedder` erasure, `ToolRegistry`/
+  `RetrieverRegistry`/`EmbedderRegistry`, `AiToolContext`/`RetrievalContext`/
+  `EmbedContext`, the retriever-as-tool adapter, and input/output validation.
+* **Checkpoint 2.5 - flows + context**: manual `Flow` registration,
+  `AiFlowContext`, `AiFlowContext::step(...)` for traced custom work,
+  `AiFlowContext::retrieve::<T>()` for deterministic retrieval, context
+  manifests and advisory undeclared-context diagnostics.
+* **Checkpoint 2.6 - agents, threads, parallel, reduce, stream** (split into
+  2.6a/2.6b): `AiAgent` + `AiAgentBuilder`, `AiFlowContext::agent::<T>()`,
+  `AgentThreadStore` trait + in-memory impl, `AiFlowContext::thread::<T>()`,
+  `AiFlowContext::reduce(...)` (2.6a); then `AiFlowContext::parallel(...)`,
+  `ParallelJoin` execution for `All`/`AllSettled`/`FirstSuccess`/`Quorum(n)`
+  with real in-flight sibling cancellation (§D15 DC-7), budget + cancellation
+  propagation for nested steps, and `FlowStreamEvent` emission into an
+  internal channel (2.6b). Optional dynamic `agent_by_id(...)` after typed
+  agents work. The curated `prelude` re-exports land as the final commit
+  (§D15 DC-3).
+
+Initial public modules:
+
+```rust
+pub mod prelude;
+pub mod generate;
+pub mod flow;
+pub mod tool;
+pub mod retrieval;
+pub mod embed;
+pub mod provider;
+pub mod step;
+pub mod agent;
+pub mod thread;
+pub mod reduce;
+pub mod trace;
+pub mod observe;
+pub mod server;
+```
+
+Exit gate: a small example can register one provider, one tool, and one
+flow manually, call the flow from Rust, run at least one traced custom
+step, one deterministic retriever, one optional-thread agent run, and
+one parallel fan-out/fan-in branch, and emit `pocopine.trace` events
+through the existing observability path.
+
+### Phase 3 - Server-Function, Auth, And Secret-Boundary Integration
+
+Wire public flows into Pocopine's existing server stack.
+
+* **Checkpoint 3.1 - public-flow-as-`#[server]` bridge** (FinalOnly path,
+  first): expose a public flow through the existing `#[server]`
+  request/response path; the macro's wasm stub
+  (`pocopine::fetch::call::<Args, R>`) is the typed client (§D15 DC-5). Map
+  `AgenkitError -> ServerError` at the boundary. Enforce the server-side model
+  alias allowlist, the per-flow tool allowlist, and the per-flow retrieval
+  source allowlist. The client sees one typed contract even when the server
+  runs multiple internal steps. No new infra.
+* **Checkpoint 3.2 - principal injection adapter** (in-facade, §D15 DC-5): a
+  thin adapter in `pocopine-agenkit` reads `Principal` from request extensions
+  and threads it through `AiFlowContext`, so tools/retrieval run under the
+  caller principal. The shared `#[server]` macro is not modified.
+* **Checkpoint 3.3 - streaming route** (§D15 DC-6): a dedicated AI-flow SSE
+  route reusing `pocopine-live` primitives (replay cursor, keep-alive,
+  structured event enum) with AI-flow semantics, consuming the 2.6b
+  `FlowStreamEvent` channel. Honor `FinalOnly`/`OutputDeltas`/`Progress`/
+  `DebugSafe`. A single per-event redaction chokepoint is the last transform
+  before the wire; it strips raw thoughts, reasoning tokens, prompts, tool
+  args, and provider payloads. Auth via `RequestContext` as the live route.
+* **Checkpoint 3.4 - secret-boundary test suite** (the gate-defining
+  checkpoint): tests that fail if a provider key/bearer/refresh/service-account
+  /signing-secret/provider-header string appears in the wasm artifact or JS
+  bundle; that no `Sensitive` field survives `public_only` redaction in any
+  emitted trace payload; that the streaming chokepoint never emits raw
+  prompts/args/thoughts/provider payloads (fuzzed with planted fake secrets);
+  that a non-allowlisted model/provider alias is rejected before any provider
+  call; and that provider/tool errors map to `ServerError` without leaking
+  provider internals. Trace id propagation into `pocopine-observe`, and
+  server-function telemetry uses the same route/body/header omission rules as
+  existing Pocopine server-function observability.
+
+Exit gate: the example app calls an AI flow from UI code like a normal
+Pocopine server function (FinalOnly) and consumes a redacted progress stream,
+can inspect its trace locally, and has tests that fail if provider credentials
+appear in client artifacts, trace payloads, or stream events.
+
+## Deferred Follow-Ups
+
+These are deliberately outside the first implementation series:
+
+* `pocopine-agenkit-macros` for `#[ai_flow]`, `#[ai_tool]`, schema
+  derivation, and generated server-function bridges;
+* provider adapter crates such as `pocopine-agenkit-rig` or
+  `pocopine-agenkit-provider-*`;
+* a focused `pocopine-debugger` product that consumes Agenkit flows and
+  Pocopine observability events;
+* best-practice docs and skills that teach traceable flow design,
+  declared context, retriever usage, and when to avoid hidden DB/file
+  reads inside flow bodies;
+* editor integrations, skill loading, stdio protocols, and commercial
+  UI surfaces;
+* eval dataset runners and production dashboard extensions.
+
+Each deferred item should prove that it can layer on
+`pocopine-agenkit-core` and `pocopine-agenkit` without adding a second
+AI runtime contract.
+
+## Acceptance Criteria
+
+This RFC can move to Accepted when it has:
+
+* final name;
+* final two-crate split;
+* explicit note on whether Rig is only a reference, a future adapter, or
+  a direct dependency hidden behind Pocopine traits;
+* first unified `pocopine_agenkit::prelude` contents;
+* first `Agenkit::builder()` and `Ai` generation API shape;
+* explicit tests for the server-only provider secret boundary;
+* `ContextManifest` and advisory context-gap diagnostic shape for
+  public flows;
+* best-practice documentation plan for traceable flow design, including
+  guidance to put this in Pocopine skills;
+* first `AiTool`, `AiRetriever`, and `AiEmbedder` trait shapes with
+  typed inputs/outputs and runtime registry erasure;
+* clear rule for when retrieval is called directly by a flow versus
+  exposed as an agent tool;
+* redaction policy for traces/logs/model/tool/flow events;
+* first `Flow`, `AiAgent`, and optional `AgentThread` API split with
+  clear ownership boundaries;
+* first `ctx.step`, `ctx.parallel`, `ctx.agent::<T>()`, and `ctx.reduce`
+  runtime shape;
+* first `ctx.thread::<T>()` shape with opaque thread ids, retention
+  policy, and redacted thread checkpoints;
+* explicit budget, cancellation, and branch-failure policy for
+  multi-step and parallel flows;
+* public `FlowStreamEvent` schema that does not expose raw thoughts,
+  provider reasoning tokens, raw prompts, tool args, or provider
+  payloads;
+* explicit `ParallelJoin` semantics for `All`, `AllSettled`,
+  `FirstSuccess`, and `Quorum(n)`;
+* unified observability mapping to `pocopine-observe`,
+  `pocopine-logging`, and `pocopine-analytics`;
+* a concrete first example app;
+* a clear boundary that keeps debugger, agent harness, VS Code, skills,
+  proc macros, provider adapters, and commercial UI work deferred until
+  the core/facade API is proven.


### PR DESCRIPTION
## What this is

Implements **[RFC-093 Pocopine Agenkit](rfcs/rfc-093-pocopine-agenkit.md)** — a Pocopine-native generative-AI runtime — Phases 0→3, plus the first provider. App flows, server functions, tools, model calls, and traces all compose through framework-owned contracts and ride the **existing** Pocopine observability / server-function / auth stacks, rather than a parallel AI telemetry runtime.

Delivered as three crates:

```mermaid
flowchart TD
    subgraph wasm["compiles on every target (wasm-friendly)"]
        core["pocopine-agenkit-core<br/>contracts & payloads<br/>(serde-only, dependency-light)"]
    end
    subgraph host["host-only (cfg(not(wasm32)))"]
        facade["pocopine-agenkit<br/>runtime facade: Agenkit/Ai builders,<br/>providers, flows, tools/retrievers/embedders,<br/>agents/threads, parallel, traces, SSE route"]
        oai["pocopine-agenkit-oai<br/>OpenAI-compatible provider<br/>(/v1/chat/completions)"]
    end
    facade --> core
    oai --> facade
    oai --> core
    facade -->|maps TraceEvent → ObservedEvent| observe["pocopine-observe (emit_tracing)"]
    facade -->|reads Principal from ext| auth["pocopine-auth"]
    browser["browser client"] -->|generated #server helpers + SSE| facade
```

## What's implemented

**Phase 0 — scaffolding & API freeze.** Two crates wired into the workspace; RFC rewritten to mirror commit-sized checkpoints; cross-cutting decisions frozen (observe-neutral core, manual error enums, object-safe boxed-future traits, facade-only prelude).

**Phase 1 — `pocopine-agenkit-core`.** Identity newtypes + leaf enums + `AgenkitError`; content/messaging; tool/retriever/embedder descriptors; flow + manifest + orchestration + `TraceEvent`/`FlowStreamEvent`. Trace trees use explicit `step_id`/`parent_step_id`/`parallel_group_id` fields (observe has no span nesting). Every payload has a serde round-trip test + a no-credential-field corpus test.

**Phase 2 — `pocopine-agenkit` facade.** Deterministic `MockProvider` first (critical path); `Agenkit::builder()` + `Ai` generation; trace-mapping layer (`TraceEvent → ObservedEvent + emit_tracing`); tool/retriever/embedder runtime; flows + `AiFlowContext` (`ctx.ai`/`ctx.step`/`ctx.retrieve`); typed agents + threads + reducers; parallel fan-out with **real in-flight cancellation** (`JoinSet::abort()` — `FirstSuccess`/`Quorum` actually abort losers); curated prelude.

**Phase 3 — server boundary.** Public-flow-as-`#[server]` bridge (model-alias + tool/source allowlists); in-facade principal injection adapter (task-local, no `#[server]` macro change); AI-flow SSE route reusing `pocopine-live` primitives with a **single redaction chokepoint**; secret-boundary test suite.

**Provider + streaming + structured output (post-Phase-3).**
- `pocopine-agenkit-oai`: OpenAI-compatible provider, native SSE streaming, strict `json_schema` structured output (falls back to `json_object`). Credentials are server-only; errors surface status + type only, never the message/key.
- `schemars`-derived **real JSON Schema** for structured output (not a marker).
- **Streaming** (`Provider::generate_stream` + `ctx.ai().stream_text()`) with a one-shot fallback for non-streaming providers.
- **Partial structured JSON** (latest commit, Genkit-style): `FlowStreamEvent::ObjectDelta { partial }` — a tolerant parser re-parses the JSON-so-far on each chunk so clients render a progressively-completing object, converging to the validated `T`.

## Secret boundary (§D10)

Credentials never leave the host: not in the wasm artifact, not in trace payloads (`Sensitive` fields stripped under `public_only`), not in stream events (the chokepoint only forwards client-safe variants), not in `ServerError` (provider/config errors collapse to a kind). Non-allowlisted model aliases are rejected *before* any provider call. A dedicated suite (`tests/secret_boundary.rs`) asserts this and goes red if a planted secret leaks.

## Testing

- **126 host tests** across the three crates (serde round-trips, trace trees, parallel cancellation, principal threading, secret boundary, streaming, partial-object convergence, OpenAI SSE via `wiremock`).
- **wasm** `clippy --all-targets -D warnings` + build clean; **host** `clippy --all-targets -D warnings` clean; `cargo fmt --check` clean.
- Runnable example: `cargo run -p pocopine-agenkit --example summarize`.

## Out of scope (deferred per RFC)

Proc-macros (`#[ai_flow]`/`#[ai_tool]`), additional provider adapter crates, the Pocopine Debugger product, eval dataset runners, durable thread stores. These must layer on these crates without introducing a second AI runtime contract.

## Review notes

- History is 7 logical commits; the suggested reading order is the commit order (RFC -> core contracts -> facade scaffold -> tool/retriever/embedder -> generation engine -> server boundary -> OpenAI provider). Each commit builds.
- A pre-merge multi-agent review was run and its findings folded in: panicked parallel branches are recorded failures (new `AgenkitError::Internal`); `public_only` redaction is applied at the trace-emission chokepoint (freeform fields Sensitive unless structurally allowlisted); `FlowStreamEvent::Unknown` gives stale clients forward compatibility; the SSE `?mode=` is clamped to the author-declared `stream_mode` cap; the OAI strict-schema gate degrades on `allOf`/`oneOf`/`definitions` instead of a provider 400.
- The OpenAI provider is wired only into tests so far (the example uses `MockProvider`).

## Known follow-ups (deliberately not in this PR)

- Thread resume has no principal/agent ownership binding yet (`ThreadBuilder::resume_or_create` trusts caller-supplied ids); needs an `AgentThreadStore` trait extension.
- `ProviderCapabilities` is declared but not yet consulted by the runtime (no capability-gated degrade paths).
- OAI: `max_tokens` vs `max_completion_tokens` per-endpoint strategy, tool-name sanitization, SSE multi-line `data:` joining per spec.
