### PR TITLE
feat(agenkit-anthropic): native Claude Messages API provider (#215)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6928,6 +6928,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "pocopine-agenkit-anthropic"
+version = "0.1.1"
+dependencies = [
+ "futures",
+ "pocopine-agenkit",
+ "pocopine-agenkit-core",
+ "reqwest 0.12.28",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "wiremock",
+]
+
+[[package]]
 name = "pocopine-agenkit-core"
 version = "0.1.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "crates/pine-richtext",
     "crates/pocopine",
     "crates/pocopine-agenkit",
+    "crates/pocopine-agenkit-anthropic",
     "crates/pocopine-agenkit-core",
     "crates/pocopine-agenkit-oai",
     "crates/pocopine-analytics",
@@ -108,6 +109,7 @@ repository = "https://github.com/mambisi/pocopine"
 # of `pocopine` get devtools on by default via its own `default`
 # feature, which forwards `pocopine-core/devtools`.
 pocopine-agenkit = { path = "crates/pocopine-agenkit", version = "0.1.0" }
+pocopine-agenkit-anthropic = { path = "crates/pocopine-agenkit-anthropic", version = "0.1.0" }
 pocopine-agenkit-core = { path = "crates/pocopine-agenkit-core", version = "0.1.0" }
 pocopine-agenkit-oai = { path = "crates/pocopine-agenkit-oai", version = "0.1.0" }
 pocopine-analytics = { path = "crates/pocopine-analytics", version = "0.1.0" }

--- a/crates/pocopine-agenkit-anthropic/Cargo.toml
+++ b/crates/pocopine-agenkit-anthropic/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "pocopine-agenkit-anthropic"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Native Anthropic Claude (Messages API) provider for Pocopine Agenkit. Implements the Agenkit Provider trait against /v1/messages with content-block mapping, forced-tool structured output, and native SSE streaming. Server-only credentials."
+
+# Host-only: depends on the host-side pocopine-agenkit runtime + reqwest, which
+# do not build for wasm32. The browser never calls a provider directly (§D10).
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+pocopine-agenkit = { workspace = true }
+pocopine-agenkit-core = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+# `stream` for SSE streaming (response.bytes_stream()).
+reqwest = { version = "0.12", default-features = false, features = [
+    "json",
+    "stream",
+    "rustls-tls-webpki-roots",
+] }
+futures = "0.3"
+# Stream the SSE response off a spawned reader task.
+tokio = { version = "1", features = ["rt", "sync"] }
+tokio-stream = "0.1"
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
+wiremock = "0.6"
+# A structured-output type for the forced-tool / streaming tests.
+schemars = "0.8"

--- a/crates/pocopine-agenkit-anthropic/src/lib.rs
+++ b/crates/pocopine-agenkit-anthropic/src/lib.rs
@@ -434,7 +434,13 @@ impl<'a> SseDecoder<'a> {
             }
             StreamEvent::MessageDelta { usage } => {
                 if let Some(usage) = usage {
+                    // `message_delta` usage is cumulative, so the latest value
+                    // wins. It may also restate `input_tokens` (e.g. when a
+                    // server-side tool inflated the prompt); take it when given.
                     self.output_tokens = usage.output_tokens;
+                    if usage.input_tokens > 0 {
+                        self.input_tokens = usage.input_tokens;
+                    }
                 }
             }
             StreamEvent::MessageStop => {

--- a/crates/pocopine-agenkit-anthropic/src/lib.rs
+++ b/crates/pocopine-agenkit-anthropic/src/lib.rs
@@ -1,0 +1,517 @@
+//! Native Anthropic **Claude (Messages API)** provider for [Pocopine
+//! Agenkit](../../rfcs/rfc-093-pocopine-agenkit.md).
+//!
+//! Implements the Agenkit `Provider` trait against `/v1/messages`, parallel to
+//! `pocopine-agenkit-oai`. This is the recommended provider when building AI
+//! apps on Pocopine (default to the latest Claude models).
+//!
+//! ```no_run
+//! use pocopine_agenkit::server::Agenkit;
+//! use pocopine_agenkit_anthropic::AnthropicProvider;
+//! use pocopine_agenkit_core::ModelRef;
+//!
+//! let agenkit = Agenkit::builder()
+//!     // Credentials are read from ANTHROPIC_API_KEY — server-only (§D10).
+//!     .provider(AnthropicProvider::from_env("anthropic").expect("ANTHROPIC_API_KEY"))
+//!     .default_model(ModelRef::new("anthropic/claude-opus-4-8"))
+//!     .build()
+//!     .unwrap();
+//! # let _ = agenkit;
+//! ```
+//!
+//! Supports text + native **SSE streaming**, function **tools** (mapped to
+//! Anthropic content blocks), and schema-constrained **structured output** via
+//! a forced single tool (Anthropic has no `response_format`). The API key lives
+//! only in the `x-api-key` header, is redacted from `Debug`, and never appears
+//! in errors (§D10).
+#![cfg(not(target_arch = "wasm32"))]
+#![forbid(unsafe_code)]
+
+mod wire;
+
+use std::collections::{BTreeMap, HashMap};
+use std::time::Duration;
+
+use futures::StreamExt;
+use pocopine_agenkit::server::{
+    BoxFuture, BoxStream, GenerateRequest, GenerateResponse, Provider, ProviderCapabilities,
+    StreamChunk,
+};
+use pocopine_agenkit_core::{AgenkitError, AgenkitResult, ToolCall, Usage};
+use serde::Deserialize;
+use tokio::sync::mpsc::UnboundedSender;
+use tokio_stream::wrappers::UnboundedReceiverStream;
+
+use wire::{
+    MessagesRequest, MessagesResponse, STRUCTURED_TOOL_NAME, StreamBlockStart, StreamDelta,
+    StreamEvent,
+};
+
+/// The default Anthropic API base URL.
+pub const DEFAULT_BASE_URL: &str = "https://api.anthropic.com/v1";
+
+/// The Anthropic API version sent in the `anthropic-version` header.
+pub const DEFAULT_ANTHROPIC_VERSION: &str = "2023-06-01";
+
+/// Default `max_tokens` when the neutral request omits one (Anthropic requires
+/// the field). Sized for a typical completion; raise via `with_default_max_tokens`.
+const DEFAULT_MAX_TOKENS: u32 = 4096;
+
+/// Default total timeout for a non-streaming request (streaming is uncapped).
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Default retries on transient failures (429 / 5xx / network).
+const DEFAULT_MAX_RETRIES: u32 = 2;
+
+/// A provider backed by the Anthropic Messages API (`/v1/messages`).
+#[derive(Clone)]
+pub struct AnthropicProvider {
+    alias: String,
+    api_key: String,
+    base_url: String,
+    version: String,
+    default_max_tokens: u32,
+    request_timeout: Duration,
+    max_retries: u32,
+    http: reqwest::Client,
+}
+
+// Hand-rolled so the API key never lands in logs or panic messages (§D10).
+impl std::fmt::Debug for AnthropicProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AnthropicProvider")
+            .field("alias", &self.alias)
+            .field("base_url", &self.base_url)
+            .field("version", &self.version)
+            .field("default_max_tokens", &self.default_max_tokens)
+            .field("api_key", &"<redacted>")
+            .finish()
+    }
+}
+
+impl AnthropicProvider {
+    /// A provider serving `alias`, authenticating with `api_key`, against the
+    /// default Anthropic base URL.
+    pub fn new(alias: impl Into<String>, api_key: impl Into<String>) -> Self {
+        Self {
+            alias: alias.into(),
+            api_key: api_key.into(),
+            base_url: DEFAULT_BASE_URL.to_string(),
+            version: DEFAULT_ANTHROPIC_VERSION.to_string(),
+            default_max_tokens: DEFAULT_MAX_TOKENS,
+            request_timeout: DEFAULT_REQUEST_TIMEOUT,
+            max_retries: DEFAULT_MAX_RETRIES,
+            // Connect timeout only on the shared client; the total-request
+            // timeout is applied per-call (non-streaming) so a long-lived SSE
+            // stream is never cut. Use `with_http_client` for finer control.
+            http: reqwest::Client::builder()
+                .connect_timeout(Duration::from_secs(15))
+                .build()
+                .unwrap_or_default(),
+        }
+    }
+
+    /// Build from the environment: `ANTHROPIC_API_KEY` (required) and optionally
+    /// `ANTHROPIC_BASE_URL`. Credentials never enter app code or client bundles.
+    pub fn from_env(alias: impl Into<String>) -> AgenkitResult<Self> {
+        let api_key = std::env::var("ANTHROPIC_API_KEY")
+            .map_err(|_| AgenkitError::config("ANTHROPIC_API_KEY is not set"))?;
+        let mut provider = Self::new(alias, api_key);
+        if let Ok(base_url) = std::env::var("ANTHROPIC_BASE_URL") {
+            provider.base_url = base_url;
+        }
+        Ok(provider)
+    }
+
+    /// Point at a compatible endpoint (e.g. a proxy or Bedrock-compatible URL).
+    pub fn with_base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = base_url.into();
+        self
+    }
+
+    /// Override the `anthropic-version` header.
+    pub fn with_version(mut self, version: impl Into<String>) -> Self {
+        self.version = version.into();
+        self
+    }
+
+    /// Set the `max_tokens` used when a request omits one.
+    pub fn with_default_max_tokens(mut self, max_tokens: u32) -> Self {
+        self.default_max_tokens = max_tokens.max(1);
+        self
+    }
+
+    /// Total timeout for a non-streaming request (streaming is never capped).
+    pub fn with_request_timeout(mut self, timeout: Duration) -> Self {
+        self.request_timeout = timeout;
+        self
+    }
+
+    /// Retries on transient failures (429 / 5xx / network errors). `0` disables.
+    pub fn with_max_retries(mut self, retries: u32) -> Self {
+        self.max_retries = retries;
+        self
+    }
+
+    /// Use a pre-configured `reqwest::Client` (timeouts, proxy, ...).
+    pub fn with_http_client(mut self, http: reqwest::Client) -> Self {
+        self.http = http;
+        self
+    }
+
+    fn endpoint(&self) -> String {
+        format!("{}/messages", self.base_url.trim_end_matches('/'))
+    }
+
+    fn post(&self, wire: &MessagesRequest, timeout: Option<Duration>) -> reqwest::RequestBuilder {
+        let mut builder = self
+            .http
+            .post(self.endpoint())
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", &self.version)
+            .json(wire);
+        if let Some(timeout) = timeout {
+            builder = builder.timeout(timeout);
+        }
+        builder
+    }
+
+    /// POST with retry on transient failures (429 / 5xx / network errors).
+    /// `timeout` caps each attempt (non-streaming only). On a terminal non-2xx
+    /// the error carries only the status/type, never the body message (§D10).
+    async fn send_with_retry(
+        &self,
+        wire: &MessagesRequest,
+        timeout: Option<Duration>,
+    ) -> AgenkitResult<reqwest::Response> {
+        let mut attempt: u32 = 0;
+        loop {
+            match self.post(wire, timeout).send().await {
+                Ok(response) if response.status().is_success() => return Ok(response),
+                Ok(response) => {
+                    let status = response.status().as_u16();
+                    if is_retryable_status(status) && attempt < self.max_retries {
+                        let delay = retry_delay(attempt, response.headers());
+                        attempt += 1;
+                        tokio::time::sleep(delay).await;
+                        continue;
+                    }
+                    let body = response.text().await.unwrap_or_default();
+                    return Err(AgenkitError::provider(anthropic_error_message(
+                        status, &body,
+                    )));
+                }
+                Err(err) => {
+                    if attempt < self.max_retries {
+                        let delay = retry_delay(attempt, &reqwest::header::HeaderMap::new());
+                        attempt += 1;
+                        tokio::time::sleep(delay).await;
+                        continue;
+                    }
+                    return Err(AgenkitError::provider(format!("request failed: {err}")));
+                }
+            }
+        }
+    }
+
+    async fn message(&self, request: GenerateRequest) -> AgenkitResult<GenerateResponse> {
+        let name_map = wire::tool_name_map(&request.tools);
+        let wire = MessagesRequest::from_agenkit(&request, false, self.default_max_tokens);
+        let response = self
+            .send_with_retry(&wire, Some(self.request_timeout))
+            .await?;
+        let body = response.text().await.map_err(|err| {
+            AgenkitError::provider(format!("reading response body failed: {err}"))
+        })?;
+        let parsed = serde_json::from_str::<MessagesResponse>(&body)
+            .map_err(|err| AgenkitError::provider(format!("invalid response shape: {err}")))?;
+        Ok(parsed.into_agenkit(&name_map))
+    }
+
+    /// Read the SSE stream into `tx`, forwarding text deltas and accumulating
+    /// tool-call fragments by content-block index.
+    async fn stream_into(
+        &self,
+        request: GenerateRequest,
+        tx: UnboundedSender<AgenkitResult<StreamChunk>>,
+    ) -> AgenkitResult<()> {
+        let name_map = wire::tool_name_map(&request.tools);
+        let wire = MessagesRequest::from_agenkit(&request, true, self.default_max_tokens);
+        // No total timeout on a stream; retry only the connect/status handshake.
+        let response = self.send_with_retry(&wire, None).await?;
+
+        // Buffer raw bytes and decode whole `\n`-terminated lines. `\n` (0x0A)
+        // never appears mid multi-byte UTF-8 sequence, so a line cut at a
+        // newline is always valid UTF-8 — unlike per-chunk `from_utf8_lossy`.
+        let mut bytes = response.bytes_stream();
+        let mut buffer: Vec<u8> = Vec::new();
+        let mut decoder = SseDecoder::new(&name_map);
+
+        while let Some(chunk) = bytes.next().await {
+            let chunk = chunk
+                .map_err(|err| AgenkitError::provider(format!("stream read failed: {err}")))?;
+            buffer.extend_from_slice(&chunk);
+            while let Some(newline) = buffer.iter().position(|&b| b == b'\n') {
+                let done = decoder.feed_line(&buffer[..newline], &tx);
+                buffer.drain(..=newline);
+                if done {
+                    return Ok(());
+                }
+            }
+        }
+        // Flush a final event buffered with no terminating blank line.
+        if !buffer.is_empty() {
+            decoder.feed_line(&buffer, &tx);
+        }
+        decoder.flush(&tx);
+        Ok(())
+    }
+}
+
+impl Provider for AnthropicProvider {
+    fn id(&self) -> &str {
+        &self.alias
+    }
+
+    fn capabilities(&self) -> ProviderCapabilities {
+        // Anthropic streams natively and calls tools, but has no native
+        // schema-constrained mode — structured output is done via a forced
+        // tool, so the runtime's JSON-mode fallback path applies.
+        ProviderCapabilities {
+            streaming: true,
+            json_schema: false,
+            tools: true,
+        }
+    }
+
+    fn generate<'a>(
+        &'a self,
+        request: GenerateRequest,
+    ) -> BoxFuture<'a, AgenkitResult<GenerateResponse>> {
+        Box::pin(self.message(request))
+    }
+
+    fn generate_stream<'a>(
+        &'a self,
+        request: GenerateRequest,
+    ) -> BoxStream<'a, AgenkitResult<StreamChunk>> {
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let provider = self.clone();
+        let forward = tx.clone();
+        tokio::spawn(async move {
+            if let Err(error) = provider.stream_into(request, forward.clone()).await {
+                let _ = forward.send(Err(error));
+            }
+        });
+        Box::pin(UnboundedReceiverStream::new(rx))
+    }
+}
+
+/// An accumulating tool-use content block.
+struct ToolAccumulator {
+    id: String,
+    name: String,
+    json: String,
+    /// True for the synthetic structured-output tool, whose JSON input is
+    /// forwarded as text deltas (so the runtime parses partial objects) rather
+    /// than surfaced as a tool call.
+    structured: bool,
+}
+
+/// Reassembles Anthropic SSE events from individual lines (blank-line-delimited
+/// per spec) and applies them to the chunk stream.
+struct SseDecoder<'a> {
+    data: Vec<String>,
+    tools: BTreeMap<u32, ToolAccumulator>,
+    input_tokens: u64,
+    output_tokens: u64,
+    name_map: &'a HashMap<String, String>,
+}
+
+impl<'a> SseDecoder<'a> {
+    fn new(name_map: &'a HashMap<String, String>) -> Self {
+        Self {
+            data: Vec::new(),
+            tools: BTreeMap::new(),
+            input_tokens: 0,
+            output_tokens: 0,
+            name_map,
+        }
+    }
+
+    /// Feed one line (without trailing `\n`). Returns `true` once the stream is
+    /// complete (`message_stop`).
+    fn feed_line(&mut self, line: &[u8], tx: &UnboundedSender<AgenkitResult<StreamChunk>>) -> bool {
+        let Ok(text) = std::str::from_utf8(line) else {
+            return false;
+        };
+        let text = text.strip_suffix('\r').unwrap_or(text);
+        if text.is_empty() {
+            return self.dispatch(tx);
+        }
+        if text.starts_with(':') {
+            return false; // comment / keep-alive
+        }
+        // Anthropic sends `event:` and `data:` lines; the data payload is
+        // self-describing via its `type`, so only `data:` matters here.
+        if let Some(value) = text.strip_prefix("data:") {
+            self.data
+                .push(value.strip_prefix(' ').unwrap_or(value).to_string());
+        }
+        false
+    }
+
+    /// Dispatch the buffered event. Returns `true` on `message_stop`.
+    fn dispatch(&mut self, tx: &UnboundedSender<AgenkitResult<StreamChunk>>) -> bool {
+        if self.data.is_empty() {
+            return false;
+        }
+        let data = std::mem::take(&mut self.data).join("\n");
+        let Ok(event) = serde_json::from_str::<StreamEvent>(data.trim()) else {
+            return false;
+        };
+        self.apply(event, tx)
+    }
+
+    /// Flush a final event with no terminating blank line.
+    fn flush(&mut self, tx: &UnboundedSender<AgenkitResult<StreamChunk>>) -> bool {
+        self.dispatch(tx)
+    }
+
+    fn apply(
+        &mut self,
+        event: StreamEvent,
+        tx: &UnboundedSender<AgenkitResult<StreamChunk>>,
+    ) -> bool {
+        match event {
+            StreamEvent::MessageStart { message } => {
+                if let Some(usage) = message.usage {
+                    self.input_tokens = usage.input_tokens;
+                }
+            }
+            StreamEvent::ContentBlockStart {
+                index,
+                content_block,
+            } => {
+                let StreamBlockStart { kind, id, name } = content_block;
+                if kind == "tool_use" {
+                    let name = name.unwrap_or_default();
+                    let structured = name == STRUCTURED_TOOL_NAME;
+                    self.tools.insert(
+                        index,
+                        ToolAccumulator {
+                            id: id.unwrap_or_default(),
+                            name,
+                            json: String::new(),
+                            structured,
+                        },
+                    );
+                }
+            }
+            StreamEvent::ContentBlockDelta { index, delta } => match delta {
+                StreamDelta::TextDelta { text } => {
+                    if !text.is_empty() {
+                        let _ = tx.send(Ok(StreamChunk::Text(text)));
+                    }
+                }
+                StreamDelta::InputJsonDelta { partial_json } => {
+                    if let Some(acc) = self.tools.get_mut(&index) {
+                        if acc.structured {
+                            // Forward as text so the runtime parses partial
+                            // structured objects and assembles the final value.
+                            if !partial_json.is_empty() {
+                                let _ = tx.send(Ok(StreamChunk::Text(partial_json)));
+                            }
+                        } else {
+                            acc.json.push_str(&partial_json);
+                        }
+                    }
+                }
+                StreamDelta::Other => {}
+            },
+            StreamEvent::ContentBlockStop { index } => {
+                self.emit_tool(index, tx);
+            }
+            StreamEvent::MessageDelta { usage } => {
+                if let Some(usage) = usage {
+                    self.output_tokens = usage.output_tokens;
+                }
+            }
+            StreamEvent::MessageStop => {
+                // Close out any tool block that never got a stop, then usage.
+                let indices: Vec<u32> = self.tools.keys().copied().collect();
+                for index in indices {
+                    self.emit_tool(index, tx);
+                }
+                if self.input_tokens > 0 || self.output_tokens > 0 {
+                    let _ = tx.send(Ok(StreamChunk::Usage(Usage::new(
+                        self.input_tokens,
+                        self.output_tokens,
+                    ))));
+                }
+                return true;
+            }
+            StreamEvent::Other => {}
+        }
+        false
+    }
+
+    /// Emit a finished (non-structured) tool call, resolving its name back to
+    /// the original tool id. Structured-tool blocks were already streamed as text.
+    fn emit_tool(&mut self, index: u32, tx: &UnboundedSender<AgenkitResult<StreamChunk>>) {
+        let Some(acc) = self.tools.remove(&index) else {
+            return;
+        };
+        if acc.structured {
+            return;
+        }
+        let args = if acc.json.trim().is_empty() {
+            serde_json::json!({})
+        } else {
+            serde_json::from_str(&acc.json).unwrap_or_else(|_| serde_json::json!({}))
+        };
+        let name = wire::resolve_tool_name(acc.name, self.name_map);
+        let _ = tx.send(Ok(StreamChunk::ToolCall(ToolCall::new(acc.id, name, args))));
+    }
+}
+
+/// Whether a non-2xx status is worth retrying: rate limits and server errors.
+fn is_retryable_status(status: u16) -> bool {
+    status == 429 || status >= 500
+}
+
+/// Backoff before the next retry: honor `retry-after` (seconds, capped) when
+/// present, else exponential from 250ms.
+fn retry_delay(attempt: u32, headers: &reqwest::header::HeaderMap) -> Duration {
+    if let Some(secs) = headers
+        .get(reqwest::header::RETRY_AFTER)
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.trim().parse::<u64>().ok())
+    {
+        return Duration::from_secs(secs.min(30));
+    }
+    Duration::from_millis(250u64.saturating_mul(1u64 << attempt.min(5)))
+}
+
+/// Build a client-safe error string from an Anthropic error body. Surfaces only
+/// the stable status/type — never the free-form message, which can echo request
+/// content or hints (§D10).
+fn anthropic_error_message(status: u16, body: &str) -> String {
+    #[derive(Deserialize)]
+    struct ErrorBody {
+        error: ErrorDetail,
+    }
+    #[derive(Deserialize)]
+    struct ErrorDetail {
+        #[serde(rename = "type", default)]
+        kind: Option<String>,
+    }
+
+    match serde_json::from_str::<ErrorBody>(body) {
+        Ok(parsed) => format!(
+            "Anthropic API error {status} (type={})",
+            parsed.error.kind.as_deref().unwrap_or("unknown")
+        ),
+        Err(_) => format!("Anthropic API error {status}"),
+    }
+}

