### PR TITLE
feat(pocopine-ws): generic bidirectional WebSocket gateway (RFC 073 Part I)

### DIFF
--- a/.claude/skills/client-server-modules/SKILL.md
+++ b/.claude/skills/client-server-modules/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: client-server-modules
+description: >-
+  Use when creating or restructuring a pocopine library crate that has
+  host-only and/or wasm-only code (anything depending on axum/tokio for the
+  server, or wasm-bindgen/web-sys for the browser). Put platform code in
+  `server` and/or `client` modules gated ONCE at the crate root, instead of
+  sprinkling `#[cfg(target_arch = "wasm32")]` on every item and every `pub
+  use`. Covers the lib.rs gating pattern, when to use a `server.rs` file vs a
+  `server/` folder, sibling-import paths, and the Cargo.toml target tables.
+---
+
+# Client / server module split
+
+In pocopine, most library crates have code that only compiles on one target:
+the **server/host** side (axum, tokio, `pocopine_auth::RequestContext`, DB
+drivers) and the **client/browser** side (`wasm-bindgen`, `web-sys`,
+`pocopine-core`). Do **not** gate each item and each `pub use` with its own
+`#[cfg(...)]`. Gate **once**, at the module boundary.
+
+## The rule
+
+1. Host-only code lives under a `server` module. Browser-only code lives under
+   a `client` module. Cross-target code (pure data types, codecs) can stay at
+   the crate root or in plain modules.
+2. The crate root applies the platform `#[cfg(...)]` to the **module
+   declaration and its re-export** — and nowhere else.
+3. Inside `server`/`client`, **no `cfg` attributes**. Submodules reference
+   siblings with `super::` (or `crate::server::…` from nested test modules).
+4. One file (`server.rs`) if small; a folder (`server/mod.rs` + submodules) if
+   it will hold lots of code.
+
+## Canonical `lib.rs`
+
+Host-only crate (e.g. a server gateway). On wasm32 the crate is empty:
+
+```rust
+//! Crate docs …
+
+#[cfg(not(target_arch = "wasm32"))]
+pub mod server;
+
+// Re-export the API at the crate root so `mycrate::Thing` and
+// `mycrate::server::Thing` both resolve (mirrors pocopine-live).
+#[cfg(not(target_arch = "wasm32"))]
+pub use server::*;
+```
+
+Crate with both sides:
+
+```rust
+#[cfg(not(target_arch = "wasm32"))]
+pub mod server;
+#[cfg(not(target_arch = "wasm32"))]
+pub use server::*;
+
+#[cfg(target_arch = "wasm32")]
+pub mod client;
+#[cfg(target_arch = "wasm32")]
+pub use client::*;
+
+// Anything that compiles everywhere stays in a normal module:
+pub mod protocol; // shared wire types, codecs, errors
+```
+
+That is the **only** place `#[cfg(target_arch = …)]` appears. Two lines per
+side, not one per export.
+
+## Folder layout (lots of code → `server/`)
+
+```
+src/
+  lib.rs            # crate docs + the cfg-gated `pub mod server;` + re-export
+  server/
+    mod.rs          # `mod a; mod b; …  pub use a::*; pub use b::*;`  (NO cfg)
+    frame.rs
+    gateway.rs
+    route.rs
+```
+
+`server/mod.rs` aggregates and re-exports — it carries no `cfg`:
+
+```rust
+//! Host-side implementation. One cfg gate at the crate root (see the
+//! client-server-modules skill); submodules below carry no cfg.
+mod frame;
+mod gateway;
+mod route;
+
+pub use frame::Frame;
+pub use gateway::Gateway;
+pub use route::{routes, STREAM_PATH};
+```
+
+Small crate → a single `src/server.rs` file instead of the folder. Same
+gating in `lib.rs`.
+
+## Sibling imports inside the module
+
+From a submodule, reach a sibling via `super::`:
+
+```rust
+// in server/frame.rs
+use super::error::WsError;
+use super::varint::read_var_uint;
+```
+
+From a **nested** module (e.g. a `#[cfg(test)] mod tests`), the absolute path
+is clearest:
+
+```rust
+// in server/control.rs  ->  mod tests
+use crate::server::frame::FrameKind;
+```
+
+Intra-doc links that point at re-exported items keep using `crate::Thing`
+(they resolve through the root re-export). Links to a private submodule path
+use the full `crate::server::frame` path.
+
+## Cargo.toml: target dependency tables
+
+Put host deps under the host target table and wasm deps under the wasm table,
+so a default `cargo build` / wasm clippy does not try to compile axum/tokio
+for wasm:
+
+```toml
+[dependencies]                       # cross-target only
+serde = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+axum = { version = "0.7", features = ["ws"] }   # ws is OFF by default — enable it
+tokio = { version = "1", features = ["rt", "macros", "sync", "time"] }
+pocopine-auth = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = { workspace = true }
+web-sys = { version = "0.3", features = ["…"] }
+```
+
+If a crate is purely host-only, move **all** deps (serde included) under the
+`cfg(not(target_arch = "wasm32"))` table so the wasm build truly has nothing.
+
+## Why
+
+- One gate, not N. Adding a new `pub fn`/`pub struct` doesn't mean remembering
+  yet another `#[cfg(...)]` — the module boundary already covers it.
+- `cargo build` (default target is wasm32 in this workspace) and the CI wasm
+  clippy gate stay green, because host-only deps never reach the wasm target.
+- The public API reads cleanly: `mycrate::routes` on the server,
+  `mycrate::Client` in the browser, both backed by one cfg line.
+
+## Reference implementations
+
+- **`pocopine-ws`** — host-only gateway; everything under `src/server/`, one
+  `pub mod server;` gate. The canonical example of this skill.
+- **`pocopine-live`** — uses the older `mod host` / `mod browser` names with
+  root re-exports (`pub use host::{LiveHub, routes};`). Same idea; new crates
+  use `server` / `client` naming.
+
+## Anti-patterns
+
+```rust
+// DON'T: a cfg on every item and every re-export
+#[cfg(not(target_arch = "wasm32"))] mod frame;
+#[cfg(not(target_arch = "wasm32"))] mod gateway;
+#[cfg(not(target_arch = "wasm32"))] mod route;
+#[cfg(not(target_arch = "wasm32"))] pub use frame::Frame;
+#[cfg(not(target_arch = "wasm32"))] pub use gateway::Gateway;
+#[cfg(not(target_arch = "wasm32"))] pub use route::routes;
+// … this is what the `server` module exists to collapse into two lines.
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -549,7 +549,7 @@ dependencies = [
  "http-body-util",
  "md-5 0.11.0",
  "pin-project-lite",
- "sha1",
+ "sha1 0.11.0",
  "sha2 0.11.0",
  "tracing",
 ]
@@ -761,6 +761,7 @@ checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
  "axum-core 0.4.5",
+ "base64 0.22.1",
  "bytes",
  "futures-util",
  "http 1.4.0",
@@ -779,8 +780,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1 0.10.6",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower 0.5.3",
  "tower-layer",
  "tower-service",
@@ -5804,7 +5807,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7579,6 +7582,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pocopine-ws"
+version = "0.1.1"
+dependencies = [
+ "async-trait",
+ "axum 0.7.9",
+ "bytes",
+ "futures-util",
+ "pocopine-auth",
+ "pocopine-crypto",
+ "pocopine-events",
+ "pocopine-observe",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9001,6 +9023,17 @@ dependencies = [
 
 [[package]]
 name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha1"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
@@ -10334,6 +10367,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10764,6 +10809,24 @@ dependencies = [
  "target-triple",
  "termcolor",
  "toml 1.1.2+spec-1.1.0",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.4.0",
+ "httparse",
+ "log",
+ "rand 0.8.6",
+ "sha1 0.10.6",
+ "thiserror 1.0.69",
+ "utf-8",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ members = [
     "crates/pocopine-template-parser",
     "crates/pocopine-ts-rs",
     "crates/pocopine-ts-rs-macros",
+    "crates/pocopine-ws",
     "examples/blog",
     "examples/charts",
     "examples/counter",

--- a/crates/pocopine-ws/Cargo.toml
+++ b/crates/pocopine-ws/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "pocopine-ws"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Generic bidirectional WebSocket gateway for pocopine apps (RFC 073)."
+
+[features]
+default = []
+# Forwards through pocopine-events for multi-process fan-out (Phase C).
+redis = ["pocopine-events/redis"]
+
+# The gateway is host-only (axum WebSocket server). Mirrors pocopine-live:
+# all deps live under cfg(not(target_arch = "wasm32")) so the crate compiles
+# to an empty lib on wasm32 and does not break workspace wasm builds.
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+axum = { version = "0.7", features = ["ws"] }
+bytes = "1"
+futures-util = "0.3"
+tokio = { version = "1", features = ["rt", "macros", "sync", "time"] }
+tracing = { workspace = true }
+async-trait = "0.1"
+serde = { workspace = true }
+serde_json = "1"
+pocopine-auth = { workspace = true }
+pocopine-events = { workspace = true }
+pocopine-observe = { workspace = true }
+pocopine-crypto = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+axum = { version = "0.7", features = ["ws"] }
+tokio = { version = "1", features = [
+    "macros",
+    "rt-multi-thread",
+    "time",
+    "sync",
+    "net",
+] }
+tokio-tungstenite = "0.24"
+futures-util = "0.3"

--- a/crates/pocopine-ws/src/lib.rs
+++ b/crates/pocopine-ws/src/lib.rs
@@ -1,0 +1,55 @@
+//! # pocopine-ws
+//!
+//! A generic, payload-agnostic bidirectional WebSocket gateway for pocopine
+//! apps (RFC 073, Part I). It is the bidirectional counterpart to
+//! `pocopine-live`'s server-to-client SSE invalidation: where SSE is
+//! read-only, `pocopine-ws` lets clients push frames back, which CRDT
+//! collaboration (`pocopine-collab`) and messaging (`pocopine-chat`,
+//! RFC 106) both require.
+//!
+//! The gateway owns the transport concerns and nothing else:
+//!
+//! - a binary [`Frame`] envelope tagged by a `subprotocol_id` it treats as
+//!   opaque routing metadata,
+//! - Discord-style connection liveness ([`Control::Hello`] /
+//!   [`Control::Heartbeat`] / heartbeat-ack / zombie detection),
+//!   per-subscription sequence numbers and [`Control::Resume`] replay,
+//! - per-topic authorization through the app's [`pocopine_auth::RequestContext`],
+//! - fan-out behind the [`Fanout`] trait.
+//!
+//! Application semantics (CRDT merge, chat ordering/receipts) live in
+//! consumer crates, never here.
+//!
+//! ## Quick start
+//!
+//! ```no_run
+//! # #[cfg(not(target_arch = "wasm32"))]
+//! # fn demo() -> axum::Router {
+//! use pocopine_ws::{WsGateway, routes};
+//!
+//! let gateway = WsGateway::local().allow_all_topics();
+//! routes(gateway)
+//! # }
+//! ```
+//!
+//! ## Module layout
+//!
+//! This crate is host-only. Following the `client-server-modules` convention,
+//! all server code lives under the [`server`] module, gated once at the crate
+//! root; on wasm32 this crate is empty. The server API is also re-exported at
+//! the crate root, so `pocopine_ws::routes` and `pocopine_ws::server::routes`
+//! both resolve.
+//!
+//! ## Fan-out
+//!
+//! Fan-out is abstracted by [`Fanout`]. [`LocalFanout`] is the in-process
+//! implementation (per-topic ring buffer for sequencing/replay plus a broadcast
+//! channel for live delivery). A multi-process implementation backed by the
+//! `pocopine-events` Redis spine is the RFC 073 Phase C follow-up; the
+//! [`Fanout`] trait is the seam it slots into.
+
+#[cfg(not(target_arch = "wasm32"))]
+pub mod server;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use server::*;

