### PR TITLE
fix(agenkit): harden the RFC-093 shipped surface (#214)

### DIFF
--- a/crates/pocopine-agenkit-core/src/events.rs
+++ b/crates/pocopine-agenkit-core/src/events.rs
@@ -25,6 +25,10 @@ pub const AI_STEP_STARTED: &str = "ai_step_started";
 pub const AI_STEP_COMPLETED: &str = "ai_step_completed";
 /// A flow step failed.
 pub const AI_STEP_FAILED: &str = "ai_step_failed";
+/// A flow step was cancelled before finishing (e.g. a losing parallel branch
+/// aborted in flight). A terminal event, so a client reconstructing the trace
+/// tree can close a branch that started but neither completed nor failed.
+pub const AI_STEP_CANCELLED: &str = "ai_step_cancelled";
 
 // Parallel and reducer steps.
 /// A parallel fan-out group began.

--- a/crates/pocopine-agenkit-core/src/stream.rs
+++ b/crates/pocopine-agenkit-core/src/stream.rs
@@ -136,6 +136,15 @@ pub enum FlowStreamEvent {
         /// The public error kind.
         error_kind: String,
     },
+    /// A branch was cancelled in flight (a losing branch aborted by an
+    /// early-exit join). Terminal, so a client can close a branch that started
+    /// but never completed or failed.
+    BranchCancelled {
+        /// The parallel group id.
+        group_id: ParallelGroupId,
+        /// The branch's step id.
+        step_id: StepId,
+    },
     /// A parallel group finished.
     ParallelCompleted {
         /// The parallel group id.

--- a/crates/pocopine-agenkit-oai/src/lib.rs
+++ b/crates/pocopine-agenkit-oai/src/lib.rs
@@ -28,7 +28,8 @@
 
 mod wire;
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
+use std::time::Duration;
 
 use futures::StreamExt;
 use pocopine_agenkit::server::{
@@ -45,6 +46,27 @@ use wire::{ChatRequest, ChatResponse, StreamEvent};
 /// The default OpenAI API base URL.
 pub const DEFAULT_BASE_URL: &str = "https://api.openai.com/v1";
 
+/// Default total timeout for a non-streaming request (streaming is never
+/// capped — an SSE stream is long-lived by design).
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Default number of retries on transient failures (429 / 5xx / network).
+const DEFAULT_MAX_RETRIES: u32 = 2;
+
+/// Which output-token-limit field a Chat Completions request sends.
+///
+/// OpenAI's o-series / gpt-5-class models reject the legacy `max_tokens` and
+/// require `max_completion_tokens`; most compatible gateways still want
+/// `max_tokens`. The provider picks the right one automatically by base URL
+/// (see [`OpenAiProvider::with_max_tokens_param`] to override).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MaxTokensParam {
+    /// Send legacy `max_tokens` (broad gateway compatibility).
+    MaxTokens,
+    /// Send `max_completion_tokens` (required by newer OpenAI models).
+    MaxCompletionTokens,
+}
+
 /// A provider backed by an OpenAI-compatible `/v1/chat/completions` endpoint.
 #[derive(Clone)]
 pub struct OpenAiProvider {
@@ -54,6 +76,12 @@ pub struct OpenAiProvider {
     organization: Option<String>,
     /// Use native strict `json_schema` structured output (vs `json_object`).
     strict_schema: bool,
+    /// Which output-token field to send; `None` auto-derives from `base_url`.
+    max_tokens_param: Option<MaxTokensParam>,
+    /// Total timeout for a non-streaming request.
+    request_timeout: Duration,
+    /// Retries on transient failures (429 / 5xx / network errors).
+    max_retries: u32,
     http: reqwest::Client,
 }
 
@@ -67,11 +95,15 @@ impl OpenAiProvider {
             base_url: DEFAULT_BASE_URL.to_string(),
             organization: None,
             strict_schema: true,
-            // A connect timeout only: an unreachable endpoint fails fast, but
-            // a long-lived SSE stream is never cut by a total-request timeout.
-            // Use `with_http_client` for finer control.
+            max_tokens_param: None,
+            request_timeout: DEFAULT_REQUEST_TIMEOUT,
+            max_retries: DEFAULT_MAX_RETRIES,
+            // A connect timeout only on the shared client: an unreachable
+            // endpoint fails fast. The total-request timeout is applied
+            // per-call (non-streaming only) so a long-lived SSE stream is never
+            // cut. Use `with_http_client` for finer control.
             http: reqwest::Client::builder()
-                .connect_timeout(std::time::Duration::from_secs(15))
+                .connect_timeout(Duration::from_secs(15))
                 .build()
                 .unwrap_or_default(),
         }
@@ -108,6 +140,24 @@ impl OpenAiProvider {
         self
     }
 
+    /// Force which output-token field is sent, overriding base-URL detection.
+    pub fn with_max_tokens_param(mut self, param: MaxTokensParam) -> Self {
+        self.max_tokens_param = Some(param);
+        self
+    }
+
+    /// Total timeout for a non-streaming request (streaming is never capped).
+    pub fn with_request_timeout(mut self, timeout: Duration) -> Self {
+        self.request_timeout = timeout;
+        self
+    }
+
+    /// Retries on transient failures (429 / 5xx / network errors). `0` disables.
+    pub fn with_max_retries(mut self, retries: u32) -> Self {
+        self.max_retries = retries;
+        self
+    }
+
     /// Use a pre-configured `reqwest::Client` (timeouts, proxy, ...).
     pub fn with_http_client(mut self, http: reqwest::Client) -> Self {
         self.http = http;
@@ -118,7 +168,21 @@ impl OpenAiProvider {
         format!("{}/chat/completions", self.base_url.trim_end_matches('/'))
     }
 
-    fn post(&self, wire: &ChatRequest) -> reqwest::RequestBuilder {
+    /// The output-token field to send: an explicit override, else
+    /// `max_completion_tokens` for the official OpenAI host and the legacy
+    /// `max_tokens` for any other (gateway) base URL. (Newer OpenAI models
+    /// require `max_completion_tokens`; most gateways still want `max_tokens`.)
+    fn max_tokens_param(&self) -> MaxTokensParam {
+        self.max_tokens_param.unwrap_or_else(|| {
+            if self.base_url.contains("api.openai.com") {
+                MaxTokensParam::MaxCompletionTokens
+            } else {
+                MaxTokensParam::MaxTokens
+            }
+        })
+    }
+
+    fn post(&self, wire: &ChatRequest, timeout: Option<Duration>) -> reqwest::RequestBuilder {
         let mut builder = self
             .http
             .post(self.endpoint())
@@ -127,29 +191,62 @@ impl OpenAiProvider {
         if let Some(organization) = &self.organization {
             builder = builder.header("OpenAI-Organization", organization);
         }
+        if let Some(timeout) = timeout {
+            builder = builder.timeout(timeout);
+        }
         builder
     }
 
+    /// POST with retry on transient failures (429 / 5xx / network errors),
+    /// returning the successful response. `timeout` caps each attempt (set only
+    /// for non-streaming calls). On a terminal non-2xx, the error carries only
+    /// the stable status/type, never the body message (§D10).
+    async fn send_with_retry(
+        &self,
+        wire: &ChatRequest,
+        timeout: Option<Duration>,
+    ) -> AgenkitResult<reqwest::Response> {
+        let mut attempt: u32 = 0;
+        loop {
+            match self.post(wire, timeout).send().await {
+                Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) => {
+                    let status = response.status().as_u16();
+                    if is_retryable_status(status) && attempt < self.max_retries {
+                        let delay = retry_delay(attempt, response.headers());
+                        attempt += 1;
+                        tokio::time::sleep(delay).await;
+                        continue;
+                    }
+                    let body = response.text().await.unwrap_or_default();
+                    return Err(AgenkitError::provider(openai_error_message(status, &body)));
+                }
+                Err(err) => {
+                    if attempt < self.max_retries {
+                        let delay = retry_delay(attempt, &reqwest::header::HeaderMap::new());
+                        attempt += 1;
+                        tokio::time::sleep(delay).await;
+                        continue;
+                    }
+                    return Err(AgenkitError::provider(format!("request failed: {err}")));
+                }
+            }
+        }
+    }
+
     async fn chat(&self, request: GenerateRequest) -> AgenkitResult<GenerateResponse> {
-        let wire = ChatRequest::from_agenkit(&request, false, self.strict_schema);
+        let name_map = wire::tool_name_map(&request.tools);
+        let wire =
+            ChatRequest::from_agenkit(&request, false, self.strict_schema, self.max_tokens_param());
         let response = self
-            .post(&wire)
-            .send()
-            .await
-            .map_err(|err| AgenkitError::provider(format!("request failed: {err}")))?;
-        let status = response.status();
+            .send_with_retry(&wire, Some(self.request_timeout))
+            .await?;
         let body = response.text().await.map_err(|err| {
             AgenkitError::provider(format!("reading response body failed: {err}"))
         })?;
-        if !status.is_success() {
-            return Err(AgenkitError::provider(openai_error_message(
-                status.as_u16(),
-                &body,
-            )));
-        }
         serde_json::from_str::<ChatResponse>(&body)
             .map_err(|err| AgenkitError::provider(format!("invalid response shape: {err}")))?
-            .into_agenkit()
+            .into_agenkit(&name_map)
     }
 
     /// Read the SSE stream into `tx`, forwarding text deltas and accumulating
@@ -159,20 +256,11 @@ impl OpenAiProvider {
         request: GenerateRequest,
         tx: UnboundedSender<AgenkitResult<StreamChunk>>,
     ) -> AgenkitResult<()> {
-        let wire = ChatRequest::from_agenkit(&request, true, self.strict_schema);
-        let response = self
-            .post(&wire)
-            .send()
-            .await
-            .map_err(|err| AgenkitError::provider(format!("request failed: {err}")))?;
-        let status = response.status();
-        if !status.is_success() {
-            let body = response.text().await.unwrap_or_default();
-            return Err(AgenkitError::provider(openai_error_message(
-                status.as_u16(),
-                &body,
-            )));
-        }
+        let name_map = wire::tool_name_map(&request.tools);
+        let wire =
+            ChatRequest::from_agenkit(&request, true, self.strict_schema, self.max_tokens_param());
+        // No total timeout on a stream; retry only the connect/status handshake.
+        let response = self.send_with_retry(&wire, None).await?;
 
         // Buffer raw bytes and only decode whole `\n`-terminated lines. `\n`
         // (0x0A) never appears inside a multi-byte UTF-8 sequence, so a line cut
@@ -182,6 +270,7 @@ impl OpenAiProvider {
         let mut bytes = response.bytes_stream();
         let mut buffer: Vec<u8> = Vec::new();
         let mut tools: BTreeMap<u32, ToolAccumulator> = BTreeMap::new();
+        let mut decoder = SseDecoder::default();
 
         while let Some(chunk) = bytes.next().await {
             let chunk = chunk
@@ -189,50 +278,108 @@ impl OpenAiProvider {
             buffer.extend_from_slice(&chunk);
 
             while let Some(newline) = buffer.iter().position(|&b| b == b'\n') {
-                let done = apply_sse_line(&buffer[..newline], &mut tools, &tx);
+                let done = decoder.feed_line(&buffer[..newline], &mut tools, &tx);
                 buffer.drain(..=newline);
                 if done {
-                    emit_tool_calls(tools, &tx);
+                    emit_tool_calls(tools, &tx, &name_map);
                     return Ok(());
                 }
             }
         }
 
-        // Flush a final line that arrived without a trailing newline (a gateway
-        // that closes the body right after the last `data:` and omits `[DONE]`).
+        // A final line that arrived without a trailing newline, then flush any
+        // event still buffered with no terminating blank line (a gateway that
+        // closes the body right after the last `data:` and omits `[DONE]`).
         if !buffer.is_empty() {
-            apply_sse_line(&buffer, &mut tools, &tx);
+            decoder.feed_line(&buffer, &mut tools, &tx);
         }
-        emit_tool_calls(tools, &tx);
+        decoder.flush(&mut tools, &tx);
+        emit_tool_calls(tools, &tx, &name_map);
         Ok(())
     }
 }
 
-/// Parse one SSE line and apply it to the accumulators. Returns `true` when the
-/// terminal `data: [DONE]` sentinel was seen. Keep-alive/comment/undecodable
-/// lines are ignored.
-fn apply_sse_line(
-    line: &[u8],
+/// Reassembles SSE events from individual lines. Per the spec an event is
+/// terminated by a blank line and may carry several `data:` fields that join
+/// with `\n` — so a gateway that splits one JSON payload across multiple
+/// `data:` lines is parsed correctly instead of being silently dropped.
+#[derive(Default)]
+struct SseDecoder {
+    /// `data:` field values accumulated for the in-progress event.
+    data: Vec<String>,
+}
+
+impl SseDecoder {
+    /// Feed one line (without its trailing `\n`). Returns `true` when the
+    /// terminal `[DONE]` sentinel was dispatched.
+    fn feed_line(
+        &mut self,
+        line: &[u8],
+        tools: &mut BTreeMap<u32, ToolAccumulator>,
+        tx: &UnboundedSender<AgenkitResult<StreamChunk>>,
+    ) -> bool {
+        let Ok(text) = std::str::from_utf8(line) else {
+            return false;
+        };
+        // Tolerate CRLF: strip a `\r` left by splitting a `\r\n` stream on `\n`.
+        let text = text.strip_suffix('\r').unwrap_or(text);
+        // A blank line is the event boundary: dispatch what we've buffered.
+        if text.is_empty() {
+            return self.dispatch(tools, tx);
+        }
+        // A comment / keep-alive line (starts with `:`).
+        if text.starts_with(':') {
+            return false;
+        }
+        // Accumulate `data:` fields; ignore other SSE fields (event:, id:, ...).
+        if let Some(value) = text.strip_prefix("data:") {
+            // SSE strips exactly one optional leading space after the colon.
+            let value = value.strip_prefix(' ').unwrap_or(value);
+            self.data.push(value.to_string());
+        }
+        false
+    }
+
+    /// Dispatch the buffered event: join its `data:` fields with `\n` and apply.
+    /// Returns `true` if it was `[DONE]`. Clears the buffer either way.
+    fn dispatch(
+        &mut self,
+        tools: &mut BTreeMap<u32, ToolAccumulator>,
+        tx: &UnboundedSender<AgenkitResult<StreamChunk>>,
+    ) -> bool {
+        if self.data.is_empty() {
+            return false;
+        }
+        let data = std::mem::take(&mut self.data).join("\n");
+        let data = data.trim();
+        if data == "[DONE]" {
+            return true;
+        }
+        // Ignore unparseable keep-alive / comment payloads.
+        if let Ok(event) = serde_json::from_str::<StreamEvent>(data) {
+            apply_event(event, tools, tx);
+        }
+        false
+    }
+
+    /// Flush an event buffered with no terminating blank line. Returns `true`
+    /// if it was `[DONE]`.
+    fn flush(
+        &mut self,
+        tools: &mut BTreeMap<u32, ToolAccumulator>,
+        tx: &UnboundedSender<AgenkitResult<StreamChunk>>,
+    ) -> bool {
+        self.dispatch(tools, tx)
+    }
+}
+
+/// Apply one decoded stream event: forward text deltas, accumulate tool-call
+/// fragments by index, and forward usage.
+fn apply_event(
+    event: StreamEvent,
     tools: &mut BTreeMap<u32, ToolAccumulator>,
     tx: &UnboundedSender<AgenkitResult<StreamChunk>>,
-) -> bool {
-    let Ok(text) = std::str::from_utf8(line) else {
-        return false;
-    };
-    let Some(data) = text.trim().strip_prefix("data:") else {
-        return false;
-    };
-    let data = data.trim();
-    if data.is_empty() {
-        return false;
-    }
-    if data == "[DONE]" {
-        return true;
-    }
-    // Ignore unparseable keep-alive / comment lines.
-    let Ok(event) = serde_json::from_str::<StreamEvent>(data) else {
-        return false;
-    };
+) {
     for choice in event.choices {
         if let Some(content) = choice.delta.content
             && !content.is_empty()
@@ -257,7 +404,24 @@ fn apply_sse_line(
     if let Some(usage) = event.usage {
         let _ = tx.send(Ok(StreamChunk::Usage(usage.into_usage())));
     }
-    false
+}
+
+/// Whether a non-2xx status is worth retrying: rate limits and server errors.
+fn is_retryable_status(status: u16) -> bool {
+    status == 429 || status >= 500
+}
+
+/// Backoff before the next retry: honor `Retry-After` (seconds, capped) when
+/// present, otherwise exponential from 250ms (250ms, 500ms, 1s, ...).
+fn retry_delay(attempt: u32, headers: &reqwest::header::HeaderMap) -> Duration {
+    if let Some(secs) = headers
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.trim().parse::<u64>().ok())
+    {
+        return Duration::from_secs(secs.min(30));
+    }
+    Duration::from_millis(250u64.saturating_mul(1u64 << attempt.min(5)))
 }
 
 impl Provider for OpenAiProvider {
@@ -302,6 +466,7 @@ struct ToolAccumulator {
 fn emit_tool_calls(
     tools: BTreeMap<u32, ToolAccumulator>,
     tx: &UnboundedSender<AgenkitResult<StreamChunk>>,
+    name_map: &HashMap<String, String>,
 ) {
     for (_, acc) in tools {
         // Empty (zero-argument tool) or truncated args default to `{}`, not
@@ -313,9 +478,9 @@ fn emit_tool_calls(
         } else {
             serde_json::from_str(&acc.arguments).unwrap_or_else(|_| serde_json::json!({}))
         };
-        let _ = tx.send(Ok(StreamChunk::ToolCall(ToolCall::new(
-            acc.id, acc.name, args,
-        ))));
+        // Reverse the outbound name sanitization so dispatch finds the real tool.
+        let name = wire::resolve_tool_name(acc.name, name_map);
+        let _ = tx.send(Ok(StreamChunk::ToolCall(ToolCall::new(acc.id, name, args))));
     }
 }
 
@@ -366,18 +531,19 @@ mod tests {
 
     #[test]
     fn buffered_lines_reassemble_a_codepoint_split_across_chunks() {
-        // Two SSE `data:` events whose JSON content carries multi-byte chars
-        // ("café", "naïve 🚀"), fed as a byte stream that is re-sliced at
-        // arbitrary boundaries — including in the middle of a multi-byte char.
+        // Two SSE events (blank-line delimited, per spec) whose JSON content
+        // carries multi-byte chars ("café", "naïve 🚀"), fed as a byte stream
+        // re-sliced at arbitrary boundaries — including mid multi-byte char.
         let sse = concat!(
-            "data: {\"choices\":[{\"delta\":{\"content\":\"café \"}}]}\n",
-            "data: {\"choices\":[{\"delta\":{\"content\":\"naïve 🚀\"}}]}\n",
-            "data: [DONE]\n",
+            "data: {\"choices\":[{\"delta\":{\"content\":\"café \"}}]}\n\n",
+            "data: {\"choices\":[{\"delta\":{\"content\":\"naïve 🚀\"}}]}\n\n",
+            "data: [DONE]\n\n",
         )
         .as_bytes();
 
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         let mut tools = BTreeMap::new();
+        let mut decoder = SseDecoder::default();
         let mut buffer: Vec<u8> = Vec::new();
         // Drive the exact buffering loop from `stream_into`, chunking every 3
         // bytes so multi-byte sequences straddle chunk boundaries.
@@ -385,7 +551,7 @@ mod tests {
         for chunk in sse.chunks(3) {
             buffer.extend_from_slice(chunk);
             while let Some(newline) = buffer.iter().position(|&b| b == b'\n') {
-                if apply_sse_line(&buffer[..newline], &mut tools, &tx) {
+                if decoder.feed_line(&buffer[..newline], &mut tools, &tx) {
                     done = true;
                 }
                 buffer.drain(..=newline);
@@ -396,12 +562,31 @@ mod tests {
     }
 
     #[test]
-    fn trailing_line_without_newline_is_flushed() {
-        // A final `data:` event with no terminating newline and no `[DONE]`.
+    fn multi_line_data_fields_are_joined_before_parsing() {
+        // A spec-conformant gateway split one JSON payload across two `data:`
+        // lines; they must join with `\n` and parse as a single event.
         let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
         let mut tools = BTreeMap::new();
-        let line = br#"data: {"choices":[{"delta":{"content":"last"}}]}"#;
-        apply_sse_line(line, &mut tools, &tx);
+        let mut decoder = SseDecoder::default();
+        decoder.feed_line(br#"data: {"choices":[{"delta":"#, &mut tools, &tx);
+        decoder.feed_line(br#"data: {"content":"joined"}}]}"#, &mut tools, &tx);
+        let done = decoder.feed_line(b"", &mut tools, &tx); // blank line dispatches
+        assert!(!done);
+        assert_eq!(drain_text(&mut rx), "joined");
+    }
+
+    #[test]
+    fn trailing_event_without_blank_line_is_flushed() {
+        // A final `data:` event with no terminating blank line and no `[DONE]`.
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut tools = BTreeMap::new();
+        let mut decoder = SseDecoder::default();
+        decoder.feed_line(
+            br#"data: {"choices":[{"delta":{"content":"last"}}]}"#,
+            &mut tools,
+            &tx,
+        );
+        decoder.flush(&mut tools, &tx);
         assert_eq!(drain_text(&mut rx), "last");
     }
 
@@ -417,10 +602,54 @@ mod tests {
                 arguments: String::new(), // a zero-argument tool call
             },
         );
-        emit_tool_calls(tools, &tx);
+        emit_tool_calls(tools, &tx, &HashMap::new());
         let Ok(StreamChunk::ToolCall(call)) = rx.try_recv().unwrap() else {
             panic!("expected a tool call");
         };
         assert_eq!(call.args, serde_json::json!({}));
+    }
+
+    #[test]
+    fn streamed_tool_name_is_mapped_back_to_the_original_id() {
+        // The model replies with the sanitized name; the reverse map restores
+        // the original tool id so dispatch finds the real tool.
+        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+        let mut tools = BTreeMap::new();
+        tools.insert(
+            0,
+            ToolAccumulator {
+                id: "call_1".to_string(),
+                name: "weather_lookup".to_string(),
+                arguments: "{}".to_string(),
+            },
+        );
+        let name_map =
+            HashMap::from([("weather_lookup".to_string(), "weather.lookup".to_string())]);
+        emit_tool_calls(tools, &tx, &name_map);
+        let Ok(StreamChunk::ToolCall(call)) = rx.try_recv().unwrap() else {
+            panic!("expected a tool call");
+        };
+        assert_eq!(call.tool_id, "weather.lookup");
+    }
+
+    #[test]
+    fn retry_delay_honors_retry_after_then_falls_back_to_exponential() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(reqwest::header::RETRY_AFTER, "2".parse().unwrap());
+        assert_eq!(retry_delay(0, &headers), Duration::from_secs(2));
+
+        let empty = reqwest::header::HeaderMap::new();
+        assert_eq!(retry_delay(0, &empty), Duration::from_millis(250));
+        assert_eq!(retry_delay(1, &empty), Duration::from_millis(500));
+        assert_eq!(retry_delay(2, &empty), Duration::from_millis(1000));
+    }
+
+    #[test]
+    fn only_rate_limit_and_server_errors_are_retryable() {
+        assert!(is_retryable_status(429));
+        assert!(is_retryable_status(500));
+        assert!(is_retryable_status(503));
+        assert!(!is_retryable_status(400));
+        assert!(!is_retryable_status(401));
     }
 }

--- a/crates/pocopine-agenkit-oai/src/wire.rs
+++ b/crates/pocopine-agenkit-oai/src/wire.rs
@@ -1,9 +1,56 @@
 //! OpenAI Chat Completions wire types and the mapping to/from Agenkit's
 //! neutral request/response.
 
+use std::collections::HashMap;
+
 use pocopine_agenkit::server::{FinishReason, GenerateRequest, GenerateResponse};
-use pocopine_agenkit_core::{AgenkitError, AgenkitResult, Content, Message, Role, ToolCall, Usage};
+use pocopine_agenkit_core::{
+    AgenkitError, AgenkitResult, Content, Message, Role, ToolCall, ToolDescriptor, Usage,
+};
 use serde::{Deserialize, Serialize};
+
+use crate::MaxTokensParam;
+
+/// OpenAI requires tool/function names to match `^[a-zA-Z0-9_-]{1,64}$`. Map
+/// every other byte to `_` and cap at 64; an empty/all-invalid name becomes
+/// `_`. Passing an id through unsanitized (e.g. one with a `.`) earns an opaque
+/// 400 from the API, so the provider sanitizes on the way out and reverses the
+/// mapping on the way back (see [`tool_name_map`]).
+pub(crate) fn sanitize_tool_name(name: &str) -> String {
+    let mut out: String = name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    // Every char is now ASCII (1 byte), so byte index 64 is a char boundary.
+    out.truncate(64);
+    if out.is_empty() {
+        out.push('_');
+    }
+    out
+}
+
+/// Build the reverse map (sanitized name → original tool id) for a request's
+/// tools, so a tool call the model makes under the sanitized name dispatches to
+/// the real tool. Identity for already-valid ids.
+pub(crate) fn tool_name_map(tools: &[ToolDescriptor]) -> HashMap<String, String> {
+    tools
+        .iter()
+        .map(|tool| (sanitize_tool_name(&tool.id), tool.id.clone()))
+        .collect()
+}
+
+/// Resolve a wire tool-call name back to the original tool id; passes names
+/// through unchanged when there is no mapping (no tools declared, or an
+/// already-valid name).
+pub(crate) fn resolve_tool_name(name: String, name_map: &HashMap<String, String>) -> String {
+    name_map.get(&name).cloned().unwrap_or(name)
+}
 
 // ---- request ----------------------------------------------------------------
 
@@ -15,8 +62,13 @@ pub(crate) struct ChatRequest {
     pub(crate) tools: Vec<WireTool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) response_format: Option<ResponseFormat>,
+    /// Legacy output-token cap, accepted by most compatible gateways.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) max_tokens: Option<u32>,
+    /// Output-token cap required by OpenAI's o-series / gpt-5-class models
+    /// (which reject `max_tokens`). Exactly one of the two is ever set.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) max_completion_tokens: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) stream: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -30,11 +82,13 @@ pub(crate) struct StreamOptions {
 
 impl ChatRequest {
     /// Map a neutral request. `stream` toggles SSE; `strict_schema` selects
-    /// native `json_schema` structured output (vs `json_object`).
+    /// native `json_schema` structured output (vs `json_object`);
+    /// `max_tokens_param` selects which output-token field to send.
     pub(crate) fn from_agenkit(
         request: &GenerateRequest,
         stream: bool,
         strict_schema: bool,
+        max_tokens_param: MaxTokensParam,
     ) -> Self {
         let structured = request.json_schema.is_some();
 
@@ -55,6 +109,12 @@ impl ChatRequest {
         messages.extend(request.messages.iter().map(WireMessage::from_message));
 
         let has_tools = !request.tools.is_empty();
+        // o-series / gpt-5-class models reject `max_tokens`; compatible gateways
+        // reject `max_completion_tokens`. Send exactly the one the endpoint wants.
+        let (max_tokens, max_completion_tokens) = match max_tokens_param {
+            MaxTokensParam::MaxTokens => (request.max_tokens, None),
+            MaxTokensParam::MaxCompletionTokens => (None, request.max_tokens),
+        };
         Self {
             model: request.model.model().to_string(),
             messages,
@@ -68,7 +128,8 @@ impl ChatRequest {
                 strict_schema,
                 has_tools,
             ),
-            max_tokens: request.max_tokens,
+            max_tokens,
+            max_completion_tokens,
             stream: stream.then_some(true),
             stream_options: stream.then_some(StreamOptions {
                 include_usage: true,
@@ -289,7 +350,9 @@ impl WireToolCall {
             id: call.id.clone(),
             kind: "function",
             function: WireFunctionCall {
-                name: call.tool_id.clone(),
+                // Match the sanitized name the tool was offered under, so a
+                // replayed assistant turn stays consistent with the tool defs.
+                name: sanitize_tool_name(&call.tool_id),
                 arguments: serde_json::to_string(&call.args).unwrap_or_else(|_| "{}".to_string()),
             },
         }
@@ -319,7 +382,7 @@ impl WireTool {
         Self {
             kind: "function",
             function: WireFunctionDef {
-                name: descriptor.id.clone(),
+                name: sanitize_tool_name(&descriptor.id),
                 description: descriptor.description.clone(),
                 parameters,
             },
@@ -359,7 +422,10 @@ pub(crate) struct ChatResponse {
 }
 
 impl ChatResponse {
-    pub(crate) fn into_agenkit(self) -> AgenkitResult<GenerateResponse> {
+    pub(crate) fn into_agenkit(
+        self,
+        name_map: &HashMap<String, String>,
+    ) -> AgenkitResult<GenerateResponse> {
         let choice = self
             .choices
             .into_iter()
@@ -371,7 +437,7 @@ impl ChatResponse {
             .message
             .tool_calls
             .into_iter()
-            .map(ResponseToolCall::into_call)
+            .map(|call| call.into_call(name_map))
             .collect();
         let finish_reason = finish_reason(choice.finish_reason.as_deref());
         let usage = self.usage.map(WireUsage::into_usage);
@@ -407,10 +473,14 @@ pub(crate) struct ResponseToolCall {
 }
 
 impl ResponseToolCall {
-    fn into_call(self) -> ToolCall {
+    fn into_call(self, name_map: &HashMap<String, String>) -> ToolCall {
         let args =
             serde_json::from_str(&self.function.arguments).unwrap_or(serde_json::Value::Null);
-        ToolCall::new(self.id, self.function.name, args)
+        ToolCall::new(
+            self.id,
+            resolve_tool_name(self.function.name, name_map),
+            args,
+        )
     }
 }
 
@@ -509,6 +579,34 @@ mod tests {
         assert!(required.contains(&serde_json::json!("count")));
         assert!(schema.get("$schema").is_none());
         assert!(schema["properties"]["count"].get("format").is_none());
+    }
+
+    #[test]
+    fn sanitize_tool_name_conforms_to_openai_pattern() {
+        // Valid names pass through unchanged.
+        assert_eq!(sanitize_tool_name("search_docs"), "search_docs");
+        assert_eq!(sanitize_tool_name("a-b_C9"), "a-b_C9");
+        // Disallowed bytes (dots, spaces, slashes, non-ASCII) become `_`.
+        assert_eq!(sanitize_tool_name("weather.lookup"), "weather_lookup");
+        assert_eq!(sanitize_tool_name("my tool/v2"), "my_tool_v2");
+        assert_eq!(sanitize_tool_name("café"), "caf_");
+        // Over-long names are capped at 64 bytes.
+        assert_eq!(sanitize_tool_name(&"x".repeat(100)).len(), 64);
+        // An all-invalid / empty name still produces a non-empty valid name.
+        assert_eq!(sanitize_tool_name(""), "_");
+    }
+
+    #[test]
+    fn tool_name_map_reverses_sanitization() {
+        use pocopine_agenkit_core::ToolDescriptor;
+        let tools = [ToolDescriptor::new("weather.lookup", "Look up weather")];
+        let map = tool_name_map(&tools);
+        assert_eq!(
+            resolve_tool_name("weather_lookup".to_string(), &map),
+            "weather.lookup"
+        );
+        // An unmapped name (already valid, or no tools) passes through.
+        assert_eq!(resolve_tool_name("other".to_string(), &map), "other");
     }
 
     #[test]

--- a/crates/pocopine-agenkit-oai/tests/wire.rs
+++ b/crates/pocopine-agenkit-oai/tests/wire.rs
@@ -6,8 +6,8 @@ use futures::StreamExt;
 use pocopine_agenkit::server::{
     Agenkit, AiFlowContext, Flow, GenerateRequest, Provider, StreamChunk,
 };
-use pocopine_agenkit_core::{AgenkitResult, FlowStreamEvent, Message, ModelRef};
-use pocopine_agenkit_oai::OpenAiProvider;
+use pocopine_agenkit_core::{AgenkitResult, FlowStreamEvent, Message, ModelRef, ToolDescriptor};
+use pocopine_agenkit_oai::{MaxTokensParam, OpenAiProvider};
 use serde::Deserialize;
 use serde_json::json;
 use wiremock::matchers::{header, method, path};
@@ -114,6 +114,147 @@ async fn maps_tool_calls_from_the_response() {
     assert_eq!(response.tool_calls.len(), 1);
     assert_eq!(response.tool_calls[0].tool_id, "search_docs");
     assert_eq!(response.tool_calls[0].args, json!({"query": "uploads"}));
+}
+
+#[tokio::test]
+async fn gateway_base_url_sends_legacy_max_tokens() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(|req: &Request| {
+            let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap();
+            // A non-official base URL defaults to the legacy field.
+            assert_eq!(body["max_tokens"], 128);
+            assert!(body.get("max_completion_tokens").is_none());
+            ResponseTemplate::new(200)
+                .set_body_json(json!({"choices": [{"message": {"content": "ok"}}]}))
+        })
+        .mount(&server)
+        .await;
+
+    let request = GenerateRequest {
+        max_tokens: Some(128),
+        ..text_request("hi")
+    };
+    provider(&server).generate(request).await.unwrap();
+}
+
+#[tokio::test]
+async fn max_completion_tokens_override_is_sent() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(|req: &Request| {
+            let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap();
+            // The override forces the new field (what o-series / gpt-5 require).
+            assert_eq!(body["max_completion_tokens"], 128);
+            assert!(body.get("max_tokens").is_none());
+            ResponseTemplate::new(200)
+                .set_body_json(json!({"choices": [{"message": {"content": "ok"}}]}))
+        })
+        .mount(&server)
+        .await;
+
+    let request = GenerateRequest {
+        max_tokens: Some(128),
+        ..text_request("hi")
+    };
+    provider(&server)
+        .with_max_tokens_param(MaxTokensParam::MaxCompletionTokens)
+        .generate(request)
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn retries_a_transient_server_error_then_succeeds() {
+    let server = MockServer::start().await;
+    // First a 503 (retryable), then a 200. `up_to_n_times` + ordering: mount the
+    // 503 mock with a hit cap so the second attempt falls through to the 200.
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(503).set_body_json(json!({
+            "error": {"type": "server_error"}
+        })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "choices": [{"message": {"content": "recovered"}, "finish_reason": "stop"}]
+        })))
+        .mount(&server)
+        .await;
+
+    let response = provider(&server)
+        .generate(text_request("hi"))
+        .await
+        .unwrap();
+    assert_eq!(response.text_output(), "recovered");
+}
+
+#[tokio::test]
+async fn gives_up_after_max_retries_without_leaking_body() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(ResponseTemplate::new(500).set_body_json(json!({
+            "error": {"message": "internal boom sk-proj-LEAK", "type": "server_error"}
+        })))
+        .mount(&server)
+        .await;
+
+    let error = provider(&server)
+        .with_max_retries(1)
+        .generate(text_request("hi"))
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), "provider");
+    let rendered = error.to_string();
+    assert!(rendered.contains("500"));
+    assert!(
+        !rendered.contains("sk-proj-LEAK"),
+        "leaked body: {rendered}"
+    );
+}
+
+#[tokio::test]
+async fn sanitizes_tool_names_outbound_and_maps_them_back() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(|req: &Request| {
+            let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap();
+            // The dotted tool id was sanitized for the wire.
+            assert_eq!(body["tools"][0]["function"]["name"], "weather_lookup");
+            // The model replies using that sanitized name.
+            ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "message": {
+                        "role": "assistant",
+                        "content": null,
+                        "tool_calls": [{
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "weather_lookup", "arguments": "{}"}
+                        }]
+                    },
+                    "finish_reason": "tool_calls"
+                }]
+            }))
+        })
+        .mount(&server)
+        .await;
+
+    let request = GenerateRequest {
+        tools: vec![ToolDescriptor::new("weather.lookup", "Look up weather")],
+        ..text_request("weather?")
+    };
+    let response = provider(&server).generate(request).await.unwrap();
+    // ...and the response maps it back to the real tool id so dispatch works.
+    assert_eq!(response.tool_calls.len(), 1);
+    assert_eq!(response.tool_calls[0].tool_id, "weather.lookup");
 }
 
 #[tokio::test]

--- a/crates/pocopine-agenkit/src/server/agent.rs
+++ b/crates/pocopine-agenkit/src/server/agent.rs
@@ -208,6 +208,7 @@ impl<A: AiAgent> AgentRun<A> {
                 .store
                 .append(
                     &thread.id,
+                    thread.owner(),
                     vec![
                         ThreadMessage::new(Role::User, input_text),
                         ThreadMessage::new(Role::Assistant, output_text),

--- a/crates/pocopine-agenkit/src/server/agent.rs
+++ b/crates/pocopine-agenkit/src/server/agent.rs
@@ -237,6 +237,16 @@ async fn run_loop<A: AiAgent>(
         .iter()
         .filter_map(|id| run.inner.tools.get(id).map(|tool| tool.descriptor()))
         .collect();
+    // Honor the provider's declared tool capability: there is no graceful
+    // degrade for tool calling, so an agent that needs tools on a provider that
+    // can't call them fails fast rather than silently looping without them.
+    if !tools.is_empty() && !provider.capabilities().tools {
+        return Err(AgenkitError::config(format!(
+            "provider `{}` does not support tool calling, but agent `{}` declares tools",
+            provider.id(),
+            A::ID
+        )));
+    }
     let schema = super::schema::json_schema_for::<A::Output>();
 
     let mut messages = Vec::new();

--- a/crates/pocopine-agenkit/src/server/generate.rs
+++ b/crates/pocopine-agenkit/src/server/generate.rs
@@ -18,7 +18,7 @@ use schemars::JsonSchema;
 use serde::de::DeserializeOwned;
 
 use super::agenkit::AgenkitInner;
-use super::provider::{FinishReason, GenerateRequest, GenerateResponse, StreamChunk};
+use super::provider::{FinishReason, GenerateRequest, GenerateResponse, Provider, StreamChunk};
 use super::run::RunState;
 use super::schema::json_schema_for;
 
@@ -121,9 +121,10 @@ impl Ai {
     }
 
     async fn run(&self, json_schema: Option<serde_json::Value>) -> AgenkitResult<GenerateResponse> {
-        let request = self.build_request(json_schema)?;
+        let mut request = self.build_request(json_schema)?;
         self.inner.check_model_allowed(&request.model)?;
         let provider = self.inner.providers.resolve(&request.model)?;
+        apply_structured_fallback(&mut request, provider.as_ref());
         let model = request.model.clone();
 
         let Some(run) = &self.tracer else {
@@ -204,9 +205,10 @@ impl Ai {
         json_schema: Option<serde_json::Value>,
         structured: bool,
     ) -> AgenkitResult<GenerateResponse> {
-        let request = self.build_request(json_schema)?;
+        let mut request = self.build_request(json_schema)?;
         self.inner.check_model_allowed(&request.model)?;
         let provider = self.inner.providers.resolve(&request.model)?;
+        apply_structured_fallback(&mut request, provider.as_ref());
         let model = request.model.clone();
 
         let model_step = self.tracer.as_ref().map(|run| {
@@ -227,7 +229,14 @@ impl Ai {
             step_id
         });
 
-        let mut stream = provider.generate_stream(request);
+        // Honor the provider's declared streaming capability: stream natively
+        // when supported, else fall back to a one-shot generation adapted to the
+        // streaming contract (§D13).
+        let mut stream = if provider.capabilities().streaming {
+            provider.generate_stream(request)
+        } else {
+            super::provider::fallback_stream(provider.as_ref(), request)
+        };
         let mut text = String::new();
         let mut tool_calls = Vec::new();
         let mut usage = None;
@@ -328,6 +337,29 @@ impl Ai {
     }
 }
 
+/// Capability-gated structured-output degrade path (§D13): when the resolved
+/// provider reports no native schema-constrained output
+/// (`capabilities().json_schema == false`), append an explicit instruction so
+/// the model still returns a JSON object conforming to the requested schema.
+/// The schema stays on the request (a provider that *does* support it natively
+/// — `json_schema == true` — gets no instruction and uses it directly). No-op
+/// for non-structured requests.
+fn apply_structured_fallback(request: &mut GenerateRequest, provider: &dyn Provider) {
+    let Some(schema) = request.json_schema.clone() else {
+        return;
+    };
+    if provider.capabilities().json_schema {
+        return;
+    }
+    let note = format!(
+        "Respond with a single JSON object that conforms to this JSON Schema, and nothing else:\n{schema}"
+    );
+    request.system = Some(match request.system.take() {
+        Some(existing) => format!("{existing}\n\n{note}"),
+        None => note,
+    });
+}
+
 /// An [`Ai`] request bound to a structured output type `T`.
 pub struct AiStructured<T> {
     ai: Ai,
@@ -401,15 +433,83 @@ impl<T: DeserializeOwned + JsonSchema> AiStructured<T> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{Arc, Mutex};
+
     use super::super::agenkit::Agenkit;
-    use super::super::provider::MockProvider;
-    use pocopine_agenkit_core::ModelRef;
+    use super::super::provider::{
+        BoxFuture, BoxStream, GenerateRequest, GenerateResponse, MockProvider, Provider,
+        ProviderCapabilities, StreamChunk,
+    };
+    use pocopine_agenkit_core::{AgenkitResult, ModelRef};
     use serde::Deserialize;
 
     fn runtime(provider: MockProvider) -> Agenkit {
         Agenkit::builder()
             .provider(provider)
             .default_model(ModelRef::new("local/default"))
+            .build()
+            .unwrap()
+    }
+
+    /// A provider with configurable capabilities that records the `system` of
+    /// the request it receives, so tests can assert how the runtime degrades.
+    #[derive(Clone)]
+    struct ProbeProvider {
+        caps: ProviderCapabilities,
+        last_system: Arc<Mutex<Option<String>>>,
+        panic_on_stream: bool,
+    }
+
+    impl ProbeProvider {
+        fn new(caps: ProviderCapabilities) -> Self {
+            Self {
+                caps,
+                last_system: Arc::new(Mutex::new(None)),
+                panic_on_stream: false,
+            }
+        }
+    }
+
+    impl Provider for ProbeProvider {
+        fn id(&self) -> &str {
+            "probe"
+        }
+
+        fn capabilities(&self) -> ProviderCapabilities {
+            self.caps
+        }
+
+        fn generate<'a>(
+            &'a self,
+            request: GenerateRequest,
+        ) -> BoxFuture<'a, AgenkitResult<GenerateResponse>> {
+            *self.last_system.lock().unwrap() = request.system.clone();
+            let structured = request.json_schema.is_some();
+            Box::pin(async move {
+                Ok(if structured {
+                    GenerateResponse::structured(serde_json::json!({"title": "X", "words": 1}))
+                } else {
+                    GenerateResponse::text("plain")
+                })
+            })
+        }
+
+        fn generate_stream<'a>(
+            &'a self,
+            request: GenerateRequest,
+        ) -> BoxStream<'a, AgenkitResult<StreamChunk>> {
+            assert!(
+                !self.panic_on_stream,
+                "runtime must not call generate_stream when streaming is unsupported"
+            );
+            super::super::provider::fallback_stream(self, request)
+        }
+    }
+
+    fn probe_runtime(provider: ProbeProvider) -> Agenkit {
+        Agenkit::builder()
+            .provider(provider)
+            .default_model(ModelRef::new("probe/default"))
             .build()
             .unwrap()
     }
@@ -477,6 +577,64 @@ mod tests {
             .unwrap();
         let result = agenkit.ai().prompt("x").generate_text().await;
         assert_eq!(result.unwrap_err().kind(), "config");
+    }
+
+    #[tokio::test]
+    async fn no_native_json_schema_injects_a_prompt_instruction() {
+        // A provider reporting `json_schema: false` gets an explicit instruction
+        // to emit conforming JSON (the capability-gated degrade path).
+        let provider = ProbeProvider::new(ProviderCapabilities {
+            streaming: true,
+            json_schema: false,
+            tools: true,
+        });
+        let seen = provider.last_system.clone();
+        let agenkit = probe_runtime(provider);
+        let _: Summary = agenkit
+            .ai()
+            .prompt("summarize")
+            .schema::<Summary>()
+            .generate_structured()
+            .await
+            .unwrap();
+        let system = seen.lock().unwrap().clone().unwrap_or_default();
+        assert!(
+            system.contains("JSON Schema"),
+            "expected an injected schema instruction, got: {system:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn native_json_schema_provider_gets_no_injection() {
+        // A provider reporting `json_schema: true` constrains generation itself,
+        // so the runtime must not inject a fallback instruction.
+        let provider = ProbeProvider::new(ProviderCapabilities::all());
+        let seen = provider.last_system.clone();
+        let agenkit = probe_runtime(provider);
+        let _: Summary = agenkit
+            .ai()
+            .system("be terse")
+            .prompt("summarize")
+            .schema::<Summary>()
+            .generate_structured()
+            .await
+            .unwrap();
+        assert_eq!(seen.lock().unwrap().clone(), Some("be terse".to_string()));
+    }
+
+    #[tokio::test]
+    async fn no_native_streaming_uses_one_shot_fallback() {
+        // A provider reporting `streaming: false` must be driven via the one-shot
+        // fallback — the runtime must not call its native `generate_stream`.
+        let mut provider = ProbeProvider::new(ProviderCapabilities {
+            streaming: false,
+            json_schema: true,
+            tools: true,
+        });
+        provider.panic_on_stream = true; // fails the test if generate_stream is hit
+        let agenkit = probe_runtime(provider);
+        let text = agenkit.ai().prompt("hi").stream_text().await.unwrap();
+        assert_eq!(text, "plain");
     }
 
     #[test]

--- a/crates/pocopine-agenkit/src/server/mod.rs
+++ b/crates/pocopine-agenkit/src/server/mod.rs
@@ -41,5 +41,7 @@ pub use provider::{
 pub use reduce::ReduceBuilder;
 pub use retrieval::{AiRetriever, DynRetriever, RetrieverRegistry, retriever_as_tool};
 pub use stream_route::{AI_FLOW_STREAM_PATH, ai_flow_stream_router, stream_filter};
-pub use thread::{AgentThreadHandle, AgentThreadStore, InMemoryThreadStore, ThreadBuilder};
+pub use thread::{
+    AgentThreadHandle, AgentThreadStore, InMemoryThreadStore, ThreadBuilder, ThreadOwner,
+};
 pub use tool::{AiTool, DynTool, ToolRegistry};

--- a/crates/pocopine-agenkit/src/server/parallel.rs
+++ b/crates/pocopine-agenkit/src/server/parallel.rs
@@ -178,6 +178,11 @@ impl<'a, T: Send + 'static> ParallelBuilder<'a, T> {
         let mut successes: Vec<T> = Vec::new();
         let mut success_count: u32 = 0;
         let mut first_error: Option<AgenkitError> = None;
+        // Track which branches reached a terminal (completed/failed) event so
+        // any started-but-undrained branch left behind by `abort_all` can be
+        // closed with a cancelled event — otherwise a client reconstructing the
+        // tree sees forever-open branches under a completed group (§D7/§D8).
+        let mut settled = vec![false; branch_steps.len()];
 
         while let Some(joined) = set.join_next().await {
             let (index, result) = match joined {
@@ -219,6 +224,7 @@ impl<'a, T: Send + 'static> ParallelBuilder<'a, T> {
                         group_id: group_id.clone(),
                         step_id,
                     });
+                    settled[index] = true;
                     successes.push(value);
                     success_count += 1;
                     if success_count >= target
@@ -245,6 +251,7 @@ impl<'a, T: Send + 'static> ParallelBuilder<'a, T> {
                         step_id,
                         error_kind: error.kind().to_string(),
                     });
+                    settled[index] = true;
                     if first_error.is_none() {
                         first_error = Some(error);
                     }
@@ -254,6 +261,31 @@ impl<'a, T: Send + 'static> ParallelBuilder<'a, T> {
                     }
                 }
             }
+        }
+
+        // Close any branch that started but was aborted in flight (an
+        // early-exit join broke out of the drain loop with losers still
+        // running). Each gets a terminal cancelled event so the trace tree has
+        // no dangling open branches under the completed group.
+        for (index, done) in settled.iter().enumerate() {
+            if *done {
+                continue;
+            }
+            let step_id = branch_steps[index].clone();
+            run.emit(
+                run.event(
+                    events::AI_STEP_CANCELLED,
+                    StepKind::Agent,
+                    StepStatus::Cancelled,
+                )
+                .with_step(step_id.clone())
+                .with_parallel_group(group_id.clone())
+                .with_field("branch", branch_names[index].clone()),
+            );
+            run.stream(FlowStreamEvent::BranchCancelled {
+                group_id: group_id.clone(),
+                step_id,
+            });
         }
 
         run.emit(

--- a/crates/pocopine-agenkit/src/server/provider.rs
+++ b/crates/pocopine-agenkit/src/server/provider.rs
@@ -214,6 +214,19 @@ pub trait Provider: Send + Sync + 'static {
     }
 }
 
+/// One-shot stream fallback the runtime uses for a provider that reports no
+/// native streaming (`capabilities().streaming == false`): run `generate` and
+/// adapt its result to the streaming contract. This is the capability-gated
+/// degrade path — distinct from the [`Provider::generate_stream`] trait default,
+/// because here the runtime decides based on the declared capability rather than
+/// on whether the method was overridden.
+pub(crate) fn fallback_stream(
+    provider: &dyn Provider,
+    request: GenerateRequest,
+) -> BoxStream<'_, AgenkitResult<StreamChunk>> {
+    default_stream(provider.generate(request))
+}
+
 /// Turn a one-shot generation future into a [`StreamChunk`] stream.
 fn default_stream<'a>(
     future: BoxFuture<'a, AgenkitResult<GenerateResponse>>,

--- a/crates/pocopine-agenkit/src/server/stream_route.rs
+++ b/crates/pocopine-agenkit/src/server/stream_route.rs
@@ -62,6 +62,7 @@ pub fn stream_filter(event: &FlowStreamEvent, mode: StreamMode) -> bool {
         | BranchStarted { .. }
         | BranchCompleted { .. }
         | BranchFailed { .. }
+        | BranchCancelled { .. }
         | ParallelCompleted { .. }
         | ReducerStarted { .. }
         | ReducerDecision { .. }

--- a/crates/pocopine-agenkit/src/server/thread.rs
+++ b/crates/pocopine-agenkit/src/server/thread.rs
@@ -14,7 +14,7 @@
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, MutexGuard};
 
 use pocopine_agenkit_core::{
     AgenkitError, AgenkitResult, AgentThreadId, StepKind, StepStatus, ThreadMessage,
@@ -125,6 +125,15 @@ impl InMemoryThreadStore {
     pub fn new() -> Self {
         Self::default()
     }
+
+    /// Lock the thread map, surfacing a poisoned mutex as a propagable error
+    /// rather than panicking. Poisoning means another task panicked mid-write;
+    /// callers get an internal error they can handle instead of a crash.
+    fn lock(&self) -> AgenkitResult<MutexGuard<'_, HashMap<String, ThreadEntry>>> {
+        self.threads
+            .lock()
+            .map_err(|_| AgenkitError::internal("thread store mutex poisoned"))
+    }
 }
 
 impl AgentThreadStore for InMemoryThreadStore {
@@ -136,14 +145,18 @@ impl AgentThreadStore for InMemoryThreadStore {
     ) -> BoxFuture<'_, AgenkitResult<AgentThreadId>> {
         let seq = self.seq.fetch_add(1, Ordering::Relaxed);
         let id = AgentThreadId::new(format!("th-{agent_id}-{seq}"));
-        self.threads.lock().unwrap().insert(
-            id.as_str().to_string(),
-            ThreadEntry {
-                owner: owner.key().map(str::to_string),
-                messages: Vec::new(),
-            },
-        );
-        Box::pin(async move { Ok(id) })
+        let owner = owner.key().map(str::to_string);
+        let result = self.lock().map(|mut threads| {
+            threads.insert(
+                id.as_str().to_string(),
+                ThreadEntry {
+                    owner,
+                    messages: Vec::new(),
+                },
+            );
+            id
+        });
+        Box::pin(async move { result })
     }
 
     fn load(
@@ -153,14 +166,13 @@ impl AgentThreadStore for InMemoryThreadStore {
     ) -> BoxFuture<'_, AgenkitResult<Option<Vec<ThreadMessage>>>> {
         // A thread owned by a different principal reads as not-found, so a
         // caller probing ids learns nothing about other principals' threads.
-        let result = self
-            .threads
-            .lock()
-            .unwrap()
-            .get(id.as_str())
-            .filter(|entry| entry.owner.as_deref() == owner.key())
-            .map(|entry| entry.messages.clone());
-        Box::pin(async move { Ok(result) })
+        let result = self.lock().map(|threads| {
+            threads
+                .get(id.as_str())
+                .filter(|entry| entry.owner.as_deref() == owner.key())
+                .map(|entry| entry.messages.clone())
+        });
+        Box::pin(async move { result })
     }
 
     fn append(
@@ -169,15 +181,16 @@ impl AgentThreadStore for InMemoryThreadStore {
         owner: ThreadOwner<'_>,
         messages: Vec<ThreadMessage>,
     ) -> BoxFuture<'_, AgenkitResult<()>> {
-        let mut threads = self.threads.lock().unwrap();
-        let result = match threads.get_mut(id.as_str()) {
-            Some(entry) if entry.owner.as_deref() == owner.key() => {
-                entry.messages.extend(messages);
-                Ok(())
+        let result = self.lock().and_then(|mut threads| {
+            match threads.get_mut(id.as_str()) {
+                Some(entry) if entry.owner.as_deref() == owner.key() => {
+                    entry.messages.extend(messages);
+                    Ok(())
+                }
+                // Missing, or owned by someone else: refuse without revealing which.
+                _ => Err(AgenkitError::not_found("thread not found")),
             }
-            // Missing, or owned by someone else: refuse without revealing which.
-            _ => Err(AgenkitError::not_found("thread not found")),
-        };
+        });
         Box::pin(async move { result })
     }
 
@@ -188,14 +201,15 @@ impl AgentThreadStore for InMemoryThreadStore {
     ) -> BoxFuture<'_, AgenkitResult<()>> {
         // Idempotent: only the owner can delete; a foreign/missing id is a
         // silent no-op so deletion never doubles as an existence oracle.
-        let mut threads = self.threads.lock().unwrap();
-        if threads
-            .get(id.as_str())
-            .is_some_and(|entry| entry.owner.as_deref() == owner.key())
-        {
-            threads.remove(id.as_str());
-        }
-        Box::pin(async move { Ok(()) })
+        let result = self.lock().map(|mut threads| {
+            if threads
+                .get(id.as_str())
+                .is_some_and(|entry| entry.owner.as_deref() == owner.key())
+            {
+                threads.remove(id.as_str());
+            }
+        });
+        Box::pin(async move { result })
     }
 }
 
@@ -390,5 +404,30 @@ mod tests {
         assert!(store.load(&id, alice).await.unwrap().is_none());
         // But another anonymous caller shares the anonymous bucket.
         assert!(store.load(&id, anon).await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn poisoned_lock_surfaces_an_error_instead_of_panicking() {
+        let store = Arc::new(InMemoryThreadStore::new());
+        // Poison the mutex: panic while holding the lock on another thread.
+        let poisoner = store.clone();
+        let _ = std::thread::spawn(move || {
+            let _guard = poisoner.threads.lock().unwrap();
+            panic!("intentionally poison the lock");
+        })
+        .join();
+
+        // Every store access now returns an internal error, not a panic.
+        let owner = ThreadOwner::anonymous();
+        let id = AgentThreadId::new("th-x");
+        assert_eq!(store.load(&id, owner).await.unwrap_err().kind(), "internal");
+        assert_eq!(
+            store
+                .create("debugger", owner, ThreadRetention::Session)
+                .await
+                .unwrap_err()
+                .kind(),
+            "internal"
+        );
     }
 }

--- a/crates/pocopine-agenkit/src/server/thread.rs
+++ b/crates/pocopine-agenkit/src/server/thread.rs
@@ -4,45 +4,119 @@
 //! seam so v1 ships an in-memory store while a future durable store can drop
 //! in. Thread ids exposed to callers are opaque Pocopine ids; provider-backed
 //! ids (if any) never leak (§D10).
+//!
+//! Threads are **owner-scoped**: every store access carries a [`ThreadOwner`]
+//! derived from the caller [`Principal`], so resuming a thread can never expose
+//! another principal's conversation history. The owner travels through the
+//! store seam (not just the resume path) so durable backends enforce the same
+//! invariant — and so adding it stays a cheap trait change now rather than a
+//! breaking one once durable stores exist (issue #214).
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
 use pocopine_agenkit_core::{
-    AgenkitResult, AgentThreadId, StepKind, StepStatus, ThreadMessage, ThreadRetention, events,
+    AgenkitError, AgenkitResult, AgentThreadId, StepKind, StepStatus, ThreadMessage,
+    ThreadRetention, events,
 };
+use pocopine_auth::Principal;
 
 use super::provider::BoxFuture;
 use super::run::RunState;
 
+/// An opaque key identifying the principal that owns a thread.
+///
+/// Derived from the request [`Principal`]: the authenticated user id, or
+/// `None` for anonymous callers. Anonymous callers all share one bucket
+/// because there is no identity to scope a thread to — the security property
+/// this enforces is "an authenticated user cannot read another principal's
+/// thread", which is exactly the cross-user leak issue #214 closes.
+///
+/// The key is borrowed so passing it through the store seam never allocates;
+/// stores convert it to an owned key ([`ThreadOwner::key`]) when persisting.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ThreadOwner<'a> {
+    key: Option<&'a str>,
+}
+
+impl<'a> ThreadOwner<'a> {
+    /// The owner key for a request principal.
+    pub fn from_principal(principal: &'a Principal) -> Self {
+        Self {
+            key: principal.user().map(|user| user.id.as_str()),
+        }
+    }
+
+    /// The anonymous owner (no authenticated user).
+    pub fn anonymous() -> Self {
+        Self { key: None }
+    }
+
+    /// The borrowed owner key, `None` for anonymous callers. Durable stores
+    /// persist and compare against this; the in-memory store does too.
+    pub fn key(&self) -> Option<&str> {
+        self.key
+    }
+
+    /// Rebuild an owner from a previously captured key (used by the thread
+    /// handle to replay its owner on later reads/appends).
+    pub(crate) fn from_opt(key: Option<&'a str>) -> Self {
+        Self { key }
+    }
+}
+
 /// Durable-or-not storage for agent threads.
+///
+/// Every method carries the caller's [`ThreadOwner`] so the store can scope
+/// access to the principal that created the thread. Implementations MUST treat
+/// a thread owned by a different owner as inaccessible: `load` returns `None`
+/// (indistinguishable from a missing thread — no existence oracle), and
+/// `append`/`delete` must not touch it.
 pub trait AgentThreadStore: Send + Sync + 'static {
-    /// Create a new thread for `agent_id`, returning its opaque id.
+    /// Create a new thread for `agent_id` owned by `owner`, returning its
+    /// opaque id.
     fn create(
         &self,
         agent_id: &str,
+        owner: ThreadOwner<'_>,
         retention: ThreadRetention,
     ) -> BoxFuture<'_, AgenkitResult<AgentThreadId>>;
 
-    /// Load a thread's message history, or `None` if it does not exist.
-    fn load(&self, id: &AgentThreadId) -> BoxFuture<'_, AgenkitResult<Option<Vec<ThreadMessage>>>>;
+    /// Load a thread's message history if it exists **and** is owned by
+    /// `owner`; otherwise `None`.
+    fn load(
+        &self,
+        id: &AgentThreadId,
+        owner: ThreadOwner<'_>,
+    ) -> BoxFuture<'_, AgenkitResult<Option<Vec<ThreadMessage>>>>;
 
-    /// Append messages to a thread.
+    /// Append messages to a thread owned by `owner`.
     fn append(
         &self,
         id: &AgentThreadId,
+        owner: ThreadOwner<'_>,
         messages: Vec<ThreadMessage>,
     ) -> BoxFuture<'_, AgenkitResult<()>>;
 
-    /// Delete a thread and its state.
-    fn delete(&self, id: &AgentThreadId) -> BoxFuture<'_, AgenkitResult<()>>;
+    /// Delete a thread and its state if it is owned by `owner`.
+    fn delete(
+        &self,
+        id: &AgentThreadId,
+        owner: ThreadOwner<'_>,
+    ) -> BoxFuture<'_, AgenkitResult<()>>;
+}
+
+/// One stored thread: its owner key plus message history.
+struct ThreadEntry {
+    owner: Option<String>,
+    messages: Vec<ThreadMessage>,
 }
 
 /// The default in-memory thread store (tests, examples, single-process apps).
 #[derive(Default)]
 pub struct InMemoryThreadStore {
-    threads: Mutex<HashMap<String, Vec<ThreadMessage>>>,
+    threads: Mutex<HashMap<String, ThreadEntry>>,
     seq: AtomicU64,
 }
 
@@ -57,47 +131,83 @@ impl AgentThreadStore for InMemoryThreadStore {
     fn create(
         &self,
         agent_id: &str,
+        owner: ThreadOwner<'_>,
         _retention: ThreadRetention,
     ) -> BoxFuture<'_, AgenkitResult<AgentThreadId>> {
         let seq = self.seq.fetch_add(1, Ordering::Relaxed);
         let id = AgentThreadId::new(format!("th-{agent_id}-{seq}"));
-        self.threads
-            .lock()
-            .unwrap()
-            .insert(id.as_str().to_string(), Vec::new());
+        self.threads.lock().unwrap().insert(
+            id.as_str().to_string(),
+            ThreadEntry {
+                owner: owner.key().map(str::to_string),
+                messages: Vec::new(),
+            },
+        );
         Box::pin(async move { Ok(id) })
     }
 
-    fn load(&self, id: &AgentThreadId) -> BoxFuture<'_, AgenkitResult<Option<Vec<ThreadMessage>>>> {
-        let result = self.threads.lock().unwrap().get(id.as_str()).cloned();
+    fn load(
+        &self,
+        id: &AgentThreadId,
+        owner: ThreadOwner<'_>,
+    ) -> BoxFuture<'_, AgenkitResult<Option<Vec<ThreadMessage>>>> {
+        // A thread owned by a different principal reads as not-found, so a
+        // caller probing ids learns nothing about other principals' threads.
+        let result = self
+            .threads
+            .lock()
+            .unwrap()
+            .get(id.as_str())
+            .filter(|entry| entry.owner.as_deref() == owner.key())
+            .map(|entry| entry.messages.clone());
         Box::pin(async move { Ok(result) })
     }
 
     fn append(
         &self,
         id: &AgentThreadId,
+        owner: ThreadOwner<'_>,
         messages: Vec<ThreadMessage>,
     ) -> BoxFuture<'_, AgenkitResult<()>> {
-        self.threads
-            .lock()
-            .unwrap()
-            .entry(id.as_str().to_string())
-            .or_default()
-            .extend(messages);
-        Box::pin(async move { Ok(()) })
+        let mut threads = self.threads.lock().unwrap();
+        let result = match threads.get_mut(id.as_str()) {
+            Some(entry) if entry.owner.as_deref() == owner.key() => {
+                entry.messages.extend(messages);
+                Ok(())
+            }
+            // Missing, or owned by someone else: refuse without revealing which.
+            _ => Err(AgenkitError::not_found("thread not found")),
+        };
+        Box::pin(async move { result })
     }
 
-    fn delete(&self, id: &AgentThreadId) -> BoxFuture<'_, AgenkitResult<()>> {
-        self.threads.lock().unwrap().remove(id.as_str());
+    fn delete(
+        &self,
+        id: &AgentThreadId,
+        owner: ThreadOwner<'_>,
+    ) -> BoxFuture<'_, AgenkitResult<()>> {
+        // Idempotent: only the owner can delete; a foreign/missing id is a
+        // silent no-op so deletion never doubles as an existence oracle.
+        let mut threads = self.threads.lock().unwrap();
+        if threads
+            .get(id.as_str())
+            .is_some_and(|entry| entry.owner.as_deref() == owner.key())
+        {
+            threads.remove(id.as_str());
+        }
         Box::pin(async move { Ok(()) })
     }
 }
 
-/// A handle to a thread within a flow run: its id plus the store to reach it.
+/// A handle to a thread within a flow run: its id, the store to reach it, and
+/// the owner key captured when the thread was opened.
 #[derive(Clone)]
 pub struct AgentThreadHandle {
     pub(crate) id: AgentThreadId,
     pub(crate) store: Arc<dyn AgentThreadStore>,
+    /// Owner key captured at create/resume time, replayed on every store
+    /// access so later reads/appends stay scoped to the opening principal.
+    pub(crate) owner: Option<String>,
 }
 
 impl AgentThreadHandle {
@@ -106,9 +216,18 @@ impl AgentThreadHandle {
         &self.id
     }
 
+    /// The owner this handle accesses the store under.
+    pub(crate) fn owner(&self) -> ThreadOwner<'_> {
+        ThreadOwner::from_opt(self.owner.as_deref())
+    }
+
     /// Load the current message history.
     pub async fn history(&self) -> AgenkitResult<Vec<ThreadMessage>> {
-        Ok(self.store.load(&self.id).await?.unwrap_or_default())
+        Ok(self
+            .store
+            .load(&self.id, self.owner())
+            .await?
+            .unwrap_or_default())
     }
 }
 
@@ -125,11 +244,17 @@ impl ThreadBuilder {
         Self { run, agent_id }
     }
 
-    /// Create a fresh thread for the agent.
+    /// The owner key for this run's caller principal.
+    fn owner(&self) -> ThreadOwner<'_> {
+        ThreadOwner::from_principal(&self.run.principal)
+    }
+
+    /// Create a fresh thread for the agent, owned by the caller principal.
     pub async fn create(&self) -> AgenkitResult<AgentThreadHandle> {
         let store = self.run.inner.thread_store.clone();
+        let owner = self.owner();
         let id = store
-            .create(self.agent_id, ThreadRetention::Session)
+            .create(self.agent_id, owner, ThreadRetention::Session)
             .await?;
         self.run.emit(
             self.run
@@ -141,17 +266,27 @@ impl ThreadBuilder {
                 .with_field("thread_id", id.as_str())
                 .with_field("agent_id", self.agent_id),
         );
-        Ok(AgentThreadHandle { id, store })
+        Ok(AgentThreadHandle {
+            id,
+            store,
+            owner: owner.key().map(str::to_string),
+        })
     }
 
-    /// Resume the thread with `id` if it exists, otherwise create a new one.
+    /// Resume the thread with `id` if it exists **and is owned by the caller**,
+    /// otherwise create a new one.
+    ///
+    /// Resuming a thread that belongs to a different principal is rejected: the
+    /// owner-scoped `load` reads it as missing, so the caller falls through to
+    /// a fresh thread instead of inheriting another principal's history.
     pub async fn resume_or_create(
         &self,
         id: Option<AgentThreadId>,
     ) -> AgenkitResult<AgentThreadHandle> {
         let store = self.run.inner.thread_store.clone();
+        let owner = self.owner();
         if let Some(id) = id
-            && store.load(&id).await?.is_some()
+            && store.load(&id, owner).await?.is_some()
         {
             self.run.emit(
                 self.run
@@ -163,7 +298,11 @@ impl ThreadBuilder {
                     .with_field("thread_id", id.as_str())
                     .with_field("agent_id", self.agent_id),
             );
-            return Ok(AgentThreadHandle { id, store });
+            return Ok(AgentThreadHandle {
+                id,
+                store,
+                owner: owner.key().map(str::to_string),
+            });
         }
         self.create().await
     }
@@ -173,24 +312,83 @@ impl ThreadBuilder {
 mod tests {
     use super::*;
     use pocopine_agenkit_core::Role;
+    use pocopine_auth::AuthUser;
+
+    fn alice() -> Principal {
+        Principal::from_user(AuthUser::new("alice"))
+    }
+
+    fn bob() -> Principal {
+        Principal::from_user(AuthUser::new("bob"))
+    }
 
     #[tokio::test]
     async fn in_memory_store_round_trips() {
         let store = InMemoryThreadStore::new();
+        let owner = ThreadOwner::anonymous();
         let id = store
-            .create("debugger", ThreadRetention::Session)
+            .create("debugger", owner, ThreadRetention::Session)
             .await
             .unwrap();
         store
             .append(
                 &id,
+                owner,
                 vec![ThreadMessage::new(Role::User, "why did it fail?")],
             )
             .await
             .unwrap();
-        let history = store.load(&id).await.unwrap().unwrap();
+        let history = store.load(&id, owner).await.unwrap().unwrap();
         assert_eq!(history.len(), 1);
-        store.delete(&id).await.unwrap();
-        assert!(store.load(&id).await.unwrap().is_none());
+        store.delete(&id, owner).await.unwrap();
+        assert!(store.load(&id, owner).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn foreign_principal_cannot_read_or_mutate_anothers_thread() {
+        let store = InMemoryThreadStore::new();
+        let (alice_p, bob_p) = (alice(), bob());
+        let alice = ThreadOwner::from_principal(&alice_p);
+        let bob = ThreadOwner::from_principal(&bob_p);
+
+        let id = store
+            .create("debugger", alice, ThreadRetention::Session)
+            .await
+            .unwrap();
+        store
+            .append(&id, alice, vec![ThreadMessage::new(Role::User, "secret")])
+            .await
+            .unwrap();
+
+        // Bob cannot read Alice's thread — it reads as not-found.
+        assert!(store.load(&id, bob).await.unwrap().is_none());
+        // Bob cannot append to it.
+        assert!(
+            store
+                .append(&id, bob, vec![ThreadMessage::new(Role::User, "inject")])
+                .await
+                .is_err()
+        );
+        // Bob's delete is a silent no-op — Alice's thread survives intact.
+        store.delete(&id, bob).await.unwrap();
+        let history = store.load(&id, alice).await.unwrap().unwrap();
+        assert_eq!(history.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn anonymous_and_authenticated_owners_are_distinct() {
+        let store = InMemoryThreadStore::new();
+        let alice_p = alice();
+        let anon = ThreadOwner::anonymous();
+        let alice = ThreadOwner::from_principal(&alice_p);
+
+        let id = store
+            .create("debugger", anon, ThreadRetention::Session)
+            .await
+            .unwrap();
+        // An authenticated caller cannot pick up an anonymous thread.
+        assert!(store.load(&id, alice).await.unwrap().is_none());
+        // But another anonymous caller shares the anonymous bucket.
+        assert!(store.load(&id, anon).await.unwrap().is_some());
     }
 }

--- a/crates/pocopine-agenkit/tests/capabilities.rs
+++ b/crates/pocopine-agenkit/tests/capabilities.rs
@@ -1,0 +1,125 @@
+#![cfg(not(target_arch = "wasm32"))]
+//! Issue #214 item 3: the runtime honors `ProviderCapabilities`. Here: an agent
+//! that declares tools on a provider that can't call them fails fast with a
+//! config error (there is no graceful degrade for tool calling). The streaming
+//! and json_schema degrade paths are covered by `generate.rs` unit tests.
+
+mod common;
+
+use common::block_on;
+use pocopine_agenkit::server::{
+    Agenkit, AiAgent, AiAgentBuilder, AiFlowContext, AiTool, AiToolContext, BoxFuture, BoxStream,
+    Flow, GenerateRequest, GenerateResponse, Provider, ProviderCapabilities, StreamChunk,
+};
+use pocopine_agenkit_core::{AgenkitResult, ModelRef, ToolDescriptor};
+use serde::{Deserialize, Serialize};
+
+/// A provider that supports plain generation but not tool calling.
+struct NoToolsProvider;
+
+impl Provider for NoToolsProvider {
+    fn id(&self) -> &str {
+        "local"
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        ProviderCapabilities {
+            streaming: true,
+            json_schema: true,
+            tools: false,
+        }
+    }
+
+    fn generate<'a>(
+        &'a self,
+        _request: GenerateRequest,
+    ) -> BoxFuture<'a, AgenkitResult<GenerateResponse>> {
+        Box::pin(async move { Ok(GenerateResponse::text("unused")) })
+    }
+
+    fn generate_stream<'a>(
+        &'a self,
+        _request: GenerateRequest,
+    ) -> BoxStream<'a, AgenkitResult<StreamChunk>> {
+        Box::pin(futures::stream::empty())
+    }
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+struct LookupIn {
+    term: String,
+}
+
+#[derive(Serialize, schemars::JsonSchema)]
+struct LookupOut {
+    fact: String,
+}
+
+struct Lookup;
+
+impl AiTool for Lookup {
+    const ID: &'static str = "lookup";
+    type Input = LookupIn;
+    type Output = LookupOut;
+
+    fn descriptor() -> ToolDescriptor {
+        ToolDescriptor::new("lookup", "Look up a fact")
+    }
+
+    fn call(
+        &self,
+        input: LookupIn,
+        _ctx: AiToolContext,
+    ) -> BoxFuture<'_, AgenkitResult<LookupOut>> {
+        Box::pin(async move { Ok(LookupOut { fact: input.term }) })
+    }
+}
+
+#[derive(Serialize, Deserialize, schemars::JsonSchema)]
+struct Question {
+    question: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, schemars::JsonSchema)]
+struct Answer {
+    answer: String,
+}
+
+struct Researcher;
+
+impl AiAgent for Researcher {
+    const ID: &'static str = "researcher";
+    type Input = Question;
+    type Output = Answer;
+
+    fn configure(builder: AiAgentBuilder<Self>) -> AiAgentBuilder<Self> {
+        builder
+            .system("Use the tool.")
+            .tools(["lookup"])
+            .max_steps(2)
+    }
+}
+
+async fn research(input: Question, ctx: AiFlowContext) -> AgenkitResult<Answer> {
+    ctx.agent::<Researcher>().input(input).run().await
+}
+
+#[test]
+fn agent_with_tools_on_a_toolless_provider_fails_fast() {
+    let agenkit = Agenkit::builder()
+        .provider(NoToolsProvider)
+        .default_model(ModelRef::new("local/default"))
+        .tool(Lookup)
+        .flow(Flow::new("research", research).uses_agent("researcher"))
+        .build()
+        .unwrap();
+
+    let result: Result<Answer, _> = block_on(agenkit.run_flow_typed(
+        "research",
+        Question {
+            question: "hi".to_string(),
+        },
+    ));
+    let error = result.expect_err("a toolless provider must reject a tool-using agent");
+    assert_eq!(error.kind(), "config", "error: {error}");
+}

--- a/crates/pocopine-agenkit/tests/parallel_stream.rs
+++ b/crates/pocopine-agenkit/tests/parallel_stream.rs
@@ -190,6 +190,59 @@ fn all_settled_join_records_a_panicked_branch_but_keeps_survivors() {
 }
 
 #[test]
+fn first_success_emits_cancelled_terminal_for_aborted_loser() {
+    // The losing branch is aborted in flight by `FirstSuccess`. It emitted a
+    // `BranchStarted`, so the stream must close it with a terminal
+    // `BranchCancelled` — never leave it forever-open under the completed group.
+    let (agenkit, _) = runtime();
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let winner: i32 = block_on(async {
+        let value = agenkit
+            .run_flow_streaming("race", serde_json::json!(null), tx)
+            .await
+            .unwrap();
+        serde_json::from_value(value).unwrap()
+    });
+    assert_eq!(winner, 1);
+
+    let mut events = Vec::new();
+    while let Ok(event) = rx.try_recv() {
+        events.push(event);
+    }
+    let count = |pred: fn(&FlowStreamEvent) -> bool| events.iter().filter(|e| pred(e)).count();
+
+    assert_eq!(
+        count(|e| matches!(e, FlowStreamEvent::BranchStarted { .. })),
+        2,
+        "both branches started"
+    );
+    assert_eq!(
+        count(|e| matches!(e, FlowStreamEvent::BranchCompleted { .. })),
+        1,
+        "the winner completed"
+    );
+    assert_eq!(
+        count(|e| matches!(e, FlowStreamEvent::BranchCancelled { .. })),
+        1,
+        "the aborted loser must be closed with a cancelled terminal"
+    );
+    // Every started branch reached exactly one terminal: no dangling open branch.
+    let started = count(|e| matches!(e, FlowStreamEvent::BranchStarted { .. }));
+    let terminal = count(|e| {
+        matches!(
+            e,
+            FlowStreamEvent::BranchCompleted { .. }
+                | FlowStreamEvent::BranchFailed { .. }
+                | FlowStreamEvent::BranchCancelled { .. }
+        )
+    });
+    assert_eq!(
+        started, terminal,
+        "every branch must reach a terminal event"
+    );
+}
+
+#[test]
 fn streaming_emits_public_flow_events() {
     let (agenkit, _) = runtime();
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();

--- a/crates/pocopine-agenkit/tests/thread_ownership.rs
+++ b/crates/pocopine-agenkit/tests/thread_ownership.rs
@@ -1,0 +1,122 @@
+#![cfg(not(target_arch = "wasm32"))]
+//! Issue #214 item 1: thread resume is owner-scoped. A flow that wires
+//! caller-supplied input into a thread id must not let one principal read or
+//! continue another principal's conversation history.
+
+mod common;
+
+use common::block_on;
+use pocopine_agenkit::server::{
+    Agenkit, AiAgent, AiAgentBuilder, AiFlowContext, Flow, MockProvider,
+};
+use pocopine_agenkit_core::{AgenkitResult, AgentThreadId, ModelRef};
+use pocopine_auth::{AuthUser, Principal};
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, schemars::JsonSchema)]
+struct Question {
+    question: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, schemars::JsonSchema)]
+struct Answer {
+    answer: String,
+}
+
+struct Echo;
+
+impl AiAgent for Echo {
+    const ID: &'static str = "echo";
+    type Input = Question;
+    type Output = Answer;
+
+    fn configure(builder: AiAgentBuilder<Self>) -> AiAgentBuilder<Self> {
+        builder.system("Answer the question.").max_steps(1)
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, schemars::JsonSchema)]
+struct ThreadOut {
+    thread_id: String,
+    history_len: usize,
+}
+
+/// Open a fresh thread and run the agent once so it has history, returning the
+/// new thread id and its message count.
+async fn start(_input: (), ctx: AiFlowContext) -> AgenkitResult<ThreadOut> {
+    let thread = ctx.thread::<Echo>().resume_or_create(None).await?;
+    ctx.agent::<Echo>()
+        .thread(thread.clone())
+        .input(Question {
+            question: "hi".to_string(),
+        })
+        .run()
+        .await?;
+    Ok(ThreadOut {
+        thread_id: thread.id().as_str().to_string(),
+        history_len: thread.history().await?.len(),
+    })
+}
+
+/// Resume the supplied thread id (if owned by the caller) and report what is
+/// visible — without running the agent, so it neither appends nor mutates.
+async fn peek(input: String, ctx: AiFlowContext) -> AgenkitResult<ThreadOut> {
+    let thread = ctx
+        .thread::<Echo>()
+        .resume_or_create(Some(AgentThreadId::new(input)))
+        .await?;
+    Ok(ThreadOut {
+        thread_id: thread.id().as_str().to_string(),
+        history_len: thread.history().await?.len(),
+    })
+}
+
+fn runtime() -> Agenkit {
+    Agenkit::builder()
+        .provider(
+            MockProvider::new("local").default_structured(serde_json::json!({"answer": "ok"})),
+        )
+        .default_model(ModelRef::new("local/default"))
+        .flow(Flow::new("start", start).uses_agent("echo").public())
+        .flow(Flow::new("peek", peek).uses_agent("echo").public())
+        .build()
+        .unwrap()
+}
+
+fn alice() -> Principal {
+    Principal::from_user(AuthUser::new("alice"))
+}
+
+fn bob() -> Principal {
+    Principal::from_user(AuthUser::new("bob"))
+}
+
+#[test]
+fn principal_cannot_resume_another_principals_thread() {
+    let agenkit = runtime();
+
+    // Bob starts a thread; the agent run appends one user + one assistant msg.
+    let bobs: ThreadOut = block_on(agenkit.run_public_flow_as(bob(), "start", ())).unwrap();
+    assert_eq!(bobs.history_len, 2);
+
+    // Alice tries to resume Bob's thread id: resume is rejected, she gets a
+    // fresh empty thread with a different id — never Bob's history.
+    let alices: ThreadOut =
+        block_on(agenkit.run_public_flow_as(alice(), "peek", bobs.thread_id.clone())).unwrap();
+    assert_eq!(alices.history_len, 0, "Alice must not see Bob's history");
+    assert_ne!(
+        alices.thread_id, bobs.thread_id,
+        "Alice must not be handed Bob's thread"
+    );
+
+    // An anonymous caller is likewise denied Bob's authenticated thread.
+    let anons: ThreadOut =
+        block_on(agenkit.run_public_flow("peek", bobs.thread_id.clone())).unwrap();
+    assert_eq!(anons.history_len, 0, "anonymous must not see Bob's history");
+
+    // Bob himself resumes his own thread and sees its history intact.
+    let resumed: ThreadOut =
+        block_on(agenkit.run_public_flow_as(bob(), "peek", bobs.thread_id.clone())).unwrap();
+    assert_eq!(resumed.thread_id, bobs.thread_id);
+    assert_eq!(resumed.history_len, 2, "owner must resume their own thread");
+}


### PR DESCRIPTION
Hardens the RFC-093 shipped surface (PR #199). Closes #214 — all five sub-items, one focused commit each, independently reviewable.

## Items

| Commit | Item | What |
|--------|------|------|
| `6b6da55` | **1 · Thread ownership** (authz) | A `ThreadOwner` (derived from the caller `Principal`) is threaded through every `AgentThreadStore` method. A thread owned by another principal reads as **not-found** (no existence oracle), so `resume_or_create` can't return one user's history to another — it falls back to a fresh thread instead. The cheap-now trait change before durable stores depend on it. |
| `7c0a1a8` | **5 · Parallel cancellation** | After an early-exit join (`FirstSuccess`/`Quorum`, or `All`-on-failure) aborts the losers, each started-but-undrained branch now gets a terminal `AI_STEP_CANCELLED` trace event + a `FlowStreamEvent::BranchCancelled` stream event — no more forever-open branches under a completed group. |
| `102383b` | **2 · `max_completion_tokens`** + **4 · OAI hardening** | o-series/gpt-5 reject legacy `max_tokens`; gateways reject `max_completion_tokens` → send the right one (auto by base URL, overridable). Plus: tool-name sanitization to `^[a-zA-Z0-9_-]{1,64}$` with reverse-mapping on the response; default total timeout (non-streaming) + 429/5xx retry-with-backoff (honors `Retry-After`); spec-conformant SSE that joins multi-line `data:` fields on the blank-line event boundary. |
| `ae9532f` | **3 · `ProviderCapabilities`** | Was declared but never consulted. **Wired** (not deleted): the runtime now honors `streaming` (one-shot fallback), `json_schema` (prompt-instruction fallback), and `tools` (fail-fast when an agent needs tools a provider can't call). |

## The ownership fix

```mermaid
flowchart TD
    A["resume_or_create(B's thread id)<br/>caller = principal A"] --> B{"store.load(id, owner=A)"}
    B -->|"thread owned by B ≠ A"| C["returns None<br/>(indistinguishable from missing)"]
    C --> D["fall back to create()<br/>→ fresh empty thread for A"]
    B -->|"owner matches"| E["resume: return A's own history"]
    style C fill:#1a130c,stroke:#f8ae45,color:#f8ae45
    style D fill:#1a130c,stroke:#f8ae45,color:#f8ae45
```

The owner key travels through the **store seam** (not just the resume path), so durable backends enforce the same invariant.

## Notes

- **#3 → #215**: capabilities is now genuinely consulted, so the Anthropic provider can honor it as #215 intends (report `json_schema: false` for tool-forcing, `streaming: true`; the runtime degrade paths handle the rest).
- **`tools` flag** is enforced as a fail-fast config error (tool calling has no graceful degrade). Easy to switch to silent tool-dropping if preferred.
- OpenAI reports all-capable, so its behavior is unchanged; the mock reports `json_schema: false`, so existing structured tests now exercise the injection path.
- Error mapping still surfaces only status/type, never the body (§D10); retries preserve that.

## Verification

- **120 tests** pass across `pocopine-agenkit-core`, `pocopine-agenkit`, `pocopine-agenkit-oai` (new unit + wiremock + integration tests for every item).
- Host **and** wasm32 `clippy -D warnings` clean; `fmt --check` clean on the touched crates.
- Pre-existing `fmt` drift in `pine-layout` (untouched here) left alone.
