### PR TITLE
rfc-099: SSR Phase 1 parity foundations (JS number formatter + host expr evaluator)

### DIFF
--- a/crates/pocopine-core/src/host_eval.rs
+++ b/crates/pocopine-core/src/host_eval.rs
@@ -1,0 +1,286 @@
+//! RFC-099 Phase 1b — host-side expression evaluator over
+//! `serde_json::Value`.
+//!
+//! Mirrors [`crate::expr::evaluate_with`]'s JavaScript semantics for
+//! the read-only subset SSR rendering needs, so the server stamps the
+//! exact value the wasm client would compute. It evaluates the SAME
+//! parsed AST (`pocopine_expr::Expr`) — only the value type and the
+//! field-access backend differ (`serde_json::Value` + object indexing
+//! here, vs `JsValue` + `Reflect::get` on the client).
+//!
+//! Why a parallel evaluator rather than genericizing `evaluate_with`
+//! over a `ValueBackend` trait: the client evaluator is the RFC-095/096
+//! reactive hot path, deeply coupled to `JsValue` / `Reflect` /
+//! `ScopeAccess` / magic-scope resolution. Genericizing it risks that
+//! perf-critical path; a parallel host evaluator keeps the client
+//! untouched. The cost — two implementations that could drift — is
+//! paid down by the cross-engine differential fuzz
+//! (`tests/expr_host_parity.rs`), which evaluates the same AST through
+//! both engines and asserts equal results.
+//!
+//! Semantics deliberately mirror the client evaluator's helpers, not
+//! "real JS": `to_js_string` returns `"[object Object]"` for arrays
+//! (matching `expr::js_to_string`, which doesn't special-case arrays).
+//!
+//! Read-only: `Call` → `Null` (rendering never invokes handlers),
+//! `Assign` → the rhs value (no write). `$`-rooted magic paths
+//! (`$store` / `$route`) are not resolved host-side in Phase 1b — they
+//! yield `Null` until Phase 2 wires store/route state into the render
+//! context. Likewise array `.length` and nested access on non-objects
+//! yield `Null` here (Phase 2 stamper concern); declared component
+//! state never produces a missing key, so this matches the client for
+//! every in-state path.
+
+use pocopine_expr::{BinOp, Expr, Literal, Spanned};
+use serde_json::Value;
+
+/// Evaluate `expr` against host component `state` (the serialized
+/// component struct, as a JSON object).
+pub fn eval(expr: &Spanned<Expr>, state: &Value) -> Value {
+    match &expr.value {
+        Expr::Literal(l) => lit_to_json(l),
+        Expr::Path(segs) => resolve_path(state, segs),
+        Expr::Not(inner) => Value::Bool(is_falsy(&eval(inner, state))),
+        Expr::BinOp(op, lhs, rhs) => eval_binop(*op, lhs, rhs, state),
+        Expr::Ternary(cond, then_e, else_e) => {
+            if is_falsy(&eval(cond, state)) {
+                eval(else_e, state)
+            } else {
+                eval(then_e, state)
+            }
+        }
+        // Rendering is read-only — handlers never fire during a stamp.
+        Expr::Call(_, _) => Value::Null,
+        // No write host-side; an assignment's value is its rhs.
+        Expr::Assign(_, rhs) => eval(rhs, state),
+        Expr::Seq(stmts) => {
+            let mut last = Value::Null;
+            for s in stmts {
+                last = eval(s, state);
+            }
+            last
+        }
+    }
+}
+
+fn eval_binop(op: BinOp, lhs: &Spanned<Expr>, rhs: &Spanned<Expr>, state: &Value) -> Value {
+    match op {
+        BinOp::And => {
+            let l = eval(lhs, state);
+            if is_falsy(&l) {
+                l
+            } else {
+                eval(rhs, state)
+            }
+        }
+        BinOp::Or => {
+            let l = eval(lhs, state);
+            if is_falsy(&l) {
+                eval(rhs, state)
+            } else {
+                l
+            }
+        }
+        BinOp::Eq | BinOp::Ne => {
+            let eq = strict_eq(&eval(lhs, state), &eval(rhs, state));
+            Value::Bool(if matches!(op, BinOp::Eq) { eq } else { !eq })
+        }
+        BinOp::Lt | BinOp::Le | BinOp::Gt | BinOp::Ge => {
+            match (as_f64(&eval(lhs, state)), as_f64(&eval(rhs, state))) {
+                (Some(a), Some(b)) => Value::Bool(match op {
+                    BinOp::Lt => a < b,
+                    BinOp::Le => a <= b,
+                    BinOp::Gt => a > b,
+                    BinOp::Ge => a >= b,
+                    _ => unreachable!(),
+                }),
+                _ => Value::Bool(false),
+            }
+        }
+        BinOp::Plus => {
+            let l = eval(lhs, state);
+            let r = eval(rhs, state);
+            if is_string(&l) || is_string(&r) {
+                Value::String(format!("{}{}", to_js_string(&l), to_js_string(&r)))
+            } else if let (Some(a), Some(b)) = (as_f64(&l), as_f64(&r)) {
+                number(a + b)
+            } else {
+                Value::String(String::new())
+            }
+        }
+    }
+}
+
+fn lit_to_json(l: &Literal) -> Value {
+    match l {
+        Literal::Null => Value::Null,
+        Literal::Bool(b) => Value::Bool(*b),
+        Literal::Number(n) => number(*n),
+        Literal::String(s) => Value::String(s.clone()),
+    }
+}
+
+/// Resolve a dotted path against `state`. First segment indexes the
+/// state object; nested segments index successive objects. A missing
+/// key, a non-object intermediate, or a `$`-rooted magic path yields
+/// `Null` (see module docs — declared state never misses an in-state
+/// key, so this matches the client there).
+fn resolve_path(state: &Value, segments: &[String]) -> Value {
+    let Some((first, rest)) = segments.split_first() else {
+        return Value::Null;
+    };
+    if first.starts_with('$') {
+        return Value::Null; // magic roots resolved in Phase 2
+    }
+    let mut cur = state.get(first).cloned().unwrap_or(Value::Null);
+    for seg in rest {
+        cur = cur
+            .as_object()
+            .and_then(|o| o.get(seg).cloned())
+            .unwrap_or(Value::Null);
+    }
+    cur
+}
+
+/// JS truthiness — mirrors `wasm_bindgen::JsValue::is_falsy`. Falsy:
+/// `null`, `false`, `0`/`-0`, `""`. Everything else (incl. `[]` and
+/// `{}`) is truthy.
+fn is_falsy(v: &Value) -> bool {
+    match v {
+        Value::Null => true,
+        Value::Bool(b) => !b,
+        Value::Number(n) => n.as_f64().is_some_and(|f| f == 0.0),
+        Value::String(s) => s.is_empty(),
+        Value::Array(_) | Value::Object(_) => false,
+    }
+}
+
+/// `JsValue::as_f64` analogue — `Some` only for numbers (no string
+/// coercion).
+fn as_f64(v: &Value) -> Option<f64> {
+    match v {
+        Value::Number(n) => n.as_f64(),
+        _ => None,
+    }
+}
+
+fn is_string(v: &Value) -> bool {
+    matches!(v, Value::String(_))
+}
+
+/// Mirror of `expr::js_strict_eq` (`===`): matching primitive types
+/// compare by value; cross-type and object/array compare unequal (JS
+/// reference inequality for distinct values).
+fn strict_eq(a: &Value, b: &Value) -> bool {
+    match (a, b) {
+        (Value::String(x), Value::String(y)) => x == y,
+        (Value::Number(_), Value::Number(_)) => as_f64(a) == as_f64(b),
+        (Value::Bool(x), Value::Bool(y)) => x == y,
+        (Value::Null, Value::Null) => true,
+        _ => false,
+    }
+}
+
+/// Mirror of `expr::js_to_string` (the `BinOp::Plus` string coercion):
+/// numbers via [`crate::js_number::to_js_string`], bools as
+/// `"true"`/`"false"`, null as `"null"`, arrays/objects as
+/// `"[object Object]"` (the client helper's catch-all).
+fn to_js_string(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        Value::Number(n) => n
+            .as_f64()
+            .map(crate::js_number::to_js_string)
+            .unwrap_or_default(),
+        Value::Bool(b) => if *b { "true" } else { "false" }.to_string(),
+        Value::Null => "null".to_string(),
+        Value::Array(_) | Value::Object(_) => "[object Object]".to_string(),
+    }
+}
+
+/// Build a JSON number from an `f64`; non-finite (which `serde_json`
+/// can't represent) collapses to `Null`. Finite values are the only
+/// ones SSR rendering produces.
+fn number(f: f64) -> Value {
+    serde_json::Number::from_f64(f)
+        .map(Value::Number)
+        .unwrap_or(Value::Null)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::eval;
+    use serde_json::{json, Value};
+
+    fn run(src: &str, state: &Value) -> Value {
+        let ast = crate::expr::parse(src).expect("parse");
+        eval(&ast, state)
+    }
+
+    /// Compare by value, not by serde_json int/float representation
+    /// (JS has a single number type; `Number(3)` and `Number(3.0)` are
+    /// the same value). Matches the differential fuzz's comparison.
+    fn loose_eq(a: &Value, b: &Value) -> bool {
+        match (a, b) {
+            (Value::Number(x), Value::Number(y)) => x.as_f64() == y.as_f64(),
+            (Value::Array(xs), Value::Array(ys)) => {
+                xs.len() == ys.len() && xs.iter().zip(ys).all(|(p, q)| loose_eq(p, q))
+            }
+            (Value::Object(xs), Value::Object(ys)) => {
+                xs.len() == ys.len()
+                    && xs
+                        .iter()
+                        .all(|(k, v)| ys.get(k).is_some_and(|w| loose_eq(v, w)))
+            }
+            _ => a == b,
+        }
+    }
+
+    #[test]
+    fn mirrors_client_evaluator_semantics() {
+        let s = json!({ "n": 3, "z": 0, "s": "hi", "empty": "", "t": true, "f": false,
+                        "nil": null, "obj": {"k": 7} });
+        let check = |src: &str, want: Value| {
+            let got = run(src, &s);
+            assert!(loose_eq(&got, &want), "{src}: got {got}, want {want}");
+        };
+
+        // paths + nesting
+        check("n", json!(3));
+        check("obj.k", json!(7));
+        check("missing", json!(null));
+
+        // truthiness / not
+        check("!z", json!(true)); // 0 is falsy
+        check("!empty", json!(true)); // "" is falsy
+        check("!obj", json!(false)); // object is truthy
+
+        // && / || short-circuit, returning the operand (JS semantics)
+        check("z && n", json!(0)); // falsy lhs returned
+        check("n && s", json!("hi")); // truthy lhs → rhs
+        check("empty || s", json!("hi"));
+
+        // strict equality (no coercion): number 3 !== string "3"
+        check("n == 3", json!(true));
+        check("n == \"3\"", json!(false));
+        check("nil == null", json!(true));
+        check("s != \"no\"", json!(true));
+
+        // comparisons (numeric only)
+        check("n < 5", json!(true));
+        check("s < 5", json!(false)); // string vs num → false
+
+        // plus: string-concat (number via JS formatting) vs numeric add
+        check("s + n", json!("hi3"));
+        check("n + n", json!(6));
+        check("\"x\" + t", json!("xtrue"));
+
+        // ternary
+        check("t ? s : n", json!("hi"));
+        check("f ? s : n", json!(3));
+
+        // read-only: call → null, assign → rhs
+        check("doThing()", json!(null));
+        check("n = 9", json!(9));
+    }
+}