--- a/crates/pocopine-ws/src/server/control.rs
+++ b/crates/pocopine-ws/src/server/control.rs
@@ -1,0 +1,165 @@
+//! Control-frame bodies (RFC 073 §8–§9).
+//!
+//! Control frames (`FrameKind::Control`) carry a JSON-tagged [`Control`]
+//! value as their payload. JSON (rather than a bespoke binary encoding) keeps
+//! the lifecycle protocol debuggable and forward-compatible; the surrounding
+//! frame envelope is still the binary varUint header from
+//! [`crate::server::frame`].
+//! Data frames never use this module — their payloads are opaque bytes.
+
+use serde::{Deserialize, Serialize};
+
+use super::error::WsError;
+use super::frame::Frame;
+
+/// A `(topic, last_seq)` pair used by Heartbeat and Resume. On Resume the
+/// `subprotocol_id` tells the gateway how to tag replayed/live Data frames for
+/// the topic (Heartbeat acks leave it at its `0` default).
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct TopicSeq {
+    pub topic: String,
+    pub last_seq: u64,
+    #[serde(default)]
+    pub subprotocol_id: u64,
+}
+
+/// The gateway lifecycle control messages exchanged over `FrameKind::Control`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum Control {
+    /// Server → client, immediately after upgrade.
+    Hello {
+        session_id: String,
+        heartbeat_interval_ms: u32,
+        protocol: String,
+    },
+    /// Client → server liveness ping. Carries the client's highest processed
+    /// seq per topic so the server can detect drift.
+    Heartbeat {
+        #[serde(default)]
+        acks: Vec<TopicSeq>,
+    },
+    /// Server → client reply to a Heartbeat.
+    HeartbeatAck {},
+    /// Server → client: a Subscribe was accepted; `topic_ref` is the compact
+    /// handle to use on subsequent Data/Unsubscribe frames for this topic.
+    SubscribeAck { topic: String, topic_ref: u64 },
+    /// Server → client: a topic was left.
+    Unsubscribed { topic: String },
+    /// Client → server: resume an existing session, replaying each topic from
+    /// `last_seq`.
+    Resume {
+        session_id: String,
+        #[serde(default)]
+        topics: Vec<TopicSeq>,
+    },
+    /// Server → client: a topic's resume backlog has been flushed in order.
+    Resumed { topic: String },
+    /// Server → client: a resume cursor is unreplayable or the subscription
+    /// lagged; the client must re-subscribe fresh.
+    Gap { topic: String, reason: String },
+    /// Server → client: a typed error (forbidden topic, oversized frame, ...).
+    Error { code: String, message: String },
+}
+
+impl Control {
+    /// JSON-encode the control body.
+    pub fn encode(&self) -> Result<Vec<u8>, WsError> {
+        serde_json::to_vec(self).map_err(|err| WsError::frame(format!("control encode: {err}")))
+    }
+
+    /// Decode a control body from a control frame payload.
+    pub fn decode(bytes: &[u8]) -> Result<Self, WsError> {
+        serde_json::from_slice(bytes)
+            .map_err(|err| WsError::frame(format!("control decode: {err}")))
+    }
+
+    /// Wrap this control body in a `FrameKind::Control` frame.
+    pub fn into_frame(&self) -> Result<Frame, WsError> {
+        Ok(Frame::control(self.encode()?))
+    }
+
+    /// Convenience constructor for an [`Control::Error`].
+    pub fn error(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self::Error {
+            code: code.into(),
+            message: message.into(),
+        }
+    }
+
+    /// Convenience constructor for an [`Control::Gap`].
+    pub fn gap(topic: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self::Gap {
+            topic: topic.into(),
+            reason: reason.into(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::frame::FrameKind;
+
+    fn roundtrip(control: Control) {
+        let bytes = control.encode().expect("encode");
+        let decoded = Control::decode(&bytes).expect("decode");
+        assert_eq!(decoded, control);
+    }
+
+    #[test]
+    fn roundtrips_all_variants() {
+        roundtrip(Control::Hello {
+            session_id: "s1".into(),
+            heartbeat_interval_ms: 15_000,
+            protocol: "pocopine.ws.v1".into(),
+        });
+        roundtrip(Control::Heartbeat {
+            acks: vec![TopicSeq {
+                topic: "collab:abc".into(),
+                last_seq: 12,
+                subprotocol_id: 0,
+            }],
+        });
+        roundtrip(Control::HeartbeatAck {});
+        roundtrip(Control::SubscribeAck {
+            topic: "collab:abc".into(),
+            topic_ref: 1,
+        });
+        roundtrip(Control::Unsubscribed {
+            topic: "collab:abc".into(),
+        });
+        roundtrip(Control::Resume {
+            session_id: "s1".into(),
+            topics: vec![TopicSeq {
+                topic: "collab:abc".into(),
+                last_seq: 9,
+                subprotocol_id: 1,
+            }],
+        });
+        roundtrip(Control::Resumed {
+            topic: "collab:abc".into(),
+        });
+        roundtrip(Control::gap("collab:abc", "cursor_not_replayable"));
+        roundtrip(Control::error("forbidden_topic", "denied"));
+    }
+
+    #[test]
+    fn heartbeat_acks_default_to_empty() {
+        let decoded = Control::decode(br#"{"type":"heartbeat"}"#).expect("decode");
+        assert_eq!(decoded, Control::Heartbeat { acks: vec![] });
+    }
+
+    #[test]
+    fn wraps_into_control_frame() {
+        let frame = Control::HeartbeatAck {}.into_frame().expect("frame");
+        assert_eq!(frame.kind, FrameKind::Control);
+        let body = Control::decode(&frame.payload).expect("decode body");
+        assert_eq!(body, Control::HeartbeatAck {});
+    }
+
+    #[test]
+    fn rejects_unknown_type() {
+        assert!(Control::decode(br#"{"type":"nope"}"#).is_err());
+    }
+}

--- a/crates/pocopine-ws/src/server/error.rs
+++ b/crates/pocopine-ws/src/server/error.rs
@@ -1,0 +1,89 @@
+//! Error type for the `pocopine-ws` gateway.
+//!
+//! Hand-rolled `Display`/`Error` impls (no `thiserror`) to match the
+//! convention in `pocopine-events`, which also rolls its own error enum.
+
+use std::fmt;
+
+use pocopine_events::EventError;
+
+/// Errors surfaced by the gateway, frame codec, and fan-out layer.
+#[derive(Debug)]
+pub enum WsError {
+    /// A frame could not be decoded (bad varuint, unknown kind, malformed
+    /// control JSON, truncated buffer).
+    Frame(String),
+    /// A topic string could not be resolved to a valid [`pocopine_events::Topic`].
+    Topic(EventError),
+    /// A frame exceeded the gateway's `max_frame_bytes`.
+    TooLarge { size: usize, max: usize },
+    /// A live subscription fell behind in real time and lost ordering
+    /// (`skipped` messages were dropped). Mirrors
+    /// [`pocopine_events::EventError::SubscriptionLagged`].
+    Lagged(u64),
+    /// A resume cursor is older than retention; the client must re-subscribe
+    /// fresh. Mirrors `ReplayBatch.gap == true`.
+    Gap,
+    /// The connection's `RequestContext` was denied access to a topic.
+    Forbidden(String),
+    /// The peer violated the protocol (e.g. a Data frame for an unknown
+    /// `topic_ref`).
+    Protocol(String),
+    /// The underlying transport or fan-out source closed.
+    Closed,
+}
+
+impl WsError {
+    /// Build a [`WsError::Frame`] from anything stringy.
+    pub fn frame(msg: impl Into<String>) -> Self {
+        Self::Frame(msg.into())
+    }
+
+    /// Build a [`WsError::Protocol`] from anything stringy.
+    pub fn protocol(msg: impl Into<String>) -> Self {
+        Self::Protocol(msg.into())
+    }
+
+    /// Build a [`WsError::Forbidden`] from anything stringy.
+    pub fn forbidden(msg: impl Into<String>) -> Self {
+        Self::Forbidden(msg.into())
+    }
+}
+
+impl fmt::Display for WsError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Frame(msg) => write!(f, "ws frame error: {msg}"),
+            Self::Topic(err) => write!(f, "ws topic error: {err}"),
+            Self::TooLarge { size, max } => {
+                write!(f, "ws frame too large: {size} bytes (max {max})")
+            }
+            Self::Lagged(skipped) => {
+                write!(f, "ws subscription lagged: {skipped} messages skipped")
+            }
+            Self::Gap => write!(f, "ws resume cursor not replayable (gap)"),
+            Self::Forbidden(topic) => write!(f, "ws topic forbidden: {topic}"),
+            Self::Protocol(msg) => write!(f, "ws protocol error: {msg}"),
+            Self::Closed => write!(f, "ws transport closed"),
+        }
+    }
+}
+
+impl std::error::Error for WsError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Topic(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
+impl From<EventError> for WsError {
+    fn from(err: EventError) -> Self {
+        match err {
+            EventError::SubscriptionLagged { skipped } => Self::Lagged(skipped),
+            EventError::Gap { .. } => Self::Gap,
+            other => Self::Topic(other),
+        }
+    }
+}

--- a/crates/pocopine-ws/src/server/fanout.rs
+++ b/crates/pocopine-ws/src/server/fanout.rs
@@ -1,0 +1,380 @@
+//! Fan-out abstraction and the in-process implementation (RFC 073 §9–§10.2).
+//!
+//! [`Fanout`] is the seam between the gateway and the message bus. For each
+//! topic it must: assign a topic-local monotonic cursor on publish, replay
+//! retained messages after a given cursor (for [`crate::Control::Resume`]),
+//! signal a gap when a resume cursor is no longer retained, and deliver live
+//! messages to subscribers.
+//!
+//! [`LocalFanout`] is the single-process implementation: a per-topic ring
+//! buffer (for sequencing + replay) plus a `tokio::sync::broadcast` channel
+//! (for live delivery). The multi-process implementation backed by the
+//! `pocopine-events` Redis spine is the RFC 073 Phase C follow-up and will
+//! implement this same trait — there `seq` is gateway-assigned and the opaque
+//! `EventCursor` is mapped to it, whereas here the cursor *is* the seq.
+
+use std::collections::{HashMap, VecDeque};
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use pocopine_events::Topic;
+use tokio::sync::broadcast;
+
+use super::error::WsError;
+
+/// Default per-topic ring/broadcast capacity.
+pub const DEFAULT_TOPIC_CAPACITY: usize = 1024;
+
+/// A delivered fan-out message: a topic-local monotonic cursor (>= 1) and the
+/// opaque payload bytes.
+pub type TopicMessage = (u64, Bytes);
+
+/// The message-bus seam the gateway fans out over.
+#[async_trait]
+pub trait Fanout: Send + Sync + 'static {
+    /// Append `payload` to `topic`'s log, returning the assigned topic-local
+    /// monotonic cursor (>= 1).
+    async fn publish(&self, topic: &Topic, payload: Bytes) -> Result<u64, WsError>;
+
+    /// Subscribe to `topic`, replaying retained messages strictly after
+    /// `after` (`None` = a fresh subscribe; deliver retained tail then live).
+    /// The returned [`TopicStream`] yields replayed messages first, then live
+    /// ones, with no gap or duplication across the boundary.
+    async fn subscribe(&self, topic: &Topic, after: Option<u64>) -> Result<TopicStream, WsError>;
+}
+
+/// A per-topic message stream: retained replay followed by live broadcast.
+pub struct TopicStream {
+    replay: std::vec::IntoIter<TopicMessage>,
+    gap: bool,
+    rx: broadcast::Receiver<TopicMessage>,
+}
+
+impl TopicStream {
+    /// True if the requested resume cursor was older than retention, so a hole
+    /// exists before the replayed messages. The client must re-subscribe fresh
+    /// (and, for collab, re-run the sync handshake).
+    pub fn gap(&self) -> bool {
+        self.gap
+    }
+
+    /// Return the next message: drained replay first, then live broadcast.
+    /// `Ok(None)` means the topic channel closed; `Err(WsError::Lagged)` means
+    /// the live subscription fell behind and lost ordering.
+    pub async fn next(&mut self) -> Result<Option<TopicMessage>, WsError> {
+        if let Some(msg) = self.replay.next() {
+            return Ok(Some(msg));
+        }
+        match self.rx.recv().await {
+            Ok(msg) => Ok(Some(msg)),
+            Err(broadcast::error::RecvError::Closed) => Ok(None),
+            Err(broadcast::error::RecvError::Lagged(skipped)) => Err(WsError::Lagged(skipped)),
+        }
+    }
+}
+
+/// Per-topic append-only ring buffer assigning monotonic sequence numbers.
+struct TopicLog {
+    next_seq: u64,
+    capacity: usize,
+    ring: VecDeque<TopicMessage>,
+}
+
+impl TopicLog {
+    fn new(capacity: usize) -> Self {
+        Self {
+            next_seq: 1,
+            capacity: capacity.max(1),
+            ring: VecDeque::new(),
+        }
+    }
+
+    fn append(&mut self, payload: Bytes) -> TopicMessage {
+        let seq = self.next_seq;
+        self.next_seq += 1;
+        let msg = (seq, payload);
+        self.ring.push_back(msg.clone());
+        while self.ring.len() > self.capacity {
+            self.ring.pop_front();
+        }
+        msg
+    }
+
+    fn earliest_seq(&self) -> Option<u64> {
+        self.ring.front().map(|(seq, _)| *seq)
+    }
+
+    /// Returns `(replay, gap)`. A fresh subscribe (`None`) replays the retained
+    /// tail with no gap. A resume (`Some(after)`) replays messages with seq
+    /// strictly greater than `after`, flagging a gap if the cursor is no longer
+    /// replayable: either a seq in `(after, earliest)` was evicted, or the
+    /// cursor is ahead of any seq we have ever issued (a stale/forged cursor).
+    fn replay_after(&self, after: Option<u64>) -> (Vec<TopicMessage>, bool) {
+        match after {
+            None => (self.ring.iter().cloned().collect(), false),
+            Some(after) => {
+                // `head` is the last seq assigned (0 if none). A cursor past it
+                // is unreplayable — and this early return also avoids any
+                // overflow on `after.saturating_add(1)` for huge cursors.
+                let head = self.next_seq.saturating_sub(1);
+                if after > head {
+                    return (Vec::new(), true);
+                }
+                let events = self
+                    .ring
+                    .iter()
+                    .filter(|(seq, _)| *seq > after)
+                    .cloned()
+                    .collect();
+                let gap = match self.earliest_seq() {
+                    Some(earliest) => earliest > after.saturating_add(1),
+                    None => false,
+                };
+                (events, gap)
+            }
+        }
+    }
+}
+
+struct TopicChannel {
+    log: TopicLog,
+    tx: broadcast::Sender<TopicMessage>,
+}
+
+impl TopicChannel {
+    fn new(capacity: usize) -> Self {
+        let (tx, _rx) = broadcast::channel(capacity.max(1));
+        Self {
+            log: TopicLog::new(capacity),
+            tx,
+        }
+    }
+}
+
+/// Single-process [`Fanout`]. Topics are created lazily on first publish or
+/// subscribe and never removed (matching `pocopine-events`'s per-process
+/// memory backend, which also retains topic state for the process lifetime).
+pub struct LocalFanout {
+    capacity: usize,
+    topics: Mutex<HashMap<Topic, TopicChannel>>,
+}
+
+impl LocalFanout {
+    /// A fan-out with the default per-topic capacity.
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_TOPIC_CAPACITY)
+    }
+
+    /// A fan-out whose per-topic ring buffer and broadcast channel hold
+    /// `capacity` messages.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            capacity: capacity.max(1),
+            topics: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl Default for LocalFanout {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Fanout for LocalFanout {
+    async fn publish(&self, topic: &Topic, payload: Bytes) -> Result<u64, WsError> {
+        // std::Mutex is held without crossing an .await — safe in async.
+        let mut topics = self.topics.lock().expect("fanout mutex poisoned");
+        let channel = topics
+            .entry(topic.clone())
+            .or_insert_with(|| TopicChannel::new(self.capacity));
+        let msg = channel.log.append(payload);
+        let seq = msg.0;
+        // Ignore the "no live receivers" error — the ring still retains it.
+        let _ = channel.tx.send(msg);
+        Ok(seq)
+    }
+
+    async fn subscribe(&self, topic: &Topic, after: Option<u64>) -> Result<TopicStream, WsError> {
+        // Snapshot replay and subscribe to the broadcast under the SAME lock so
+        // no publish can slip between the two (no missed or duplicated message
+        // across the replay/live boundary).
+        let mut topics = self.topics.lock().expect("fanout mutex poisoned");
+        let channel = topics
+            .entry(topic.clone())
+            .or_insert_with(|| TopicChannel::new(self.capacity));
+        let (events, gap) = channel.log.replay_after(after);
+        let rx = channel.tx.subscribe();
+        Ok(TopicStream {
+            replay: events.into_iter(),
+            gap,
+            rx,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn topic(name: &str) -> Topic {
+        Topic::new(name).expect("valid topic")
+    }
+
+    fn bytes(b: &[u8]) -> Bytes {
+        Bytes::copy_from_slice(b)
+    }
+
+    #[test]
+    fn topic_log_assigns_monotonic_seqs() {
+        let mut log = TopicLog::new(8);
+        assert_eq!(log.append(bytes(b"a")).0, 1);
+        assert_eq!(log.append(bytes(b"b")).0, 2);
+        assert_eq!(log.append(bytes(b"c")).0, 3);
+    }
+
+    #[test]
+    fn topic_log_replay_fresh_returns_tail() {
+        let mut log = TopicLog::new(8);
+        log.append(bytes(b"a"));
+        log.append(bytes(b"b"));
+        let (events, gap) = log.replay_after(None);
+        assert!(!gap);
+        assert_eq!(
+            events.iter().map(|(s, _)| *s).collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+    }
+
+    #[test]
+    fn topic_log_replay_after_filters() {
+        let mut log = TopicLog::new(8);
+        for b in [b"a", b"b", b"c"] {
+            log.append(bytes(b));
+        }
+        let (events, gap) = log.replay_after(Some(1));
+        assert!(!gap);
+        assert_eq!(
+            events.iter().map(|(s, _)| *s).collect::<Vec<_>>(),
+            vec![2, 3]
+        );
+    }
+
+    #[test]
+    fn topic_log_eviction_drops_oldest() {
+        let mut log = TopicLog::new(2);
+        for b in [b"a", b"b", b"c"] {
+            log.append(bytes(b));
+        }
+        // Ring holds seqs 2,3 now (capacity 2).
+        assert_eq!(log.earliest_seq(), Some(2));
+    }
+
+    #[test]
+    fn topic_log_gap_when_resume_cursor_evicted() {
+        let mut log = TopicLog::new(2);
+        for b in [b"a", b"b", b"c", b"d"] {
+            log.append(bytes(b));
+        }
+        // Ring holds seqs 3,4. Resuming after seq 1 has a hole (seq 2 gone).
+        let (_, gap) = log.replay_after(Some(1));
+        assert!(gap);
+        // Resuming after seq 3 is fine (4 is retained).
+        let (events, gap) = log.replay_after(Some(3));
+        assert!(!gap);
+        assert_eq!(events.iter().map(|(s, _)| *s).collect::<Vec<_>>(), vec![4]);
+    }
+
+    #[test]
+    fn topic_log_caught_up_resume_is_empty_no_gap() {
+        let mut log = TopicLog::new(8);
+        log.append(bytes(b"a"));
+        let (events, gap) = log.replay_after(Some(1));
+        assert!(!gap);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn topic_log_future_cursor_reports_gap() {
+        let mut log = TopicLog::new(8);
+        log.append(bytes(b"a"));
+        log.append(bytes(b"b"));
+        // Client claims seq 5 but only 1,2 were ever issued — unreplayable.
+        let (events, gap) = log.replay_after(Some(5));
+        assert!(gap);
+        assert!(events.is_empty());
+    }
+
+    #[test]
+    fn topic_log_max_cursor_does_not_panic() {
+        let mut log = TopicLog::new(8);
+        log.append(bytes(b"a"));
+        // u64::MAX cursor must not overflow `after + 1`; it is just a gap.
+        let (events, gap) = log.replay_after(Some(u64::MAX));
+        assert!(gap);
+        assert!(events.is_empty());
+    }
+
+    #[tokio::test]
+    async fn publish_then_subscribe_replays() {
+        let fanout = LocalFanout::new();
+        let topic = topic("collab:abc");
+        assert_eq!(fanout.publish(&topic, bytes(b"one")).await.unwrap(), 1);
+        assert_eq!(fanout.publish(&topic, bytes(b"two")).await.unwrap(), 2);
+
+        let mut stream = fanout.subscribe(&topic, None).await.unwrap();
+        assert!(!stream.gap());
+        assert_eq!(stream.next().await.unwrap(), Some((1, bytes(b"one"))));
+        assert_eq!(stream.next().await.unwrap(), Some((2, bytes(b"two"))));
+    }
+
+    #[tokio::test]
+    async fn subscribe_then_publish_delivers_live() {
+        let fanout = LocalFanout::new();
+        let topic = topic("collab:abc");
+        let mut stream = fanout.subscribe(&topic, None).await.unwrap();
+        fanout.publish(&topic, bytes(b"live")).await.unwrap();
+        assert_eq!(stream.next().await.unwrap(), Some((1, bytes(b"live"))));
+    }
+
+    #[tokio::test]
+    async fn replay_and_live_are_contiguous() {
+        let fanout = LocalFanout::new();
+        let topic = topic("collab:abc");
+        fanout.publish(&topic, bytes(b"1")).await.unwrap();
+        let mut stream = fanout.subscribe(&topic, None).await.unwrap();
+        fanout.publish(&topic, bytes(b"2")).await.unwrap();
+        // Replayed seq 1, then live seq 2 — no gap, no duplicate.
+        assert_eq!(stream.next().await.unwrap().unwrap().0, 1);
+        assert_eq!(stream.next().await.unwrap().unwrap().0, 2);
+    }
+
+    #[tokio::test]
+    async fn resume_after_eviction_reports_gap() {
+        let fanout = LocalFanout::with_capacity(2);
+        let topic = topic("collab:abc");
+        for b in [b"a", b"b", b"c", b"d"] {
+            fanout.publish(&topic, bytes(b)).await.unwrap();
+        }
+        let stream = fanout.subscribe(&topic, Some(1)).await.unwrap();
+        assert!(stream.gap());
+    }
+
+    #[tokio::test]
+    async fn overflowed_live_subscriber_lags() {
+        let fanout = LocalFanout::with_capacity(2);
+        let topic = topic("collab:abc");
+        // Subscribe (no replay), then overflow the broadcast buffer before
+        // reading.
+        let mut stream = fanout.subscribe(&topic, None).await.unwrap();
+        for b in [b"a", b"b", b"c", b"d", b"e"] {
+            fanout.publish(&topic, bytes(b)).await.unwrap();
+        }
+        match stream.next().await {
+            Err(WsError::Lagged(_)) => {}
+            other => panic!("expected Lagged, got {other:?}"),
+        }
+    }
+}

--- a/crates/pocopine-ws/src/server/frame.rs
+++ b/crates/pocopine-ws/src/server/frame.rs
@@ -1,0 +1,214 @@
+//! Binary frame envelope (RFC 073 §7).
+//!
+//! ```text
+//! frame := varUint(frame_kind)
+//!          varUint(subprotocol_id)
+//!          varUint(topic_ref)        # 0 for control frames not bound to a topic
+//!          varUint(seq)             # per-subscription seq on delivered Data; 0 otherwise
+//!          payload_bytes            # opaque to the gateway
+//! ```
+//!
+//! The gateway parses only this header; the trailing `payload_bytes` are
+//! opaque to it. Control frames (kind 0) carry a JSON [`crate::Control`]
+//! body by convention; Data frames (kind 3) carry an opaque application
+//! payload the gateway never decodes. `seq` carries the monotonic
+//! per-subscription sequence number on server→client Data frames (RFC 073
+//! §9); it is 0 on control frames and on client→server frames.
+
+use bytes::Bytes;
+
+use super::error::WsError;
+use super::varint::{read_var_uint, write_var_uint};
+
+/// Top-level frame discriminant.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum FrameKind {
+    /// Gateway lifecycle (Hello, Heartbeat, Resume, Gap, ...). Payload is a
+    /// JSON [`crate::Control`] body.
+    Control,
+    /// Request to join a topic. Payload is the UTF-8 topic string.
+    Subscribe,
+    /// Leave a topic identified by `topic_ref`. Payload is empty.
+    Unsubscribe,
+    /// An application (sub-protocol) message bound to `topic_ref`.
+    Data,
+}
+
+impl FrameKind {
+    fn to_u64(self) -> u64 {
+        match self {
+            Self::Control => 0,
+            Self::Subscribe => 1,
+            Self::Unsubscribe => 2,
+            Self::Data => 3,
+        }
+    }
+
+    fn from_u64(value: u64) -> Result<Self, WsError> {
+        match value {
+            0 => Ok(Self::Control),
+            1 => Ok(Self::Subscribe),
+            2 => Ok(Self::Unsubscribe),
+            3 => Ok(Self::Data),
+            other => Err(WsError::frame(format!("unknown frame_kind {other}"))),
+        }
+    }
+}
+
+/// A decoded frame envelope plus its opaque payload.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Frame {
+    pub kind: FrameKind,
+    pub subprotocol_id: u64,
+    pub topic_ref: u64,
+    pub seq: u64,
+    pub payload: Bytes,
+}
+
+impl Frame {
+    /// Construct an arbitrary frame.
+    pub fn new(
+        kind: FrameKind,
+        subprotocol_id: u64,
+        topic_ref: u64,
+        seq: u64,
+        payload: impl Into<Bytes>,
+    ) -> Self {
+        Self {
+            kind,
+            subprotocol_id,
+            topic_ref,
+            seq,
+            payload: payload.into(),
+        }
+    }
+
+    /// A control frame (kind 0, sub-protocol 0, topic_ref 0, seq 0).
+    pub fn control(payload: impl Into<Bytes>) -> Self {
+        Self::new(FrameKind::Control, 0, 0, 0, payload)
+    }
+
+    /// A Subscribe frame naming `topic` for `subprotocol_id`.
+    pub fn subscribe(subprotocol_id: u64, topic: &str) -> Self {
+        Self::new(
+            FrameKind::Subscribe,
+            subprotocol_id,
+            0,
+            0,
+            Bytes::copy_from_slice(topic.as_bytes()),
+        )
+    }
+
+    /// An Unsubscribe frame for `topic_ref`.
+    pub fn unsubscribe(topic_ref: u64) -> Self {
+        Self::new(FrameKind::Unsubscribe, 0, topic_ref, 0, Bytes::new())
+    }
+
+    /// A server→client Data frame for `topic_ref` carrying `seq` and an opaque
+    /// application payload.
+    pub fn data(subprotocol_id: u64, topic_ref: u64, seq: u64, payload: impl Into<Bytes>) -> Self {
+        Self::new(FrameKind::Data, subprotocol_id, topic_ref, seq, payload)
+    }
+
+    /// Serialize the envelope header followed by the payload.
+    pub fn encode(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(self.payload.len() + 5);
+        write_var_uint(&mut buf, self.kind.to_u64());
+        write_var_uint(&mut buf, self.subprotocol_id);
+        write_var_uint(&mut buf, self.topic_ref);
+        write_var_uint(&mut buf, self.seq);
+        buf.extend_from_slice(&self.payload);
+        buf
+    }
+
+    /// Decode a frame from a complete WebSocket binary message.
+    pub fn decode(bytes: &[u8]) -> Result<Self, WsError> {
+        let mut pos = 0usize;
+        let kind = FrameKind::from_u64(read_var_uint(bytes, &mut pos)?)?;
+        let subprotocol_id = read_var_uint(bytes, &mut pos)?;
+        let topic_ref = read_var_uint(bytes, &mut pos)?;
+        let seq = read_var_uint(bytes, &mut pos)?;
+        let payload = Bytes::copy_from_slice(&bytes[pos..]);
+        Ok(Self {
+            kind,
+            subprotocol_id,
+            topic_ref,
+            seq,
+            payload,
+        })
+    }
+
+    /// Interpret the payload as a UTF-8 string (used for Subscribe frames).
+    pub fn payload_str(&self) -> Result<&str, WsError> {
+        std::str::from_utf8(&self.payload)
+            .map_err(|_| WsError::frame("frame payload is not valid UTF-8"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrips_data_frame() {
+        let frame = Frame::data(1, 42, 7, Bytes::from_static(b"\x00\x01\x02opaque"));
+        let encoded = frame.encode();
+        let decoded = Frame::decode(&encoded).expect("decode");
+        assert_eq!(decoded, frame);
+        assert_eq!(decoded.kind, FrameKind::Data);
+        assert_eq!(decoded.subprotocol_id, 1);
+        assert_eq!(decoded.topic_ref, 42);
+        assert_eq!(decoded.seq, 7);
+    }
+
+    #[test]
+    fn roundtrips_control_frame() {
+        let frame = Frame::control(Bytes::from_static(b"{\"type\":\"heartbeat_ack\"}"));
+        let decoded = Frame::decode(&frame.encode()).expect("decode");
+        assert_eq!(decoded.kind, FrameKind::Control);
+        assert_eq!(decoded.subprotocol_id, 0);
+        assert_eq!(decoded.topic_ref, 0);
+        assert_eq!(decoded.seq, 0);
+        assert_eq!(decoded.payload, frame.payload);
+    }
+
+    #[test]
+    fn subscribe_frame_carries_topic_name() {
+        let frame = Frame::subscribe(1, "collab:abc");
+        let decoded = Frame::decode(&frame.encode()).expect("decode");
+        assert_eq!(decoded.kind, FrameKind::Subscribe);
+        assert_eq!(decoded.subprotocol_id, 1);
+        assert_eq!(decoded.payload_str().unwrap(), "collab:abc");
+    }
+
+    #[test]
+    fn empty_payload_roundtrips() {
+        let frame = Frame::unsubscribe(7);
+        let decoded = Frame::decode(&frame.encode()).expect("decode");
+        assert_eq!(decoded, frame);
+        assert!(decoded.payload.is_empty());
+        assert_eq!(decoded.topic_ref, 7);
+    }
+
+    #[test]
+    fn large_values_roundtrip() {
+        let frame = Frame::data(9, u32::MAX as u64 + 5, u64::MAX, Bytes::from_static(b"x"));
+        let decoded = Frame::decode(&frame.encode()).expect("decode");
+        assert_eq!(decoded.topic_ref, u32::MAX as u64 + 5);
+        assert_eq!(decoded.seq, u64::MAX);
+    }
+
+    #[test]
+    fn unknown_kind_errors() {
+        // frame_kind = 9 (varuint single byte), then three zero varuints.
+        let bytes = [9u8, 0, 0, 0];
+        assert!(Frame::decode(&bytes).is_err());
+    }
+
+    #[test]
+    fn truncated_header_errors() {
+        // Only frame_kind present, missing the rest of the header.
+        let bytes = [3u8];
+        assert!(Frame::decode(&bytes).is_err());
+    }
+}

--- a/crates/pocopine-ws/src/server/gateway.rs
+++ b/crates/pocopine-ws/src/server/gateway.rs
@@ -1,0 +1,206 @@
+//! The gateway hub: configuration, topic policy/resolver, and shared state
+//! (RFC 073 §10–§11).
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use pocopine_auth::RequestContext;
+use pocopine_events::Topic;
+
+use super::error::WsError;
+use super::fanout::{Fanout, LocalFanout};
+
+/// WebSocket sub-protocol identifier advertised in `Sec-WebSocket-Protocol`
+/// and the [`crate::Control::Hello`] frame.
+pub const WS_PROTOCOL_V1: &str = "pocopine.ws.v1";
+
+/// Default heartbeat interval the server asks clients to use.
+const DEFAULT_HEARTBEAT_MS: u32 = 15_000;
+/// Default number of missed heartbeat intervals before a connection is a
+/// zombie.
+const DEFAULT_ZOMBIE_GRACE: u32 = 3;
+/// Default maximum size of a single inbound frame (1 MiB).
+const DEFAULT_MAX_FRAME_BYTES: usize = 1 << 20;
+/// Default bounded outbound queue depth per connection.
+const DEFAULT_OUTBOUND_QUEUE: usize = 256;
+/// Default cap on concurrent topic subscriptions per connection.
+const DEFAULT_MAX_SUBSCRIPTIONS: usize = 256;
+/// Default cap on a topic-name string (bytes).
+const DEFAULT_MAX_TOPIC_BYTES: usize = 512;
+
+/// Per-topic authorization policy: may this `RequestContext` join this `Topic`?
+///
+/// Mirrors `LiveHub::with_topic_policy`'s synchronous bool shape (RFC 073
+/// §10.1). Capability-bearing consumers (e.g. collab read-only vs read-write)
+/// layer a richer async authorizer on top in their own crates.
+pub type TopicPolicy = Arc<dyn Fn(&RequestContext, &Topic) -> bool + Send + Sync>;
+
+/// Resolves a client-supplied topic string to a canonical `Topic`.
+pub type TopicResolver = Arc<dyn Fn(&str) -> Result<Topic, WsError> + Send + Sync>;
+
+/// Tunable connection limits and liveness timings.
+#[derive(Clone, Copy, Debug)]
+pub struct GatewayConfig {
+    /// Interval the server asks clients to heartbeat at.
+    pub heartbeat_interval_ms: u32,
+    /// Missed heartbeat intervals tolerated before the connection is closed.
+    pub zombie_grace: u32,
+    /// Hard cap on a single inbound frame; larger frames are rejected.
+    pub max_frame_bytes: usize,
+    /// Bounded per-connection outbound queue depth (backpressure).
+    pub outbound_queue: usize,
+    /// Cap on concurrent topic subscriptions per connection.
+    pub max_subscriptions: usize,
+    /// Cap on a topic-name string length, in bytes.
+    pub max_topic_bytes: usize,
+}
+
+impl Default for GatewayConfig {
+    fn default() -> Self {
+        Self {
+            heartbeat_interval_ms: DEFAULT_HEARTBEAT_MS,
+            zombie_grace: DEFAULT_ZOMBIE_GRACE,
+            max_frame_bytes: DEFAULT_MAX_FRAME_BYTES,
+            outbound_queue: DEFAULT_OUTBOUND_QUEUE,
+            max_subscriptions: DEFAULT_MAX_SUBSCRIPTIONS,
+            max_topic_bytes: DEFAULT_MAX_TOPIC_BYTES,
+        }
+    }
+}
+
+/// The mountable gateway. Clone-cheap (all shared state is behind `Arc`), as
+/// axum 0.7 requires router state to be `Clone`.
+#[derive(Clone)]
+pub struct WsGateway {
+    fanout: Arc<dyn Fanout>,
+    policy: TopicPolicy,
+    resolver: TopicResolver,
+    config: GatewayConfig,
+    sessions: Arc<AtomicU64>,
+}
+
+impl WsGateway {
+    /// Build a gateway over an explicit [`Fanout`].
+    ///
+    /// The default topic policy denies every topic (matching `LiveHub`'s safe
+    /// default); open it with [`WsGateway::allow_all_topics`],
+    /// [`WsGateway::allow_topics`], or [`WsGateway::with_topic_policy`]. The
+    /// default resolver maps a topic string straight to a `Topic`.
+    pub fn new(fanout: Arc<dyn Fanout>) -> Self {
+        Self {
+            fanout,
+            policy: Arc::new(|_, _| false),
+            resolver: Arc::new(|topic| Topic::new(topic).map_err(WsError::from)),
+            config: GatewayConfig::default(),
+            sessions: Arc::new(AtomicU64::new(0)),
+        }
+    }
+
+    /// Build a gateway backed by the in-process [`LocalFanout`] (single
+    /// process / tests).
+    pub fn local() -> Self {
+        Self::new(Arc::new(LocalFanout::new()))
+    }
+
+    /// Replace the per-topic authorization policy.
+    pub fn with_topic_policy(
+        mut self,
+        policy: impl Fn(&RequestContext, &Topic) -> bool + Send + Sync + 'static,
+    ) -> Self {
+        self.policy = Arc::new(policy);
+        self
+    }
+
+    /// Allow any connection to join any topic. Use only when topic access is
+    /// enforced elsewhere or is genuinely public.
+    pub fn allow_all_topics(self) -> Self {
+        self.with_topic_policy(|_, _| true)
+    }
+
+    /// Allow only the given set of `Topic`s.
+    pub fn allow_topics(self, topics: impl IntoIterator<Item = Topic>) -> Self {
+        let allowed: Arc<Vec<Topic>> = Arc::new(topics.into_iter().collect());
+        self.with_topic_policy(move |_, topic| allowed.iter().any(|t| t == topic))
+    }
+
+    /// Replace the topic-string → `Topic` resolver.
+    pub fn with_resolver(
+        mut self,
+        resolver: impl Fn(&str) -> Result<Topic, WsError> + Send + Sync + 'static,
+    ) -> Self {
+        self.resolver = Arc::new(resolver);
+        self
+    }
+
+    /// Override connection limits / liveness timings.
+    pub fn with_config(mut self, config: GatewayConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    // --- internal accessors used by the route/session machinery ---
+
+    pub(crate) fn fanout(&self) -> &Arc<dyn Fanout> {
+        &self.fanout
+    }
+
+    pub(crate) fn config(&self) -> GatewayConfig {
+        self.config
+    }
+
+    pub(crate) fn resolve(&self, topic: &str) -> Result<Topic, WsError> {
+        (self.resolver)(topic)
+    }
+
+    pub(crate) fn authorize(&self, ctx: &RequestContext, topic: &Topic) -> bool {
+        (self.policy)(ctx, topic)
+    }
+
+    pub(crate) fn next_session_id(&self) -> String {
+        let n = self.sessions.fetch_add(1, Ordering::Relaxed);
+        format!("ws-{n}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pocopine_auth::RequestContext;
+
+    fn anon_ctx() -> RequestContext {
+        RequestContext::new(
+            axum::http::Method::GET,
+            "/__pocopine/ws/v1".parse().unwrap(),
+            axum::http::HeaderMap::new(),
+        )
+    }
+
+    #[test]
+    fn default_policy_denies_all_topics() {
+        let gateway = WsGateway::local();
+        let topic = Topic::new("collab:abc").unwrap();
+        assert!(!gateway.authorize(&anon_ctx(), &topic));
+    }
+
+    #[test]
+    fn allow_topics_permits_only_listed() {
+        let allowed = Topic::new("collab:abc").unwrap();
+        let other = Topic::new("collab:xyz").unwrap();
+        let gateway = WsGateway::local().allow_topics([allowed.clone()]);
+        assert!(gateway.authorize(&anon_ctx(), &allowed));
+        assert!(!gateway.authorize(&anon_ctx(), &other));
+    }
+
+    #[test]
+    fn session_ids_are_unique() {
+        let gateway = WsGateway::local();
+        assert_ne!(gateway.next_session_id(), gateway.next_session_id());
+    }
+
+    #[test]
+    fn default_resolver_rejects_blank_topic() {
+        let gateway = WsGateway::local();
+        assert!(gateway.resolve("").is_err());
+        assert!(gateway.resolve("collab:abc").is_ok());
+    }
+}

--- a/crates/pocopine-ws/src/server/mod.rs
+++ b/crates/pocopine-ws/src/server/mod.rs
@@ -1,0 +1,21 @@
+//! Host-side gateway implementation (RFC 073 Part I).
+//!
+//! Everything host-only lives under this module so the crate root needs only
+//! a single `#[cfg(not(target_arch = "wasm32"))]` gate rather than one per
+//! item (see the `client-server-modules` skill). Submodules below carry no
+//! `cfg` attributes themselves.
+
+mod control;
+mod error;
+mod fanout;
+mod frame;
+mod gateway;
+mod route;
+mod varint;
+
+pub use control::{Control, TopicSeq};
+pub use error::WsError;
+pub use fanout::{DEFAULT_TOPIC_CAPACITY, Fanout, LocalFanout, TopicMessage, TopicStream};
+pub use frame::{Frame, FrameKind};
+pub use gateway::{GatewayConfig, TopicPolicy, TopicResolver, WS_PROTOCOL_V1, WsGateway};
+pub use route::{WS_STREAM_PATH, routes};

--- a/crates/pocopine-ws/src/server/route.rs
+++ b/crates/pocopine-ws/src/server/route.rs
@@ -1,0 +1,440 @@
+//! The axum WebSocket route and per-connection session loop (RFC 073 §6, §8–§11).
+//!
+//! `routes(gateway)` mounts a single upgrade endpoint, mirroring
+//! `pocopine_live::routes`. Each upgraded connection runs [`run_session`],
+//! which sends a [`Control::Hello`], then multiplexes:
+//!
+//! - inbound frames (Subscribe / Unsubscribe / Data / Heartbeat / Resume),
+//! - a bounded outbound queue drained by a writer task,
+//! - per-topic pump tasks forwarding fan-out messages as Data frames,
+//! - a heartbeat watchdog that closes zombie connections.
+//!
+//! The session loop NEVER blocks on the outbound queue: control/ack frames are
+//! enqueued with `try_send`, and a full queue (a slow/stuck consumer) closes
+//! the connection. This keeps the watchdog branch of the `select!` always
+//! reachable, so a peer that holds the socket open but stops reading is still
+//! reaped.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use axum::Router;
+use axum::body::Body;
+use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
+use axum::extract::{FromRequestParts, State};
+use axum::http::Request;
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use futures_util::{SinkExt, StreamExt};
+use pocopine_auth::RequestContext;
+use pocopine_events::Topic;
+use pocopine_observe::LOG_TARGET;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tokio::time::{Instant, MissedTickBehavior, interval};
+
+use super::control::Control;
+use super::error::WsError;
+use super::fanout::TopicStream;
+use super::frame::{Frame, FrameKind};
+use super::gateway::{GatewayConfig, WS_PROTOCOL_V1, WsGateway};
+
+/// Mount path for the gateway upgrade endpoint.
+pub const WS_STREAM_PATH: &str = "/__pocopine/ws/v1";
+
+/// Build the axum router for the gateway. Mirrors `pocopine_live::routes`:
+/// the [`WsGateway`] is the router state, reachable in the handler via
+/// `State<WsGateway>`.
+pub fn routes(gateway: WsGateway) -> Router {
+    Router::new()
+        .route(WS_STREAM_PATH, get(upgrade_handler))
+        .with_state(gateway)
+}
+
+async fn upgrade_handler(State(gateway): State<WsGateway>, request: Request<Body>) -> Response {
+    let config = gateway.config();
+    // Build the auth context from request parts BEFORE upgrading; the upgraded
+    // socket task no longer has the original request. `RequestContext` is not
+    // an axum extractor (no `FromRequestParts` impl) — assemble it by hand,
+    // exactly as pocopine-live's SSE handler does.
+    let (mut parts, _body) = request.into_parts();
+    let ctx = RequestContext::from_parts(
+        parts.method.clone(),
+        parts.uri.clone(),
+        parts.headers.clone(),
+        parts.extensions.clone(),
+    );
+    match WebSocketUpgrade::from_request_parts(&mut parts, &()).await {
+        // Cap message/frame size at the transport layer so an oversized message
+        // is rejected before the whole payload is buffered (the in-handler
+        // `max_frame_bytes` check is then a cheap second guard).
+        Ok(upgrade) => upgrade
+            .protocols([WS_PROTOCOL_V1])
+            .max_message_size(config.max_frame_bytes)
+            .max_frame_size(config.max_frame_bytes)
+            .on_upgrade(move |socket| run_session(socket, gateway, ctx)),
+        Err(rejection) => rejection.into_response(),
+    }
+}
+
+/// A live topic subscription owned by a session.
+struct TopicEntry {
+    topic: Topic,
+    name: String,
+    pump: JoinHandle<()>,
+}
+
+/// Per-connection state machine.
+struct Session {
+    session_id: String,
+    gateway: WsGateway,
+    ctx: RequestContext,
+    out: mpsc::Sender<Message>,
+    config: GatewayConfig,
+    topics: HashMap<u64, TopicEntry>,
+    topic_by_name: HashMap<String, u64>,
+    next_topic_ref: u64,
+    last_heartbeat: Instant,
+    /// Set when an outbound enqueue fails (full queue / writer gone); the
+    /// session loop closes the connection at the next boundary.
+    should_close: bool,
+}
+
+/// Drive one upgraded WebSocket connection to completion.
+async fn run_session(socket: WebSocket, gateway: WsGateway, ctx: RequestContext) {
+    let config = gateway.config();
+    let hb_ms = config.heartbeat_interval_ms.max(1);
+    let (mut sink, mut stream) = socket.split();
+    let (out_tx, mut out_rx) = mpsc::channel::<Message>(config.outbound_queue.max(1));
+
+    // Writer task: drains the bounded outbound queue to the socket.
+    let writer = tokio::spawn(async move {
+        while let Some(msg) = out_rx.recv().await {
+            if sink.send(msg).await.is_err() {
+                break;
+            }
+        }
+        let _ = sink.close().await;
+    });
+
+    let session_id = gateway.next_session_id();
+    tracing::info!(target: LOG_TARGET, session = %session_id, "ws session opened");
+
+    let hello = Control::Hello {
+        session_id: session_id.clone(),
+        heartbeat_interval_ms: hb_ms,
+        protocol: WS_PROTOCOL_V1.to_string(),
+    };
+    if !send_control(&out_tx, &hello).await {
+        writer.abort();
+        return;
+    }
+
+    let mut session = Session {
+        session_id,
+        gateway,
+        ctx,
+        out: out_tx,
+        config,
+        topics: HashMap::new(),
+        topic_by_name: HashMap::new(),
+        next_topic_ref: 1,
+        last_heartbeat: Instant::now(),
+        should_close: false,
+    };
+
+    let mut watchdog = interval(Duration::from_millis(u64::from(hb_ms)));
+    watchdog.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    watchdog.tick().await; // discard the immediate first tick
+
+    loop {
+        tokio::select! {
+            inbound = stream.next() => match inbound {
+                Some(Ok(Message::Binary(data))) => {
+                    if let Err(err) = session.handle_message(&data).await {
+                        tracing::warn!(
+                            target: LOG_TARGET,
+                            session = %session.session_id,
+                            error = %err,
+                            "ws frame rejected"
+                        );
+                        session.send(&Control::error("bad_frame", err.to_string()));
+                    }
+                }
+                Some(Ok(Message::Close(_))) | None => break,
+                Some(Ok(Message::Text(_))) => {
+                    session.send(&Control::error("bad_frame", "binary frames only"));
+                }
+                Some(Ok(Message::Ping(_))) | Some(Ok(Message::Pong(_))) => {}
+                Some(Err(_)) => break,
+            },
+            _ = watchdog.tick() => {
+                if session.is_zombie() {
+                    tracing::warn!(
+                        target: LOG_TARGET,
+                        session = %session.session_id,
+                        "ws connection zombied (missed heartbeats)"
+                    );
+                    break;
+                }
+            }
+        }
+
+        if session.should_close {
+            tracing::warn!(
+                target: LOG_TARGET,
+                session = %session.session_id,
+                "ws outbound queue full; closing slow consumer"
+            );
+            break;
+        }
+    }
+
+    session.shutdown();
+    writer.abort();
+    tracing::info!(target: LOG_TARGET, session = %session.session_id, "ws session closed");
+}
+
+impl Session {
+    fn is_zombie(&self) -> bool {
+        // Clamp the interval the same way the watchdog period is clamped, so a
+        // configured interval of 0 cannot make every fresh connection a zombie.
+        let interval_ms = u64::from(self.config.heartbeat_interval_ms.max(1));
+        let grace = u64::from(self.config.zombie_grace.max(1));
+        self.last_heartbeat.elapsed() > Duration::from_millis(interval_ms * grace)
+    }
+
+    /// Enqueue a control frame WITHOUT blocking. A full queue (slow consumer)
+    /// or a closed writer marks the session for close; it never parks the
+    /// session loop, so the heartbeat watchdog stays live.
+    fn send(&mut self, control: &Control) -> bool {
+        match control.into_frame() {
+            Ok(frame) => match self.out.try_send(Message::Binary(frame.encode())) {
+                Ok(()) => true,
+                Err(_) => {
+                    self.should_close = true;
+                    false
+                }
+            },
+            Err(_) => false,
+        }
+    }
+
+    async fn handle_message(&mut self, data: &[u8]) -> Result<(), WsError> {
+        if data.len() > self.config.max_frame_bytes {
+            return Err(WsError::TooLarge {
+                size: data.len(),
+                max: self.config.max_frame_bytes,
+            });
+        }
+        let frame = Frame::decode(data)?;
+        match frame.kind {
+            FrameKind::Control => self.handle_control(&frame).await,
+            FrameKind::Subscribe => self.handle_subscribe(&frame).await,
+            FrameKind::Unsubscribe => self.handle_unsubscribe(&frame),
+            FrameKind::Data => self.handle_data(&frame).await,
+        }
+    }
+
+    async fn handle_control(&mut self, frame: &Frame) -> Result<(), WsError> {
+        match Control::decode(&frame.payload)? {
+            Control::Heartbeat { .. } => {
+                self.last_heartbeat = Instant::now();
+                self.send(&Control::HeartbeatAck {});
+                Ok(())
+            }
+            Control::Resume { topics, .. } => {
+                for entry in topics {
+                    self.open_topic(
+                        &entry.topic,
+                        entry.subprotocol_id,
+                        Some(entry.last_seq),
+                        true,
+                    )
+                    .await;
+                }
+                Ok(())
+            }
+            _ => Err(WsError::protocol("unexpected control frame from client")),
+        }
+    }
+
+    async fn handle_subscribe(&mut self, frame: &Frame) -> Result<(), WsError> {
+        let topic_name = frame.payload_str()?.to_string();
+        self.open_topic(&topic_name, frame.subprotocol_id, None, false)
+            .await;
+        Ok(())
+    }
+
+    fn handle_unsubscribe(&mut self, frame: &Frame) -> Result<(), WsError> {
+        if let Some(entry) = self.topics.remove(&frame.topic_ref) {
+            entry.pump.abort();
+            self.topic_by_name.remove(&entry.name);
+            self.send(&Control::Unsubscribed { topic: entry.name });
+        }
+        Ok(())
+    }
+
+    async fn handle_data(&mut self, frame: &Frame) -> Result<(), WsError> {
+        let (topic, name) = match self.topics.get(&frame.topic_ref) {
+            Some(entry) => (entry.topic.clone(), entry.name.clone()),
+            None => {
+                return Err(WsError::protocol(format!(
+                    "data for unknown topic_ref {}",
+                    frame.topic_ref
+                )));
+            }
+        };
+        // Re-check write authorization on every inbound write (RFC 073 §10.1).
+        if !self.gateway.authorize(&self.ctx, &topic) {
+            return Err(WsError::forbidden(name));
+        }
+        self.gateway
+            .fanout()
+            .publish(&topic, frame.payload.clone())
+            .await?;
+        Ok(())
+    }
+
+    /// Resolve, authorize, subscribe, spawn the pump, and acknowledge a topic.
+    /// `after = Some(_)` (a Resume) replays from that cursor and emits
+    /// [`Control::Resumed`]; `after = None` (a fresh Subscribe) emits
+    /// [`Control::SubscribeAck`]. A re-subscribe to a live topic replaces it,
+    /// but only AFTER the new subscription is confirmed gap-free, so a gapped
+    /// Resume cannot tear down a healthy subscription.
+    async fn open_topic(
+        &mut self,
+        topic_name: &str,
+        subprotocol_id: u64,
+        after: Option<u64>,
+        resumed: bool,
+    ) {
+        if topic_name.len() > self.config.max_topic_bytes {
+            self.send(&Control::error("bad_topic", "topic name too long"));
+            return;
+        }
+        let topic = match self.gateway.resolve(topic_name) {
+            Ok(topic) => topic,
+            Err(err) => {
+                self.send(&Control::error("bad_topic", err.to_string()));
+                return;
+            }
+        };
+        if !self.gateway.authorize(&self.ctx, &topic) {
+            self.send(&Control::error(
+                "forbidden_topic",
+                format!("topic '{topic_name}' denied"),
+            ));
+            return;
+        }
+
+        // Per-connection subscription cap (new topics only; re-subscribe to an
+        // already-joined topic is always allowed).
+        let already_subscribed = self.topic_by_name.contains_key(topic_name);
+        if !already_subscribed && self.topics.len() >= self.config.max_subscriptions {
+            self.send(&Control::error(
+                "too_many_subscriptions",
+                "subscription limit reached",
+            ));
+            return;
+        }
+
+        // Open the new subscription BEFORE tearing down any existing one.
+        let stream = match self.gateway.fanout().subscribe(&topic, after).await {
+            Ok(stream) => stream,
+            Err(err) => {
+                self.send(&Control::error("subscribe_failed", err.to_string()));
+                return;
+            }
+        };
+        if stream.gap() {
+            // Unreplayable cursor: tell the client to re-subscribe fresh and
+            // leave any existing healthy subscription untouched.
+            self.send(&Control::gap(topic_name, "cursor_not_replayable"));
+            return;
+        }
+
+        // Commit: replace any existing subscription to this topic.
+        if let Some(old_ref) = self.topic_by_name.remove(topic_name)
+            && let Some(entry) = self.topics.remove(&old_ref)
+        {
+            entry.pump.abort();
+        }
+
+        let topic_ref = self.next_topic_ref;
+        self.next_topic_ref += 1;
+
+        let pump = tokio::spawn(pump_topic(
+            stream,
+            self.out.clone(),
+            subprotocol_id,
+            topic_ref,
+            topic_name.to_string(),
+        ));
+        self.topics.insert(
+            topic_ref,
+            TopicEntry {
+                topic,
+                name: topic_name.to_string(),
+                pump,
+            },
+        );
+        self.topic_by_name.insert(topic_name.to_string(), topic_ref);
+
+        let ack = if resumed {
+            Control::Resumed {
+                topic: topic_name.to_string(),
+            }
+        } else {
+            Control::SubscribeAck {
+                topic: topic_name.to_string(),
+                topic_ref,
+            }
+        };
+        self.send(&ack);
+    }
+
+    fn shutdown(&mut self) {
+        for (_, entry) in self.topics.drain() {
+            entry.pump.abort();
+        }
+        self.topic_by_name.clear();
+    }
+}
+
+/// Forward one topic's fan-out messages to the connection as Data frames, each
+/// carrying its per-subscription `seq`.
+async fn pump_topic(
+    mut stream: TopicStream,
+    out: mpsc::Sender<Message>,
+    subprotocol_id: u64,
+    topic_ref: u64,
+    topic_name: String,
+) {
+    loop {
+        match stream.next().await {
+            Ok(Some((seq, payload))) => {
+                let frame = Frame::data(subprotocol_id, topic_ref, seq, payload);
+                if out.send(Message::Binary(frame.encode())).await.is_err() {
+                    break; // connection closed
+                }
+            }
+            Ok(None) => break, // topic channel closed
+            Err(WsError::Lagged(_)) | Err(WsError::Gap) => {
+                let _ = send_control(&out, &Control::gap(&topic_name, "subscription_lagged")).await;
+                break; // client must re-subscribe fresh
+            }
+            Err(_) => break,
+        }
+    }
+}
+
+/// Encode and enqueue a control frame (awaiting backpressure); returns whether
+/// it was queued. Used by the per-topic pump tasks and the pre-loop Hello, where
+/// blocking on the queue is safe; the session loop uses [`Session::send`].
+async fn send_control(out: &mpsc::Sender<Message>, control: &Control) -> bool {
+    match control.into_frame() {
+        Ok(frame) => out.send(Message::Binary(frame.encode())).await.is_ok(),
+        Err(_) => false,
+    }
+}

--- a/crates/pocopine-ws/src/server/varint.rs
+++ b/crates/pocopine-ws/src/server/varint.rs
@@ -1,0 +1,133 @@
+//! lib0 `varUint` codec.
+//!
+//! RFC 073 §7 specifies the frame envelope uses lib0 `varUint` (LEB128 of an
+//! unsigned integer) — the same encoding the Yjs collab payloads use
+//! internally, so the envelope and the application payload can share one
+//! decoder. This module is the shared decoder.
+
+use super::error::WsError;
+
+/// Maximum bytes a `u64` LEB128 value may occupy (ceil(64 / 7) == 10).
+const MAX_VARUINT_BYTES: usize = 10;
+
+/// Append `value` to `buf` as a lib0 `varUint` (LEB128, little-endian groups
+/// of 7 bits, high bit = "more bytes follow").
+pub fn write_var_uint(buf: &mut Vec<u8>, mut value: u64) {
+    loop {
+        let byte = (value & 0x7f) as u8;
+        value >>= 7;
+        if value == 0 {
+            buf.push(byte);
+            return;
+        }
+        buf.push(byte | 0x80);
+    }
+}
+
+/// Read a lib0 `varUint` starting at `*pos`, advancing `*pos` past it.
+///
+/// Errors if the buffer ends mid-value or the value would overflow `u64`.
+pub fn read_var_uint(buf: &[u8], pos: &mut usize) -> Result<u64, WsError> {
+    let mut result: u64 = 0;
+    let mut shift: u32 = 0;
+    let mut read = 0usize;
+
+    loop {
+        let byte = *buf
+            .get(*pos)
+            .ok_or_else(|| WsError::frame("varuint: unexpected end of buffer"))?;
+        *pos += 1;
+        read += 1;
+
+        // The final (10th) byte of a u64 may only carry the top bit; reject
+        // anything that would shift past 64 bits.
+        if shift >= 64 || read > MAX_VARUINT_BYTES {
+            return Err(WsError::frame("varuint: value overflows u64"));
+        }
+        result |= u64::from(byte & 0x7f)
+            .checked_shl(shift)
+            .ok_or_else(|| WsError::frame("varuint: value overflows u64"))?;
+
+        if byte & 0x80 == 0 {
+            return Ok(result);
+        }
+        shift += 7;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn roundtrip(value: u64) {
+        let mut buf = Vec::new();
+        write_var_uint(&mut buf, value);
+        let mut pos = 0;
+        let decoded = read_var_uint(&buf, &mut pos).expect("decode");
+        assert_eq!(decoded, value, "value {value} did not round-trip");
+        assert_eq!(
+            pos,
+            buf.len(),
+            "decoder consumed wrong byte count for {value}"
+        );
+    }
+
+    #[test]
+    fn roundtrips_boundary_values() {
+        for value in [
+            0,
+            1,
+            0x7f,
+            0x80,
+            0x3fff,
+            0x4000,
+            300,
+            16_384,
+            u32::MAX as u64,
+            u64::MAX - 1,
+            u64::MAX,
+        ] {
+            roundtrip(value);
+        }
+    }
+
+    #[test]
+    fn single_byte_for_small_values() {
+        let mut buf = Vec::new();
+        write_var_uint(&mut buf, 0x7f);
+        assert_eq!(buf, vec![0x7f]);
+
+        buf.clear();
+        write_var_uint(&mut buf, 0x80);
+        assert_eq!(buf, vec![0x80, 0x01]);
+    }
+
+    #[test]
+    fn truncated_buffer_errors() {
+        // High bit set but no following byte.
+        let buf = [0x80u8];
+        let mut pos = 0;
+        assert!(read_var_uint(&buf, &mut pos).is_err());
+    }
+
+    #[test]
+    fn overlong_buffer_errors() {
+        // 11 continuation bytes — would overflow u64.
+        let buf = [0xffu8; 11];
+        let mut pos = 0;
+        assert!(read_var_uint(&buf, &mut pos).is_err());
+    }
+
+    #[test]
+    fn reads_sequential_values() {
+        let mut buf = Vec::new();
+        write_var_uint(&mut buf, 3);
+        write_var_uint(&mut buf, 300);
+        write_var_uint(&mut buf, 1);
+        let mut pos = 0;
+        assert_eq!(read_var_uint(&buf, &mut pos).unwrap(), 3);
+        assert_eq!(read_var_uint(&buf, &mut pos).unwrap(), 300);
+        assert_eq!(read_var_uint(&buf, &mut pos).unwrap(), 1);
+        assert_eq!(pos, buf.len());
+    }
+}

--- a/crates/pocopine-ws/tests/gateway.rs
+++ b/crates/pocopine-ws/tests/gateway.rs
@@ -1,0 +1,205 @@
+//! End-to-end gateway tests: boot the axum router on an ephemeral port and
+//! drive it with a real WebSocket client (tokio-tungstenite).
+
+use futures_util::{SinkExt, Stream, StreamExt};
+use pocopine_ws::{Control, Frame, FrameKind, GatewayConfig, TopicSeq, WsGateway, routes};
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::{Error as TungError, Message as WsMessage};
+
+/// Boot `gateway` on a random local port; return the ws:// URL.
+async fn spawn(gateway: WsGateway) -> String {
+    let app = routes(gateway);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("ws://{addr}/__pocopine/ws/v1")
+}
+
+/// Read the next binary frame, skipping ping/pong/text.
+async fn next_frame<S>(ws: &mut S) -> Frame
+where
+    S: Stream<Item = Result<WsMessage, TungError>> + Unpin,
+{
+    loop {
+        match ws
+            .next()
+            .await
+            .expect("stream ended")
+            .expect("ws transport error")
+        {
+            WsMessage::Binary(data) => return Frame::decode(&data).expect("decode frame"),
+            WsMessage::Close(_) => panic!("server closed unexpectedly"),
+            _ => {}
+        }
+    }
+}
+
+/// Read the next frame and decode it as a control body.
+async fn next_control<S>(ws: &mut S) -> Control
+where
+    S: Stream<Item = Result<WsMessage, TungError>> + Unpin,
+{
+    let frame = next_frame(ws).await;
+    assert_eq!(frame.kind, FrameKind::Control, "expected a control frame");
+    Control::decode(&frame.payload).expect("decode control")
+}
+
+/// Read frames until a Data frame arrives (skipping control frames).
+async fn next_data<S>(ws: &mut S) -> Frame
+where
+    S: Stream<Item = Result<WsMessage, TungError>> + Unpin,
+{
+    loop {
+        let frame = next_frame(ws).await;
+        if frame.kind == FrameKind::Data {
+            return frame;
+        }
+    }
+}
+
+fn send_bytes(frame: Frame) -> WsMessage {
+    WsMessage::Binary(frame.encode())
+}
+
+#[tokio::test]
+async fn subscribe_then_publish_echoes_with_seq() {
+    let url = spawn(WsGateway::local().allow_all_topics()).await;
+    let (mut ws, _resp) = connect_async(url).await.unwrap();
+
+    assert!(matches!(next_control(&mut ws).await, Control::Hello { .. }));
+
+    ws.send(send_bytes(Frame::subscribe(1, "topic:1")))
+        .await
+        .unwrap();
+    let topic_ref = match next_control(&mut ws).await {
+        Control::SubscribeAck { topic, topic_ref } => {
+            assert_eq!(topic, "topic:1");
+            topic_ref
+        }
+        other => panic!("expected SubscribeAck, got {other:?}"),
+    };
+
+    ws.send(send_bytes(Frame::data(1, topic_ref, 0, &b"hello"[..])))
+        .await
+        .unwrap();
+    let echo = next_data(&mut ws).await;
+    assert_eq!(echo.kind, FrameKind::Data);
+    assert_eq!(echo.topic_ref, topic_ref);
+    assert_eq!(echo.subprotocol_id, 1);
+    assert_eq!(echo.seq, 1, "first delivered message has seq 1");
+    assert_eq!(echo.payload_str().unwrap(), "hello");
+}
+
+#[tokio::test]
+async fn heartbeat_is_acked() {
+    let url = spawn(WsGateway::local().allow_all_topics()).await;
+    let (mut ws, _resp) = connect_async(url).await.unwrap();
+    assert!(matches!(next_control(&mut ws).await, Control::Hello { .. }));
+
+    let heartbeat = Control::Heartbeat { acks: vec![] }.into_frame().unwrap();
+    ws.send(send_bytes(heartbeat)).await.unwrap();
+    assert!(matches!(
+        next_control(&mut ws).await,
+        Control::HeartbeatAck {}
+    ));
+}
+
+#[tokio::test]
+async fn default_deny_rejects_subscribe() {
+    // No allow_* call: the gateway denies every topic.
+    let url = spawn(WsGateway::local()).await;
+    let (mut ws, _resp) = connect_async(url).await.unwrap();
+    assert!(matches!(next_control(&mut ws).await, Control::Hello { .. }));
+
+    ws.send(send_bytes(Frame::subscribe(1, "topic:1")))
+        .await
+        .unwrap();
+    match next_control(&mut ws).await {
+        Control::Error { code, .. } => assert_eq!(code, "forbidden_topic"),
+        other => panic!("expected forbidden error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn resume_replays_messages_after_last_seq() {
+    let url = spawn(WsGateway::local().allow_all_topics()).await;
+
+    // Connection 1: subscribe and publish two messages.
+    let (mut ws1, _r1) = connect_async(url.clone()).await.unwrap();
+    assert!(matches!(
+        next_control(&mut ws1).await,
+        Control::Hello { .. }
+    ));
+    ws1.send(send_bytes(Frame::subscribe(1, "topic:1")))
+        .await
+        .unwrap();
+    let topic_ref = match next_control(&mut ws1).await {
+        Control::SubscribeAck { topic_ref, .. } => topic_ref,
+        other => panic!("expected SubscribeAck, got {other:?}"),
+    };
+    ws1.send(send_bytes(Frame::data(1, topic_ref, 0, &b"m1"[..])))
+        .await
+        .unwrap();
+    assert_eq!(next_data(&mut ws1).await.seq, 1);
+    ws1.send(send_bytes(Frame::data(1, topic_ref, 0, &b"m2"[..])))
+        .await
+        .unwrap();
+    assert_eq!(next_data(&mut ws1).await.seq, 2);
+    drop(ws1); // disconnect
+
+    // Connection 2: resume the topic after seq 1 — expect the seq-2 replay.
+    let (mut ws2, _r2) = connect_async(url).await.unwrap();
+    assert!(matches!(
+        next_control(&mut ws2).await,
+        Control::Hello { .. }
+    ));
+    let resume = Control::Resume {
+        session_id: "any".into(),
+        topics: vec![TopicSeq {
+            topic: "topic:1".into(),
+            last_seq: 1,
+            subprotocol_id: 1,
+        }],
+    };
+    ws2.send(send_bytes(resume.into_frame().unwrap()))
+        .await
+        .unwrap();
+
+    let replayed = next_data(&mut ws2).await;
+    assert_eq!(
+        replayed.seq, 2,
+        "resume replays only messages after last_seq"
+    );
+    assert_eq!(replayed.payload_str().unwrap(), "m2");
+}
+
+#[tokio::test]
+async fn subscription_cap_rejects_extra_topics() {
+    let config = GatewayConfig {
+        max_subscriptions: 1,
+        ..GatewayConfig::default()
+    };
+    let url = spawn(WsGateway::local().allow_all_topics().with_config(config)).await;
+    let (mut ws, _resp) = connect_async(url).await.unwrap();
+    assert!(matches!(next_control(&mut ws).await, Control::Hello { .. }));
+
+    // First subscription is accepted.
+    ws.send(send_bytes(Frame::subscribe(1, "topic:1")))
+        .await
+        .unwrap();
+    assert!(matches!(
+        next_control(&mut ws).await,
+        Control::SubscribeAck { .. }
+    ));
+
+    // Second distinct topic exceeds the per-connection cap.
+    ws.send(send_bytes(Frame::subscribe(1, "topic:2")))
+        .await
+        .unwrap();
+    match next_control(&mut ws).await {
+        Control::Error { code, .. } => assert_eq!(code, "too_many_subscriptions"),
+        other => panic!("expected too_many_subscriptions, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

Adds **`pocopine-ws`**, the generic bidirectional WebSocket gateway from RFC 073 (Part I) — the bidirectional counterpart to `pocopine-live`'s server-to-client SSE invalidation. CRDT collaboration (`pocopine-collab`) and messaging (`pocopine-chat`, RFC 106) will both consume it.

The gateway owns **transport concerns only** — framing, liveness, sequencing/resume, per-topic auth, fan-out — and treats application payloads as opaque, tagged by a `subprotocol_id` it never decodes.

```mermaid
flowchart TB
  Browser["Browser (Yjs / chat client)"]
  Browser -- "SSE reads — pocopine-live" --> Web
  Browser -- "WebSocket — pocopine-ws" --> Web
  subgraph Web["web process (axum)"]
    GW["WsGateway<br/>framing · liveness · seq/RESUME · per-topic auth"]
    GW --> Fanout{{"Fanout trait"}}
  end
  Fanout -- "now" --> Local["LocalFanout<br/>in-process: per-topic ring buffer + tokio broadcast"]
  Fanout -. "Phase C" .-> Redis["RedisFanout over pocopine-events<br/>multi-instance fan-out"]
```

## What's implemented

- **Frame envelope** (binary, lib0 varUint): `kind · subprotocol_id · topic_ref · seq · payload`.
- **Liveness** (Discord-style): `Hello` / `Heartbeat` / `HeartbeatAck`, per-subscription sequence numbers, `Resume` with in-order replay + gap detection, zombie reaping.
- **Per-topic authorization** via `pocopine_auth::RequestContext`, mirroring `LiveHub::with_topic_policy` / `allow_topics` (default-deny).
- **Fan-out** behind a `Fanout` trait. `LocalFanout` (in-process) ships now; the Redis / `pocopine-events` multi-process impl is the **Phase C** follow-up and slots into the same trait — no gateway changes.

## API — mirrors `pocopine-live`

```rust
let gateway = WsGateway::local().allow_all_topics();
let router = pocopine_ws::routes(gateway); // mounts /__pocopine/ws/v1
```

## Module layout

Host-only crate following the new **`client-server-modules`** convention (skill added in this PR): all server code under one `#[cfg(not(target_arch = "wasm32"))] pub mod server;` gate — not a per-item `cfg` — and empty on wasm32.

## Quality

- **39 tests** — codec round-trips, fan-out ring buffer (seq / gap / lag), and 5 end-to-end tests over a live socket: subscribe → echo with `seq`, heartbeat-ack, default-deny rejection, **RESUME-after-disconnect**, and the subscription cap.
- `cargo clippy -D warnings` clean on **host and wasm32**; `cargo fmt --check` clean.
- Hardened after an adversarial review: `try_send` on the session loop so a stuck consumer can't starve the heartbeat watchdog; overflow-safe resume-cursor handling; transport-level frame-size cap; per-connection subscription + topic-name caps; subscribe-before-teardown on `Resume`.

## Scope & follow-ups

- Implements RFC 073 **Part I** (transport). `pocopine-collab` (Part II) and `pocopine-chat` (RFC 106) are separate; the RFC docs live on a sibling branch.
- **Phase C** — Redis-backed `Fanout` for multi-instance fan-out (`LocalFanout` is single-process; no cross-replica delivery, and idle topics aren't reaped yet).
- **Phase D** — deterministic topic → shard routing.
- Doc drift to reconcile when the RFC lands: RFC 073 §7 still says `room`/`room_ref` and omits the `seq` envelope field; the code uses `topic`/`topic_ref` + `seq`.
