### PR TITLE
docs(rfcs): correct status of implemented-but-mislabeled RFCs (audit)

### DIFF
--- a/rfcs/rfc-001-components.md
+++ b/rfcs/rfc-001-components.md
@@ -2,7 +2,7 @@
 
 | Field  | Value |
 |---|---|
-| **Status** | Accepted |
+| **Status** | Implemented |
 | **Author** | pocopine team |
 | **Created** | 2026-04-18 |
 | **Supersedes** | — |

--- a/rfcs/rfc-002-app-stores-servers.md
+++ b/rfcs/rfc-002-app-stores-servers.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Accepted |
+| **Status** | Implemented |
 | **Author** | pocopine team |
 | **Created** | 2026-04-18 |
 | **Supersedes** | — |

--- a/rfcs/rfc-003-router.md
+++ b/rfcs/rfc-003-router.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Accepted |
+| **Status** | Implemented |
 | **Author** | pocopine team |
 | **Created** | 2026-04-18 |
 | **Supersedes** | — |

--- a/rfcs/rfc-004-pp-for.md
+++ b/rfcs/rfc-004-pp-for.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Accepted |
+| **Status** | Implemented |
 | **Author** | pocopine team |
 | **Created** | 2026-04-19 |
 | **Supersedes** | — |

--- a/rfcs/rfc-015-pp-anchor.md
+++ b/rfcs/rfc-015-pp-anchor.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Accepted |
+| **Status** | Implemented |
 | **Author** | pocopine team |
 | **Created** | 2026-04-19 |
 | **Supersedes** | — |

--- a/rfcs/rfc-016-pp-resize-pp-intersect.md
+++ b/rfcs/rfc-016-pp-resize-pp-intersect.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Accepted |
+| **Status** | Implemented |
 | **Author** | pocopine team |
 | **Created** | 2026-04-19 |
 | **Supersedes** | — |

--- a/rfcs/rfc-017-click-outside.md
+++ b/rfcs/rfc-017-click-outside.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Accepted |
+| **Status** | Implemented |
 | **Author** | pocopine team |
 | **Created** | 2026-04-19 |
 | **Supersedes** | — |

--- a/rfcs/rfc-018-id-magic.md
+++ b/rfcs/rfc-018-id-magic.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Accepted |
+| **Status** | Superseded by RFC-095 — the `$id` magic was removed in the signals rewrite (zero usage; `ctx.scope_id` covers it). Only the `+` string-concat operator from this RFC survives. |
 | **Author** | pocopine team |
 | **Created** | 2026-04-19 |
 | **Supersedes** | — |

--- a/rfcs/rfc-019-pp-as.md
+++ b/rfcs/rfc-019-pp-as.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Accepted |
+| **Status** | Implemented |
 | **Author** | pocopine team |
 | **Created** | 2026-04-19 |
 | **Supersedes** | — |

--- a/rfcs/rfc-020-shorthand-prefixes.md
+++ b/rfcs/rfc-020-shorthand-prefixes.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Accepted |
+| **Status** | Implemented |
 | **Author** | pocopine team |
 | **Created** | 2026-04-19 |
 | **Supersedes** | — |

--- a/rfcs/rfc-021-scroll-lock.md
+++ b/rfcs/rfc-021-scroll-lock.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Accepted |
+| **Status** | Implemented |
 | **Author** | pocopine team |
 | **Created** | 2026-04-19 |
 | **Supersedes** | — |

--- a/rfcs/rfc-022-pp-roving.md
+++ b/rfcs/rfc-022-pp-roving.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Accepted |
+| **Status** | Implemented |
 | **Author** | pocopine team |
 | **Created** | 2026-04-19 |
 | **Supersedes** | — |

--- a/rfcs/rfc-024-expression-values.md
+++ b/rfcs/rfc-024-expression-values.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Accepted |
+| **Status** | Implemented |
 | **Author** | pocopine team |
 | **Created** | 2026-04-19 |
 | **Supersedes** | — |

--- a/rfcs/rfc-026-post-mount-watch-field.md
+++ b/rfcs/rfc-026-post-mount-watch-field.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Accepted |
+| **Status** | Implemented — the `post_mount` hook shipped but was renamed `on_ready` by RFC-029; `#[watch(field)]` shipped as specified. |
 | **Author** | pocopine team |
 | **Created** | 2026-04-19 |
 | **Supersedes** | — |

