### PR TITLE
rfc-098: core hardening — atomic effect lifecycle, non-reentrant dispatch, deterministic order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5855,6 +5855,7 @@ name = "pocopine-core"
 version = "0.2.0"
 dependencies = [
  "console_error_panic_hook",
+ "indexmap 2.14.0",
  "js-sys",
  "once_cell",
  "phf 0.13.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5865,6 +5865,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen 0.6.5",
  "serde_json",
+ "slab",
  "unicode-segmentation",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,12 @@ pocopine-sync-sqlite = { path = "crates/pocopine-sync-sqlite", version = "0.1.0"
 pocopine-template-parser = { path = "crates/pocopine-template-parser", version = "0.1.0" }
 pocopine-ts-rs = { path = "crates/pocopine-ts-rs", version = "0.1.0" }
 pine-richtext = { path = "crates/pine-richtext", version = "0.1.0" }
+# RFC-098 — insertion-ordered subscriber/queue sets (H4 determinism)
+# and the generational effect slab (H2). indexmap keeps its `std`
+# default (the `RandomState` hasher + `IndexSet::new()`); iteration is
+# insertion-ordered regardless of hasher. Both are wasm32-proven.
+indexmap = { version = "2" }
+slab = { version = "0.4" }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"

--- a/crates/pocopine-core/Cargo.toml
+++ b/crates/pocopine-core/Cargo.toml
@@ -60,6 +60,10 @@ phf = { version = "0.13", features = ["macros"] }
 # differential-fuzz failure replays from its seed alone (HashSet
 # iteration order varied per run). Same asymptotics as HashSet.
 indexmap = { workspace = true }
+# RFC-098 H2 — one generational slab for the effect lifecycle
+# (body + scheduler + cleanups + signal deps), replacing four parallel
+# tables. EffectId = generation<<32 | slot; stale ids resolve to None.
+slab = { workspace = true }
 
 [dependencies.web-sys]
 version = "0.3"

--- a/crates/pocopine-core/Cargo.toml
+++ b/crates/pocopine-core/Cargo.toml
@@ -56,6 +56,10 @@ unicode-segmentation = "1"
 # &'static ComponentVTable>` populated by the `app!{}` macro
 # at expansion time from an explicit `components: [...]` list.
 phf = { version = "0.13", features = ["macros"] }
+# RFC-098 H4 — insertion-ordered subscriber sets + flush queue so a
+# differential-fuzz failure replays from its seed alone (HashSet
+# iteration order varied per run). Same asymptotics as HashSet.
+indexmap = { workspace = true }
 
 [dependencies.web-sys]
 version = "0.3"

--- a/crates/pocopine-core/src/devtools/hooks.rs
+++ b/crates/pocopine-core/src/devtools/hooks.rs
@@ -109,9 +109,10 @@ pub(crate) fn fire_handler_invoke(scope: ScopeId, name: &str, args: &Array, dura
     }
 }
 
-/// Fired after `dispatch_subs` extends QUEUE. Receives a snapshot
-/// of the effect ids that were just queued (not the full queue) so
-/// the handler doesn't have to diff.
+/// Fired once per outermost `dispatch_signal`, after its worklist
+/// drain has queued effects. Receives the snapshot of effect ids
+/// queued across the whole drain (not the full queue) so the handler
+/// doesn't have to diff.
 pub(crate) fn fire_queue_change(added: &[EffectId]) {
     let hook = HOOKS.with(|h| h.borrow().on_queue_change.clone());
     if let Some(f) = hook {

--- a/crates/pocopine-core/src/reactive.rs
+++ b/crates/pocopine-core/src/reactive.rs
@@ -20,6 +20,12 @@ use std::cell::{Cell, RefCell};
 use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
+// RFC-098 H4 — `IndexSet` gives HashSet's API with deterministic
+// (insertion-ordered) iteration, so dispatch + flush order is
+// replayable from a fuzz seed. `SIGNAL_REVERSE` stays a `HashSet`:
+// its iteration is never observable (it only drives removals).
+use indexmap::IndexSet;
+
 use js_sys::Promise;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::JsValue;
@@ -78,10 +84,17 @@ thread_local! {
     /// THE dependency table (RFC-095 W3a): subscriber lists for
     /// signals — which, post-unification, includes every tracked
     /// component field via `FIELD_SIGNALS` interning.
-    static SIGNAL_DEPS: RefCell<HashMap<SignalId, HashSet<EffectId>>> = RefCell::new(HashMap::new());
+    // RFC-098 H4 — subscriber sets are `IndexSet` so dispatch visits
+    // effects in registration order, deterministically. Removal MUST
+    // use `shift_remove` (not the default swap-remove) to keep the
+    // surviving order stable.
+    static SIGNAL_DEPS: RefCell<HashMap<SignalId, IndexSet<EffectId>>> = RefCell::new(HashMap::new());
     static SIGNAL_REVERSE: RefCell<HashMap<EffectId, HashSet<SignalId>>> = RefCell::new(HashMap::new());
 
-    static QUEUE: RefCell<HashSet<EffectId>> = RefCell::new(HashSet::new());
+    // RFC-098 H4 — `IndexSet` so `flush` drains in the order effects
+    // were queued; set semantics still dedupe an effect a single
+    // dispatch queues twice.
+    static QUEUE: RefCell<IndexSet<EffectId>> = RefCell::new(IndexSet::new());
     static FLUSH_SCHEDULED: Cell<bool> = const { Cell::new(false) };
     static CLEANUPS: RefCell<HashMap<EffectId, Vec<CleanupFn>>> = RefCell::new(HashMap::new());
     static BATCHING: Cell<u32> = const { Cell::new(0) };
@@ -227,7 +240,10 @@ fn clear_deps_for(id: EffectId) {
             let mut d = d.borrow_mut();
             for sid in sig_keys {
                 if let Some(set) = d.get_mut(&sid) {
-                    set.remove(&id);
+                    // shift_remove (not swap_remove) keeps survivors in
+                    // registration order — H4 determinism (else a teardown
+                    // reorders the next dispatch).
+                    set.shift_remove(&id);
                     if set.is_empty() {
                         d.remove(&sid);
                     }
@@ -255,7 +271,8 @@ pub fn release(id: EffectId) {
     EFFECTS.with(|e| e.borrow_mut().remove(&id));
     SCHEDULERS.with(|s| s.borrow_mut().remove(&id));
     QUEUE.with(|q| {
-        q.borrow_mut().remove(&id);
+        // shift_remove keeps any concurrently-queued effects in order.
+        q.borrow_mut().shift_remove(&id);
     });
 }
 
@@ -345,7 +362,7 @@ pub fn track_signal(signal_id: SignalId) {
 /// queue, schedule flush if needed. Factored out so `trigger` and
 /// `trigger_signal` share the dispatch path — they diverge only on
 /// how they look up subscribers.
-fn dispatch_subs(subs: &HashSet<EffectId>) {
+fn dispatch_subs(subs: &IndexSet<EffectId>) {
     if subs.is_empty() {
         return;
     }
@@ -427,7 +444,7 @@ pub fn trigger(scope_id: ScopeId, key: &str) {
     let Some(sid) = field_signal(scope_id, key, false) else {
         return;
     };
-    let subs: Option<HashSet<EffectId>> = SIGNAL_DEPS.with(|d| d.borrow().get(&sid).cloned());
+    let subs: Option<IndexSet<EffectId>> = SIGNAL_DEPS.with(|d| d.borrow().get(&sid).cloned());
     if let Some(subs) = subs {
         dispatch_subs(&subs);
     }
@@ -436,7 +453,8 @@ pub fn trigger(scope_id: ScopeId, key: &str) {
 /// Signal-targeted trigger. Skips the `(scope_id, key)` lookup path
 /// entirely — signal deps live in their own table keyed on `SignalId`.
 pub fn trigger_signal(signal_id: SignalId) {
-    let subs: Option<HashSet<EffectId>> = SIGNAL_DEPS.with(|d| d.borrow().get(&signal_id).cloned());
+    let subs: Option<IndexSet<EffectId>> =
+        SIGNAL_DEPS.with(|d| d.borrow().get(&signal_id).cloned());
     if let Some(subs) = subs {
         dispatch_subs(&subs);
     }
@@ -571,7 +589,7 @@ fn flush() {
     FLUSH_SCHEDULED.with(|f| f.set(false));
     // Snapshot and clear so effects that re-trigger during their run land
     // in the next batch, not the current one.
-    let ids: Vec<EffectId> = QUEUE.with(|q| q.borrow_mut().drain().collect());
+    let ids: Vec<EffectId> = QUEUE.with(|q| q.borrow_mut().drain(..).collect());
     for id in ids {
         let f = EFFECTS.with(|e| e.borrow().get(&id).cloned());
         if let Some(f) = f {
@@ -615,10 +633,9 @@ pub fn stats() -> (usize, usize) {
 // panels (PR D onwards). Gated behind the devtools feature so they
 // don't contribute to default-feature-off release binaries.
 
-/// Snapshot of the effect ids currently queued for the next flush.
-/// Order is unspecified — `QUEUE` is a `HashSet`. Consumers that
-/// need deterministic ordering should sort by id at the display
-/// boundary.
+/// Snapshot of the effect ids currently queued for the next flush,
+/// in the order the next flush will run them — `QUEUE` is insertion-
+/// ordered (RFC-098 H4), so this is deterministic and replayable.
 #[cfg(feature = "devtools")]
 pub fn queue_snapshot() -> Vec<EffectId> {
     QUEUE.with(|q| q.borrow().iter().copied().collect())

--- a/crates/pocopine-core/src/reactive.rs
+++ b/crates/pocopine-core/src/reactive.rs
@@ -99,14 +99,6 @@ thread_local! {
     static CLEANUPS: RefCell<HashMap<EffectId, Vec<CleanupFn>>> = RefCell::new(HashMap::new());
     static BATCHING: Cell<u32> = const { Cell::new(0) };
     static AUTO_FLUSH: Cell<bool> = const { Cell::new(true) };
-
-    /// Reusable scratch buffer for `trigger`'s subscriber snapshot.
-    /// `trigger` must iterate subscribers outside the `DEPS` borrow
-    /// because running an effect can mutate `DEPS` (via
-    /// `clear_deps_for`). A per-thread scratch `Vec` avoids the
-    /// `HashSet::clone()` allocation every hot-path `trigger` used
-    /// to pay.
-    static TRIGGER_SCRATCH: RefCell<Vec<EffectId>> = RefCell::new(Vec::with_capacity(16));
 }
 
 /// Toggle the automatic microtask flush. Production code leaves this at
@@ -358,45 +350,41 @@ pub fn track_signal(signal_id: SignalId) {
     });
 }
 
-/// Snapshot `subs` into a local buffer, route per-effect scheduler or
-/// queue, schedule flush if needed. Factored out so `trigger` and
-/// `trigger_signal` share the dispatch path — they diverge only on
-/// how they look up subscribers.
-fn dispatch_subs(subs: &IndexSet<EffectId>) {
-    if subs.is_empty() {
+/// Dispatch signal `sid`: snapshot its subscribers under a short
+/// borrow, drop the borrow, then route each — schedulers fire inline,
+/// the rest accumulate in `QUEUE` for the next flush. Shared by
+/// `trigger` and `trigger_signal`, which diverge only on how they find
+/// `sid`.
+///
+/// RFC-098 H1 — ONE copy. The old path cloned the subscriber set in
+/// the caller AND copied that clone into a thread-local scratch (whose
+/// only purpose was avoiding the clone the caller had just made); a
+/// `mem::take`/restore dance protected the shared scratch from
+/// re-entrant dispatch. Here the single snapshot `Vec` is local, and
+/// the `SIGNAL_DEPS` borrow is released before any effect runs — so a
+/// scheduler that re-triggers (re-entering `dispatch_signal`) neither
+/// clobbers a shared buffer nor hits a borrow conflict, with no scratch
+/// to manage.
+fn dispatch_signal(sid: SignalId) {
+    // Snapshot subscriber ids in insertion order (H4) under a borrow
+    // that ends with this `with` — running an effect/scheduler below
+    // can mutate `SIGNAL_DEPS` (via `clear_deps_for`), so the borrow
+    // must not outlive the copy.
+    let local: Vec<EffectId> = SIGNAL_DEPS.with(|d| {
+        d.borrow()
+            .get(&sid)
+            .map(|set| set.iter().copied().collect())
+            .unwrap_or_default()
+    });
+    if local.is_empty() {
         return;
     }
-    // Take ownership of the thread-local scratch so re-entrant
-    // dispatch_subs calls (an inline scheduler that mutates a signal
-    // and triggers another dispatch) don't clobber our buffer
-    // mid-iteration. Pre-fix, the shared scratch surfaced as
-    // "RefCell already borrowed" or "index out of bounds: len 0
-    // index N" deep in the trigger path — both symptoms of the inner
-    // call having `clear()`ed the outer call's snapshot.
-    let mut local = TRIGGER_SCRATCH.with(|s| std::mem::take(&mut *s.borrow_mut()));
-    local.clear();
-    local.extend(subs.iter().copied());
-    let ids_len = local.len();
-    if ids_len == 0 {
-        // Restore the (empty, possibly pre-grown) buffer for reuse.
-        TRIGGER_SCRATCH.with(|s| {
-            let mut current = s.borrow_mut();
-            if local.capacity() > current.capacity() {
-                *current = local;
-            }
-        });
-        return;
-    }
-    // Drain the local buffer into dispatch. Schedulers fire inline;
-    // the rest accumulate in QUEUE. No intermediate HashSet<EffectId>
-    // clone, and re-entry is safe because each dispatch owns its
-    // own buffer.
     let mut any_queued = false;
     // Devtools — collect the just-queued ids so the hook sees the
     // delta, not the whole queue. Empty when feature is off.
     #[cfg(feature = "devtools")]
     let mut newly_queued: Vec<EffectId> = Vec::new();
-    for &eid in local.iter().take(ids_len) {
+    for eid in local {
         let sched = SCHEDULERS.with(|s| s.borrow().get(&eid).cloned());
         match sched {
             Some(s) => s(eid),
@@ -410,16 +398,6 @@ fn dispatch_subs(subs: &IndexSet<EffectId>) {
             }
         }
     }
-    local.clear();
-    // Return the buffer for the next non-reentrant call to reuse —
-    // keep whichever copy has the larger capacity so we don't lose
-    // the pre-grown allocation.
-    TRIGGER_SCRATCH.with(|s| {
-        let mut current = s.borrow_mut();
-        if local.capacity() > current.capacity() {
-            *current = local;
-        }
-    });
     #[cfg(feature = "devtools")]
     if !newly_queued.is_empty() {
         crate::devtools::hooks::fire_queue_change(&newly_queued);
@@ -444,20 +422,13 @@ pub fn trigger(scope_id: ScopeId, key: &str) {
     let Some(sid) = field_signal(scope_id, key, false) else {
         return;
     };
-    let subs: Option<IndexSet<EffectId>> = SIGNAL_DEPS.with(|d| d.borrow().get(&sid).cloned());
-    if let Some(subs) = subs {
-        dispatch_subs(&subs);
-    }
+    dispatch_signal(sid);
 }
 
 /// Signal-targeted trigger. Skips the `(scope_id, key)` lookup path
 /// entirely — signal deps live in their own table keyed on `SignalId`.
 pub fn trigger_signal(signal_id: SignalId) {
-    let subs: Option<IndexSet<EffectId>> =
-        SIGNAL_DEPS.with(|d| d.borrow().get(&signal_id).cloned());
-    if let Some(subs) = subs {
-        dispatch_subs(&subs);
-    }
+    dispatch_signal(signal_id);
     // Devtools hook — fires on every signal trigger regardless of
     // whether there are subscribers, so `last_changed` still updates
     // for "unread" signals the graph panel displays.

--- a/crates/pocopine-core/src/reactive.rs
+++ b/crates/pocopine-core/src/reactive.rs
@@ -99,6 +99,16 @@ thread_local! {
     static CLEANUPS: RefCell<HashMap<EffectId, Vec<CleanupFn>>> = RefCell::new(HashMap::new());
     static BATCHING: Cell<u32> = const { Cell::new(0) };
     static AUTO_FLUSH: Cell<bool> = const { Cell::new(true) };
+
+    /// RFC-098 H3 — trampoline state. `dispatch_signal` is
+    /// non-reentrant: the outermost call sets `DISPATCH_DEPTH` to 1 and
+    /// owns the `WORKLIST` drain loop. A trigger fired by an inline
+    /// scheduler re-enters with depth > 0, appends its signal to the
+    /// worklist, and unwinds — dispatch never recurses, so the
+    /// re-entrancy the old scratch dance defended against is
+    /// structurally impossible.
+    static DISPATCH_DEPTH: Cell<u32> = const { Cell::new(0) };
+    static WORKLIST: RefCell<Vec<SignalId>> = const { RefCell::new(Vec::new()) };
 }
 
 /// Toggle the automatic microtask flush. Production code leaves this at
@@ -356,48 +366,83 @@ pub fn track_signal(signal_id: SignalId) {
 /// `trigger` and `trigger_signal`, which diverge only on how they find
 /// `sid`.
 ///
-/// RFC-098 H1 — ONE copy. The old path cloned the subscriber set in
-/// the caller AND copied that clone into a thread-local scratch (whose
-/// only purpose was avoiding the clone the caller had just made); a
-/// `mem::take`/restore dance protected the shared scratch from
-/// re-entrant dispatch. Here the single snapshot `Vec` is local, and
-/// the `SIGNAL_DEPS` borrow is released before any effect runs — so a
-/// scheduler that re-triggers (re-entering `dispatch_signal`) neither
-/// clobbers a shared buffer nor hits a borrow conflict, with no scratch
-/// to manage.
+/// RFC-098 H1 — ONE copy per signal (a local snapshot `Vec`, borrow
+/// dropped before any effect runs); H3 — a trampoline, so dispatch
+/// never recurses.
+///
+/// A trigger fired by an inline scheduler re-enters here with
+/// `DISPATCH_DEPTH > 0`: it appends its signal to the `WORKLIST` and
+/// unwinds. The outermost frame owns the drain loop, popping the
+/// worklist until empty. Schedulers still run inline (computed
+/// laziness needs the `dirty` mark to be synchronous); only the
+/// downstream triggers they fire are deferred. Net effect: the old
+/// `mem::take` scratch dance — and the two re-entrancy crashes its
+/// comments commemorated — are deleted, not defended.
 fn dispatch_signal(sid: SignalId) {
-    // Snapshot subscriber ids in insertion order (H4) under a borrow
-    // that ends with this `with` — running an effect/scheduler below
-    // can mutate `SIGNAL_DEPS` (via `clear_deps_for`), so the borrow
-    // must not outlive the copy.
-    let local: Vec<EffectId> = SIGNAL_DEPS.with(|d| {
-        d.borrow()
-            .get(&sid)
-            .map(|set| set.iter().copied().collect())
-            .unwrap_or_default()
-    });
-    if local.is_empty() {
+    if DISPATCH_DEPTH.with(|d| d.get()) > 0 {
+        // Re-entrant: a scheduler triggered another signal. Enqueue and
+        // unwind — the outermost frame drives the loop.
+        WORKLIST.with(|w| w.borrow_mut().push(sid));
         return;
     }
+    DISPATCH_DEPTH.with(|d| d.set(1));
+
     let mut any_queued = false;
-    // Devtools — collect the just-queued ids so the hook sees the
-    // delta, not the whole queue. Empty when feature is off.
+    // Devtools — collect the just-queued ids across the whole drain so
+    // the hook fires once per outermost dispatch. Empty when off.
     #[cfg(feature = "devtools")]
     let mut newly_queued: Vec<EffectId> = Vec::new();
-    for eid in local {
-        let sched = SCHEDULERS.with(|s| s.borrow().get(&eid).cloned());
-        match sched {
-            Some(s) => s(eid),
-            None => {
-                QUEUE.with(|q| {
-                    q.borrow_mut().insert(eid);
-                });
-                any_queued = true;
-                #[cfg(feature = "devtools")]
-                newly_queued.push(eid);
+    // Debug-only drain bound: a true dependency cycle (a scheduler
+    // re-triggering a signal upstream of itself) would grow the
+    // worklist without end — convert that hang into a loud failure.
+    #[cfg(debug_assertions)]
+    let mut drains: usize = 0;
+
+    let mut cursor = sid;
+    loop {
+        // Snapshot `cursor`'s subscribers in insertion order (H4) under
+        // a borrow that ends with this `with` — running an effect or
+        // scheduler below can mutate `SIGNAL_DEPS` (via
+        // `clear_deps_for`), so the borrow must not outlive the copy.
+        let local: Vec<EffectId> = SIGNAL_DEPS.with(|d| {
+            d.borrow()
+                .get(&cursor)
+                .map(|set| set.iter().copied().collect())
+                .unwrap_or_default()
+        });
+        for eid in local {
+            let sched = SCHEDULERS.with(|s| s.borrow().get(&eid).cloned());
+            match sched {
+                // Inline; any trigger it fires lands in WORKLIST above.
+                Some(s) => s(eid),
+                None => {
+                    QUEUE.with(|q| {
+                        q.borrow_mut().insert(eid);
+                    });
+                    any_queued = true;
+                    #[cfg(feature = "devtools")]
+                    newly_queued.push(eid);
+                }
             }
         }
+        match WORKLIST.with(|w| w.borrow_mut().pop()) {
+            Some(next) => cursor = next,
+            None => break,
+        }
+        #[cfg(debug_assertions)]
+        {
+            drains += 1;
+            debug_assert!(
+                drains < 1_000_000,
+                "RFC-098 H3: dispatch worklist exceeded 1e6 drains — likely a \
+                 reactive dependency cycle (a scheduler re-triggering a signal \
+                 upstream of itself)"
+            );
+        }
     }
+
+    DISPATCH_DEPTH.with(|d| d.set(0));
+
     #[cfg(feature = "devtools")]
     if !newly_queued.is_empty() {
         crate::devtools::hooks::fire_queue_change(&newly_queued);

--- a/crates/pocopine-core/src/reactive.rs
+++ b/crates/pocopine-core/src/reactive.rs
@@ -23,7 +23,7 @@
 
 use std::borrow::Cow;
 use std::cell::{Cell, RefCell};
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::rc::Rc;
 
 // RFC-098 H4 — `IndexSet` gives HashSet's API with deterministic
@@ -91,8 +91,10 @@ pub struct EffectOptions {
 }
 
 thread_local! {
-    // Ids start at 1 — 0 stays unallocated as an easy-to-spot
-    // "never minted" value in debugger output.
+    // Scope/Signal ids start at 1 (0 stays an easy-to-spot
+    // "never minted" sentinel for them). Effect ids are NOT drawn from
+    // here post-RFC-098 — they're slab slots, so the first effect is
+    // legitimately `EffectId(0)`.
     static NEXT_ID: Cell<u64> = const { Cell::new(1) };
     static CURRENT_EFFECT: Cell<Option<EffectId>> = const { Cell::new(None) };
     /// RFC-098 H2 — the one effect table. `EffectId = generation<<32 |
@@ -139,8 +141,13 @@ thread_local! {
     /// worklist, and unwinds — dispatch never recurses, so the
     /// re-entrancy the old scratch dance defended against is
     /// structurally impossible.
+    ///
+    /// The worklist is a FIFO `VecDeque` (push_back / pop_front): a
+    /// signal deferred earlier is dispatched earlier, so cross-branch
+    /// sibling effects keep trigger order — matching the old recursive
+    /// dispatch and honoring H4's registration-order invariant.
     static DISPATCH_DEPTH: Cell<u32> = const { Cell::new(0) };
-    static WORKLIST: RefCell<Vec<SignalId>> = const { RefCell::new(Vec::new()) };
+    static WORKLIST: RefCell<VecDeque<SignalId>> = const { RefCell::new(VecDeque::new()) };
 }
 
 /// Toggle the automatic microtask flush. Production code leaves this at
@@ -172,11 +179,15 @@ fn pack_effect_id(slot: usize, generation: u32) -> EffectId {
     debug_assert!(slot <= u32::MAX as usize, "effect slot exceeds u32");
     let packed = ((generation as u64) << 32) | (slot as u64 & 0xFFFF_FFFF);
     // The teardown lists round-trip an EffectId through `f64`
-    // (`mount.rs` stores `id.0 as f64`), exact only below 2^53 —
-    // which holds while generation < 2^21 (~2M reuses of one slot).
-    debug_assert!(
+    // (`mount.rs` stores `id.0 as f64`), exact only below 2^53 — which
+    // holds while generation < 2^21 (~2M reuses of one slot). A hard
+    // (release-mode) assert: past that bound the round-trip would lose
+    // precision and corrupt DOM-expando teardown SILENTLY, so fail
+    // loud instead. One `u64 < const` compare per effect mint —
+    // negligible beside the slab insert.
+    assert!(
         packed < (1u64 << 53),
-        "EffectId {packed:#x} exceeds f64-exact range — slot reused >2^21 times (generation overflow)"
+        "EffectId {packed:#x} exceeds f64-exact range — a slab slot was reused >2^21 times (generation overflow)"
     );
     EffectId(packed)
 }
@@ -510,7 +521,7 @@ fn dispatch_signal(sid: SignalId) {
     if DISPATCH_DEPTH.with(|d| d.get()) > 0 {
         // Re-entrant: a scheduler triggered another signal. Enqueue and
         // unwind — the outermost frame drives the loop.
-        WORKLIST.with(|w| w.borrow_mut().push(sid));
+        WORKLIST.with(|w| w.borrow_mut().push_back(sid));
         return;
     }
     DISPATCH_DEPTH.with(|d| d.set(1));
@@ -559,7 +570,7 @@ fn dispatch_signal(sid: SignalId) {
                 }
             }
         }
-        match WORKLIST.with(|w| w.borrow_mut().pop()) {
+        match WORKLIST.with(|w| w.borrow_mut().pop_front()) {
             Some(next) => cursor = next,
             None => break,
         }

--- a/crates/pocopine-core/src/reactive.rs
+++ b/crates/pocopine-core/src/reactive.rs
@@ -3,11 +3,17 @@
 //! RFC-095 W3a — **one dependency graph.** Component fields are
 //! interned as signals: the first time an effect tracks
 //! `(ScopeId, key)`, the pair mints a `SignalId` (see
-//! `FIELD_SIGNALS`), and from then on the field subscribes,
-//! triggers, and tears down through the same `SIGNAL_DEPS` /
-//! `SIGNAL_REVERSE` tables `Signal<T>` and `Computed<T>` use.
-//! The string key is hashed once per track/trigger to find the
-//! id; subscriber-list operations are `u64`-keyed.
+//! `FIELD_SIGNALS`), and from then on the field subscribes through
+//! the same `SIGNAL_DEPS` forward table `Signal<T>` and
+//! `Computed<T>` use. The string key is hashed once per
+//! track/trigger to find the id; subscriber-list operations are
+//! `u64`-keyed.
+//!
+//! RFC-098 — effect lifecycle state (body, scheduler, cleanups, and
+//! the inverse dep set) lives in one generational `EFFECT_SLAB`
+//! entry; `EffectId` packs `generation << 32 | slot`. Subscriber
+//! sets and the flush `QUEUE` are insertion-ordered (`IndexSet`),
+//! and dispatch is a non-reentrant trampoline.
 //!
 //! Effects subscribe when a tracked read fires inside one (proxy
 //! `get` trap or the RFC-095 W1 scoped root reader). A write
@@ -22,9 +28,11 @@ use std::rc::Rc;
 
 // RFC-098 H4 — `IndexSet` gives HashSet's API with deterministic
 // (insertion-ordered) iteration, so dispatch + flush order is
-// replayable from a fuzz seed. `SIGNAL_REVERSE` stays a `HashSet`:
-// its iteration is never observable (it only drives removals).
+// replayable from a fuzz seed.
 use indexmap::IndexSet;
+// RFC-098 H2 — one generational slab holds every effect's lifecycle
+// state (body, scheduler, cleanups, signal deps) in a single entry.
+use slab::Slab;
 
 use js_sys::Promise;
 use wasm_bindgen::closure::Closure;
@@ -51,6 +59,25 @@ type EffectFn = Rc<dyn Fn()>;
 type SchedulerFn = Rc<dyn Fn(EffectId)>;
 type CleanupFn = Box<dyn FnOnce()>;
 
+/// RFC-098 H2 — all of one effect's lifecycle state in a single slab
+/// entry, replacing the four parallel `EFFECTS` / `SCHEDULERS` /
+/// `CLEANUPS` / `SIGNAL_REVERSE` tables that were permitted to
+/// disagree. `release` now removes exactly one entry, so a
+/// half-released effect is unrepresentable.
+struct EffectEntry {
+    /// Slot generation. The packed `EffectId` carries the generation
+    /// it was minted at; a stale id (held past `release`, whose slot
+    /// has been reused) mismatches and resolves to `None`.
+    generation: u32,
+    body: EffectFn,
+    scheduler: Option<SchedulerFn>,
+    cleanups: Vec<CleanupFn>,
+    /// Inverse dependency set (was `SIGNAL_REVERSE[id]`): the signals
+    /// this effect subscribes to, so `clear_deps_for` is O(deps).
+    /// Order is never observed, so a plain `HashSet` is right.
+    deps: HashSet<SignalId>,
+}
+
 /// Runtime configuration for an effect. See [`effect_with`].
 #[derive(Default, Clone)]
 pub struct EffectOptions {
@@ -68,8 +95,15 @@ thread_local! {
     // "never minted" value in debugger output.
     static NEXT_ID: Cell<u64> = const { Cell::new(1) };
     static CURRENT_EFFECT: Cell<Option<EffectId>> = const { Cell::new(None) };
-    static EFFECTS: RefCell<HashMap<EffectId, EffectFn>> = RefCell::new(HashMap::new());
-    static SCHEDULERS: RefCell<HashMap<EffectId, SchedulerFn>> = RefCell::new(HashMap::new());
+    /// RFC-098 H2 — the one effect table. `EffectId = generation<<32 |
+    /// slot`; the slab reuses freed slots, `EFFECT_GENERATIONS` bumps
+    /// the per-slot generation on release so a reused slot mints a
+    /// fresh id and any stale id resolves to `None`. ScopeId/SignalId
+    /// keep the `NEXT_ID` counter; only effects use slot addressing.
+    static EFFECT_SLAB: RefCell<Slab<EffectEntry>> = const { RefCell::new(Slab::new()) };
+    /// Per-slot generation, bumped each time a slot is released so the
+    /// next occupant of that slot is distinguishable from the last.
+    static EFFECT_GENERATIONS: RefCell<Vec<u32>> = const { RefCell::new(Vec::new()) };
     /// RFC-095 W3a — field-signal interning. Each `(scope, field
     /// key)` pair lazily mints a `SignalId` the first time an
     /// effect tracks it; from then on the field IS that signal in
@@ -89,14 +123,12 @@ thread_local! {
     // use `shift_remove` (not the default swap-remove) to keep the
     // surviving order stable.
     static SIGNAL_DEPS: RefCell<HashMap<SignalId, IndexSet<EffectId>>> = RefCell::new(HashMap::new());
-    static SIGNAL_REVERSE: RefCell<HashMap<EffectId, HashSet<SignalId>>> = RefCell::new(HashMap::new());
 
     // RFC-098 H4 — `IndexSet` so `flush` drains in the order effects
     // were queued; set semantics still dedupe an effect a single
     // dispatch queues twice.
     static QUEUE: RefCell<IndexSet<EffectId>> = RefCell::new(IndexSet::new());
     static FLUSH_SCHEDULED: Cell<bool> = const { Cell::new(false) };
-    static CLEANUPS: RefCell<HashMap<EffectId, Vec<CleanupFn>>> = RefCell::new(HashMap::new());
     static BATCHING: Cell<u32> = const { Cell::new(0) };
     static AUTO_FLUSH: Cell<bool> = const { Cell::new(true) };
 
@@ -128,16 +160,61 @@ pub fn next_scope_id() -> ScopeId {
     })
 }
 
-fn next_effect_id() -> EffectId {
-    NEXT_ID.with(|c| {
-        let id = c.get();
-        c.set(id + 1);
-        EffectId(id)
+// ── RFC-098 H2 — generational effect-id encoding ─────────────────
+//
+// `EffectId.0 = (generation as u64) << 32 | (slot as u64)`. The slot
+// is the slab key (dense from 0); the generation distinguishes
+// successive occupants of a reused slot. `EffectId` stays a `Copy u64`
+// so the DOM-expando teardown lists and devtools are untouched.
+
+#[inline]
+fn pack_effect_id(slot: usize, generation: u32) -> EffectId {
+    debug_assert!(slot <= u32::MAX as usize, "effect slot exceeds u32");
+    let packed = ((generation as u64) << 32) | (slot as u64 & 0xFFFF_FFFF);
+    // The teardown lists round-trip an EffectId through `f64`
+    // (`mount.rs` stores `id.0 as f64`), exact only below 2^53 —
+    // which holds while generation < 2^21 (~2M reuses of one slot).
+    debug_assert!(
+        packed < (1u64 << 53),
+        "EffectId {packed:#x} exceeds f64-exact range — slot reused >2^21 times (generation overflow)"
+    );
+    EffectId(packed)
+}
+
+#[inline]
+fn unpack_effect_id(id: EffectId) -> (usize, u32) {
+    ((id.0 & 0xFFFF_FFFF) as usize, (id.0 >> 32) as u32)
+}
+
+/// Run `f` against `id`'s live slab entry, or return `None` if the id
+/// is stale — its slot is empty or has been reused under a newer
+/// generation. `f` runs while the slab is borrowed, so it must NOT run
+/// user code (body / scheduler / cleanups): clone or take what's
+/// needed out and drop the borrow first.
+fn with_effect<R>(id: EffectId, f: impl FnOnce(&EffectEntry) -> R) -> Option<R> {
+    let (slot, generation) = unpack_effect_id(id);
+    EFFECT_SLAB.with(|s| {
+        s.borrow()
+            .get(slot)
+            .filter(|e| e.generation == generation)
+            .map(f)
     })
 }
 
-/// Allocate a fresh `SignalId`. Signals share the id pool with effects and
-/// scopes so numeric ids are globally unique across the runtime.
+/// Mutable counterpart to [`with_effect`]. Same borrow caveat: `f`
+/// must not run user code.
+fn with_effect_mut<R>(id: EffectId, f: impl FnOnce(&mut EffectEntry) -> R) -> Option<R> {
+    let (slot, generation) = unpack_effect_id(id);
+    EFFECT_SLAB.with(|s| {
+        s.borrow_mut()
+            .get_mut(slot)
+            .filter(|e| e.generation == generation)
+            .map(f)
+    })
+}
+
+/// Allocate a fresh `SignalId`. Signals share the id pool with scopes
+/// so numeric ids are globally unique across the runtime.
 pub fn next_signal_id() -> SignalId {
     NEXT_ID.with(|c| {
         let id = c.get();
@@ -188,12 +265,32 @@ pub fn effect_with(f: impl Fn() + 'static, opts: EffectOptions) -> EffectId {
 // / pp-if / pp-text / pp-bind closure types before this
 // consolidation.
 fn effect_with_dyn(f: EffectFn, opts: EffectOptions) -> EffectId {
-    let id = next_effect_id();
-    EFFECTS.with(|e| e.borrow_mut().insert(id, f.clone()));
-    if let Some(sched) = opts.scheduler {
-        SCHEDULERS.with(|s| s.borrow_mut().insert(id, sched));
-    }
-    if !opts.lazy {
+    let EffectOptions { lazy, scheduler } = opts;
+    let id = EFFECT_SLAB.with(|slab| {
+        let mut slab = slab.borrow_mut();
+        let entry = slab.vacant_entry();
+        let slot = entry.key();
+        // Generation for this slot: 0 the first time, else one past the
+        // last occupant (`EFFECT_GENERATIONS[slot]` was bumped on its
+        // release). The freshly-inserted entry uses the SAME slot the
+        // VacantEntry reported.
+        let generation = EFFECT_GENERATIONS.with(|g| {
+            let mut g = g.borrow_mut();
+            if slot >= g.len() {
+                g.resize(slot + 1, 0);
+            }
+            g[slot]
+        });
+        entry.insert(EffectEntry {
+            generation,
+            body: f.clone(),
+            scheduler,
+            cleanups: Vec::new(),
+            deps: HashSet::new(),
+        });
+        pack_effect_id(slot, generation)
+    });
+    if !lazy {
         run_effect(id, &f);
     }
     id
@@ -234,9 +331,12 @@ fn now_ms() -> f64 {
 }
 
 fn clear_deps_for(id: EffectId) {
-    // RFC-095 W3a — one graph: component fields are interned
-    // signals, so this single sweep covers both.
-    let sig_keys: Option<HashSet<SignalId>> = SIGNAL_REVERSE.with(|r| r.borrow_mut().remove(&id));
+    // RFC-095 W3a — one graph: component fields are interned signals,
+    // so this single sweep covers both. Take the effect's dep set out
+    // of its slab entry (short borrow, no user code), then unsubscribe
+    // it from each signal. A stale/released id yields `None` — nothing
+    // to clear.
+    let sig_keys: Option<HashSet<SignalId>> = with_effect_mut(id, |e| std::mem::take(&mut e.deps));
     if let Some(sig_keys) = sig_keys {
         SIGNAL_DEPS.with(|d| {
             let mut d = d.borrow_mut();
@@ -256,7 +356,10 @@ fn clear_deps_for(id: EffectId) {
 }
 
 fn run_cleanups(id: EffectId) {
-    let pending: Option<Vec<CleanupFn>> = CLEANUPS.with(|c| c.borrow_mut().remove(&id));
+    // Take the cleanups out under a short borrow, then run them with no
+    // slab borrow held — a cleanup may re-enter (e.g. release another
+    // effect, mutating the slab).
+    let pending: Option<Vec<CleanupFn>> = with_effect_mut(id, |e| std::mem::take(&mut e.cleanups));
     if let Some(pending) = pending {
         for f in pending {
             f();
@@ -265,24 +368,46 @@ fn run_cleanups(id: EffectId) {
 }
 
 /// Remove an effect entirely; all its dependency edges go with it.
+/// RFC-098 H2 — one slab `remove`, so the lifecycle is atomic; a
+/// double-release or a stale id is a no-op (generation mismatch).
 pub fn release(id: EffectId) {
     // Final cleanups run first: an effect that opens a resource should
-    // close it before it ceases to exist.
+    // close it before it ceases to exist. (These take from the entry,
+    // so they must precede the removal below.)
     run_cleanups(id);
     clear_deps_for(id);
-    EFFECTS.with(|e| e.borrow_mut().remove(&id));
-    SCHEDULERS.with(|s| s.borrow_mut().remove(&id));
-    QUEUE.with(|q| {
-        // shift_remove keeps any concurrently-queued effects in order.
-        q.borrow_mut().shift_remove(&id);
+    let (slot, generation) = unpack_effect_id(id);
+    let removed = EFFECT_SLAB.with(|s| {
+        let mut s = s.borrow_mut();
+        // Only remove when the id is live — guards double-release and
+        // stale ids from evicting a slot's newer occupant.
+        if s.get(slot).is_some_and(|e| e.generation == generation) {
+            s.remove(slot);
+            true
+        } else {
+            false
+        }
     });
+    if removed {
+        // Bump the slot's generation so its next occupant gets a fresh
+        // id and this id (now stale) resolves to None forever.
+        EFFECT_GENERATIONS.with(|g| {
+            if let Some(slot_gen) = g.borrow_mut().get_mut(slot) {
+                *slot_gen = slot_gen.wrapping_add(1);
+            }
+        });
+        QUEUE.with(|q| {
+            // shift_remove keeps any concurrently-queued effects in order.
+            q.borrow_mut().shift_remove(&id);
+        });
+    }
 }
 
 /// Register a function to run when the enclosing effect reruns or is
 /// released. No-op when called outside an effect.
 pub fn on_cleanup(f: impl FnOnce() + 'static) {
     let Some(id) = current_effect() else { return };
-    CLEANUPS.with(|c| c.borrow_mut().entry(id).or_default().push(Box::new(f)));
+    with_effect_mut(id, |e| e.cleanups.push(Box::new(f)));
 }
 
 /// RFC-095 W3a — resolve (or lazily mint) the `SignalId` interned
@@ -355,9 +480,12 @@ pub fn track_signal(signal_id: SignalId) {
     SIGNAL_DEPS.with(|d| {
         d.borrow_mut().entry(signal_id).or_default().insert(id);
     });
-    SIGNAL_REVERSE.with(|r| {
-        r.borrow_mut().entry(id).or_default().insert(signal_id);
-    });
+    // Record the inverse edge in the effect's own entry (was
+    // SIGNAL_REVERSE). `current_effect()` is set only while a live
+    // effect runs, so the entry exists; if it somehow doesn't (stale),
+    // this no-ops — the forward edge above is harmless on its own (it
+    // just dispatches to an id that resolves to None).
+    with_effect_mut(id, |e| e.deps.insert(signal_id));
 }
 
 /// Dispatch signal `sid`: snapshot its subscribers under a short
@@ -411,11 +539,17 @@ fn dispatch_signal(sid: SignalId) {
                 .unwrap_or_default()
         });
         for eid in local {
-            let sched = SCHEDULERS.with(|s| s.borrow().get(&eid).cloned());
+            // Resolve the subscriber's scheduler, cloned out so the slab
+            // borrow drops before it runs. Three outcomes:
+            //   None         — stale id (released mid-dispatch): skip.
+            //   Some(None)    — live, no scheduler: queue for flush.
+            //   Some(Some(s)) — live computed/custom: run inline.
+            let sched = with_effect(eid, |e| e.scheduler.clone());
             match sched {
+                None => continue,
                 // Inline; any trigger it fires lands in WORKLIST above.
-                Some(s) => s(eid),
-                None => {
+                Some(Some(s)) => s(eid),
+                Some(None) => {
                     QUEUE.with(|q| {
                         q.borrow_mut().insert(eid);
                     });
@@ -486,8 +620,9 @@ pub fn trigger_signal(signal_id: SignalId) {
 /// cleanups. Effects associated with the scope are independently
 /// released via `mount::release_subtree` → `release(EffectId)`;
 /// this evicts the scope's interned field signals and their
-/// subscriber lists. Stale `SIGNAL_REVERSE` entries on
-/// still-living effects degrade to no-ops at their release.
+/// subscriber lists. A still-living effect's inverse dep set (in its
+/// slab entry) may briefly name an evicted signal; that entry just
+/// won't be found at the effect's next teardown — a harmless no-op.
 pub fn clear_scope(scope_id: ScopeId) {
     let sids: Vec<SignalId> = FIELD_SIGNALS.with(|f| {
         f.borrow_mut()
@@ -607,9 +742,12 @@ fn flush() {
     // in the next batch, not the current one.
     let ids: Vec<EffectId> = QUEUE.with(|q| q.borrow_mut().drain(..).collect());
     for id in ids {
-        let f = EFFECTS.with(|e| e.borrow().get(&id).cloned());
-        if let Some(f) = f {
-            run_effect(id, &f);
+        // Clone the body out (Rc bump) and drop the slab borrow before
+        // running it. A `None` means the effect was released after it
+        // was queued — skip it.
+        let body = with_effect(id, |e| e.body.clone());
+        if let Some(body) = body {
+            run_effect(id, &body);
         }
     }
 }
@@ -617,9 +755,9 @@ fn flush() {
 /// Force-rerun a specific effect right now. Used by primitives like
 /// `computed` that drive their own scheduling via [`EffectOptions`].
 pub fn run_now(id: EffectId) {
-    let f = EFFECTS.with(|e| e.borrow().get(&id).cloned());
-    if let Some(f) = f {
-        run_effect(id, &f);
+    let body = with_effect(id, |e| e.body.clone());
+    if let Some(body) = body {
+        run_effect(id, &body);
     }
 }
 
@@ -640,7 +778,7 @@ pub fn stats() -> (usize, usize) {
     // surface) — same growth signal the health panel watched.
     let dep_count =
         FIELD_SIGNALS.with(|f| f.borrow().values().map(|inner| inner.len()).sum::<usize>());
-    (EFFECTS.with(|e| e.borrow().len()), dep_count)
+    (EFFECT_SLAB.with(|s| s.borrow().len()), dep_count)
 }
 
 // ── devtools read-only snapshots ─────────────────────────────────
@@ -689,7 +827,7 @@ pub fn signal_graph_snapshot() -> Vec<SignalSnapshot> {
 /// microtask queue.
 #[cfg(feature = "devtools")]
 pub fn is_scheduler_routed(id: EffectId) -> bool {
-    SCHEDULERS.with(|s| s.borrow().contains_key(&id))
+    with_effect(id, |e| e.scheduler.is_some()).unwrap_or(false)
 }
 
 // Keep unused-import noise away when `wasm-bindgen-futures` features drift.

--- a/crates/pocopine-core/tests/reactive.rs
+++ b/crates/pocopine-core/tests/reactive.rs
@@ -1171,3 +1171,48 @@ fn slab_generation_reuse_rejects_stale_id() {
         "fresh effect at the reused slot still reacts"
     );
 }
+
+/// H3 + H4 — when inline schedulers defer downstream signals to the
+/// worklist, sibling branches drain FIFO (trigger order). With the old
+/// LIFO drain the two branches would queue in reverse; this asserts the
+/// registration-order guarantee across a diamond. (Single-signal order
+/// is covered by `dispatch_runs_effects_in_subscription_order`.)
+#[wasm_bindgen_test]
+fn worklist_preserves_fifo_sibling_order() {
+    setup();
+    let (s, set_s) = signal(0_i32);
+
+    // Two computeds read `s`; created C1 then C2.
+    let s_1 = s.clone();
+    let c1 = Rc::new(computed(move || s_1.get() + 1));
+    let s_2 = s.clone();
+    let c2 = Rc::new(computed(move || s_2.get() + 1));
+
+    let order: Rc<RefCell<Vec<&'static str>>> = Rc::new(RefCell::new(Vec::new()));
+
+    // E_x reads C1, E_y reads C2 — created in that order, so `s`'s
+    // subscriber order (and thus the worklist push order) is [C1, C2].
+    let c1_e = c1.clone();
+    let order_x = order.clone();
+    effect(move || {
+        c1_e.get();
+        order_x.borrow_mut().push("x");
+    });
+    let c2_e = c2.clone();
+    let order_y = order.clone();
+    effect(move || {
+        c2_e.get();
+        order_y.borrow_mut().push("y");
+    });
+
+    order.borrow_mut().clear(); // discard initial-run records
+    set_s.set(5);
+    flush_sync();
+    // C1 deferred before C2; FIFO drain dispatches C1 first, so E_x
+    // queues and runs before E_y. (LIFO would give ["y", "x"].)
+    assert_eq!(
+        *order.borrow(),
+        vec!["x", "y"],
+        "cross-branch sibling effects must keep FIFO trigger order"
+    );
+}

--- a/crates/pocopine-core/tests/reactive.rs
+++ b/crates/pocopine-core/tests/reactive.rs
@@ -3,14 +3,14 @@
 
 #![cfg(target_arch = "wasm32")]
 
-use std::cell::Cell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use js_sys::Reflect;
 use pocopine_core::{
-    batch, computed, effect, flush_sync, on_cleanup, on_scope_unmount_for, release, rw_signal,
-    set_auto_flush, signal, spawn_for_scope, spawn_latest, spawn_latest_for_scope, spawn_scoped,
-    watch, watch_scope_field_now, Scope,
+    batch, computed, effect, flush_sync, on_cleanup, on_scope_unmount_for, release, run_now,
+    rw_signal, set_auto_flush, signal, spawn_for_scope, spawn_latest, spawn_latest_for_scope,
+    spawn_scoped, watch, watch_scope_field_now, Scope,
 };
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::JsValue;
@@ -1010,4 +1010,164 @@ fn differential_fuzz_fine_grained_matches_oracle() {
             );
         }
     }
+}
+
+// ── RFC-098 core-hardening gates ─────────────────────────────────
+
+/// H4 — dispatch + flush visit subscribers in registration order,
+/// deterministically (was `HashSet`, varied per run). The observable
+/// guarantee that makes a fuzz failure replay from its seed.
+#[wasm_bindgen_test]
+fn dispatch_runs_effects_in_subscription_order() {
+    setup();
+    let (s, setter) = signal(0_i32);
+    let order: Rc<RefCell<Vec<i32>>> = Rc::new(RefCell::new(Vec::new()));
+    // Five effects subscribe to `s` in order 0..5 (subscription order
+    // == creation order, since each tracks on its initial run).
+    for k in 0..5 {
+        let order_w = order.clone();
+        let s_k = s.clone();
+        effect(move || {
+            s_k.get();
+            order_w.borrow_mut().push(k);
+        });
+    }
+    order.borrow_mut().clear(); // discard the initial-run records
+    setter.set(1);
+    flush_sync();
+    assert_eq!(
+        *order.borrow(),
+        vec![0, 1, 2, 3, 4],
+        "H4: effects must dispatch in registration order"
+    );
+}
+
+/// H1 + H2 — an effect released by another effect mid-flush is safe:
+/// no panic (the snapshot borrow is dropped before bodies run), and
+/// the released effect's id resolves to None (never reruns, stale ops
+/// are inert).
+#[wasm_bindgen_test]
+fn release_during_dispatch_is_safe() {
+    setup();
+    let (s, setter) = signal(0_i32);
+    let a_runs = Rc::new(Cell::new(0));
+    let b_runs = Rc::new(Cell::new(0));
+
+    // A subscribes first, so it dispatches first (H4). When armed, A's
+    // rerun releases B before B's turn in the same flush.
+    let target: Rc<Cell<Option<pocopine_core::EffectId>>> = Rc::new(Cell::new(None));
+    let a_runs_w = a_runs.clone();
+    let s_a = s.clone();
+    let target_a = target.clone();
+    effect(move || {
+        s_a.get();
+        a_runs_w.set(a_runs_w.get() + 1);
+        if let Some(b) = target_a.take() {
+            release(b);
+        }
+    });
+
+    let b_runs_w = b_runs.clone();
+    let s_b = s.clone();
+    let b_id = effect(move || {
+        s_b.get();
+        b_runs_w.set(b_runs_w.get() + 1);
+    });
+
+    assert_eq!(a_runs.get(), 1);
+    assert_eq!(b_runs.get(), 1); // both ran once on creation
+
+    // Arm the release, then trigger: A reruns and releases B mid-flush.
+    target.set(Some(b_id));
+    setter.set(1);
+    flush_sync();
+    assert_eq!(a_runs.get(), 2);
+    assert_eq!(
+        b_runs.get(),
+        1,
+        "B must not rerun after release mid-dispatch"
+    );
+
+    // The stale id is inert and does not touch A; A still reacts.
+    release(b_id); // no-op, no panic
+    run_now(b_id); // no-op, no panic
+    setter.set(2);
+    flush_sync();
+    assert_eq!(a_runs.get(), 3);
+    assert_eq!(b_runs.get(), 1);
+}
+
+/// H3 — a chain of computeds (A→B→C) propagates through the trampoline
+/// without recursion: an inline scheduler's downstream trigger lands on
+/// the worklist, drained by the outermost dispatch. The reading effect
+/// sees the fully-propagated value, each computed recomputes lazily.
+#[wasm_bindgen_test]
+fn scheduler_triggers_scheduler_three_deep() {
+    setup();
+    let (src, set_src) = signal(2_i32);
+
+    let src_a = src.clone();
+    let a = Rc::new(computed(move || src_a.get() + 1)); // 3
+    let a_b = a.clone();
+    let b = Rc::new(computed(move || a_b.get() * 2)); // 6
+    let b_c = b.clone();
+    let c = Rc::new(computed(move || b_c.get() + 10)); // 16
+
+    let seen = Rc::new(Cell::new(0));
+    let evals = Rc::new(Cell::new(0));
+    let seen_w = seen.clone();
+    let evals_w = evals.clone();
+    let c_eff = c.clone();
+    effect(move || {
+        evals_w.set(evals_w.get() + 1);
+        seen_w.set(c_eff.get());
+    });
+    assert_eq!(seen.get(), 16);
+    let evals_after_init = evals.get();
+
+    // One source mutation propagates A→B→C→effect in a single dispatch.
+    set_src.set(5);
+    flush_sync();
+    assert_eq!(seen.get(), (5 + 1) * 2 + 10); // 22
+    assert_eq!(
+        evals.get(),
+        evals_after_init + 1,
+        "the reading effect must rerun exactly once for a 3-deep chain"
+    );
+}
+
+/// H2 — releasing an effect frees its slab slot; the next effect reuses
+/// it under a bumped generation, so the freed id is distinct and stays
+/// inert (ABA safety).
+#[wasm_bindgen_test]
+fn slab_generation_reuse_rejects_stale_id() {
+    setup();
+    let stale = effect(|| {});
+    release(stale);
+
+    // The next effect reuses the freed slot with generation + 1.
+    let (s, setter) = signal(0_i32);
+    let runs = Rc::new(Cell::new(0));
+    let runs_w = runs.clone();
+    let s_c = s.clone();
+    let fresh = effect(move || {
+        s_c.get();
+        runs_w.set(runs_w.get() + 1);
+    });
+    assert_ne!(
+        stale, fresh,
+        "reused slot must mint a distinct id (generation bump)"
+    );
+    assert_eq!(runs.get(), 1);
+
+    // Stale-id operations are no-ops and must not disturb `fresh`.
+    release(stale);
+    run_now(stale);
+    setter.set(1);
+    flush_sync();
+    assert_eq!(
+        runs.get(),
+        2,
+        "fresh effect at the reused slot still reacts"
+    );
 }


### PR DESCRIPTION
Implements [RFC-098](rfcs/rfc-098-core-hardening.md). Hardens the reactive core's **failure surface** — effect state smeared across four tables permitted to disagree, re-entrancy that was survived rather than impossible, and nondeterministic dispatch order that made rare bugs unreplayable. Judged by correctness + maintainability; **zero public API change, zero authoring change**, performance required only to be neutral.

All changes are confined to `crates/pocopine-core/src/reactive.rs` (+ two manifest deps, a devtools doc, and the test file). Landed in RFC phase order, one bisectable commit each.

## The four changes

```mermaid
flowchart LR
    subgraph Before
        direction TB
        A1["EFFECTS / SCHEDULERS / CLEANUPS /<br/>SIGNAL_REVERSE — 4 tables, may disagree"]
        H1b["HashSet subs + QUEUE<br/>order varies per run"]
        R1["recursive dispatch + scratch dance"]
    end
    subgraph After
        direction TB
        S["Slab of EffectEntry<br/>one atomic entry per effect"]
        H4["IndexSet subs + QUEUE<br/>insertion-ordered"]
        TR["trampoline: depth flag + FIFO worklist"]
    end
    Before ==> After
```

| | Change | Why |
|---|---|---|
| **H4** | `SIGNAL_DEPS` values + `QUEUE` → `indexmap::IndexSet` (removals use `shift_remove`) | `HashSet` iteration order varied per run → an order-dependent bug was an unreplayable fuzz failure. Now every W0 differential-fuzz failure **replays from its seed**. Same asymptotics. |
| **H1** | `dispatch_subs(&set)` → `dispatch_signal(sid)`: one local snapshot under a short borrow | The old path cloned the subscriber set **and** copied it into a thread-local scratch (whose sole purpose was avoiding that clone), guarded by a `mem::take`/restore dance. Collapsed to one copy; `TRIGGER_SCRATCH` deleted. |
| **H3** | Trampoline: `DISPATCH_DEPTH` + a FIFO `VecDeque` worklist | A computed scheduler can `trigger_signal` its own subs, re-entering dispatch mid-iteration. Now a re-entrant trigger appends to the worklist and unwinds; the outermost call drains it. Re-entrancy is **structurally impossible**, not defended — the scratch dance (which commemorated two real crashes) is gone. |
| **H2** | `EFFECTS`+`SCHEDULERS`+`CLEANUPS`+`SIGNAL_REVERSE` → one `Slab<EffectEntry>` | Four parallel tables, permitted to disagree, every lifecycle op visiting all of them. Now `release(id)` removes **one** entry (atomic). `EffectId = generation<<32 \| slot` (still `Copy u64`); a stale id (slot reused) resolves to `None` via generation mismatch — forgetting-is-safe preserved, now O(1) with slot reuse. |

`ScopeId`/`SignalId` keep the `NEXT_ID` counter; only effects move to slab addressing. No ownership tree (the DOM via `release_subtree` **is** the hierarchy — RFC non-goal).

## Verification

| Gate | Result |
|---|---|
| W0 reactive battery — `wasm-pack test --node` (default / `--features devtools`) | ✅ **30 / 33** — incl. the differential fuzz + 5 new RFC-098 §4 tests |
| Consumer mount/emit (`rfc_056_emit`, node) · keyed-list (`template_plan`, firefox) | ✅ **9 · 43** |
| `EffectId(0)` / cross-type-id / sentinel scan | ✅ none — `EffectId` is opaque to all consumers |
| `cargo clippy --target wasm32 --all-features -Dwarnings` · `cargo fmt --all` | ✅ clean |
| **Perf A/B** (chromium, reversed double-run, vs `main`) | ✅ geomean **−0.4% / −1.5%** (branch slightly faster) — neutral within ±2% |

**New tests** (RFC-098 §4): `dispatch_runs_effects_in_subscription_order` (H4), `release_during_dispatch_is_safe` (H1/H2), `scheduler_triggers_scheduler_three_deep` (H3), `slab_generation_reuse_rejects_stale_id` (H2), `worklist_preserves_fifo_sibling_order` (H3 FIFO).

## Adversarial review

A multi-agent review attacked each invariant (determinism, borrow discipline, slab ABA, perf, API surface). **Zero must-fix.** Three should-consider refinements were applied in the final commit:
- worklist **LIFO → FIFO** so cross-branch sibling effects keep trigger order (honoring H4's registration-order invariant; matches `main`);
- the f64-range generation guard promoted from `debug_assert!` to a release `assert!` (silent corruption → loud, at the 2²¹-slot-reuse ceiling);
- stale doc fixes (`NEXT_ID` "0 unallocated" now only applies to Scope/Signal; devtools `fire_queue_change` fires once per outermost dispatch).

The one rejected "must-fix" (`DISPATCH_DEPTH` stuck on a scheduler panic) is moot: `panic = "abort"` on `wasm32` — no unwinding, nothing to corrupt, and not a regression (the old scratch had the identical property).

## Note

The perf A/B is a headless-chromium pair in a dev VM — decisively neutral here, but the canonical ±2% certification belongs in a stable CI bench env. The two theoretical watch-items are `shift_remove` (teardown-only) and H1's per-dispatch `Vec` alloc; neither showed in the A/B (`clear` is −3.5%, `runLots` +0.2%). Cheap remedy ready if a regression ever surfaces: a depth-guarded reusable snapshot buffer.