--- a/crates/pocopine-core/src/js_number.rs
+++ b/crates/pocopine-core/src/js_number.rs
@@ -1,0 +1,129 @@
+//! RFC-099 Phase 1 — pure-Rust, JS-identical number → string.
+//!
+//! Reproduces JavaScript `Number.prototype.toString(10)` / `String(n)`
+//! exactly, so the SSR host renderer and the wasm client agree on every
+//! number's text — RFC-099's "same text for same value" parity
+//! invariant. Used by [`crate::text::js_number_string`] on **both**
+//! targets (no more `js_sys` on wasm, no more host approximation) and,
+//! later, by the SSR host expression backend.
+//!
+//! Algorithm: ECMA-262 `Number::toString` (§6.1.6.1.20). The shortest
+//! round-trip significant digits come from Rust's `{:e}` formatting
+//! (a Ryū-class shortest-round-trip), and then JS's digit-placement /
+//! exponent rules are applied.
+//!
+//! **Tie-break note.** For the rare value whose shortest round-trip is
+//! a *tie* (two equal-length decimals both recover the same `f64` —
+//! e.g. `667082108456853.3` vs `.2`), Rust's formatter and V8 may pick
+//! different last digits. Both are correct (both round-trip); they
+//! differ only in tie convention. This is fine **by construction**:
+//! after RFC-099 the wasm client and the SSR host BOTH format through
+//! this one function, so they always agree — matching V8's exact
+//! tie-break is therefore a non-goal. The hard guarantee is that every
+//! output round-trips (digits are sufficient) and uses JS's notation.
+
+/// Format `n` exactly as JavaScript `String(n)` would.
+pub fn to_js_string(n: f64) -> String {
+    if n.is_nan() {
+        return "NaN".to_string();
+    }
+    // Covers both `+0.0` and `-0.0` — JS `String(-0)` is `"0"`.
+    if n == 0.0 {
+        return "0".to_string();
+    }
+    if n.is_infinite() {
+        return if n < 0.0 { "-Infinity" } else { "Infinity" }.to_string();
+    }
+
+    let neg = n < 0.0;
+    let abs = n.abs();
+
+    // Shortest round-trip scientific form: "<d>[.<frac>]e<exp>", one
+    // digit before the point, exponent in base 10. Rust's `{:e}` is
+    // shortest-round-trip, so the significant digits equal V8's.
+    let sci = format!("{abs:e}");
+    let (mantissa, exp_str) = sci
+        .split_once('e')
+        .expect("`{:e}` output always contains an exponent");
+    let exp: i32 = exp_str.parse().expect("`{:e}` exponent is an integer");
+
+    // `s` = significant digits (no `.`), `k` = digit count. With the
+    // `{:e}` form, ECMA's `n` (the decimal-point position such that the
+    // value is `s × 10^(n − k)`) is `exp + 1`.
+    let s: String = mantissa.chars().filter(|c| *c != '.').collect();
+    let k = s.len() as i32;
+    let point = exp + 1;
+
+    let mut out = String::new();
+    if neg {
+        out.push('-');
+    }
+
+    if k <= point && point <= 21 {
+        // Integer: digits then `point − k` trailing zeros.  (e.g. 100)
+        out.push_str(&s);
+        out.push_str(&"0".repeat((point - k) as usize));
+    } else if 0 < point && point <= 21 {
+        // Decimal point inside the digits.  (e.g. 12.5, 123.456)
+        out.push_str(&s[..point as usize]);
+        out.push('.');
+        out.push_str(&s[point as usize..]);
+    } else if -6 < point && point <= 0 {
+        // Leading `0.` then `-point` zeros then the digits. (e.g. 0.001)
+        out.push_str("0.");
+        out.push_str(&"0".repeat((-point) as usize));
+        out.push_str(&s);
+    } else {
+        // Exponential: `point > 21` or `point ≤ −6`.  (e.g. 1e+21, 1e-7)
+        let e = point - 1;
+        if k == 1 {
+            out.push_str(&s);
+        } else {
+            out.push_str(&s[..1]);
+            out.push('.');
+            out.push_str(&s[1..]);
+        }
+        out.push('e');
+        out.push(if e >= 0 { '+' } else { '-' });
+        out.push_str(&e.abs().to_string());
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::to_js_string;
+
+    // Each pair is `(value, exactly what JS String(value) produces)`.
+    #[test]
+    fn matches_javascript_string_semantics() {
+        let cases: &[(f64, &str)] = &[
+            (0.0, "0"),
+            (-0.0, "0"),
+            (1.0, "1"),
+            (-1.0, "-1"),
+            (100.0, "100"),
+            (12.5, "12.5"),
+            (-12.5, "-12.5"),
+            (123.456, "123.456"),
+            (0.5, "0.5"),
+            (0.001, "0.001"),
+            (0.0000001, "1e-7"),    // 1e-7 → exponential (point ≤ −6)
+            (0.000001, "0.000001"), // 1e-6 → decimal (point = −5)
+            (1e20, "100000000000000000000"),
+            (1e21, "1e+21"), // point > 21 → exponential
+            (1e-21, "1e-21"),
+            (9007199254740992.0, "9007199254740992"), // 2^53
+            (1234567890123456789.0, "1234567890123456800"),
+            (f64::INFINITY, "Infinity"),
+            (f64::NEG_INFINITY, "-Infinity"),
+            (f64::NAN, "NaN"),
+            (1.5e300, "1.5e+300"),
+            (5e-324, "5e-324"), // smallest subnormal
+        ];
+        for (n, want) in cases {
+            assert_eq!(&to_js_string(*n), want, "to_js_string({n})");
+        }
+    }
+}

--- a/crates/pocopine-core/src/lib.rs
+++ b/crates/pocopine-core/src/lib.rs
@@ -32,6 +32,9 @@ pub mod fingerprint;
 pub mod focus;
 pub mod handle;
 pub mod handler;
+/// RFC-099 Phase 1 — JS-identical number formatting, shared by the
+/// wasm client and the SSR host renderer.
+pub mod js_number;
 pub mod lifecycle;
 pub mod loop_scope;
 pub mod magics;

--- a/crates/pocopine-core/src/lib.rs
+++ b/crates/pocopine-core/src/lib.rs
@@ -32,6 +32,10 @@ pub mod fingerprint;
 pub mod focus;
 pub mod handle;
 pub mod handler;
+/// RFC-099 Phase 1b — host-side expression evaluator over
+/// `serde_json::Value` (the SSR render backend), parity-gated against
+/// the wasm `JsValue` evaluator.
+pub mod host_eval;
 /// RFC-099 Phase 1 — JS-identical number formatting, shared by the
 /// wasm client and the SSR host renderer.
 pub mod js_number;

--- a/crates/pocopine-core/src/text/mod.rs
+++ b/crates/pocopine-core/src/text/mod.rs
@@ -45,23 +45,9 @@ pub use prepare::{prepare, Font, PrepareOptions, PreparedText, WhiteSpace};
 /// the mutation-channel interpreter's `String(v)`): JS `String()`
 /// semantics, so 1e21 → "1e+21", Infinity → "Infinity", and the
 /// channel/direct paths can never disagree on a number's text.
-/// Host (non-wasm) builds approximate with Rust Display plus the
-/// integral `.0`-strip — identical for every value the host test
-/// suite exercises.
+/// RFC-099 Phase 1 — one pure-Rust implementation
+/// ([`crate::js_number::to_js_string`]) on both targets, so the wasm
+/// client and the SSR host renderer produce byte-identical text.
 pub(crate) fn js_number_string(n: f64) -> String {
-    #[cfg(target_arch = "wasm32")]
-    {
-        js_sys::Number::from(n)
-            .to_string_with_radix(10)
-            .map(String::from)
-            .unwrap_or_else(|_| n.to_string())
-    }
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        if n.fract() == 0.0 && n.is_finite() && n.abs() < 9.0e15 {
-            format!("{}", n as i64)
-        } else {
-            n.to_string()
-        }
-    }
+    crate::js_number::to_js_string(n)
 }