--- a/rfcs/rfc-027-provide-inject.md
+++ b/rfcs/rfc-027-provide-inject.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Accepted |
+| **Status** | Implemented — `provide`/`inject` shipped; the string-key surface in this doc was later superseded by the typed `ContextKey` of RFC-030/056. |
 | **Author** | pocopine team |
 | **Created** | 2026-04-19 |
 | **Supersedes** | — |

--- a/rfcs/rfc-028-emit.md
+++ b/rfcs/rfc-028-emit.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Accepted |
+| **Status** | Implemented |
 | **Author** | pocopine team |
 | **Created** | 2026-04-19 |
 | **Supersedes** | — |

--- a/rfcs/rfc-029-on-ready-rename.md
+++ b/rfcs/rfc-029-on-ready-rename.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Accepted |
+| **Status** | Implemented |
 | **Author** | pocopine team |
 | **Created** | 2026-04-19 |
 | **Supersedes** | — |

--- a/rfcs/rfc-064-performance-roadmap.md
+++ b/rfcs/rfc-064-performance-roadmap.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Draft (revised 2026-04-29 per council feedback) |
+| **Status** | Implemented (roadmap delivered across RFC-094/095/096/101) |
 | **Author** | pocopine team |
 | **Created** | 2026-04-29 |
 | **Supersedes** | — |

--- a/rfcs/rfc-082-pocopine-storage.md
+++ b/rfcs/rfc-082-pocopine-storage.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Accepted |
+| **Status** | Implemented |
 | **Author** | pocopine team |
 | **Created** | 2026-05-24 |
 | **Related** | [RFC 002 - Application framework, stores, server functions](./rfc-002-app-stores-servers.md), [RFC 023 - Pine MVP](./rfc-023-pine-mvp.md), [RFC 066 - Server-function auth and access policy](./rfc-066-server-function-auth.md), [RFC 076 - App plugin lifecycle](./rfc-076-app-plugin-lifecycle.md), [RFC 077 - Server plugin lifecycle](./rfc-077-server-plugin-lifecycle.md), [RFC 080 - Heroku-style deploy contract](./rfc-080-deploy-contract.md) |

--- a/rfcs/rfc-084-typed-slot-props.md
+++ b/rfcs/rfc-084-typed-slot-props.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Accepted (Phases 1–2 compound-side `props = T` validation landed; Phase 3 caller-side `pp-let` checking + compile-fail tests pending) |
+| **Status** | Accepted (Phases 1, 2, 4 landed; Phase 3 caller-side `pp-let` prop-type checking + compile-fail tests pending) |
 | **Author** | pocopine team |
 | **Created** | 2026-05-26 |
 | **Related** | [`rfc-044-props.md`](./rfc-044-props.md), [`rfc-049-slot-contracts.md`](./rfc-049-slot-contracts.md), [`rfc-050-template-ast.md`](./rfc-050-template-ast.md), [`rfc-081-component-handle-refs.md`](./rfc-081-component-handle-refs.md) |

