### PR TITLE
pine-layout: headless responsive layout + workspace shells (RFC-103, RFC-105)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9943,6 +9943,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "workspace-demo"
+version = "0.1.1"
+dependencies = [
+ "pine-layout",
+ "pocopine",
+ "serde",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5538,6 +5538,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pine-layout"
+version = "0.1.1"
+dependencies = [
+ "js-sys",
+ "pocopine",
+ "pocopine-core",
+ "serde",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-bindgen-test",
+ "web-sys",
+]
+
+[[package]]
 name = "pine-motion"
 version = "0.1.1"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4294,6 +4294,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "layout-demo"
+version = "0.1.1"
+dependencies = [
+ "pine-layout",
+ "pine-motion",
+ "pocopine",
+ "serde",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,7 @@ members = [
     "examples/sync",
     "examples/tailwind",
     "examples/todo",
+    "examples/workspace",
 ]
 
 # The CLI builds for the host; everything else builds for wasm32. Exclude the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ members = [
     "examples/file-browser",
     "examples/hn",
     "examples/keep",
+    "examples/layout",
     "examples/live",
     "examples/observability-frontend",
     "examples/observability-smoke",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/pine-charts",
     "crates/pine-icons",
     "crates/pine-icons-macros",
+    "crates/pine-layout",
     "crates/pine-motion",
     "crates/pine-richtext",
     "crates/pocopine",

--- a/crates/pine-layout/Cargo.toml
+++ b/crates/pine-layout/Cargo.toml
@@ -1,0 +1,51 @@
+[package]
+name = "pine-layout"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Headless, responsive layout primitives for Pine and pocopine."
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+doctest = false
+
+[dependencies]
+js-sys = { workspace = true }
+pocopine = { path = "../pocopine" }
+pocopine-core = { workspace = true }
+serde = { workspace = true }
+wasm-bindgen = { workspace = true }
+
+[dependencies.web-sys]
+version = "0.3"
+features = [
+    "Element",
+    "Event",
+    "EventTarget",
+    "HtmlElement",
+    "MediaQueryList",
+    "Node",
+    "Window",
+]
+
+[dev-dependencies]
+js-sys = { workspace = true }
+pocopine-core = { workspace = true }
+wasm-bindgen-futures = { workspace = true }
+wasm-bindgen-test = "0.3"
+
+[dev-dependencies.web-sys]
+version = "0.3"
+features = [
+    "CustomEvent",
+    "Document",
+    "Element",
+    "Event",
+    "HtmlElement",
+    "KeyboardEvent",
+    "KeyboardEventInit",
+    "MediaQueryList",
+    "Node",
+    "Window",
+]

--- a/crates/pine-layout/src/app_shell/PineAppShell.poco
+++ b/crates/pine-layout/src/app_shell/PineAppShell.poco
@@ -1,0 +1,7 @@
+<root class="pine-app-shell"
+      pp-ref="shell"
+      :data-breakpoint="breakpoint"
+      :data-nav-mode="nav_mode"
+      :data-nav-open="nav_open">
+  <slot></slot>
+</root>

--- a/crates/pine-layout/src/app_shell/PineAppShellContent.poco
+++ b/crates/pine-layout/src/app_shell/PineAppShellContent.poco
@@ -1,0 +1,3 @@
+<root class="pine-app-shell-content" role="main">
+  <slot></slot>
+</root>

--- a/crates/pine-layout/src/app_shell/PineAppShellFooter.poco
+++ b/crates/pine-layout/src/app_shell/PineAppShellFooter.poco
@@ -1,0 +1,3 @@
+<root class="pine-app-shell-footer" role="contentinfo">
+  <slot></slot>
+</root>

--- a/crates/pine-layout/src/app_shell/PineAppShellHeader.poco
+++ b/crates/pine-layout/src/app_shell/PineAppShellHeader.poco
@@ -1,0 +1,3 @@
+<root class="pine-app-shell-header" role="banner">
+  <slot></slot>
+</root>

--- a/crates/pine-layout/src/app_shell/PineAppShellSidebar.poco
+++ b/crates/pine-layout/src/app_shell/PineAppShellSidebar.poco
@@ -1,0 +1,10 @@
+<root class="pine-app-shell-sidebar"
+      pp-ref="sidebar"
+      role="navigation"
+      :id="nav_id"
+      :aria-label="label"
+      :data-nav-mode="nav_mode"
+      :data-state="nav_open ? 'open' : 'closed'"
+      @keydown.escape="close_nav">
+  <slot></slot>
+</root>

--- a/crates/pine-layout/src/app_shell/PineAppShellTrigger.poco
+++ b/crates/pine-layout/src/app_shell/PineAppShellTrigger.poco
@@ -1,0 +1,8 @@
+<root class="pine-app-shell-trigger"
+      type="button"
+      :data-nav-mode="nav_mode"
+      :aria-expanded="nav_open ? 'true' : 'false'"
+      :aria-controls="nav_id"
+      @click="toggle">
+  <slot></slot>
+</root>

--- a/crates/pine-layout/src/app_shell/mod.rs
+++ b/crates/pine-layout/src/app_shell/mod.rs
@@ -34,6 +34,7 @@
 //! ```
 
 use crate::breakpoint::{install, Breakpoint};
+use crate::floating as drawer;
 use pocopine::prelude::*;
 use serde::{Deserialize, Serialize};
 
@@ -92,16 +93,9 @@ impl PineAppShell {
     /// `rail_at` / `sidebar_at` thresholds. Closes the drawer when the
     /// viewport grows out of drawer mode so focus/scroll are released.
     fn recompute_nav_mode(&mut self) {
-        let bp = Breakpoint::from_token(&self.breakpoint).unwrap_or(Breakpoint::Base);
-        let rail = Breakpoint::from_token(&self.rail_at).unwrap_or(Breakpoint::Md);
-        let sidebar = Breakpoint::from_token(&self.sidebar_at).unwrap_or(Breakpoint::Xl);
-        self.nav_mode = if bp.rank() >= sidebar.rank() {
-            "sidebar".into()
-        } else if bp.rank() >= rail.rank() {
-            "rail".into()
-        } else {
-            "drawer".into()
-        };
+        self.nav_mode =
+            crate::breakpoint::nav_mode(&self.breakpoint, &self.rail_at, &self.sidebar_at)
+                .to_string();
         if self.nav_mode != "drawer" && self.nav_open {
             // Leaving drawer mode — the Sidebar's watcher releases the
             // focus trap + scroll lock when it sees this flip to false.
@@ -281,64 +275,6 @@ impl PineAppShellTrigger {
             shell.update(|s| s.toggle_nav());
         }
     }
-}
-
-// ── Drawer runtime — modal focus trap + scroll lock ───────────────
-//
-// Focus traps / saved-focus handles aren't serde-friendly, so they
-// live in a per-scope side-table keyed by the Sidebar's scope id —
-// the same shape `pine::overlay` uses for Dialog/Popover.
-
-#[cfg(target_arch = "wasm32")]
-mod drawer {
-    use pocopine::{focus, scroll_lock};
-    use std::cell::RefCell;
-    use std::collections::HashMap;
-    use web_sys::Element;
-
-    struct Runtime {
-        saved: focus::Saved,
-        // Held purely for its `Drop` — dropping detaches the trap.
-        _trap: focus::TrapHandle,
-    }
-
-    thread_local! {
-        static DRAWERS: RefCell<HashMap<u64, Runtime>> = RefCell::new(HashMap::new());
-    }
-
-    /// Activate the modal drawer: lock scroll, save focus, trap focus
-    /// inside `el`, and move focus to its first focusable. Idempotent.
-    pub(super) fn open(scope: u64, el: &Element) {
-        let already = DRAWERS.with(|d| d.borrow().contains_key(&scope));
-        if already {
-            return;
-        }
-        scroll_lock::lock();
-        let saved = focus::save();
-        let trap = focus::trap(el);
-        let _ = focus::auto_focus_first(el);
-        DRAWERS.with(|d| {
-            d.borrow_mut().insert(scope, Runtime { saved, _trap: trap });
-        });
-    }
-
-    /// Deactivate the drawer: untrap, unlock scroll, restore focus.
-    /// Idempotent.
-    pub(super) fn close(scope: u64) {
-        let rt = DRAWERS.with(|d| d.borrow_mut().remove(&scope));
-        if let Some(rt) = rt {
-            // `_trap` drops here, detaching the focus trap.
-            scroll_lock::unlock();
-            focus::restore(rt.saved);
-        }
-    }
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-mod drawer {
-    use web_sys::Element;
-    pub(super) fn open(_scope: u64, _el: &Element) {}
-    pub(super) fn close(_scope: u64) {}
 }
 
 #[cfg(test)]

--- a/crates/pine-layout/src/app_shell/mod.rs
+++ b/crates/pine-layout/src/app_shell/mod.rs
@@ -1,0 +1,432 @@
+//! `<pine-app-shell-*>` — adaptive application scaffold (compound).
+//!
+//! Six parts: a **Root** that owns the breakpoint engine + the
+//! adaptive-navigation state machine, and five regions
+//! (**Header**, **Sidebar**, **Content**, **Footer**, **Trigger**).
+//!
+//! The Root resolves the viewport tier and derives a `nav_mode` from
+//! it — `drawer` (narrow), `rail` (medium), or `sidebar` (wide),
+//! mirroring Material's bottom-bar → rail → drawer progression and
+//! Apple's collapse-to-stack-in-compact behavior. It surfaces
+//! `data-breakpoint` + `data-nav-mode` on its element and provides the
+//! `SHELL` context; the regions read it. **Headless** — the author's
+//! CSS decides what each `nav_mode` looks like:
+//!
+//! ```css
+//! .pine-app-shell { display: grid; }
+//! .pine-app-shell[data-nav-mode="drawer"]  { grid-template-columns: 1fr; }
+//! .pine-app-shell[data-nav-mode="rail"]    { grid-template-columns: 4rem 1fr; }
+//! .pine-app-shell[data-nav-mode="sidebar"] { grid-template-columns: 16rem 1fr; }
+//! /* the drawer slides in only in drawer mode: */
+//! .pine-app-shell-sidebar[data-nav-mode="drawer"]               { position: fixed; transform: translateX(-100%); }
+//! .pine-app-shell-sidebar[data-nav-mode="drawer"][data-state="open"] { transform: none; }
+//! ```
+//!
+//! ```html
+//! <pine-app-shell pp-model:breakpoint="bp">
+//!   <pine-app-shell-header>
+//!     <pine-app-shell-trigger>☰</pine-app-shell-trigger>
+//!   </pine-app-shell-header>
+//!   <pine-app-shell-sidebar label="Main">…nav…</pine-app-shell-sidebar>
+//!   <pine-app-shell-content>…page…</pine-app-shell-content>
+//!   <pine-app-shell-footer>…</pine-app-shell-footer>
+//! </pine-app-shell>
+//! ```
+
+use crate::breakpoint::{install, Breakpoint};
+use pocopine::prelude::*;
+use serde::{Deserialize, Serialize};
+
+create_context!(SHELL: Handle<PineAppShell>);
+
+// ── Root ──────────────────────────────────────────────────────────
+
+/// The application scaffold root. Owns the breakpoint engine and the
+/// adaptive-navigation state machine. See module docs.
+#[derive(Serialize, Deserialize)]
+#[component(template = "PineAppShell.poco", role = "scope")]
+pub struct PineAppShell {
+    /// Current viewport tier — `base`/`sm`/`md`/`lg`/`xl`/`2xl`.
+    /// Engine-driven; emitted on `pp:update:breakpoint`.
+    #[model]
+    pub breakpoint: String,
+    /// Whether the drawer is open. Only meaningful while
+    /// `nav_mode == "drawer"`. Emitted on `pp:update:nav_open`.
+    #[model]
+    pub nav_open: bool,
+    /// Derived navigation mode — `drawer`/`rail`/`sidebar`.
+    pub nav_mode: String,
+    /// Smallest tier at which navigation becomes a persistent rail.
+    /// Defaults to `md`.
+    #[prop]
+    pub rail_at: String,
+    /// Smallest tier at which navigation becomes a full sidebar.
+    /// Defaults to `xl`.
+    #[prop]
+    pub sidebar_at: String,
+    /// Tier assumed before `matchMedia` resolves (and the permanent
+    /// value on non-wasm / SSR). Defaults to `base`.
+    #[prop]
+    pub initial: String,
+    /// Stable id for the navigation landmark, used to wire the
+    /// Trigger's `aria-controls` to the Sidebar.
+    pub nav_id: String,
+}
+
+impl Default for PineAppShell {
+    fn default() -> Self {
+        Self {
+            breakpoint: String::new(),
+            nav_open: false,
+            nav_mode: "drawer".into(),
+            rail_at: "md".into(),
+            sidebar_at: "xl".into(),
+            initial: "base".into(),
+            nav_id: String::new(),
+        }
+    }
+}
+
+impl PineAppShell {
+    /// Recompute `nav_mode` from the current breakpoint and the
+    /// `rail_at` / `sidebar_at` thresholds. Closes the drawer when the
+    /// viewport grows out of drawer mode so focus/scroll are released.
+    fn recompute_nav_mode(&mut self) {
+        let bp = Breakpoint::from_token(&self.breakpoint).unwrap_or(Breakpoint::Base);
+        let rail = Breakpoint::from_token(&self.rail_at).unwrap_or(Breakpoint::Md);
+        let sidebar = Breakpoint::from_token(&self.sidebar_at).unwrap_or(Breakpoint::Xl);
+        self.nav_mode = if bp.rank() >= sidebar.rank() {
+            "sidebar".into()
+        } else if bp.rank() >= rail.rank() {
+            "rail".into()
+        } else {
+            "drawer".into()
+        };
+        if self.nav_mode != "drawer" && self.nav_open {
+            // Leaving drawer mode — the Sidebar's watcher releases the
+            // focus trap + scroll lock when it sees this flip to false.
+            self.nav_open = false;
+        }
+    }
+
+    /// Toggle the drawer (no-op outside drawer mode).
+    pub fn toggle_nav(&mut self) {
+        if self.nav_mode == "drawer" {
+            self.nav_open = !self.nav_open;
+        }
+    }
+
+    /// Open the drawer (no-op outside drawer mode).
+    pub fn open_nav(&mut self) {
+        if self.nav_mode == "drawer" {
+            self.nav_open = true;
+        }
+    }
+
+    /// Close the drawer.
+    pub fn close_nav(&mut self) {
+        self.nav_open = false;
+    }
+}
+
+#[handlers]
+impl PineAppShell {
+    fn on_setup(&mut self) {
+        if let Some(scope) = pocopine::current_scope_id() {
+            self.nav_id = format!("pine-app-shell-nav-{}", scope.0);
+        }
+        if self.breakpoint.is_empty() {
+            self.breakpoint = self.initial.clone();
+        }
+        self.recompute_nav_mode();
+        SHELL.provide(this::<Self>());
+    }
+
+    fn on_ready(&self, handle: Handle<Self>) {
+        let sink = handle;
+        install(std::rc::Rc::new(move |bp: Breakpoint| {
+            sink.update(|s| {
+                s.breakpoint = bp.as_str().to_string();
+                s.recompute_nav_mode();
+            });
+        }));
+    }
+}
+
+// ── Header / Content / Footer — landmark regions ──────────────────
+
+/// Top app-bar region. Renders a `role="banner"` landmark.
+#[derive(Default, Serialize, Deserialize)]
+#[component(template = "PineAppShellHeader.poco", role = "panel")]
+pub struct PineAppShellHeader {}
+
+#[handlers]
+impl PineAppShellHeader {}
+
+/// Main content region. Renders a `role="main"` landmark.
+#[derive(Default, Serialize, Deserialize)]
+#[component(template = "PineAppShellContent.poco", role = "panel")]
+pub struct PineAppShellContent {}
+
+#[handlers]
+impl PineAppShellContent {}
+
+/// Footer region. Renders a `role="contentinfo"` landmark.
+#[derive(Default, Serialize, Deserialize)]
+#[component(template = "PineAppShellFooter.poco", role = "panel")]
+pub struct PineAppShellFooter {}
+
+#[handlers]
+impl PineAppShellFooter {}
+
+// ── Sidebar — the adaptive navigation region ──────────────────────
+
+/// Primary navigation region. Renders a `role="navigation"` landmark
+/// carrying `data-nav-mode` + `data-state`. In `drawer` mode it
+/// behaves like a modal: Escape closes it, focus is trapped while
+/// open, and the page scroll is locked. (Scrim / outside-click
+/// dismissal is deferred to v2 — a capture-phase `@click.outside` on
+/// the sidebar would treat the toggle as "outside" and fight it.)
+#[derive(Default, Serialize, Deserialize)]
+#[component(template = "PineAppShellSidebar.poco", role = "panel")]
+pub struct PineAppShellSidebar {
+    /// Accessible name for the navigation landmark.
+    #[prop]
+    pub label: String,
+    /// Mirrored from the shell — drives `data-nav-mode`.
+    #[observe(SHELL)]
+    pub nav_mode: String,
+    /// Mirrored from the shell — drives `data-state` (open/closed).
+    #[observe(SHELL)]
+    pub nav_open: bool,
+    /// Mirrored from the shell — the navigation landmark's `id`
+    /// (the Trigger's `aria-controls` target).
+    #[observe(SHELL)]
+    pub nav_id: String,
+    /// This sidebar's own scope id, captured at setup as the drawer
+    /// side-table key.
+    pub scope: u64,
+}
+
+#[handlers]
+impl PineAppShellSidebar {
+    fn on_setup(&mut self) {
+        if let Some(scope) = pocopine::current_scope_id() {
+            self.scope = scope.0;
+        }
+    }
+
+    fn on_ready(&self, handle: Handle<Self>, refs: pocopine::Refs) {
+        let Some(el) = refs.get("sidebar") else {
+            return;
+        };
+        let Some(shell) = SHELL.inject() else {
+            return;
+        };
+        let shell_scope = shell.scope_id();
+        let scope = handle.with(|s| s.scope);
+
+        // Drive the focus trap + scroll lock off the shell's `nav_open`
+        // (proven cross-scope watch, like Splitter watches `sizes`).
+        let el_for_watch = el.clone();
+        let shell_for_watch = shell.clone();
+        pocopine::watch_scope_field_scoped::<bool, _>(shell_scope, "nav_open", move |open, _| {
+            let mode = shell_for_watch.with(|s| s.nav_mode.clone());
+            if *open && mode == "drawer" {
+                drawer::open(scope, &el_for_watch);
+            } else {
+                drawer::close(scope);
+            }
+        });
+
+        // Release the drawer if the sidebar unmounts while open.
+        pocopine::on_scope_unmount(move || drawer::close(scope));
+    }
+
+    /// Close the drawer (Escape). No-op outside drawer mode so a
+    /// visible rail/sidebar isn't affected by stray key events.
+    pub fn close_nav(&mut self) {
+        if self.nav_mode != "drawer" {
+            return;
+        }
+        if let Some(shell) = SHELL.inject() {
+            shell.update(|s| s.close_nav());
+        }
+    }
+}
+
+// ── Trigger — the hamburger toggle ────────────────────────────────
+
+/// A `<button>` that toggles the drawer. Mirrors the drawer state onto
+/// `aria-expanded` and points `aria-controls` at the Sidebar.
+#[derive(Default, Serialize, Deserialize)]
+#[component(template = "PineAppShellTrigger.poco", role = "interactive")]
+pub struct PineAppShellTrigger {
+    /// Mirrored from the shell — drives `aria-expanded`.
+    #[observe(SHELL)]
+    pub nav_open: bool,
+    /// Mirrored from the shell — drives `data-nav-mode` (so authors can
+    /// hide the trigger outside drawer mode).
+    #[observe(SHELL)]
+    pub nav_mode: String,
+    /// Mirrored from the shell — the `aria-controls` target id.
+    #[observe(SHELL)]
+    pub nav_id: String,
+}
+
+#[handlers]
+impl PineAppShellTrigger {
+    pub fn toggle(&mut self) {
+        if let Some(shell) = SHELL.inject() {
+            shell.update(|s| s.toggle_nav());
+        }
+    }
+}
+
+// ── Drawer runtime — modal focus trap + scroll lock ───────────────
+//
+// Focus traps / saved-focus handles aren't serde-friendly, so they
+// live in a per-scope side-table keyed by the Sidebar's scope id —
+// the same shape `pine::overlay` uses for Dialog/Popover.
+
+#[cfg(target_arch = "wasm32")]
+mod drawer {
+    use pocopine::{focus, scroll_lock};
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+    use web_sys::Element;
+
+    struct Runtime {
+        saved: focus::Saved,
+        // Held purely for its `Drop` — dropping detaches the trap.
+        _trap: focus::TrapHandle,
+    }
+
+    thread_local! {
+        static DRAWERS: RefCell<HashMap<u64, Runtime>> = RefCell::new(HashMap::new());
+    }
+
+    /// Activate the modal drawer: lock scroll, save focus, trap focus
+    /// inside `el`, and move focus to its first focusable. Idempotent.
+    pub(super) fn open(scope: u64, el: &Element) {
+        let already = DRAWERS.with(|d| d.borrow().contains_key(&scope));
+        if already {
+            return;
+        }
+        scroll_lock::lock();
+        let saved = focus::save();
+        let trap = focus::trap(el);
+        let _ = focus::auto_focus_first(el);
+        DRAWERS.with(|d| {
+            d.borrow_mut().insert(scope, Runtime { saved, _trap: trap });
+        });
+    }
+
+    /// Deactivate the drawer: untrap, unlock scroll, restore focus.
+    /// Idempotent.
+    pub(super) fn close(scope: u64) {
+        let rt = DRAWERS.with(|d| d.borrow_mut().remove(&scope));
+        if let Some(rt) = rt {
+            // `_trap` drops here, detaching the focus trap.
+            scroll_lock::unlock();
+            focus::restore(rt.saved);
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+mod drawer {
+    use web_sys::Element;
+    pub(super) fn open(_scope: u64, _el: &Element) {}
+    pub(super) fn close(_scope: u64) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A shell at tier `bp` with the given `rail_at`/`sidebar_at`
+    /// thresholds, nav_mode recomputed.
+    fn shell(bp: &str, rail_at: &str, sidebar_at: &str) -> PineAppShell {
+        let mut s = PineAppShell {
+            breakpoint: bp.into(),
+            rail_at: rail_at.into(),
+            sidebar_at: sidebar_at.into(),
+            ..PineAppShell::default()
+        };
+        s.recompute_nav_mode();
+        s
+    }
+
+    #[test]
+    fn nav_mode_default_thresholds() {
+        // rail_at = md, sidebar_at = xl (the defaults).
+        let expect = [
+            ("base", "drawer"),
+            ("sm", "drawer"),
+            ("md", "rail"),
+            ("lg", "rail"),
+            ("xl", "sidebar"),
+            ("2xl", "sidebar"),
+        ];
+        for (bp, mode) in expect {
+            assert_eq!(shell(bp, "md", "xl").nav_mode, mode, "at {bp}");
+        }
+    }
+
+    #[test]
+    fn nav_mode_custom_thresholds() {
+        // Rail only from lg, full sidebar only at 2xl.
+        let expect = [
+            ("md", "drawer"),
+            ("lg", "rail"),
+            ("xl", "rail"),
+            ("2xl", "sidebar"),
+        ];
+        for (bp, mode) in expect {
+            assert_eq!(shell(bp, "lg", "2xl").nav_mode, mode, "at {bp}");
+        }
+    }
+
+    #[test]
+    fn toggle_only_acts_in_drawer_mode() {
+        let mut drawer = shell("base", "md", "xl");
+        assert_eq!(drawer.nav_mode, "drawer");
+        assert!(!drawer.nav_open);
+        drawer.toggle_nav();
+        assert!(drawer.nav_open, "drawer toggles open");
+        drawer.toggle_nav();
+        assert!(!drawer.nav_open, "drawer toggles closed");
+
+        let mut rail = shell("md", "md", "xl");
+        assert_eq!(rail.nav_mode, "rail");
+        rail.toggle_nav();
+        assert!(!rail.nav_open, "rail mode ignores toggle");
+    }
+
+    #[test]
+    fn open_close_semantics() {
+        let mut s = shell("base", "md", "xl");
+        s.open_nav();
+        assert!(s.nav_open);
+        s.close_nav();
+        assert!(!s.nav_open);
+
+        let mut rail = shell("xl", "md", "xl");
+        rail.open_nav();
+        assert!(!rail.nav_open, "open_nav is a no-op outside drawer mode");
+    }
+
+    #[test]
+    fn growing_out_of_drawer_closes_the_drawer() {
+        let mut s = shell("base", "md", "xl");
+        s.open_nav();
+        assert!(s.nav_open);
+        // Viewport grows to lg → rail mode; the open drawer must close
+        // so focus/scroll get released.
+        s.breakpoint = "lg".into();
+        s.recompute_nav_mode();
+        assert_eq!(s.nav_mode, "rail");
+        assert!(!s.nav_open, "drawer auto-closes when it leaves drawer mode");
+    }
+}

--- a/crates/pine-layout/src/breakpoint/PineBreakpoint.poco
+++ b/crates/pine-layout/src/breakpoint/PineBreakpoint.poco
@@ -1,0 +1,3 @@
+<root class="pine-breakpoint" :data-breakpoint="value">
+  <slot></slot>
+</root>

--- a/crates/pine-layout/src/breakpoint/mod.rs
+++ b/crates/pine-layout/src/breakpoint/mod.rs
@@ -1,0 +1,276 @@
+//! Breakpoint engine + `<pine-breakpoint>` provider.
+//!
+//! The engine watches the viewport via `matchMedia` at the five
+//! Stylekit thresholds and resolves the largest matching tier. It is
+//! the shared core behind both `<pine-breakpoint>` and
+//! `<pine-app-shell>`; any component can reuse [`install`] to react to
+//! breakpoint changes.
+
+use pocopine::prelude::*;
+use serde::{Deserialize, Serialize};
+
+create_context!(BREAKPOINT: Handle<PineBreakpoint>);
+
+/// A responsive tier. Thresholds match Pine Stylekit's `sm:`/`md:`/
+/// `lg:`/`xl:`/`2xl:` utility prefixes exactly, so a reactive
+/// `data-breakpoint` value never disagrees with a utility class.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Breakpoint {
+    /// `< 640px`.
+    Base,
+    /// `≥ 640px`.
+    Sm,
+    /// `≥ 768px`.
+    Md,
+    /// `≥ 1024px`.
+    Lg,
+    /// `≥ 1280px`.
+    Xl,
+    /// `≥ 1536px`.
+    Xxl,
+}
+
+impl Breakpoint {
+    /// Ascending `(tier, min-width-px)` pairs above [`Breakpoint::Base`].
+    pub const TIERS: [(Breakpoint, u32); 5] = [
+        (Breakpoint::Sm, 640),
+        (Breakpoint::Md, 768),
+        (Breakpoint::Lg, 1024),
+        (Breakpoint::Xl, 1280),
+        (Breakpoint::Xxl, 1536),
+    ];
+
+    /// Token string — `base`/`sm`/`md`/`lg`/`xl`/`2xl`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Breakpoint::Base => "base",
+            Breakpoint::Sm => "sm",
+            Breakpoint::Md => "md",
+            Breakpoint::Lg => "lg",
+            Breakpoint::Xl => "xl",
+            Breakpoint::Xxl => "2xl",
+        }
+    }
+
+    /// Parse a token string back into a tier. `None` for anything that
+    /// is not one of the six tokens.
+    pub fn from_token(s: &str) -> Option<Self> {
+        Some(match s {
+            "base" => Breakpoint::Base,
+            "sm" => Breakpoint::Sm,
+            "md" => Breakpoint::Md,
+            "lg" => Breakpoint::Lg,
+            "xl" => Breakpoint::Xl,
+            "2xl" => Breakpoint::Xxl,
+            _ => return None,
+        })
+    }
+
+    /// Ordinal rank (`Base = 0 … Xxl = 5`) for ordered comparisons —
+    /// e.g. "is the viewport at least `md`?" is `bp.rank() >=
+    /// Breakpoint::Md.rank()`.
+    pub fn rank(self) -> u8 {
+        match self {
+            Breakpoint::Base => 0,
+            Breakpoint::Sm => 1,
+            Breakpoint::Md => 2,
+            Breakpoint::Lg => 3,
+            Breakpoint::Xl => 4,
+            Breakpoint::Xxl => 5,
+        }
+    }
+
+    /// Lower bound of this tier, in CSS pixels.
+    pub fn min_width(self) -> u32 {
+        match self {
+            Breakpoint::Base => 0,
+            Breakpoint::Sm => 640,
+            Breakpoint::Md => 768,
+            Breakpoint::Lg => 1024,
+            Breakpoint::Xl => 1280,
+            Breakpoint::Xxl => 1536,
+        }
+    }
+}
+
+/// Live `matchMedia` `change` listeners, retained for the scope's
+/// lifetime and detached together on unmount.
+#[cfg(target_arch = "wasm32")]
+type ChangeListeners =
+    std::rc::Rc<std::cell::RefCell<Vec<wasm_bindgen::closure::Closure<dyn FnMut(web_sys::Event)>>>>;
+
+/// Install a viewport breakpoint watcher for the current scope.
+///
+/// Calls `on_change` once with the initial tier (deferred past the
+/// `on_ready` borrow) and again on every threshold crossing. All
+/// `matchMedia` listeners are detached automatically when the scope
+/// unmounts. Must be called from a component lifecycle hook so the
+/// scope context is live.
+#[cfg(target_arch = "wasm32")]
+pub fn install(on_change: std::rc::Rc<dyn Fn(Breakpoint)>) {
+    use std::cell::RefCell;
+    use std::rc::Rc;
+    use wasm_bindgen::closure::Closure;
+    use wasm_bindgen::JsCast;
+
+    let Some(window) = web_sys::window() else {
+        return;
+    };
+
+    let mut list = Vec::with_capacity(Breakpoint::TIERS.len());
+    for (_tier, min_px) in Breakpoint::TIERS {
+        if let Ok(Some(mql)) = window.match_media(&format!("(min-width: {min_px}px)")) {
+            list.push(mql);
+        }
+    }
+    let mqls = Rc::new(list);
+
+    // One `change` listener per MediaQueryList. Each recomputes the
+    // resolved tier from the full set, so we never miss a crossing.
+    let closures: ChangeListeners = Rc::new(RefCell::new(Vec::with_capacity(mqls.len())));
+    for mql in mqls.iter() {
+        let mqls_for_cb = mqls.clone();
+        let on_change_for_cb = on_change.clone();
+        let cb = Closure::<dyn FnMut(web_sys::Event)>::new(move |_ev: web_sys::Event| {
+            on_change_for_cb(resolve(&mqls_for_cb));
+        });
+        let _ = mql.add_event_listener_with_callback("change", cb.as_ref().unchecked_ref());
+        closures.borrow_mut().push(cb);
+    }
+
+    // Detach + drop on unmount. Registered synchronously here (not in
+    // `tick::next`) so the scope binding is still live.
+    let mqls_for_cleanup = mqls.clone();
+    let closures_for_cleanup = closures.clone();
+    pocopine::on_scope_unmount(move || {
+        {
+            let cbs = closures_for_cleanup.borrow();
+            for (mql, cb) in mqls_for_cleanup.iter().zip(cbs.iter()) {
+                let _ =
+                    mql.remove_event_listener_with_callback("change", cb.as_ref().unchecked_ref());
+            }
+        }
+        closures_for_cleanup.borrow_mut().clear();
+    });
+
+    // Seed the initial value past the `on_ready` immutable borrow.
+    let initial = resolve(&mqls);
+    pocopine::tick::next(move || on_change(initial));
+}
+
+/// Largest tier whose `min-width` query currently matches. `TIERS` is
+/// ascending, so the last match wins.
+#[cfg(target_arch = "wasm32")]
+fn resolve(mqls: &[web_sys::MediaQueryList]) -> Breakpoint {
+    let mut current = Breakpoint::Base;
+    for (i, (tier, _px)) in Breakpoint::TIERS.iter().enumerate() {
+        if mqls.get(i).map(|m| m.matches()).unwrap_or(false) {
+            current = *tier;
+        }
+    }
+    current
+}
+
+/// Non-wasm / SSR builds have no viewport: the breakpoint stays at its
+/// configured `initial` value.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn install(_on_change: std::rc::Rc<dyn Fn(Breakpoint)>) {}
+
+/// `<pine-breakpoint>` — a standalone responsive provider.
+///
+/// Resolves the current viewport tier and exposes it three ways:
+/// `data-breakpoint` on its element (for CSS), the `BREAKPOINT`
+/// context (descendant components can `#[observe(BREAKPOINT)] value`),
+/// and the `pp:update:value` model event (`pp-model:value="bp"` in app
+/// logic). Ships no layout of its own — set `.pine-breakpoint {
+/// display: contents }` if you need it to be transparent.
+///
+/// ```html
+/// <pine-breakpoint pp-model:value="bp">
+///   <p>Viewport is at the {{bp}} tier.</p>
+/// </pine-breakpoint>
+/// ```
+#[derive(Serialize, Deserialize)]
+#[component(template = "PineBreakpoint.poco", role = "panel")]
+pub struct PineBreakpoint {
+    /// Current tier — `base`/`sm`/`md`/`lg`/`xl`/`2xl`.
+    #[model]
+    pub value: String,
+    /// Tier assumed before `matchMedia` resolves, and the permanent
+    /// value on non-wasm / SSR targets. Defaults to `base`.
+    #[prop]
+    pub initial: String,
+}
+
+impl Default for PineBreakpoint {
+    fn default() -> Self {
+        Self {
+            value: String::new(),
+            initial: "base".into(),
+        }
+    }
+}
+
+#[handlers]
+impl PineBreakpoint {
+    fn on_setup(&mut self) {
+        if self.value.is_empty() {
+            self.value = self.initial.clone();
+        }
+        BREAKPOINT.provide(this::<Self>());
+    }
+
+    fn on_ready(&self, handle: Handle<Self>) {
+        let sink = handle;
+        install(std::rc::Rc::new(move |bp: Breakpoint| {
+            sink.update(|s| s.value = bp.as_str().to_string());
+        }));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Breakpoint::*;
+    use super::*;
+
+    const ALL: [Breakpoint; 6] = [Base, Sm, Md, Lg, Xl, Xxl];
+
+    #[test]
+    fn token_roundtrips() {
+        for bp in ALL {
+            assert_eq!(Breakpoint::from_token(bp.as_str()), Some(bp));
+        }
+        assert_eq!(Base.as_str(), "base");
+        assert_eq!(Xxl.as_str(), "2xl");
+        assert_eq!(Breakpoint::from_token("nope"), None);
+        assert_eq!(Breakpoint::from_token(""), None);
+    }
+
+    #[test]
+    fn rank_is_strictly_ascending() {
+        for pair in ALL.windows(2) {
+            assert!(pair[0].rank() < pair[1].rank(), "{pair:?} not ascending");
+        }
+    }
+
+    #[test]
+    fn min_widths_match_stylekit() {
+        assert_eq!(Base.min_width(), 0);
+        assert_eq!(Sm.min_width(), 640);
+        assert_eq!(Md.min_width(), 768);
+        assert_eq!(Lg.min_width(), 1024);
+        assert_eq!(Xl.min_width(), 1280);
+        assert_eq!(Xxl.min_width(), 1536);
+    }
+
+    #[test]
+    fn tiers_are_ascending_and_match_min_width() {
+        let widths: Vec<u32> = Breakpoint::TIERS.iter().map(|(_, w)| *w).collect();
+        let mut sorted = widths.clone();
+        sorted.sort_unstable();
+        assert_eq!(widths, sorted, "TIERS must be ascending");
+        for (tier, w) in Breakpoint::TIERS {
+            assert_eq!(tier.min_width(), w);
+        }
+    }
+}

--- a/crates/pine-layout/src/breakpoint/mod.rs
+++ b/crates/pine-layout/src/breakpoint/mod.rs
@@ -93,6 +93,24 @@ impl Breakpoint {
     }
 }
 
+/// Derive the adaptive navigation mode (`drawer`/`rail`/`sidebar`) for a
+/// breakpoint, given the tiers at which the nav becomes a persistent rail
+/// and then a full sidebar. Shared by `app_shell` and `workspace` so both
+/// step the nav identically. Unknown tokens fall back to the AppShell
+/// defaults (`rail_at = md`, `sidebar_at = xl`).
+pub fn nav_mode(breakpoint: &str, rail_at: &str, sidebar_at: &str) -> &'static str {
+    let bp = Breakpoint::from_token(breakpoint).unwrap_or(Breakpoint::Base);
+    let rail = Breakpoint::from_token(rail_at).unwrap_or(Breakpoint::Md);
+    let sidebar = Breakpoint::from_token(sidebar_at).unwrap_or(Breakpoint::Xl);
+    if bp.rank() >= sidebar.rank() {
+        "sidebar"
+    } else if bp.rank() >= rail.rank() {
+        "rail"
+    } else {
+        "drawer"
+    }
+}
+
 /// Live `matchMedia` `change` listeners, retained for the scope's
 /// lifetime and detached together on unmount.
 #[cfg(target_arch = "wasm32")]

--- a/crates/pine-layout/src/container/PineContainer.poco
+++ b/crates/pine-layout/src/container/PineContainer.poco
@@ -1,0 +1,5 @@
+<root class="pine-container"
+      :data-size="size"
+      :data-safe-area="safe_area">
+  <slot></slot>
+</root>

--- a/crates/pine-layout/src/container/mod.rs
+++ b/crates/pine-layout/src/container/mod.rs
@@ -1,0 +1,35 @@
+//! `<pine-container>` — a max-width content column.
+//!
+//! Headless: emits `class="pine-container"` plus `data-size` and
+//! `data-safe-area` hooks. The author's CSS (or Stylekit utilities)
+//! decides the actual max-widths and whether to center:
+//!
+//! ```css
+//! .pine-container { margin-inline: auto; width: 100%; }
+//! .pine-container[data-size="md"]  { max-width: 48rem; }
+//! .pine-container[data-size="lg"]  { max-width: 64rem; }
+//! .pine-container[data-safe-area]  { padding: env(safe-area-inset-top)
+//!                                            env(safe-area-inset-right)
+//!                                            env(safe-area-inset-bottom)
+//!                                            env(safe-area-inset-left); }
+//! ```
+
+use pocopine::prelude::*;
+use serde::{Deserialize, Serialize};
+
+/// A centered, max-width content column. See module docs.
+#[derive(Default, Serialize, Deserialize)]
+#[component(template = "PineContainer.poco", role = "panel")]
+pub struct PineContainer {
+    /// Max-width token — e.g. `sm`/`md`/`lg`/`xl`/`2xl`/`full`, or any
+    /// author-defined value. Surfaced as `data-size`.
+    #[prop]
+    pub size: String,
+    /// Opt into safe-area inset padding. Surfaced as the boolean
+    /// `data-safe-area` attribute (present when `true`).
+    #[prop]
+    pub safe_area: bool,
+}
+
+#[handlers]
+impl PineContainer {}

--- a/crates/pine-layout/src/floating.rs
+++ b/crates/pine-layout/src/floating.rs
@@ -1,0 +1,60 @@
+//! Shared floating-overlay runtime — modal focus trap + scroll lock.
+//!
+//! Used by the AppShell drawer (`app_shell`) and the Workspace floating
+//! Aside (`workspace`). Focus traps / saved-focus handles aren't
+//! serde-friendly, so they live in a per-scope side-table keyed by the
+//! floating element's scope id — the same shape `pine::overlay` uses for
+//! Dialog/Popover. Idempotent open/close.
+
+#[cfg(target_arch = "wasm32")]
+mod imp {
+    use pocopine::{focus, scroll_lock};
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+    use web_sys::Element;
+
+    struct Runtime {
+        saved: focus::Saved,
+        // Held purely for its `Drop` — dropping detaches the trap.
+        _trap: focus::TrapHandle,
+    }
+
+    thread_local! {
+        static ACTIVE: RefCell<HashMap<u64, Runtime>> = RefCell::new(HashMap::new());
+    }
+
+    /// Activate: lock scroll, save focus, trap focus inside `el`, and move
+    /// focus to its first focusable.
+    pub(crate) fn open(scope: u64, el: &Element) {
+        let already = ACTIVE.with(|d| d.borrow().contains_key(&scope));
+        if already {
+            return;
+        }
+        scroll_lock::lock();
+        let saved = focus::save();
+        let trap = focus::trap(el);
+        let _ = focus::auto_focus_first(el);
+        ACTIVE.with(|d| {
+            d.borrow_mut().insert(scope, Runtime { saved, _trap: trap });
+        });
+    }
+
+    /// Deactivate: untrap, unlock scroll, restore focus.
+    pub(crate) fn close(scope: u64) {
+        let rt = ACTIVE.with(|d| d.borrow_mut().remove(&scope));
+        if let Some(rt) = rt {
+            // `_trap` drops here, detaching the focus trap.
+            scroll_lock::unlock();
+            focus::restore(rt.saved);
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+mod imp {
+    use web_sys::Element;
+    pub(crate) fn open(_scope: u64, _el: &Element) {}
+    pub(crate) fn close(_scope: u64) {}
+}
+
+pub(crate) use imp::{close, open};

--- a/crates/pine-layout/src/grid/PineGrid.poco
+++ b/crates/pine-layout/src/grid/PineGrid.poco
@@ -1,0 +1,5 @@
+<root class="pine-grid"
+      :data-cols="cols"
+      :data-gap="gap">
+  <slot></slot>
+</root>

--- a/crates/pine-layout/src/grid/PineGridItem.poco
+++ b/crates/pine-layout/src/grid/PineGridItem.poco
@@ -1,0 +1,5 @@
+<root class="pine-grid-item"
+      :data-span="span"
+      :data-start="start">
+  <slot></slot>
+</root>

--- a/crates/pine-layout/src/grid/mod.rs
+++ b/crates/pine-layout/src/grid/mod.rs
@@ -1,0 +1,60 @@
+//! `<pine-grid>` + `<pine-grid-item>` — a 12-column responsive grid
+//! (the cross-system column-count consensus: Atlassian's 12, Material
+//! and Bootstrap/Tailwind all 12-friendly).
+//!
+//! Headless: the grid emits `class="pine-grid"` + `data-cols`/
+//! `data-gap`; items emit `class="pine-grid-item"` + `data-span`/
+//! `data-start`. The author's CSS supplies the grid. Responsive column
+//! counts are best expressed with Stylekit utilities directly on the
+//! element (`<pine-grid class="grid-cols-12 md:grid-cols-6">`) or with
+//! media queries against the `data-*` hooks:
+//!
+//! ```css
+//! .pine-grid { display: grid; }
+//! .pine-grid[data-cols="12"] { grid-template-columns: repeat(12, 1fr); }
+//! .pine-grid[data-gap="4"]   { gap: 1rem; }
+//! .pine-grid-item[data-span="6"]  { grid-column: span 6; }
+//! .pine-grid-item[data-start="4"] { grid-column-start: 4; }
+//! ```
+
+use pocopine::prelude::*;
+use serde::{Deserialize, Serialize};
+
+/// A grid container. See module docs.
+#[derive(Serialize, Deserialize)]
+#[component(template = "PineGrid.poco", role = "panel")]
+pub struct PineGrid {
+    /// Number of columns. Defaults to `12`. Surfaced as `data-cols`.
+    #[prop]
+    pub cols: String,
+    /// Gap token between cells. Surfaced as `data-gap`.
+    #[prop]
+    pub gap: String,
+}
+
+impl Default for PineGrid {
+    fn default() -> Self {
+        Self {
+            cols: "12".into(),
+            gap: String::new(),
+        }
+    }
+}
+
+#[handlers]
+impl PineGrid {}
+
+/// A single cell in a [`PineGrid`]. See module docs.
+#[derive(Default, Serialize, Deserialize)]
+#[component(template = "PineGridItem.poco", role = "panel")]
+pub struct PineGridItem {
+    /// Number of columns this cell spans. Surfaced as `data-span`.
+    #[prop]
+    pub span: String,
+    /// 1-based column the cell starts at. Surfaced as `data-start`.
+    #[prop]
+    pub start: String,
+}
+
+#[handlers]
+impl PineGridItem {}

--- a/crates/pine-layout/src/inline/PineInline.poco
+++ b/crates/pine-layout/src/inline/PineInline.poco
@@ -1,0 +1,7 @@
+<root class="pine-inline"
+      :data-gap="gap"
+      :data-align="align"
+      :data-justify="justify"
+      :data-wrap="wrap">
+  <slot></slot>
+</root>

--- a/crates/pine-layout/src/inline/mod.rs
+++ b/crates/pine-layout/src/inline/mod.rs
@@ -1,0 +1,39 @@
+//! `<pine-inline>` — horizontal one-dimensional layout (Atlassian's
+//! `Inline`).
+//!
+//! Headless: emits `class="pine-inline"` plus `data-gap`/`data-align`/
+//! `data-justify`/`data-wrap` hooks. The author's CSS supplies the
+//! flexbox:
+//!
+//! ```css
+//! .pine-inline { display: flex; flex-direction: row; align-items: center; }
+//! .pine-inline[data-wrap]          { flex-wrap: wrap; }
+//! .pine-inline[data-justify="between"] { justify-content: space-between; }
+//! ```
+
+use pocopine::prelude::*;
+use serde::{Deserialize, Serialize};
+
+/// Arranges its children horizontally. See module docs.
+#[derive(Default, Serialize, Deserialize)]
+#[component(template = "PineInline.poco", role = "panel")]
+pub struct PineInline {
+    /// Gap token between children. Surfaced as `data-gap`.
+    #[prop]
+    pub gap: String,
+    /// Cross-axis (vertical) alignment — e.g. `start`/`center`/`end`/
+    /// `baseline`. Surfaced as `data-align`.
+    #[prop]
+    pub align: String,
+    /// Main-axis (horizontal) distribution — e.g. `start`/`center`/
+    /// `between`. Surfaced as `data-justify`.
+    #[prop]
+    pub justify: String,
+    /// Allow children to wrap onto multiple rows. Surfaced as the
+    /// boolean `data-wrap` attribute.
+    #[prop]
+    pub wrap: bool,
+}
+
+#[handlers]
+impl PineInline {}

--- a/crates/pine-layout/src/lib.rs
+++ b/crates/pine-layout/src/lib.rs
@@ -44,9 +44,11 @@
 pub mod app_shell;
 pub mod breakpoint;
 pub mod container;
+mod floating;
 pub mod grid;
 pub mod inline;
 pub mod stack;
+pub mod workspace;
 
 pub use app_shell::{
     PineAppShell, PineAppShellContent, PineAppShellFooter, PineAppShellHeader, PineAppShellSidebar,
@@ -57,6 +59,10 @@ pub use container::PineContainer;
 pub use grid::{PineGrid, PineGridItem};
 pub use inline::PineInline;
 pub use stack::PineStack;
+pub use workspace::{
+    PineWorkspace, PineWorkspaceAside, PineWorkspaceBottom, PineWorkspaceFooter,
+    PineWorkspaceHeader, PineWorkspaceMain, PineWorkspacePanel, PineWorkspaceSidebar,
+};
 
 /// Register every Pine Layout custom-element tag. Call once at
 /// startup, before mounting any template that uses the tags.
@@ -73,4 +79,12 @@ pub fn register_all() {
     PineAppShellContent::register();
     PineAppShellFooter::register();
     PineAppShellTrigger::register();
+    PineWorkspace::register();
+    PineWorkspaceHeader::register();
+    PineWorkspaceFooter::register();
+    PineWorkspaceMain::register();
+    PineWorkspaceSidebar::register();
+    PineWorkspaceAside::register();
+    PineWorkspacePanel::register();
+    PineWorkspaceBottom::register();
 }

--- a/crates/pine-layout/src/lib.rs
+++ b/crates/pine-layout/src/lib.rs
@@ -1,0 +1,76 @@
+//! Pine Layout — headless, responsive layout primitives for pocopine.
+//!
+//! Pine Layout is to *responsiveness* what core Pine is to behavior:
+//! it ships **zero CSS**. Every component exposes a semantic class
+//! name (`pine-grid`, `pine-app-shell`) plus `data-*` attributes
+//! (`data-breakpoint="md"`, `data-nav-mode="rail"`, `data-cols="12"`)
+//! and reactive state — authors do all the actual layout in their own
+//! CSS, or with Pine Stylekit utility classes (`grid grid-cols-12
+//! md:grid-cols-6`). The library's value is one canonical breakpoint
+//! vocabulary and the adaptive-navigation state machine, not opinions
+//! about how things look.
+//!
+//! # Breakpoints
+//!
+//! The reactive breakpoint resolves to the **same** thresholds Pine
+//! Stylekit uses for its `sm:`/`md:`/`lg:`/`xl:`/`2xl:` utility
+//! prefixes, so `data-breakpoint == "md"` and a `md:` class never
+//! disagree:
+//!
+//! | tier  | min-width |
+//! |-------|-----------|
+//! | base  | 0         |
+//! | sm    | 640px     |
+//! | md    | 768px     |
+//! | lg    | 1024px    |
+//! | xl    | 1280px    |
+//! | 2xl   | 1536px    |
+//!
+//! # Using Pine Layout
+//!
+//! ```ignore
+//! use pocopine::prelude::*;
+//!
+//! fn main() {
+//!     pine_layout::register_all();
+//!     App::new().register::<MyApp>().run();
+//! }
+//! ```
+//!
+//! `register_all` registers every Pine Layout component's custom-
+//! element tag so authors can drop `<pine-app-shell>`, `<pine-grid>`
+//! etc. into their templates.
+
+pub mod app_shell;
+pub mod breakpoint;
+pub mod container;
+pub mod grid;
+pub mod inline;
+pub mod stack;
+
+pub use app_shell::{
+    PineAppShell, PineAppShellContent, PineAppShellFooter, PineAppShellHeader, PineAppShellSidebar,
+    PineAppShellTrigger,
+};
+pub use breakpoint::{Breakpoint, PineBreakpoint};
+pub use container::PineContainer;
+pub use grid::{PineGrid, PineGridItem};
+pub use inline::PineInline;
+pub use stack::PineStack;
+
+/// Register every Pine Layout custom-element tag. Call once at
+/// startup, before mounting any template that uses the tags.
+pub fn register_all() {
+    PineBreakpoint::register();
+    PineContainer::register();
+    PineStack::register();
+    PineInline::register();
+    PineGrid::register();
+    PineGridItem::register();
+    PineAppShell::register();
+    PineAppShellHeader::register();
+    PineAppShellSidebar::register();
+    PineAppShellContent::register();
+    PineAppShellFooter::register();
+    PineAppShellTrigger::register();
+}

--- a/crates/pine-layout/src/stack/PineStack.poco
+++ b/crates/pine-layout/src/stack/PineStack.poco
@@ -1,0 +1,6 @@
+<root class="pine-stack"
+      :data-gap="gap"
+      :data-align="align"
+      :data-justify="justify">
+  <slot></slot>
+</root>

--- a/crates/pine-layout/src/stack/mod.rs
+++ b/crates/pine-layout/src/stack/mod.rs
@@ -1,0 +1,34 @@
+//! `<pine-stack>` — vertical one-dimensional layout (Atlassian's
+//! `Stack`).
+//!
+//! Headless: emits `class="pine-stack"` plus `data-gap`/`data-align`/
+//! `data-justify` hooks. The author's CSS supplies the flexbox:
+//!
+//! ```css
+//! .pine-stack { display: flex; flex-direction: column; }
+//! .pine-stack[data-gap="4"]        { gap: 1rem; }
+//! .pine-stack[data-align="center"] { align-items: center; }
+//! ```
+
+use pocopine::prelude::*;
+use serde::{Deserialize, Serialize};
+
+/// Stacks its children vertically. See module docs.
+#[derive(Default, Serialize, Deserialize)]
+#[component(template = "PineStack.poco", role = "panel")]
+pub struct PineStack {
+    /// Gap token between children. Surfaced as `data-gap`.
+    #[prop]
+    pub gap: String,
+    /// Cross-axis (horizontal) alignment — e.g. `start`/`center`/
+    /// `end`/`stretch`. Surfaced as `data-align`.
+    #[prop]
+    pub align: String,
+    /// Main-axis (vertical) distribution — e.g. `start`/`center`/
+    /// `between`. Surfaced as `data-justify`.
+    #[prop]
+    pub justify: String,
+}
+
+#[handlers]
+impl PineStack {}

--- a/crates/pine-layout/src/workspace/PineWorkspace.poco
+++ b/crates/pine-layout/src/workspace/PineWorkspace.poco
@@ -1,0 +1,3 @@
+<root class="pine-workspace" :data-breakpoint="breakpoint">
+  <slot></slot>
+</root>

--- a/crates/pine-layout/src/workspace/PineWorkspaceAside.poco
+++ b/crates/pine-layout/src/workspace/PineWorkspaceAside.poco
@@ -1,0 +1,24 @@
+<root class="pine-workspace-aside"
+      pp-ref="aside"
+      role="complementary"
+      :id="id"
+      :aria-label="label"
+      :data-side="side"
+      :data-aside-state="open ? 'open' : 'closed'"
+      :data-dragging="dragging"
+      :style="'--pine-aside-size:' + display_size + 'px'">
+  <slot></slot>
+  <div class="pine-workspace-aside-resize"
+       role="separator"
+       aria-orientation="vertical"
+       :aria-valuenow="size"
+       :aria-valuemin="min"
+       :aria-valuemax="max"
+       tabindex="0"
+       @pointerdown="on_resize_start"
+       @keydown.arrow-right.prevent="nudge_grow"
+       @keydown.arrow-left.prevent="nudge_shrink"
+       @keydown.home.prevent="to_min"
+       @keydown.end.prevent="to_max"
+       @dblclick="reset_size"></div>
+</root>

--- a/crates/pine-layout/src/workspace/PineWorkspaceBottom.poco
+++ b/crates/pine-layout/src/workspace/PineWorkspaceBottom.poco
@@ -1,0 +1,23 @@
+<root class="pine-workspace-bottom"
+      role="complementary"
+      :id="id"
+      :aria-label="label"
+      :data-edge="edge"
+      :data-state="open ? 'open' : 'closed'"
+      :data-dragging="dragging"
+      :style="'--pine-bottom-size:' + display_size + 'px'">
+  <slot></slot>
+  <div class="pine-workspace-bottom-resize"
+       role="separator"
+       aria-orientation="horizontal"
+       :aria-valuenow="size"
+       :aria-valuemin="min"
+       :aria-valuemax="max"
+       tabindex="0"
+       @pointerdown="on_resize_start"
+       @keydown.arrow-up.prevent="nudge_grow"
+       @keydown.arrow-down.prevent="nudge_shrink"
+       @keydown.home.prevent="to_min"
+       @keydown.end.prevent="to_max"
+       @dblclick="reset_size"></div>
+</root>

--- a/crates/pine-layout/src/workspace/PineWorkspaceFooter.poco
+++ b/crates/pine-layout/src/workspace/PineWorkspaceFooter.poco
@@ -1,0 +1,3 @@
+<root class="pine-workspace-footer" role="contentinfo">
+  <slot></slot>
+</root>

--- a/crates/pine-layout/src/workspace/PineWorkspaceHeader.poco
+++ b/crates/pine-layout/src/workspace/PineWorkspaceHeader.poco
@@ -1,0 +1,3 @@
+<root class="pine-workspace-header" role="banner">
+  <slot></slot>
+</root>

--- a/crates/pine-layout/src/workspace/PineWorkspaceMain.poco
+++ b/crates/pine-layout/src/workspace/PineWorkspaceMain.poco
@@ -1,0 +1,3 @@
+<root class="pine-workspace-main" role="main">
+  <slot></slot>
+</root>

--- a/crates/pine-layout/src/workspace/PineWorkspacePanel.poco
+++ b/crates/pine-layout/src/workspace/PineWorkspacePanel.poco
@@ -1,0 +1,8 @@
+<root class="pine-workspace-panel"
+      role="navigation"
+      :id="id"
+      :aria-label="label"
+      :data-side="side"
+      :data-state="open ? 'open' : 'closed'">
+  <slot></slot>
+</root>

--- a/crates/pine-layout/src/workspace/PineWorkspaceSidebar.poco
+++ b/crates/pine-layout/src/workspace/PineWorkspaceSidebar.poco
@@ -1,0 +1,26 @@
+<root class="pine-workspace-sidebar"
+      pp-ref="sidebar"
+      role="navigation"
+      :id="id"
+      :aria-label="label"
+      :data-state="display_collapsed ? 'collapsed' : 'expanded'"
+      :data-flyout="flyout"
+      :data-dragging="dragging"
+      :style="'--pine-sidebar-size:' + display_size + 'px'"
+      @mouseenter="on_hover"
+      @mouseleave="on_unhover">
+  <slot></slot>
+  <div class="pine-workspace-sidebar-resize"
+       role="separator"
+       aria-orientation="vertical"
+       :aria-valuenow="size"
+       :aria-valuemin="collapse_at"
+       :aria-valuemax="max"
+       :tabindex="display_collapsed ? -1 : 0"
+       @pointerdown="on_resize_start"
+       @keydown.arrow-right.prevent="nudge_grow"
+       @keydown.arrow-left.prevent="nudge_shrink"
+       @keydown.home.prevent="to_min"
+       @keydown.end.prevent="to_max"
+       @dblclick="reset_size"></div>
+</root>

--- a/crates/pine-layout/src/workspace/mod.rs
+++ b/crates/pine-layout/src/workspace/mod.rs
@@ -1,0 +1,610 @@
+//! `<pine-workspace-*>` — content-heavy multi-region workspace shell
+//! (RFC-105).
+//!
+//! A separate component family from [`crate::app_shell`]: the workspace
+//! frame adds the *trailing* edge (a resizable detail Aside, outer
+//! panels, a bottom panel) and a resizable, rail-collapsing sidebar, on top
+//! of the same headless `data-*` + breakpoint contract.
+//!
+//! **Headless** — every region emits a class + `data-*` state; the one
+//! dynamic dimension CSS can't express statically (a resizable width/height)
+//! is published as a `--pine-*-size` custom property the author's grid
+//! consumes. Author CSS does the layout:
+//!
+//! ```css
+//! .pine-workspace { display: grid; grid-template-columns: auto 1fr auto; }
+//! .pine-workspace-sidebar { width: var(--pine-sidebar-size, 260px); }
+//! .pine-workspace-sidebar[data-state="collapsed"] { /* rail look */ }
+//! ```
+
+pub(crate) mod resize;
+
+use crate::workspace::resize::Axis;
+use pocopine::prelude::*;
+use serde::{Deserialize, Serialize};
+
+create_context!(WORKSPACE: Handle<PineWorkspace>);
+
+// ── Root ──────────────────────────────────────────────────────────
+
+/// The workspace frame. Owns the breakpoint engine, provides the
+/// `WORKSPACE` context (regions read the shared id base + breakpoint), and
+/// is the grid container the author styles.
+#[derive(Serialize, Deserialize)]
+#[component(template = "PineWorkspace.poco", role = "scope")]
+pub struct PineWorkspace {
+    /// Current viewport tier — engine-driven; emitted on `pp:update:breakpoint`.
+    #[model]
+    pub breakpoint: String,
+    /// Tier assumed before `matchMedia` resolves (and on non-wasm). Default `base`.
+    #[prop]
+    pub initial: String,
+    /// Stable id base; regions derive `{id_base}-{region}` so a Trigger's
+    /// `aria-controls` can target them.
+    pub id_base: String,
+}
+
+impl Default for PineWorkspace {
+    fn default() -> Self {
+        Self {
+            breakpoint: String::new(),
+            initial: "base".into(),
+            id_base: String::new(),
+        }
+    }
+}
+
+#[handlers]
+impl PineWorkspace {
+    fn on_setup(&mut self) {
+        if let Some(scope) = pocopine::current_scope_id() {
+            self.id_base = format!("pine-workspace-{}", scope.0);
+        }
+        if self.breakpoint.is_empty() {
+            self.breakpoint = self.initial.clone();
+        }
+        WORKSPACE.provide(this::<Self>());
+    }
+
+    fn on_ready(&self, handle: Handle<Self>) {
+        let sink = handle;
+        crate::breakpoint::install(std::rc::Rc::new(move |bp| {
+            sink.update(|s| s.breakpoint = bp.as_str().to_string());
+        }));
+    }
+}
+
+/// Read the workspace's id base from context, suffixing `region`.
+fn region_id(region: &str) -> String {
+    WORKSPACE
+        .inject()
+        .map(|w| w.with(|s| format!("{}-{region}", s.id_base)))
+        .unwrap_or_default()
+}
+
+// ── Main ──────────────────────────────────────────────────────────
+
+/// The primary content region — the flex-fill remainder. Renders a
+/// `role="main"` landmark.
+#[derive(Default, Serialize, Deserialize)]
+#[component(template = "PineWorkspaceMain.poco", role = "panel")]
+pub struct PineWorkspaceMain {}
+
+#[handlers]
+impl PineWorkspaceMain {}
+
+// ── Sidebar — resizable primary nav with rail-collapse + flyout ────
+
+/// Primary navigation column. Resizable by a grab handle, collapses to a
+/// thin **rail** (below the `collapse_at` drag threshold or via toggle / a
+/// narrow viewport), and shows a hover **flyout** while collapsed. Publishes
+/// its width as `--pine-sidebar-size`.
+#[derive(Serialize, Deserialize)]
+#[component(template = "PineWorkspaceSidebar.poco", role = "panel")]
+pub struct PineWorkspaceSidebar {
+    /// Accessible name for the navigation landmark.
+    #[prop]
+    pub label: String,
+    /// Expanded width (px). Two-way via `pp-model:size` for persistence.
+    #[model]
+    pub size: f64,
+    /// Whether collapsed to the rail. Two-way via `pp-model:collapsed`.
+    #[model]
+    pub collapsed: bool,
+    /// Rail width when collapsed (px). Default 56.
+    #[prop]
+    pub rail_size: f64,
+    /// Max expanded width (px). Default 480.
+    #[prop]
+    pub max: f64,
+    /// Release width below which the drag snaps to the rail (px). Default 160.
+    #[prop]
+    pub collapse_at: f64,
+    /// Reset-to (double-click) / initial width (px). Default 260.
+    #[prop]
+    pub default: f64,
+    /// Tier below which the sidebar auto-collapses to the rail. Default `lg`.
+    #[prop]
+    pub collapse_below: String,
+    /// Responsive override — set true while the viewport is below
+    /// `collapse_below`. Kept separate from the user/`pp-model` `collapsed`
+    /// so the two never race; the rendered state is the OR of both.
+    pub responsive_rail: bool,
+    /// Rendered collapsed state — `collapsed || responsive_rail`.
+    pub display_collapsed: bool,
+    /// Rendered width — `rail_size` when collapsed, else `size`.
+    pub display_size: f64,
+    /// Hover-flyout open (only meaningful while collapsed).
+    pub flyout: bool,
+    /// Mid-drag flag (drives `data-dragging` so author CSS can suppress
+    /// transitions during the drag).
+    pub dragging: bool,
+    /// Landmark id (Trigger `aria-controls` target).
+    pub id: String,
+    /// Own scope id.
+    pub scope: u64,
+}
+
+impl Default for PineWorkspaceSidebar {
+    fn default() -> Self {
+        let mut this = Self {
+            label: String::new(),
+            size: 260.0,
+            collapsed: false,
+            rail_size: 56.0,
+            max: 480.0,
+            collapse_at: 160.0,
+            default: 260.0,
+            collapse_below: "lg".into(),
+            responsive_rail: false,
+            display_collapsed: false,
+            display_size: 260.0,
+            flyout: false,
+            dragging: false,
+            id: String::new(),
+            scope: 0,
+        };
+        this.sync_display();
+        this
+    }
+}
+
+impl PineWorkspaceSidebar {
+    fn sync_display(&mut self) {
+        self.display_collapsed = self.collapsed || self.responsive_rail;
+        self.display_size = if self.display_collapsed {
+            self.rail_size
+        } else {
+            self.size
+        };
+    }
+
+    /// Apply a released drag width: snap to the rail below `collapse_at`,
+    /// else keep the (clamped) expanded width.
+    fn commit_resize(&mut self, raw: f64) {
+        self.dragging = false;
+        if raw < self.collapse_at {
+            self.collapsed = true;
+        } else {
+            self.collapsed = false;
+            self.size = raw.clamp(self.collapse_at, self.max);
+        }
+        self.sync_display();
+    }
+
+    fn set_size(&mut self, px: f64) {
+        self.collapsed = false;
+        self.size = px.clamp(self.collapse_at, self.max);
+        self.sync_display();
+    }
+}
+
+#[handlers]
+impl PineWorkspaceSidebar {
+    fn on_setup(&mut self) {
+        if let Some(scope) = pocopine::current_scope_id() {
+            self.scope = scope.0;
+        }
+        self.id = region_id("sidebar");
+        self.sync_display();
+    }
+
+    fn on_ready(&self, handle: Handle<Self>) {
+        // Auto-collapse to the rail below `collapse_below`.
+        let Some(ws) = WORKSPACE.inject() else {
+            return;
+        };
+        let ws_scope = ws.scope_id();
+        let sink = handle;
+        pocopine::watch_scope_field_scoped::<String, _>(ws_scope, "breakpoint", move |bp, _| {
+            let below = sink.with(|s| {
+                let cur = crate::breakpoint::Breakpoint::from_token(bp)
+                    .unwrap_or(crate::breakpoint::Breakpoint::Base);
+                let thresh = crate::breakpoint::Breakpoint::from_token(&s.collapse_below)
+                    .unwrap_or(crate::breakpoint::Breakpoint::Lg);
+                cur.rank() < thresh.rank()
+            });
+            sink.update(|s| {
+                s.responsive_rail = below;
+                s.sync_display();
+            });
+        });
+    }
+
+    /// Keep the rendered state in sync when the user/`pp-model` toggles
+    /// `collapsed`.
+    #[watch(collapsed)]
+    fn on_collapsed(&mut self, _new: bool, _old: Option<bool>) {
+        self.sync_display();
+    }
+
+    /// Begin a pointer-drag resize from the grab handle.
+    pub fn on_resize_start(&mut self, ev: wasm_bindgen::JsValue) {
+        if self.display_collapsed {
+            return;
+        }
+        use wasm_bindgen::JsCast;
+        let Ok(ev) = ev.dyn_into::<web_sys::PointerEvent>() else {
+            return;
+        };
+        ev.prevent_default();
+        let start = ev.client_x() as f64;
+        let (size, rail, max) = (self.size, self.rail_size, self.max);
+        let h_size = this::<Self>();
+        let h_commit = h_size.clone();
+        resize::start_drag(
+            Axis::Horizontal,
+            false,
+            start,
+            size,
+            rail,
+            max,
+            None,
+            std::rc::Rc::new(move |px| {
+                h_size.update(|s| {
+                    s.dragging = true;
+                    s.size = px;
+                    s.sync_display();
+                });
+            }),
+            std::rc::Rc::new(move |px| h_commit.update(|s| s.commit_resize(px))),
+        );
+    }
+
+    pub fn toggle(&mut self) {
+        self.collapsed = !self.collapsed;
+        self.sync_display();
+    }
+    pub fn nudge_grow(&mut self) {
+        self.set_size(self.size + 16.0);
+    }
+    pub fn nudge_shrink(&mut self) {
+        self.set_size(self.size - 16.0);
+    }
+    pub fn to_min(&mut self) {
+        self.set_size(self.collapse_at);
+    }
+    pub fn to_max(&mut self) {
+        self.set_size(self.max);
+    }
+    pub fn reset_size(&mut self) {
+        self.set_size(self.default);
+    }
+    pub fn on_hover(&mut self) {
+        if self.display_collapsed {
+            self.flyout = true;
+        }
+    }
+    pub fn on_unhover(&mut self) {
+        self.flyout = false;
+    }
+}
+
+// ── Aside — trailing detail panel: resizable docked column ────────
+
+/// Trailing contextual/detail panel (task detail, AI, comments) — a
+/// resizable, collapsible in-grid column. App-controlled via
+/// `pp-model:open`; publishes its width as `--pine-aside-size`.
+#[derive(Serialize, Deserialize)]
+#[component(template = "PineWorkspaceAside.poco", role = "panel")]
+pub struct PineWorkspaceAside {
+    /// Accessible name for the complementary landmark.
+    #[prop]
+    pub label: String,
+    /// Anchor edge — `end` (right, default) or `start` (left).
+    #[prop]
+    pub side: String,
+    /// Min / max / reset-to width (px).
+    #[prop]
+    pub min: f64,
+    #[prop]
+    pub max: f64,
+    #[prop]
+    pub default: f64,
+    /// Whether the panel is shown. Two-way via `pp-model:open`.
+    #[model]
+    pub open: bool,
+    /// Width (px). Two-way via `pp-model:size`.
+    #[model]
+    pub size: f64,
+    /// Rendered width (mirrors `size`).
+    pub display_size: f64,
+    /// Mid-drag flag.
+    pub dragging: bool,
+    /// Landmark id.
+    pub id: String,
+}
+
+impl Default for PineWorkspaceAside {
+    fn default() -> Self {
+        Self {
+            label: String::new(),
+            side: "end".into(),
+            min: 240.0,
+            max: 560.0,
+            default: 320.0,
+            open: false,
+            size: 320.0,
+            display_size: 320.0,
+            dragging: false,
+            id: String::new(),
+        }
+    }
+}
+
+impl PineWorkspaceAside {
+    /// End-anchored (right) grows as the pointer moves left.
+    fn invert(&self) -> bool {
+        self.side != "start"
+    }
+
+    fn set_size(&mut self, px: f64) {
+        self.size = px.clamp(self.min, self.max);
+        self.display_size = self.size;
+    }
+}
+
+#[handlers]
+impl PineWorkspaceAside {
+    fn on_setup(&mut self) {
+        self.id = region_id("aside");
+        self.display_size = self.size;
+    }
+
+    pub fn on_resize_start(&mut self, ev: wasm_bindgen::JsValue) {
+        use wasm_bindgen::JsCast;
+        let Ok(ev) = ev.dyn_into::<web_sys::PointerEvent>() else {
+            return;
+        };
+        ev.prevent_default();
+        let start = ev.client_x() as f64;
+        let (size, min, max, invert) = (self.size, self.min, self.max, self.invert());
+        let h_size = this::<Self>();
+        let h_commit = h_size.clone();
+        resize::start_drag(
+            Axis::Horizontal,
+            invert,
+            start,
+            size,
+            min,
+            max,
+            None,
+            std::rc::Rc::new(move |px| {
+                h_size.update(|s| {
+                    s.dragging = true;
+                    s.set_size(px);
+                });
+            }),
+            std::rc::Rc::new(move |px| {
+                h_commit.update(|s| {
+                    s.dragging = false;
+                    s.set_size(px);
+                });
+            }),
+        );
+    }
+
+    pub fn nudge_grow(&mut self) {
+        self.set_size(self.size + 16.0);
+    }
+    pub fn nudge_shrink(&mut self) {
+        self.set_size(self.size - 16.0);
+    }
+    pub fn to_min(&mut self) {
+        self.set_size(self.min);
+    }
+    pub fn to_max(&mut self) {
+        self.set_size(self.max);
+    }
+    pub fn reset_size(&mut self) {
+        self.set_size(self.default);
+    }
+}
+
+// ── Header / Footer — landmark bars ────────────────────────────────
+
+/// Top app-bar / banner. Renders a `role="banner"` landmark.
+#[derive(Default, Serialize, Deserialize)]
+#[component(template = "PineWorkspaceHeader.poco", role = "panel")]
+pub struct PineWorkspaceHeader {}
+
+#[handlers]
+impl PineWorkspaceHeader {}
+
+/// Status bar / footer. Renders a `role="contentinfo"` landmark.
+#[derive(Default, Serialize, Deserialize)]
+#[component(template = "PineWorkspaceFooter.poco", role = "panel")]
+pub struct PineWorkspaceFooter {}
+
+#[handlers]
+impl PineWorkspaceFooter {}
+
+// ── Outer Panel — collapsible secondary nav (start / end) ──────────
+
+/// Outer secondary-nav column (Atlassian LeftPanel/RightPanel, VS Code
+/// activity-bar region). Collapsible via `pp-model:open`; `side` picks the
+/// edge. Fixed-width by author CSS (resize is the Sidebar/Aside's job).
+#[derive(Serialize, Deserialize)]
+#[component(template = "PineWorkspacePanel.poco", role = "panel")]
+pub struct PineWorkspacePanel {
+    /// `start` (left, default) or `end` (right).
+    #[prop]
+    pub side: String,
+    /// Accessible name for the navigation landmark.
+    #[prop]
+    pub label: String,
+    /// Shown / hidden. Two-way via `pp-model:open`.
+    #[model]
+    pub open: bool,
+    /// Landmark id.
+    pub id: String,
+}
+
+impl Default for PineWorkspacePanel {
+    fn default() -> Self {
+        Self {
+            side: "start".into(),
+            label: String::new(),
+            open: true,
+            id: String::new(),
+        }
+    }
+}
+
+#[handlers]
+impl PineWorkspacePanel {
+    fn on_setup(&mut self) {
+        let suffix = if self.side == "end" {
+            "panel-end"
+        } else {
+            "panel-start"
+        };
+        self.id = region_id(suffix);
+    }
+
+    pub fn close(&mut self) {
+        self.open = false;
+    }
+}
+
+// ── Bottom Panel — terminal/console: vertical resize + collapse ────
+
+/// Bottom (or top) panel — terminal/console/output. Resizes vertically and
+/// collapses. `edge` relocates it (author CSS keys on `data-edge`).
+/// Publishes its height as `--pine-bottom-size`.
+#[derive(Serialize, Deserialize)]
+#[component(template = "PineWorkspaceBottom.poco", role = "panel")]
+pub struct PineWorkspaceBottom {
+    /// Accessible name for the complementary landmark.
+    #[prop]
+    pub label: String,
+    /// `bottom` (default) or `top`.
+    #[prop]
+    pub edge: String,
+    /// Min / max / reset-to height (px).
+    #[prop]
+    pub min: f64,
+    #[prop]
+    pub max: f64,
+    #[prop]
+    pub default: f64,
+    /// Shown / hidden. Two-way via `pp-model:open`.
+    #[model]
+    pub open: bool,
+    /// Height (px). Two-way via `pp-model:size`.
+    #[model]
+    pub size: f64,
+    /// Rendered height (mirrors `size`).
+    pub display_size: f64,
+    /// Mid-drag flag.
+    pub dragging: bool,
+    /// Landmark id.
+    pub id: String,
+}
+
+impl Default for PineWorkspaceBottom {
+    fn default() -> Self {
+        Self {
+            label: String::new(),
+            edge: "bottom".into(),
+            min: 120.0,
+            max: 600.0,
+            default: 240.0,
+            open: false,
+            size: 240.0,
+            display_size: 240.0,
+            dragging: false,
+            id: String::new(),
+        }
+    }
+}
+
+impl PineWorkspaceBottom {
+    fn set_size(&mut self, px: f64) {
+        self.size = px.clamp(self.min, self.max);
+        self.display_size = self.size;
+    }
+}
+
+#[handlers]
+impl PineWorkspaceBottom {
+    fn on_setup(&mut self) {
+        self.id = region_id("bottom");
+        self.display_size = self.size;
+    }
+
+    pub fn close(&mut self) {
+        self.open = false;
+    }
+
+    pub fn on_resize_start(&mut self, ev: wasm_bindgen::JsValue) {
+        use wasm_bindgen::JsCast;
+        let Ok(ev) = ev.dyn_into::<web_sys::PointerEvent>() else {
+            return;
+        };
+        ev.prevent_default();
+        let start = ev.client_y() as f64;
+        // Bottom-docked: handle on top edge, dragging up (negative dy) grows.
+        let invert = self.edge != "top";
+        let (size, min, max) = (self.size, self.min, self.max);
+        let h_size = this::<Self>();
+        let h_commit = h_size.clone();
+        resize::start_drag(
+            Axis::Vertical,
+            invert,
+            start,
+            size,
+            min,
+            max,
+            None,
+            std::rc::Rc::new(move |px| {
+                h_size.update(|s| {
+                    s.dragging = true;
+                    s.set_size(px);
+                });
+            }),
+            std::rc::Rc::new(move |px| {
+                h_commit.update(|s| {
+                    s.dragging = false;
+                    s.set_size(px);
+                });
+            }),
+        );
+    }
+
+    pub fn nudge_grow(&mut self) {
+        self.set_size(self.size + 16.0);
+    }
+    pub fn nudge_shrink(&mut self) {
+        self.set_size(self.size - 16.0);
+    }
+    pub fn to_min(&mut self) {
+        self.set_size(self.min);
+    }
+    pub fn to_max(&mut self) {
+        self.set_size(self.max);
+    }
+    pub fn reset_size(&mut self) {
+        self.set_size(self.default);
+    }
+}

--- a/crates/pine-layout/src/workspace/resize.rs
+++ b/crates/pine-layout/src/workspace/resize.rs
@@ -1,0 +1,163 @@
+//! Self-contained pointer + keyboard resize for workspace regions.
+//!
+//! pine-layout ships its **own** resize engine rather than depending on the
+//! `pine` crate's `splitter`. This replicates splitter's document-listener
+//! drag pattern (`events::on` pointermove/up/cancel held in a
+//! `ListenerHandle` vec, cleared on release) for a single edge handle, plus
+//! a pure [`resolve_size`] for clamp + snap-to-collapse that is unit-tested
+//! on the host.
+
+/// The axis a resize handle drags along.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Axis {
+    /// Horizontal drag resizes width (sidebar / aside / outer panels).
+    Horizontal,
+    /// Vertical drag resizes height (bottom panel).
+    Vertical,
+}
+
+/// Pure resize math (host-testable): apply a pointer `delta` to a starting
+/// size, flip it for end-anchored handles (`invert`), clamp to `[min, max]`,
+/// and snap to `min` when the result falls below `collapse_at`.
+pub(crate) fn resolve_size(
+    start: f64,
+    delta: f64,
+    invert: bool,
+    min: f64,
+    max: f64,
+    collapse_at: Option<f64>,
+) -> f64 {
+    let signed = if invert { -delta } else { delta };
+    let size = (start + signed).clamp(min, max);
+    match collapse_at {
+        Some(threshold) if size < threshold => min,
+        _ => size,
+    }
+}
+
+/// Begin a pointer drag from a region's resize handle.
+///
+/// `start_pointer` is the pointer's client coordinate (x for `Horizontal`,
+/// y for `Vertical`) at pointerdown; `invert` flips the delta for
+/// end-anchored regions (a right-side aside grows as the pointer moves
+/// left). `on_size` fires live with each clamped size during the drag;
+/// `on_commit` fires once on release with the final, snap-resolved size.
+#[cfg(target_arch = "wasm32")]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn start_drag(
+    axis: Axis,
+    invert: bool,
+    start_pointer: f64,
+    start_size: f64,
+    min: f64,
+    max: f64,
+    collapse_at: Option<f64>,
+    on_size: std::rc::Rc<dyn Fn(f64)>,
+    on_commit: std::rc::Rc<dyn Fn(f64)>,
+) {
+    use pocopine::events::{self, ev, ListenerHandle};
+    use std::cell::RefCell;
+    use std::rc::Rc;
+    use web_sys::PointerEvent;
+
+    let Some(doc) = web_sys::window().and_then(|w| w.document()) else {
+        return;
+    };
+    let handles: Rc<RefCell<Vec<ListenerHandle>>> = Rc::new(RefCell::new(Vec::with_capacity(3)));
+
+    let pointer_of = move |ev: &PointerEvent| {
+        if axis == Axis::Vertical {
+            ev.client_y() as f64
+        } else {
+            ev.client_x() as f64
+        }
+    };
+
+    // During the drag the size only clamps (no snap) so the handle tracks
+    // the pointer; the collapse snap applies on release.
+    let move_handle = events::on(&doc, ev::pointermove, move |ev: PointerEvent| {
+        ev.prevent_default();
+        let size = resolve_size(
+            start_size,
+            pointer_of(&ev) - start_pointer,
+            invert,
+            min,
+            max,
+            None,
+        );
+        on_size(size);
+    });
+
+    let release = {
+        let handles = handles.clone();
+        move |ev: PointerEvent| {
+            let delta = pointer_of(&ev) - start_pointer;
+            on_commit(resolve_size(
+                start_size,
+                delta,
+                invert,
+                min,
+                max,
+                collapse_at,
+            ));
+            handles.borrow_mut().clear();
+        }
+    };
+    let up = events::on(&doc, ev::pointerup, release.clone());
+    let cancel = events::on(&doc, ev::pointercancel, release);
+    handles.borrow_mut().extend([move_handle, up, cancel]);
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn start_drag(
+    _axis: Axis,
+    _invert: bool,
+    _start_pointer: f64,
+    _start_size: f64,
+    _min: f64,
+    _max: f64,
+    _collapse_at: Option<f64>,
+    _on_size: std::rc::Rc<dyn Fn(f64)>,
+    _on_commit: std::rc::Rc<dyn Fn(f64)>,
+) {
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clamps_to_min_max() {
+        assert_eq!(
+            resolve_size(240.0, 1000.0, false, 180.0, 480.0, None),
+            480.0
+        );
+        assert_eq!(
+            resolve_size(240.0, -1000.0, false, 180.0, 480.0, None),
+            180.0
+        );
+        assert_eq!(resolve_size(240.0, 40.0, false, 180.0, 480.0, None), 280.0);
+    }
+
+    #[test]
+    fn invert_flips_delta_for_end_anchored() {
+        // Right-side aside: pointer moving left (negative delta) grows it.
+        assert_eq!(resolve_size(280.0, -50.0, true, 200.0, 500.0, None), 330.0);
+        assert_eq!(resolve_size(280.0, 50.0, true, 200.0, 500.0, None), 230.0);
+    }
+
+    #[test]
+    fn snaps_to_collapsed_below_threshold() {
+        // Atlassian-style: drag a 240 sidebar below the 200 threshold -> 20px rail.
+        assert_eq!(
+            resolve_size(240.0, -60.0, false, 20.0, 480.0, Some(200.0)),
+            20.0
+        );
+        // Still above the threshold -> keep the dragged width.
+        assert_eq!(
+            resolve_size(240.0, -20.0, false, 20.0, 480.0, Some(200.0)),
+            220.0
+        );
+    }
+}

--- a/crates/pine-layout/tests/layout.rs
+++ b/crates/pine-layout/tests/layout.rs
@@ -1,0 +1,225 @@
+//! Pine Layout browser tests. Run with
+//! `wasm-pack test --firefox --headless crates/pine-layout`.
+//!
+//! The breakpoint *state machine* (nav-mode derivation, toggle
+//! semantics, the `Breakpoint` enum) is covered by deterministic host
+//! unit tests in `src/`; those don't need a viewport. These browser
+//! tests cover the DOM contract that needs a real document: rendered
+//! `data-*` hooks, ARIA wiring, and the drawer toggle.
+
+#![cfg(target_arch = "wasm32")]
+
+use wasm_bindgen::JsCast;
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+use web_sys::{window, Element};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+fn doc() -> web_sys::Document {
+    window().unwrap().document().unwrap()
+}
+
+/// Mount a fragment of custom-element markup and fire every
+/// registered component's mount/ready hooks (the same shape Pine's
+/// own browser tests use).
+fn mount(host_html: &str) -> Element {
+    pine_layout::register_all();
+    pocopine_core::animate::disable_transitions();
+    let body = doc().body().unwrap();
+    let host = doc().create_element("div").unwrap();
+    host.set_inner_html(host_html);
+    body.append_child(&host).unwrap();
+
+    let names = pocopine_core::templates::registered_template_names();
+    if !names.is_empty() {
+        let selector = names.join(",");
+        if let Ok(matches) = host.query_selector_all(&selector) {
+            for i in 0..matches.length() {
+                let Some(node) = matches.item(i) else {
+                    continue;
+                };
+                let Ok(el) = node.dyn_into::<Element>() else {
+                    continue;
+                };
+                if !host.contains(Some(el.as_ref())) {
+                    continue;
+                }
+                let tag = el.local_name();
+                pocopine_core::mount::mount_child_component(&el, &tag);
+                pocopine_core::mount::finalize_compiled_subtree(&el);
+            }
+        }
+    }
+    host
+}
+
+async fn tick() {
+    for _ in 0..3 {
+        let p = js_sys::Promise::resolve(&wasm_bindgen::JsValue::NULL);
+        let _ = wasm_bindgen_futures::JsFuture::from(p).await;
+    }
+}
+
+async fn sleep_ms(ms: i32) {
+    let p = js_sys::Promise::new(&mut |resolve: js_sys::Function, _reject| {
+        let w = window().unwrap();
+        let _ =
+            w.set_timeout_with_callback_and_timeout_and_arguments_0(resolve.unchecked_ref(), ms);
+    });
+    let _ = wasm_bindgen_futures::JsFuture::from(p).await;
+}
+
+async fn settle() {
+    tick().await;
+    sleep_ms(0).await;
+    tick().await;
+}
+
+fn q(host: &Element, selector: &str) -> Element {
+    host.query_selector(selector)
+        .unwrap()
+        .unwrap_or_else(|| panic!("no element for `{selector}`"))
+}
+
+fn dispatch_click(el: &Element) {
+    el.dispatch_event(&web_sys::Event::new("click").unwrap())
+        .unwrap();
+}
+
+// ── structural primitives — data-* hooks ──────────────────────────
+
+#[wasm_bindgen_test]
+async fn grid_reflects_cols_and_gap() {
+    let host = mount(
+        r#"<pine-grid cols="12" gap="4"><pine-grid-item span="6" start="3"></pine-grid-item></pine-grid>"#,
+    );
+    settle().await;
+    let grid = q(&host, ".pine-grid");
+    assert_eq!(grid.get_attribute("data-cols").as_deref(), Some("12"));
+    assert_eq!(grid.get_attribute("data-gap").as_deref(), Some("4"));
+    let item = q(&host, ".pine-grid-item");
+    assert_eq!(item.get_attribute("data-span").as_deref(), Some("6"));
+    assert_eq!(item.get_attribute("data-start").as_deref(), Some("3"));
+}
+
+#[wasm_bindgen_test]
+async fn stack_and_inline_reflect_props() {
+    let host = mount(
+        r#"<pine-stack gap="6" align="center"></pine-stack>
+           <pine-inline gap="2" justify="between" wrap="true"></pine-inline>"#,
+    );
+    settle().await;
+    let stack = q(&host, ".pine-stack");
+    assert_eq!(stack.get_attribute("data-gap").as_deref(), Some("6"));
+    assert_eq!(stack.get_attribute("data-align").as_deref(), Some("center"));
+    let inline = q(&host, ".pine-inline");
+    assert_eq!(
+        inline.get_attribute("data-justify").as_deref(),
+        Some("between")
+    );
+    assert!(
+        inline.has_attribute("data-wrap"),
+        "data-wrap present when wrap=true"
+    );
+}
+
+#[wasm_bindgen_test]
+async fn container_reflects_size_and_safe_area() {
+    let host = mount(r#"<pine-container size="lg" safe-area="true"></pine-container>"#);
+    settle().await;
+    let c = q(&host, ".pine-container");
+    assert_eq!(c.get_attribute("data-size").as_deref(), Some("lg"));
+    assert!(c.has_attribute("data-safe-area"));
+}
+
+// ── breakpoint provider ───────────────────────────────────────────
+
+#[wasm_bindgen_test]
+async fn breakpoint_provider_resolves_a_known_tier() {
+    let host = mount(r#"<pine-breakpoint></pine-breakpoint>"#);
+    settle().await;
+    let bp = q(&host, ".pine-breakpoint");
+    let token = bp.get_attribute("data-breakpoint").unwrap_or_default();
+    assert!(
+        ["base", "sm", "md", "lg", "xl", "2xl"].contains(&token.as_str()),
+        "resolved tier `{token}` is not a known token"
+    );
+}
+
+// ── app shell — ARIA wiring + drawer toggle ───────────────────────
+
+#[wasm_bindgen_test]
+async fn app_shell_wires_aria_controls_to_the_sidebar() {
+    // Thresholds at 2xl keep the shell in drawer mode for any realistic
+    // headless viewport (< 1536px).
+    let host = mount(
+        r#"<pine-app-shell rail-at="2xl" sidebar-at="2xl">
+             <pine-app-shell-header>
+               <pine-app-shell-trigger>menu</pine-app-shell-trigger>
+             </pine-app-shell-header>
+             <pine-app-shell-sidebar label="Main">nav</pine-app-shell-sidebar>
+             <pine-app-shell-content>page</pine-app-shell-content>
+           </pine-app-shell>"#,
+    );
+    settle().await;
+
+    let sidebar = q(&host, ".pine-app-shell-sidebar");
+    let trigger = q(&host, ".pine-app-shell-trigger");
+    assert_eq!(sidebar.get_attribute("role").as_deref(), Some("navigation"));
+    let nav_id = sidebar.get_attribute("id").unwrap_or_default();
+    assert!(!nav_id.is_empty(), "sidebar has a generated id");
+    assert_eq!(
+        trigger.get_attribute("aria-controls").as_deref(),
+        Some(nav_id.as_str()),
+        "trigger aria-controls points at the sidebar id"
+    );
+}
+
+#[wasm_bindgen_test]
+async fn trigger_toggles_the_drawer_in_drawer_mode() {
+    let host = mount(
+        r#"<pine-app-shell rail-at="2xl" sidebar-at="2xl">
+             <pine-app-shell-trigger>menu</pine-app-shell-trigger>
+             <pine-app-shell-sidebar label="Main">nav</pine-app-shell-sidebar>
+           </pine-app-shell>"#,
+    );
+    settle().await;
+
+    let shell = q(&host, ".pine-app-shell");
+    let trigger = q(&host, ".pine-app-shell-trigger");
+    let sidebar = q(&host, ".pine-app-shell-sidebar");
+
+    // Precondition: drawer mode, closed.
+    assert_eq!(
+        shell.get_attribute("data-nav-mode").as_deref(),
+        Some("drawer")
+    );
+    assert_eq!(
+        sidebar.get_attribute("data-state").as_deref(),
+        Some("closed")
+    );
+    assert_eq!(
+        trigger.get_attribute("aria-expanded").as_deref(),
+        Some("false")
+    );
+
+    dispatch_click(&trigger);
+    settle().await;
+    assert!(shell.has_attribute("data-nav-open"), "shell marked open");
+    assert_eq!(sidebar.get_attribute("data-state").as_deref(), Some("open"));
+    assert_eq!(
+        trigger.get_attribute("aria-expanded").as_deref(),
+        Some("true")
+    );
+
+    dispatch_click(&trigger);
+    settle().await;
+    assert_eq!(
+        sidebar.get_attribute("data-state").as_deref(),
+        Some("closed")
+    );
+    assert_eq!(
+        trigger.get_attribute("aria-expanded").as_deref(),
+        Some("false")
+    );
+}

--- a/crates/pine-layout/tests/workspace.rs
+++ b/crates/pine-layout/tests/workspace.rs
@@ -1,0 +1,163 @@
+//! Pine Workspace (RFC-105) browser tests. Run with
+//! `wasm-pack test --firefox --headless crates/pine-layout`.
+
+#![cfg(target_arch = "wasm32")]
+
+use wasm_bindgen::JsCast;
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+use web_sys::{window, Element};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+fn doc() -> web_sys::Document {
+    window().unwrap().document().unwrap()
+}
+
+fn mount(host_html: &str) -> Element {
+    pine_layout::register_all();
+    pocopine_core::animate::disable_transitions();
+    let body = doc().body().unwrap();
+    let host = doc().create_element("div").unwrap();
+    host.set_inner_html(host_html);
+    body.append_child(&host).unwrap();
+
+    let names = pocopine_core::templates::registered_template_names();
+    if !names.is_empty() {
+        let selector = names.join(",");
+        if let Ok(matches) = host.query_selector_all(&selector) {
+            for i in 0..matches.length() {
+                let Some(node) = matches.item(i) else {
+                    continue;
+                };
+                let Ok(el) = node.dyn_into::<Element>() else {
+                    continue;
+                };
+                if !host.contains(Some(el.as_ref())) {
+                    continue;
+                }
+                let tag = el.local_name();
+                pocopine_core::mount::mount_child_component(&el, &tag);
+                pocopine_core::mount::finalize_compiled_subtree(&el);
+            }
+        }
+    }
+    host
+}
+
+async fn tick() {
+    for _ in 0..3 {
+        let p = js_sys::Promise::resolve(&wasm_bindgen::JsValue::NULL);
+        let _ = wasm_bindgen_futures::JsFuture::from(p).await;
+    }
+}
+async fn sleep_ms(ms: i32) {
+    let p = js_sys::Promise::new(&mut |resolve: js_sys::Function, _reject| {
+        let w = window().unwrap();
+        let _ =
+            w.set_timeout_with_callback_and_timeout_and_arguments_0(resolve.unchecked_ref(), ms);
+    });
+    let _ = wasm_bindgen_futures::JsFuture::from(p).await;
+}
+async fn settle() {
+    tick().await;
+    sleep_ms(0).await;
+    tick().await;
+}
+fn q(host: &Element, sel: &str) -> Element {
+    host.query_selector(sel)
+        .unwrap()
+        .unwrap_or_else(|| panic!("no element for `{sel}`"))
+}
+
+const FRAME: &str = r#"
+<pine-workspace>
+  <pine-workspace-header>head</pine-workspace-header>
+  <pine-workspace-sidebar label="Nav" collapse-below="base">nav</pine-workspace-sidebar>
+  <pine-workspace-main>main</pine-workspace-main>
+  <pine-workspace-aside label="Detail" size="320">detail</pine-workspace-aside>
+  <pine-workspace-footer>status</pine-workspace-footer>
+</pine-workspace>
+"#;
+
+#[wasm_bindgen_test]
+async fn workspace_regions_render_with_landmarks() {
+    let host = mount(FRAME);
+    settle().await;
+    assert_eq!(
+        q(&host, ".pine-workspace-header")
+            .get_attribute("role")
+            .as_deref(),
+        Some("banner")
+    );
+    assert_eq!(
+        q(&host, ".pine-workspace-main")
+            .get_attribute("role")
+            .as_deref(),
+        Some("main")
+    );
+    assert_eq!(
+        q(&host, ".pine-workspace-sidebar")
+            .get_attribute("role")
+            .as_deref(),
+        Some("navigation")
+    );
+    assert_eq!(
+        q(&host, ".pine-workspace-aside")
+            .get_attribute("role")
+            .as_deref(),
+        Some("complementary")
+    );
+    assert!(q(&host, ".pine-workspace").has_attribute("data-breakpoint"));
+}
+
+#[wasm_bindgen_test]
+async fn sidebar_publishes_size_var_and_resize_handle() {
+    let host = mount(FRAME);
+    settle().await;
+    let sb = q(&host, ".pine-workspace-sidebar");
+    assert_eq!(sb.get_attribute("data-state").as_deref(), Some("expanded"));
+    let style = sb.get_attribute("style").unwrap_or_default();
+    assert!(
+        style.contains("--pine-sidebar-size:"),
+        "sidebar publishes its width var, got `{style}`"
+    );
+    let handle = q(&host, ".pine-workspace-sidebar-resize");
+    assert_eq!(handle.get_attribute("role").as_deref(), Some("separator"));
+    assert!(handle.has_attribute("aria-valuenow"));
+}
+
+#[wasm_bindgen_test]
+async fn aside_renders_state_side_and_size_var() {
+    let host = mount(FRAME);
+    settle().await;
+    let aside = q(&host, ".pine-workspace-aside");
+    // Closed until opened (app-controlled via pp-model:open).
+    assert_eq!(
+        aside.get_attribute("data-aside-state").as_deref(),
+        Some("closed")
+    );
+    assert_eq!(aside.get_attribute("data-side").as_deref(), Some("end"));
+    let style = aside.get_attribute("style").unwrap_or_default();
+    assert!(style.contains("--pine-aside-size:"), "got `{style}`");
+    assert!(!aside.get_attribute("id").unwrap_or_default().is_empty());
+}
+
+#[wasm_bindgen_test]
+async fn sidebar_auto_collapses_below_threshold() {
+    // Default collapse_below="lg": below lg the sidebar collapses to the rail.
+    let host = mount(
+        r#"<pine-workspace><pine-workspace-sidebar label="Nav">nav</pine-workspace-sidebar></pine-workspace>"#,
+    );
+    settle().await;
+    let bp = q(&host, ".pine-workspace")
+        .get_attribute("data-breakpoint")
+        .unwrap_or_default();
+    let sb = q(&host, ".pine-workspace-sidebar");
+    if matches!(bp.as_str(), "base" | "sm" | "md") {
+        assert_eq!(
+            sb.get_attribute("data-state").as_deref(),
+            Some("collapsed"),
+            "below lg ({bp}) the sidebar auto-collapses to the rail"
+        );
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ New here? Start with **[Getting Started](./getting-started/introduction.md)**.
 **Styling & UI**
 
 - [Pine Stylekit](./guides/styling/stylekit.md) — the utility-CSS compiler and `@theme` tokens.
+- [Layout (`pine-layout`)](./guides/layout/README.md) — headless responsive layout: the breakpoint engine, structural primitives, the adaptive [AppShell](./guides/layout/app-shell.md), and the [Workspace](./guides/layout/workspace.md) shell.
 - [Animation](./guides/styling/animation.md) — presets, FLIP, and the WAAPI escape hatch.
 - [Icons](./guides/styling/icons.md) — tree-shaken Tabler icons.
 - [Charts](./guides/styling/charts/README.md) — SVG-first chart primitives.

--- a/docs/guides/layout/README.md
+++ b/docs/guides/layout/README.md
@@ -1,0 +1,241 @@
+---
+title: "Layout — pine-layout"
+description: "Headless, responsive layout primitives for pocopine: the breakpoint engine, structural primitives, the adaptive AppShell, and the content-heavy Workspace shell."
+---
+
+# pine-layout
+
+`pine-layout` is a Pine sub-library for **scaffolding responsive
+applications**. It is to *responsiveness* what core Pine is to *behavior*:
+it ships **zero CSS**. Every component exposes a semantic class name, a set
+of `data-*` state attributes, and — for the one dimension a static
+stylesheet can't express (a resizable width/height) — a `--pine-*-size`
+custom property. **Your CSS** (hand-written, or Pine Stylekit utilities)
+does the actual layout.
+
+What it gives you instead of opinions about how things look:
+
+1. **One canonical breakpoint vocabulary** (`base`/`sm`/`md`/`lg`/`xl`/`2xl`)
+   resolved from the viewport, surfaced three ways.
+2. **Structural primitives** — `Container`, `Stack`, `Inline`, `Grid`.
+3. **`<pine-app-shell>`** — an adaptive `drawer → rail → sidebar`
+   navigation shell. *(RFC-103, see [app-shell.md](./app-shell.md).)*
+4. **`<pine-workspace>`** — a content-heavy multi-region shell with
+   resizable, collapsible regions. *(RFC-105, see [workspace.md](./workspace.md).)*
+
+```mermaid
+graph LR
+  app["your app"] --> PL["pine-layout"]
+  PL --> BP["breakpoint engine"]
+  PL --> PRIM["Container · Stack · Inline · Grid"]
+  PL --> AS["AppShell<br/>drawer → rail → sidebar"]
+  PL --> WS["Workspace<br/>sidebar │ main │ aside │ panels"]
+  BP -.->|data-breakpoint · context · pp-model| app
+```
+
+## Install & register
+
+`pine-layout` ships its components as custom-element tags. Register them
+once at startup, before mounting any template that uses them.
+
+```toml
+# Cargo.toml
+[dependencies]
+pine-layout = { path = "../../crates/pine-layout" }
+pocopine = { path = "../../crates/pocopine" }
+```
+
+```rust
+use pocopine::prelude::*;
+
+#[wasm_bindgen(start)]
+pub fn main() {
+    pine_layout::register_all();        // <pine-app-shell>, <pine-grid>, …
+    App::new().register::<MyApp>().run();
+}
+```
+
+> Apps `use pine_layout::…` directly — the library is **not** re-exported
+> through the `pocopine` umbrella while its surface is still settling.
+
+## The headless contract
+
+This is the heart of the library. No component ships a stylesheet or sets
+visual styles inline. Instead every component publishes its state four ways
+— pick whichever your situation needs:
+
+| # | Mechanism | Looks like | Use it for |
+|---|---|---|---|
+| 1 | **Semantic class** | `<div class="pine-grid">` | the base CSS target |
+| 2 | **`data-*` attributes** | `data-breakpoint="md"`, `data-nav-mode="rail"`, `data-state="open"` | attribute-selector styling (`.pine-app-shell[data-nav-mode="rail"] { … }`) |
+| 3 | **CSS custom property** | `style="--pine-sidebar-size: 240px"` | the one *dynamic numeric* dimension (resizable width/height) — author CSS reads it with `var()` |
+| 4 | **Reactive state** | `#[model]` (→ `pp:update:*`, `pp-model:`) + context (`#[observe(CTX)]`) | app logic that needs the value, or descendant components that react |
+
+So a grid:
+
+```html
+<!-- template -->
+<pine-grid cols="12" gap="4">…</pine-grid>
+```
+
+```css
+/* your CSS — pine-layout ships none of this */
+.pine-grid { display: grid; }
+.pine-grid[data-cols="12"] { grid-template-columns: repeat(12, 1fr); }
+.pine-grid[data-gap="4"]   { gap: 1rem; }
+/* …or just drop Stylekit utilities on the element:
+   <pine-grid class="grid grid-cols-12 md:grid-cols-6"> */
+```
+
+Because Pine Stylekit only scans **app** source (not dependency crates),
+`pine-layout` self-contains its contract in `data-*`/custom-properties and
+never relies on the app's Stylekit glob picking up the library's templates.
+
+## Breakpoints
+
+The reactive breakpoint resolves to the **same** thresholds Pine Stylekit
+uses for its `sm:`/`md:`/`lg:`/`xl:`/`2xl:` utility prefixes — so
+`data-breakpoint == "md"` and a `md:` utility class never disagree.
+
+| tier  | min-width | rank |
+|-------|-----------|------|
+| `base`| 0         | 0    |
+| `sm`  | 640px     | 1    |
+| `md`  | 768px     | 2    |
+| `lg`  | 1024px    | 3    |
+| `xl`  | 1280px    | 4    |
+| `2xl` | 1536px    | 5    |
+
+### `<pine-breakpoint>` — a standalone provider
+
+Resolves the current tier and exposes it three ways: `data-breakpoint` (for
+CSS), the `BREAKPOINT` context (descendants), and a `pp:update:value` model
+event (app logic). Ships no layout of its own.
+
+```html
+<pine-breakpoint pp-model:value="bp">
+  <p>Viewport is at the {{bp}} tier.</p>
+</pine-breakpoint>
+```
+
+| Field | Kind | Default | Notes |
+|---|---|---|---|
+| `value` | `#[model]` String | resolves on mount | the tier; emits `pp:update:value` |
+| `initial` | `#[prop]` String | `base` | value before `matchMedia` resolves (and the permanent value on non-wasm / SSR) |
+
+### The `Breakpoint` API
+
+For Rust-side logic the `pine_layout::breakpoint` module exposes:
+
+```rust
+use pine_layout::breakpoint::Breakpoint;
+
+Breakpoint::from_token("md")      // -> Some(Breakpoint::Md)
+Breakpoint::Md.as_str()           // -> "md"
+Breakpoint::Md.min_width()        // -> 768
+Breakpoint::Xl.rank() >= Breakpoint::Md.rank()   // "is the viewport at least md?"
+Breakpoint::TIERS                 // ascending [(Sm,640), (Md,768), …]
+```
+
+`breakpoint::install(on_change)` is the engine itself — register a
+`matchMedia` watcher for the current scope (used internally by the shells);
+`breakpoint::nav_mode(bp, rail_at, sidebar_at)` derives `drawer`/`rail`/
+`sidebar` from a tier (shared by AppShell and Workspace).
+
+> **wasm-gated.** On non-wasm / SSR there is no viewport: the breakpoint
+> stays at its configured `initial` value, so host builds compile and behave
+> deterministically.
+
+## Structural primitives
+
+Thin, headless layout containers — they emit a class + `data-*` mirrors of
+their props and nothing else. They give a consistent, documented vocabulary
+and styling hooks; you supply the flexbox/grid (or Stylekit utilities).
+
+### `<pine-container>` — max-width content column
+
+| Prop | Type | Surfaced as |
+|---|---|---|
+| `size` | String (`sm`/`md`/`lg`/… or any token) | `data-size` |
+| `safe-area` | bool | `data-safe-area` (present when true) |
+
+```css
+.pine-container { margin-inline: auto; width: 100%; }
+.pine-container[data-size="lg"] { max-width: 64rem; }
+.pine-container[data-safe-area] { padding: env(safe-area-inset-top) env(safe-area-inset-right)
+                                          env(safe-area-inset-bottom) env(safe-area-inset-left); }
+```
+
+### `<pine-stack>` / `<pine-inline>` — 1-D layout
+
+`Stack` is vertical, `Inline` is horizontal (Atlassian's primitives).
+
+| Prop | Both | `Inline` only |
+|---|---|---|
+| `gap` | `data-gap` | |
+| `align` | `data-align` (cross axis) | |
+| `justify` | `data-justify` (main axis) | |
+| `wrap` | | `data-wrap` (bool) |
+
+```css
+.pine-stack  { display: flex; flex-direction: column; }
+.pine-inline { display: flex; flex-direction: row; align-items: center; }
+.pine-stack[data-gap="4"]            { gap: 1rem; }
+.pine-inline[data-justify="between"] { justify-content: space-between; }
+.pine-inline[data-wrap]              { flex-wrap: wrap; }
+```
+
+### `<pine-grid>` + `<pine-grid-item>` — 12-column grid
+
+| Component | Prop | Default | Surfaced as |
+|---|---|---|---|
+| `pine-grid` | `cols` | `12` | `data-cols` |
+| | `gap` | | `data-gap` |
+| `pine-grid-item` | `span` | | `data-span` |
+| | `start` | | `data-start` |
+
+```css
+.pine-grid { display: grid; }
+.pine-grid[data-cols="12"] { grid-template-columns: repeat(12, 1fr); }
+.pine-grid-item[data-span="6"]  { grid-column: span 6; }
+.pine-grid-item[data-start="4"] { grid-column-start: 4; }
+@media (max-width: 720px) { .pine-grid { grid-template-columns: 1fr; } }
+```
+
+Responsive column counts are best expressed in CSS — a media query against
+the `data-*` hooks, or Stylekit utilities directly on the element
+(`<pine-grid class="grid grid-cols-12 md:grid-cols-6">`).
+
+## Which shell?
+
+| | `<pine-app-shell>` | `<pine-workspace>` |
+|---|---|---|
+| **For** | sites & apps with a primary nav | content-heavy / productivity apps |
+| **Nav** | drawer → rail → sidebar (mobile drawer) | resizable sidebar + rail collapse + flyout |
+| **Regions** | header · sidebar · content · footer | + detail aside · outer panels · bottom panel |
+| **Resizing** | — | every panel (own resize engine) |
+| **Guide** | [app-shell.md](./app-shell.md) | [workspace.md](./workspace.md) |
+
+They're independent families — pick one. (The Workspace is *not* an
+extension of the AppShell.)
+
+## Examples
+
+Two runnable demos, each with hand-written CSS that styles the headless
+hooks:
+
+```bash
+cargo run -p pocopine-cli -- dev --path examples/layout      # AppShell
+cargo run -p pocopine-cli -- dev --path examples/workspace   # Workspace
+```
+
+## Design notes
+
+- Breakpoint changes mutate `data-*` only — never focus or scroll.
+- Animate transitions with **pine-motion** (imperative, toggle-driven), not
+  declarative CSS transitions on a property that also reflows at a
+  breakpoint — otherwise the reflow animates an unwanted slide. The examples
+  show the pattern.
+- Background grounding: `docs/internal/research/layout-design-systems.md`
+  and `…/workspace-shell-layouts.md` (fact-checked Apple HIG · Material 3 ·
+  Atlassian · VS Code · PatternFly · Workday · Dockview).

--- a/docs/guides/layout/app-shell.md
+++ b/docs/guides/layout/app-shell.md
@@ -1,0 +1,206 @@
+---
+title: "AppShell — adaptive navigation"
+description: "<pine-app-shell>: an adaptive drawer → rail → sidebar navigation shell with a modal drawer (focus trap, scroll lock, Esc, ARIA). Headless — you style each mode."
+---
+
+# AppShell
+
+`<pine-app-shell>` is an application scaffold whose primary navigation
+adapts to the viewport: a **drawer** (off-canvas, narrow) → a **rail**
+(icon-only, medium) → a full **sidebar** (wide). It's **headless** — it
+computes the `nav_mode` and manages the modal-drawer *behavior*; **your
+CSS** decides what each mode looks like.
+
+```mermaid
+graph LR
+  base["base / sm"] -->|drawer| D["off-canvas drawer + ☰"]
+  md["md / lg"] -->|rail| R["icon rail"]
+  xl["xl / 2xl"] -->|sidebar| S["full sidebar"]
+```
+
+## Anatomy
+
+A compound of six custom elements:
+
+| Tag | Role | What it is |
+|---|---|---|
+| `<pine-app-shell>` | scope | the root: breakpoint engine + nav state machine + `SHELL` context |
+| `<pine-app-shell-header>` | `banner` | top bar (sticky) |
+| `<pine-app-shell-sidebar>` | `navigation` | the adaptive nav region; modal drawer in drawer mode |
+| `<pine-app-shell-content>` | `main` | the page content |
+| `<pine-app-shell-footer>` | `contentinfo` | footer |
+| `<pine-app-shell-trigger>` | `interactive` (`<button>`) | the hamburger toggle |
+
+Header/content/footer are thin landmark regions (`<div role="…">`). The
+shell wires the regions together through the `SHELL` context — you don't
+pass props between them.
+
+## Root props & state
+
+| Field | Kind | Default | Surfaced as |
+|---|---|---|---|
+| `breakpoint` | `#[model]` String | engine-driven | `data-breakpoint` · `pp:update:breakpoint` |
+| `nav_open` | `#[model]` bool | `false` | `data-nav-open` · `pp:update:nav_open` |
+| `nav_mode` | derived String | — | `data-nav-mode` (`drawer`/`rail`/`sidebar`) |
+| `rail_at` | `#[prop]` String | `md` | tier at which nav becomes a rail |
+| `sidebar_at` | `#[prop]` String | `xl` | tier at which nav becomes a full sidebar |
+| `initial` | `#[prop]` String | `base` | tier before `matchMedia` resolves / on SSR |
+
+**`nav_mode` derivation** (overridable via the two thresholds):
+
+```
+breakpoint:  base   sm     md    lg     xl      2xl
+nav_mode:    drawer drawer rail  rail   sidebar sidebar      (rail_at=md, sidebar_at=xl)
+```
+
+When the viewport grows **out** of drawer mode, an open drawer auto-closes
+(so focus/scroll are released).
+
+## The data-* hooks you style against
+
+| Element | Attribute | Values |
+|---|---|---|
+| root | `data-breakpoint` | `base`…`2xl` |
+| root | `data-nav-mode` | `drawer` / `rail` / `sidebar` |
+| root | `data-nav-open` | present while the drawer is open |
+| sidebar | `data-nav-mode` | mirrors the root |
+| sidebar | `data-state` | `open` / `closed` (drawer) |
+| trigger | `data-nav-mode` | mirrors the root (hide the ☰ unless `drawer`) |
+| trigger | `aria-expanded` | `true` / `false` |
+
+## A complete app shell
+
+The component is pure composition — no Rust state beyond what you want to
+bind. Here `bp` is two-way bound so a badge can show the live tier.
+
+```rust
+// src/lib.rs
+use pocopine::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(display = "contents")]
+pub struct AppDemo {
+    pub bp: String,   // live breakpoint, via pp-model:breakpoint
+}
+
+#[handlers]
+impl AppDemo {}
+
+#[wasm_bindgen(start)]
+pub fn main() {
+    pine_layout::register_all();
+    App::new().register::<AppDemo>().run();
+}
+```
+
+```html
+<!-- src/AppDemo.poco -->
+<div class="demo-root">
+  <pine-app-shell class="shell" pp-model:breakpoint="bp">
+
+    <pine-app-shell-header class="shell-header">
+      <pine-app-shell-trigger class="burger" aria-label="Toggle navigation">☰</pine-app-shell-trigger>
+      <span class="brand">My&nbsp;App</span>
+    </pine-app-shell-header>
+
+    <pine-app-shell-sidebar class="shell-sidebar" label="Main">
+      <nav>
+        <a href="#"><span class="ico">▦</span><span class="nav-label">Dashboard</span></a>
+        <a href="#"><span class="ico">◷</span><span class="nav-label">Activity</span></a>
+        <a href="#"><span class="ico">⚙</span><span class="nav-label">Settings</span></a>
+      </nav>
+    </pine-app-shell-sidebar>
+
+    <pine-app-shell-content class="shell-content">…page…</pine-app-shell-content>
+    <pine-app-shell-footer class="shell-footer">status</pine-app-shell-footer>
+
+  </pine-app-shell>
+  <span class="bp-badge" pp-text="bp"></span>
+</div>
+```
+
+```css
+/* styles.css — the library ships none of this */
+.shell {
+  display: grid;
+  min-height: 100vh;
+  grid-template-rows: 3.5rem 1fr auto;
+  grid-template-columns: var(--sidebar-w, 16rem) 1fr;
+  grid-template-areas: "header header" "sidebar content" "footer footer";
+}
+.shell[data-nav-mode="rail"]    { grid-template-columns: 4.5rem 1fr; }
+.shell[data-nav-mode="drawer"] {
+  grid-template-columns: 1fr;
+  grid-template-areas: "header" "content" "footer";
+}
+.shell-header  { grid-area: header; }
+.shell-sidebar { grid-area: sidebar; }
+.shell-content { grid-area: content; }
+.shell-footer  { grid-area: footer; }
+
+/* RAIL: hide the labels */
+.shell-sidebar[data-nav-mode="rail"] .nav-label { display: none; }
+
+/* DRAWER: off-canvas; resting position is instant (no CSS transition on
+   transform — see "Animating" below) */
+.shell-sidebar[data-nav-mode="drawer"] {
+  position: fixed; inset: 0 auto 0 0; width: 16rem; z-index: 40;
+  transform: translateX(-100%);
+}
+.shell-sidebar[data-nav-mode="drawer"][data-state="open"] { transform: translateX(0); }
+
+/* the ☰ only appears in drawer mode */
+.burger { display: none; }
+.burger[data-nav-mode="drawer"] { display: inline-flex; }
+```
+
+## How the trigger and drawer work
+
+- **The trigger** is a real `<button>`. Clicking it calls the shell's
+  `toggle_nav()` through the `SHELL` context (it only acts in drawer mode);
+  `aria-expanded` mirrors `nav_open` and `aria-controls` points at the
+  sidebar's generated id.
+- **The drawer** (sidebar in `drawer` mode while open) is a modal: focus is
+  trapped inside it, page scroll is locked, **Escape closes it**, and focus
+  is restored to the trigger on close. This reuses the same overlay runtime
+  as Pine's Dialog.
+
+> **No outside-click / scrim dismissal in v1.** A capture-phase
+> `@click.outside` on the sidebar treats the hamburger as "outside" and
+> cancels the toggle (the known Pine dropdown trigger-while-open bug), so the
+> drawer closes via the toggle or **Esc**. A backdrop sub-component is the
+> planned addition.
+
+## Binding to app logic
+
+Both `breakpoint` and `nav_open` are `#[model]`s:
+
+```html
+<pine-app-shell pp-model:breakpoint="bp" pp-model:nav_open="nav_open">
+```
+
+- `pp-model:breakpoint="bp"` keeps an app field in sync with the live tier
+  (e.g. to conditionally render).
+- `@pp:update:nav_open="on_toggle"` fires whenever the drawer opens/closes.
+
+## Accessibility
+
+- Regions emit landmark roles (`banner` / `navigation` / `main` /
+  `contentinfo`); the sidebar is `<… role="navigation" aria-label>`.
+- Drawer mode adds dialog semantics: focus trap, Esc, focus restore.
+- The trigger is a real `<button>` with `aria-expanded` / `aria-controls`.
+
+## Gotchas
+
+- **Breakpoints are fixed to Stylekit's scale** (640/768/1024/1280/1536).
+  Don't invent your own — `data-breakpoint == "md"` is guaranteed to match a
+  `md:` utility.
+- **Animate the drawer with pine-motion**, fired from the toggle — not a
+  declarative `transition: transform` (which would also fire when a
+  breakpoint reflow flips the nav into drawer mode, animating an unwanted
+  slide-out). See `examples/layout` for the imperative pattern.
+- **Don't `pp-show` a component host.** To hide the trigger outside drawer
+  mode, style its `data-nav-mode` (as above), not `pp-show`.
+
+See the full demo in [`examples/layout`](../../../examples/layout).

--- a/docs/guides/layout/workspace.md
+++ b/docs/guides/layout/workspace.md
@@ -1,0 +1,262 @@
+---
+title: "Workspace — multi-region shell"
+description: "<pine-workspace>: a content-heavy frame (resizable rail/sidebar │ main │ detail aside │ outer + bottom panels) with an own resize engine. Headless — you style the grid."
+---
+
+# Workspace
+
+`<pine-workspace>` is the content-heavy frame for productivity apps — the
+Atlassian / VS-Code shape: a resizable rail/sidebar, the main region, a
+trailing detail **Aside**, optional outer panels, and a bottom panel. Every
+panel resizes (drag or keyboard); the sidebar collapses to a rail with a
+hover flyout. It's **headless** — it manages the *behavior* and publishes
+each panel's size; **your CSS grid** does the layout.
+
+```
+ [panel]  sidebar │            main             │  aside   [panel]
+  collapse  resize │      flex-fill remainder      │  resize  collapse
+           rail/flyout                              open/close
+                    └──────────── bottom ──────────┘
+                          resize · collapse · edge
+```
+
+It's an **independent family** from `<pine-app-shell>` — not an extension.
+Use it when you need resizable multi-region content; use the AppShell for a
+simple adaptive nav.
+
+## Anatomy
+
+| Tag | Role | Capabilities |
+|---|---|---|
+| `<pine-workspace>` | scope | root: breakpoint engine + `WORKSPACE` context + the grid container |
+| `<pine-workspace-header>` | `banner` | top bar |
+| `<pine-workspace-sidebar>` | `navigation` | **resize** · collapse-to-rail · hover flyout · auto-rail |
+| `<pine-workspace-main>` | `main` | the flex-fill remainder |
+| `<pine-workspace-aside>` | `complementary` | **resize** · open/close (a docked detail column) |
+| `<pine-workspace-panel side="start\|end">` | `navigation` | outer secondary nav · collapse |
+| `<pine-workspace-bottom>` | `complementary` | **vertical resize** · collapse · edge-relocatable |
+| `<pine-workspace-footer>` | `contentinfo` | status bar |
+
+## The size custom property
+
+A resizable panel's width/height is genuinely dynamic, so the component
+publishes it as a CSS custom property on its own element; your CSS reads it
+with `var()` and the grid uses an `auto` track:
+
+```css
+.pine-workspace { display: grid; grid-template-columns: auto 1fr auto; }
+.pine-workspace-sidebar { width: var(--pine-sidebar-size, 260px); }
+.pine-workspace-aside   { width: var(--pine-aside-size, 320px); }
+.pine-workspace-bottom  { height: var(--pine-bottom-size, 240px); }
+```
+
+| Region | Custom property |
+|---|---|
+| sidebar | `--pine-sidebar-size` |
+| aside | `--pine-aside-size` |
+| bottom | `--pine-bottom-size` (height) |
+
+While a drag is in progress the panel carries **`data-dragging`** — gate
+your transitions on it so the splitter tracks the pointer 1:1:
+
+```css
+[data-dragging] { transition: none !important; }
+```
+
+## Region props & state
+
+### Root `<pine-workspace>`
+
+| Field | Kind | Default | Surfaced as |
+|---|---|---|---|
+| `breakpoint` | `#[model]` String | engine-driven | `data-breakpoint` · `pp:update:breakpoint` |
+| `initial` | `#[prop]` String | `base` | tier before resolve / on SSR |
+
+### `<pine-workspace-sidebar>`
+
+| Field | Kind | Default | Notes |
+|---|---|---|---|
+| `label` | `#[prop]` | | nav landmark name |
+| `size` | `#[model]` f64 | 260 | width; `pp-model:size` to persist |
+| `collapsed` | `#[model]` bool | false | user rail state; `pp-model:collapsed` |
+| `rail_size` | `#[prop]` f64 | 56 | width when collapsed |
+| `max` | `#[prop]` f64 | 480 | max expanded width |
+| `collapse_at` | `#[prop]` f64 | 160 | drag below this → snap to rail |
+| `default` | `#[prop]` f64 | 260 | double-click reset target |
+| `collapse_below` | `#[prop]` String | `lg` | tier below which it auto-rails |
+
+Emits: `data-state` (`expanded`/`collapsed`), `data-flyout` (hover while
+collapsed), `data-dragging`, and `--pine-sidebar-size`.
+
+> The rendered collapse state is `collapsed || responsive_rail` — the user
+> intent (`pp-model:collapsed`) and the responsive auto-rail are kept in
+> **separate** fields so the two never fight.
+
+### `<pine-workspace-aside>`
+
+A resizable, collapsible docked column.
+
+| Field | Kind | Default | Notes |
+|---|---|---|---|
+| `label` | `#[prop]` | | landmark name |
+| `side` | `#[prop]` String | `end` | `end` (right) or `start` (left) — sets the resize direction |
+| `open` | `#[model]` bool | false | shown/hidden; `pp-model:open` |
+| `size` | `#[model]` f64 | 320 | width; `pp-model:size` |
+| `min` / `max` / `default` | `#[prop]` f64 | 240 / 560 / 320 | resize bounds + reset |
+
+Emits: `data-side`, `data-aside-state` (`open`/`closed`), `data-dragging`,
+`--pine-aside-size`.
+
+### `<pine-workspace-bottom>`
+
+| Field | Kind | Default | Notes |
+|---|---|---|---|
+| `label` | `#[prop]` | | landmark name |
+| `edge` | `#[prop]` String | `bottom` | `bottom` or `top` (sets drag direction; style via `data-edge`) |
+| `open` | `#[model]` bool | false | `pp-model:open` |
+| `size` | `#[model]` f64 | 240 | height; `pp-model:size` |
+| `min` / `max` / `default` | `#[prop]` f64 | 120 / 600 / 240 | resize bounds + reset |
+
+Emits: `data-edge`, `data-state`, `data-dragging`, `--pine-bottom-size`.
+
+### `<pine-workspace-panel>`
+
+| Field | Kind | Default | Notes |
+|---|---|---|---|
+| `side` | `#[prop]` String | `start` | `start` / `end` |
+| `label` | `#[prop]` | | landmark name |
+| `open` | `#[model]` bool | true | `pp-model:open` |
+
+Emits: `data-side`, `data-state` (`open`/`closed`).
+
+## Resize handles
+
+Each resizable region embeds a grab handle (`role="separator"` +
+`aria-orientation` + `aria-valuenow/min/max`). Style it as a thin strip on
+the panel's edge:
+
+```css
+.pine-workspace-sidebar { position: relative; }
+.pine-workspace-sidebar-resize { position: absolute; top: 0; right: 0; width: 10px; height: 100%; cursor: ew-resize; }
+.pine-workspace-sidebar-resize::after { content: ""; position: absolute; inset: 0 0 0 auto; width: 2px; }
+.pine-workspace-sidebar-resize:hover::after { background: var(--accent); }
+/* aside handle → .pine-workspace-aside-resize (left edge);
+   bottom handle → .pine-workspace-bottom-resize (top edge, cursor ns-resize) */
+```
+
+Keyboard (when the handle is focused): **arrows** nudge ±16px, **Home/End**
+jump to min/max, **double-click** resets to `default`. The size is a
+`#[model]`, so `pp-model:size="my_layout"` persists and restores it.
+
+## State is app-controlled
+
+There's no generic `<pine-workspace-trigger>` — regions are driven by your
+app via `pp-model`, which keeps the policy in your hands and the components
+headless:
+
+```html
+<pine-workspace pp-model:breakpoint="bp">
+  <pine-workspace-sidebar pp-model:collapsed="sidebar_collapsed" …>
+  <pine-workspace-aside  pp-model:open="aside_open" …>
+  <pine-workspace-bottom pp-model:open="bottom_open" …>
+```
+
+```rust
+#[handlers]
+impl WorkspaceDemo {
+    pub fn toggle_sidebar(&mut self) { self.sidebar_collapsed = !self.sidebar_collapsed; }
+    pub fn toggle_aside(&mut self)   { self.aside_open = !self.aside_open; }
+    pub fn toggle_bottom(&mut self)  { self.bottom_open = !self.bottom_open; }
+}
+```
+
+The **sidebar's auto-rail is built in** (it watches the workspace breakpoint
+and rails below `collapse_below`). For other responsive policy — e.g. hide
+the outer panels on narrow — drive it from the app with a `#[watch(bp)]`
+(the `bp` field is bound via `pp-model:breakpoint`):
+
+```rust
+#[watch(bp)]
+fn on_bp(&mut self, bp: String, _: Option<String>) {
+    self.panel_open = !matches!(bp.as_str(), "base" | "sm" | "md");
+}
+```
+
+## A minimal workspace
+
+```html
+<!-- src/WorkspaceDemo.poco -->
+<pine-workspace class="ws" pp-model:breakpoint="bp">
+  <pine-workspace-header class="ws-header">
+    <button class="ws-btn" pp-on:click="toggle_sidebar">☰</button>
+    <span class="ws-brand">My&nbsp;App</span>
+    <span class="ws-grow"></span>
+    <button class="ws-btn" pp-on:click="toggle_aside">Detail</button>
+  </pine-workspace-header>
+
+  <pine-workspace-sidebar class="ws-sidebar" label="Primary" pp-model:collapsed="sidebar_collapsed">
+    <nav>…icon + <span class="nav-label">label</span> rows…</nav>
+  </pine-workspace-sidebar>
+
+  <pine-workspace-main class="ws-main">…page…</pine-workspace-main>
+
+  <pine-workspace-aside class="ws-aside" label="Detail" pp-model:open="aside_open">
+    <div class="ws-aside-inner">…task detail / AI / comments…</div>
+  </pine-workspace-aside>
+
+  <pine-workspace-footer class="ws-footer"><span pp-text="bp"></span></pine-workspace-footer>
+</pine-workspace>
+```
+
+```css
+.ws {
+  display: grid; height: 100vh;
+  grid-template-columns: auto 1fr auto;
+  grid-template-rows: 48px 1fr auto;
+  grid-template-areas: "header header header" "sidebar main aside" "footer footer footer";
+}
+.ws-header { grid-area: header; } .ws-sidebar { grid-area: sidebar; position: relative; }
+.ws-main { grid-area: main; overflow: auto; } .ws-aside { grid-area: aside; position: relative; }
+.ws-footer { grid-area: footer; }
+
+.ws-sidebar { width: var(--pine-sidebar-size, 260px); overflow: hidden; }
+.ws-sidebar[data-state="collapsed"] .nav-label { display: none; }
+.ws-sidebar[data-state="collapsed"][data-flyout] { position: absolute; inset: 0 auto 0 0; width: 240px; z-index: 60; }
+.ws-sidebar[data-state="collapsed"][data-flyout] .nav-label { display: inline; }
+
+.ws-aside { width: var(--pine-aside-size, 320px); }
+.ws-aside[data-aside-state="closed"] { display: none; }
+
+[data-dragging] { transition: none !important; }
+```
+
+(See [`examples/workspace`](../../../examples/workspace) for the full,
+styled version.)
+
+## Accessibility
+
+Landmark roles per region; resize handles are `role="separator"` with
+`aria-orientation` + `aria-valuenow/min/max` and full keyboard support
+(W3C APG window-splitter pattern).
+
+## Gotchas
+
+- **Own-field reactions need `#[watch(field)]`, not
+  `watch_scope_field_scoped`** — the latter is for *cross-scope* watching
+  (a region reading the root's `breakpoint`); it does **not** fire for a
+  component's own fields. (Bit us: a `pp-model` field updated its bindings
+  but a same-scope watch never ran.)
+- **Resize handles are clipped by `overflow: hidden`** — keep the handle
+  *inside* the panel edge (`right: 0`), or the grab strip vanishes.
+- **The custom property must sit on the panel**, not the grid container —
+  CSS custom properties inherit *down*, so the grid can't read a child's
+  `--pine-*-size`. That's why each panel uses an `auto` track and sets its
+  own size.
+
+## Deferred
+
+The Aside's **floating/overlay** mode (dock↔float toggle) was prototyped and
+pulled from v1 to keep the shell clean — the `floating` overlay runtime
+stays for the AppShell drawer, and re-introducing the Aside float is a
+contained follow-up. Also future: drag-to-detach floating groups, panel
+drag-to-dock, a generic workspace trigger. See `rfcs/rfc-105-pine-workspace.md`.

--- a/docs/internal/research/layout-design-systems.md
+++ b/docs/internal/research/layout-design-systems.md
@@ -1,0 +1,154 @@
+# Layout & Responsiveness in Major Design Systems — Research for `pine-layout`
+
+> Fact-checked research base for RFC-103 (`pine-layout`). Compiled 2026-06-13.
+> Every numeric claim below survived 3-vote adversarial verification (24/25
+> claims confirmed). Claims that could **not** be verified from primary sources
+> are explicitly marked ⚠️ UNVERIFIED so we don't bake folklore into the API.
+
+## TL;DR
+
+All three systems converge on the same shape:
+
+1. **Viewport-tier responsiveness** — a small set of named width buckets drives
+   layout, not a continuum.
+2. **A handful of layout primitives** — a container, a vertical stacker, a
+   horizontal stacker, plus a column grid.
+3. **Canonical multi-pane patterns** that reflow from one column on narrow
+   screens to two/three on wide ones (list-detail, supporting pane, feed).
+
+They diverge sharply on **exact numbers**, and the numbers are not directly
+comparable: Atlassian uses CSS **px**, Material uses density-independent **dp**,
+Apple uses **pt**. A web/WASM library must pick **px** as canonical and treat
+dp/pt thresholds as *conceptual tiers*.
+
+```
+NARROW ───────────────────────────────────────────────────► WIDE
+single column          two columns               three columns
+stacked nav            nav rail                  nav drawer / sidebar
+bottom bar             list-detail (1 pane)      list-detail (both panes)
+```
+
+## Side-by-side: the verified numbers
+
+| Dimension            | Apple HIG                              | Material 3                                   | Atlassian DS (grid-beta)                         |
+|----------------------|----------------------------------------|----------------------------------------------|--------------------------------------------------|
+| **Size model**       | `compact` / `regular` size classes (H+V) | Window size classes (compact/medium/expanded…) ⚠️ exact dp unverified | 6 px breakpoints `xxs…xl`                         |
+| **Breakpoints**      | coarse (2 classes per axis)            | ~600dp, ~840dp tiers ⚠️ UNVERIFIED            | xxs 320–479 · xs 480–767 · s 768–1023 · m 1024–1439 · l 1440–1767 · xl 1768+ |
+| **Grid columns**     | n/a (Auto Layout / stacks)             | grid varies by class                          | **2 → 6 → 12** (xxs → xs/s → m/l/xl)             |
+| **Gutters**          | system spacing                         | 4dp/8dp grid                                  | **12px** small, **16px** large                   |
+| **Outer margins**    | safe-area + layout margins             | per size class                                | **16px** small, **32px** large                   |
+| **Spacing base**     | 8pt baseline grid ⚠️ UNVERIFIED         | 4dp / 8dp grid                                | **8px base**, scale `space.0…space.1000`         |
+| **Touch target**     | 44pt ⚠️ UNVERIFIED                       | 48dp ⚠️ UNVERIFIED                             | —                                                |
+
+## Per-system detail
+
+### Apple — Human Interface Guidelines
+
+- **Split View** is the canonical adaptive container: a **two- or three-column**
+  interface — *primary column + optional supplementary column + secondary
+  content pane*. Default split devotes **⅓ to primary, ⅔ to secondary**; a
+  half-and-half layout is also available. Apple says to **prefer a split view in
+  a `regular` (not `compact`) environment** — it needs horizontal space.
+  [HIG: Split Views]
+- **SwiftUI `NavigationSplitView`** is the code embodiment: multi-column on
+  iPad/macOS/large iPhones-in-landscape, and **auto-collapses to a single-column
+  `NavigationStack` in a compact horizontal size class**. Two-column form takes
+  sidebar-first/detail-second; three-column form inserts a content column where
+  each column's selection drives the next, with an automatic sidebar-toggle.
+  [Apple docs: NavigationSplitView]
+- **`safeAreaLayoutGuide`** (UIKit) is the containment/inset mechanism: "the
+  portion of your view that is unobscured by bars and other content" — not
+  covered by navigation bars, tab bars, toolbars, or ancestor views.
+  [Apple docs: safeAreaLayoutGuide]
+
+### Material 3 / Android — Adaptive design
+
+- **Three canonical layouts**, each designed to reflow across all window size
+  classes: **List-Detail**, **Feed**, **Supporting Pane**.
+  [m3.material.io + developer.android.com: canonical-layouts]
+  - **List-Detail**: expanded width shows **both** list and detail
+    simultaneously; medium/compact show **one** pane (list *or* detail) based on
+    interaction.
+  - **Supporting Pane**: **50/50** split at medium width; **70/30**
+    (main/supporting) at expanded width.
+- **`SlidingPaneLayout` reflow rule** (the buildable heuristic): two panes show
+  side-by-side **only when available width ≥ the combined minimum widths of both
+  panes** (e.g. 200dp list + 400dp detail ⇒ needs ≥600dp). Below that they
+  collapse to single-pane, top view filling the width, revealed/dismissed by an
+  edge-drag. [developer.android.com: twopane]
+- **Adaptive navigation** swaps by width: **bottom bar** (compact) → **navigation
+  rail** (medium+) → **navigation drawer** (very large, ~1200dp+).
+  [codelab + m3 navigation-drawer guidelines] — *medium confidence; the drawer
+  tier and exact dp are partially unverified.*
+
+### Atlassian — Design System (the most web-native, precise numbers)
+
+- **6 breakpoints**, two tiers: small viewports **XXS/XS/S (320–1023px)**, large
+  viewports **M/L/XL (1024px+)**. [atlassian.design: grid-beta]
+- **12-column grid**: column count steps **2 (xxs) → 6 (xs/s) → 12 (m/l/xl)**;
+  content spans **3–12 columns**. Gutters **12px** small / **16px** large; outer
+  margins **16px** small / **32px** large. [grid-beta]
+- **Spacing**: **8px base**; tokens
+  `space.0`(0) `space.025`(2) `space.050`(4) `space.075`(6) `space.100`(8)
+  `space.150`(12) `space.200`(16) `space.250`(20) `space.300`(24) `space.400`(32)
+  `space.500`(40) `space.600`(48) `space.800`(64) `space.1000`(80). Gaps
+  (no 700/900) are intentional. [atlassian.design: spacing]
+- **Primitives**: core trio **Box** (container), **Inline** (horizontal),
+  **Stack** (vertical); plus **Flex** (CSS flexbox), **Grid** (CSS Grid), and
+  **Bleed** (negative whitespace). [atlassian.design: primitives]
+- ⚠️ Atlassian also ships a *separate* `Breakpoints` primitive with
+  `xxs/xs/sm/md/lg/xl` naming — **distinct** from the grid-beta breakpoints.
+  Don't conflate them.
+
+## Container queries vs viewport
+
+Best practice (MDN) combines **both**: viewport media queries drive **page
+structure** (app shell, page grid); **container queries** drive **component**
+responsiveness so a card/pane adapts to its parent slot regardless of where it's
+placed. Container queries are stably supported (Chrome 105+, Firefox 110+,
+Safari 16+). → `pine-layout` should let *page-level* primitives (AppShell, page
+Grid) key off the viewport and *component-level* primitives (cards, SplitPane)
+optionally key off their container.
+
+## Implications for `pine-layout`
+
+1. **Breakpoints — align to Stylekit, don't invent.** `pocopine-stylekit`
+   already ships Tailwind's scale: `sm 640 · md 768 · lg 1024 · xl 1280 ·
+   2xl 1536`. A component's reactive `breakpoint` state **must** resolve to these
+   exact thresholds, or `breakpoint == "md"` and the `md:` utility prefix
+   disagree. This single constraint settles the "which breakpoints" open
+   question that the research couldn't (Atlassian-6 vs Material-tiers): **reuse
+   Stylekit's 5.**
+2. **Spacing — reuse Stylekit's spacing scale** (already an 8px/4px-based
+   `p-*`/`gap-*` system) rather than adding a parallel `space.*` token set.
+3. **Grid — 12 columns** is the cross-system consensus (Atlassian explicit;
+   Material/Bootstrap/Tailwind all 12-friendly).
+4. **Canonical patterns worth shipping as components**: `AppShell` (adaptive
+   nav: bar→rail→drawer/sidebar), `Container` (max-width + safe-area aware),
+   `Stack`/`Inline` (1-D fl*), `Grid` (12-col), and a **`SplitPane`/`ListDetail`**
+   primitive whose two-pane→one-pane reflow follows the combined-min-width rule.
+5. **Reflow heuristic = combined-min-width**, not a hard breakpoint — this is the
+   one genuinely portable algorithm from the research (Android `SlidingPaneLayout`).
+
+## Caveats (read before trusting a number)
+
+- Numbers differ in **unit** (px/dp/pt) — not directly comparable.
+- The Atlassian grid is explicitly **beta**; its numbers may shift.
+- Material's clean "compact/medium/expanded" taxonomy and the **44pt/48dp** touch
+  targets and **8pt** baseline grid were **requested but not verified** from
+  primary sources here — widely known, but treat as unconfirmed.
+- Apple's developer.apple.com pages are JS-rendered; some SwiftUI claims lean on
+  an authoritative secondary source (Hacking with Swift) plus Apple initializer
+  names rather than verbatim primary fetches.
+
+## Primary sources
+
+- Apple HIG — Split Views: https://developer.apple.com/design/human-interface-guidelines/split-views
+- Apple — NavigationSplitView: https://developer.apple.com/documentation/swiftui/navigationsplitview
+- Apple — safeAreaLayoutGuide: https://developer.apple.com/documentation/uikit/uiview/safearealayoutguide
+- Material/Android — Canonical layouts: https://developer.android.com/develop/adaptive-apps/guides/canonical-layouts
+- Android — SlidingPaneLayout (twopane): https://developer.android.com/develop/ui/views/layout/twopane
+- Atlassian — Grid (beta): https://atlassian.design/foundations/grid-beta
+- Atlassian — Spacing: https://atlassian.design/foundations/spacing
+- Atlassian — Primitives: https://atlassian.design/components/primitives/overview
+- MDN — Container queries: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_queries

--- a/docs/internal/research/workspace-shell-layouts.md
+++ b/docs/internal/research/workspace-shell-layouts.md
@@ -1,0 +1,155 @@
+# Multi-Region Workspace-Shell Layouts — Research for `pine-layout` v2
+
+> Fact-checked research base for the content-heavy "workspace shell" (the
+> `rail/sidebar │ main │ detail aside │ panel` frame with float/anchor
+> trailing panels). Compiled 2026-06-13. 25/25 claims survived 3-vote
+> adversarial verification. Claims marked ⚠️ are unverified.
+
+## TL;DR
+
+The canonical content-heavy apps converge on a small, repeatable **named-region
+model** with three orthogonal per-region capabilities — **resizable**,
+**collapsible**, **floatable** — and one trailing panel that toggles
+**dock (anchor) ↔ float (overlay)**. Resizing is always a splitter/sash with
+min/max + snap-to-collapse + persisted sizes — which is exactly Pine's existing
+`splitter`. pine-layout v1's `drawer→rail→sidebar` nav is the *leading* edge of
+this model; v2 adds the *trailing* edge.
+
+```
+ outside ◄───────────────────────── regions ─────────────────────────► outside
+ [LeftPanel] [Sidebar] │      Main / Content       │ [Aside] [RightPanel]
+   368px   240→rail20   │   flex-fill, scrolls      │  280px    368px
+            resize       │   the ONLY remainder      │ resize+FLOAT
+            collapse                                    collapse
+                          [ BottomPanel — relocatable, resize, collapse ]
+```
+
+## Verified region dimensions — Atlassian `@atlaskit/page-layout`
+
+Confirmed verbatim against the published build + `atlassian-frontend-mirror`
+source constants:
+
+| Region | Default | Notes |
+|--------|---------|-------|
+| Banner | 56px tall | full-width, sticky |
+| TopNavigation | 56px tall | sticky |
+| LeftPanel | 368px | outer secondary nav, flush |
+| **LeftSidebar** | **240px** | **resizable, collapses to 20px rail (16px mobile) — NOT zero** |
+| Main | flex | the only remainder/scroll region |
+| RightSidebar | 280px | trailing |
+| RightPanel | 368px | outer, mirror of LeftPanel |
+| Aside | — | trailing contextual panel |
+
+**LeftSidebar resize/collapse mechanics** (from `resize-control` source):
+- drag handle (`data-grab-area` / `data-resize-control` / `data-resize-button`)
+- release `width < 200` → collapse to **20px rail** (`collapseLeftSidebar`)
+- `200 ≤ width < 240` → snap back up to 240
+- `width ≥ 240` → keep dragged width
+- collapsed rail shows a **240px hover flyout** after **200ms**, **300ms** transition (desktop; mobile = click-toggle + Esc)
+- state attrs: `data-is-sidebar-dragging`, `data-is-sidebar-collapsing`
+
+⚠️ `@atlaskit/page-layout` is **deprecated** in favour of
+`@atlaskit/navigation-system` (SideNav/Panel/Aside). The numbers above are
+accurate in the still-published build; the **new** system's names/defaults were
+**not** characterized — open gap. pine-layout should use its own headless names
+informed by both, not mirror a deprecated API.
+
+## VS Code workbench — the multi-region skeleton
+
+Six named areas (+ Title/Status bars): **Activity Bar · Primary Side Bar**
+(left default; Explorer/Search/SCM) **· Editor · Panel** (bottom) **· Secondary
+Side Bar** (opposite Primary; default Chat) **· Status Bar**. Key behaviors:
+- **Primary Side Bar side is user-configurable** (left↔right; `workbench.sideBar.location`).
+- **Secondary Side Bar** is independently toggleable; **context-dependent default
+  visibility** (shown with a folder open, hidden in an empty window).
+- **Panel is relocatable** to left/right/bottom/top of the editor.
+- **Priority contrast**: Primary = high-visibility (extensions contribute Views);
+  Secondary = auxiliary (populated by dragging Views in). → a region model should
+  encode a visibility priority.
+
+## Float ↔ Anchor — a first-class dual mode
+
+| Source | Anchored / dock | Floating / overlay |
+|--------|-----------------|--------------------|
+| **PatternFly** drawer | `inline` — beside content, compacts/pushes (still visible) | `overlay` — on top, must close to see covered content |
+| **Workday Canvas** Side Panel | push **and resize** content (expand/collapse toggle) | `alternate` variant over a scrim; page non-interactive; close button, no collapse |
+| **Dockview** | edge-docked groups, snap to border | detach group to freely-positioned floating overlay |
+
+- PatternFly: **add a splitter to resize the inline drawer**; omit it when content
+  has enough space; orientation vertical or horizontal. → compose Pine's splitter.
+- ⚠️ Vendors document the two modes as **configured alternatives** ("either…or…",
+  a variant prop), **not** a live in-place dock↔float flip preserving
+  content/scroll/focus. **That live toggle is pine-layout's own design to build.**
+
+## Sidebar collapse — two documented targets
+
+- **Atlaskit**: collapse to a **20px rail** + hover flyout (re-expand affordance).
+- **Linear**: **full collapse to hidden** (`[` shortcut / edge-click / command
+  palette). → pine-layout should support both (rail = v1 AppShell default; hide
+  as an option).
+
+## Resizable-panel UX contract (W3C APG + react-resizable-panels + allotment + reka-ui)
+
+splitter/sash drag · per-panel **min/max** · **snap-to-collapse threshold** ·
+**double-click-to-reset** · **persisted sizes** · **keyboard resize** (arrows,
+Shift = larger step, Home/End to extremes; `role="separator"` + `aria-valuenow`).
+
+**Pine `splitter` already has**: per-panel min/max, keyboard (1% / Shift 10% /
+Home-End), `role="separator"` + `aria-valuenow`, and `pp-model:sizes`
+persistence. **Missing for parity**: explicit snap-to-collapse threshold +
+double-click-reset.
+
+## Responsive collapse order (synthesis)
+
+As width shrinks, collapse **outside-in**:
+1. **RightPanel / LeftPanel** (outer secondary) hide first
+2. **Aside** switches anchored → **float** (stops reserving column width)
+3. **BottomPanel** shrinks or hides
+4. **Sidebar** steps `sidebar → rail → drawer` (existing AppShell progression)
+
+Gate N side-by-side panes on a **combined-min-width** rule: show them only when
+`viewport ≥ Σ(pane min-widths) + Main floor (~600–640px)` — the same
+combined-min-width heuristic from the v1 layout research (Android
+`SlidingPaneLayout`).
+
+## Implications for `pine-layout`
+
+1. **Extend the existing AppShell** rather than a separate shell — the trailing
+   regions (`Aside`, `Panel`) are opt-in additions to the v1 `Header/Sidebar/
+   Content/Footer` set; the leading `drawer→rail→sidebar` nav already exists.
+2. **The `Aside` is the one floatable region** — reuse v1's drawer runtime
+   (scrim + focus-trap + scroll-lock + Esc) for its float mode; anchored mode is
+   an in-grid resizable column.
+3. **Resize = compose a splitter** — but Pine's `splitter` lives in `crates/pine`
+   (a primitives layering issue for `pine-layout` to depend on). Options:
+   (a) pine-layout ships its own minimal single-split resize handle;
+   (b) extract the resize engine to `pocopine-core` (per the *core-owns-engines*
+   doctrine) and share it with `pine::splitter`; (c) author composes
+   `pine::splitter` themselves. Decision pending.
+4. **Stay headless** — every region emits a class + `data-*` (`data-aside-mode`,
+   `data-aside-state`, `data-region`, etc.); author CSS grid does the layout, as
+   in v1.
+
+## Caveats
+
+- `@atlaskit/page-layout` deprecated (constants still accurate); navigation-system
+  not characterized.
+- Live dock↔float flip is **our** design, not a cited vendor behavior.
+- **ClickUp / Notion / Slack** docking specifics did **not** survive verification
+  (no first-party source); only **Linear** did. Treat "those apps dock/float the
+  AI panel" as unconfirmed.
+- Synthesis (region set, capability matrix, collapse order, ~600–640px Main floor)
+  is opinionated recommendation aggregated from the verified claims + the existing
+  codebase — not a single cited spec.
+
+## Primary sources
+
+- Atlassian page-layout: https://atlaskit.atlassian.com/packages/design-system/page-layout · https://www.npmjs.com/package/@atlaskit/page-layout
+- Atlassian navigation-system: https://atlassian.design/components/navigation-system/layout
+- VS Code UI: https://code.visualstudio.com/docs/getstarted/userinterface · https://code.visualstudio.com/docs/configure/custom-layout · https://code.visualstudio.com/api/ux-guidelines/sidebars
+- PatternFly drawer: https://www.patternfly.org/components/drawer/design-guidelines/
+- Workday Canvas Side Panel: https://canvas.workday.com/components/containers/side-panel
+- Dockview: https://dockview.dev/ · https://dockview.dev/docs/core/groups/floatingGroups/
+- Linear collapsible sidebar: https://linear.app/changelog/unpublished-collapsible-sidebar
+- W3C APG window splitter: https://www.w3.org/WAI/ARIA/apg/patterns/windowsplitter/
+- react-resizable-panels: https://github.com/bvaughn/react-resizable-panels · allotment: https://github.com/johnwalley/allotment

--- a/examples/layout/Cargo.toml
+++ b/examples/layout/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "layout-demo"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[package.metadata.pocopine]
+port = 3011
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+pine-layout = { path = "../../crates/pine-layout" }
+pine-motion = { path = "../../crates/pine-motion" }
+pocopine = { path = "../../crates/pocopine" }
+serde = { workspace = true }
+wasm-bindgen = { workspace = true }
+
+[dependencies.web-sys]
+version = "0.3"
+features = ["Animation", "Document", "Element", "Window"]

--- a/examples/layout/README.md
+++ b/examples/layout/README.md
@@ -1,0 +1,59 @@
+# pine-layout — responsive app shell
+
+A styled showcase of [`pine-layout`](../../crates/pine-layout): a single
+`<pine-app-shell>` whose navigation adapts from an off-canvas **drawer**
+(narrow) → an icon **rail** (medium) → a full **sidebar** (wide) as the
+viewport crosses the Stylekit breakpoints.
+
+## Run
+
+```bash
+cargo run -p pocopine-cli -- dev --path examples/layout
+```
+
+Then open the URL it prints (the dev server defaults to
+<http://localhost:5243>; pass `--port` to pick another) and **resize the
+window**. The corner badge shows the live breakpoint tier.
+
+## The point: zero CSS in the library
+
+`pine-layout` ships no stylesheet. Every visual decision in this demo
+lives in [`styles.css`](./styles.css), keyed off the `data-*` hooks the
+components emit:
+
+| Hook | Where | Drives |
+|------|-------|--------|
+| `data-nav-mode="drawer\|rail\|sidebar"` | shell + sidebar + trigger | the whole adaptive layout |
+| `data-state="open\|closed"` | sidebar | the drawer slide-in |
+| `data-breakpoint="md"` | shell | (available for CSS / `pp-model`) |
+| `data-cols` / `data-span` / `data-gap` | grid / items | the 12-col content grid |
+
+The breakpoint is also two-way bound into app state via
+`pp-model:breakpoint="bp"` and rendered in the badge — proof the tier is
+available to logic, not just CSS.
+
+## What's exercised
+
+- `<pine-app-shell>` + Header / Sidebar / Content / Footer / Trigger —
+  adaptive nav, modal drawer (focus trap, scroll lock, **Esc** to close,
+  ARIA `aria-controls` wiring).
+- `<pine-container>` / `<pine-stack>` / `<pine-inline>` / `<pine-grid>` +
+  `<pine-grid-item>` — the headless structural primitives.
+- [`pine-motion`](../../crates/pine-motion) — the drawer slide is a
+  `pine_motion::animate(&sidebar, …, Spring::gentle())` fired from a
+  `#[watch(nav_open)]` (see `src/lib.rs`).
+
+## Notes
+
+- The drawer slide is animated **imperatively** with `pine-motion`, only
+  on a user toggle — *not* a CSS `transition`. That's deliberate: a
+  declarative `transition: transform` would also fire when a breakpoint
+  reflow flips the nav into drawer mode, animating an unwanted slide-out.
+  Driving it from the toggle means resizing into drawer width just snaps.
+- The drawer closes via the hamburger toggle or **Esc**. Scrim /
+  outside-click dismissal is deferred to `pine-layout` v2 (see
+  [RFC-103](../../rfcs/rfc-103-pine-layout.md) §10) — a capture-phase
+  outside listener would fight the toggle.
+- Responsive column counts (the grid collapsing to one column on narrow
+  screens) are a plain author media query in `styles.css`; the library
+  only emits the `data-cols` / `data-span` hooks.

--- a/examples/layout/index.html
+++ b/examples/layout/index.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>pine-layout — responsive app shell</title>
+  <!-- Hand-written CSS: pine-layout ships zero CSS, so the whole look
+       lives here, keyed off the components' data-* hooks. -->
+  <link rel="stylesheet" href="/styles.css" />
+</head>
+<body>
+  <div pp-app>
+    <layout-demo></layout-demo>
+  </div>
+  <script type="module">
+    import init from "/pkg/layout_demo.js";
+    init();
+  </script>
+</body>
+</html>

--- a/examples/layout/src/LayoutDemo.poco
+++ b/examples/layout/src/LayoutDemo.poco
@@ -1,0 +1,84 @@
+<div class="demo-root">
+  <pine-app-shell class="demo-shell" pp-model:breakpoint="bp" pp-model:nav_open="nav_open">
+
+    <pine-app-shell-header class="demo-header">
+      <pine-app-shell-trigger class="demo-burger" aria-label="Toggle navigation">
+        <span class="demo-burger-bars"></span>
+      </pine-app-shell-trigger>
+      <span class="demo-brand"><span class="demo-logo">◆</span> Pine&nbsp;Layout</span>
+      <span class="demo-hint">resize the window →</span>
+    </pine-app-shell-header>
+
+    <pine-app-shell-sidebar class="demo-sidebar" label="Primary navigation">
+      <nav class="demo-nav">
+        <a class="demo-nav-item is-active" href="#"><span class="demo-ico">▦</span><span class="nav-label">Dashboard</span></a>
+        <a class="demo-nav-item" href="#"><span class="demo-ico">◷</span><span class="nav-label">Activity</span></a>
+        <a class="demo-nav-item" href="#"><span class="demo-ico">⬡</span><span class="nav-label">Projects</span></a>
+        <a class="demo-nav-item" href="#"><span class="demo-ico">◐</span><span class="nav-label">Reports</span></a>
+        <a class="demo-nav-item" href="#"><span class="demo-ico">⚙</span><span class="nav-label">Settings</span></a>
+      </nav>
+    </pine-app-shell-sidebar>
+
+    <pine-app-shell-content class="demo-content">
+      <pine-container class="demo-container" size="lg">
+        <pine-stack class="demo-stack" gap="6">
+
+          <header class="demo-page-head">
+            <h1>Responsive app shell</h1>
+            <p>
+              The navigation is one <code>&lt;pine-app-shell&gt;</code>. It swaps between an off-canvas
+              <strong>drawer</strong>, an icon <strong>rail</strong>, and a full <strong>sidebar</strong>
+              as the viewport crosses the Stylekit breakpoints — driven entirely by the CSS in
+              <code>styles.css</code>. The library ships none.
+            </p>
+          </header>
+
+          <pine-inline class="demo-chips" gap="2" wrap="true">
+            <span class="demo-chip">base &lt; 640</span>
+            <span class="demo-chip">sm · 640</span>
+            <span class="demo-chip">md · 768 → rail</span>
+            <span class="demo-chip">lg · 1024 → rail</span>
+            <span class="demo-chip">xl · 1280 → sidebar</span>
+            <span class="demo-chip">2xl · 1536</span>
+          </pine-inline>
+
+          <pine-grid class="demo-grid" cols="12" gap="4">
+            <pine-grid-item class="demo-card" span="4">
+              <span class="demo-card-label">Nav mode</span>
+              <span class="demo-card-value">drawer · rail · sidebar</span>
+              <span class="demo-card-foot">derived from <code>data-breakpoint</code></span>
+            </pine-grid-item>
+            <pine-grid-item class="demo-card" span="4">
+              <span class="demo-card-label">Drawer a11y</span>
+              <span class="demo-card-value">focus trap · scroll lock</span>
+              <span class="demo-card-foot">Escape closes · ARIA wired</span>
+            </pine-grid-item>
+            <pine-grid-item class="demo-card" span="4">
+              <span class="demo-card-label">Styling</span>
+              <span class="demo-card-value">100% yours</span>
+              <span class="demo-card-foot">class + <code>data-*</code> hooks</span>
+            </pine-grid-item>
+          </pine-grid>
+
+          <section class="demo-note">
+            <h2>Try it</h2>
+            <ul>
+              <li>Narrow window → the hamburger appears; tap it to slide the <strong>drawer</strong> in, <kbd>Esc</kbd> to close.</li>
+              <li>Medium width → the drawer collapses to an icon <strong>rail</strong> (labels hidden by CSS).</li>
+              <li>Wide → a full <strong>sidebar</strong> with labels. The badge in the corner shows the live tier.</li>
+            </ul>
+          </section>
+
+        </pine-stack>
+      </pine-container>
+    </pine-app-shell-content>
+
+    <pine-app-shell-footer class="demo-footer">
+      <span>pine-layout — headless responsive primitives</span>
+      <span class="demo-footer-rfc">RFC-103</span>
+    </pine-app-shell-footer>
+
+  </pine-app-shell>
+
+  <span class="demo-bp" aria-hidden="true" pp-text="bp"></span>
+</div>

--- a/examples/layout/src/lib.rs
+++ b/examples/layout/src/lib.rs
@@ -1,0 +1,92 @@
+//! `pine-layout` showcase — a responsive application shell that adapts
+//! its navigation (drawer → rail → sidebar) as the viewport grows.
+//!
+//! `pine-layout` ships **zero CSS**: the look lives in `styles.css`,
+//! keyed off the `data-nav-mode` / `data-state` / `data-breakpoint`
+//! hooks the components emit. The drawer slide is animated with
+//! **`pine-motion`** — imperatively, only on toggle — so resizing
+//! *into* drawer width just snaps (no CSS transition is armed, so
+//! there's nothing to flash). Resize the window to watch it reflow.
+
+use pocopine::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(display = "contents")]
+pub struct LayoutDemo {
+    /// Live breakpoint, two-way bound from `<pine-app-shell>` via
+    /// `pp-model:breakpoint`. Drives the corner badge.
+    pub bp: String,
+    /// Drawer open state, two-way bound via `pp-model:nav_open`. The
+    /// `#[watch]` below animates the slide whenever it flips.
+    pub nav_open: bool,
+}
+
+#[handlers]
+impl LayoutDemo {
+    /// Animate the drawer with pine-motion on every open/close. We do
+    /// this imperatively (rather than a CSS `transition`) precisely so
+    /// a breakpoint-driven reflow into drawer mode doesn't animate —
+    /// only a real user toggle does.
+    #[watch(nav_open)]
+    fn on_nav_open(&mut self, open: bool, old: Option<bool>) {
+        // Skip the initial seed — only animate genuine toggles.
+        if old.is_some() {
+            slide_drawer(open);
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn slide_drawer(open: bool) {
+    use pine_motion::{animate, AnimationHandle, Tween};
+    use std::cell::RefCell;
+
+    // Retain the latest handle past this call (dropping it would cancel
+    // the WAAPI animation). One drawer in this demo → one slot.
+    thread_local! {
+        static SLIDE: RefCell<Option<AnimationHandle>> = const { RefCell::new(None) };
+    }
+
+    let Some(sidebar) = web_sys::window()
+        .and_then(|w| w.document())
+        .and_then(|d| d.query_selector(".pine-app-shell-sidebar").ok().flatten())
+    else {
+        return;
+    };
+    // Only the off-canvas drawer slides; the rail / sidebar are static.
+    if sidebar.get_attribute("data-nav-mode").as_deref() != Some("drawer") {
+        return;
+    }
+
+    let (from, to) = if open {
+        ("translateX(-100%)", "translateX(0)")
+    } else {
+        ("translateX(0)", "translateX(-100%)")
+    };
+    // A plain ease-out — smooth in, no spring overshoot.
+    let handle = animate(
+        &sidebar,
+        &[("transform", from, to)],
+        Tween::new().duration(240.0).ease_out(),
+    );
+    // pine-motion runs with `fill: forwards`, which would keep overriding
+    // the element's transform forever — even after a breakpoint reflow
+    // turns the sidebar back into an in-grid rail/sidebar (leaving it
+    // stuck off-canvas). Cancel the WAAPI animation once it finishes so
+    // the element falls back to its CSS (data-state-driven) transform in
+    // every mode. CSS already holds the matching end value, so there's no
+    // visible jump.
+    let anim = handle.raw().clone();
+    handle.on_finish(move || anim.cancel());
+    SLIDE.with(|s| *s.borrow_mut() = Some(handle));
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn slide_drawer(_open: bool) {}
+
+#[wasm_bindgen(start)]
+pub fn main() {
+    pine_layout::register_all();
+    App::new().register::<LayoutDemo>().run();
+}

--- a/examples/layout/styles.css
+++ b/examples/layout/styles.css
@@ -1,0 +1,247 @@
+/* ===========================================================================
+   pine-layout demo — ALL of the layout lives here, none of it in the library.
+   Every rule keys off a headless hook the components emit:
+     .demo-shell[data-nav-mode="drawer|rail|sidebar"]   ← adaptive nav
+     .demo-sidebar[data-state="open|closed"]            ← drawer slide
+     .demo-burger[data-nav-mode="drawer"]               ← show hamburger only when useful
+   =========================================================================== */
+
+:root {
+  --cocoa: #1a130c;
+  --cocoa-2: #241a10;
+  --amber: #f8ae45;
+  --amber-ink: #3a2a10;
+  --cream: #fbf7f0;
+  --card: #ffffff;
+  --ink: #2a2018;
+  --muted: #8a7d6d;
+  --line: #ece4d8;
+  --line-dark: #3a2c1c;
+  --sidebar-w: 16rem;
+  --rail-w: 4.5rem;
+  --header-h: 3.5rem;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--cream);
+  color: var(--ink);
+  font: 15px/1.5 system-ui, -apple-system, "Segoe UI", sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+code, kbd { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 0.85em; }
+code { color: #b5560f; background: #fff3e2; padding: 0.05em 0.35em; border-radius: 4px; }
+kbd { background: var(--cocoa); color: var(--cream); padding: 0.1em 0.4em; border-radius: 4px; }
+a { color: inherit; text-decoration: none; }
+
+/* ── shell grid — the only thing that changes per nav mode ──────────────── */
+
+.demo-shell {
+  display: grid;
+  min-height: 100vh;
+  grid-template-rows: var(--header-h) 1fr auto;
+  grid-template-columns: var(--sidebar-w) 1fr;
+  grid-template-areas:
+    "header  header"
+    "sidebar content"
+    "footer  footer";
+  /* Animate the rail <-> sidebar width reflow (same track count, so
+     the columns interpolate). drawer mode is a single column — a
+     different track count — so that boundary snaps, which is fine. */
+  transition: grid-template-columns 0.32s ease;
+}
+.demo-shell[data-nav-mode="rail"]    { grid-template-columns: var(--rail-w) 1fr; }
+.demo-shell[data-nav-mode="drawer"] {
+  grid-template-columns: 1fr;
+  grid-template-areas:
+    "header"
+    "content"
+    "footer";
+}
+
+.demo-header  { grid-area: header; }
+.demo-sidebar { grid-area: sidebar; }
+.demo-content { grid-area: content; }
+.demo-footer  { grid-area: footer; }
+
+/* ── header ─────────────────────────────────────────────────────────────── */
+
+.demo-header {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  display: flex;
+  align-items: center;
+  gap: 0.85rem;
+  padding: 0 1.1rem;
+  background: color-mix(in oklab, var(--card) 88%, transparent);
+  backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--line);
+}
+.demo-brand { font-weight: 650; letter-spacing: -0.01em; display: flex; align-items: center; gap: 0.5rem; }
+.demo-logo  { color: var(--amber); font-size: 1.15rem; }
+.demo-hint  { margin-left: auto; color: var(--muted); font-size: 0.8rem; }
+
+/* hamburger — only meaningful (and only shown) in drawer mode */
+.demo-burger {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  background: var(--card);
+  color: var(--ink);
+  cursor: pointer;
+}
+.demo-burger[data-nav-mode="drawer"] { display: inline-flex; }
+.demo-burger:hover { background: #fff7ec; border-color: var(--amber); }
+.demo-burger-bars,
+.demo-burger-bars::before,
+.demo-burger-bars::after {
+  content: "";
+  display: block;
+  width: 18px;
+  height: 2px;
+  border-radius: 2px;
+  background: currentColor;
+}
+.demo-burger-bars { position: relative; }
+.demo-burger-bars::before { position: absolute; top: -6px; }
+.demo-burger-bars::after  { position: absolute; top: 6px; }
+
+/* ── sidebar — cocoa surface, amber accents ─────────────────────────────── */
+
+.demo-sidebar {
+  background: var(--cocoa);
+  color: #cdbfab;
+  border-right: 1px solid var(--line-dark);
+  padding: 0.85rem 0.6rem;
+  overflow-y: auto;
+}
+.demo-nav { display: flex; flex-direction: column; gap: 0.2rem; }
+.demo-nav-item {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+  padding: 0.6rem 0.7rem;
+  border-radius: 9px;
+  color: #cdbfab;
+  white-space: nowrap;
+  transition: background 0.12s, color 0.12s;
+}
+.demo-ico { width: 1.25rem; text-align: center; font-size: 1.05rem; flex: none; }
+.demo-nav-item:hover { background: var(--cocoa-2); color: var(--cream); }
+.demo-nav-item.is-active { background: var(--amber); color: var(--amber-ink); font-weight: 600; }
+
+/* RAIL: collapse to icons only */
+.demo-sidebar[data-nav-mode="rail"] .nav-label { display: none; }
+.demo-sidebar[data-nav-mode="rail"] .demo-nav-item { justify-content: center; padding: 0.6rem 0; }
+
+/* DRAWER: off-canvas. data-state drives the resting transform
+   instantly (no CSS transition) — so a breakpoint reflow into drawer
+   width just snaps. The slide between these two states is animated
+   imperatively by pine-motion in lib.rs, fired only on a user toggle. */
+.demo-sidebar[data-nav-mode="drawer"] {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  width: var(--sidebar-w);
+  z-index: 40;
+  transform: translateX(-100%);
+  box-shadow: 0 0 0 100vmax transparent;
+}
+.demo-sidebar[data-nav-mode="drawer"][data-state="open"] {
+  transform: translateX(0);
+  box-shadow: 0.5rem 0 2.5rem rgba(0, 0, 0, 0.35), 0 0 0 100vmax rgba(26, 19, 12, 0.45);
+}
+
+/* ── content ────────────────────────────────────────────────────────────── */
+
+.demo-content { padding: 1.75rem 1.25rem 2.5rem; }
+.demo-container { max-width: 72rem; margin-inline: auto; width: 100%; }
+.demo-stack { display: flex; flex-direction: column; gap: 1.6rem; }
+
+.demo-page-head h1 { margin: 0 0 0.4rem; font-size: 1.7rem; letter-spacing: -0.02em; }
+.demo-page-head p  { margin: 0; max-width: 60ch; color: #5b4f40; }
+
+.demo-chips { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+.demo-chip {
+  font-size: 0.78rem;
+  padding: 0.3rem 0.6rem;
+  border-radius: 999px;
+  background: #fff;
+  border: 1px solid var(--line);
+  color: #6b5d4c;
+}
+
+/* responsive 12-col grid (author-written — the library only emits data-cols) */
+.demo-grid { display: grid; grid-template-columns: repeat(12, 1fr); gap: 1rem; }
+.demo-card {
+  grid-column: span 4;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 1.1rem;
+  background: var(--card);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  box-shadow: 0 1px 2px rgba(26, 19, 12, 0.04);
+}
+.demo-card-label { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); }
+.demo-card-value { font-size: 1.1rem; font-weight: 650; color: var(--cocoa); }
+.demo-card-foot  { font-size: 0.8rem; color: #6b5d4c; }
+@media (max-width: 720px) {
+  .demo-grid { grid-template-columns: 1fr; }
+  .demo-card { grid-column: auto; }
+}
+
+.demo-note {
+  background: #fff;
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--amber);
+  border-radius: 12px;
+  padding: 1.1rem 1.25rem;
+}
+.demo-note h2 { margin: 0 0 0.5rem; font-size: 1rem; }
+.demo-note ul { margin: 0; padding-left: 1.1rem; color: #5b4f40; }
+.demo-note li { margin: 0.3rem 0; }
+
+/* ── footer ─────────────────────────────────────────────────────────────── */
+
+.demo-footer {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.9rem 1.25rem;
+  border-top: 1px solid var(--line);
+  background: #fff;
+  color: var(--muted);
+  font-size: 0.8rem;
+}
+.demo-footer-rfc { margin-left: auto; font-family: ui-monospace, monospace; color: #b5560f; }
+
+/* ── live breakpoint badge (fixed corner) ───────────────────────────────── */
+
+.demo-bp {
+  position: fixed;
+  right: 0.9rem;
+  bottom: 0.9rem;
+  z-index: 60;
+  min-width: 2.5rem;
+  padding: 0.3rem 0.65rem;
+  text-align: center;
+  font: 600 0.8rem/1 ui-monospace, monospace;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--amber-ink);
+  background: var(--amber);
+  border-radius: 999px;
+  box-shadow: 0 4px 14px rgba(26, 19, 12, 0.25);
+}
+.demo-bp:empty::before { content: "…"; }

--- a/examples/workspace/Cargo.toml
+++ b/examples/workspace/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "workspace-demo"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+[package.metadata.pocopine]
+port = 3012
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+pine-layout = { path = "../../crates/pine-layout" }
+pocopine = { path = "../../crates/pocopine" }
+serde = { workspace = true }
+wasm-bindgen = { workspace = true }

--- a/examples/workspace/README.md
+++ b/examples/workspace/README.md
@@ -1,0 +1,40 @@
+# pine-workspace — content-heavy multi-region shell
+
+A showcase of [`pine-layout`](../../crates/pine-layout)'s **workspace** family
+(RFC-105): a resizable rail/sidebar │ main │ a resizable detail **Aside** │ a
+collapsible bottom console — the Atlassian/VS-Code-style frame for productivity
+apps.
+
+## Run
+
+```bash
+cargo run -p pocopine-cli -- dev --path examples/workspace
+```
+
+Open the URL it prints (defaults to <http://localhost:5243>; the configured port
+is 3012 — pass `--port` to choose).
+
+## Try it
+
+- **Drag the splitters** between regions to resize (double-click a handle to
+  reset; arrow keys nudge when focused).
+- **Detail** toggles the trailing Aside (a resizable docked column).
+- **Resize the window**: the sidebar auto-collapses to a rail (hover it for the
+  flyout).
+- **Console** toggles the bottom panel (drag its top edge to resize).
+
+## Zero CSS in the library
+
+`pine-layout` ships no stylesheet. The whole layout in
+[`styles.css`](./styles.css) keys off the regions' headless hooks:
+
+| Hook | Region | Drives |
+|------|--------|--------|
+| `--pine-sidebar-size` / `--pine-aside-size` / `--pine-bottom-size` | sidebar / aside / bottom | the resizable dimension |
+| `data-state="expanded\|collapsed"` / `data-flyout` | sidebar | rail collapse + hover flyout |
+| `data-aside-state="open\|closed"` | aside | show / hide |
+| `data-dragging` | any resizable | suppress transitions mid-drag |
+| `data-breakpoint` | workspace root | the live tier (badge) |
+
+Region state (sidebar collapsed, aside open, bottom open) is held in app fields
+and two-way-bound with `pp-model` — see `src/lib.rs` / `WorkspaceDemo.poco`.

--- a/examples/workspace/index.html
+++ b/examples/workspace/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>pine-workspace — multi-region shell</title>
+  <!-- pine-layout ships zero CSS: the whole frame is in styles.css. -->
+  <link rel="stylesheet" href="/styles.css" />
+</head>
+<body>
+  <div pp-app>
+    <workspace-demo></workspace-demo>
+  </div>
+  <script type="module">
+    import init from "/pkg/workspace_demo.js";
+    init();
+  </script>
+</body>
+</html>

--- a/examples/workspace/src/WorkspaceDemo.poco
+++ b/examples/workspace/src/WorkspaceDemo.poco
@@ -1,0 +1,70 @@
+<pine-workspace class="ws" pp-model:breakpoint="bp">
+
+  <pine-workspace-header class="ws-header">
+    <button class="ws-icon-btn" pp-on:click="toggle_sidebar" aria-label="Toggle sidebar">
+      <span class="ws-burger"></span>
+    </button>
+    <span class="ws-brand"><span class="ws-logo">◆</span>&nbsp;Pine&nbsp;Workspace</span>
+    <span class="ws-grow"></span>
+    <button class="ws-btn" pp-on:click="toggle_bottom">Console</button>
+    <button class="ws-btn ws-btn-accent" pp-on:click="toggle_aside">Detail</button>
+  </pine-workspace-header>
+
+  <pine-workspace-sidebar class="ws-sidebar" label="Primary navigation" pp-model:collapsed="sidebar_collapsed">
+    <nav class="ws-nav">
+      <a class="ws-nav-item is-active" href="#"><span class="ws-ico">▦</span><span class="nav-label">Dashboard</span></a>
+      <a class="ws-nav-item" href="#"><span class="ws-ico">◷</span><span class="nav-label">Activity</span></a>
+      <a class="ws-nav-item" href="#"><span class="ws-ico">⬡</span><span class="nav-label">Projects</span></a>
+      <a class="ws-nav-item" href="#"><span class="ws-ico">◐</span><span class="nav-label">Reports</span></a>
+      <a class="ws-nav-item" href="#"><span class="ws-ico">⚙</span><span class="nav-label">Settings</span></a>
+    </nav>
+  </pine-workspace-sidebar>
+
+  <pine-workspace-main class="ws-main">
+    <div class="ws-main-inner">
+      <h1>Workspace shell</h1>
+      <p>
+        A content-heavy frame: a resizable rail/sidebar, the main region, and a trailing
+        <strong>Aside</strong> — a resizable docked column you can open and close.
+        <code>pine-layout</code> ships no CSS — this entire layout is author CSS reacting
+        to <code>data-*</code> + <code>--pine-*-size</code>.
+      </p>
+      <ul class="ws-tips">
+        <li>Drag the splitters between regions to resize (double-click to reset).</li>
+        <li>Toggle the trailing <strong>Detail</strong> panel and the <strong>Console</strong>.</li>
+        <li>Narrow the window: the sidebar auto-collapses to a rail (hover it for the flyout).</li>
+      </ul>
+      <div class="ws-cards">
+        <div class="ws-card"><span>Sidebar</span><strong>resize · rail · flyout</strong></div>
+        <div class="ws-card"><span>Aside</span><strong>resize · open / close</strong></div>
+        <div class="ws-card"><span>Bottom</span><strong>resize · collapse</strong></div>
+      </div>
+    </div>
+  </pine-workspace-main>
+
+  <pine-workspace-aside class="ws-aside" label="Detail panel" pp-model:open="aside_open">
+    <div class="ws-aside-inner">
+      <header class="ws-aside-head">
+        <strong>Detail</strong>
+        <button class="ws-icon-btn" pp-on:click="toggle_aside" aria-label="Close detail">✕</button>
+      </header>
+      <p>A task detail / AI / comments panel — a resizable column you can open and close.</p>
+      <p class="ws-muted">Drag the left edge to resize (double-click to reset).</p>
+    </div>
+  </pine-workspace-aside>
+
+  <pine-workspace-bottom class="ws-bottom" label="Console" pp-model:open="bottom_open">
+    <header class="ws-bottom-head">
+      <strong>Console</strong>
+      <button class="ws-icon-btn" pp-on:click="toggle_bottom" aria-label="Close console">✕</button>
+    </header>
+    <pre class="ws-console">pine-workspace ready · drag the top edge to resize this panel</pre>
+  </pine-workspace-bottom>
+
+  <pine-workspace-footer class="ws-footer">
+    <span>pine-workspace — RFC-105</span>
+    <span class="ws-grow"></span>
+    <span class="ws-bp" aria-hidden="true" pp-text="bp"></span>
+  </pine-workspace-footer>
+
+</pine-workspace>

--- a/examples/workspace/src/lib.rs
+++ b/examples/workspace/src/lib.rs
@@ -1,0 +1,55 @@
+//! `pine-workspace` showcase (RFC-105) — a content-heavy multi-region
+//! shell: resizable rail/sidebar │ main │ a resizable detail Aside │ a
+//! collapsible bottom console.
+//!
+//! `pine-layout` ships **zero CSS** — the whole frame is the author CSS in
+//! `styles.css`, keyed off the regions' `data-*` state + the
+//! `--pine-*-size` width/height custom properties. Region state is held in
+//! app fields and two-way-bound with `pp-model`. Drag the splitters to
+//! resize; narrow the window to watch the sidebar auto-rail.
+
+use pocopine::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+#[component(display = "contents")]
+pub struct WorkspaceDemo {
+    /// Live breakpoint (badge), bound from `<pine-workspace>`.
+    pub bp: String,
+    /// Sidebar collapsed-to-rail state (`pp-model:collapsed`).
+    pub sidebar_collapsed: bool,
+    /// Aside open (`pp-model:open`).
+    pub aside_open: bool,
+    /// Bottom console open (`pp-model:open`).
+    pub bottom_open: bool,
+}
+
+impl Default for WorkspaceDemo {
+    fn default() -> Self {
+        Self {
+            bp: String::new(),
+            sidebar_collapsed: false,
+            aside_open: true,
+            bottom_open: false,
+        }
+    }
+}
+
+#[handlers]
+impl WorkspaceDemo {
+    pub fn toggle_sidebar(&mut self) {
+        self.sidebar_collapsed = !self.sidebar_collapsed;
+    }
+    pub fn toggle_aside(&mut self) {
+        self.aside_open = !self.aside_open;
+    }
+    pub fn toggle_bottom(&mut self) {
+        self.bottom_open = !self.bottom_open;
+    }
+}
+
+#[wasm_bindgen(start)]
+pub fn main() {
+    pine_layout::register_all();
+    App::new().register::<WorkspaceDemo>().run();
+}

--- a/examples/workspace/styles.css
+++ b/examples/workspace/styles.css
@@ -1,0 +1,175 @@
+/* ===========================================================================
+   pine-workspace demo — the ENTIRE layout is here; the library ships none.
+   Regions expose: data-state / data-aside-mode / data-flyout / data-dragging
+   and a --pine-*-size custom property for the one dynamic (resizable) dimension.
+   =========================================================================== */
+
+:root {
+  --cocoa: #1a130c;
+  --cocoa-2: #241a10;
+  --amber: #f8ae45;
+  --amber-ink: #3a2a10;
+  --cream: #fbf7f0;
+  --card: #ffffff;
+  --ink: #2a2018;
+  --muted: #8a7d6d;
+  --line: #ece4d8;
+  --line-dark: #3a2c1c;
+  --header-h: 48px;
+}
+
+* { box-sizing: border-box; }
+body { margin: 0; font: 14px/1.5 system-ui, -apple-system, "Segoe UI", sans-serif; color: var(--ink); }
+code { font-family: ui-monospace, Menlo, monospace; font-size: 0.85em; color: #b5560f; background: #fff3e2; padding: 0.05em 0.35em; border-radius: 4px; }
+a { color: inherit; text-decoration: none; }
+
+/* While any region is mid-drag, freeze transitions so the splitter tracks
+   the pointer 1:1 (the lesson from the v1 drawer). */
+[data-dragging] { transition: none !important; }
+
+/* ── the grid ──────────────────────────────────────────────────────────── */
+
+.ws {
+  display: grid;
+  height: 100vh;
+  grid-template-columns: auto 1fr auto;
+  grid-template-rows: var(--header-h) 1fr auto auto;
+  grid-template-areas:
+    "header  header  header"
+    "sidebar main    aside"
+    "sidebar bottom  aside"
+    "footer  footer  footer";
+  background: var(--cream);
+  position: relative;
+  overflow: hidden;
+}
+.ws-header { grid-area: header; }
+.ws-sidebar { grid-area: sidebar; }
+.ws-main   { grid-area: main; }
+.ws-aside  { grid-area: aside; }
+.ws-bottom { grid-area: bottom; }
+.ws-footer { grid-area: footer; }
+
+/* ── header ────────────────────────────────────────────────────────────── */
+
+.ws-header {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0 0.75rem;
+  background: color-mix(in oklab, var(--card) 90%, transparent);
+  border-bottom: 1px solid var(--line);
+  z-index: 30;
+}
+.ws-brand { font-weight: 650; letter-spacing: -0.01em; }
+.ws-logo { color: var(--amber); }
+.ws-grow { flex: 1; }
+.ws-btn {
+  font: inherit; font-size: 0.82rem; padding: 0.35rem 0.7rem; border-radius: 8px;
+  border: 1px solid var(--line); background: var(--card); color: var(--ink); cursor: pointer;
+}
+.ws-btn:hover { border-color: var(--amber); background: #fff7ec; }
+.ws-btn-accent { background: var(--amber); border-color: var(--amber); color: var(--amber-ink); font-weight: 600; }
+.ws-icon-btn {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 2rem; height: 2rem; border: 1px solid var(--line); border-radius: 8px;
+  background: var(--card); color: var(--ink); cursor: pointer;
+}
+.ws-icon-btn:hover { border-color: var(--amber); }
+.ws-burger, .ws-burger::before, .ws-burger::after { content: ""; display: block; width: 16px; height: 2px; background: currentColor; border-radius: 2px; }
+.ws-burger { position: relative; }
+.ws-burger::before { position: absolute; top: -5px; }
+.ws-burger::after  { position: absolute; top: 5px; }
+
+/* ── sidebar: width from the var; collapses to a rail; hover flyout ───── */
+
+.ws-sidebar {
+  position: relative;
+  width: var(--pine-sidebar-size, 260px);
+  background: var(--cocoa);
+  color: #cdbfab;
+  border-right: 1px solid var(--line-dark);
+  padding: 0.6rem 0.5rem;
+  overflow: hidden;
+  transition: width 0.16s ease;
+}
+.ws-nav { display: flex; flex-direction: column; gap: 0.15rem; }
+.ws-nav-item { display: flex; align-items: center; gap: 0.75rem; padding: 0.55rem 0.6rem; border-radius: 8px; color: #cdbfab; white-space: nowrap; }
+.ws-ico { width: 1.2rem; text-align: center; flex: none; font-size: 1rem; }
+.ws-nav-item:hover { background: var(--cocoa-2); color: var(--cream); }
+.ws-nav-item.is-active { background: var(--amber); color: var(--amber-ink); font-weight: 600; }
+
+.ws-sidebar[data-state="collapsed"] .nav-label { display: none; }
+.ws-sidebar[data-state="collapsed"] .ws-nav-item { justify-content: center; padding: 0.55rem 0; }
+/* flyout: overlay-expand the rail on hover (doesn't push content) */
+.ws-sidebar[data-state="collapsed"][data-flyout] {
+  position: absolute; inset: 0 auto 0 0; z-index: 60; width: 240px;
+  box-shadow: 0.35rem 0 1.5rem rgba(0, 0, 0, 0.35);
+}
+.ws-sidebar[data-state="collapsed"][data-flyout] .nav-label { display: inline; }
+.ws-sidebar[data-state="collapsed"][data-flyout] .ws-nav-item { justify-content: flex-start; padding: 0.55rem 0.6rem; }
+
+/* ── resize handles (sidebar right edge, aside left edge, bottom top edge) ─ */
+
+.pine-workspace-sidebar-resize,
+.pine-workspace-aside-resize { position: absolute; top: 0; width: 10px; height: 100%; cursor: ew-resize; z-index: 5; }
+.pine-workspace-sidebar-resize { right: 0; }
+.pine-workspace-aside-resize { left: 0; }
+.pine-workspace-bottom-resize { position: absolute; left: 0; right: 0; top: 0; height: 10px; cursor: ns-resize; z-index: 5; }
+/* a 2px indicator flush on the region's edge (= the visual border) */
+.pine-workspace-sidebar-resize::after { content: ""; position: absolute; top: 0; bottom: 0; right: 0; width: 2px; }
+.pine-workspace-aside-resize::after { content: ""; position: absolute; top: 0; bottom: 0; left: 0; width: 2px; }
+.pine-workspace-bottom-resize::after { content: ""; position: absolute; left: 0; right: 0; top: 0; height: 2px; }
+.pine-workspace-sidebar-resize:hover::after,
+.pine-workspace-aside-resize:hover::after,
+.pine-workspace-bottom-resize:hover::after { background: var(--amber); }
+
+/* ── main ──────────────────────────────────────────────────────────────── */
+
+.ws-main { overflow: auto; }
+.ws-main-inner { max-width: 64rem; margin-inline: auto; padding: 1.75rem 1.5rem; }
+.ws-main h1 { margin: 0 0 0.5rem; font-size: 1.6rem; letter-spacing: -0.02em; }
+.ws-main p { max-width: 60ch; color: #5b4f40; }
+.ws-tips { color: #5b4f40; padding-left: 1.1rem; }
+.ws-tips li { margin: 0.3rem 0; }
+.ws-cards { display: grid; grid-template-columns: repeat(3, 1fr); gap: 0.9rem; margin-top: 1.25rem; }
+.ws-card { background: var(--card); border: 1px solid var(--line); border-radius: 12px; padding: 1rem; display: flex; flex-direction: column; gap: 0.25rem; }
+.ws-card span { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--muted); }
+.ws-card strong { color: var(--cocoa); }
+@media (max-width: 700px) { .ws-cards { grid-template-columns: 1fr; } }
+
+/* ── aside: anchored column ↔ floating overlay ↔ closed ─────────────────── */
+
+.ws-aside {
+  position: relative;
+  width: var(--pine-aside-size, 320px);
+  background: var(--card);
+  border-left: 1px solid var(--line);
+  overflow: auto;
+  transition: width 0.16s ease;
+}
+.ws-aside[data-aside-state="closed"] { display: none; }
+.ws-aside-inner { padding: 1rem 1.1rem; }
+.ws-aside-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.5rem; }
+.ws-muted { color: var(--muted); font-size: 0.85rem; }
+
+/* ── bottom console ────────────────────────────────────────────────────── */
+
+.ws-bottom {
+  position: relative;
+  height: var(--pine-bottom-size, 240px);
+  background: var(--cocoa);
+  color: #cdbfab;
+  border-top: 1px solid var(--line-dark);
+  overflow: auto;
+}
+.ws-bottom[data-state="closed"] { display: none; }
+.ws-bottom-head { display: flex; align-items: center; justify-content: space-between; padding: 0.4rem 0.75rem; border-bottom: 1px solid var(--line-dark); }
+.ws-bottom-head .ws-icon-btn { background: transparent; border-color: var(--line-dark); color: #cdbfab; }
+.ws-console { margin: 0; padding: 0.75rem; font-family: ui-monospace, Menlo, monospace; font-size: 0.82rem; color: #b9a98f; }
+
+/* ── footer / status bar ───────────────────────────────────────────────── */
+
+.ws-footer { display: flex; align-items: center; gap: 0.75rem; padding: 0.3rem 0.9rem; background: var(--card); border-top: 1px solid var(--line); color: var(--muted); font-size: 0.78rem; }
+.ws-bp { font-family: ui-monospace, monospace; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: var(--amber-ink); background: var(--amber); border-radius: 999px; padding: 0.1rem 0.5rem; }
+.ws-bp:empty::before { content: "…"; }

--- a/rfcs/rfc-103-pine-layout.md
+++ b/rfcs/rfc-103-pine-layout.md
@@ -1,0 +1,187 @@
+# RFC 103 - `pine-layout`: headless responsive layout primitives
+
+| Field | Value |
+|---|---|
+| **Status** | Implemented (v1 — Foundation + AppShell; SplitPane/ListDetail deferred to v2) |
+| **Author** | pocopine team |
+| **Created** | 2026-06-13 |
+| **Related** | [`rfc-092-pocopine-stylekit.md`](./rfc-092-pocopine-stylekit.md) (breakpoint scale + container queries this crate aligns to), [`docs/internal/research/layout-design-systems.md`](../docs/internal/research/layout-design-systems.md) (fact-checked Apple/Material/Atlassian research base), core Pine (`crates/pine` — the headless / zero-CSS doctrine) |
+
+## 1. Summary
+
+`pine-layout` is a new Pine sub-library for **scaffolding responsive
+applications**. It ships **zero CSS** — exactly like core Pine. Its
+value is not opinions about how layouts *look*; it is:
+
+1. **One canonical breakpoint vocabulary** (`base`/`sm`/`md`/`lg`/`xl`/
+   `2xl`) resolved from the viewport, surfaced three ways — a
+   `data-breakpoint` attribute (for CSS), a `BREAKPOINT`/`SHELL`
+   context (for descendant components), and a `pp:update:breakpoint`
+   model event (for app logic).
+2. **An adaptive-navigation state machine** (`<pine-app-shell>`) that
+   derives a `nav_mode` of `drawer` → `rail` → `sidebar` from the
+   breakpoint and manages the modal-drawer behavior (focus trap,
+   scroll lock, Escape, ARIA) — leaving every pixel of styling to the
+   author.
+3. **A small set of thin structural primitives** (`Container`,
+   `Stack`, `Inline`, `Grid`/`GridItem`) that give a consistent,
+   documented vocabulary + `data-*` hooks for author CSS or Stylekit
+   utilities.
+
+It is a *responsiveness-behavior* library, not a CSS library.
+
+## 2. Motivation & prior art
+
+The design was grounded in a fact-checked sweep of the three major
+design systems (full citations in the research doc):
+
+| Dimension | Apple HIG | Material 3 | Atlassian DS |
+|---|---|---|---|
+| Size model | `compact`/`regular` | window size classes | **6 px breakpoints** `xxs…xl` |
+| Grid | Auto Layout / stacks | 4/8dp grid | **2→6→12 cols** |
+| Spacing | 8pt baseline | 4dp/8dp | **8px base**, `space.0…space.1000` |
+| Multi-pane | Split View (⅓/⅔) | List-Detail · Feed · Supporting (50/50→70/30) | grid-driven |
+| Adaptive nav | tab bar → sidebar/split | bottom bar → rail → drawer | side nav |
+| Reflow rule | collapse in compact | **combined-min-width** (`SlidingPaneLayout`) | column count |
+
+All three converge on: **named viewport tiers → a few layout
+primitives → canonical multi-pane patterns that reflow narrow→wide**,
+and diverge on exact numbers (and unit — px vs dp vs pt). The one
+portable algorithm worth stealing is Android's *combined-min-width*
+pane-reflow rule (deferred to v2 with SplitPane).
+
+## 3. The decisive constraint: align to Stylekit
+
+`pocopine-stylekit` already ships the Tailwind breakpoint scale
+(`crates/pocopine-stylekit/src/registry.rs:3140`):
+
+| tier | min-width |
+|------|-----------|
+| `sm` | 640px |
+| `md` | 768px |
+| `lg` | 1024px |
+| `xl` | 1280px |
+| `2xl`| 1536px |
+
+`pine-layout`'s reactive breakpoint **must** resolve to these exact
+thresholds, or `data-breakpoint == "md"` and the `md:` utility prefix
+would disagree. This settles the "Atlassian-6 vs Material-tiers"
+question the research left open: **reuse Stylekit's 5** (plus `base`).
+
+## 4. The headless contract
+
+No `.css` file, no `style=` for visual properties. Every component
+exposes state four ways:
+
+```
+1. semantic class ....... <div class="pine-grid">                  (author CSS target)
+2. data-* attributes .... data-breakpoint="md"  data-cols="12"     (attribute selectors)
+                          data-nav-mode="rail"  data-state="open"
+3. reactive context ..... create_context!(SHELL) + child #[observe(SHELL)]
+4. model events ......... #[model] breakpoint / nav_open  (pp:update:*, pp-model bind)
+```
+
+The author writes the layout CSS, or drops Stylekit utilities straight
+onto the elements (`<pine-grid class="grid grid-cols-12 md:grid-cols-6">`).
+Stylekit only scans app source (not dependency crates), so the crate
+deliberately self-contains its contract in `data-*`/context/model and
+never relies on the app's Stylekit glob picking up its templates.
+
+## 5. Breakpoint engine — `src/breakpoint.rs`
+
+- `enum Breakpoint { Base, Sm, Md, Lg, Xl, Xxl }` with `as_str`,
+  `from_token`, `rank`, `min_width`, and an ascending `TIERS` table.
+- `install(on_change)` registers one `matchMedia("(min-width: Npx)")`
+  per threshold (mirroring the established `prefers-reduced-motion`
+  pattern in `pocopine-core/src/animate/motion.rs`), resolves the
+  largest matching tier, calls `on_change` on every crossing, and
+  detaches all listeners on scope unmount. The initial value is seeded
+  through `tick::next` to clear the `on_ready` immutable borrow.
+- **wasm-gated**: on non-wasm / SSR there is no viewport, so the
+  breakpoint stays at its configured `initial` (default `base`).
+
+`<pine-breakpoint>` is a thin standalone provider over the engine for
+non-AppShell pages.
+
+## 6. AppShell — adaptive-nav state machine
+
+`nav_mode` is derived from the breakpoint and the `rail_at` /
+`sidebar_at` thresholds (defaults `md` / `xl`):
+
+```
+breakpoint:  base   sm     md    lg     xl      2xl
+nav_mode:    drawer drawer rail  rail   sidebar sidebar
+             └ off-canvas ┘     └ rail ┘  └ full sidebar ┘
+```
+
+Six parts, all headless (`#[component(role = "panel")]` → `<div>` with
+landmark ARIA `role` attributes, matching how `pine::separator` sets
+its role):
+
+| Tag | Role | Behavior |
+|---|---|---|
+| `<pine-app-shell>` | `scope` | owns the engine + state machine; provides `SHELL`; `#[model] breakpoint`, `#[model] nav_open`; emits `data-breakpoint`/`data-nav-mode`/`data-nav-open` |
+| `<pine-app-shell-header>` | `banner` | landmark region |
+| `<pine-app-shell-sidebar>` | `navigation` | adaptive nav; `data-nav-mode`/`data-state`; in drawer mode: focus trap + scroll lock + Escape |
+| `<pine-app-shell-content>` | `main` | landmark region |
+| `<pine-app-shell-footer>` | `contentinfo` | landmark region |
+| `<pine-app-shell-trigger>` | `interactive` (`<button>`) | hamburger toggle; `aria-expanded` + `aria-controls` → sidebar id |
+
+Growing the viewport out of drawer mode auto-closes an open drawer so
+focus/scroll are released. The drawer's modal runtime (saved focus +
+trap handle) lives in a per-scope thread-local side-table keyed by the
+sidebar's scope id — the same shape `pine::overlay` uses, since those
+handles aren't serde-friendly component fields. The sidebar reacts to
+`nav_open` via `watch_scope_field_scoped` (the proven cross-scope watch
+Splitter uses), not an `#[observe]`→`#[watch]` chain.
+
+## 7. Structural primitives
+
+All `#[component(role = "panel")]`, all headless — they emit a class +
+`data-*` mirrors of their props and nothing else:
+
+- `<pine-container>` — `size`, `safe_area`
+- `<pine-stack>` — `gap`, `align`, `justify`
+- `<pine-inline>` — `gap`, `align`, `justify`, `wrap`
+- `<pine-grid>` (default `cols="12"`) + `<pine-grid-item>` (`span`, `start`)
+
+## 8. Accessibility
+
+Landmark roles on every shell region; `<button>` trigger with
+`aria-expanded`/`aria-controls`; drawer focus trap + scroll lock +
+Escape + focus restore. Breakpoint changes mutate `data-*` only — no
+focus or scroll side-effects.
+
+## 9. Testing
+
+- **Host unit tests** (`cargo test -p pine-layout`, deterministic, no
+  DOM): the full `Breakpoint` enum and the `nav_mode` state machine
+  across all tiers + custom thresholds + toggle/open/close semantics +
+  drawer auto-close.
+- **Browser tests** (`wasm-pack test --firefox --headless`): rendered
+  `data-*` hooks, ARIA wiring (trigger `aria-controls` → sidebar id),
+  and the drawer toggle.
+
+## 10. Deliberate non-goals / deferred to v2
+
+- **Scrim / outside-click drawer dismissal.** A capture-phase
+  `@click.outside` on the sidebar treats the toggle as "outside" and
+  cancels it (the known Pine dropdown trigger-while-open bug). v1 ships
+  Escape + toggle; a dedicated backdrop sub-component is the v2 fix.
+- **`<pine-split-pane>` / `<pine-list-detail>`** multi-pane reflow via
+  the combined-min-width rule (`ResizeObserver`; ⅓/⅔ + 50/50/70-30).
+- **Container-query-driven** component responsiveness (`@container` —
+  Stylekit already supports it).
+- **`pocopine` umbrella re-export** — apps `use pine_layout::…` until
+  the API stabilizes (per the defer-umbrella-reexports doctrine).
+
+## 11. Implementation status (v1)
+
+| Unit | Status |
+|---|---|
+| Crate scaffold + workspace registration | ✅ |
+| Breakpoint engine + `<pine-breakpoint>` | ✅ |
+| `Container`/`Stack`/`Inline`/`Grid`/`GridItem` | ✅ |
+| AppShell compound (6 parts) + nav state machine | ✅ |
+| Host unit tests (9) + browser tests (6) | ✅ green |
+| SplitPane / ListDetail · scrim dismissal · container queries | ⏳ v2 |

--- a/rfcs/rfc-105-pine-workspace.md
+++ b/rfcs/rfc-105-pine-workspace.md
@@ -1,0 +1,147 @@
+# RFC 105 - `pine-workspace`: content-heavy multi-region workspace shell
+
+| Field | Value |
+|---|---|
+| **Status** | Implemented (full region set) |
+| **Author** | pocopine team |
+| **Created** | 2026-06-14 |
+| **Related** | [`rfc-103-pine-layout.md`](./rfc-103-pine-layout.md) (the v1 AppShell + breakpoint engine this builds on), [`docs/internal/research/workspace-shell-layouts.md`](../docs/internal/research/workspace-shell-layouts.md) (fact-checked Atlassian/VS Code/PatternFly/Workday/Dockview research), `crates/pine/src/splitter` (the resize reference — *not* a dependency) |
+
+## 1. Summary
+
+`pine-layout`'s v1 `<pine-app-shell>` (RFC-103) covers the **leading** edge of an
+app frame — adaptive `drawer→rail→sidebar` nav. RFC-105 adds the **trailing**
+edge for content-heavy / productivity apps: a separate **`<pine-workspace>`**
+family with a multi-region frame —
+
+```
+ [panel] rail/sidebar │ main │ detail aside │ [panel]
+                              └── bottom ──┘
+```
+
+— where the trailing **Aside is a resizable docked column**, the **Sidebar**
+resizes + collapses to a rail with a hover flyout, and a **Bottom** panel
+resizes vertically. (A floating/overlay mode for the Aside was prototyped and
+**deferred** — see §6.) Still **headless** (zero CSS): regions emit
+a class + `data-*` state + a `--pine-*-size` custom property for the one dynamic
+(resizable) dimension; author CSS does the layout.
+
+## 2. Grounding (research)
+
+Verified (25/25 claims) against primary sources — see the research doc:
+- **Atlassian `@atlaskit/page-layout`**: named regions; LeftSidebar resizes,
+  collapses to a **20px rail** (not zero) below a 200px drag threshold, hover
+  flyout. Region defaults (sidebar 240 / aside 280 / panel 368).
+- **VS Code workbench**: Activity Bar · Primary/Secondary Side Bars · Editor ·
+  relocatable Panel; independently-toggled trailing bar.
+- **Float vs anchor** is a first-class dual mode: PatternFly `overlay`/`inline`,
+  Workday "push+resize OR float over scrim", Dockview detach-to-float. (Vendors
+  document them as *configured alternatives*; the **live in-place flip** is our
+  design.)
+
+## 3. Region model (`src/workspace/`)
+
+```
+<pine-workspace>          root: grid container · breakpoint engine · WORKSPACE ctx
+  <pine-workspace-header>     banner (sticky)
+  <pine-workspace-panel side=…>  outer secondary nav · collapsible
+  <pine-workspace-sidebar>    primary nav · RESIZE + collapse-to-rail + flyout
+  <pine-workspace-main>       content · flex-fill remainder
+  <pine-workspace-aside>      detail/AI panel · resizable docked column · collapsible
+  <pine-workspace-bottom>     console · vertical resize + collapse + edge
+  <pine-workspace-footer>     status bar (sticky)
+```
+
+| Region | resizable | collapsible |
+|---|:--:|:--:|
+| Sidebar | ✅ grab handle | ✅ → rail + flyout |
+| Aside | ✅ | ✅ (`open`) |
+| Bottom | ✅ (vertical) | ✅ (edge-relocatable) |
+| Panel (outer) | — | ✅ |
+| Header/Footer/Main | — | Header/Footer show/hide |
+
+## 4. Headless contract
+
+No `.css`, no `style=` for visual properties. Each region emits: a class; `data-*`
+state (`data-state`, `data-aside-state`, `data-flyout`, `data-dragging`, …); and
+a **`--pine-<region>-size`** custom property carrying the one dynamic dimension a
+static stylesheet can't express. Author CSS:
+
+```css
+.pine-workspace { display: grid; grid-template-columns: auto 1fr auto; }
+.pine-workspace-sidebar { width: var(--pine-sidebar-size, 260px); }
+.pine-workspace-aside { width: var(--pine-aside-size, 320px); }
+.pine-workspace-aside[data-aside-state="closed"] { display: none; }
+[data-dragging] { transition: none; }   /* freeze transitions mid-drag */
+```
+
+## 5. The own resize engine (`src/workspace/resize.rs`)
+
+Self-contained — **no dependency on `pine`/`splitter`**. A pure, host-tested
+`resolve_size(start, delta, invert, min, max, collapse_at)` (clamp + snap) plus a
+wasm `start_drag` that installs document `pointermove`/`up`/`cancel` via
+`pocopine::events::{on, ev}` (held in a `ListenerHandle` vec, cleared on
+release), replicating `splitter`'s pattern. Each resizable region embeds a
+`role="separator"` handle (keyboard arrows / Home-End / double-click-reset) and
+stores `#[model] size` (persisted via `pp-model:size`).
+
+## 6. Aside — resizable docked column
+
+The Aside is an in-grid, resizable column shown/hidden via `pp-model:open`
+(`data-aside-state`), with the same resize handle + `--pine-aside-size`
+contract as the Sidebar.
+
+**Floating deferred.** A dock↔float toggle (overlay + scrim + the shared
+`floating` focus-trap runtime, with auto-float below a breakpoint) was
+prototyped on top of this. It worked, but the overlay layering and live
+toggle added enough complexity — and enough rough edges (focus-targeting on
+re-open, scrim stacking contexts) — that it's **pulled from v1** to keep the
+shell clean. The `floating` runtime (`src/floating.rs`) remains, shared by the
+AppShell drawer; re-introducing the Aside float is a contained follow-up. The
+float-vs-anchor research (§2) stands for when it lands.
+
+## 7. Responsive — decentralized
+
+The root runs the breakpoint engine; each region **watches the root's
+`breakpoint`** and derives its own state from its threshold, so the collapse
+order falls out outside-in (panels hide → bottom collapses → sidebar rails),
+with no central solver. The Sidebar keeps user intent (`collapsed`, `pp-model`)
+**separate** from the responsive override (`responsive_rail`, internal) so the
+two never race; the rendered state is their OR.
+
+## 8. Decisions
+
+- **Own resize**, not a `pine::splitter` dependency (avoids a layering inversion;
+  the engine is small).
+- **New family**, not an AppShell extension — AppShell stays the simple nav shell.
+- **No generic `<pine-workspace-trigger>`** — regions are app-controlled via
+  `pp-model` (open/collapsed) + region-local affordances; cleaner and headless.
+  A generic trigger can come later.
+- **Aside is anchored-only** in v1 — float deferred (§6).
+
+## 9. Accessibility
+
+Landmark roles per region (`banner`/`navigation`/`main`/`complementary`/
+`contentinfo`); resize handles `role="separator"` + `aria-orientation` +
+`aria-valuenow/min/max` + keyboard (W3C APG window-splitter).
+
+## 10. Verification
+
+- **Host unit tests**: `resolve_size` clamp/snap; `nav_mode` (shared helper);
+  AppShell's existing tests unchanged.
+- **Browser tests** (`tests/workspace.rs`): regions render with landmarks, the
+  size var + resize handle + ARIA, aside state, sidebar auto-collapse.
+- **Playwright** drive of `examples/workspace`: sidebar/aside drag-resize, the
+  Detail toggle, and narrow-viewport auto-rail — all confirmed.
+
+## 11. Implementation status
+
+| Unit | Status |
+|---|---|
+| Resize engine + shared `nav_mode` helper | ✅ |
+| Root · Main · Sidebar (resize/rail/flyout) | ✅ |
+| Aside (resizable docked column + collapse) | ✅ |
+| Outer Panel · Bottom · Header · Footer | ✅ |
+| `floating` runtime (shared with AppShell drawer) | ✅ |
+| Browser + host tests · `examples/workspace` | ✅ green |
+| Aside float (overlay/dock toggle) · drag-to-detach · panel drag-to-dock · generic trigger | ⏳ later |


### PR DESCRIPTION
Adds **`pine-layout`** — a new headless Pine sub-library for scaffolding responsive applications — plus two demo apps. Purely **additive**: a new crate + two `examples/`, root `Cargo.toml` members, research docs, and two RFCs. No existing crates are modified.

Grounded in fact-checked research (Apple HIG · Material 3 · Atlassian · VS Code · PatternFly · Workday · Dockview; persisted under `docs/internal/research/`).

## What's in it

```mermaid
graph LR
  PL["pine-layout (crate)"] --> BP["breakpoint engine<br/>matchMedia @ 640/768/1024/1280/1536<br/>(aligned to Stylekit)"]
  PL --> PRIM["Container · Stack · Inline · Grid"]
  PL --> AS["AppShell — RFC-103<br/>drawer → rail → sidebar"]
  PL --> WS["Workspace — RFC-105<br/>sidebar │ main │ aside │ panels"]
  WS --> RZ["own resize engine<br/>drag · keyboard · snap-to-collapse · persist"]
  AS -. shares .-> FL["floating runtime<br/>focus-trap drawer"]
```

**RFC-103 — foundation + AppShell.** The reactive breakpoint engine (one vocabulary, surfaced as `data-breakpoint` + context + a `pp:update:breakpoint` model), the headless structural primitives, and `<pine-app-shell>` whose nav adapts **drawer → rail → sidebar** with a modal drawer (focus-trap + scroll-lock + Esc + ARIA).

**RFC-105 — workspace shell.** A separate `<pine-workspace>` family for content-heavy apps: a resizable rail/sidebar (grab-handle + collapse-to-rail + hover flyout) │ main │ a resizable detail **Aside** │ outer + bottom panels. Ships its **own** resize engine (no `pine::splitter` dependency).

**Headless throughout** — zero CSS shipped. Every region emits a semantic class + `data-*` state + a `--pine-*-size` custom property for the one dynamic (resizable) dimension; the author's CSS (or Pine Stylekit utilities) does the layout. The two examples are the proof: the whole look lives in their `styles.css`.

The drawer/regions animate with **pine-motion** (imperative, toggle-driven), which is why a breakpoint reflow snaps instead of flashing.

## Layout sketch

```
AppShell:    [rail↔sidebar] │ main                     (drawer overlay on mobile)
Workspace:   rail/sidebar   │ main │ detail aside │ [outer panels]
                                   └──── bottom ─────┘
```

## Tests

- **Host unit tests** (deterministic): breakpoint enum, AppShell nav-mode state machine, resize clamp/snap math.
- **Browser tests** (`wasm-pack test --firefox`): rendered `data-*` hooks, ARIA wiring, drawer toggle, workspace regions + size vars + auto-collapse.
- **Playwright** drove both example apps end-to-end (adaptive nav across breakpoints; sidebar/aside drag-resize). Host + wasm clippy `-D warnings` + fmt all green.

## Deferred (noted in the RFCs)

- Workspace Aside **floating/overlay** mode — prototyped and pulled from v1 to keep the shell clean (the `floating` runtime stays for the AppShell drawer); a contained follow-up.
- SplitPane/ListDetail multi-pane reflow; drag-to-detach floating groups; a generic workspace trigger; `pocopine` umbrella re-export (API still settling — apps `use pine_layout::…`).

## Notes

- The change touches no existing crate, so it's isolated from any pre-existing CI state on `main`.
- RFCs: `rfcs/rfc-103-pine-layout.md`, `rfcs/rfc-105-pine-workspace.md`. Examples: `examples/layout`, `examples/workspace`.