--- a/crates/pocopine-agenkit-anthropic/src/wire.rs
+++ b/crates/pocopine-agenkit-anthropic/src/wire.rs
@@ -1,0 +1,539 @@
+//! Anthropic Messages API wire types and the mapping to/from Agenkit's neutral
+//! request/response.
+//!
+//! The Messages API differs from OpenAI Chat Completions in three ways this
+//! module bridges: the system prompt is a **top-level field** (not a message
+//! role), tool use/results are **content blocks** inside user/assistant
+//! messages (there is no `tool` role), and there is **no `response_format`** —
+//! structured output is obtained by forcing a single tool whose `input_schema`
+//! is the desired shape.
+
+use std::collections::HashMap;
+
+use pocopine_agenkit::server::{FinishReason, GenerateRequest, GenerateResponse};
+use pocopine_agenkit_core::{Content, Message, Role, ToolCall, ToolDescriptor, Usage};
+use serde::{Deserialize, Serialize};
+
+/// Name of the synthetic tool used to coax schema-shaped structured output.
+/// Conforms to Anthropic's `^[a-zA-Z0-9_-]{1,64}$` tool-name rule.
+pub(crate) const STRUCTURED_TOOL_NAME: &str = "structured_output";
+
+// ---- tool-name sanitization -------------------------------------------------
+
+/// Anthropic requires tool names to match `^[a-zA-Z0-9_-]{1,64}$` (same rule as
+/// OpenAI). Map every other byte to `_` and cap at 64; an empty/all-invalid
+/// name becomes `_`. The provider sanitizes on the way out and reverses the
+/// mapping on the way back (see [`tool_name_map`]).
+pub(crate) fn sanitize_tool_name(name: &str) -> String {
+    let mut out: String = name
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    out.truncate(64);
+    if out.is_empty() {
+        out.push('_');
+    }
+    out
+}
+
+/// Reverse map (sanitized name → original tool id) for a request's tools, so a
+/// tool call the model makes under the sanitized name dispatches to the real
+/// tool. Identity for already-valid ids.
+pub(crate) fn tool_name_map(tools: &[ToolDescriptor]) -> HashMap<String, String> {
+    tools
+        .iter()
+        .map(|tool| (sanitize_tool_name(&tool.id), tool.id.clone()))
+        .collect()
+}
+
+/// Resolve a wire tool-call name back to the original tool id; passes names
+/// through unchanged when there is no mapping.
+pub(crate) fn resolve_tool_name(name: String, name_map: &HashMap<String, String>) -> String {
+    name_map.get(&name).cloned().unwrap_or(name)
+}
+
+// ---- request ----------------------------------------------------------------
+
+#[derive(Serialize)]
+pub(crate) struct MessagesRequest {
+    pub(crate) model: String,
+    /// Anthropic **requires** `max_tokens`; the provider supplies a default
+    /// when the neutral request leaves it unset.
+    pub(crate) max_tokens: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) system: Option<String>,
+    pub(crate) messages: Vec<WireMessage>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub(crate) tools: Vec<WireTool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) tool_choice: Option<ToolChoice>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) stream: Option<bool>,
+}
+
+impl MessagesRequest {
+    /// Map a neutral request. `stream` toggles SSE; `default_max_tokens` fills
+    /// the required cap when the request omits one.
+    pub(crate) fn from_agenkit(
+        request: &GenerateRequest,
+        stream: bool,
+        default_max_tokens: u32,
+    ) -> Self {
+        // The Messages API has no system role: hoist `request.system` plus any
+        // System-role messages into the top-level `system` field.
+        let mut system = request.system.clone();
+        for message in &request.messages {
+            if message.role == Role::System {
+                append_system(&mut system, message.content.as_text());
+            }
+        }
+
+        let messages = fold_messages(&request.messages);
+
+        let mut tools: Vec<WireTool> = request
+            .tools
+            .iter()
+            .map(WireTool::from_descriptor)
+            .collect();
+        let has_user_tools = !tools.is_empty();
+
+        // Structured output: Anthropic has no `response_format`. With no user
+        // tools, force a single tool whose `input_schema` is the requested
+        // shape — the model must "call" it, yielding schema-constrained JSON.
+        // With user tools present we cannot force (it would suppress them), so
+        // we fall back to plain text the runtime parses (graceful degrade).
+        let mut tool_choice = None;
+        if let Some(schema) = &request.json_schema
+            && !has_user_tools
+        {
+            tools.push(WireTool {
+                name: STRUCTURED_TOOL_NAME.to_string(),
+                description: "Return the final answer as a structured JSON object.".to_string(),
+                input_schema: normalize_schema(schema),
+            });
+            tool_choice = Some(ToolChoice {
+                kind: "tool",
+                name: STRUCTURED_TOOL_NAME.to_string(),
+            });
+        }
+
+        Self {
+            model: request.model.model().to_string(),
+            max_tokens: request.max_tokens.unwrap_or(default_max_tokens),
+            system,
+            messages,
+            tools,
+            tool_choice,
+            stream: stream.then_some(true),
+        }
+    }
+}
+
+fn append_system(system: &mut Option<String>, text: String) {
+    if text.is_empty() {
+        return;
+    }
+    *system = Some(match system.take() {
+        Some(existing) => format!("{existing}\n{text}"),
+        None => text,
+    });
+}
+
+/// Map neutral messages to Anthropic messages, folding consecutive same-role
+/// messages into one (the Messages API expects content blocks grouped per
+/// turn — e.g. several tool results belong in one user message).
+fn fold_messages(messages: &[Message]) -> Vec<WireMessage> {
+    let mut folded: Vec<WireMessage> = Vec::new();
+    for message in messages {
+        let (role, blocks) = match message.role {
+            Role::System => continue, // hoisted to top-level `system`
+            Role::User => ("user", text_block(&message.content).into_iter().collect()),
+            Role::Assistant => assistant_blocks(message),
+            Role::Tool => ("user", tool_result_blocks(message)),
+        };
+        if blocks.is_empty() {
+            continue;
+        }
+        match folded.last_mut() {
+            Some(last) if last.role == role => last.content.extend(blocks),
+            _ => folded.push(WireMessage {
+                role,
+                content: blocks,
+            }),
+        }
+    }
+    folded
+}
+
+fn text_block(content: &Content) -> Option<ContentBlock> {
+    let text = content.as_text();
+    (!text.is_empty()).then_some(ContentBlock::Text { text })
+}
+
+fn assistant_blocks(message: &Message) -> (&'static str, Vec<ContentBlock>) {
+    let mut blocks: Vec<ContentBlock> = text_block(&message.content).into_iter().collect();
+    for call in &message.tool_calls {
+        blocks.push(ContentBlock::ToolUse {
+            id: call.id.clone(),
+            name: sanitize_tool_name(&call.tool_id),
+            input: call.args.clone(),
+        });
+    }
+    ("assistant", blocks)
+}
+
+fn tool_result_blocks(message: &Message) -> Vec<ContentBlock> {
+    let Some(tool_use_id) = message.tool_call_id.clone() else {
+        return Vec::new();
+    };
+    vec![ContentBlock::ToolResult {
+        tool_use_id,
+        content: message.content.as_text(),
+    }]
+}
+
+/// Anthropic's `input_schema` is plain JSON Schema; drop the `$schema` meta key
+/// schemars emits (harmless but unnecessary on the wire).
+fn normalize_schema(schema: &serde_json::Value) -> serde_json::Value {
+    let mut schema = schema.clone();
+    if let Some(map) = schema.as_object_mut() {
+        map.remove("$schema");
+    }
+    schema
+}
+
+#[derive(Serialize)]
+pub(crate) struct WireMessage {
+    pub(crate) role: &'static str,
+    pub(crate) content: Vec<ContentBlock>,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum ContentBlock {
+    Text {
+        text: String,
+    },
+    ToolUse {
+        id: String,
+        name: String,
+        input: serde_json::Value,
+    },
+    ToolResult {
+        tool_use_id: String,
+        content: String,
+    },
+}
+
+#[derive(Serialize)]
+pub(crate) struct ToolChoice {
+    #[serde(rename = "type")]
+    pub(crate) kind: &'static str,
+    pub(crate) name: String,
+}
+
+#[derive(Serialize)]
+pub(crate) struct WireTool {
+    pub(crate) name: String,
+    pub(crate) description: String,
+    pub(crate) input_schema: serde_json::Value,
+}
+
+impl WireTool {
+    fn from_descriptor(descriptor: &ToolDescriptor) -> Self {
+        let input_schema = descriptor
+            .input
+            .json_schema
+            .clone()
+            .map(|schema| normalize_schema(&schema))
+            .unwrap_or_else(|| serde_json::json!({ "type": "object" }));
+        Self {
+            name: sanitize_tool_name(&descriptor.id),
+            description: descriptor.description.clone(),
+            input_schema,
+        }
+    }
+}
+
+// ---- non-streaming response -------------------------------------------------
+
+#[derive(Deserialize)]
+pub(crate) struct MessagesResponse {
+    #[serde(default)]
+    pub(crate) content: Vec<ResponseBlock>,
+    #[serde(default)]
+    pub(crate) stop_reason: Option<String>,
+    #[serde(default)]
+    pub(crate) usage: Option<WireUsage>,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum ResponseBlock {
+    Text {
+        text: String,
+    },
+    ToolUse {
+        id: String,
+        name: String,
+        #[serde(default)]
+        input: serde_json::Value,
+    },
+    /// Ignore block types we don't model (e.g. `thinking`).
+    #[serde(other)]
+    Other,
+}
+
+impl MessagesResponse {
+    pub(crate) fn into_agenkit(self, name_map: &HashMap<String, String>) -> GenerateResponse {
+        let mut text = String::new();
+        let mut tool_calls = Vec::new();
+        let mut structured: Option<serde_json::Value> = None;
+
+        for block in self.content {
+            match block {
+                ResponseBlock::Text { text: fragment } => text.push_str(&fragment),
+                ResponseBlock::ToolUse { id, name, input } => {
+                    if name == STRUCTURED_TOOL_NAME {
+                        // The forced structured tool: its input IS the answer.
+                        structured = Some(input);
+                    } else {
+                        tool_calls.push(ToolCall::new(
+                            id,
+                            resolve_tool_name(name, name_map),
+                            input,
+                        ));
+                    }
+                }
+                ResponseBlock::Other => {}
+            }
+        }
+
+        let mut response = match structured {
+            Some(value) => GenerateResponse::structured(value),
+            None => GenerateResponse::text(text),
+        };
+        response.tool_calls = tool_calls;
+        response.usage = self.usage.map(WireUsage::into_usage);
+        response.finish_reason = finish_reason(self.stop_reason.as_deref());
+        response
+    }
+}
+
+#[derive(Deserialize)]
+pub(crate) struct WireUsage {
+    #[serde(default)]
+    pub(crate) input_tokens: u64,
+    #[serde(default)]
+    pub(crate) output_tokens: u64,
+}
+
+impl WireUsage {
+    pub(crate) fn into_usage(self) -> Usage {
+        Usage::new(self.input_tokens, self.output_tokens)
+    }
+}
+
+pub(crate) fn finish_reason(raw: Option<&str>) -> FinishReason {
+    match raw {
+        Some("max_tokens") => FinishReason::Length,
+        Some("tool_use") => FinishReason::ToolCalls,
+        _ => FinishReason::Stop,
+    }
+}
+
+// ---- streaming events -------------------------------------------------------
+
+/// One decoded Anthropic SSE event. The `data:` payload is self-describing via
+/// its `type`, so the `event:` line is ignored.
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum StreamEvent {
+    MessageStart {
+        message: StreamMessageStart,
+    },
+    ContentBlockStart {
+        index: u32,
+        content_block: StreamBlockStart,
+    },
+    ContentBlockDelta {
+        index: u32,
+        delta: StreamDelta,
+    },
+    ContentBlockStop {
+        index: u32,
+    },
+    MessageDelta {
+        #[serde(default)]
+        usage: Option<WireUsage>,
+    },
+    MessageStop,
+    /// `ping` and any future event types.
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct StreamMessageStart {
+    #[serde(default)]
+    pub(crate) usage: Option<WireUsage>,
+}
+
+#[derive(Deserialize)]
+pub(crate) struct StreamBlockStart {
+    #[serde(rename = "type")]
+    pub(crate) kind: String,
+    #[serde(default)]
+    pub(crate) id: Option<String>,
+    #[serde(default)]
+    pub(crate) name: Option<String>,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum StreamDelta {
+    TextDelta {
+        text: String,
+    },
+    InputJsonDelta {
+        partial_json: String,
+    },
+    #[serde(other)]
+    Other,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pocopine_agenkit_core::{Content, ModelRef};
+
+    fn to_value(request: &MessagesRequest) -> serde_json::Value {
+        serde_json::to_value(request).unwrap()
+    }
+
+    #[test]
+    fn sanitize_tool_name_conforms_to_pattern() {
+        assert_eq!(sanitize_tool_name("get_weather"), "get_weather");
+        assert_eq!(sanitize_tool_name("weather.lookup"), "weather_lookup");
+        assert_eq!(sanitize_tool_name("café"), "caf_");
+        assert_eq!(sanitize_tool_name(&"x".repeat(100)).len(), 64);
+        assert_eq!(sanitize_tool_name(""), "_");
+    }
+
+    #[test]
+    fn hoists_system_field_and_system_messages() {
+        let request = GenerateRequest {
+            model: ModelRef::new("anthropic/claude-opus-4-8"),
+            system: Some("be brief".to_string()),
+            messages: vec![
+                Message::new(Role::System, "also be kind"),
+                Message::new(Role::User, "hi"),
+            ],
+            ..GenerateRequest::default()
+        };
+        let wire = MessagesRequest::from_agenkit(&request, false, 4096);
+        assert_eq!(wire.system.as_deref(), Some("be brief\nalso be kind"));
+        // The system message is hoisted out, leaving only the user turn.
+        let value = to_value(&wire);
+        assert_eq!(value["messages"].as_array().unwrap().len(), 1);
+        assert_eq!(value["messages"][0]["role"], "user");
+        assert_eq!(value["max_tokens"], 4096);
+    }
+
+    #[test]
+    fn forces_a_tool_for_structured_output_without_user_tools() {
+        let request = GenerateRequest {
+            model: ModelRef::new("anthropic/claude-opus-4-8"),
+            messages: vec![Message::new(Role::User, "summarize")],
+            json_schema: Some(serde_json::json!({"type": "object", "properties": {}})),
+            ..GenerateRequest::default()
+        };
+        let value = to_value(&MessagesRequest::from_agenkit(&request, false, 4096));
+        assert_eq!(value["tool_choice"]["type"], "tool");
+        assert_eq!(value["tool_choice"]["name"], STRUCTURED_TOOL_NAME);
+        assert_eq!(value["tools"][0]["name"], STRUCTURED_TOOL_NAME);
+    }
+
+    #[test]
+    fn does_not_force_a_tool_when_user_tools_are_present() {
+        let request = GenerateRequest {
+            model: ModelRef::new("anthropic/claude-opus-4-8"),
+            messages: vec![Message::new(Role::User, "summarize")],
+            tools: vec![ToolDescriptor::new("search", "Search")],
+            json_schema: Some(serde_json::json!({"type": "object"})),
+            ..GenerateRequest::default()
+        };
+        let value = to_value(&MessagesRequest::from_agenkit(&request, false, 4096));
+        assert!(value.get("tool_choice").is_none() || value["tool_choice"].is_null());
+        assert_eq!(value["tools"][0]["name"], "search");
+    }
+
+    #[test]
+    fn folds_assistant_tool_use_and_tool_result_turns() {
+        let request = GenerateRequest {
+            model: ModelRef::new("anthropic/claude-opus-4-8"),
+            messages: vec![
+                Message::new(Role::User, "weather?"),
+                Message {
+                    role: Role::Assistant,
+                    content: Content::text(""),
+                    tool_calls: vec![ToolCall::new(
+                        "toolu_1",
+                        "get_weather",
+                        serde_json::json!({"city": "Paris"}),
+                    )],
+                    tool_call_id: None,
+                },
+                Message {
+                    role: Role::Tool,
+                    content: Content::text("sunny"),
+                    tool_calls: vec![],
+                    tool_call_id: Some("toolu_1".to_string()),
+                },
+            ],
+            ..GenerateRequest::default()
+        };
+        let value = to_value(&MessagesRequest::from_agenkit(&request, false, 4096));
+        let messages = value["messages"].as_array().unwrap();
+        assert_eq!(messages.len(), 3);
+        assert_eq!(messages[1]["role"], "assistant");
+        assert_eq!(messages[1]["content"][0]["type"], "tool_use");
+        assert_eq!(messages[2]["role"], "user");
+        assert_eq!(messages[2]["content"][0]["type"], "tool_result");
+        assert_eq!(messages[2]["content"][0]["tool_use_id"], "toolu_1");
+    }
+
+    #[test]
+    fn response_maps_text_tool_and_structured() {
+        let name_map = tool_name_map(&[ToolDescriptor::new("weather.lookup", "w")]);
+        // A real tool call: sanitized name maps back to the original id.
+        let resp: MessagesResponse = serde_json::from_value(serde_json::json!({
+            "content": [{"type": "tool_use", "id": "toolu_1", "name": "weather_lookup", "input": {"city": "Paris"}}],
+            "stop_reason": "tool_use",
+            "usage": {"input_tokens": 5, "output_tokens": 3}
+        }))
+        .unwrap();
+        let mapped = resp.into_agenkit(&name_map);
+        assert_eq!(mapped.tool_calls.len(), 1);
+        assert_eq!(mapped.tool_calls[0].tool_id, "weather.lookup");
+
+        // The forced structured tool surfaces as a structured value, not a call.
+        let resp: MessagesResponse = serde_json::from_value(serde_json::json!({
+            "content": [{"type": "tool_use", "id": "toolu_2", "name": STRUCTURED_TOOL_NAME, "input": {"title": "X"}}],
+            "stop_reason": "tool_use"
+        }))
+        .unwrap();
+        let mapped = resp.into_agenkit(&HashMap::new());
+        assert!(mapped.tool_calls.is_empty());
+        assert_eq!(
+            mapped.structured_value(),
+            Some(&serde_json::json!({"title": "X"}))
+        );
+    }
+}

--- a/crates/pocopine-agenkit-anthropic/tests/contract.rs
+++ b/crates/pocopine-agenkit-anthropic/tests/contract.rs
@@ -1,0 +1,178 @@
+#![cfg(not(target_arch = "wasm32"))]
+//! Contract tests: drive the provider with **verbatim** payloads copied from
+//! Anthropic's published Messages API docs/OpenAPI spec, so a drift between our
+//! wire decoding and the real contract fails CI — without any network call.
+//!
+//! Fixtures captured from <https://platform.claude.com/docs/en/api/messages-streaming>
+//! against OpenAPI spec hash `5ce93251…` (see the `reference-anthropic-openapi-spec`
+//! memory). If Anthropic changes the wire shape, refresh these strings.
+
+use futures::StreamExt;
+use pocopine_agenkit::server::{GenerateRequest, Provider, StreamChunk};
+use pocopine_agenkit_anthropic::AnthropicProvider;
+use pocopine_agenkit_core::{Message, ModelRef};
+use serde_json::json;
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn provider(server: &MockServer) -> AnthropicProvider {
+    AnthropicProvider::new("anthropic", "test-key").with_base_url(format!("{}/v1", server.uri()))
+}
+
+fn text_request() -> GenerateRequest {
+    GenerateRequest {
+        model: ModelRef::new("anthropic/claude-opus-4-8"),
+        messages: vec![Message::user("hi")],
+        ..GenerateRequest::default()
+    }
+}
+
+async fn mount_sse(server: &MockServer, body: &'static str) {
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(body),
+        )
+        .mount(server)
+        .await;
+}
+
+async fn drain(
+    provider: &AnthropicProvider,
+) -> (String, Vec<pocopine_agenkit_core::ToolCall>, Option<u64>) {
+    let mut stream = provider.generate_stream(text_request());
+    let (mut text, mut tools, mut usage) = (String::new(), Vec::new(), None);
+    while let Some(chunk) = stream.next().await {
+        match chunk.unwrap() {
+            StreamChunk::Text(t) => text.push_str(&t),
+            StreamChunk::ToolCall(c) => tools.push(c),
+            StreamChunk::Usage(u) => usage = Some(u.total()),
+        }
+    }
+    (text, tools, usage)
+}
+
+/// Verbatim "Basic streaming request" example from the Messages streaming docs.
+const BASIC_TEXT_SSE: &str = r#"event: message_start
+data: {"type": "message_start", "message": {"id": "msg_1nZdL29xx5MUA1yADyHTEsnR8uuvGzszyY", "type": "message", "role": "assistant", "content": [], "model": "claude-opus-4-8", "stop_reason": null, "stop_sequence": null, "usage": {"input_tokens": 25, "output_tokens": 1}}}
+
+event: content_block_start
+data: {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}
+
+event: ping
+data: {"type": "ping"}
+
+event: content_block_delta
+data: {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Hello"}}
+
+event: content_block_delta
+data: {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "!"}}
+
+event: content_block_stop
+data: {"type": "content_block_stop", "index": 0}
+
+event: message_delta
+data: {"type": "message_delta", "delta": {"stop_reason": "end_turn", "stop_sequence":null}, "usage": {"output_tokens": 15}}
+
+event: message_stop
+data: {"type": "message_stop"}
+
+"#;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn decodes_the_documented_basic_text_stream() {
+    let server = MockServer::start().await;
+    mount_sse(&server, BASIC_TEXT_SSE).await;
+
+    let (text, tools, usage) = drain(&provider(&server)).await;
+    assert_eq!(text, "Hello!");
+    assert!(tools.is_empty());
+    // input_tokens (25, message_start) + output_tokens (15, cumulative message_delta).
+    assert_eq!(usage, Some(40));
+}
+
+/// Verbatim "Streaming request with tool use" example: a text block (index 0)
+/// followed by a `tool_use` block (index 1) whose input arrives as
+/// `input_json_delta` fragments. (Trimmed only by removing `ping`-only noise.)
+const TOOL_USE_SSE: &str = r#"event: message_start
+data: {"type":"message_start","message":{"id":"msg_014p7gG3wDgGV9EUtLvnow3U","type":"message","role":"assistant","model":"claude-opus-4-8","stop_sequence":null,"usage":{"input_tokens":472,"output_tokens":2},"content":[],"stop_reason":null}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Let me check"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"tool_use","id":"toolu_01T1x1fJ34qAmk2tNTrN7Up6","name":"get_weather","input":{}}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"{\"location\":"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":" \"San"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":" Francisc"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":"o,"}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"input_json_delta","partial_json":" CA\"}"}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"tool_use","stop_sequence":null},"usage":{"output_tokens":89}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+"#;
+
+#[tokio::test(flavor = "multi_thread")]
+async fn decodes_the_documented_tool_use_stream() {
+    let server = MockServer::start().await;
+    mount_sse(&server, TOOL_USE_SSE).await;
+
+    let (text, tools, usage) = drain(&provider(&server)).await;
+    assert_eq!(text, "Let me check");
+    assert_eq!(tools.len(), 1);
+    assert_eq!(tools[0].tool_id, "get_weather");
+    assert_eq!(tools[0].args, json!({"location": "San Francisco, CA"}));
+    assert_eq!(usage, Some(472 + 89));
+}
+
+/// Verbatim non-streaming `Message` response object from the spec.
+#[tokio::test]
+async fn decodes_the_documented_message_response() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "id": "msg_01XFDUDYJgAACzvnptvVoYEL",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-opus-4-8",
+            "content": [{"type": "text", "text": "Hi! My name is Claude."}],
+            "stop_reason": "end_turn",
+            "stop_sequence": null,
+            "usage": {"input_tokens": 10, "output_tokens": 25}
+        })))
+        .mount(&server)
+        .await;
+
+    let response = provider(&server).generate(text_request()).await.unwrap();
+    assert_eq!(response.text_output(), "Hi! My name is Claude.");
+    assert_eq!(response.usage.unwrap().total(), 35);
+}

