### PR TITLE
rfc-101: per-row mount allocation hardening (P1–P4: ~10→1 alloc/row)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5866,6 +5866,7 @@ dependencies = [
  "serde-wasm-bindgen 0.6.5",
  "serde_json",
  "slab",
+ "smallvec",
  "unicode-segmentation",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,6 +131,9 @@ pine-richtext = { path = "crates/pine-richtext", version = "0.1.0" }
 # insertion-ordered regardless of hasher. Both are wasm32-proven.
 indexmap = { version = "2" }
 slab = { version = "0.4" }
+# RFC-101 P1 — inline per-row RowInstance vecs (binding_cache,
+# listener_routes) so the common small row mounts with zero heap blocks.
+smallvec = { version = "1" }
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"

--- a/crates/pocopine-core/Cargo.toml
+++ b/crates/pocopine-core/Cargo.toml
@@ -64,6 +64,9 @@ indexmap = { workspace = true }
 # (body + scheduler + cleanups + signal deps), replacing four parallel
 # tables. EffectId = generation<<32 | slot; stale ids resolve to None.
 slab = { workspace = true }
+# RFC-101 P1 — inline the per-row RowInstance vecs (binding_cache,
+# listener_routes) so a small row mounts with zero heap blocks.
+smallvec = { workspace = true }
 
 [dependencies.web-sys]
 version = "0.3"

--- a/crates/pocopine-core/src/directives/for_.rs
+++ b/crates/pocopine-core/src/directives/for_.rs
@@ -120,9 +120,14 @@ fn first_layout_child(el: &Element) -> Option<Element> {
     children.item(0)
 }
 
-fn retract_from_prior(prior: &Rc<RefCell<Vec<PrevItem>>>, key: &Rc<str>) {
+fn retract_from_prior(prior: &Rc<RefCell<Vec<PrevItem>>>, key: &RowKey) {
     let mut p = prior.borrow_mut();
-    p.retain(|item| !(Rc::ptr_eq(&item.key, key) && item.leaving));
+    // RFC-101 P3 — value equality, not `Rc::ptr_eq`: `RowKey::Int`
+    // has no pointer identity. The retract callback is handed a clone
+    // of the leaver's own key (`key_for_retract`), so `==` matches the
+    // same logical row; this is strictly more correct than pointer
+    // identity and only runs on the (cold) leave path.
+    p.retain(|item| !(item.key == *key && item.leaving));
 }
 
 /// Fire enter-subtree on every `el` in `clones`, spacing them by
@@ -549,9 +554,9 @@ fn run_naive(
 /// `LoopScope` in place on reuse without serializing through JS.
 ///
 /// The key is shared between `PrevItem`, the pool lookup, and the
-/// dedup-tracking set via `Rc<str>` — one allocation per unique
-/// key per reconcile instead of two (the HashSet insert used to
-/// clone a fresh `String`).
+/// dedup-tracking set via [`RowKey`] — integer keys (the common
+/// case) cost zero heap allocations; the dup-set insert clones an
+/// `i64`, not a fresh `String`.
 ///
 /// `leaving` is true while the clone is mid-leave (its transition
 /// is playing; the remove-from-DOM callback hasn't fired). We keep
@@ -562,7 +567,7 @@ struct PrevItem {
     element: Element,
     scope_id: ScopeId,
     loop_state: Rc<RefCell<LoopScope>>,
-    key: Rc<str>,
+    key: RowKey,
     item_value: JsValue,
     item_sig: String,
     leaving: bool,
@@ -570,7 +575,7 @@ struct PrevItem {
 
 /// One minted-but-unmounted channel row: scope id, pool key,
 /// item value, and the row's LoopScope.
-type ChannelRowMeta = (ScopeId, Rc<str>, JsValue, Rc<RefCell<LoopScope>>);
+type ChannelRowMeta = (ScopeId, RowKey, JsValue, Rc<RefCell<LoopScope>>);
 
 /// RFC-095 W4 — mount `pairs.len()` fresh rows (indices
 /// `start..start+pairs.len()` of `arr`) through the mutation
@@ -588,7 +593,7 @@ fn channel_mount_range(
     arr: &Array,
     start: usize,
     total: usize,
-    pairs: Vec<(Rc<str>, JsValue)>,
+    pairs: Vec<(RowKey, JsValue)>,
     item_name: &Rc<str>,
     parent_scope_id: ScopeId,
     inject_parent_id: ScopeId,
@@ -694,7 +699,7 @@ fn create_keyed_prev_item(
     parent_scope_id: ScopeId,
     inject_parent_id: ScopeId,
     template: &ForTemplate,
-    key: Rc<str>,
+    key: RowKey,
     body: Option<crate::directives::for_plan::ForBodyFn>,
     elide_proxy: bool,
 ) -> Option<PrevItem> {
@@ -790,7 +795,7 @@ fn try_append_fast_path(
     arr: &Array,
     total: usize,
     mut old_prior: Vec<PrevItem>,
-    seen_cell: &Rc<RefCell<HashSet<Rc<str>>>>,
+    seen_cell: &Rc<RefCell<HashSet<RowKey>>>,
     key_resolver: &KeyResolver,
     item_name: &Rc<str>,
     parent_proxy: &JsValue,
@@ -849,22 +854,11 @@ fn try_append_fast_path(
     if elide_proxy && crate::mutation_channel::enabled() {
         if let (Some(plan), Some(proto)) = (row_plan, template.prototype()) {
             if let Some(slot) = crate::directives::for_plan::channel_slot(plan) {
-                let mut pairs: Vec<(Rc<str>, JsValue)> = Vec::with_capacity(total - old_len);
+                let mut pairs: Vec<(RowKey, JsValue)> = Vec::with_capacity(total - old_len);
                 for i in old_len..total {
                     let item = arr.get(i as u32);
                     let key_val = key_resolver.resolve(&item, i, parent_proxy);
-                    let raw_key: Rc<str> = stringify_key(&key_val).into();
-                    let key = if seen.insert(raw_key.clone()) {
-                        raw_key
-                    } else {
-                        console::warn_1(&JsValue::from_str(&format!(
-                            "pp-for: duplicate pp-key {:?} at index {i}; treating as new",
-                            &*raw_key
-                        )));
-                        let dup: Rc<str> = format!("{}__dup_{i}", &*raw_key).into();
-                        seen.insert(dup.clone());
-                        dup
-                    };
+                    let key = dedup_row_key(&key_val, &mut seen, i);
                     pairs.push((key, item));
                 }
                 crate::profiler::reconcile::record_row_iter(row_iter_start);
@@ -904,18 +898,7 @@ fn try_append_fast_path(
     for i in old_len..total {
         let item = arr.get(i as u32);
         let key_val = key_resolver.resolve(&item, i, parent_proxy);
-        let raw_key: Rc<str> = stringify_key(&key_val).into();
-        let key = if seen.insert(raw_key.clone()) {
-            raw_key
-        } else {
-            console::warn_1(&JsValue::from_str(&format!(
-                "pp-for: duplicate pp-key {:?} at index {i}; treating as new",
-                &*raw_key
-            )));
-            let dup: Rc<str> = format!("{}__dup_{i}", &*raw_key).into();
-            seen.insert(dup.clone());
-            dup
-        };
+        let key = dedup_row_key(&key_val, &mut seen, i);
         let Some(entry) = create_keyed_prev_item(
             item_name,
             item,
@@ -984,7 +967,7 @@ fn try_prepend_fast_path(
     arr: &Array,
     total: usize,
     old_prior: Vec<PrevItem>,
-    seen_cell: &Rc<RefCell<HashSet<Rc<str>>>>,
+    seen_cell: &Rc<RefCell<HashSet<RowKey>>>,
     key_resolver: &KeyResolver,
     item_name: &Rc<str>,
     parent_proxy: &JsValue,
@@ -1046,18 +1029,7 @@ fn try_prepend_fast_path(
     for i in 0..added {
         let item = arr.get(i as u32);
         let key_val = key_resolver.resolve(&item, i, parent_proxy);
-        let raw_key: Rc<str> = stringify_key(&key_val).into();
-        let key = if seen.insert(raw_key.clone()) {
-            raw_key
-        } else {
-            console::warn_1(&JsValue::from_str(&format!(
-                "pp-for: duplicate pp-key {:?} at index {i}; treating as new",
-                &*raw_key
-            )));
-            let dup: Rc<str> = format!("{}__dup_{i}", &*raw_key).into();
-            seen.insert(dup.clone());
-            dup
-        };
+        let key = dedup_row_key(&key_val, &mut seen, i);
         let Some(entry) = create_keyed_prev_item(
             item_name,
             item,
@@ -1344,8 +1316,8 @@ fn run_keyed(
     // reusing them keeps rehash / grow costs out of the hot path
     // for long-lived lists (N items reconciled K times allocates
     // once, not K times).
-    let pool_cell: Rc<RefCell<HashMap<Rc<str>, PrevItem>>> = Rc::new(RefCell::new(HashMap::new()));
-    let seen_cell: Rc<RefCell<HashSet<Rc<str>>>> = Rc::new(RefCell::new(HashSet::new()));
+    let pool_cell: Rc<RefCell<HashMap<RowKey, PrevItem>>> = Rc::new(RefCell::new(HashMap::new()));
+    let seen_cell: Rc<RefCell<HashSet<RowKey>>> = Rc::new(RefCell::new(HashSet::new()));
     // RFC-095 W1 — see run_naive's items_reader note.
     let items_reader = crate::scope::scoped_root_reader(parent_scope_id);
 
@@ -1527,22 +1499,11 @@ fn run_keyed(
         if pool_initially_empty && total > 0 && elide_proxy && crate::mutation_channel::enabled() {
             if let (Some(plan), Some(proto)) = (row_plan.as_ref(), template.prototype()) {
                 if let Some(slot) = crate::directives::for_plan::channel_slot(plan) {
-                    let mut pairs: Vec<(Rc<str>, JsValue)> = Vec::with_capacity(total);
+                    let mut pairs: Vec<(RowKey, JsValue)> = Vec::with_capacity(total);
                     for i in 0..total {
                         let item = arr.get(i as u32);
                         let key_val = key_resolver.resolve(&item, i, &parent_proxy);
-                        let raw_key: Rc<str> = stringify_key(&key_val).into();
-                        let key: Rc<str> = if seen.insert(raw_key.clone()) {
-                            raw_key
-                        } else {
-                            console::warn_1(&JsValue::from_str(&format!(
-                                "pp-for: duplicate pp-key {:?} at index {i}; treating as new",
-                                &*raw_key
-                            )));
-                            let dup: Rc<str> = format!("{}__dup_{i}", &*raw_key).into();
-                            seen.insert(dup.clone());
-                            dup
-                        };
+                        let key = dedup_row_key(&key_val, &mut seen, i);
                         pairs.push((key, item));
                     }
                     crate::profiler::reconcile::record_row_iter(row_iter_start);
@@ -1577,7 +1538,6 @@ fn run_keyed(
         for i in 0..total {
             let item = arr.get(i as u32);
             let key_val = key_resolver.resolve(&item, i, &parent_proxy);
-            let raw_key: Rc<str> = stringify_key(&key_val).into();
             // Cold-pool optimisation: skip the `item_signature`
             // (only meaningful across reconciles) and the
             // `pool.remove` (always None when pool is empty).
@@ -1595,17 +1555,7 @@ fn run_keyed(
                 // DOM's point of view and JSON.stringify is pure waste.
                 String::new()
             };
-            let key: Rc<str> = if seen.insert(raw_key.clone()) {
-                raw_key
-            } else {
-                console::warn_1(&JsValue::from_str(&format!(
-                    "pp-for: duplicate pp-key {:?} at index {i}; treating as new",
-                    &*raw_key
-                )));
-                let dup: Rc<str> = format!("{}__dup_{i}", &*raw_key).into();
-                seen.insert(dup.clone());
-                dup
-            };
+            let key = dedup_row_key(&key_val, &mut seen, i);
 
             let pool_lookup = if pool_initially_empty {
                 None
@@ -1767,7 +1717,7 @@ fn run_keyed(
         // reuses the clone — instead of spawning a duplicate next to
         // the still-leaving original. The remove callback retracts
         // the entry from `prior` once the clone is truly gone.
-        let mut leaver_flip_snapshots: HashMap<Rc<str>, (Element, web_sys::DomRect)> =
+        let mut leaver_flip_snapshots: HashMap<RowKey, (Element, web_sys::DomRect)> =
             if pool.is_empty() {
                 HashMap::new()
             } else {
@@ -1874,7 +1824,7 @@ fn run_keyed(
                 let el = entry.element.clone();
                 let el_for_cb = el.clone();
                 let scope_id_for_unmount = entry.scope_id;
-                let key_for_retract = Rc::clone(&entry.key);
+                let key_for_retract = entry.key.clone();
                 let prior_for_retract = prior.clone();
                 if !crate::directives::transition::has_transition_in_subtree(&el) {
                     if let Some(parent) = el.parent_node() {
@@ -1965,7 +1915,7 @@ fn run_keyed(
         // `getBoundingClientRect` on it returns zero. The visible
         // layout box lives on the inner rendered root (the first
         // element child). Snapshot + animate that.
-        let mut flip_snapshots: HashMap<Rc<str>, (Element, web_sys::DomRect)> = HashMap::new();
+        let mut flip_snapshots: HashMap<RowKey, (Element, web_sys::DomRect)> = HashMap::new();
         if has_leavers {
             flip_snapshots = std::mem::take(&mut leaver_flip_snapshots);
         } else if !already_ordered {
@@ -2250,6 +2200,68 @@ impl KeyResolver {
 /// Canonicalise a key value to a string. Strings come through
 /// unwrapped so adjacent hashes (`123` as number vs. string) don't
 /// collide with their JSON-quoted form.
+/// RFC-101 P3 — a row's reconcile key. The common case (`pp-key`
+/// over numeric ids, e.g. jsbench `Row.id: usize`) is an integer that
+/// carries NO heap allocation; everything else falls back to the
+/// canonical string form (byte-identical to [`stringify_key`], so
+/// string keys are unchanged on the wire).
+///
+/// Derived `Eq`/`Hash` discriminate on the variant first, so `Int(5)`
+/// and `Str("5")` never compare equal or collide — which is also the
+/// correct semantics (a stable `pp-key` expression keys a given list
+/// on one shape, never both) and removes a latent collision the
+/// all-`String` form had (numeric `5` stringified to `"5"` and *would*
+/// have aliased a string key `"5"`).
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+enum RowKey {
+    Int(i64),
+    Str(Rc<str>),
+}
+
+impl std::fmt::Display for RowKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RowKey::Int(n) => write!(f, "{n}"),
+            RowKey::Str(s) => f.write_str(s),
+        }
+    }
+}
+
+/// Largest f64 that round-trips exactly through an integer (2^53).
+/// JS numbers beyond this lose integer precision, so two distinct ids
+/// could alias to the same `i64` — those fall back to the string form.
+const MAX_EXACT_INT_F64: f64 = 9_007_199_254_740_992.0;
+
+/// Resolve a JS key value to a [`RowKey`]. Integral, in-range numbers
+/// take the zero-alloc `Int` path; strings/bools/null/objects reuse
+/// [`stringify_key`] verbatim for a byte-identical `Str` key.
+fn row_key(v: &JsValue) -> RowKey {
+    if let Some(n) = v.as_f64() {
+        if n.is_finite() && n.fract() == 0.0 && n.abs() < MAX_EXACT_INT_F64 {
+            return RowKey::Int(n as i64);
+        }
+    }
+    RowKey::Str(stringify_key(v).into())
+}
+
+/// Resolve a row's key and disambiguate duplicates against `seen`,
+/// matching the prior inline behaviour: a repeat key warns and is
+/// re-mounted under a synthetic `…__dup_<i>` string key. Shared by
+/// every append/prepend/mount construction site.
+fn dedup_row_key(key_val: &JsValue, seen: &mut HashSet<RowKey>, i: usize) -> RowKey {
+    let raw_key = row_key(key_val);
+    if seen.insert(raw_key.clone()) {
+        raw_key
+    } else {
+        console::warn_1(&JsValue::from_str(&format!(
+            "pp-for: duplicate pp-key {raw_key} at index {i}; treating as new"
+        )));
+        let dup = RowKey::Str(format!("{raw_key}__dup_{i}").into());
+        seen.insert(dup.clone());
+        dup
+    }
+}
+
 fn stringify_key(v: &JsValue) -> String {
     if v.is_undefined() || v.is_null() {
         return String::new();

--- a/crates/pocopine-core/src/directives/for_.rs
+++ b/crates/pocopine-core/src/directives/for_.rs
@@ -24,6 +24,7 @@ use std::collections::{HashMap, HashSet};
 use std::rc::Rc;
 
 use js_sys::{Array, Object, Reflect};
+use smallvec::SmallVec;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsValue;
 use web_sys::{console, DocumentFragment, Element, HtmlTemplateElement, Node};
@@ -648,10 +649,10 @@ fn channel_mount_range(
     for (r, (scope_id, key, item, loop_rc)) in metas.into_iter().enumerate() {
         let base = (r * stride) as u32;
         let root: Element = out.get(base).unchecked_into();
-        let binding_nodes: Box<[Element]> = (0..b)
+        let binding_nodes: SmallVec<[Element; 4]> = (0..b)
             .map(|j| out.get(base + 1 + j as u32).unchecked_into())
             .collect();
-        let listener_nodes: Vec<Element> = (0..l)
+        let listener_nodes: SmallVec<[Element; 2]> = (0..l)
             .map(|j| out.get(base + 1 + (b + j) as u32).unchecked_into())
             .collect();
         channel_rows.push(crate::directives::for_plan::ChannelRow {

--- a/crates/pocopine-core/src/directives/for_plan.rs
+++ b/crates/pocopine-core/src/directives/for_plan.rs
@@ -28,6 +28,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 use js_sys::{Object, Reflect};
+use smallvec::SmallVec;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::JsValue;
@@ -1011,6 +1012,14 @@ fn nearest_component_name(el: &Element) -> Option<String> {
 /// `trigger_scope`, so update cycles skip the entire reactive
 /// dispatch + Reflect::get tracking machinery and just walk a
 /// flat array of cached values.
+/// RFC-101 P1 — the per-row binding cache, inline for the common small
+/// row (≤4 bindings) so it costs zero heap blocks; spills to the heap
+/// only for wide rows. jsbench rows have 3 bindings.
+type BindingCache = SmallVec<[Option<Rc<str>>; 4]>;
+/// RFC-101 P1 — per-row delegated listener routes, inline for ≤2
+/// listeners (jsbench rows have 2: select + remove).
+type ListenerRoutes = SmallVec<[RowListenerRoute; 2]>;
+
 struct RowInstance {
     plan: Rc<CompiledRowPlan>,
     /// Element handles resolved from `plan.bindings[i].node_path`
@@ -1020,7 +1029,7 @@ struct RowInstance {
     /// the slot is currently absent / not-yet-written. Compared
     /// against the new evaluation each tick to skip DOM writes
     /// when nothing changed.
-    binding_cache: Vec<Option<Rc<str>>>,
+    binding_cache: BindingCache,
     /// `js_sys::Proxy` for the row scope. Lazy-minted: when the
     /// plan is FastExpr-only (see [`is_proxy_elision_eligible`]),
     /// this stays `None` through mount and is built on first
@@ -1034,7 +1043,7 @@ struct RowInstance {
     loop_state: Option<Rc<RefCell<LoopScope>>>,
     /// Per-row listener routes used by the list-level delegated
     /// listener installed for compiled row plans.
-    listener_routes: Box<[RowListenerRoute]>,
+    listener_routes: ListenerRoutes,
     /// `(parent_scope_id, plan_ptr)` membership key for the
     /// list-level parent-state watcher (see [`ListWatcherKey`]).
     /// Lets the watcher iterate exactly its rows on re-fire and
@@ -1181,7 +1190,7 @@ pub(crate) fn mount_rows_compiled(
     crate::profiler::mount::record_node_path_resolution(node_path_start);
 
     let binding_start = crate::profiler::mount::start();
-    let mut binding_caches: Vec<Vec<Option<Rc<str>>>> = Vec::with_capacity(rows.len());
+    let mut binding_caches: Vec<BindingCache> = Vec::with_capacity(rows.len());
     let mut loop_states: Vec<Option<Rc<RefCell<LoopScope>>>> = Vec::with_capacity(rows.len());
     let mut parent_links: Vec<Option<ScopeId>> = Vec::with_capacity(rows.len());
     for ((_, scope_id, proxy), binding_nodes) in rows.iter().zip(resolved_binding_nodes.iter()) {
@@ -1189,7 +1198,7 @@ pub(crate) fn mount_rows_compiled(
         let parent_link = loop_state
             .as_ref()
             .map(|state| state.borrow().parent_scope_id);
-        let mut binding_cache: Vec<Option<Rc<str>>> = vec![None; plan.bindings.len()];
+        let mut binding_cache: BindingCache = SmallVec::from_elem(None, plan.bindings.len());
         {
             let loop_borrow = loop_state.as_ref().map(|state| state.borrow());
             let loop_ref = loop_borrow.as_deref();
@@ -1210,7 +1219,7 @@ pub(crate) fn mount_rows_compiled(
     crate::profiler::mount::record_initial_binding_apply(binding_start);
 
     let listener_start = crate::profiler::mount::start();
-    let mut listener_routes: Vec<Box<[RowListenerRoute]>> = Vec::with_capacity(rows.len());
+    let mut listener_routes: Vec<ListenerRoutes> = Vec::with_capacity(rows.len());
     for (row_root, _, _) in rows {
         listener_routes.push(resolve_listener_routes(plan, row_root));
         crate::profiler::mount::record_compiled_row_mounted();
@@ -1561,8 +1570,8 @@ fn apply_binding(
     }
 }
 
-fn resolve_listener_routes(plan: &CompiledRowPlan, row_root: &Element) -> Box<[RowListenerRoute]> {
-    let mut routes: Vec<RowListenerRoute> = Vec::with_capacity(plan.listeners.len());
+fn resolve_listener_routes(plan: &CompiledRowPlan, row_root: &Element) -> ListenerRoutes {
+    let mut routes: ListenerRoutes = SmallVec::with_capacity(plan.listeners.len());
     for listener in &plan.listeners {
         let Some(node) = resolve_node_path(row_root, listener.node_path) else {
             console::warn_1(&JsValue::from_str(&format!(
@@ -1577,7 +1586,7 @@ fn resolve_listener_routes(plan: &CompiledRowPlan, row_root: &Element) -> Box<[R
             ast: listener.ast.clone(),
         });
     }
-    routes.into_boxed_slice()
+    routes
 }
 
 // ─── RFC-095 W4 — mutation-channel bridge ───────────────────────
@@ -1759,7 +1768,7 @@ pub(crate) fn register_channel_rows(
     ROW_INSTANCES.with(|m| {
         let mut map = m.borrow_mut();
         for row in rows {
-            let listener_routes: Box<[RowListenerRoute]> = plan
+            let listener_routes: ListenerRoutes = plan
                 .listeners
                 .iter()
                 .zip(row.listener_nodes)
@@ -1776,7 +1785,7 @@ pub(crate) fn register_channel_rows(
                 RowInstance {
                     plan: plan.clone(),
                     binding_nodes: row.binding_nodes,
-                    binding_cache: vec![None; plan.bindings.len()],
+                    binding_cache: SmallVec::from_elem(None, plan.bindings.len()),
                     proxy: RefCell::new(None),
                     loop_state: Some(row.loop_state),
                     listener_routes,

--- a/crates/pocopine-core/src/directives/for_plan.rs
+++ b/crates/pocopine-core/src/directives/for_plan.rs
@@ -1019,12 +1019,21 @@ type BindingCache = SmallVec<[Option<Rc<str>>; 4]>;
 /// RFC-101 P1 — per-row delegated listener routes, inline for ≤2
 /// listeners (jsbench rows have 2: select + remove).
 type ListenerRoutes = SmallVec<[RowListenerRoute; 2]>;
+/// RFC-101 P2 — the per-row binding-node handles resolved at mount,
+/// inline for ≤4 bindings so the common row holds them with no heap
+/// block (was `Box<[Element]>`, one allocation per row). Spills only
+/// for wide rows.
+pub(crate) type BindingNodes = SmallVec<[Element; 4]>;
+/// RFC-101 P2 — the transient per-row listener-node handles the
+/// channel returns, inline for ≤2 listeners (was `Vec<Element>`, one
+/// allocation per row, consumed building [`ListenerRoutes`]).
+pub(crate) type ListenerNodes = SmallVec<[Element; 2]>;
 
 struct RowInstance {
     plan: Rc<CompiledRowPlan>,
     /// Element handles resolved from `plan.bindings[i].node_path`
-    /// once at mount.
-    binding_nodes: Box<[Element]>,
+    /// once at mount. RFC-101 P2 — inline for ≤4 bindings.
+    binding_nodes: BindingNodes,
     /// Last serialised value written per binding. `None` means
     /// the slot is currently absent / not-yet-written. Compared
     /// against the new evaluation each tick to skip DOM writes
@@ -1172,9 +1181,9 @@ pub(crate) fn mount_rows_compiled(
     let mut watcher: Option<ListWatcherKey> = None;
 
     let node_path_start = crate::profiler::mount::start();
-    let mut resolved_binding_nodes: Vec<Box<[Element]>> = Vec::with_capacity(rows.len());
+    let mut resolved_binding_nodes: Vec<BindingNodes> = Vec::with_capacity(rows.len());
     for (row_root, _, _) in rows {
-        let mut binding_nodes: Vec<Element> = Vec::with_capacity(plan.bindings.len());
+        let mut binding_nodes: BindingNodes = SmallVec::with_capacity(plan.bindings.len());
         for b in &plan.bindings {
             let Some(node) = resolve_node_path(row_root, b.node_path) else {
                 console::warn_1(&JsValue::from_str(&format!(
@@ -1185,7 +1194,7 @@ pub(crate) fn mount_rows_compiled(
             };
             binding_nodes.push(node);
         }
-        resolved_binding_nodes.push(binding_nodes.into_boxed_slice());
+        resolved_binding_nodes.push(binding_nodes);
     }
     crate::profiler::mount::record_node_path_resolution(node_path_start);
 
@@ -1744,8 +1753,8 @@ fn build_channel_descriptor(plan: &CompiledRowPlan) -> Option<u32> {
 /// interpreter, plus the Rust-side scope the caller minted.
 pub(crate) struct ChannelRow {
     pub scope_id: ScopeId,
-    pub binding_nodes: Box<[Element]>,
-    pub listener_nodes: Vec<Element>,
+    pub binding_nodes: BindingNodes,
+    pub listener_nodes: ListenerNodes,
     pub loop_state: Rc<RefCell<LoopScope>>,
 }
 

--- a/crates/pocopine-core/src/scope.rs
+++ b/crates/pocopine-core/src/scope.rs
@@ -348,7 +348,13 @@ impl Scope {
     pub fn new<T: ComponentState + 'static>(state: Rc<RefCell<T>>) -> Self {
         let id = next_scope_id();
         let erased: Rc<RefCell<dyn ComponentState>> = state.clone();
-        let typed: Rc<dyn Any> = Rc::new(state);
+        // RFC-101 P4 — erase `state` straight to `Rc<dyn Any>` via an
+        // unsizing coercion (a fat-pointer rebind, no heap block)
+        // instead of `Rc::new(state)`, which boxed the already-`Rc`
+        // state inside a SECOND `Rc` purely to satisfy `Any`. Saves one
+        // allocation per scope mint — per pp-for row, on the hot path.
+        // `typed()` now recovers it with `Rc::downcast` (see below).
+        let typed: Rc<dyn Any> = state;
         let scope = Scope {
             id,
             state: erased,
@@ -464,7 +470,11 @@ impl Scope {
     /// Recover the typed inner `Rc<RefCell<T>>`, if `T` matches the struct
     /// this scope was created with. `None` on type mismatch.
     pub fn typed<T: 'static>(&self) -> Option<Rc<RefCell<T>>> {
-        self.typed.downcast_ref::<Rc<RefCell<T>>>().cloned()
+        // RFC-101 P4 — `typed` now stores the state's own
+        // `Rc<RefCell<T>>` erased as `Rc<dyn Any>` (no double-Rc), so
+        // recover it by downcasting the `Rc` itself. Returns `None` on
+        // type mismatch, exactly as the old `downcast_ref` did.
+        self.typed.clone().downcast::<RefCell<T>>().ok()
     }
 
     /// Build a `js_sys::Proxy` whose `get` trap records dependencies and

--- a/rfcs/rfc-101-per-row-mount-allocation.md
+++ b/rfcs/rfc-101-per-row-mount-allocation.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Draft |
+| **Status** | Implemented (P1–P4), measured |
 | **Author** | pocopine team |
 | **Created** | 2026-06-13 |
 | **Related** | [`rfc-054`] (the compiled-row mutation channel being measured), [`rfc-096-signals-first-reactive-core.md`](./rfc-096-signals-first-reactive-core.md) (typed text lane), [`rfc-097-field-handles.md`](./rfc-097-field-handles.md) (per-field-typed codegen — the rail the typed key reuses), [`rfc-098-core-hardening.md`](./rfc-098-core-hardening.md) (the prior reactive-core hardening pass) |
@@ -15,6 +15,15 @@ Mounting a `pp-for` list costs **~10 Rust heap allocations per row**
 only to stay **neutral** and correctness gated on the W0 battery +
 keyed-symmetry. It is a follow-on to RFC-098 (which hardened the
 reactive *core*); this hardens the per-row *mount path*.
+
+**Outcome (P1–P4 shipped).** The four per-row buckets were removed in
+sequence, each measured before/after on the same harness:
+`runLots(10000)` total Rust allocations **118134 → 41133** (the
+framework's channel-mount cost dropped from **~10/row to 1/row** — the
+single remaining alloc is the genuine `LoopScope` reactive identity).
+Wall-clock stayed neutral (release A/B: mean 426.3 ms vs baseline
+427.6 ms, inside a ±50 ms noise band), wasm grew **+4.4 KB**, and every
+phase held the full reactive + keyed-symmetry batteries green.
 
 The headline of this RFC is the **measurement, not a hunch**. An
 allocation-attribution harness (a counting `#[global_allocator]` read at
@@ -56,35 +65,66 @@ its construction/access sites; the API (`binding_cache[j]`, iterate
 `listener_routes`) is unchanged (SmallVec is Deref-compatible). Lowest
 risk; ships first as the template for the harness-driven before/after.
 
-### P2 — SoA the `ChannelRow` build
+### P2 — Inline the `ChannelRow` node vecs (SmallVec) ✅
 
-Each `ChannelRow` carries `binding_nodes: Box<[Element]>` +
-`listener_nodes: Vec<Element>` — two heap blocks per row. But the
-channel's `out` array is **already columnar** (`out.get(row*stride+j)`).
-So a row can hold a `(base, stride)` offset into shared per-list buffers
-instead of N per-row boxes, collapsing 2 allocs/row to a handful per
-*list*. Resident-memory win too (these live for the row's lifetime).
-Medium risk (touches the channel mount + `RowInstance` access).
+Each `ChannelRow` carries `binding_nodes: Box<[Element]>` (resident in
+`RowInstance`) + `listener_nodes: Vec<Element>` (transient, consumed
+building `listener_routes`) — two heap blocks per row. **Shipped as the
+SmallVec completion of P1** (`SmallVec<[Element; 4]>` / `<[Element; 2]>`,
+inline for the common 3-binding/2-listener row). **~2 allocs/row → ~0**
+(measured: ChannelRow bucket 20006 → 6 on runLots).
 
-### P3 — Typed key
+*Rejected the full columnar SoA* (a `(base, stride)` offset into shared
+per-list buffers, what this section originally proposed): it reintroduces
+an index-invalidation problem the keyed swap/remove reconcile would have
+to maintain (tombstones / offset shifts on row removal), for no resident
+win over inline storage. Inline `SmallVec` captures the same allocation
+*and* resident win with no offset bookkeeping. Indexing is unchanged
+(`SmallVec` Derefs to a slice).
 
-`stringify_key` allocates a `String` + `Rc<str>` **per row** even when
-`pp-key="item.id"` is a `usize`. A typed key —
-`enum RowKey { Int(u64), Str(Rc<str>) }`, `Hash + Eq + Clone` — skips
-both for numeric keys. **~2 allocs/row → ~0 for numeric keys.** This is
-where the *typed-field-access* capability (RFC-096 `field_as_text`,
-RFC-097's per-field codegen) actually pays — not in marshalling. Higher
-effort: `RowKey` threads through the keyed-diff machinery (`PrevItem`,
-the pool, the `seen` set, dedup — ~80 sites in `for_.rs`); gated on the
-keyed-symmetry battery + the differential fuzz.
+### P3 — Typed key ✅
 
-### P4 — Per-row scope-mint reduction (open / hard)
+`stringify_key` allocated a `String` + `Rc<str>` **per row** even when
+`pp-key="item.id"` is a `usize`. Shipped `enum RowKey { Int(i64), Str(Rc<str>) }`
+(`Hash + Eq + Clone`): an integral, exact-range JS number takes the
+zero-alloc `Int` path; everything else reuses `stringify_key` verbatim
+for a byte-identical `Str` key. **~2 allocs/row → ~0 for numeric keys**
+(measured: keying bucket 20001 → 1 on runLots; string-key lists keep
+their one `Rc<str>` alloc, as expected). `i64` (not `u64`) so negative
+ids round-trip; gated to the f64 exact-integer range (2⁵³) so large ids
+fall back to `Str` rather than aliasing.
 
-`Scope::new` + `LoopScope` `Rc` + `set_parent` is 2 allocs/row of
-*per-row reactive identity*. Reducing it means pooling/reusing scopes or
-a lighter `LoopScope` representation — the deepest change, and **not
-larger than the others**, so it is last. Likely its own follow-up RFC;
-listed here for completeness of the attribution.
+Derived `Eq`/`Hash` discriminate on the variant, so `Int(5)` and
+`Str("5")` never collide — which also **fixes a latent aliasing bug** the
+all-`String` form had. `RowKey` threads through the keyed-diff machinery
+(`PrevItem`, the pool `HashMap<RowKey,_>`, the `seen` `HashSet<RowKey>`,
+the two flip-snapshot maps, dedup — **53 sites**, all private to
+`for_.rs`). The one genuinely-risky edit: `retract_from_prior` switches
+`Rc::ptr_eq` → value `==` (an `Int` has no pointer identity) — strictly
+more correct, on the cold leave path only. The 5 near-identical
+construction sites collapsed into one `dedup_row_key` helper.
+
+### P4 — Erase scope state without the double-Rc box ✅
+
+`Scope::new` is 2 allocs/row of per-row reactive identity:
+`Rc::new(RefCell::new(LoopScope{…}))` (the genuine identity) **and**
+`Rc::new(state)` — which boxed the *already-`Rc`* state inside a **second
+`Rc`** purely to satisfy the `Rc<dyn Any>` erasure. The second box is
+removable with **zero plumbing**: erase `state` directly to `Rc<dyn Any>`
+via an unsizing coercion (a fat-pointer rebind, no heap block) and
+recover it in `typed::<T>()` with `Rc::downcast::<RefCell<T>>` instead of
+`downcast_ref::<Rc<…>>`. Identical contract; every consumer goes through
+the `typed()` method (no direct field access anywhere), so it is fully
+encapsulated and benefits **all** scopes, not just rows. **~2 → ~1
+alloc/row** (measured: scope-mint bucket 20009 → 10009).
+
+*Rejected scope pooling* (this section's original "reuse scopes" idea):
+reusing a `ScopeId` across reconciles is a use-after-logical-free —
+`FIELD_SIGNALS` / `SIGNAL_DEPS` / `PROJECTIONS` / `PARENTS` /
+`ROW_INSTANCES` are all keyed by a bare, non-generational `u64`, and an
+in-flight leave callback / queued effect / delegated listener can still
+hold an `Rc` clone of the recycled `LoopScope`. The remaining 1 alloc/row
+(the `LoopScope` `Rc` itself) is therefore left in place by design.
 
 ## 4. Non-goals (binding)
 
@@ -114,17 +154,30 @@ listed here for completeness of the attribution.
 - **Neutrality:** a chromium A/B (`select`/`update`/`runLots`/`clear`)
   within ±2% geomean, reversed double-run (the RFC-098 protocol).
 
-## 6. Phasing
+## 6. Phasing (measured)
 
-| phase | change | allocs/row | risk |
-|---|---|---|---|
-| P1 | `RowInstance` SmallVec | ~2 → 0 | low |
-| P2 | `ChannelRow` SoA (offsets into the columnar `out`) | ~2 → ~0 | medium |
-| P3 | typed `RowKey` | ~2 → ~0 (numeric) | medium (keyed-diff surface) |
-| P4 | per-row scope-mint reduction | ~2 → ? | high / open |
+Each phase landed independently, gated on the harness before/after + the
+full battery. `runLots(10000)` total Rust allocations, measured on the
+attribution branch after each cherry-pick:
 
-Each phase lands independently, gated on the harness before/after + the
-full battery + an A/B. P1 first (lowest risk, validates the loop).
+| phase | change | bucket allocs/row | runLots total | risk | status |
+|---|---|---|---:|---|---|
+| — | baseline (`main`) | — | 118134 | — | — |
+| P1 | `RowInstance` SmallVec (`binding_cache` + `listener_routes`) | 2.0 → 0 | 96134 | low | ✅ |
+| P2 | `ChannelRow` SmallVec (`binding_nodes` + `listener_nodes`) | 2.0 → 0 | 74134 | low | ✅ |
+| P3 | typed `RowKey` (`Int` no-alloc for numeric keys) | 2.0 → 0 | 52134 | medium | ✅ |
+| P4 | scope state erased without the double-`Rc` box | 2.0 → 1.0 | 41133 | medium | ✅ |
+
+The framework's per-row channel-mount allocation went **~10/row → 1/row**
+(the surviving alloc is the `LoopScope` `Rc`, kept by design — see P4).
+Full-stack release wall-clock A/B: mean **426.3 ms** vs baseline
+**427.6 ms** on `runLots(10000) ×25` — neutral within the metric's
+±50 ms noise floor (the ~100K-alloc reduction is sub-millisecond and
+below resolution; the A/B's role is to rule out a regression). wasm
+**+4.4 KB**. Reactive battery 30/30 + 9/9 and the firefox
+keyed-symmetry battery (`template_plan` 43/43, plus `refs_typed`,
+`component_refs`, `typed_slot_props` for P4's `typed()` change) green at
+every phase.
 
 ## 7. Relation to RFC-097
 

--- a/rfcs/rfc-101-per-row-mount-allocation.md
+++ b/rfcs/rfc-101-per-row-mount-allocation.md
@@ -1,0 +1,137 @@
+# RFC 101 - Per-row mount allocation hardening
+
+| Field | Value |
+|---|---|
+| **Status** | Draft |
+| **Author** | pocopine team |
+| **Created** | 2026-06-13 |
+| **Related** | [`rfc-054`] (the compiled-row mutation channel being measured), [`rfc-096-signals-first-reactive-core.md`](./rfc-096-signals-first-reactive-core.md) (typed text lane), [`rfc-097-field-handles.md`](./rfc-097-field-handles.md) (per-field-typed codegen — the rail the typed key reuses), [`rfc-098-core-hardening.md`](./rfc-098-core-hardening.md) (the prior reactive-core hardening pass) |
+
+## 1. Summary
+
+Mounting a `pp-for` list costs **~10 Rust heap allocations per row**
+(runLots(10000) ≈ 106K allocations). This RFC reduces that — judged by
+**allocation count** (deterministic, measured), with wall-clock required
+only to stay **neutral** and correctness gated on the W0 battery +
+keyed-symmetry. It is a follow-on to RFC-098 (which hardened the
+reactive *core*); this hardens the per-row *mount path*.
+
+The headline of this RFC is the **measurement, not a hunch**. An
+allocation-attribution harness (a counting `#[global_allocator]` read at
+mount-phase boundaries) showed the per-row cost is **not** what we
+assumed — it is four even ~2-alloc/row buckets, and the thing we
+*expected* to dominate (serde marshalling) allocates ~0 Rust heap.
+
+## 2. The measured attribution (evidence)
+
+Per row, mutation channel on (production), `run(1000)` and
+`runLots(10000)` identical:
+
+| bucket | allocs/row | what it is | this RFC |
+|---|---:|---|---|
+| mount stamping (DOM / binding-apply / node-path / listener) | **~0** | JS-side; `set_inner_html`/`Reflect` create JS objects, not Rust heap | — (already lean) |
+| **scope mint** (`Scope::new` + `LoopScope` `Rc` + `set_parent`) | **2.0** | per-row reactive identity | P4 (hard floor) |
+| **`ChannelRow` build** (`binding_nodes: Box<[Element]>` + `listener_nodes: Vec`) | **2.0** | per-row DOM-handle vecs | P2 |
+| **`RowInstance`** (`binding_cache: Vec` + `listener_routes: Box<[…]>`) | **2.0** | per-row instance vecs | **P1** |
+| **keying** (`stringify_key` → `String` → `Rc<str>`) | **2.0** | per-row key, even for a numeric `pp-key` | P3 |
+| other (harness `format!` ~1 + field read + misc) | ~3 | bench-side + plumbing | — |
+| **total** | **~11** | | |
+
+**Two findings that redirected the whole effort:**
+
+1. **serde marshalling is not a Rust allocator.** `serde_wasm_bindgen::to_value(&Vec<Row>)` for 10000 rows = **1** Rust allocation (it builds JS-side objects, counted by V8). The "typed columnar marshalling" lane we scoped to cut it would not move the Rust alloc count — it is a JS-GC/wall-clock play only, deferred until a wall-clock A/B justifies it. (See §6 non-goals.)
+2. **There is no single dominant allocator** — it is 4 × ~2/row across four distinct per-row structures. Reduction is therefore a set of independent, individually-measurable changes, not one refactor.
+
+## 3. The optimizations
+
+### P1 — Inline the `RowInstance` per-row vecs (SmallVec)
+
+`RowInstance` holds `binding_cache: vec![None; plan.bindings.len()]`
+and `listener_routes: Box<[RowListenerRoute]>` — two heap blocks per
+row, both small (jsbench rows: 3 bindings, ≤2 listeners). Store them in
+`SmallVec<[_; N]>` so the common small case lives inline in the
+instance (which already lives in the `ROW_INSTANCES` map), heap-spilling
+only on large rows. **~2 allocs/row → ~0.** Contained to `RowInstance` +
+its construction/access sites; the API (`binding_cache[j]`, iterate
+`listener_routes`) is unchanged (SmallVec is Deref-compatible). Lowest
+risk; ships first as the template for the harness-driven before/after.
+
+### P2 — SoA the `ChannelRow` build
+
+Each `ChannelRow` carries `binding_nodes: Box<[Element]>` +
+`listener_nodes: Vec<Element>` — two heap blocks per row. But the
+channel's `out` array is **already columnar** (`out.get(row*stride+j)`).
+So a row can hold a `(base, stride)` offset into shared per-list buffers
+instead of N per-row boxes, collapsing 2 allocs/row to a handful per
+*list*. Resident-memory win too (these live for the row's lifetime).
+Medium risk (touches the channel mount + `RowInstance` access).
+
+### P3 — Typed key
+
+`stringify_key` allocates a `String` + `Rc<str>` **per row** even when
+`pp-key="item.id"` is a `usize`. A typed key —
+`enum RowKey { Int(u64), Str(Rc<str>) }`, `Hash + Eq + Clone` — skips
+both for numeric keys. **~2 allocs/row → ~0 for numeric keys.** This is
+where the *typed-field-access* capability (RFC-096 `field_as_text`,
+RFC-097's per-field codegen) actually pays — not in marshalling. Higher
+effort: `RowKey` threads through the keyed-diff machinery (`PrevItem`,
+the pool, the `seen` set, dedup — ~80 sites in `for_.rs`); gated on the
+keyed-symmetry battery + the differential fuzz.
+
+### P4 — Per-row scope-mint reduction (open / hard)
+
+`Scope::new` + `LoopScope` `Rc` + `set_parent` is 2 allocs/row of
+*per-row reactive identity*. Reducing it means pooling/reusing scopes or
+a lighter `LoopScope` representation — the deepest change, and **not
+larger than the others**, so it is last. Likely its own follow-up RFC;
+listed here for completeness of the attribution.
+
+## 4. Non-goals (binding)
+
+1. **Typed columnar marshalling for Rust allocs.** Refuted by
+   measurement (serde → JS is ~0 Rust alloc). Off the table *as an
+   allocation lever*; revisit only as a wall-clock/JS-GC change with a
+   timing A/B that justifies rewriting the channel interpreter.
+2. **Mount stamping.** Already ~0 Rust alloc/row (RFC-054). Untouched.
+3. **Wall-clock objectives.** Like RFC-098, the gate is allocation-count
+   reduction + wall-clock *neutrality*; a per-alloc cut that regresses
+   dispatch latency is rejected.
+4. **Authoring surface.** Purely internal; `pp-for`/`pp-key` semantics
+   unchanged.
+
+## 5. Verification
+
+- **Allocation-attribution harness** (the deterministic gate): a
+  counting `#[global_allocator]` in the jsbench harness feeds
+  `alloc_profile`, read at mount-phase boundaries; the driver reports
+  per-bucket allocs/row for `run`/`runLots`/`select`/`update`/`add`
+  before and after each phase. P1 must drop the `RowInstance` bucket
+  from ~2.0 to ~0/row with the others unchanged.
+- **Correctness:** the W0 reactive battery (`wasm-pack test --node
+  crates/pocopine-core`) + the keyed-symmetry/`template_plan` firefox
+  battery, green at every phase. P2/P3 especially must pass keyed
+  reconcile (swap/remove/reorder) + the differential fuzz.
+- **Neutrality:** a chromium A/B (`select`/`update`/`runLots`/`clear`)
+  within ±2% geomean, reversed double-run (the RFC-098 protocol).
+
+## 6. Phasing
+
+| phase | change | allocs/row | risk |
+|---|---|---|---|
+| P1 | `RowInstance` SmallVec | ~2 → 0 | low |
+| P2 | `ChannelRow` SoA (offsets into the columnar `out`) | ~2 → ~0 | medium |
+| P3 | typed `RowKey` | ~2 → ~0 (numeric) | medium (keyed-diff surface) |
+| P4 | per-row scope-mint reduction | ~2 → ? | high / open |
+
+Each phase lands independently, gated on the harness before/after + the
+full battery + an A/B. P1 first (lowest risk, validates the loop).
+
+## 7. Relation to RFC-097
+
+RFC-097 (field handles) is a **different axis** — per-field stream
+updates + `&self`-skips-the-sweep — and does not touch the per-row mount
+path. The connection is the **codegen rail**: RFC-097 specifies
+emitting per-field *typed* accessors on a generated trait (the RFC-081
+precedent); P3's typed key and any future typed row-field access reuse
+that machinery. The two RFCs are complementary, not overlapping; neither
+blocks the other.


### PR DESCRIPTION
RFC-101 + all four phases, each driven by a measured allocation-attribution harness (a counting `#[global_allocator]` read at mount-phase boundaries). Mounting a `pp-for` row cost **~10 Rust allocs/row** in four even ~2/row buckets; this removes them.

## Measured (runLots(10000), the deterministic gate)

| phase | change | bucket effect | runLots total allocs |
|---|---|---|---:|
| baseline (`main`) | — | — | 118,134 |
| **P1** | `RowInstance` SmallVec (`binding_cache` + `listener_routes`) | register 2.0→0 | 96,134 |
| **P2** | `ChannelRow` SmallVec (`binding_nodes` + `listener_nodes`) | ChannelRow 2.0→0 | 74,134 |
| **P3** | typed `RowKey { Int(i64), Str(Rc<str>) }` | keying 2.0→0 (numeric) | 52,134 |
| **P4** | erase scope state without the double-`Rc` box | scope-mint 2.0→**1.0** | 41,133 |

Framework per-row channel-mount cost: **~10/row → 1/row**. The surviving alloc is the genuine `LoopScope` `Rc` — kept by design (pooling it is a use-after-logical-free on the non-generational `ScopeId`).

## The measurement also refuted the assumed lever
`serde_wasm_bindgen::to_value(&Vec<Row>)` for 10k rows = **1** Rust alloc — it builds JS-side objects (counted by V8, not the Rust allocator). The "typed columnar serde lane" we'd scoped is off the table for Rust allocs (RFC §4).

## Design calls made against the original RFC text (after reading the code)
- **P2** shipped as inline `SmallVec`, *not* the full columnar SoA the draft proposed — SoA reintroduces an index-invalidation problem the keyed swap/remove reconcile would have to maintain (tombstones / offset shifts), for no resident win over inline.
- **P4** was far cheaper than "hard/open": the removable alloc was a gratuitous **double-`Rc`** (`Rc::new(state)` boxing an already-`Rc` value for the `Rc<dyn Any>` erasure). Killed with a zero-plumbing unsizing coercion + `Rc::downcast` in `typed::<T>()` — benefits *every* scope, not just rows. No pooling.
- **P3** uses `i64` (negative ids round-trip) gated to the f64 exact-integer range (2⁵³); derived `Eq`/`Hash` make `Int(5)` ≠ `Str("5")`, which also **fixes a latent aliasing bug** the all-`String` form had.

## Correctness + neutrality
- Every phase: reactive battery **30/30 + 9/9**, firefox `template_plan` **43/43** (keyed swap/remove/reorder/dup). P4 also `refs_typed` 5/5, `component_refs` 6/6, `typed_slot_props` 1/1 (it changes every scope's `typed()`). wasm clippy `--all-features` + fmt clean throughout.
- The single riskiest line — P3's `retract_from_prior` switching `Rc::ptr_eq` → value `==` (an `Int` has no pointer identity; strictly more correct, cold leave path) — is covered by the keyed battery.
- **Wall-clock A/B** (release profile, full stack vs fresh baseline, runLots ×25): mean **426.3 ms** vs **427.6 ms** — neutral within the ±50ms noise floor. The ~100k-alloc reduction is sub-millisecond and below the metric's resolution; the A/B's role is to rule out a regression, which it does. wasm **+4.4 KB**.