--- a/rfcs/rfc-095-reactive-core-de-alpine.md
+++ b/rfcs/rfc-095-reactive-core-de-alpine.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | In progress on `perf-reactive-dirty-tracking`: W2 landed (−7.1% geomean), W1 landed (proxy-free root reads), W3a landed (one dependency graph — fields interned as signals; DEPS/REVERSE deleted), dead Alpine magics removed (\$el/\$refs/\$dispatch/\$id); W5 tried and reverted with measurements; W0 COMPLETE (semantics tests + 1000-op differential fuzz vs oracle + keyed fast-path symmetry gates); W3b landed (plan-gated lazy proxy minting); W3c expanded into [`rfc-096-signals-first-reactive-core.md`](./rfc-096-signals-first-reactive-core.md) (the full signals switch); W4 LANDED (descriptor variant — runLots −8.7%, gap to vanilla 1.41×→1.29×; see §7) |
+| **Status** | Implemented (landed in 0.2.0 via `perf-reactive-dirty-tracking`; W3c expanded into RFC-096). W2 landed (−7.1% geomean), W1 landed (proxy-free root reads), W3a landed (one dependency graph — fields interned as signals; DEPS/REVERSE deleted), dead Alpine magics removed (\$el/\$refs/\$dispatch/\$id); W5 tried and reverted with measurements; W0 COMPLETE (semantics tests + 1000-op differential fuzz vs oracle + keyed fast-path symmetry gates); W3b landed (plan-gated lazy proxy minting); W3c expanded into [`rfc-096-signals-first-reactive-core.md`](./rfc-096-signals-first-reactive-core.md) (the full signals switch); W4 LANDED (descriptor variant — runLots −8.7%, gap to vanilla 1.41×→1.29×; see §7) |
 | **Author** | pocopine team |
 | **Created** | 2026-06-10 |
 | **Related** | [`rfc-054`](./rfc-054-compiled-row-plans.md), [`rfc-058-compiled-views-walker-removal.md`](./rfc-058-compiled-views-walker-removal.md), [`rfc-094-conditional-chains-and-enum-matching.md`](./rfc-094-conditional-chains-and-enum-matching.md) |

--- a/rfcs/rfc-098-core-hardening.md
+++ b/rfcs/rfc-098-core-hardening.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Draft |
+| **Status** | Implemented (H1–H4 landed on main, PR #202) |
 | **Author** | pocopine team |
 | **Created** | 2026-06-12 |
 | **Related** | [`rfc-095-reactive-core-de-alpine.md`](./rfc-095-reactive-core-de-alpine.md) (W0 harness, W5 revert), [`rfc-096-signals-first-reactive-core.md`](./rfc-096-signals-first-reactive-core.md) (the engine being hardened) |

--- a/rfcs/rfc-100-asset-pipeline.md
+++ b/rfcs/rfc-100-asset-pipeline.md
@@ -2,7 +2,7 @@
 
 | Field | Value |
 |---|---|
-| **Status** | Draft |
+| **Status** | Accepted (v1 pipeline landed — see the §12 implementation-state table for per-feature status) |
 | **Author** | pocopine team |
 | **Created** | 2026-06-12 |
 | **Related** | [`rfc-080-deploy-contract.md`](./rfc-080-deploy-contract.md) (deploy orchestration, credentials.toml, adapter API doctrine), [`rfc-082-pocopine-storage.md`](./rfc-082-pocopine-storage.md) (upload protocol — *not* this pipeline; see §3), [`rfc-099-ssr-hydration.md`](./rfc-099-ssr-hydration.md) (SSR serves the same URLs), `docs/internal/roadmap-0.2.x.md` (0.2.1 publishing pipeline) |


### PR DESCRIPTION

An evidence-based audit (each RFC's design cross-checked against the
code + main's git log) found 23 RFCs whose Status understated reality.

Fully implemented on main, bumped Accepted/Draft -> Implemented:
  001 components, 002 app/stores/servers, 003 router, 004 pp-for,
  015 pp-anchor, 016 pp-resize/intersect, 017 click-outside, 019 pp-as,
  020 shorthand prefixes, 021 scroll-lock, 022 pp-roving,
  024 expression-values, 028 emit, 029 on-ready-rename,
  082 pocopine-storage, 064 performance-roadmap (delivered across
  094/095/096/101), 095 reactive-core (0.2.0; W3c became RFC-096),
  098 core-hardening (was Draft despite landing on main as PR #202).
The early batch was inconsistent — 005-014 already said Implemented
while 001-004/015-022 lingered on Accepted.

Implemented-but-superseded (relabeled with a note, not a bare word):
  018 id-magic -> Superseded by RFC-095 ($id removed; only the `+`
  operator survives); 026 post_mount -> Implemented (hook renamed
  on_ready by RFC-029); 027 provide/inject -> Implemented (string-key
  surface superseded by typed ContextKey, RFC-030/056).

Refinements:
  084 typed-slot-props -> Phase 4 has since landed (Phase 3 still
  pending); 100 asset-pipeline -> Accepted (v1 landed; §12 table is the
  per-feature source of truth).

Genuinely-partial (Accepted: ...landed; ...pending) and not-yet-built
Drafts (042/046/047/059/065/073/079/099) were left unchanged — their
status already matches reality. Docs only.