--- a/crates/pocopine-agenkit-anthropic/tests/wire.rs
+++ b/crates/pocopine-agenkit-anthropic/tests/wire.rs
@@ -1,0 +1,383 @@
+#![cfg(not(target_arch = "wasm32"))]
+//! Integration tests for the Anthropic Messages API provider, driven against a
+//! `wiremock` server (no real API calls / credentials).
+
+use futures::StreamExt;
+use pocopine_agenkit::server::{
+    Agenkit, AiFlowContext, Flow, GenerateRequest, Provider, StreamChunk,
+};
+use pocopine_agenkit_anthropic::AnthropicProvider;
+use pocopine_agenkit_core::{AgenkitResult, FlowStreamEvent, Message, ModelRef, ToolDescriptor};
+use serde_json::json;
+use wiremock::matchers::{header, method, path};
+use wiremock::{Mock, MockServer, Request, ResponseTemplate};
+
+fn provider(server: &MockServer) -> AnthropicProvider {
+    AnthropicProvider::new("anthropic", "test-key").with_base_url(format!("{}/v1", server.uri()))
+}
+
+fn text_request(prompt: &str) -> GenerateRequest {
+    GenerateRequest {
+        model: ModelRef::new("anthropic/claude-opus-4-8"),
+        messages: vec![Message::user(prompt)],
+        ..GenerateRequest::default()
+    }
+}
+
+/// Build one Anthropic SSE event (`event:` + `data:` lines, blank-line ended).
+fn sse(event: &str, data: serde_json::Value) -> String {
+    format!(
+        "event: {event}\ndata: {}\n\n",
+        serde_json::to_string(&data).unwrap()
+    )
+}
+
+#[tokio::test]
+async fn maps_text_and_sends_anthropic_headers_with_required_max_tokens() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .and(header("x-api-key", "test-key"))
+        .and(header("anthropic-version", "2023-06-01"))
+        .respond_with(|req: &Request| {
+            let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap();
+            // The provider namespace is stripped and max_tokens is always set.
+            assert_eq!(body["model"], "claude-opus-4-8");
+            assert_eq!(body["max_tokens"], 4096);
+            assert_eq!(body["system"], "be brief");
+            ResponseTemplate::new(200).set_body_json(json!({
+                "content": [{"type": "text", "text": "uploads use presigned URLs"}],
+                "stop_reason": "end_turn",
+                "usage": {"input_tokens": 7, "output_tokens": 5}
+            }))
+        })
+        .mount(&server)
+        .await;
+
+    let request = GenerateRequest {
+        system: Some("be brief".to_string()),
+        ..text_request("how do uploads work?")
+    };
+    let response = provider(&server).generate(request).await.unwrap();
+    assert_eq!(response.text_output(), "uploads use presigned URLs");
+    assert_eq!(response.usage.unwrap().total(), 12);
+}
+
+#[tokio::test]
+async fn maps_tools_and_reverse_maps_sanitized_names() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(|req: &Request| {
+            let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap();
+            // The dotted tool id is sanitized to Anthropic's name rule.
+            assert_eq!(body["tools"][0]["name"], "weather_lookup");
+            assert_eq!(body["tools"][0]["input_schema"]["type"], "object");
+            ResponseTemplate::new(200).set_body_json(json!({
+                "content": [{
+                    "type": "tool_use",
+                    "id": "toolu_1",
+                    "name": "weather_lookup",
+                    "input": {"city": "Paris"}
+                }],
+                "stop_reason": "tool_use"
+            }))
+        })
+        .mount(&server)
+        .await;
+
+    let request = GenerateRequest {
+        tools: vec![ToolDescriptor::new("weather.lookup", "Look up weather")],
+        ..text_request("weather?")
+    };
+    let response = provider(&server).generate(request).await.unwrap();
+    assert_eq!(response.tool_calls.len(), 1);
+    // ...and the response tool name maps back to the original id for dispatch.
+    assert_eq!(response.tool_calls[0].tool_id, "weather.lookup");
+    assert_eq!(response.tool_calls[0].args, json!({"city": "Paris"}));
+}
+
+#[tokio::test]
+async fn forces_a_tool_for_structured_output() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(|req: &Request| {
+            let body: serde_json::Value = serde_json::from_slice(&req.body).unwrap();
+            // No user tools + a schema → a single forced structured-output tool.
+            assert_eq!(body["tool_choice"]["type"], "tool");
+            assert_eq!(body["tool_choice"]["name"], "structured_output");
+            // The model "calls" it with the structured answer.
+            ResponseTemplate::new(200).set_body_json(json!({
+                "content": [{
+                    "type": "tool_use",
+                    "id": "toolu_1",
+                    "name": "structured_output",
+                    "input": {"title": "Uploads"}
+                }],
+                "stop_reason": "tool_use"
+            }))
+        })
+        .mount(&server)
+        .await;
+
+    let request = GenerateRequest {
+        json_schema: Some(json!({"type": "object", "properties": {"title": {"type": "string"}}})),
+        ..text_request("summarize")
+    };
+    let response = provider(&server).generate(request).await.unwrap();
+    // Surfaced as a structured value (not a tool call) for the runtime to validate.
+    assert!(response.tool_calls.is_empty());
+    assert_eq!(response.text_output(), "");
+    assert_eq!(
+        response.structured_value().cloned(),
+        Some(json!({"title": "Uploads"}))
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn streams_text_deltas_and_usage() {
+    let server = MockServer::start().await;
+    let body = format!(
+        "{}{}{}{}{}{}",
+        sse(
+            "message_start",
+            json!({"type": "message_start", "message": {"usage": {"input_tokens": 3, "output_tokens": 0}}})
+        ),
+        sse(
+            "content_block_start",
+            json!({"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}})
+        ),
+        sse(
+            "content_block_delta",
+            json!({"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "uploads "}})
+        ),
+        sse(
+            "content_block_delta",
+            json!({"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "use presigned URLs"}})
+        ),
+        sse(
+            "message_delta",
+            json!({"type": "message_delta", "delta": {"stop_reason": "end_turn"}, "usage": {"output_tokens": 2}})
+        ),
+        sse("message_stop", json!({"type": "message_stop"})),
+    );
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(body),
+        )
+        .mount(&server)
+        .await;
+
+    let client = provider(&server);
+    let mut stream = client.generate_stream(text_request("how do uploads work?"));
+    let mut text = String::new();
+    let mut usage = None;
+    let mut deltas = 0;
+    while let Some(chunk) = stream.next().await {
+        match chunk.unwrap() {
+            StreamChunk::Text(fragment) => {
+                deltas += 1;
+                text.push_str(&fragment);
+            }
+            StreamChunk::Usage(reported) => usage = Some(reported),
+            StreamChunk::ToolCall(_) => {}
+        }
+    }
+    assert_eq!(text, "uploads use presigned URLs");
+    assert!(deltas >= 2, "expected incremental deltas, got {deltas}");
+    assert_eq!(usage.unwrap().total(), 5);
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn streams_a_tool_call_from_input_json_deltas() {
+    let server = MockServer::start().await;
+    let body = format!(
+        "{}{}{}{}{}",
+        sse(
+            "content_block_start",
+            json!({"type": "content_block_start", "index": 0, "content_block": {"type": "tool_use", "id": "toolu_1", "name": "get_weather", "input": {}}})
+        ),
+        sse(
+            "content_block_delta",
+            json!({"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "{\"city\":"}})
+        ),
+        sse(
+            "content_block_delta",
+            json!({"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "\"Paris\"}"}})
+        ),
+        sse(
+            "content_block_stop",
+            json!({"type": "content_block_stop", "index": 0})
+        ),
+        sse("message_stop", json!({"type": "message_stop"})),
+    );
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(body),
+        )
+        .mount(&server)
+        .await;
+
+    let client = provider(&server);
+    let mut stream = client.generate_stream(text_request("weather?"));
+    let mut tool_call = None;
+    while let Some(chunk) = stream.next().await {
+        if let StreamChunk::ToolCall(call) = chunk.unwrap() {
+            tool_call = Some(call);
+        }
+    }
+    let call = tool_call.expect("expected a streamed tool call");
+    assert_eq!(call.tool_id, "get_weather");
+    assert_eq!(call.args, json!({"city": "Paris"}));
+}
+
+#[derive(Debug, PartialEq, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+struct Summary {
+    title: String,
+    words: u32,
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn streams_structured_object_deltas_via_forced_tool() {
+    let server = MockServer::start().await;
+    // The forced structured tool's input arrives as `input_json_delta`
+    // fragments; the provider forwards them as text so the runtime parses
+    // progressively-completing partial objects.
+    let body = format!(
+        "{}{}{}{}{}",
+        sse(
+            "content_block_start",
+            json!({"type": "content_block_start", "index": 0, "content_block": {"type": "tool_use", "id": "toolu_1", "name": "structured_output", "input": {}}})
+        ),
+        sse(
+            "content_block_delta",
+            json!({"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "{\"title\":\"Obj"}})
+        ),
+        sse(
+            "content_block_delta",
+            json!({"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", "partial_json": "ect storage\",\"words\":12}"}})
+        ),
+        sse(
+            "content_block_stop",
+            json!({"type": "content_block_stop", "index": 0})
+        ),
+        sse("message_stop", json!({"type": "message_stop"})),
+    );
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "text/event-stream")
+                .set_body_string(body),
+        )
+        .mount(&server)
+        .await;
+
+    async fn summarize(_input: (), ctx: AiFlowContext) -> AgenkitResult<Summary> {
+        ctx.ai()
+            .prompt("summarize")
+            .schema::<Summary>()
+            .stream_structured()
+            .await
+    }
+
+    let agenkit = Agenkit::builder()
+        .provider(provider(&server))
+        .default_model(ModelRef::new("anthropic/claude-opus-4-8"))
+        .flow(Flow::new("summarize", summarize).public())
+        .build()
+        .unwrap();
+
+    let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel();
+    let value = agenkit
+        .run_flow_streaming("summarize", serde_json::Value::Null, tx)
+        .await
+        .unwrap();
+    let result: Summary = serde_json::from_value(value).unwrap();
+    assert_eq!(
+        result,
+        Summary {
+            title: "Object storage".to_string(),
+            words: 12
+        }
+    );
+
+    let partials = {
+        let mut acc = Vec::new();
+        while let Ok(event) = rx.try_recv() {
+            if let FlowStreamEvent::ObjectDelta { partial } = event {
+                acc.push(partial);
+            }
+        }
+        acc
+    };
+    assert!(
+        partials.len() > 1,
+        "expected incremental partials, got {partials:?}"
+    );
+}
+
+#[tokio::test]
+async fn http_error_does_not_leak_message_or_key() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+            "type": "error",
+            "error": {"type": "authentication_error", "message": "invalid x-api-key test-key"}
+        })))
+        .mount(&server)
+        .await;
+
+    let error = provider(&server)
+        .generate(text_request("hi"))
+        .await
+        .unwrap_err();
+    assert_eq!(error.kind(), "provider");
+    let rendered = error.to_string();
+    assert!(rendered.contains("401"));
+    assert!(rendered.contains("type=authentication_error"));
+    assert!(!rendered.contains("test-key"), "leaked the key: {rendered}");
+}
+
+#[tokio::test]
+async fn retries_a_transient_server_error_then_succeeds() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(529).set_body_json(json!({
+            "type": "error", "error": {"type": "overloaded_error"}
+        })))
+        .up_to_n_times(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/v1/messages"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "content": [{"type": "text", "text": "recovered"}],
+            "stop_reason": "end_turn"
+        })))
+        .mount(&server)
+        .await;
+
+    let response = provider(&server)
+        .generate(text_request("hi"))
+        .await
+        .unwrap();
+    assert_eq!(response.text_output(), "recovered");
+}
+
+#[test]
+fn debug_redacts_the_api_key() {
+    let provider = AnthropicProvider::new("anthropic", "sk-ant-SECRET");
+    let rendered = format!("{provider:?}");
+    assert!(!rendered.contains("sk-ant-SECRET"), "leaked: {rendered}");
+    assert!(rendered.contains("<redacted>"));
+}