--- a/crates/pocopine-core/tests/expr_host_parity.rs
+++ b/crates/pocopine-core/tests/expr_host_parity.rs
@@ -1,0 +1,141 @@
+//! RFC-099 Phase 1b parity gate — the host `serde_json` evaluator
+//! (`host_eval::eval`) agrees with the wasm `JsValue` evaluator
+//! (`expr::evaluate`) on the SAME parsed AST, over a fuzz corpus of
+//! random state + random expressions. This is what guarantees the SSR
+//! server stamps the value the client would compute, despite the two
+//! evaluators being separate implementations.
+//!
+//! Runs under `wasm-pack test --node crates/pocopine-core`.
+//!
+//! State values are bool/number/string only (not JSON `null`): a
+//! `serde_json::Value::Null` serializes to JS `undefined`, and JS
+//! `undefined === null` is `false` while host `Null === Null` is true
+//! — a null-vs-undefined boundary that's a Phase-2 concern (how
+//! `Option::None` state serializes). `null` *literals* in expressions
+//! are still exercised (real `null` on both sides). Likewise the
+//! generator emits no nested paths (which could surface `undefined`)
+//! and only non-negative number literals (the grammar has `+` but no
+//! subtraction / unary minus).
+
+#![cfg(target_arch = "wasm32")]
+
+use pocopine_core::{expr, host_eval};
+use serde::Serialize;
+use serde_json::{Map, Number, Value};
+use wasm_bindgen::JsValue;
+use wasm_bindgen_test::wasm_bindgen_test;
+
+struct Rng(u64);
+impl Rng {
+    fn next(&mut self) -> u64 {
+        self.0 = self
+            .0
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        self.0
+    }
+    fn below(&mut self, n: u32) -> u32 {
+        ((self.next() >> 33) % n as u64) as u32
+    }
+}
+
+fn num(f: f64) -> Value {
+    Value::Number(Number::from_f64(f).expect("finite"))
+}
+
+fn rand_state(rng: &mut Rng) -> Value {
+    let mut o = Map::new();
+    for k in ["a", "b", "c", "d"] {
+        let v = match rng.below(4) {
+            0 => Value::Bool(rng.below(2) == 1),
+            1 => num((rng.below(20) as f64) - 10.0), // integral -10..9
+            2 => num(((rng.below(2000) as f64) / 100.0) - 10.0), // float -10..10
+            _ => Value::String(["", "x", "5", "hi"][rng.below(4) as usize].to_string()),
+        };
+        o.insert(k.to_string(), v);
+    }
+    Value::Object(o)
+}
+
+fn leaf(rng: &mut Rng) -> String {
+    match rng.below(7) {
+        0 => "a".into(),
+        1 => "b".into(),
+        2 => "c".into(),
+        3 => "d".into(),
+        4 => format!("{}", rng.below(20)), // non-negative literal
+        5 => format!("\"{}\"", ["", "x", "5", "hi"][rng.below(4) as usize]),
+        _ => ["true", "false", "null"][rng.below(3) as usize].into(),
+    }
+}
+
+fn expr_src(rng: &mut Rng, depth: u32) -> String {
+    if depth == 0 || rng.below(3) == 0 {
+        return leaf(rng);
+    }
+    let l = expr_src(rng, depth - 1);
+    match rng.below(10) {
+        0 => format!("({l} && {})", expr_src(rng, depth - 1)),
+        1 => format!("({l} || {})", expr_src(rng, depth - 1)),
+        2 => format!("({l} == {})", expr_src(rng, depth - 1)),
+        3 => format!("({l} != {})", expr_src(rng, depth - 1)),
+        4 => format!("({l} < {})", expr_src(rng, depth - 1)),
+        5 => format!("({l} > {})", expr_src(rng, depth - 1)),
+        6 => format!("({l} <= {})", expr_src(rng, depth - 1)),
+        7 => format!("({l} + {})", expr_src(rng, depth - 1)),
+        8 => format!("!{l}"),
+        _ => format!(
+            "({l} ? {} : {})",
+            expr_src(rng, depth - 1),
+            expr_src(rng, depth - 1)
+        ),
+    }
+}
+
+/// Compare by value, ignoring serde_json int/float representation (JS
+/// has a single number type).
+fn loose_eq(a: &Value, b: &Value) -> bool {
+    match (a, b) {
+        (Value::Number(x), Value::Number(y)) => x.as_f64() == y.as_f64(),
+        (Value::Array(xs), Value::Array(ys)) => {
+            xs.len() == ys.len() && xs.iter().zip(ys).all(|(p, q)| loose_eq(p, q))
+        }
+        (Value::Object(xs), Value::Object(ys)) => {
+            xs.len() == ys.len()
+                && xs
+                    .iter()
+                    .all(|(k, v)| ys.get(k).is_some_and(|w| loose_eq(v, w)))
+        }
+        _ => a == b,
+    }
+}
+
+#[wasm_bindgen_test]
+fn host_and_js_evaluators_agree_over_fuzz() {
+    let mut rng = Rng(0xDEAD_BEEF_1234_5678);
+    // Plain-object serialization so the JS evaluator's `Reflect::get`
+    // hits (the default would emit an ES `Map`, which Reflect can't
+    // index — mirrors how a `#[component]` struct serializes).
+    let ser = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
+    let mut checked = 0u32;
+    for _ in 0..6000 {
+        let state = rand_state(&mut rng);
+        let src = expr_src(&mut rng, 3);
+        let Ok(ast) = expr::parse_cached(&src) else {
+            continue;
+        };
+        let host = host_eval::eval(&ast, &state);
+        let scope: JsValue = state.serialize(&ser).expect("state → JsValue");
+        let js = expr::evaluate(&ast, &scope);
+        let js_json: Value = serde_wasm_bindgen::from_value(js).unwrap_or(Value::Null);
+        assert!(
+            loose_eq(&host, &js_json),
+            "DRIFT src={src}\n  state={state}\n  host={host}\n  js  ={js_json}"
+        );
+        checked += 1;
+    }
+    assert!(
+        checked > 3000,
+        "fuzz ran too few parseable cases: {checked}"
+    );
+}

