### PR TITLE
feat: SPA boot loader + router navigation polish

### DIFF
--- a/crates/pocopine-cli/assets/loader.css
+++ b/crates/pocopine-cli/assets/loader.css
@@ -1,0 +1,68 @@
+/* pocopine boot loader — injected into pkg/index.html by `pocopine build`
+ * when `[package.metadata.pocopine.loader] enabled` (the default).
+ * Colours reuse the app's theme tokens (--brand/--bg/--destructive) with
+ * light-theme fallbacks. Keep the controller contract in sync with
+ * crates/pocopine-core/src/progress.rs (window.__pocopineProgress). */
+
+/* Full-screen logo splash — first/cold load only (it lives in the initial
+ * HTML so it paints on frame 1; removed once the app reports ready). */
+#pp-splash {
+  position: fixed;
+  inset: 0;
+  z-index: 9998;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg, #fffaf2);
+  transition: opacity 0.4s ease;
+}
+#pp-splash.pp-splash--done {
+  opacity: 0;
+  pointer-events: none;
+}
+/* Cold-start only: the injected <head> gate sets data-pp-no-splash once the
+ * splash has shown this tab session (survives reloads / full-page
+ * navigations), so it doesn't reappear on every navigation. The top bar
+ * still shows. */
+html[data-pp-no-splash] #pp-splash { display: none !important; }
+.pp-splash__logo {
+  width: 96px;
+  height: 96px;
+  animation: pp-splash-pulse 1.4s ease-in-out infinite;
+}
+@keyframes pp-splash-pulse {
+  0%, 100% { opacity: 0.55; transform: scale(0.97); }
+  50% { opacity: 1; transform: scale(1); }
+}
+
+/* Thin top progress bar — boot download + in-app/route activity. */
+#pp-loader {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  z-index: 9999;
+  overflow: hidden;
+  pointer-events: none;
+  transition: opacity 0.3s ease 0.15s;
+}
+#pp-loader.pp-loader--done { opacity: 0; }
+.pp-loader__bar {
+  height: 100%;
+  width: 100%;
+  background: var(--brand, #f8ae45);
+  box-shadow: 0 0 8px var(--brand, #f8ae45);
+  transform: translateX(-100%);
+  transition: transform 0.2s ease;
+  will-change: transform;
+}
+#pp-loader.pp-loader--error .pp-loader__bar {
+  background: var(--destructive, #c04a2b);
+  box-shadow: 0 0 8px var(--destructive, #c04a2b);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pp-splash__logo { animation: none; }
+  .pp-loader__bar { transition: none; }
+}

--- a/crates/pocopine-cli/assets/loader.js
+++ b/crates/pocopine-cli/assets/loader.js
@@ -1,0 +1,124 @@
+/* pocopine boot loader — injected into pkg/index.html by `pocopine build`.
+ *
+ * Runs as a classic <script> BEFORE the app's module boot, so it wraps
+ * `fetch` to report the real wasm download as progress. Installs the
+ * `window.__pocopineProgress` controller that `pocopine::progress` (and
+ * the router auto-hook) reuse in-app. The full-screen logo splash is
+ * removed — and the bar finished — when core reports the app ready
+ * (`progress.ready()` from AppBootCompleted) or, for router apps, when
+ * the first route paint completes.
+ *
+ * Keep the controller contract in sync with the fallback in
+ * crates/pocopine-core/src/progress.rs. */
+(function () {
+  if (window.__pocopineProgress) return;
+
+  var el = null, bar = null, pending = 0, value = 0, determinate = false, trickle = 0, resume = 0;
+
+  function ensure() {
+    el = document.getElementById("pp-loader");
+    if (!el) {
+      el = document.createElement("div");
+      el.id = "pp-loader";
+      el.setAttribute("role", "progressbar");
+      el.setAttribute("aria-label", "Loading");
+      el.setAttribute("aria-valuemin", "0");
+      el.setAttribute("aria-valuemax", "100");
+      bar = document.createElement("div");
+      bar.className = "pp-loader__bar";
+      el.appendChild(bar);
+      (document.body || document.documentElement).appendChild(el);
+    }
+    if (!bar) bar = el.querySelector(".pp-loader__bar");
+  }
+  function render() {
+    ensure();
+    var v = Math.max(0, Math.min(value, 1));
+    if (bar) bar.style.transform = "translateX(" + (v - 1) * 100 + "%)";
+    el.setAttribute("aria-valuenow", String(Math.round(v * 100)));
+  }
+  function show() { ensure(); el.classList.remove("pp-loader--done", "pp-loader--error"); }
+  function startTrickle() {
+    clearInterval(trickle);
+    trickle = setInterval(function () {
+      if (value < 0.95) { value += (0.95 - value) * 0.1; render(); }
+    }, 200);
+  }
+  function hideSplash() {
+    var s = document.getElementById("pp-splash");
+    if (!s) return;
+    s.classList.add("pp-splash--done");
+    s.addEventListener("transitionend", function () { s.remove(); }, { once: true });
+    setTimeout(function () { s.remove(); }, 700);
+  }
+  function complete() {
+    clearInterval(trickle); clearTimeout(resume);
+    pending = 0; value = 1; render();
+    ensure(); el.classList.add("pp-loader--done");
+    hideSplash();
+    setTimeout(function () {
+      value = 0; determinate = false;
+      if (bar) {
+        bar.style.transition = "none"; render();
+        requestAnimationFrame(function () { if (bar) bar.style.transition = ""; });
+      }
+      if (el) el.classList.remove("pp-loader--done");
+    }, 450);
+  }
+
+  var api = {
+    start: function () {
+      pending++; show();
+      if (pending === 1 && !determinate) {
+        if (value < 0.08) value = 0.08;
+        render(); startTrickle();
+      }
+    },
+    set: function (f) {
+      determinate = true; clearInterval(trickle); clearTimeout(resume);
+      value = Math.max(0, Math.min(f, 1)); show(); render();
+      if (value >= 1) { complete(); return; }
+      resume = setTimeout(function () { determinate = false; startTrickle(); }, 400);
+    },
+    inc: function (d) { api.set(value + d); },
+    done: function () { pending = Math.max(0, pending - 1); if (pending === 0) complete(); },
+    error: function () {
+      clearInterval(trickle); clearTimeout(resume); ensure();
+      el.classList.add("pp-loader--error"); value = 1; render(); hideSplash();
+    },
+    // App reported ready (AppBootCompleted / first route paint): drop the
+    // splash and finish the boot bar regardless of in-flight count.
+    ready: function () { complete(); },
+  };
+  window.__pocopineProgress = api;
+
+  // Track the wasm download as determinate progress. wasm-bindgen's init()
+  // fetches the (hashed) *_bg.wasm via the global fetch; wrap that one
+  // response body in a byte counter, mapping onto the first 90% of the bar
+  // (the tail trickles through compile/mount). The re-wrapped Response keeps
+  // its headers so streaming compilation still works. Restored on ready.
+  var realFetch = window.fetch.bind(window);
+  window.fetch = function (input, opts) {
+    var url = typeof input === "string" ? input : (input && input.url) || String(input);
+    var res = realFetch(input, opts);
+    if (!/\.wasm(\?|$)/.test(url)) return res;
+    return res.then(function (resp) {
+      if (!resp.body || !resp.ok) return resp;
+      var total = Number(resp.headers.get("content-length")) || 0;
+      var loaded = 0;
+      var reader = resp.body.getReader();
+      var stream = new ReadableStream({
+        pull: function (controller) {
+          return reader.read().then(function (r) {
+            if (r.done) { window.fetch = realFetch; controller.close(); return; }
+            loaded += r.value.byteLength;
+            if (total) api.set((loaded / total) * 0.9);
+            controller.enqueue(r.value);
+          });
+        },
+        cancel: function (reason) { reader.cancel(reason); },
+      });
+      return new Response(stream, { headers: resp.headers, status: resp.status, statusText: resp.statusText });
+    });
+  };
+})();

--- a/crates/pocopine-cli/assets/loader.js
+++ b/crates/pocopine-cli/assets/loader.js
@@ -13,7 +13,10 @@
 (function () {
   if (window.__pocopineProgress) return;
 
-  var el = null, bar = null, pending = 0, value = 0, determinate = false, trickle = 0, resume = 0;
+  var el = null, bar = null, pending = 0, value = 0, determinate = false, trickle = 0, resume = 0, showTimer = 0, shown = false;
+  // A navigation may run this long before the bar reveals (deferred
+  // indicator): fast routes never flash a bar; only genuinely slow work does.
+  var SHOW_DELAY = 150;
 
   function ensure() {
     el = document.getElementById("pp-loader");
@@ -38,6 +41,13 @@
     el.setAttribute("aria-valuenow", String(Math.round(v * 100)));
   }
   function show() { ensure(); el.classList.remove("pp-loader--done", "pp-loader--error"); }
+  // Reveal the bar (the deferred timer fired, or an explicit show): start the
+  // indeterminate trickle from a small head start.
+  function reveal() {
+    showTimer = 0; shown = true; show();
+    if (value < 0.08) value = 0.08;
+    render(); startTrickle();
+  }
   function startTrickle() {
     clearInterval(trickle);
     trickle = setInterval(function () {
@@ -52,12 +62,13 @@
     setTimeout(function () { s.remove(); }, 700);
   }
   function complete() {
+    clearTimeout(showTimer); showTimer = 0;
     clearInterval(trickle); clearTimeout(resume);
     pending = 0; value = 1; render();
     ensure(); el.classList.add("pp-loader--done");
     hideSplash();
     setTimeout(function () {
-      value = 0; determinate = false;
+      value = 0; determinate = false; shown = false;
       if (bar) {
         bar.style.transition = "none"; render();
         requestAnimationFrame(function () { if (bar) bar.style.transition = ""; });
@@ -67,22 +78,32 @@
   }
 
   var api = {
+    // Begin a task. Don't show yet — arm a timer so a navigation that finishes
+    // within SHOW_DELAY never flashes the bar. Slow work reveals it on fire.
     start: function () {
-      pending++; show();
-      if (pending === 1 && !determinate) {
-        if (value < 0.08) value = 0.08;
-        render(); startTrickle();
+      pending++;
+      if (pending === 1 && !determinate && !shown && !showTimer) {
+        showTimer = setTimeout(reveal, SHOW_DELAY);
       }
     },
     set: function (f) {
+      // A concrete fraction is an explicit "show progress" — reveal at once.
+      clearTimeout(showTimer); showTimer = 0; shown = true;
       determinate = true; clearInterval(trickle); clearTimeout(resume);
       value = Math.max(0, Math.min(f, 1)); show(); render();
       if (value >= 1) { complete(); return; }
       resume = setTimeout(function () { determinate = false; startTrickle(); }, 400);
     },
     inc: function (d) { api.set(value + d); },
-    done: function () { pending = Math.max(0, pending - 1); if (pending === 0) complete(); },
+    done: function () {
+      pending = Math.max(0, pending - 1);
+      if (pending > 0) return;
+      // Finished before the reveal timer fired → cancel it; never flash.
+      if (showTimer) { clearTimeout(showTimer); showTimer = 0; return; }
+      if (shown) complete();
+    },
     error: function () {
+      clearTimeout(showTimer); showTimer = 0; shown = true;
       clearInterval(trickle); clearTimeout(resume); ensure();
       el.classList.add("pp-loader--error"); value = 1; render(); hideSplash();
     },

--- a/crates/pocopine-cli/src/args.rs
+++ b/crates/pocopine-cli/src/args.rs
@@ -121,11 +121,13 @@ pub struct ServeArgs {
     /// from here.
     #[arg(long, default_value = ".")]
     pub path: PathBuf,
-    /// Port to listen on in static mode. Ignored in server-bin mode -
-    /// the bin controls its own addr. If the port is taken, the next
-    /// available port is tried (up to `port + 20`).
-    #[arg(long, default_value_t = 5243)]
-    pub port: u16,
+    /// Override the listen port (no `Cargo.toml` edit needed). In static
+    /// mode the CLI listens here (default 5243; if taken, the next free
+    /// port up to +20 is used). In server-bin mode the configured bin is
+    /// launched with `PORT=<this>`, overriding
+    /// `[package.metadata.pocopine].port` — pocopine server bins read `PORT`.
+    #[arg(long)]
+    pub port: Option<u16>,
     /// Build in release mode.
     #[arg(long)]
     pub release: bool,

--- a/crates/pocopine-cli/src/build.rs
+++ b/crates/pocopine-cli/src/build.rs
@@ -166,10 +166,82 @@ fn write_pkg_index_html(project: &Path, hashed: &[(String, String)]) -> Result<(
     for (name, hash) in hashed {
         html = rewrite_bundle_refs(&html, name, hash);
     }
+    let loader = crate::config::load(project)
+        .ok()
+        .and_then(|c| c.loader)
+        .unwrap_or_default();
+    let suffix = if loader.enabled {
+        html = inject_loader(&html, &loader);
+        " + boot loader"
+    } else {
+        ""
+    };
     std::fs::write(project.join("pkg/index.html"), html)
         .context("write generated pkg/index.html")?;
-    println!("✓ pkg/index.html → hashed bundle reference(s)");
+    println!("✓ pkg/index.html → hashed bundle reference(s){suffix}");
     Ok(())
+}
+
+/// Inject the boot loader: the splash + top-bar styles into `<head>`, the
+/// full-screen logo splash into `<body>` (so it paints on the first frame),
+/// and the controller script. The script is classic (not a module) so it
+/// runs before the app's deferred module boot and can wrap `fetch` to
+/// report the wasm download as progress. No-op if already injected.
+fn inject_loader(html: &str, loader: &crate::config::LoaderConfig) -> String {
+    if html.contains("id=\"pp-loader-style\"") {
+        return html.to_string();
+    }
+    const CSS: &str = include_str!("../assets/loader.css");
+    const JS: &str = include_str!("../assets/loader.js");
+    let mut out = html.to_string();
+
+    if let Some(at) = out.find("</head>") {
+        let mut head = format!("  <style id=\"pp-loader-style\">\n{CSS}  </style>\n");
+        if loader.splash {
+            // Show the splash once per tab session. This runs before <body>
+            // is parsed, so on a reload / full-page navigation within the
+            // session it hides the splash with no flash (the bar still shows).
+            head.push_str("  <script>(function(){try{var k=\"pp-splash-shown\";if(sessionStorage.getItem(k)){document.documentElement.setAttribute(\"data-pp-no-splash\",\"\");}else{sessionStorage.setItem(k,\"1\");}}catch(e){}})();</script>\n");
+        }
+        out.insert_str(at, &head);
+    }
+    if loader.splash
+        && let Some(logo) = loader.logo.clone().or_else(|| icon_href(html))
+    {
+        let splash = format!(
+            "\n  <div id=\"pp-splash\"><img class=\"pp-splash__logo\" src=\"{logo}\" alt=\"\" /></div>\n"
+        );
+        if let Some(start) = out.find("<body")
+            && let Some(gt) = out[start..].find('>')
+        {
+            out.insert_str(start + gt + 1, &splash);
+        }
+    }
+    if let Some(at) = out.find("</body>") {
+        out.insert_str(at, &format!("  <script>\n{JS}  </script>\n"));
+    }
+    out
+}
+
+/// Best-effort `<link rel="icon" … href="X">` href — the splash logo when
+/// none is configured explicitly.
+fn icon_href(html: &str) -> Option<String> {
+    let lower = html.to_ascii_lowercase();
+    let mut from = 0;
+    while let Some(rel) = lower[from..].find("rel=\"icon\"") {
+        let abs = from + rel;
+        let tag_start = lower[..abs].rfind('<').unwrap_or(abs);
+        let tag_end = lower[abs..].find('>').map_or(html.len(), |e| abs + e);
+        let tag = &html[tag_start..tag_end];
+        if let Some(h) = tag.find("href=\"") {
+            let rest = &tag[h + 6..];
+            if let Some(end) = rest.find('"') {
+                return Some(rest[..end].to_string());
+            }
+        }
+        from = tag_end;
+    }
+    None
 }
 
 /// Replace every `pkg/<name>.js` / `pkg/<name>.<hash8>.js` occurrence

--- a/crates/pocopine-cli/src/config.rs
+++ b/crates/pocopine-cli/src/config.rs
@@ -130,7 +130,11 @@ pub struct LoaderConfig {
 
 impl Default for LoaderConfig {
     fn default() -> Self {
-        Self { enabled: true, splash: true, logo: None }
+        Self {
+            enabled: true,
+            splash: true,
+            logo: None,
+        }
     }
 }
 

--- a/crates/pocopine-cli/src/config.rs
+++ b/crates/pocopine-cli/src/config.rs
@@ -32,6 +32,11 @@ pub struct PocopineConfig {
     /// project's `assets/` tree to the configured S3-compatible
     /// bucket under content-addressed keys.
     pub assets: Option<AssetsConfig>,
+    /// Boot loader: the full-screen logo splash (cold load) + thin top
+    /// progress bar injected into the generated `pkg/index.html`. On by
+    /// default; customize the logo / splash, or opt out via
+    /// `enabled = false`.
+    pub loader: Option<LoaderConfig>,
 }
 
 /// `[package.metadata.pocopine.assets]` — the RFC-100 asset bucket.
@@ -104,6 +109,33 @@ impl Default for StylekitConfig {
             enabled: default_sk_enabled(),
         }
     }
+}
+
+/// `[package.metadata.pocopine.loader]` — the injected boot loader: a
+/// full-screen logo splash on cold load plus a thin top progress bar that
+/// tracks the wasm download and (via `pocopine::progress`) in-app activity.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct LoaderConfig {
+    /// Inject the loader into the generated `pkg/index.html` (default true).
+    #[serde(default = "default_loader_bool")]
+    pub enabled: bool,
+    /// Show the full-screen logo splash on cold load (default true). When
+    /// false, only the top progress bar is injected.
+    #[serde(default = "default_loader_bool")]
+    pub splash: bool,
+    /// Splash logo URL. Defaults to the page's `<link rel="icon">` href.
+    pub logo: Option<String>,
+}
+
+impl Default for LoaderConfig {
+    fn default() -> Self {
+        Self { enabled: true, splash: true, logo: None }
+    }
+}
+
+fn default_loader_bool() -> bool {
+    true
 }
 
 fn default_sk_input() -> String {

--- a/crates/pocopine-cli/src/dev.rs
+++ b/crates/pocopine-cli/src/dev.rs
@@ -60,7 +60,14 @@ pub fn run(args: &ServeArgs) -> Result<()> {
     // In static mode the CLI owns the socket and runs on a background thread.
     server::check_configured_port_available(&cfg, args.port)?;
     if cfg.bin.is_some() || cfg.worker_bin.is_some() {
-        spawn_configured_bins(&mut children, &project, &cfg, args.release, &dev_env, args.port)?;
+        spawn_configured_bins(
+            &mut children,
+            &project,
+            &cfg,
+            args.release,
+            &dev_env,
+            args.port,
+        )?;
     } else {
         {
             let serve_path = project.clone();

--- a/crates/pocopine-cli/src/dev.rs
+++ b/crates/pocopine-cli/src/dev.rs
@@ -16,7 +16,7 @@ const CHANGE_MAX_COALESCE: Duration = Duration::from_secs(4);
 pub fn run(args: &ServeArgs) -> Result<()> {
     let project = args.path.canonicalize()?;
     let cfg = config::load(&args.path)?;
-    server::check_configured_port_available(&cfg)?;
+    server::check_configured_port_available(&cfg, args.port)?;
     build::wasm(&project, args.release)?;
     client_modules::build(&project, args.release)?;
     build::configured_bins(&project, &cfg, args.release)?;
@@ -58,13 +58,13 @@ pub fn run(args: &ServeArgs) -> Result<()> {
 
     // Start the serving side. In bin mode the child owns its ports + routes.
     // In static mode the CLI owns the socket and runs on a background thread.
-    server::check_configured_port_available(&cfg)?;
+    server::check_configured_port_available(&cfg, args.port)?;
     if cfg.bin.is_some() || cfg.worker_bin.is_some() {
-        spawn_configured_bins(&mut children, &project, &cfg, args.release, &dev_env)?;
+        spawn_configured_bins(&mut children, &project, &cfg, args.release, &dev_env, args.port)?;
     } else {
         {
             let serve_path = project.clone();
-            let port = args.port;
+            let port = args.port.unwrap_or(5243);
             thread::spawn(move || {
                 if let Err(e) = server::serve_static(&serve_path, port) {
                     eprintln!("server error: {e}");
@@ -116,6 +116,7 @@ pub fn run(args: &ServeArgs) -> Result<()> {
                         &cfg,
                         args.release,
                         &dev_env,
+                        args.port,
                     ) {
                         eprintln!("server restart failed: {e:#}");
                         continue;
@@ -149,15 +150,22 @@ fn spawn_configured_bins(
     cfg: &config::PocopineConfig,
     release: bool,
     dev_env: &std::collections::BTreeMap<String, String>,
+    override_port: Option<u16>,
 ) -> Result<()> {
     if let Some(bin) = cfg.bin.as_deref() {
+        // The web bin gets PORT = --port override, else the manifest port,
+        // so its bound addr matches the port the preflight checked.
+        let mut server_env = dev_env.clone();
+        if let Some(p) = override_port.or(cfg.port) {
+            server_env.insert("PORT".to_string(), p.to_string());
+        }
         children.bins.push(server::spawn_bin_with_env(
             project,
             bin,
             release,
             server::BinRole::Server,
             true,
-            dev_env,
+            &server_env,
         )?);
     }
     if let Some(worker) = cfg.worker_bin.as_deref() {
@@ -180,11 +188,12 @@ fn restart_configured_bins(
     cfg: &config::PocopineConfig,
     release: bool,
     dev_env: &std::collections::BTreeMap<String, String>,
+    override_port: Option<u16>,
 ) -> Result<()> {
     for child in children.bins.drain(..) {
         child.kill();
     }
-    spawn_configured_bins(children, project, cfg, release, dev_env)
+    spawn_configured_bins(children, project, cfg, release, dev_env, override_port)
 }
 
 fn coalesce_changes(rx: &Receiver<Change>, first: Change) -> Change {

--- a/crates/pocopine-cli/src/main.rs
+++ b/crates/pocopine-cli/src/main.rs
@@ -187,7 +187,7 @@ fn run_build(args: args::BuildArgs) -> Result<()> {
 fn run_project(args: args::ServeArgs) -> Result<()> {
     let project = args.path.canonicalize()?;
     let cfg = config::load(&args.path)?;
-    server::check_configured_port_available(&cfg)?;
+    server::check_configured_port_available(&cfg, args.port)?;
     build::wasm(&project, args.release)?;
     client_modules::build(&project, args.release)?;
     build::configured_bins(&project, &cfg, args.release)?;

--- a/crates/pocopine-cli/src/server.rs
+++ b/crates/pocopine-cli/src/server.rs
@@ -162,9 +162,12 @@ fn profile_name(release: bool) -> &'static str {
     if release { "release" } else { "debug" }
 }
 
-pub fn check_configured_port_available(cfg: &PocopineConfig) -> Result<()> {
+pub fn check_configured_port_available(
+    cfg: &PocopineConfig,
+    override_port: Option<u16>,
+) -> Result<()> {
     if cfg.bin.is_some()
-        && let Some(port) = cfg.port
+        && let Some(port) = override_port.or(cfg.port)
     {
         ensure_port_available(port)?;
     }
@@ -185,7 +188,7 @@ fn ensure_port_available(port: u16) -> Result<()> {
                 .map(|owner| format!(" by `{}` (pid {})", owner.command, owner.pid))
                 .unwrap_or_default();
             bail!(
-                "port {port} is already in use{owner}; stop the existing server or change `[package.metadata.pocopine].port`"
+                "port {port} is already in use{owner}; stop the existing server, pass `--port <PORT>`, or change `[package.metadata.pocopine].port`"
             );
         }
         Err(err) => Err(err).with_context(|| format!("check configured port {port}")),
@@ -402,8 +405,13 @@ pub fn validate_worker_backend_for_separate_process(default_redis_url: bool) -> 
     }
 }
 
-pub fn run_project(path: &Path, cfg: &PocopineConfig, release: bool, port: u16) -> Result<()> {
-    check_configured_port_available(cfg)?;
+pub fn run_project(
+    path: &Path,
+    cfg: &PocopineConfig,
+    release: bool,
+    port: Option<u16>,
+) -> Result<()> {
+    check_configured_port_available(cfg, port)?;
     if cfg.worker_bin.is_some() {
         validate_worker_backend_for_separate_process(false)?;
     }
@@ -416,7 +424,15 @@ pub fn run_project(path: &Path, cfg: &PocopineConfig, release: bool, port: u16) 
 
     match cfg.bin.as_deref() {
         Some(bin) => {
-            let server = spawn_bin(path, bin, release, BinRole::Server, false)?;
+            // Hand the effective port (--port override, else the manifest
+            // port) to the bin via PORT, so the addr it binds matches the
+            // port we just checked. pocopine server bins read PORT.
+            let mut server_env = BTreeMap::new();
+            if let Some(p) = port.or(cfg.port) {
+                server_env.insert("PORT".to_string(), p.to_string());
+            }
+            let server =
+                spawn_bin_with_env(path, bin, release, BinRole::Server, false, &server_env)?;
             let mut children = Vec::new();
             children.push(server);
             if let Some(worker) = worker {
@@ -425,18 +441,19 @@ pub fn run_project(path: &Path, cfg: &PocopineConfig, release: bool, port: u16) 
             wait_for_children(children)
         }
         None => {
+            let static_port = port.unwrap_or(5243);
             if let Some(worker) = worker {
                 let serve_path = path
                     .canonicalize()
                     .with_context(|| format!("bad serve dir: {}", path.display()))?;
                 thread::spawn(move || {
-                    if let Err(e) = serve_static(&serve_path, port) {
+                    if let Err(e) = serve_static(&serve_path, static_port) {
                         eprintln!("server error: {e}");
                     }
                 });
                 wait_for_children(vec![worker])
             } else {
-                serve_static(path, port)
+                serve_static(path, static_port)
             }
         }
     }
@@ -830,7 +847,7 @@ mod tests {
             ..PocopineConfig::default()
         };
 
-        let err = check_configured_port_available(&cfg).unwrap_err();
+        let err = check_configured_port_available(&cfg, None).unwrap_err();
         assert!(err.to_string().contains("already in use"));
     }
 
@@ -843,7 +860,7 @@ mod tests {
             ..PocopineConfig::default()
         };
 
-        check_configured_port_available(&cfg).unwrap();
+        check_configured_port_available(&cfg, None).unwrap();
     }
 
     #[test]

--- a/crates/pocopine-core/src/lib.rs
+++ b/crates/pocopine-core/src/lib.rs
@@ -42,6 +42,7 @@ pub mod path;
 pub mod payload_scope;
 pub mod plugin;
 pub mod profiler;
+pub mod progress;
 pub mod props;
 pub mod reactive;
 pub mod refs;

--- a/crates/pocopine-core/src/plugin.rs
+++ b/crates/pocopine-core/src/plugin.rs
@@ -635,6 +635,12 @@ pub(crate) fn emit<E>(event: E)
 where
     E: Clone + 'static,
 {
+    // Built-in: drive the top progress bar across route navigations
+    // (RouteNavigationStarted → show, Completed/Failed → finish). A no-op
+    // for every other event type. Kept at this single emit site so it sees
+    // all route events without touching each router emit call.
+    #[cfg(target_arch = "wasm32")]
+    crate::progress::observe_route_event(&event as &dyn std::any::Any);
     ACTIVE_PLUGINS.with(|plugins| {
         plugins.borrow().emit(event);
     });
@@ -673,7 +679,10 @@ pub(crate) fn has_component_unmounted_hooks() -> bool {
 
 #[inline]
 pub(crate) fn has_route_navigation_hooks() -> bool {
-    active_hook_mask_contains(HOOK_ROUTE_NAVIGATION_EVENTS)
+    // The built-in progress bar consumes route events to auto-drive the top
+    // loader, but only once a controller is installed (boot loader or a
+    // prior `progress` API call) — so opted-out apps still pay nothing.
+    active_hook_mask_contains(HOOK_ROUTE_NAVIGATION_EVENTS) || crate::progress::is_installed()
 }
 
 #[inline]

--- a/crates/pocopine-core/src/plugin.rs
+++ b/crates/pocopine-core/src/plugin.rs
@@ -635,12 +635,12 @@ pub(crate) fn emit<E>(event: E)
 where
     E: Clone + 'static,
 {
-    // Built-in: drive the top progress bar across route navigations
-    // (RouteNavigationStarted → show, Completed/Failed → finish). A no-op
+    // Built-in: drive the top progress bar + boot splash off the app
+    // lifecycle (AppBootCompleted/Failed) and route navigations. A no-op
     // for every other event type. Kept at this single emit site so it sees
-    // all route events without touching each router emit call.
+    // all of them without touching each emit call.
     #[cfg(target_arch = "wasm32")]
-    crate::progress::observe_route_event(&event as &dyn std::any::Any);
+    crate::progress::observe_event(&event as &dyn std::any::Any);
     ACTIVE_PLUGINS.with(|plugins| {
         plugins.borrow().emit(event);
     });

--- a/crates/pocopine-core/src/progress.rs
+++ b/crates/pocopine-core/src/progress.rs
@@ -1,0 +1,241 @@
+//! Top progress bar — the boot loader's bar, reusable from app code.
+//!
+//! A thin progress bar pinned to the top of the page (YouTube / nprogress
+//! style). It is the *same* bar the `index.html` boot loader shows while the
+//! wasm bundle downloads; after boot it stays in the DOM (hidden) so app
+//! code can reuse it for route changes, fetches, or any async work.
+//!
+//! Both layers share one JS controller installed on
+//! `window.__pocopineProgress` (idempotent): the boot script installs it
+//! pre-wasm, and this module reuses it — or injects an equivalent (bar +
+//! styles + controller) when an app ships no boot loader.
+//!
+//! Route navigations drive the bar automatically (see
+//! [`observe_route_event`]); for everything else use the API below.
+//!
+//! ```ignore
+//! // RAII: the bar shows now and finishes when `_task` is dropped — so it
+//! // can't leak on an early return or `?`.
+//! let _task = pocopine::progress::task();
+//! let rows = load_rows().await;
+//!
+//! // …or drive a determinate fraction (e.g. an upload):
+//! pocopine::progress::set(bytes_sent as f32 / total as f32);
+//! ```
+//!
+//! NOTE: the controller JS + CSS below mirror the copy in
+//! `examples/website/index.html` (and the starter template). They implement
+//! the same `window.__pocopineProgress` contract — keep them in sync.
+
+#[cfg(target_arch = "wasm32")]
+mod imp {
+    use wasm_bindgen::prelude::*;
+
+    #[wasm_bindgen(inline_js = r#"
+function install() {
+  // No-op outside a DOM (e.g. the node-based wasm test battery).
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return { start: function(){}, set: function(){}, inc: function(){}, done: function(){}, error: function(){} };
+  }
+  var w = window;
+  if (w.__pocopineProgress) return w.__pocopineProgress;
+  // Inject styles unless the boot loader already inlined them.
+  if (!document.getElementById('pp-loader-style')) {
+    var st = document.createElement('style');
+    st.id = 'pp-loader-style';
+    st.textContent =
+      '#pp-loader{position:fixed;top:0;left:0;right:0;height:3px;z-index:9999;overflow:hidden;pointer-events:none;transition:opacity .3s ease .15s}'
+      + '#pp-loader.pp-loader--done{opacity:0}'
+      + '.pp-loader__bar{height:100%;width:100%;background:var(--brand,#f8ae45);box-shadow:0 0 8px var(--brand,#f8ae45);transform:translateX(-100%);transition:transform .2s ease;will-change:transform}'
+      + '#pp-loader.pp-loader--error .pp-loader__bar{background:var(--destructive,#c04a2b);box-shadow:0 0 8px var(--destructive,#c04a2b)}'
+      + '@media (prefers-reduced-motion:reduce){#pp-loader{transition:opacity .3s ease}.pp-loader__bar{transition:none}}';
+    (document.head || document.documentElement).appendChild(st);
+  }
+  var el = null, bar = null, pending = 0, value = 0, determinate = false, trickle = 0, resume = 0;
+  function ensure() {
+    el = document.getElementById('pp-loader');
+    if (!el) {
+      el = document.createElement('div');
+      el.id = 'pp-loader';
+      el.setAttribute('role', 'progressbar');
+      el.setAttribute('aria-label', 'Loading');
+      el.setAttribute('aria-valuemin', '0');
+      el.setAttribute('aria-valuemax', '100');
+      bar = document.createElement('div');
+      bar.className = 'pp-loader__bar';
+      el.appendChild(bar);
+      (document.body || document.documentElement).appendChild(el);
+    }
+    if (!bar) bar = el.querySelector('.pp-loader__bar');
+  }
+  function render() {
+    ensure();
+    var v = Math.max(0, Math.min(value, 1));
+    if (bar) bar.style.transform = 'translateX(' + (v - 1) * 100 + '%)';
+    el.setAttribute('aria-valuenow', String(Math.round(v * 100)));
+  }
+  function show() { ensure(); el.classList.remove('pp-loader--done', 'pp-loader--error'); }
+  function startTrickle() {
+    clearInterval(trickle);
+    trickle = setInterval(function () {
+      if (value < 0.95) { value += (0.95 - value) * 0.1; render(); }
+    }, 200);
+  }
+  function complete() {
+    clearInterval(trickle); clearTimeout(resume);
+    value = 1; render(); ensure(); el.classList.add('pp-loader--done');
+    setTimeout(function () {
+      value = 0; determinate = false; pending = 0;
+      if (bar) {
+        bar.style.transition = 'none'; render();
+        requestAnimationFrame(function () { if (bar) bar.style.transition = ''; });
+      }
+      if (el) el.classList.remove('pp-loader--done');
+    }, 450);
+  }
+  var api = {
+    start: function () {
+      pending++; show();
+      if (pending === 1 && !determinate) {
+        if (value < 0.08) value = 0.08;
+        render(); startTrickle();
+      }
+    },
+    set: function (f) {
+      determinate = true; clearInterval(trickle); clearTimeout(resume);
+      value = Math.max(0, Math.min(f, 1)); show(); render();
+      if (value >= 1) { complete(); return; }
+      // Updates stopped (e.g. a download finished) → trickle the tail so
+      // the bar keeps moving through the compile/processing phase.
+      resume = setTimeout(function () { determinate = false; startTrickle(); }, 400);
+    },
+    inc: function (d) { api.set(value + d); },
+    done: function () { pending = Math.max(0, pending - 1); if (pending === 0) complete(); },
+    error: function () {
+      clearInterval(trickle); clearTimeout(resume); ensure();
+      el.classList.add('pp-loader--error'); value = 1; render();
+    },
+  };
+  w.__pocopineProgress = api;
+  return api;
+}
+export function pp_progress_start() { install().start(); }
+export function pp_progress_set(f) { install().set(f); }
+export function pp_progress_inc(d) { install().inc(d); }
+export function pp_progress_done() { install().done(); }
+export function pp_progress_error() { install().error(); }
+// Has a controller been installed (boot loader, or a prior API call)?
+// Used to gate the router auto-hook so apps that never opt into a loader
+// don't get a surprise nav bar — and so route events aren't even built.
+export function pp_progress_installed() {
+  return !!(typeof window !== 'undefined' && window.__pocopineProgress);
+}
+"#)]
+    extern "C" {
+        pub fn pp_progress_start();
+        pub fn pp_progress_set(f: f64);
+        pub fn pp_progress_inc(d: f64);
+        pub fn pp_progress_done();
+        pub fn pp_progress_error();
+        pub fn pp_progress_installed() -> bool;
+    }
+}
+
+/// Show the bar and begin one loading task. Ref-counted: the bar stays up
+/// until a matching [`finish`] for every [`start`], so concurrent tasks
+/// (and the automatic route hook) coexist.
+pub fn start() {
+    #[cfg(target_arch = "wasm32")]
+    imp::pp_progress_start();
+}
+
+/// Set a determinate fraction in `0.0..=1.0` (e.g. real download progress).
+/// Switches the bar out of trickle mode; reaching `1.0` finishes it.
+pub fn set(fraction: f32) {
+    #[cfg(target_arch = "wasm32")]
+    imp::pp_progress_set(fraction as f64);
+    #[cfg(not(target_arch = "wasm32"))]
+    let _ = fraction;
+}
+
+/// Advance the determinate fraction by `amount`.
+pub fn inc(amount: f32) {
+    #[cfg(target_arch = "wasm32")]
+    imp::pp_progress_inc(amount as f64);
+    #[cfg(not(target_arch = "wasm32"))]
+    let _ = amount;
+}
+
+/// Finish one task started with [`start`]. The bar completes and fades out
+/// once every [`start`] has a matching `finish`.
+pub fn finish() {
+    #[cfg(target_arch = "wasm32")]
+    imp::pp_progress_done();
+}
+
+/// Put the bar in its error state (turns red and stays visible) — signal a
+/// failed load so the user knows to retry.
+pub fn fail() {
+    #[cfg(target_arch = "wasm32")]
+    imp::pp_progress_error();
+}
+
+/// RAII guard returned by [`task`]: [`start`] on creation, [`finish`] on
+/// drop, so the bar can never leak on an early return, `?`, or panic.
+#[must_use = "the progress bar finishes when this guard is dropped; bind it to a variable"]
+pub struct Task {
+    _private: (),
+}
+
+/// Begin a progress task; the bar runs until the returned [`Task`] is
+/// dropped. Ideal for wrapping an `async` block.
+pub fn task() -> Task {
+    start();
+    Task { _private: () }
+}
+
+impl Task {
+    /// Set a determinate fraction for this task (see [`set`]).
+    pub fn set(&self, fraction: f32) {
+        set(fraction);
+    }
+
+    /// Advance the determinate fraction (see [`inc`]).
+    pub fn inc(&self, amount: f32) {
+        inc(amount);
+    }
+}
+
+impl Drop for Task {
+    fn drop(&mut self) {
+        finish();
+    }
+}
+
+/// Whether a progress controller is installed — i.e. the app opted in via
+/// the boot loader or a prior call to the API. The router uses this to
+/// decide whether to emit route-navigation events (and thus auto-drive the
+/// bar): apps that never use a loader pay nothing and see no nav bar.
+pub(crate) fn is_installed() -> bool {
+    #[cfg(target_arch = "wasm32")]
+    {
+        imp::pp_progress_installed()
+    }
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        false
+    }
+}
+
+/// Built-in router integration: drive the bar across route navigations.
+/// Invoked from [`crate::plugin::emit`] for every event; a no-op for
+/// anything that isn't a route-navigation lifecycle event.
+#[cfg(target_arch = "wasm32")]
+pub(crate) fn observe_route_event(ev: &dyn std::any::Any) {
+    use crate::plugin::{RouteNavigationCompleted, RouteNavigationFailed, RouteNavigationStarted};
+    if ev.is::<RouteNavigationStarted>() {
+        start();
+    } else if ev.is::<RouteNavigationCompleted>() || ev.is::<RouteNavigationFailed>() {
+        finish();
+    }
+}

--- a/crates/pocopine-core/src/progress.rs
+++ b/crates/pocopine-core/src/progress.rs
@@ -23,9 +23,10 @@
 //! pocopine::progress::set(bytes_sent as f32 / total as f32);
 //! ```
 //!
-//! NOTE: the controller JS + CSS below mirror the copy in
-//! `examples/website/index.html` (and the starter template). They implement
-//! the same `window.__pocopineProgress` contract — keep them in sync.
+//! NOTE: the controller JS + CSS below mirror the canonical boot loader in
+//! `crates/pocopine-cli/assets/loader.js` (injected into `pkg/index.html` by
+//! `pocopine build`). They implement the same `window.__pocopineProgress`
+//! contract — keep the two in sync.
 
 #[cfg(target_arch = "wasm32")]
 mod imp {
@@ -35,7 +36,7 @@ mod imp {
 function install() {
   // No-op outside a DOM (e.g. the node-based wasm test battery).
   if (typeof window === 'undefined' || typeof document === 'undefined') {
-    return { start: function(){}, set: function(){}, inc: function(){}, done: function(){}, error: function(){} };
+    return { start: function(){}, set: function(){}, inc: function(){}, done: function(){}, error: function(){}, ready: function(){} };
   }
   var w = window;
   if (w.__pocopineProgress) return w.__pocopineProgress;
@@ -51,7 +52,10 @@ function install() {
       + '@media (prefers-reduced-motion:reduce){#pp-loader{transition:opacity .3s ease}.pp-loader__bar{transition:none}}';
     (document.head || document.documentElement).appendChild(st);
   }
-  var el = null, bar = null, pending = 0, value = 0, determinate = false, trickle = 0, resume = 0;
+  var el = null, bar = null, pending = 0, value = 0, determinate = false, trickle = 0, resume = 0, showTimer = 0, shown = false;
+  // Deferred-reveal window: a navigation that finishes within SHOW_DELAY ms
+  // never flashes the bar; only genuinely slow work reveals it.
+  var SHOW_DELAY = 150;
   function ensure() {
     el = document.getElementById('pp-loader');
     if (!el) {
@@ -75,6 +79,11 @@ function install() {
     el.setAttribute('aria-valuenow', String(Math.round(v * 100)));
   }
   function show() { ensure(); el.classList.remove('pp-loader--done', 'pp-loader--error'); }
+  function reveal() {
+    showTimer = 0; shown = true; show();
+    if (value < 0.08) value = 0.08;
+    render(); startTrickle();
+  }
   function startTrickle() {
     clearInterval(trickle);
     trickle = setInterval(function () {
@@ -89,11 +98,12 @@ function install() {
     setTimeout(function () { s.remove(); }, 700);
   }
   function complete() {
+    clearTimeout(showTimer); showTimer = 0;
     clearInterval(trickle); clearTimeout(resume);
-    value = 1; render(); ensure(); el.classList.add('pp-loader--done');
+    pending = 0; value = 1; render(); ensure(); el.classList.add('pp-loader--done');
     hideSplash();
     setTimeout(function () {
-      value = 0; determinate = false; pending = 0;
+      value = 0; determinate = false; shown = false;
       if (bar) {
         bar.style.transition = 'none'; render();
         requestAnimationFrame(function () { if (bar) bar.style.transition = ''; });
@@ -102,14 +112,16 @@ function install() {
     }, 450);
   }
   var api = {
+    // Deferred reveal — fast navigations never flash the bar; slow work does.
     start: function () {
-      pending++; show();
-      if (pending === 1 && !determinate) {
-        if (value < 0.08) value = 0.08;
-        render(); startTrickle();
+      pending++;
+      if (pending === 1 && !determinate && !shown && !showTimer) {
+        showTimer = setTimeout(reveal, SHOW_DELAY);
       }
     },
     set: function (f) {
+      // A concrete fraction is an explicit "show progress" — reveal at once.
+      clearTimeout(showTimer); showTimer = 0; shown = true;
       determinate = true; clearInterval(trickle); clearTimeout(resume);
       value = Math.max(0, Math.min(f, 1)); show(); render();
       if (value >= 1) { complete(); return; }
@@ -118,8 +130,15 @@ function install() {
       resume = setTimeout(function () { determinate = false; startTrickle(); }, 400);
     },
     inc: function (d) { api.set(value + d); },
-    done: function () { pending = Math.max(0, pending - 1); if (pending === 0) complete(); },
+    done: function () {
+      pending = Math.max(0, pending - 1);
+      if (pending > 0) return;
+      // Finished before the reveal timer fired → cancel it; never flash.
+      if (showTimer) { clearTimeout(showTimer); showTimer = 0; return; }
+      if (shown) complete();
+    },
     error: function () {
+      clearTimeout(showTimer); showTimer = 0; shown = true;
       clearInterval(trickle); clearTimeout(resume); ensure();
       el.classList.add('pp-loader--error'); value = 1; render(); hideSplash();
     },
@@ -153,9 +172,15 @@ export function pp_progress_installed() {
     }
 }
 
-/// Show the bar and begin one loading task. Ref-counted: the bar stays up
-/// until a matching [`finish`] for every [`start`], so concurrent tasks
-/// (and the automatic route hook) coexist.
+/// Begin one loading task. Ref-counted: the bar stays up until a matching
+/// [`finish`] for every [`start`], so concurrent tasks (and the automatic
+/// route hook) coexist.
+///
+/// The reveal is *deferred* ~150 ms: a task that finishes within that window
+/// never flashes the bar, so quick work (e.g. an already-loaded route) feels
+/// instant. Slower work reveals the bar and — once shown — always plays its
+/// finish animation to completion. Call [`set`] instead to show a
+/// determinate fraction immediately.
 pub fn start() {
     #[cfg(target_arch = "wasm32")]
     imp::pp_progress_start();

--- a/crates/pocopine-core/src/progress.rs
+++ b/crates/pocopine-core/src/progress.rs
@@ -81,9 +81,17 @@ function install() {
       if (value < 0.95) { value += (0.95 - value) * 0.1; render(); }
     }, 200);
   }
+  function hideSplash() {
+    var s = document.getElementById('pp-splash');
+    if (!s) return;
+    s.classList.add('pp-splash--done');
+    s.addEventListener('transitionend', function () { s.remove(); }, { once: true });
+    setTimeout(function () { s.remove(); }, 700);
+  }
   function complete() {
     clearInterval(trickle); clearTimeout(resume);
     value = 1; render(); ensure(); el.classList.add('pp-loader--done');
+    hideSplash();
     setTimeout(function () {
       value = 0; determinate = false; pending = 0;
       if (bar) {
@@ -113,8 +121,10 @@ function install() {
     done: function () { pending = Math.max(0, pending - 1); if (pending === 0) complete(); },
     error: function () {
       clearInterval(trickle); clearTimeout(resume); ensure();
-      el.classList.add('pp-loader--error'); value = 1; render();
+      el.classList.add('pp-loader--error'); value = 1; render(); hideSplash();
     },
+    // App reported ready (AppBootCompleted): drop the splash + finish.
+    ready: function () { complete(); },
   };
   w.__pocopineProgress = api;
   return api;
@@ -124,6 +134,7 @@ export function pp_progress_set(f) { install().set(f); }
 export function pp_progress_inc(d) { install().inc(d); }
 export function pp_progress_done() { install().done(); }
 export function pp_progress_error() { install().error(); }
+export function pp_progress_ready() { install().ready(); }
 // Has a controller been installed (boot loader, or a prior API call)?
 // Used to gate the router auto-hook so apps that never opt into a loader
 // don't get a surprise nav bar — and so route events aren't even built.
@@ -137,6 +148,7 @@ export function pp_progress_installed() {
         pub fn pp_progress_inc(d: f64);
         pub fn pp_progress_done();
         pub fn pp_progress_error();
+        pub fn pp_progress_ready();
         pub fn pp_progress_installed() -> bool;
     }
 }
@@ -227,13 +239,33 @@ pub(crate) fn is_installed() -> bool {
     }
 }
 
-/// Built-in router integration: drive the bar across route navigations.
+/// Built-in integration: drive the bar + splash off the app lifecycle.
 /// Invoked from [`crate::plugin::emit`] for every event; a no-op for
-/// anything that isn't a route-navigation lifecycle event.
+/// anything that isn't an app-boot or route-navigation event.
+///
+/// - `AppBootCompleted` → `ready()` (drop the boot splash, finish the bar)
+/// - `AppBootFailed`    → `error()` (red bar)
+/// - `RouteNavigationStarted` / `Completed` / `Failed` → `start` / `finish`
+///
+/// App-boot events are emitted for every app unconditionally, so they're
+/// gated here on a controller actually being installed (boot loader or a
+/// prior API call) — a no-loader app self-injects nothing on boot. Route
+/// events are already gated upstream by `has_route_navigation_hooks`.
 #[cfg(target_arch = "wasm32")]
-pub(crate) fn observe_route_event(ev: &dyn std::any::Any) {
-    use crate::plugin::{RouteNavigationCompleted, RouteNavigationFailed, RouteNavigationStarted};
-    if ev.is::<RouteNavigationStarted>() {
+pub(crate) fn observe_event(ev: &dyn std::any::Any) {
+    use crate::plugin::{
+        AppBootCompleted, AppBootFailed, RouteNavigationCompleted, RouteNavigationFailed,
+        RouteNavigationStarted,
+    };
+    if ev.is::<AppBootCompleted>() {
+        if is_installed() {
+            imp::pp_progress_ready();
+        }
+    } else if ev.is::<AppBootFailed>() {
+        if is_installed() {
+            fail();
+        }
+    } else if ev.is::<RouteNavigationStarted>() {
         start();
     } else if ev.is::<RouteNavigationCompleted>() || ev.is::<RouteNavigationFailed>() {
         finish();

--- a/crates/pocopine-core/src/router.rs
+++ b/crates/pocopine-core/src/router.rs
@@ -27,7 +27,7 @@ use once_cell::unsync::OnceCell;
 use wasm_bindgen::JsValue;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::prelude::*;
-use web_sys::{Element, Event};
+use web_sys::{Element, Event, MouseEvent};
 
 use crate::app::{
     IntoRouteTarget, Loader, LoaderContext, PageMeta, PageMetaContext, PageMetaFactory,
@@ -897,6 +897,55 @@ pub fn init() {
         let _ = win.add_event_listener_with_callback("popstate", cb.as_ref().unchecked_ref());
     }
     cb.forget();
+
+    // Delegated client-side navigation: intercept plain left-clicks on
+    // same-origin `<a pp-route>` links so internal navigation never triggers
+    // a full page reload (which would re-download + recompile the wasm).
+    // Attribute-based, so it also covers links inside `pp-for` clones. Modified
+    // clicks, `target`, `download`, external/scheme hrefs, and unmarked links
+    // fall through to the browser.
+    let on_click = Closure::wrap(Box::new(move |ev: Event| {
+        let Some(me) = ev.dyn_ref::<MouseEvent>() else {
+            return;
+        };
+        if me.default_prevented()
+            || me.button() != 0
+            || me.meta_key()
+            || me.ctrl_key()
+            || me.shift_key()
+            || me.alt_key()
+        {
+            return;
+        }
+        let Some(target) = ev.target().and_then(|t| t.dyn_into::<Element>().ok()) else {
+            return;
+        };
+        let Some(anchor) = target.closest("a[pp-route]").ok().flatten() else {
+            return;
+        };
+        if anchor
+            .get_attribute("target")
+            .is_some_and(|t| !t.is_empty() && t != "_self")
+            || anchor.has_attribute("download")
+        {
+            return;
+        }
+        let Some(href) = anchor.get_attribute("href") else {
+            return;
+        };
+        // Only intercept absolute internal paths; leave external URLs,
+        // schemes (`mailto:`, `http:`), and protocol-relative `//` to the
+        // browser.
+        if !href.starts_with('/') || href.starts_with("//") {
+            return;
+        }
+        ev.prevent_default();
+        navigate(&href);
+    }) as Box<dyn FnMut(Event)>);
+    if let Some(doc) = web_sys::window().and_then(|w| w.document()) {
+        let _ = doc.add_event_listener_with_callback("click", on_click.as_ref().unchecked_ref());
+    }
+    on_click.forget();
 
     let _ = mount_current();
 }

--- a/crates/pocopine-core/src/router.rs
+++ b/crates/pocopine-core/src/router.rs
@@ -1407,6 +1407,29 @@ fn finish_route_mount(
     // the macro-emitted entries.
     mount::mount_child_component(&el, name);
     mount::finalize_compiled_subtree(&el);
+    // Route enter transition (RFC-005): copy the outlet's `pp-transition*`
+    // config onto the freshly-mounted page root and play the enter sequence,
+    // so the incoming page animates in. Applied to `el` (fresh each nav) and
+    // copied after mount so the walker doesn't consume the attrs. A no-op
+    // when the outlet declares no transition — apps swap instantly as before.
+    for attr in [
+        // RFC-038 preset shorthand (`pp-transition="fade"` / `:in` / `:out`)…
+        "pp-transition",
+        "pp-transition:in",
+        "pp-transition:out",
+        // …or the explicit six-class form.
+        "pp-transition:enter",
+        "pp-transition:enter-start",
+        "pp-transition:enter-end",
+        "pp-transition:leave",
+        "pp-transition:leave-start",
+        "pp-transition:leave-end",
+    ] {
+        if let Some(v) = outlet.get_attribute(attr) {
+            let _ = el.set_attribute(attr, &v);
+        }
+    }
+    crate::directives::transition::enter(&el, || {});
     apply_page_meta(page_meta);
 
     // The component's `Loader<T>` extractor (if any) consumed the

--- a/crates/pocopine/src/lib.rs
+++ b/crates/pocopine/src/lib.rs
@@ -42,7 +42,8 @@ pub use pocopine_core::{
     watch_scope_field_now, watch_scope_field_scoped, watch_scoped,
 };
 pub use pocopine_core::{
-    animate, dom, events, focus, profiler, refs, router, scroll_lock, storage, text, tick, timers,
+    animate, dom, events, focus, profiler, progress, refs, router, scroll_lock, storage, text,
+    tick, timers,
 };
 #[doc(inline)]
 pub use pocopine_core::{create_context, inject_key};

--- a/examples/website/index.html
+++ b/examples/website/index.html
@@ -23,15 +23,156 @@
       } catch (e) {}
     })();
   </script>
+  <!-- Boot-loader styles. A thin top progress bar (YouTube / nprogress
+       style) that fills as the wasm bundle downloads. Inlined so it
+       paints before the bundle arrives; colours reuse the styles.css
+       theme tokens (already applied above) with light-theme fallbacks.
+       The html fallback bg avoids a white flash if styles.css is slow. -->
+  <style>
+    html { background: var(--bg, #fffaf2); }
+    #pp-loader {
+      position: fixed;
+      top: 0;
+      left: 0;
+      right: 0;
+      height: 3px;
+      z-index: 9999;
+      overflow: hidden;
+      pointer-events: none;
+      transition: opacity 0.3s ease 0.15s;
+    }
+    #pp-loader.pp-loader--done { opacity: 0; }
+    .pp-loader__bar {
+      height: 100%;
+      width: 100%;
+      background: var(--brand, #f8ae45);
+      box-shadow: 0 0 8px var(--brand, #f8ae45);
+      /* translateX(-100%) = empty, translateX(0) = full. Driven by JS. */
+      transform: translateX(-100%);
+      transition: transform 0.2s ease;
+      will-change: transform;
+    }
+    #pp-loader.pp-loader--error .pp-loader__bar {
+      background: var(--destructive, #c04a2b);
+      box-shadow: 0 0 8px var(--destructive, #c04a2b);
+    }
+    @media (prefers-reduced-motion: reduce) {
+      #pp-loader { transition: opacity 0.3s ease; }
+      .pp-loader__bar { transition: none; }
+    }
+  </style>
 </head>
 <body>
+  <!-- Boot loader: a top progress bar shown while the wasm bundle
+       downloads, compiles, and mounts the app. Lives OUTSIDE `pp-app`
+       (the framework owns that subtree) and is removed by the script
+       below once the app has mounted. -->
+  <div id="pp-loader" role="progressbar" aria-label="Loading pocopine"
+       aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+    <div class="pp-loader__bar"></div>
+  </div>
+
   <div pp-app>
     <website-app></website-app>
   </div>
 
   <script type="module">
     import init from "/pkg/website.js";
-    init();
+
+    const loader = document.getElementById("pp-loader");
+    const bar = loader && loader.querySelector(".pp-loader__bar");
+    let value = 0; // 0..1, the displayed bar fraction
+    let trickle = 0;
+
+    const setBar = (v) => {
+      value = Math.max(0, Math.min(v, 1));
+      if (bar) bar.style.transform = "translateX(" + (value - 1) * 100 + "%)";
+      if (loader) loader.setAttribute("aria-valuenow", String(Math.round(value * 100)));
+    };
+
+    const removeLoader = () => {
+      if (!loader) return;
+      clearInterval(trickle);
+      loader.classList.add("pp-loader--done");
+      const done = () => loader.remove();
+      loader.addEventListener("transitionend", done, { once: true });
+      setTimeout(done, 700);
+    };
+
+    // After the bytes are in, the bar can't measure the (brief)
+    // compile + mount phase, so ease it toward 98% — like YouTube's
+    // bar — so it keeps moving instead of looking stuck. init() snaps
+    // it to 100%.
+    const startTrickle = () => {
+      clearInterval(trickle);
+      trickle = setInterval(() => {
+        if (value >= 0.98) { clearInterval(trickle); return; }
+        setBar(value + (0.98 - value) * 0.1);
+      }, 200);
+    };
+
+    // Real download progress: wasm-bindgen's init() fetches the (hashed)
+    // `*_bg.wasm` via the global `fetch`, so we wrap that one response's
+    // body in a byte-counting stream and map bytes/Content-Length onto
+    // the first 90% of the bar (the last 10% is the compile/mount tail).
+    // The re-wrapped Response keeps its headers so wasm-bindgen still
+    // stream-compiles it (with the arrayBuffer fallback). fetch is
+    // restored after init.
+    const realFetch = window.fetch.bind(window);
+    window.fetch = (input, opts) => {
+      const url =
+        typeof input === "string" ? input : (input && input.url) || String(input);
+      const res = realFetch(input, opts);
+      if (!/\.wasm(\?|$)/.test(url)) return res;
+      return res.then((resp) => {
+        if (!resp.body || !resp.ok) return resp;
+        const total = Number(resp.headers.get("content-length")) || 0;
+        if (!total) startTrickle(); // no total → just keep it moving
+        let loaded = 0;
+        const reader = resp.body.getReader();
+        const tracked = new ReadableStream({
+          async pull(controller) {
+            const { done, value: chunk } = await reader.read();
+            if (done) {
+              startTrickle(); // bytes in; compile + mount next
+              controller.close();
+              return;
+            }
+            loaded += chunk.byteLength;
+            if (total) setBar((loaded / total) * 0.9);
+            controller.enqueue(chunk);
+          },
+          cancel(reason) {
+            reader.cancel(reason);
+          },
+        });
+        return new Response(tracked, {
+          headers: resp.headers,
+          status: resp.status,
+          statusText: resp.statusText,
+        });
+      });
+    };
+
+    try {
+      await init();
+      // init() resolved → App::run() booted synchronously and mounted.
+      clearInterval(trickle);
+      setBar(1);
+      requestAnimationFrame(() => requestAnimationFrame(removeLoader));
+    } catch (err) {
+      // Leave a red bar at the top so a failed load is visible (instead
+      // of a bar stuck mid-way) — the user knows to reload.
+      clearInterval(trickle);
+      if (loader) {
+        loader.classList.add("pp-loader--error");
+        loader.setAttribute("aria-label", "Failed to load — reload the page");
+        setBar(1);
+      }
+      throw err;
+    } finally {
+      window.fetch = realFetch;
+    }
   </script>
 </body>
 </html>

--- a/examples/website/index.html
+++ b/examples/website/index.html
@@ -23,55 +23,11 @@
       } catch (e) {}
     })();
   </script>
-  <!-- Boot-loader styles. A thin top progress bar (YouTube / nprogress
-       style) that fills as the wasm bundle downloads. Inlined so it
-       paints before the bundle arrives; colours reuse the styles.css
-       theme tokens (already applied above) with light-theme fallbacks.
-       The html fallback bg avoids a white flash if styles.css is slow. -->
-  <style>
-    html { background: var(--bg, #fffaf2); }
-    #pp-loader {
-      position: fixed;
-      top: 0;
-      left: 0;
-      right: 0;
-      height: 3px;
-      z-index: 9999;
-      overflow: hidden;
-      pointer-events: none;
-      transition: opacity 0.3s ease 0.15s;
-    }
-    #pp-loader.pp-loader--done { opacity: 0; }
-    .pp-loader__bar {
-      height: 100%;
-      width: 100%;
-      background: var(--brand, #f8ae45);
-      box-shadow: 0 0 8px var(--brand, #f8ae45);
-      /* translateX(-100%) = empty, translateX(0) = full. Driven by JS. */
-      transform: translateX(-100%);
-      transition: transform 0.2s ease;
-      will-change: transform;
-    }
-    #pp-loader.pp-loader--error .pp-loader__bar {
-      background: var(--destructive, #c04a2b);
-      box-shadow: 0 0 8px var(--destructive, #c04a2b);
-    }
-    @media (prefers-reduced-motion: reduce) {
-      #pp-loader { transition: opacity 0.3s ease; }
-      .pp-loader__bar { transition: none; }
-    }
-  </style>
+  <!-- Flash insurance: styles.css (render-blocking) sets the themed body
+       background, but pin html too in case the stylesheet is slow. -->
+  <style>html { background: var(--bg, #fffaf2); }</style>
 </head>
 <body>
-  <!-- Boot loader: a top progress bar shown while the wasm bundle
-       downloads, compiles, and mounts the app. Lives OUTSIDE `pp-app`
-       (the framework owns that subtree) and is removed by the script
-       below once the app has mounted. -->
-  <div id="pp-loader" role="progressbar" aria-label="Loading pocopine"
-       aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
-    <div class="pp-loader__bar"></div>
-  </div>
-
   <div pp-app>
     <website-app></website-app>
   </div>
@@ -79,45 +35,100 @@
   <script type="module">
     import init from "/pkg/website.js";
 
-    const loader = document.getElementById("pp-loader");
-    const bar = loader && loader.querySelector(".pp-loader__bar");
-    let value = 0; // 0..1, the displayed bar fraction
-    let trickle = 0;
+    // ── Shared progress controller ──────────────────────────────────────
+    // Installs `window.__pocopineProgress` (idempotent): a thin top
+    // progress bar (YouTube / nprogress style). The boot loader below
+    // drives it with the wasm download; AFTER boot it stays installed so
+    // `pocopine::progress` (and the router's auto-hook) reuse this SAME
+    // bar in-app. Mirrors the controller in
+    // crates/pocopine-core/src/progress.rs — keep the two in sync.
+    (function () {
+      if (window.__pocopineProgress) return;
+      if (!document.getElementById("pp-loader-style")) {
+        var st = document.createElement("style");
+        st.id = "pp-loader-style";
+        st.textContent =
+          "#pp-loader{position:fixed;top:0;left:0;right:0;height:3px;z-index:9999;overflow:hidden;pointer-events:none;transition:opacity .3s ease .15s}"
+          + "#pp-loader.pp-loader--done{opacity:0}"
+          + ".pp-loader__bar{height:100%;width:100%;background:var(--brand,#f8ae45);box-shadow:0 0 8px var(--brand,#f8ae45);transform:translateX(-100%);transition:transform .2s ease;will-change:transform}"
+          + "#pp-loader.pp-loader--error .pp-loader__bar{background:var(--destructive,#c04a2b);box-shadow:0 0 8px var(--destructive,#c04a2b)}"
+          + "@media (prefers-reduced-motion:reduce){#pp-loader{transition:opacity .3s ease}.pp-loader__bar{transition:none}}";
+        (document.head || document.documentElement).appendChild(st);
+      }
+      var el = null, bar = null, pending = 0, value = 0, determinate = false, trickle = 0, resume = 0;
+      function ensure() {
+        el = document.getElementById("pp-loader");
+        if (!el) {
+          el = document.createElement("div");
+          el.id = "pp-loader";
+          el.setAttribute("role", "progressbar");
+          el.setAttribute("aria-label", "Loading");
+          el.setAttribute("aria-valuemin", "0");
+          el.setAttribute("aria-valuemax", "100");
+          bar = document.createElement("div");
+          bar.className = "pp-loader__bar";
+          el.appendChild(bar);
+          (document.body || document.documentElement).appendChild(el);
+        }
+        if (!bar) bar = el.querySelector(".pp-loader__bar");
+      }
+      function render() {
+        ensure();
+        var v = Math.max(0, Math.min(value, 1));
+        if (bar) bar.style.transform = "translateX(" + (v - 1) * 100 + "%)";
+        el.setAttribute("aria-valuenow", String(Math.round(v * 100)));
+      }
+      function show() { ensure(); el.classList.remove("pp-loader--done", "pp-loader--error"); }
+      function startTrickle() {
+        clearInterval(trickle);
+        trickle = setInterval(function () {
+          if (value < 0.95) { value += (0.95 - value) * 0.1; render(); }
+        }, 200);
+      }
+      function complete() {
+        clearInterval(trickle); clearTimeout(resume);
+        value = 1; render(); ensure(); el.classList.add("pp-loader--done");
+        setTimeout(function () {
+          value = 0; determinate = false; pending = 0;
+          if (bar) {
+            bar.style.transition = "none"; render();
+            requestAnimationFrame(function () { if (bar) bar.style.transition = ""; });
+          }
+          if (el) el.classList.remove("pp-loader--done");
+        }, 450);
+      }
+      var api = {
+        start: function () {
+          pending++; show();
+          if (pending === 1 && !determinate) {
+            if (value < 0.08) value = 0.08;
+            render(); startTrickle();
+          }
+        },
+        set: function (f) {
+          determinate = true; clearInterval(trickle); clearTimeout(resume);
+          value = Math.max(0, Math.min(f, 1)); show(); render();
+          if (value >= 1) { complete(); return; }
+          resume = setTimeout(function () { determinate = false; startTrickle(); }, 400);
+        },
+        inc: function (d) { api.set(value + d); },
+        done: function () { pending = Math.max(0, pending - 1); if (pending === 0) complete(); },
+        error: function () {
+          clearInterval(trickle); clearTimeout(resume); ensure();
+          el.classList.add("pp-loader--error"); value = 1; render();
+        },
+      };
+      window.__pocopineProgress = api;
+    })();
 
-    const setBar = (v) => {
-      value = Math.max(0, Math.min(v, 1));
-      if (bar) bar.style.transform = "translateX(" + (value - 1) * 100 + "%)";
-      if (loader) loader.setAttribute("aria-valuenow", String(Math.round(value * 100)));
-    };
+    const progress = window.__pocopineProgress;
 
-    const removeLoader = () => {
-      if (!loader) return;
-      clearInterval(trickle);
-      loader.classList.add("pp-loader--done");
-      const done = () => loader.remove();
-      loader.addEventListener("transitionend", done, { once: true });
-      setTimeout(done, 700);
-    };
-
-    // After the bytes are in, the bar can't measure the (brief)
-    // compile + mount phase, so ease it toward 98% — like YouTube's
-    // bar — so it keeps moving instead of looking stuck. init() snaps
-    // it to 100%.
-    const startTrickle = () => {
-      clearInterval(trickle);
-      trickle = setInterval(() => {
-        if (value >= 0.98) { clearInterval(trickle); return; }
-        setBar(value + (0.98 - value) * 0.1);
-      }, 200);
-    };
-
-    // Real download progress: wasm-bindgen's init() fetches the (hashed)
-    // `*_bg.wasm` via the global `fetch`, so we wrap that one response's
-    // body in a byte-counting stream and map bytes/Content-Length onto
-    // the first 90% of the bar (the last 10% is the compile/mount tail).
-    // The re-wrapped Response keeps its headers so wasm-bindgen still
-    // stream-compiles it (with the arrayBuffer fallback). fetch is
-    // restored after init.
+    // ── Boot: real wasm download progress ───────────────────────────────
+    // wasm-bindgen's init() fetches the (hashed) `*_bg.wasm` via the global
+    // `fetch`, so wrap that one response body in a byte-counting stream and
+    // map bytes/Content-Length onto the first 90% of the bar (the controller
+    // trickles the compile/mount tail). The re-wrapped Response keeps its
+    // headers so streaming compilation still works (arrayBuffer fallback).
     const realFetch = window.fetch.bind(window);
     window.fetch = (input, opts) => {
       const url =
@@ -127,24 +138,17 @@
       return res.then((resp) => {
         if (!resp.body || !resp.ok) return resp;
         const total = Number(resp.headers.get("content-length")) || 0;
-        if (!total) startTrickle(); // no total → just keep it moving
         let loaded = 0;
         const reader = resp.body.getReader();
         const tracked = new ReadableStream({
           async pull(controller) {
             const { done, value: chunk } = await reader.read();
-            if (done) {
-              startTrickle(); // bytes in; compile + mount next
-              controller.close();
-              return;
-            }
+            if (done) { controller.close(); return; }
             loaded += chunk.byteLength;
-            if (total) setBar((loaded / total) * 0.9);
+            if (total) progress.set((loaded / total) * 0.9);
             controller.enqueue(chunk);
           },
-          cancel(reason) {
-            reader.cancel(reason);
-          },
+          cancel(reason) { reader.cancel(reason); },
         });
         return new Response(tracked, {
           headers: resp.headers,
@@ -154,21 +158,12 @@
       });
     };
 
+    progress.start();
     try {
       await init();
-      // init() resolved → App::run() booted synchronously and mounted.
-      clearInterval(trickle);
-      setBar(1);
-      requestAnimationFrame(() => requestAnimationFrame(removeLoader));
+      progress.done(); // mounted → bar completes and fades out (kept in DOM for reuse)
     } catch (err) {
-      // Leave a red bar at the top so a failed load is visible (instead
-      // of a bar stuck mid-way) — the user knows to reload.
-      clearInterval(trickle);
-      if (loader) {
-        loader.classList.add("pp-loader--error");
-        loader.setAttribute("aria-label", "Failed to load — reload the page");
-        setBar(1);
-      }
+      progress.error(); // red bar — load failed, reload
       throw err;
     } finally {
       window.fetch = realFetch;

--- a/examples/website/index.html
+++ b/examples/website/index.html
@@ -23,9 +23,9 @@
       } catch (e) {}
     })();
   </script>
-  <!-- Flash insurance: styles.css (render-blocking) sets the themed body
-       background, but pin html too in case the stylesheet is slow. -->
-  <style>html { background: var(--bg, #fffaf2); }</style>
+  <!-- The boot loader (splash + top progress bar) is injected into the
+       generated pkg/index.html by `pocopine build`; configure it under
+       [package.metadata.pocopine.loader]. Nothing to hand-write here. -->
 </head>
 <body>
   <div pp-app>
@@ -34,140 +34,7 @@
 
   <script type="module">
     import init from "/pkg/website.js";
-
-    // ── Shared progress controller ──────────────────────────────────────
-    // Installs `window.__pocopineProgress` (idempotent): a thin top
-    // progress bar (YouTube / nprogress style). The boot loader below
-    // drives it with the wasm download; AFTER boot it stays installed so
-    // `pocopine::progress` (and the router's auto-hook) reuse this SAME
-    // bar in-app. Mirrors the controller in
-    // crates/pocopine-core/src/progress.rs — keep the two in sync.
-    (function () {
-      if (window.__pocopineProgress) return;
-      if (!document.getElementById("pp-loader-style")) {
-        var st = document.createElement("style");
-        st.id = "pp-loader-style";
-        st.textContent =
-          "#pp-loader{position:fixed;top:0;left:0;right:0;height:3px;z-index:9999;overflow:hidden;pointer-events:none;transition:opacity .3s ease .15s}"
-          + "#pp-loader.pp-loader--done{opacity:0}"
-          + ".pp-loader__bar{height:100%;width:100%;background:var(--brand,#f8ae45);box-shadow:0 0 8px var(--brand,#f8ae45);transform:translateX(-100%);transition:transform .2s ease;will-change:transform}"
-          + "#pp-loader.pp-loader--error .pp-loader__bar{background:var(--destructive,#c04a2b);box-shadow:0 0 8px var(--destructive,#c04a2b)}"
-          + "@media (prefers-reduced-motion:reduce){#pp-loader{transition:opacity .3s ease}.pp-loader__bar{transition:none}}";
-        (document.head || document.documentElement).appendChild(st);
-      }
-      var el = null, bar = null, pending = 0, value = 0, determinate = false, trickle = 0, resume = 0;
-      function ensure() {
-        el = document.getElementById("pp-loader");
-        if (!el) {
-          el = document.createElement("div");
-          el.id = "pp-loader";
-          el.setAttribute("role", "progressbar");
-          el.setAttribute("aria-label", "Loading");
-          el.setAttribute("aria-valuemin", "0");
-          el.setAttribute("aria-valuemax", "100");
-          bar = document.createElement("div");
-          bar.className = "pp-loader__bar";
-          el.appendChild(bar);
-          (document.body || document.documentElement).appendChild(el);
-        }
-        if (!bar) bar = el.querySelector(".pp-loader__bar");
-      }
-      function render() {
-        ensure();
-        var v = Math.max(0, Math.min(value, 1));
-        if (bar) bar.style.transform = "translateX(" + (v - 1) * 100 + "%)";
-        el.setAttribute("aria-valuenow", String(Math.round(v * 100)));
-      }
-      function show() { ensure(); el.classList.remove("pp-loader--done", "pp-loader--error"); }
-      function startTrickle() {
-        clearInterval(trickle);
-        trickle = setInterval(function () {
-          if (value < 0.95) { value += (0.95 - value) * 0.1; render(); }
-        }, 200);
-      }
-      function complete() {
-        clearInterval(trickle); clearTimeout(resume);
-        value = 1; render(); ensure(); el.classList.add("pp-loader--done");
-        setTimeout(function () {
-          value = 0; determinate = false; pending = 0;
-          if (bar) {
-            bar.style.transition = "none"; render();
-            requestAnimationFrame(function () { if (bar) bar.style.transition = ""; });
-          }
-          if (el) el.classList.remove("pp-loader--done");
-        }, 450);
-      }
-      var api = {
-        start: function () {
-          pending++; show();
-          if (pending === 1 && !determinate) {
-            if (value < 0.08) value = 0.08;
-            render(); startTrickle();
-          }
-        },
-        set: function (f) {
-          determinate = true; clearInterval(trickle); clearTimeout(resume);
-          value = Math.max(0, Math.min(f, 1)); show(); render();
-          if (value >= 1) { complete(); return; }
-          resume = setTimeout(function () { determinate = false; startTrickle(); }, 400);
-        },
-        inc: function (d) { api.set(value + d); },
-        done: function () { pending = Math.max(0, pending - 1); if (pending === 0) complete(); },
-        error: function () {
-          clearInterval(trickle); clearTimeout(resume); ensure();
-          el.classList.add("pp-loader--error"); value = 1; render();
-        },
-      };
-      window.__pocopineProgress = api;
-    })();
-
-    const progress = window.__pocopineProgress;
-
-    // ── Boot: real wasm download progress ───────────────────────────────
-    // wasm-bindgen's init() fetches the (hashed) `*_bg.wasm` via the global
-    // `fetch`, so wrap that one response body in a byte-counting stream and
-    // map bytes/Content-Length onto the first 90% of the bar (the controller
-    // trickles the compile/mount tail). The re-wrapped Response keeps its
-    // headers so streaming compilation still works (arrayBuffer fallback).
-    const realFetch = window.fetch.bind(window);
-    window.fetch = (input, opts) => {
-      const url =
-        typeof input === "string" ? input : (input && input.url) || String(input);
-      const res = realFetch(input, opts);
-      if (!/\.wasm(\?|$)/.test(url)) return res;
-      return res.then((resp) => {
-        if (!resp.body || !resp.ok) return resp;
-        const total = Number(resp.headers.get("content-length")) || 0;
-        let loaded = 0;
-        const reader = resp.body.getReader();
-        const tracked = new ReadableStream({
-          async pull(controller) {
-            const { done, value: chunk } = await reader.read();
-            if (done) { controller.close(); return; }
-            loaded += chunk.byteLength;
-            if (total) progress.set((loaded / total) * 0.9);
-            controller.enqueue(chunk);
-          },
-          cancel(reason) { reader.cancel(reason); },
-        });
-        return new Response(tracked, {
-          headers: resp.headers,
-          status: resp.status,
-          statusText: resp.statusText,
-        });
-      });
-    };
-
-    progress.start();
-    try {
-      await init();
-      progress.done(); // mounted → bar completes and fades out (kept in DOM for reuse)
-    } catch (err) {
-      progress.error(); // red bar — load failed, reload
-      throw err;
-    } finally {
-      window.fetch = realFetch;
-    }
+    init();
   </script>
 </body>
 </html>

--- a/examples/website/src/WebsiteApp.poco
+++ b/examples/website/src/WebsiteApp.poco
@@ -4,7 +4,7 @@
   <site-header></site-header>
 
   <main class="app-main">
-    <pp-outlet></pp-outlet>
+    <pp-outlet pp-transition="fade-scale"></pp-outlet>
   </main>
 
   <footer class="app-footer">

--- a/examples/website/src/components/install_cmd/install_cmd.css
+++ b/examples/website/src/components/install_cmd/install_cmd.css
@@ -1,9 +1,22 @@
 /* ─── Copyable install command ───────────────────────────────── */
 
+/* The component host sits between the page layout and the pill. Bound it to
+   its container and let it shrink (min-width:0), otherwise its min-content
+   width (the no-wrap command) lets the pill stretch past the viewport on
+   mobile — the `max-width:100%` on .install would resolve against the host's
+   overflowing width and do nothing. */
+install-cmd {
+  display: flex;
+  justify-content: center;
+  min-width: 0;
+  max-width: 100%;
+}
+
 .install {
   display: inline-flex;
   align-items: center;
   gap: 0.7rem;
+  max-width: 100%;
   font-family: var(--mono);
   font-size: 0.95rem;
   padding: 0.6rem 0.7rem 0.6rem 1rem;
@@ -12,13 +25,19 @@
   background: var(--bg);
   box-shadow: var(--shadow);
 }
-.install-prompt { color: var(--brand); font-weight: 700; }
+.install-prompt { color: var(--brand); font-weight: 700; flex: none; }
 .install-cmd {
   color: var(--fg);
   background: transparent;
   padding: 0;
   white-space: nowrap;
+  /* On narrow screens the command scrolls inside the pill rather than
+     stretching it past the viewport (which forced page-wide overflow). */
+  min-width: 0;
+  overflow-x: auto;
+  scrollbar-width: none; /* keep the pill clean (Firefox) */
 }
+.install-cmd::-webkit-scrollbar { display: none; } /* WebKit/Blink */
 .install-copy {
   display: inline-flex;
   align-items: center;
@@ -33,6 +52,7 @@
   padding: 0.35rem 0.8rem;
   cursor: pointer;
   transition: filter 0.12s;
+  flex: none; /* never shrink the Copy button; only the command area scrolls */
 }
 .install-copy:hover { filter: brightness(1.06); }
 .install-copied { color: var(--brand-fg); }

--- a/examples/website/src/components/stack_flow/stack_flow.css
+++ b/examples/website/src/components/stack_flow/stack_flow.css
@@ -41,6 +41,9 @@
   display: flex;
   flex-direction: column;
   gap: 2.75rem;
+  /* Shrink with its grid track instead of inflating it to the steps'
+     min-content (which overflowed the viewport on mobile). */
+  min-width: 0;
 }
 /* Timeline rail connecting the step nodes (faded at both ends) */
 .flow-steps::before {
@@ -61,9 +64,10 @@
      have time to play out as you scroll (no extra stages). */
   min-height: 46vh;
   display: grid;
-  grid-template-columns: 28px 1fr;
+  grid-template-columns: 28px minmax(0, 1fr);
   column-gap: 1.1rem;
   align-content: center;
+  min-width: 0;
 }
 .flow-step-num {
   grid-column: 1;
@@ -133,6 +137,9 @@
 .flow-stage {
   position: sticky;
   top: 5rem;
+  /* Shrink with its grid track so the demo (which clips its own overflow)
+     can't inflate the single mobile column past the viewport. */
+  min-width: 0;
 }
 .flow-stage .flow-cta {
   margin-top: 1.25rem;

--- a/examples/website/src/components/stack_showcase/stack_showcase.css
+++ b/examples/website/src/components/stack_showcase/stack_showcase.css
@@ -20,8 +20,11 @@
   height: 7px;
   background: var(--brand);
 }
-.sfw-corner-l { left: -4px; }
-.sfw-corner-r { right: -4px; }
+/* Flush to the section edge, not -4px past it: on mobile the section is
+   full-bleed, so a negative offset pushed these accents past the viewport
+   and forced horizontal page scroll. */
+.sfw-corner-l { left: 0; }
+.sfw-corner-r { right: 0; }
 
 .sfw-head { max-width: 48rem; margin-bottom: 1.5rem; }
 .sfw-head h2 {


### PR DESCRIPTION
Adds the WASM **boot experience** for pocopine SPAs and fixes two router gaps it exposed. All built on top of the merged edition-2024 migration (#210).

## What's in it

```mermaid
flowchart TD
    A[Cold load: index.html] -->|injected by pocopine build| B[Logo splash + top bar]
    B -->|fetch wraps download %| C[wasm bundle downloads]
    C --> D[App boots -> ready]
    D -->|splash fades, gated to once/session| E[App interactive]
    E -->|click a[pp-route]| F[Client-side navigate, no full reload]
    F --> G[Route component mounts into pp-outlet]
    G -->|pp-transition enter RFC-005| H[New page animates in]
    F -.RouteNavigation event.-> I[Top bar start -> finish]
```

### Boot loader (`feat: website / progress / loader / cli`)
- **Top progress bar** (YouTube / nprogress style) instead of a blocking spinner — users see motion, not a "refresh or wait?" guess.
- **Reusable `pocopine::progress` API** — `start / set / inc / finish / fail / task()` (RAII guard; no-ops off `wasm32`). Apps drive their own long operations through the same bar.
- **Framework-injected loader** — `pocopine build` injects the loader CSS/JS + splash into the generated `pkg/index.html` when `[package.metadata.pocopine.loader] enabled` (the default). Cold-load **logo splash** paints on frame 1; gated via sessionStorage so it shows once per tab session, not on every navigation.
- **Router auto-hook** — `RouteNavigation*` events drive the bar with no app wiring.
- **CLI `--port`** — overrides the server-bin port for `run` / `dev` (injects `PORT`), so you don't edit Cargo to dodge a port clash.

### Router fixes (`fix: router / feat: router`)
- **Client-side navigation for `pp-route`** — `router::init()` only wired `popstate`; `pp-route` links did full-page reloads (an antipattern that also re-triggered the splash). Added a delegated click interceptor with the usual guards (modifier keys, `target`, `download`, external / protocol-relative hrefs).
- **`pp-transition` on route change** — reuse the RFC-005 transition system: after a route component mounts, `finish_route_mount` copies the outlet's `pp-transition*` config onto the fresh page root and plays the enter sequence. No-op when no transition is declared or motion is reduced. The website opts in via `<pp-outlet pp-transition="fade-scale">`.

## Verification
- `cargo clippy -p pocopine-core -p pocopine --all-targets -- -D warnings` ✓
- `cargo clippy -p pocopine-core -p pocopine --target wasm32-unknown-unknown -- -D warnings` ✓
- `wasm-pack test --node crates/pocopine-core` — 41 passed / 0 failed ✓
- Headless (Playwright, `reducedMotion:'no-preference'`): cold-load splash + download %, splash fades on ready and does **not** return on nav, `pp-route` navigates client-side (no reload), and route enter fires (`pp-tx-fade-scale-from → base + pp-tx-fade-scale-to` on the incoming page).