### PR DESCRIPTION
A native Anthropic **Messages API** provider crate, parallel to `pocopine-agenkit-oai`. Closes #215.

This is the highest-leverage validation of the `Provider` seam: the Messages API differs from OpenAI Chat Completions in *every* dimension the seam abstracts — and the seam held with **no second AI runtime contract**.

## How the contracts differ (and how this bridges them)

```mermaid
flowchart LR
    subgraph N["neutral GenerateRequest"]
      S["system: Option&lt;String&gt;"]
      M["messages: System/User/Assistant/Tool"]
      T["tools + json_schema"]
    end
    subgraph A["Anthropic /v1/messages"]
      AS["top-level system field"]
      AM["user/assistant turns<br/>text / tool_use / tool_result blocks"]
      AT["tools + forced tool_choice"]
    end
    S -->|hoist + merge System msgs| AS
    M -->|fold same-role; Tool→user tool_result| AM
    T -->|no response_format →<br/>force structured_output tool| AT
```

| Dimension | OpenAI | Anthropic (this crate) |
|-----------|--------|------------------------|
| System | message role | **top-level `system`** (hoisted + System-role msgs merged) |
| Tools/results | `tool` role + `tool_calls` | **content blocks** `tool_use`/`tool_result` in user/assistant turns; no `tool` role |
| Structured output | `response_format`/`json_schema` | **forced single tool** whose `input_schema` is the shape → surfaced as a structured value |
| Streaming | `delta.content` chunks | `content_block_delta` (`text_delta` + `input_json_delta`), `message_start/stop` |
| `max_tokens` | optional | **required** → defaulted when unset |
| Auth | `Authorization: Bearer` | `x-api-key` + `anthropic-version` |