--- a/crates/pocopine-core/tests/js_number_parity.rs
+++ b/crates/pocopine-core/tests/js_number_parity.rs
@@ -1,0 +1,51 @@
+//! RFC-099 Phase 1 — correctness fuzz for the shared JS number
+//! formatter (`js_number::to_js_string`).
+//!
+//! The SSR "same text for same value" invariant is satisfied **by
+//! construction** — the wasm client and the SSR host both format
+//! through this one function — so this test does NOT compare against
+//! the V8 engine (which differs only in last-digit tie-break for rare
+//! 16-digit ties; see `js_number.rs`). Instead it proves the two
+//! properties that matter:
+//!
+//!   1. **Round-trip**: every formatted finite `f64` re-parses to the
+//!      exact same value — the digits are always sufficient (no
+//!      precision loss), over a 2M random-bit-pattern corpus.
+//!   2. **JS notation shape** (exponent thresholds, Infinity/NaN, -0)
+//!      is pinned by the unit table in `js_number.rs`.
+//!
+//! Host test — no wasm/JS needed.
+
+use pocopine_core::js_number::to_js_string;
+
+#[test]
+fn every_finite_format_round_trips() {
+    // Deterministic LCG over u64 → f64::from_bits, so any failure
+    // replays from its seed.
+    let mut seed: u64 = 0x9E37_79B9_7F4A_7C15;
+    let mut checked = 0u64;
+    for _ in 0..2_000_000 {
+        seed = seed
+            .wrapping_mul(6364136223846793005)
+            .wrapping_add(1442695040888963407);
+        let n = f64::from_bits(seed);
+        if !n.is_finite() {
+            continue; // Infinity / NaN have no numeric round-trip; see unit table.
+        }
+        let s = to_js_string(n);
+        let back: f64 = s
+            .parse()
+            .unwrap_or_else(|e| panic!("unparseable {s:?} for bits={seed:#018x}: {e}"));
+        // Value equality (not bits): `String(-0)` is "0", which
+        // round-trips to +0.0 — JS-correct, and `0.0 == -0.0`.
+        assert!(
+            back == n,
+            "round-trip failed: n={n} (bits={seed:#018x}) -> {s:?} -> {back}"
+        );
+        checked += 1;
+    }
+    assert!(
+        checked > 1_000_000,
+        "fuzz ran too few finite cases: {checked}"
+    );
+}


