### PR TITLE
fix(deploy): refresh Render checksum; run Railway drift test unauthenticated

### DIFF
--- a/crates/pocopine-deploy-railway/tests/spec_drift.rs
+++ b/crates/pocopine-deploy-railway/tests/spec_drift.rs
@@ -12,13 +12,14 @@
 //! Nothing is committed to the repo: the live schema is the source of
 //! truth, checked fresh each run.
 //!
-//! Gating — introspection requires auth, so:
-//!   * no token  → the test SKIPS (keeps offline `cargo test` green),
-//!   * token set → it runs and FAILS on drift.
+//! Gating — Railway's introspection endpoint is **unauthenticated**
+//! (same endpoint `build.rs` fetches `schema.json` from), so this test
+//! needs no token. It SKIPS only when the endpoint is unreachable, to
+//! keep offline `cargo test` green.
 //!
-//! Set `POCOPINE_REQUIRE_SPEC_DRIFT=1` (CI's spec-drift job) to turn a
-//! missing token or an unreachable endpoint into a hard failure, so
-//! drift can't slip through a silent skip.
+//! Set `POCOPINE_REQUIRE_SPEC_DRIFT=1` (CI's spec-drift job) to turn an
+//! unreachable endpoint into a hard failure, so drift can't slip
+//! through a silent skip.
 
 use std::collections::HashSet;
 
@@ -46,23 +47,8 @@ const REQUIRED_INPUT_TYPES: &[&str] = &[
     "ServiceDomainCreateInput",
 ];
 
-fn railway_token() -> Option<String> {
-    for var in [
-        "RAILWAY_API_TOKEN",
-        "POCOPINE_RAILWAY_TOKEN",
-        "RAILWAY_TOKEN",
-    ] {
-        if let Ok(t) = std::env::var(var) {
-            if !t.is_empty() {
-                return Some(t);
-            }
-        }
-    }
-    None
-}
-
-/// CI's spec-drift job sets this so a missing token / unreachable
-/// endpoint fails instead of skipping.
+/// CI's spec-drift job sets this so an unreachable endpoint fails
+/// instead of skipping.
 fn require_drift() -> bool {
     std::env::var("POCOPINE_REQUIRE_SPEC_DRIFT")
         .map(|v| !v.is_empty())
@@ -71,22 +57,12 @@ fn require_drift() -> bool {
 
 #[test]
 fn railway_schema_still_defines_the_operations_we_use() {
-    let Some(token) = railway_token() else {
-        let msg =
-            "railway spec-drift: no RAILWAY_API_TOKEN / POCOPINE_RAILWAY_TOKEN / RAILWAY_TOKEN set";
-        assert!(
-            !require_drift(),
-            "{msg} (POCOPINE_REQUIRE_SPEC_DRIFT is set)"
-        );
-        eprintln!("skipping {msg}");
-        return;
-    };
-
     let introspection = r#"{"query":"query { __schema { queryType { fields { name } } mutationType { fields { name } } types { name } } }"}"#;
 
+    // Unauthenticated — Railway's introspection endpoint needs no token
+    // (this is the same endpoint `build.rs` fetches the schema from).
     let resp = reqwest::blocking::Client::new()
         .post(RAILWAY_GRAPHQL)
-        .bearer_auth(&token)
         .header("content-type", "application/json")
         .body(introspection)
         .send();

--- a/crates/pocopine-deploy-render/tests/spec_drift.rs
+++ b/crates/pocopine-deploy-render/tests/spec_drift.rs
@@ -26,10 +26,11 @@ use sha2::{Digest, Sha256};
 const RENDER_OPENAPI_URL: &str =
     "https://api-docs.render.com/v1.0/openapi/render-public-api-1.json";
 
-/// SHA-256 of the canonicalised live spec, last reconciled 2026-05-22.
+/// SHA-256 of the canonicalised live spec, last reconciled 2026-06-13.
 /// Update this when the drift test reports a new hash for a reviewed,
-/// deliberate upstream change.
-const EXPECTED_SHA256: &str = "238b4ebd850565a73bc85740d67e485d4cec9e1e3dcfafb6a6447486ca81d48e";
+/// deliberate upstream change. (2026-06-13: benign content churn —
+/// every `REQUIRED_PATHS` endpoint still present, so no client change.)
+const EXPECTED_SHA256: &str = "770ea59aaf7a2565fb5ba598e81917206d4b663e0cf331f14988aa5b5cd5a8c4";
 
 /// Paths `crate::client` calls. `/registrycredentials` is pinned ahead
 /// of the Phase 19 auto-registry work so the dependency is guarded now.


### PR DESCRIPTION

Two spec-drift maintenance fixes, independent of any feature work.

Render: the pinned EXPECTED_SHA256 was stale (238b4ebd…, 2026-05-22) —
Render's unversioned OpenAPI spec drifted. Refreshed to 770ea59a… and
verified green. The structural assertions (every REQUIRED_PATHS endpoint
the client calls) still pass, so this is benign upstream content churn
with no src/client.rs reconciliation needed.

Railway: the drift test required a RAILWAY_API_TOKEN and SKIPPED without
one — but Railway's introspection endpoint is unauthenticated (build.rs
already fetches schema.json from it with no token). So the test was
needlessly gated and never ran in plain `cargo test` / CI. Dropped the
token requirement and the bearer_auth header; it now introspects
unauthenticated and actually verifies the structural pins. Gating
matches the Render test: skip only when unreachable (hard-fail under
POCOPINE_REQUIRE_SPEC_DRIFT). Passes token-free and under REQUIRE.

(schema.json itself is gitignored + auto-fetched by build.rs — nothing
to commit there.)