## Notable design choices

- **Structured output**: with no user tools, force a synthetic `structured_output` tool — the model *must* call it, yielding schema-constrained JSON. With user tools present, forcing would suppress them, so it degrades to plain-text JSON the runtime parses. In streaming, the forced tool's `input_json_delta` fragments are forwarded as **text** so the runtime renders progressive partial objects (`ObjectDelta`).
- **Message folding**: consecutive same-role turns merge into one message, so several tool results land in one `user` message (Messages-API-correct).
- **Capabilities**: `{ streaming: true, json_schema: false, tools: true }`. `json_schema: false` is intentional — Anthropic has no native schema mode, so the runtime's JSON-mode fallback applies for the with-tools structured case. (Composes with the runtime wiring in PR #219 / #214.3.)
- **Tool names** sanitized to Anthropic's `^[a-zA-Z0-9_-]{1,64}$` rule and reverse-mapped on the response so dispatch finds the original id.

## Secret boundary (§D10)

- Key lives only in the `x-api-key` header; **hand-rolled `Debug` redacts it** (tested).
- Errors surface only `status` + stable `type` — never the body message or key (tested with a key planted in the error body).
- `crypto/codec` routing item is **N/A**: Anthropic auth is a raw header with no signing/hashing/encoding.

## Verification

- **16 tests**: 6 wire unit (sanitize, system hoist, forced-tool, fold, response mapping) + 9 wiremock integration (headers+max_tokens, tools+reverse-map, forced structured, streaming text/tool/structured, error no-leak, retry) + Debug-redaction.
- Host **and** wasm32 `clippy -D warnings` clean; `fmt --check` clean.
- Independent of PR #219 — branches off `main`, layers only on the existing `pocopine-agenkit` public API. The two compose cleanly once both merge.