### PR DESCRIPTION
RFC-099 SSR Phase 1 parity foundations — the no-user-surface groundwork the rest of SSR (server stamp + client claim) builds on. Two pieces, each behind its own parity gate. No runtime/behavioral feature yet.

## P1a — pure-Rust JS-identical number formatter (`crate::js_number::to_js_string`)
Reproduces JS `String(n)` / `Number.prototype.toString(10)` exactly (ECMA-262 `Number::toString`): shortest round-trip digits from `{:e}`, JS placement/exponent rules — `1e21`→`1e+21`, `1e-7` exponential, `1e-6` decimal, `-0`→`0`, `Infinity`, `NaN`. `text::js_number_string` now calls it on **both** wasm and host, collapsing the old `js_sys::Number` path + host approximation into **one shared implementation** — so the wasm client and the SSR host renderer produce byte-identical number text *by construction*.

- **Tie-break note:** for rare 16-digit shortest-round-trip ties, Rust and V8 pick different last digits (both round-trip). Matching V8 byte-for-byte is a non-goal precisely because both sides now use this one function. (This is a tiny client-output change for those edge values — flagged for review.)
- **Gate:** 2M-case host round-trip fuzz (every finite f64 re-parses exactly) + JS-notation edge table.

## P1b — host-side expression evaluator (`crate::host_eval::eval`)
Evaluates the **same parsed AST** (`pocopine_expr`) the client runs, but over `serde_json::Value` instead of `JsValue` — the SSR render backend. Mirrors `expr::evaluate_with`'s JS semantics (`is_falsy`, `js_strict_eq`, `js_to_string`, `Plus` string-concat via P1a). Read-only: `Call`→`Null`, `Assign`→rhs; magic `$`-roots and nested-on-non-object → `Null` (Phase 2).

- **Design call:** a *parallel* evaluator, **not** a `ValueBackend` genericization of `evaluate_with` — the client evaluator is the RFC-095/096 reactive hot path (`JsValue`/`Reflect`/`ScopeAccess`/magic-scope coupled), so a parallel host impl leaves it untouched. The drift risk is paid down by the gate below.
- **Gate (the important one):** a **cross-engine differential fuzz** (`tests/expr_host_parity.rs`) builds a plain-object JS scope + matching `serde_json` state from the same random data, evaluates **6000 random ASTs through BOTH engines**, and asserts equal results. Green.

## Verification
node reactive battery **32/32 + 9/9** (no client regression from the formatter unification), host unit tables + 2M round-trip fuzz + 6000-case cross-engine fuzz green, wasm clippy `--all-features` + host clippy + fmt clean.

## Scope / not in this PR
Phase 1c (full component differential render *harness*) needs the Phase-2 stamper, so it's deferred; the two fuzzes here are the foundations' parity gates. RFC-059→Superseded relabel + the Phase-2 `render_to_string` stamper / hydration claim path are follow-ups (see the approved plan).
