### PR TITLE
feat(collab): pocopine-collab — multi-process CRDT collaboration over the realtime gateway (RFC 073 Part II)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12459,9 +12459,9 @@ dependencies = [
 
 [[package]]
 name = "yrs"
-version = "0.23.5"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197c2b4b298f35c3ba4d549884ac872a961112095b29f173ab45e3d5cf609018"
+checksum = "ccc6a0094c76c87b1b72ca0579bf7aa00f540957182264e6561cbde707c2ce51"
 dependencies = [
  "arc-swap",
  "async-lock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2066,6 +2066,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2664,6 +2678,9 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "fdeflate"
@@ -7127,6 +7144,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pocopine-collab"
+version = "0.1.1"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "pocopine-crypto",
+ "tokio",
+ "tracing",
+ "yrs",
+]
+
+[[package]]
 name = "pocopine-core"
 version = "0.2.0"
 dependencies = [
@@ -9209,6 +9238,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "smallstr"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "862077b1e764f04c251fe82a2ef562fd78d7cadaeb072ca7c2bcaf7217b1ff3b"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10664,7 +10702,7 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "bytes",
- "dashmap",
+ "dashmap 5.5.3",
  "futures",
  "httparse",
  "lsp-types",
@@ -12417,6 +12455,24 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "yrs"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "197c2b4b298f35c3ba4d549884ac872a961112095b29f173ab45e3d5cf609018"
+dependencies = [
+ "arc-swap",
+ "async-lock",
+ "async-trait",
+ "dashmap 6.2.1",
+ "fastrand",
+ "serde",
+ "serde_json",
+ "smallstr",
+ "smallvec",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7148,9 +7148,14 @@ name = "pocopine-collab"
 version = "0.1.1"
 dependencies = [
  "async-trait",
+ "axum 0.7.9",
  "bytes",
+ "futures-util",
  "pocopine-crypto",
+ "pocopine-events",
+ "pocopine-realtime",
  "tokio",
+ "tokio-tungstenite",
  "tracing",
  "yrs",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7153,6 +7153,7 @@ dependencies = [
  "futures-util",
  "pocopine-crypto",
  "pocopine-events",
+ "pocopine-observe",
  "pocopine-realtime",
  "tokio",
  "tokio-tungstenite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,6 +134,7 @@ pocopine-live = { path = "crates/pocopine-live", version = "0.1.0" }
 pocopine-logging = { path = "crates/pocopine-logging", version = "0.1.0" }
 pocopine-macros = { path = "crates/pocopine-macros", version = "0.1.0" }
 pocopine-observe = { path = "crates/pocopine-observe", version = "0.1.0" }
+pocopine-realtime = { path = "crates/pocopine-realtime", version = "0.1.0" }
 pocopine-server = { path = "crates/pocopine-server", version = "0.1.0" }
 pocopine-storage = { path = "crates/pocopine-storage", version = "0.1.0" }
 pocopine-storage-azure = { path = "crates/pocopine-storage-azure", version = "0.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ members = [
     "crates/pocopine-client-codegen",
     "crates/pocopine-cli",
     "crates/pocopine-codec",
+    "crates/pocopine-collab",
     "crates/pocopine-core",
     "crates/pocopine-crypto",
     "crates/pocopine-directives",

--- a/crates/pine-layout/src/app_shell/mod.rs
+++ b/crates/pine-layout/src/app_shell/mod.rs
@@ -33,7 +33,7 @@
 //! </pine-app-shell>
 //! ```
 
-use crate::breakpoint::{install, Breakpoint};
+use crate::breakpoint::{Breakpoint, install};
 use crate::floating as drawer;
 use pocopine::prelude::*;
 use serde::{Deserialize, Serialize};

--- a/crates/pine-layout/src/breakpoint/mod.rs
+++ b/crates/pine-layout/src/breakpoint/mod.rs
@@ -128,8 +128,8 @@ type ChangeListeners =
 pub fn install(on_change: std::rc::Rc<dyn Fn(Breakpoint)>) {
     use std::cell::RefCell;
     use std::rc::Rc;
-    use wasm_bindgen::closure::Closure;
     use wasm_bindgen::JsCast;
+    use wasm_bindgen::closure::Closure;
 
     let Some(window) = web_sys::window() else {
         return;

--- a/crates/pine-layout/src/workspace/resize.rs
+++ b/crates/pine-layout/src/workspace/resize.rs
@@ -55,7 +55,7 @@ pub(crate) fn start_drag(
     on_size: std::rc::Rc<dyn Fn(f64)>,
     on_commit: std::rc::Rc<dyn Fn(f64)>,
 ) {
-    use pocopine::events::{self, ev, ListenerHandle};
+    use pocopine::events::{self, ListenerHandle, ev};
     use std::cell::RefCell;
     use std::rc::Rc;
     use web_sys::PointerEvent;

--- a/crates/pine-layout/tests/layout.rs
+++ b/crates/pine-layout/tests/layout.rs
@@ -11,7 +11,7 @@
 
 use wasm_bindgen::JsCast;
 use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
-use web_sys::{window, Element};
+use web_sys::{Element, window};
 
 wasm_bindgen_test_configure!(run_in_browser);
 

--- a/crates/pine-layout/tests/workspace.rs
+++ b/crates/pine-layout/tests/workspace.rs
@@ -5,7 +5,7 @@
 
 use wasm_bindgen::JsCast;
 use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
-use web_sys::{window, Element};
+use web_sys::{Element, window};
 
 wasm_bindgen_test_configure!(run_in_browser);
 

--- a/crates/pocopine-collab/Cargo.toml
+++ b/crates/pocopine-collab/Cargo.toml
@@ -18,8 +18,10 @@ default = []
 yrs = "0.27"
 bytes = "1"
 async-trait = "0.1"
+tokio = { version = "1", features = ["rt"] }
 tracing = { workspace = true }
 pocopine-crypto = { workspace = true }
+pocopine-observe = { workspace = true }
 pocopine-realtime = { workspace = true }
 pocopine-events = { workspace = true }
 

--- a/crates/pocopine-collab/Cargo.toml
+++ b/crates/pocopine-collab/Cargo.toml
@@ -20,6 +20,11 @@ bytes = "1"
 async-trait = "0.1"
 tracing = { workspace = true }
 pocopine-crypto = { workspace = true }
+pocopine-realtime = { workspace = true }
+pocopine-events = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread", "net", "time"] }
+axum = { version = "0.7", features = ["ws"] }
+tokio-tungstenite = "0.24"
+futures-util = "0.3"

--- a/crates/pocopine-collab/Cargo.toml
+++ b/crates/pocopine-collab/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "pocopine-collab"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Server-side CRDT collaboration (yrs) for pocopine apps (RFC 073 Part II)."
+
+[features]
+default = []
+
+# Host-only: the yrs engine + sync handshake run server-side (browsers use Yjs
+# JS, not this crate). All deps live under cfg(not(target_arch = "wasm32")) so
+# the crate compiles to an empty lib on wasm32 (client-server-modules skill).
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+# Held at 0.23 (newest confirmed to build here): yrs 0.27 trips a
+# freshly-destabilized `if let` match guard that the workspace's pinned nightly
+# (rust-toolchain) rejects. Bump once yrs/the toolchain resolve it.
+yrs = "0.23"
+bytes = "1"
+async-trait = "0.1"
+tracing = { workspace = true }
+pocopine-crypto = { workspace = true }
+
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt", "rt-multi-thread"] }

--- a/crates/pocopine-collab/Cargo.toml
+++ b/crates/pocopine-collab/Cargo.toml
@@ -13,10 +13,9 @@ default = []
 # JS, not this crate). All deps live under cfg(not(target_arch = "wasm32")) so
 # the crate compiles to an empty lib on wasm32 (client-server-modules skill).
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-# Held at 0.23 (newest confirmed to build here): yrs 0.27 trips a
-# freshly-destabilized `if let` match guard that the workspace's pinned nightly
-# (rust-toolchain) rejects. Bump once yrs/the toolchain resolve it.
-yrs = "0.23"
+# yrs 0.27 uses `if let` match guards, stabilized in Rust 1.95 (Feb 2026); the
+# workspace nightly (rust-toolchain.toml) is pinned past that, so it builds.
+yrs = "0.27"
 bytes = "1"
 async-trait = "0.1"
 tracing = { workspace = true }

--- a/crates/pocopine-collab/src/lib.rs
+++ b/crates/pocopine-collab/src/lib.rs
@@ -1,0 +1,19 @@
+//! # pocopine-collab
+//!
+//! Server-side CRDT collaboration for pocopine apps (RFC 073 Part II), built on
+//! `yrs` (the Rust port of Yjs). It is a consumer of the `pocopine-realtime`
+//! gateway: a collaborative document is a topic, a Yjs binary update is a
+//! message, and an editor is a subscriber. This crate owns the *semantics* —
+//! the `yrs` document engine, the Yjs sync handshake, and persistence — while
+//! the transport (framing, sessions, fan-out) lives in `pocopine-realtime`.
+//!
+//! Host-only: the `yrs` engine and sync handshake run server-side (browsers
+//! speak Yjs in JS, not this crate). All code lives under a single
+//! `#[cfg(not(target_arch = "wasm32"))]` gate (the `client-server-modules`
+//! convention); on wasm32 this crate is empty.
+
+#[cfg(not(target_arch = "wasm32"))]
+pub mod server;
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use server::*;

--- a/crates/pocopine-collab/src/server/doc.rs
+++ b/crates/pocopine-collab/src/server/doc.rs
@@ -1,0 +1,124 @@
+//! Document identity and access.
+//!
+//! A [`CollabDoc`] hashes to a stable `doc_hash` (via `pocopine-crypto`) used
+//! for the `collab:{doc_hash}` topic on the `pocopine-realtime` gateway and for
+//! the per-document Redis keys. The hash input is length-prefixed so distinct
+//! field tuples can never collide.
+
+use pocopine_crypto::sha256_hex;
+
+/// A collaborative document's identity.
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct CollabDoc {
+    pub namespace: String,
+    pub collection: String,
+    pub id: String,
+    pub branch: String,
+}
+
+impl CollabDoc {
+    /// Construct a document identity.
+    pub fn new(
+        namespace: impl Into<String>,
+        collection: impl Into<String>,
+        id: impl Into<String>,
+        branch: impl Into<String>,
+    ) -> Self {
+        Self {
+            namespace: namespace.into(),
+            collection: collection.into(),
+            id: id.into(),
+            branch: branch.into(),
+        }
+    }
+
+    /// The canonical byte encoding of the identity. Each field is length-
+    /// prefixed (u64 LE), so no field value can forge a separator — `{"a","b"}`
+    /// and `{"a:b",""}` are guaranteed to encode (and therefore hash)
+    /// differently.
+    pub fn canonical_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        for field in [&self.namespace, &self.collection, &self.id, &self.branch] {
+            out.extend_from_slice(&(field.len() as u64).to_le_bytes());
+            out.extend_from_slice(field.as_bytes());
+        }
+        out
+    }
+
+    /// Lowercase sha256 hex of the canonical identity.
+    pub fn doc_hash(&self) -> String {
+        sha256_hex(&self.canonical_bytes())
+    }
+
+    /// The `pocopine-realtime` topic a client subscribes to for this document.
+    pub fn topic(&self) -> String {
+        format!("collab:{}", self.doc_hash())
+    }
+}
+
+/// The access a connection has to a document, resolved by the consumer's async
+/// authorizer (a superset of the gateway's bool topic policy).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CollabAccess {
+    /// May receive updates and publish document updates + awareness.
+    ReadWrite,
+    /// May receive updates and send awareness, but not publish document
+    /// updates.
+    ReadOnly,
+    /// No access.
+    Deny,
+}
+
+impl CollabAccess {
+    /// May this connection publish document updates?
+    pub fn can_write(self) -> bool {
+        matches!(self, Self::ReadWrite)
+    }
+
+    /// May this connection receive updates and join at all?
+    pub fn can_read(self) -> bool {
+        matches!(self, Self::ReadWrite | Self::ReadOnly)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn doc_hash_is_stable_and_64_hex_chars() {
+        let d = CollabDoc::new("app", "docs", "readme", "main");
+        let h = d.doc_hash();
+        assert_eq!(h.len(), 64);
+        assert!(h.chars().all(|c| c.is_ascii_hexdigit()));
+        assert_eq!(
+            h,
+            CollabDoc::new("app", "docs", "readme", "main").doc_hash()
+        );
+        assert_eq!(d.topic(), format!("collab:{h}"));
+    }
+
+    #[test]
+    fn distinct_identities_hash_differently() {
+        let a = CollabDoc::new("app", "docs", "readme", "main");
+        let b = CollabDoc::new("app", "docs", "readme", "draft");
+        assert_ne!(a.doc_hash(), b.doc_hash());
+    }
+
+    #[test]
+    fn length_prefix_prevents_field_boundary_collisions() {
+        // Without length-prefixing these could collide under a ':' separator.
+        let a = CollabDoc::new("a", "b", "", "");
+        let b = CollabDoc::new("a:b", "", "", "");
+        assert_ne!(a.doc_hash(), b.doc_hash());
+    }
+
+    #[test]
+    fn access_predicates() {
+        assert!(CollabAccess::ReadWrite.can_write());
+        assert!(CollabAccess::ReadWrite.can_read());
+        assert!(!CollabAccess::ReadOnly.can_write());
+        assert!(CollabAccess::ReadOnly.can_read());
+        assert!(!CollabAccess::Deny.can_read());
+    }
+}

--- a/crates/pocopine-collab/src/server/error.rs
+++ b/crates/pocopine-collab/src/server/error.rs
@@ -1,0 +1,36 @@
+//! Error type for `pocopine-collab` (hand-rolled, matching the workspace
+//! convention in `pocopine-events` / `pocopine-realtime`).
+
+use std::fmt;
+
+pub type CollabResult<T> = Result<T, CollabError>;
+
+/// Errors surfaced by the collab engine and store.
+#[derive(Debug)]
+pub enum CollabError {
+    /// A CRDT update or state vector could not be decoded.
+    Decode(String),
+    /// A decoded update could not be applied to the document.
+    Apply(String),
+    /// A `CollabStore` backend failed.
+    Store(String),
+}
+
+impl CollabError {
+    /// Build a [`CollabError::Store`] from anything stringy.
+    pub fn store(msg: impl Into<String>) -> Self {
+        Self::Store(msg.into())
+    }
+}
+
+impl fmt::Display for CollabError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Decode(msg) => write!(f, "collab decode error: {msg}"),
+            Self::Apply(msg) => write!(f, "collab apply error: {msg}"),
+            Self::Store(msg) => write!(f, "collab store error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for CollabError {}

--- a/crates/pocopine-collab/src/server/handler.rs
+++ b/crates/pocopine-collab/src/server/handler.rs
@@ -35,11 +35,17 @@ use async_trait::async_trait;
 use bytes::Bytes;
 use pocopine_events::Topic;
 use pocopine_observe::LOG_TARGET;
-use pocopine_realtime::{Fanout, InboundData, Reaction, SubprotocolHandler, WsError};
+use pocopine_realtime::{Fanout, InboundData, Reaction, SubprotocolHandler, TopicStream, WsError};
 use tokio::task::JoinHandle;
 
 use super::protocol::CollabMessage;
+use super::store::{CollabSnapshot, CollabStore};
 use super::sync::CollabDocument;
+
+/// Save a checkpoint snapshot once this many fan-out updates have been folded
+/// in. Far below the fan-out's retention window, so the snapshot cursor always
+/// stays replayable and the durable base never lags into an eviction gap.
+const CHECKPOINT_EVERY: u64 = 64;
 
 /// Server-side CRDT collaboration over the realtime gateway.
 ///
@@ -49,8 +55,14 @@ use super::sync::CollabDocument;
 /// loop that folds every fanned-out update — including those published by other
 /// processes — into the local document. Without this, a process's document only
 /// ever saw its own clients' edits and replicas behind a Redis fan-out diverged.
+///
+/// With a [`CollabStore`] ([`Self::with_store`]) the loop also loads the durable
+/// snapshot on start and checkpoints the folded document back, so state survives
+/// process restart and fan-out retention eviction.
 pub struct CollabSync {
     fanout: Arc<dyn Fanout>,
+    store: Option<Arc<dyn CollabStore>>,
+    checkpoint_every: u64,
     topics: Mutex<HashMap<Topic, Arc<TopicState>>>,
 }
 
@@ -68,8 +80,25 @@ impl CollabSync {
     pub fn new(fanout: Arc<dyn Fanout>) -> Self {
         Self {
             fanout,
+            store: None,
+            checkpoint_every: CHECKPOINT_EVERY,
             topics: Mutex::new(HashMap::new()),
         }
+    }
+
+    /// Attach a durable [`CollabStore`]: each topic's apply loop then loads the
+    /// snapshot on start and checkpoints the folded document back periodically.
+    pub fn with_store(mut self, store: Arc<dyn CollabStore>) -> Self {
+        self.store = Some(store);
+        self
+    }
+
+    /// Checkpoint to the [`CollabStore`] every `n` folded updates (default
+    /// [`CHECKPOINT_EVERY`]). Lower trades more write load for a fresher durable
+    /// base; keep it well under the fan-out retention window.
+    pub fn with_checkpoint_every(mut self, n: u64) -> Self {
+        self.checkpoint_every = n.max(1);
+        self
     }
 
     /// The per-topic state, created — and its apply loop spawned — on first
@@ -85,6 +114,8 @@ impl CollabSync {
         let doc = Arc::new(Mutex::new(CollabDocument::new()));
         let apply_loop = tokio::spawn(run_apply_loop(
             self.fanout.clone(),
+            self.store.clone(),
+            self.checkpoint_every,
             topic.clone(),
             doc.clone(),
         ));
@@ -179,17 +210,45 @@ fn ensure_writable(inbound: &InboundData<'_>) -> Result<(), WsError> {
 /// (the local `on_data` path only ever sees this process's own clients). yrs
 /// makes re-applying our own published updates a no-op, so this is safe to run
 /// alongside the optimistic apply in `on_data`.
-async fn run_apply_loop(fanout: Arc<dyn Fanout>, topic: Topic, doc: Arc<Mutex<CollabDocument>>) {
-    let mut stream = match fanout.subscribe(&topic, None).await {
-        Ok(stream) => stream,
-        Err(err) => {
-            tracing::warn!(target: LOG_TARGET, error = %err, "collab apply loop: subscribe failed");
-            return;
+///
+/// With a [`CollabStore`] the loop also seeds the document from the durable
+/// snapshot on start (resuming the fan-out at the snapshot's cursor) and
+/// checkpoints the folded document back every [`CHECKPOINT_EVERY`] updates.
+async fn run_apply_loop(
+    fanout: Arc<dyn Fanout>,
+    store: Option<Arc<dyn CollabStore>>,
+    checkpoint_every: u64,
+    topic: Topic,
+    doc: Arc<Mutex<CollabDocument>>,
+) {
+    let doc_key = topic.as_str();
+
+    // Seed from the durable snapshot, then resume the fan-out at its cursor.
+    let mut after = None;
+    if let Some(store) = &store {
+        match store.load_snapshot(doc_key).await {
+            Ok(Some(snapshot)) => {
+                if let Ok(doc) = doc.lock() {
+                    let _ = doc.apply_update(&snapshot.blob);
+                }
+                after = Some(snapshot.last_seq);
+            }
+            Ok(None) => {}
+            Err(err) => {
+                tracing::warn!(target: LOG_TARGET, error = %err, topic = doc_key, "collab apply loop: load_snapshot failed");
+            }
         }
+    }
+
+    let mut stream = match subscribe_recovering(&fanout, &topic, after).await {
+        Some(stream) => stream,
+        None => return,
     };
+
+    let mut folded = 0u64;
     loop {
         match stream.next().await {
-            Ok(Some((_seq, payload))) => {
+            Ok(Some((seq, payload))) => {
                 // Broadcasts are tagged `Update` messages; a malformed or
                 // non-Update frame must never kill the convergence loop.
                 if let Ok(CollabMessage::Update(update)) = CollabMessage::decode(&payload)
@@ -197,19 +256,73 @@ async fn run_apply_loop(fanout: Arc<dyn Fanout>, topic: Topic, doc: Arc<Mutex<Co
                 {
                     let _ = doc.apply_update(&update);
                 }
+                folded += 1;
+                if let Some(store) = &store
+                    && folded >= checkpoint_every
+                {
+                    folded = 0;
+                    checkpoint(store.as_ref(), doc_key, &doc, seq).await;
+                }
             }
             // Fan-out closed (topic torn down / shutdown).
             Ok(None) => break,
-            // Lagged or gapped: re-subscribe fresh to replay the retained tail
-            // and resume — never die silently on a recoverable hiccup.
-            Err(_) => match fanout.subscribe(&topic, None).await {
-                Ok(replacement) => stream = replacement,
-                Err(err) => {
-                    tracing::warn!(target: LOG_TARGET, error = %err, "collab apply loop: resubscribe failed");
-                    break;
-                }
+            // Lagged or gapped: re-subscribe to replay the retained tail and
+            // resume — never die silently on a recoverable hiccup.
+            Err(_) => match subscribe_recovering(&fanout, &topic, None).await {
+                Some(replacement) => stream = replacement,
+                None => break,
             },
         }
+    }
+}
+
+/// Subscribe to `topic` at `after`, transparently recovering an unreplayable
+/// cursor by replaying the whole retained tail. Returns `None` if the fan-out
+/// itself is unreachable.
+async fn subscribe_recovering(
+    fanout: &Arc<dyn Fanout>,
+    topic: &Topic,
+    after: Option<u64>,
+) -> Option<TopicStream> {
+    match fanout.subscribe(topic, after).await {
+        Ok(stream) if !stream.gap() => Some(stream),
+        Ok(_gapped) => {
+            // The snapshot cursor aged past retention; replay what is retained.
+            // The evicted middle is unrecoverable (the retention bound).
+            tracing::warn!(target: LOG_TARGET, topic = topic.as_str(), "collab apply loop: resume gap, replaying retained tail");
+            match fanout.subscribe(topic, None).await {
+                Ok(stream) => Some(stream),
+                Err(err) => {
+                    tracing::warn!(target: LOG_TARGET, error = %err, "collab apply loop: subscribe failed");
+                    None
+                }
+            }
+        }
+        Err(err) => {
+            tracing::warn!(target: LOG_TARGET, error = %err, "collab apply loop: subscribe failed");
+            None
+        }
+    }
+}
+
+/// Persist the folded document as the new durable base, current to `last_seq`.
+/// The document lock is never held across the `.await`.
+async fn checkpoint(
+    store: &dyn CollabStore,
+    doc_key: &str,
+    doc: &Arc<Mutex<CollabDocument>>,
+    last_seq: u64,
+) {
+    let snapshot = {
+        let Ok(doc) = doc.lock() else { return };
+        CollabSnapshot {
+            blob: Bytes::from(doc.full_update()),
+            state_vector: Bytes::from(doc.state_vector()),
+            last_seq,
+        }
+    };
+    if let Err(err) = store.save_snapshot(doc_key, snapshot).await {
+        tracing::warn!(target: LOG_TARGET, error = %err, topic = doc_key, "collab apply loop: save_snapshot failed");
     }
 }
 
@@ -520,6 +633,59 @@ mod tests {
         assert!(
             converged,
             "process B should converge to A's edit via the shared fan-out"
+        );
+    }
+
+    #[tokio::test]
+    async fn checkpoints_to_the_store_and_a_fresh_process_reloads_it() {
+        use super::super::store::{CollabStore, MemoryCollabStore};
+
+        let store: Arc<dyn CollabStore> = Arc::new(MemoryCollabStore::new());
+        let topic = Topic::new("collab:doc").unwrap();
+
+        // Process 1 checkpoints on every folded update.
+        let fanout1: Arc<dyn Fanout> = Arc::new(LocalFanout::new());
+        let p1 = CollabSync::new(fanout1.clone())
+            .with_store(store.clone())
+            .with_checkpoint_every(1);
+
+        // An edit on p1; publish the broadcast so p1's apply loop folds + saves.
+        let edit = CollabDocument::new();
+        edit.insert_text("body", 0, "durable");
+        let reaction = feed(
+            &p1,
+            &topic,
+            CollabMessage::Update(Bytes::from(edit.full_update())),
+        )
+        .await;
+        for payload in reaction.broadcasts() {
+            fanout1.publish(&topic, payload.clone()).await.unwrap();
+        }
+        let mut saved = false;
+        for _ in 0..200 {
+            if store.load_snapshot(topic.as_str()).await.unwrap().is_some() {
+                saved = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert!(saved, "the apply loop should checkpoint a snapshot");
+
+        // Process 2 starts on a DIFFERENT (empty) fan-out — a restart — and must
+        // recover the document from the durable store, not the stream.
+        let fanout2: Arc<dyn Fanout> = Arc::new(LocalFanout::new());
+        let p2 = CollabSync::new(fanout2).with_store(store.clone());
+        let mut reloaded = false;
+        for _ in 0..200 {
+            if handler_text(&p2, &topic, "body").await.contains("durable") {
+                reloaded = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert!(
+            reloaded,
+            "a fresh process should reload the document from the store"
         );
     }
 }

--- a/crates/pocopine-collab/src/server/handler.rs
+++ b/crates/pocopine-collab/src/server/handler.rs
@@ -22,7 +22,7 @@
 //! is layered by a richer authorizer in a follow-up.
 
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -35,12 +35,15 @@ use super::sync::CollabDocument;
 /// Server-side CRDT collaboration over the realtime gateway.
 ///
 /// Shared across every connection and topic (held behind an `Arc` by the
-/// gateway). One authoritative document per topic lives behind a `Mutex`; the
-/// document operations are synchronous and never cross an `.await`, so the lock
-/// is never held across a suspension point.
+/// gateway). Each topic's authoritative document lives behind its OWN `Mutex`,
+/// so a slow operation on one document (e.g. encoding a large state vector)
+/// never blocks edits to any other topic; the outer map lock is held only long
+/// enough to look up the per-topic handle. The document operations are
+/// synchronous and never cross an `.await`, so neither lock is held across a
+/// suspension point.
 #[derive(Default)]
 pub struct CollabSync {
-    docs: Mutex<HashMap<Topic, CollabDocument>>,
+    docs: Mutex<HashMap<Topic, Arc<Mutex<CollabDocument>>>>,
 }
 
 impl CollabSync {
@@ -48,6 +51,17 @@ impl CollabSync {
     /// message.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// The per-topic document handle, created on first access.
+    fn document(&self, topic: &Topic) -> Result<Arc<Mutex<CollabDocument>>, WsError> {
+        let mut docs = self
+            .docs
+            .lock()
+            .map_err(|_| WsError::backend("collab document map poisoned"))?;
+        Ok(Arc::clone(docs.entry(topic.clone()).or_insert_with(|| {
+            Arc::new(Mutex::new(CollabDocument::new()))
+        })))
     }
 }
 
@@ -57,13 +71,10 @@ impl SubprotocolHandler for CollabSync {
         let message = CollabMessage::decode(inbound.payload)
             .map_err(|err| WsError::protocol(err.to_string()))?;
 
-        let mut docs = self
-            .docs
+        let document = self.document(inbound.topic)?;
+        let doc = document
             .lock()
-            .map_err(|_| WsError::backend("collab document map poisoned"))?;
-        let doc = docs
-            .entry(inbound.topic.clone())
-            .or_insert_with(CollabDocument::new);
+            .map_err(|_| WsError::backend("collab document mutex poisoned"))?;
 
         let mut reaction = Reaction::new();
         match message {
@@ -76,14 +87,42 @@ impl SubprotocolHandler for CollabSync {
                 // ...and our own state vector, so it sends back what WE lack.
                 reaction.reply(CollabMessage::SyncStep1(Bytes::from(doc.state_vector())).encode());
             }
-            CollabMessage::SyncStep2(update) | CollabMessage::Update(update) => {
-                doc.apply_update(&update)
-                    .map_err(|err| WsError::protocol(err.to_string()))?;
-                reaction.broadcast(CollabMessage::Update(update).encode());
+            CollabMessage::SyncStep2(update) => {
+                // Relabel a handshake SyncStep2 as a live Update for peers.
+                if let Some(payload) = broadcast_if_advanced(&doc, &update, || {
+                    CollabMessage::Update(update.clone()).encode()
+                })? {
+                    reaction.broadcast(payload);
+                }
+            }
+            CollabMessage::Update(update) => {
+                // Already a tagged Update on the wire — forward the original
+                // payload verbatim (a cheap `Bytes` refcount bump, no re-encode).
+                if let Some(payload) =
+                    broadcast_if_advanced(&doc, &update, || inbound.payload.clone())?
+                {
+                    reaction.broadcast(payload);
+                }
             }
         }
         Ok(reaction)
     }
+}
+
+/// Apply `update` to `doc`; return the to-broadcast payload (built lazily by
+/// `payload`) only if the document actually advanced. A no-op update — a
+/// duplicate, or a peer that had nothing new — is applied but NOT fanned out,
+/// so it never wakes every subscriber or burns a slot of the bounded fan-out
+/// replay window.
+fn broadcast_if_advanced(
+    doc: &CollabDocument,
+    update: &[u8],
+    payload: impl FnOnce() -> Bytes,
+) -> Result<Option<Bytes>, WsError> {
+    let before = doc.state_vector();
+    doc.apply_update(update)
+        .map_err(|err| WsError::protocol(err.to_string()))?;
+    Ok((doc.state_vector() != before).then(payload))
 }
 
 #[cfg(test)]
@@ -128,6 +167,27 @@ mod tests {
             decode(&reaction.broadcasts()[0]),
             CollabMessage::Update(_)
         ));
+    }
+
+    #[tokio::test]
+    async fn a_noop_update_is_applied_but_not_rebroadcast() {
+        let server = CollabSync::new();
+        let topic = Topic::new("collab:doc").unwrap();
+        let edit = CollabDocument::new();
+        edit.insert_text("body", 0, "hello");
+        let update = Bytes::from(edit.full_update());
+
+        // First application advances the document and fans out.
+        let first = feed(&server, &topic, CollabMessage::Update(update.clone())).await;
+        assert_eq!(first.broadcasts().len(), 1);
+
+        // Re-applying the identical update changes nothing: still applied, but
+        // NOT fanned out again (no subscriber wake, no replay-window slot burnt).
+        let second = feed(&server, &topic, CollabMessage::Update(update)).await;
+        assert!(
+            second.broadcasts().is_empty(),
+            "a duplicate / no-op update must not be rebroadcast"
+        );
     }
 
     #[tokio::test]

--- a/crates/pocopine-collab/src/server/handler.rs
+++ b/crates/pocopine-collab/src/server/handler.rs
@@ -75,6 +75,16 @@ struct TopicState {
     apply_loop: JoinHandle<()>,
 }
 
+impl Drop for TopicState {
+    fn drop(&mut self) {
+        // A dropped `JoinHandle` only DETACHES the task, leaving the loop parked
+        // on the fan-out forever (it holds its own `Fanout`/`Doc` clones). Abort
+        // on every drop path — eviction, `CollabSync` drop, reconfiguration — so
+        // eviction is not the only way the loop stops. `abort` is idempotent.
+        self.apply_loop.abort();
+    }
+}
+
 impl CollabSync {
     /// Build a handler over the fan-out the gateway also publishes to. They MUST
     /// be the same [`Fanout`] instance, or peer updates will not converge.
@@ -155,22 +165,16 @@ impl SubprotocolHandler for CollabSync {
             }
             CollabMessage::SyncStep2(update) => {
                 ensure_writable(&inbound)?;
+                apply_update(&doc, &update)?;
                 // Relabel a handshake SyncStep2 as a live Update for peers.
-                if let Some(payload) = broadcast_if_advanced(&doc, &update, || {
-                    CollabMessage::Update(update.clone()).encode()
-                })? {
-                    reaction.broadcast(payload);
-                }
+                reaction.broadcast(CollabMessage::Update(update).encode());
             }
             CollabMessage::Update(update) => {
                 ensure_writable(&inbound)?;
+                apply_update(&doc, &update)?;
                 // Already a tagged Update on the wire — forward the original
                 // payload verbatim (a cheap `Bytes` refcount bump, no re-encode).
-                if let Some(payload) =
-                    broadcast_if_advanced(&doc, &update, || inbound.payload.clone())?
-                {
-                    reaction.broadcast(payload);
-                }
+                reaction.broadcast(inbound.payload.clone());
             }
         }
         Ok(reaction)
@@ -199,20 +203,18 @@ impl SubprotocolHandler for CollabSync {
     }
 }
 
-/// Apply `update` to `doc`; return the to-broadcast payload (built lazily by
-/// `payload`) only if the document actually advanced. A no-op update — a
-/// duplicate, or a peer that had nothing new — is applied but NOT fanned out,
-/// so it never wakes every subscriber or burns a slot of the bounded fan-out
-/// replay window.
-fn broadcast_if_advanced(
-    doc: &CollabDocument,
-    update: &[u8],
-    payload: impl FnOnce() -> Bytes,
-) -> Result<Option<Bytes>, WsError> {
-    let before = doc.state_vector();
+/// Apply an inbound `update` to the local document.
+///
+/// We deliberately do NOT suppress "no-op-looking" updates by comparing state
+/// vectors: a yrs delete-only update does not advance the state vector (deletes
+/// live in the delete-set), and an out-of-order update that references
+/// not-yet-integrated state is buffered as *pending* without advancing it
+/// either. Both are real edits that MUST still be fanned out, so the caller
+/// broadcasts unconditionally on success. (Suppressing a genuinely-empty
+/// update would need to inspect the update's own content, not the doc's SV.)
+fn apply_update(doc: &CollabDocument, update: &[u8]) -> Result<(), WsError> {
     doc.apply_update(update)
-        .map_err(|err| WsError::protocol(err.to_string()))?;
-    Ok((doc.state_vector() != before).then(payload))
+        .map_err(|err| WsError::protocol(err.to_string()))
 }
 
 /// Refuse a document-mutating message (Update / SyncStep2) from a connection the
@@ -265,6 +267,12 @@ async fn run_apply_loop(
         None => return,
     };
 
+    // The durable cursor must only move FORWARD. `highest_seq` tracks the
+    // furthest seq folded; a recovery replay (which re-reads the retained tail
+    // from a lower seq) must never checkpoint a cursor below what we already
+    // persisted, or a restart could resume into an evicted gap.
+    let mut highest_seq = after.unwrap_or(0);
+    let mut last_checkpointed = after.unwrap_or(0);
     let mut folded = 0u64;
     loop {
         match stream.next().await {
@@ -276,12 +284,16 @@ async fn run_apply_loop(
                 {
                     let _ = doc.apply_update(&update);
                 }
+                highest_seq = highest_seq.max(seq);
                 folded += 1;
                 if let Some(store) = &store
                     && folded >= checkpoint_every
                 {
                     folded = 0;
-                    checkpoint(store.as_ref(), doc_key, &doc, seq).await;
+                    if highest_seq > last_checkpointed {
+                        checkpoint(store.as_ref(), doc_key, &doc, highest_seq).await;
+                        last_checkpointed = highest_seq;
+                    }
                 }
             }
             // Fan-out closed (topic torn down / shutdown).
@@ -413,23 +425,64 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_noop_update_is_applied_but_not_rebroadcast() {
+    async fn a_delete_only_update_is_still_broadcast() {
+        // Regression guard: a delete does NOT advance the yrs state vector
+        // (deletes live in the delete-set), so the old state-vector "no-op
+        // guard" silently dropped every deletion from the fan-out. It must be
+        // fanned out like any other edit.
         let server = sync();
         let topic = Topic::new("collab:doc").unwrap();
-        let edit = CollabDocument::new();
-        edit.insert_text("body", 0, "hello");
-        let update = Bytes::from(edit.full_update());
 
-        // First application advances the document and fans out.
-        let first = feed(&server, &topic, CollabMessage::Update(update.clone())).await;
-        assert_eq!(first.broadcasts().len(), 1);
+        // Seed "hello" on the server.
+        let base = CollabDocument::new();
+        base.insert_text("body", 0, "hello");
+        feed(
+            &server,
+            &topic,
+            CollabMessage::Update(Bytes::from(base.full_update())),
+        )
+        .await;
 
-        // Re-applying the identical update changes nothing: still applied, but
-        // NOT fanned out again (no subscriber wake, no replay-window slot burnt).
-        let second = feed(&server, &topic, CollabMessage::Update(update)).await;
-        assert!(
-            second.broadcasts().is_empty(),
-            "a duplicate / no-op update must not be rebroadcast"
+        // Produce a delete-only delta: load the same state, delete, diff.
+        let editor = CollabDocument::from_snapshot(&base.full_update()).unwrap();
+        let before = editor.state_vector();
+        editor.delete_text("body", 0, 2); // remove "he"
+        let delete_delta = editor.diff(&before).unwrap();
+
+        let reaction = feed(
+            &server,
+            &topic,
+            CollabMessage::Update(Bytes::from(delete_delta)),
+        )
+        .await;
+        assert_eq!(
+            reaction.broadcasts().len(),
+            1,
+            "a delete-only update must still be fanned out"
+        );
+    }
+
+    #[tokio::test]
+    async fn an_out_of_order_update_is_still_broadcast() {
+        // Regression guard: an update that references not-yet-integrated state
+        // is buffered by yrs as pending and does NOT advance the state vector,
+        // so the old guard dropped it — yet it is a real edit peers need.
+        let server = sync();
+        let topic = Topic::new("collab:doc").unwrap();
+
+        // Build U2 ("def" at index 3) that causally depends on U1 ("abc"),
+        // which the server is NOT given — U2 will buffer pending on apply.
+        let source = CollabDocument::new();
+        source.insert_text("body", 0, "abc");
+        let before_u2 = source.state_vector();
+        source.insert_text("body", 3, "def");
+        let u2 = source.diff(&before_u2).unwrap();
+
+        let reaction = feed(&server, &topic, CollabMessage::Update(Bytes::from(u2))).await;
+        assert_eq!(
+            reaction.broadcasts().len(),
+            1,
+            "an out-of-order (pending) update must still be fanned out"
         );
     }
 

--- a/crates/pocopine-collab/src/server/handler.rs
+++ b/crates/pocopine-collab/src/server/handler.rs
@@ -69,9 +69,10 @@ pub struct CollabSync {
 /// Per-topic state: the document and the apply loop keeping it converged.
 struct TopicState {
     doc: Arc<Mutex<CollabDocument>>,
-    /// Held so the loop can be aborted when the topic is evicted (a follow-up);
-    /// the task also ends when the fan-out closes.
-    _apply_loop: JoinHandle<()>,
+    /// The convergence apply loop. Aborted when the topic goes idle (its last
+    /// local subscriber leaves); the document then reloads from the store on the
+    /// next subscriber.
+    apply_loop: JoinHandle<()>,
 }
 
 impl CollabSync {
@@ -119,10 +120,7 @@ impl CollabSync {
             topic.clone(),
             doc.clone(),
         ));
-        let state = Arc::new(TopicState {
-            doc,
-            _apply_loop: apply_loop,
-        });
+        let state = Arc::new(TopicState { doc, apply_loop });
         topics.insert(topic.clone(), state.clone());
         Ok(state)
     }
@@ -176,6 +174,28 @@ impl SubprotocolHandler for CollabSync {
             }
         }
         Ok(reaction)
+    }
+
+    /// First local subscriber: start the topic's convergence apply loop so this
+    /// process folds in peer edits even before any local client writes.
+    fn on_topic_active(&self, topic: &Topic) {
+        // Creating the state spawns the apply loop. Errors only on a poisoned
+        // lock, where the next `on_data` will surface it.
+        let _ = self.topic_state(topic);
+    }
+
+    /// Last local subscriber left: free the topic's document and stop its apply
+    /// loop. State is durable (checkpointed to the store) and reloads on the
+    /// next subscriber, so this is pure resource reclamation.
+    fn on_topic_idle(&self, topic: &Topic) {
+        let evicted = self
+            .topics
+            .lock()
+            .ok()
+            .and_then(|mut topics| topics.remove(topic));
+        if let Some(state) = evicted {
+            state.apply_loop.abort();
+        }
     }
 }
 
@@ -687,5 +707,56 @@ mod tests {
             reloaded,
             "a fresh process should reload the document from the store"
         );
+    }
+
+    #[tokio::test]
+    async fn idle_eviction_frees_the_topic_then_reactivation_reloads_it() {
+        use super::super::store::{CollabStore, MemoryCollabStore};
+
+        let store: Arc<dyn CollabStore> = Arc::new(MemoryCollabStore::new());
+        let fanout: Arc<dyn Fanout> = Arc::new(LocalFanout::new());
+        let server = CollabSync::new(fanout.clone())
+            .with_store(store.clone())
+            .with_checkpoint_every(1);
+        let topic = Topic::new("collab:doc").unwrap();
+
+        // First subscriber activates the topic; an edit is folded + checkpointed.
+        server.on_topic_active(&topic);
+        let edit = CollabDocument::new();
+        edit.insert_text("body", 0, "kept");
+        let reaction = feed(
+            &server,
+            &topic,
+            CollabMessage::Update(Bytes::from(edit.full_update())),
+        )
+        .await;
+        for payload in reaction.broadcasts() {
+            fanout.publish(&topic, payload.clone()).await.unwrap();
+        }
+        for _ in 0..200 {
+            if store.load_snapshot(topic.as_str()).await.unwrap().is_some() {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+
+        // Last subscriber leaves: the topic's document + apply loop are released.
+        server.on_topic_idle(&topic);
+        assert!(
+            server.topics.lock().unwrap().get(&topic).is_none(),
+            "an idle topic must be freed"
+        );
+
+        // A new subscriber reactivates it; the document comes back from the store.
+        server.on_topic_active(&topic);
+        let mut recovered = false;
+        for _ in 0..200 {
+            if handler_text(&server, &topic, "body").await.contains("kept") {
+                recovered = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert!(recovered, "reactivating an evicted topic should recover it");
     }
 }

--- a/crates/pocopine-collab/src/server/handler.rs
+++ b/crates/pocopine-collab/src/server/handler.rs
@@ -1,0 +1,251 @@
+//! The server-side collab handler: a [`pocopine_realtime::SubprotocolHandler`]
+//! that runs the Yjs sync handshake over the gateway (RFC 073 Part II).
+//!
+//! [`CollabSync`] holds one authoritative [`CollabDocument`] per topic and
+//! reacts to each inbound collab message:
+//!
+//! - **SyncStep1** (a peer's state vector) → reply to that peer with the diff it
+//!   is missing (SyncStep2) *and* the server's own state vector (SyncStep1), so
+//!   the peer sends back what the server lacks. This is the two-way handshake.
+//! - **SyncStep2 / Update** (state the server was missing / a live edit) → apply
+//!   it to the authoritative document and broadcast it as an Update so every
+//!   other subscriber — including peers on other processes — converges.
+//!
+//! Because CRDT merges are commutative and idempotent, the unordered
+//! reply-vs-broadcast delivery the gateway provides is safe, and a client
+//! applying its own echoed Update is a no-op.
+//!
+//! This increment keeps documents in process memory; durable load/compaction
+//! through [`CollabStore`](super::store::CollabStore) is the next step. Write
+//! authorization is the gateway's per-topic policy; finer-grained
+//! read-only-vs-read-write access ([`CollabAccess`](super::doc::CollabAccess))
+//! is layered by a richer authorizer in a follow-up.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use pocopine_events::Topic;
+use pocopine_realtime::{InboundData, Reaction, SubprotocolHandler, WsError};
+
+use super::protocol::CollabMessage;
+use super::sync::CollabDocument;
+
+/// Server-side CRDT collaboration over the realtime gateway.
+///
+/// Shared across every connection and topic (held behind an `Arc` by the
+/// gateway). One authoritative document per topic lives behind a `Mutex`; the
+/// document operations are synchronous and never cross an `.await`, so the lock
+/// is never held across a suspension point.
+#[derive(Default)]
+pub struct CollabSync {
+    docs: Mutex<HashMap<Topic, CollabDocument>>,
+}
+
+impl CollabSync {
+    /// A handler with no documents yet; each is created on its topic's first
+    /// message.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl SubprotocolHandler for CollabSync {
+    async fn on_data(&self, inbound: InboundData<'_>) -> Result<Reaction, WsError> {
+        let message = CollabMessage::decode(inbound.payload)
+            .map_err(|err| WsError::protocol(err.to_string()))?;
+
+        let mut docs = self
+            .docs
+            .lock()
+            .map_err(|_| WsError::backend("collab document map poisoned"))?;
+        let doc = docs
+            .entry(inbound.topic.clone())
+            .or_insert_with(CollabDocument::new);
+
+        let mut reaction = Reaction::new();
+        match message {
+            CollabMessage::SyncStep1(state_vector) => {
+                // Reply with what this peer is missing...
+                let diff = doc
+                    .diff(&state_vector)
+                    .map_err(|err| WsError::protocol(err.to_string()))?;
+                reaction.reply(CollabMessage::SyncStep2(Bytes::from(diff)).encode());
+                // ...and our own state vector, so it sends back what WE lack.
+                reaction.reply(CollabMessage::SyncStep1(Bytes::from(doc.state_vector())).encode());
+            }
+            CollabMessage::SyncStep2(update) | CollabMessage::Update(update) => {
+                doc.apply_update(&update)
+                    .map_err(|err| WsError::protocol(err.to_string()))?;
+                reaction.broadcast(CollabMessage::Update(update).encode());
+            }
+        }
+        Ok(reaction)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Decode one collab message from raw frame bytes.
+    fn decode(bytes: &Bytes) -> CollabMessage {
+        CollabMessage::decode(bytes).expect("decode collab message")
+    }
+
+    /// Feed one inbound collab message to the server and return its reaction.
+    async fn feed(server: &CollabSync, topic: &Topic, message: CollabMessage) -> Reaction {
+        let payload = message.encode();
+        server
+            .on_data(InboundData {
+                topic,
+                payload: &payload,
+            })
+            .await
+            .expect("handler accepted the message")
+    }
+
+    #[tokio::test]
+    async fn an_update_is_applied_and_broadcast() {
+        let server = CollabSync::new();
+        let topic = Topic::new("collab:doc").unwrap();
+
+        let edit = CollabDocument::new();
+        edit.insert_text("body", 0, "hello");
+        let reaction = feed(
+            &server,
+            &topic,
+            CollabMessage::Update(Bytes::from(edit.full_update())),
+        )
+        .await;
+
+        // An update fans out to everyone and replies to no one.
+        assert!(reaction.replies().is_empty());
+        assert_eq!(reaction.broadcasts().len(), 1);
+        assert!(matches!(
+            decode(&reaction.broadcasts()[0]),
+            CollabMessage::Update(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn handshake_converges_server_and_client_both_ways() {
+        let server = CollabSync::new();
+        let topic = Topic::new("collab:doc").unwrap();
+
+        // Seed the server with prior shared state (an earlier peer's edit).
+        let seed = CollabDocument::new();
+        seed.insert_text("body", 0, "shared ");
+        feed(
+            &server,
+            &topic,
+            CollabMessage::Update(Bytes::from(seed.full_update())),
+        )
+        .await;
+
+        // A fresh client carrying its own concurrent edit starts the handshake.
+        let client = CollabDocument::new();
+        client.insert_text("body", 0, "local ");
+
+        // Client → SyncStep1(client_sv); server replies SyncStep2 + SyncStep1.
+        let reaction = feed(
+            &server,
+            &topic,
+            CollabMessage::SyncStep1(Bytes::from(client.state_vector())),
+        )
+        .await;
+        assert!(reaction.broadcasts().is_empty());
+        assert_eq!(reaction.replies().len(), 2);
+
+        // Apply the server's catch-up; the client now holds the shared state.
+        let catch_up = match decode(&reaction.replies()[0]) {
+            CollabMessage::SyncStep2(update) => update,
+            other => panic!("expected SyncStep2, got {other:?}"),
+        };
+        let server_sv = match decode(&reaction.replies()[1]) {
+            CollabMessage::SyncStep1(sv) => sv,
+            other => panic!("expected SyncStep1, got {other:?}"),
+        };
+        client.apply_update(&catch_up).unwrap();
+        assert!(client.text("body").contains("shared"));
+
+        // Client → SyncStep2(what the server is missing).
+        let client_diff = client.diff(&server_sv).unwrap();
+        let reaction = feed(
+            &server,
+            &topic,
+            CollabMessage::SyncStep2(Bytes::from(client_diff)),
+        )
+        .await;
+        assert!(reaction.replies().is_empty());
+        assert_eq!(reaction.broadcasts().len(), 1, "the client's edit fans out");
+
+        // The authoritative server doc now holds BOTH edits — prove it by
+        // syncing a brand-new peer from scratch.
+        let fresh = CollabDocument::new();
+        let reaction = feed(
+            &server,
+            &topic,
+            CollabMessage::SyncStep1(Bytes::from(fresh.state_vector())),
+        )
+        .await;
+        let full = match decode(&reaction.replies()[0]) {
+            CollabMessage::SyncStep2(update) => update,
+            other => panic!("expected SyncStep2, got {other:?}"),
+        };
+        fresh.apply_update(&full).unwrap();
+        let text = fresh.text("body");
+        assert!(
+            text.contains("shared") && text.contains("local"),
+            "got {text:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn topics_are_isolated() {
+        let server = CollabSync::new();
+        let a = Topic::new("collab:a").unwrap();
+        let b = Topic::new("collab:b").unwrap();
+
+        let edit = CollabDocument::new();
+        edit.insert_text("body", 0, "in-a");
+        feed(
+            &server,
+            &a,
+            CollabMessage::Update(Bytes::from(edit.full_update())),
+        )
+        .await;
+
+        // Topic b is untouched: a fresh peer there catches up to an empty doc.
+        let fresh = CollabDocument::new();
+        let reaction = feed(
+            &server,
+            &b,
+            CollabMessage::SyncStep1(Bytes::from(fresh.state_vector())),
+        )
+        .await;
+        let full = match decode(&reaction.replies()[0]) {
+            CollabMessage::SyncStep2(update) => update,
+            other => panic!("expected SyncStep2, got {other:?}"),
+        };
+        fresh.apply_update(&full).unwrap();
+        assert_eq!(fresh.text("body"), "");
+    }
+
+    #[tokio::test]
+    async fn rejects_a_malformed_payload() {
+        let server = CollabSync::new();
+        let topic = Topic::new("collab:doc").unwrap();
+        let empty = Bytes::new();
+        let err = server
+            .on_data(InboundData {
+                topic: &topic,
+                payload: &empty,
+            })
+            .await
+            .unwrap_err();
+        assert!(matches!(err, WsError::Protocol(_)));
+    }
+}

--- a/crates/pocopine-collab/src/server/handler.rs
+++ b/crates/pocopine-collab/src/server/handler.rs
@@ -15,11 +15,14 @@
 //! reply-vs-broadcast delivery the gateway provides is safe, and a client
 //! applying its own echoed Update is a no-op.
 //!
+//! Write access is enforced via the gateway's write policy
+//! ([`InboundData::can_write`]): a read-only connection may run SyncStep1 (read
+//! down) but its Update / SyncStep2 messages are refused, and it is never
+//! prompted with the server's SyncStep1. This is the realtime-layer counterpart
+//! of [`CollabAccess`](super::doc::CollabAccess).
+//!
 //! This increment keeps documents in process memory; durable load/compaction
-//! through [`CollabStore`](super::store::CollabStore) is the next step. Write
-//! authorization is the gateway's per-topic policy; finer-grained
-//! read-only-vs-read-write access ([`CollabAccess`](super::doc::CollabAccess))
-//! is layered by a richer authorizer in a follow-up.
+//! through [`CollabStore`](super::store::CollabStore) is the next step.
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -79,15 +82,20 @@ impl SubprotocolHandler for CollabSync {
         let mut reaction = Reaction::new();
         match message {
             CollabMessage::SyncStep1(state_vector) => {
-                // Reply with what this peer is missing...
+                // Reply with what this peer is missing (read access is enough).
                 let diff = doc
                     .diff(&state_vector)
                     .map_err(|err| WsError::protocol(err.to_string()))?;
                 reaction.reply(CollabMessage::SyncStep2(Bytes::from(diff)).encode());
-                // ...and our own state vector, so it sends back what WE lack.
-                reaction.reply(CollabMessage::SyncStep1(Bytes::from(doc.state_vector())).encode());
+                // Only writers are asked for what WE lack: prompting a read-only
+                // peer with our state vector would invite a write it cannot make.
+                if inbound.can_write {
+                    reaction
+                        .reply(CollabMessage::SyncStep1(Bytes::from(doc.state_vector())).encode());
+                }
             }
             CollabMessage::SyncStep2(update) => {
+                ensure_writable(&inbound)?;
                 // Relabel a handshake SyncStep2 as a live Update for peers.
                 if let Some(payload) = broadcast_if_advanced(&doc, &update, || {
                     CollabMessage::Update(update.clone()).encode()
@@ -96,6 +104,7 @@ impl SubprotocolHandler for CollabSync {
                 }
             }
             CollabMessage::Update(update) => {
+                ensure_writable(&inbound)?;
                 // Already a tagged Update on the wire — forward the original
                 // payload verbatim (a cheap `Bytes` refcount bump, no re-encode).
                 if let Some(payload) =
@@ -125,6 +134,16 @@ fn broadcast_if_advanced(
     Ok((doc.state_vector() != before).then(payload))
 }
 
+/// Refuse a document-mutating message (Update / SyncStep2) from a connection the
+/// gateway's write policy marked read-only.
+fn ensure_writable(inbound: &InboundData<'_>) -> Result<(), WsError> {
+    if inbound.can_write {
+        Ok(())
+    } else {
+        Err(WsError::forbidden("read-only collab connection"))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -134,16 +153,29 @@ mod tests {
         CollabMessage::decode(bytes).expect("decode collab message")
     }
 
-    /// Feed one inbound collab message to the server and return its reaction.
+    /// Feed one inbound collab message from a writer and return its reaction.
     async fn feed(server: &CollabSync, topic: &Topic, message: CollabMessage) -> Reaction {
+        feed_as(server, topic, message, true)
+            .await
+            .expect("handler accepted the message")
+    }
+
+    /// Feed one message with an explicit write capability, returning the raw
+    /// result so read-only rejections can be asserted.
+    async fn feed_as(
+        server: &CollabSync,
+        topic: &Topic,
+        message: CollabMessage,
+        can_write: bool,
+    ) -> Result<Reaction, WsError> {
         let payload = message.encode();
         server
             .on_data(InboundData {
                 topic,
                 payload: &payload,
+                can_write,
             })
             .await
-            .expect("handler accepted the message")
     }
 
     #[tokio::test]
@@ -303,9 +335,56 @@ mod tests {
             .on_data(InboundData {
                 topic: &topic,
                 payload: &empty,
+                can_write: true,
             })
             .await
             .unwrap_err();
         assert!(matches!(err, WsError::Protocol(_)));
+    }
+
+    #[tokio::test]
+    async fn read_only_connection_can_sync_down_but_not_write() {
+        let server = CollabSync::new();
+        let topic = Topic::new("collab:doc").unwrap();
+
+        // Seed the server with some state (via a writer).
+        let seed = CollabDocument::new();
+        seed.insert_text("body", 0, "shared");
+        feed(
+            &server,
+            &topic,
+            CollabMessage::Update(Bytes::from(seed.full_update())),
+        )
+        .await;
+
+        // A read-only peer's SyncStep1 is honored (it may catch up) but it is
+        // NOT prompted with the server's SyncStep1 (no write is invited).
+        let viewer = CollabDocument::new();
+        let reaction = feed_as(
+            &server,
+            &topic,
+            CollabMessage::SyncStep1(Bytes::from(viewer.state_vector())),
+            false,
+        )
+        .await
+        .expect("read is allowed");
+        assert_eq!(reaction.replies().len(), 1, "only the catch-up SyncStep2");
+        assert!(matches!(
+            decode(&reaction.replies()[0]),
+            CollabMessage::SyncStep2(_)
+        ));
+
+        // A read-only peer attempting to write is refused.
+        let edit = CollabDocument::new();
+        edit.insert_text("body", 0, "sneaky");
+        let err = feed_as(
+            &server,
+            &topic,
+            CollabMessage::Update(Bytes::from(edit.full_update())),
+            false,
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, WsError::Forbidden(_)));
     }
 }

--- a/crates/pocopine-collab/src/server/handler.rs
+++ b/crates/pocopine-collab/src/server/handler.rs
@@ -21,8 +21,12 @@
 //! prompted with the server's SyncStep1. This is the realtime-layer counterpart
 //! of [`CollabAccess`](super::doc::CollabAccess).
 //!
-//! This increment keeps documents in process memory; durable load/compaction
-//! through [`CollabStore`](super::store::CollabStore) is the next step.
+//! Every process **self-subscribes** to each topic's fan-out and folds peer
+//! updates into its local document, so replicas behind a multi-process fan-out
+//! (Redis) converge — not just the clients of one process. This closes the gap
+//! where the document was only ever mutated by inbound frames on the local
+//! connection. Durable load/compaction through
+//! [`CollabStore`](super::store::CollabStore) is the next step.
 
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
@@ -30,41 +34,66 @@ use std::sync::{Arc, Mutex};
 use async_trait::async_trait;
 use bytes::Bytes;
 use pocopine_events::Topic;
-use pocopine_realtime::{InboundData, Reaction, SubprotocolHandler, WsError};
+use pocopine_observe::LOG_TARGET;
+use pocopine_realtime::{Fanout, InboundData, Reaction, SubprotocolHandler, WsError};
+use tokio::task::JoinHandle;
 
 use super::protocol::CollabMessage;
 use super::sync::CollabDocument;
 
 /// Server-side CRDT collaboration over the realtime gateway.
 ///
-/// Shared across every connection and topic (held behind an `Arc` by the
-/// gateway). Each topic's authoritative document lives behind its OWN `Mutex`,
-/// so a slow operation on one document (e.g. encoding a large state vector)
-/// never blocks edits to any other topic; the outer map lock is held only long
-/// enough to look up the per-topic handle. The document operations are
-/// synchronous and never cross an `.await`, so neither lock is held across a
-/// suspension point.
-#[derive(Default)]
+/// Holds one authoritative document per topic, each behind its own `Mutex` (a
+/// slow op on one topic never blocks another). Crucially, [`CollabSync`] owns
+/// the SAME [`Fanout`] the gateway publishes to and spawns a per-topic apply
+/// loop that folds every fanned-out update — including those published by other
+/// processes — into the local document. Without this, a process's document only
+/// ever saw its own clients' edits and replicas behind a Redis fan-out diverged.
 pub struct CollabSync {
-    docs: Mutex<HashMap<Topic, Arc<Mutex<CollabDocument>>>>,
+    fanout: Arc<dyn Fanout>,
+    topics: Mutex<HashMap<Topic, Arc<TopicState>>>,
+}
+
+/// Per-topic state: the document and the apply loop keeping it converged.
+struct TopicState {
+    doc: Arc<Mutex<CollabDocument>>,
+    /// Held so the loop can be aborted when the topic is evicted (a follow-up);
+    /// the task also ends when the fan-out closes.
+    _apply_loop: JoinHandle<()>,
 }
 
 impl CollabSync {
-    /// A handler with no documents yet; each is created on its topic's first
-    /// message.
-    pub fn new() -> Self {
-        Self::default()
+    /// Build a handler over the fan-out the gateway also publishes to. They MUST
+    /// be the same [`Fanout`] instance, or peer updates will not converge.
+    pub fn new(fanout: Arc<dyn Fanout>) -> Self {
+        Self {
+            fanout,
+            topics: Mutex::new(HashMap::new()),
+        }
     }
 
-    /// The per-topic document handle, created on first access.
-    fn document(&self, topic: &Topic) -> Result<Arc<Mutex<CollabDocument>>, WsError> {
-        let mut docs = self
-            .docs
+    /// The per-topic state, created — and its apply loop spawned — on first
+    /// access.
+    fn topic_state(&self, topic: &Topic) -> Result<Arc<TopicState>, WsError> {
+        let mut topics = self
+            .topics
             .lock()
-            .map_err(|_| WsError::backend("collab document map poisoned"))?;
-        Ok(Arc::clone(docs.entry(topic.clone()).or_insert_with(|| {
-            Arc::new(Mutex::new(CollabDocument::new()))
-        })))
+            .map_err(|_| WsError::backend("collab topic map poisoned"))?;
+        if let Some(state) = topics.get(topic) {
+            return Ok(state.clone());
+        }
+        let doc = Arc::new(Mutex::new(CollabDocument::new()));
+        let apply_loop = tokio::spawn(run_apply_loop(
+            self.fanout.clone(),
+            topic.clone(),
+            doc.clone(),
+        ));
+        let state = Arc::new(TopicState {
+            doc,
+            _apply_loop: apply_loop,
+        });
+        topics.insert(topic.clone(), state.clone());
+        Ok(state)
     }
 }
 
@@ -74,8 +103,9 @@ impl SubprotocolHandler for CollabSync {
         let message = CollabMessage::decode(inbound.payload)
             .map_err(|err| WsError::protocol(err.to_string()))?;
 
-        let document = self.document(inbound.topic)?;
-        let doc = document
+        let state = self.topic_state(inbound.topic)?;
+        let doc = state
+            .doc
             .lock()
             .map_err(|_| WsError::backend("collab document mutex poisoned"))?;
 
@@ -144,9 +174,57 @@ fn ensure_writable(inbound: &InboundData<'_>) -> Result<(), WsError> {
     }
 }
 
+/// Subscribe to `topic`'s fan-out and fold every update into `doc` forever, so
+/// edits made through *other* processes converge into this process's document
+/// (the local `on_data` path only ever sees this process's own clients). yrs
+/// makes re-applying our own published updates a no-op, so this is safe to run
+/// alongside the optimistic apply in `on_data`.
+async fn run_apply_loop(fanout: Arc<dyn Fanout>, topic: Topic, doc: Arc<Mutex<CollabDocument>>) {
+    let mut stream = match fanout.subscribe(&topic, None).await {
+        Ok(stream) => stream,
+        Err(err) => {
+            tracing::warn!(target: LOG_TARGET, error = %err, "collab apply loop: subscribe failed");
+            return;
+        }
+    };
+    loop {
+        match stream.next().await {
+            Ok(Some((_seq, payload))) => {
+                // Broadcasts are tagged `Update` messages; a malformed or
+                // non-Update frame must never kill the convergence loop.
+                if let Ok(CollabMessage::Update(update)) = CollabMessage::decode(&payload)
+                    && let Ok(doc) = doc.lock()
+                {
+                    let _ = doc.apply_update(&update);
+                }
+            }
+            // Fan-out closed (topic torn down / shutdown).
+            Ok(None) => break,
+            // Lagged or gapped: re-subscribe fresh to replay the retained tail
+            // and resume — never die silently on a recoverable hiccup.
+            Err(_) => match fanout.subscribe(&topic, None).await {
+                Ok(replacement) => stream = replacement,
+                Err(err) => {
+                    tracing::warn!(target: LOG_TARGET, error = %err, "collab apply loop: resubscribe failed");
+                    break;
+                }
+            },
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
+    use pocopine_realtime::LocalFanout;
+
     use super::*;
+
+    /// A handler over a fresh in-process fan-out (no peers).
+    fn sync() -> CollabSync {
+        CollabSync::new(Arc::new(LocalFanout::new()))
+    }
 
     /// Decode one collab message from raw frame bytes.
     fn decode(bytes: &Bytes) -> CollabMessage {
@@ -180,7 +258,7 @@ mod tests {
 
     #[tokio::test]
     async fn an_update_is_applied_and_broadcast() {
-        let server = CollabSync::new();
+        let server = sync();
         let topic = Topic::new("collab:doc").unwrap();
 
         let edit = CollabDocument::new();
@@ -203,7 +281,7 @@ mod tests {
 
     #[tokio::test]
     async fn a_noop_update_is_applied_but_not_rebroadcast() {
-        let server = CollabSync::new();
+        let server = sync();
         let topic = Topic::new("collab:doc").unwrap();
         let edit = CollabDocument::new();
         edit.insert_text("body", 0, "hello");
@@ -224,7 +302,7 @@ mod tests {
 
     #[tokio::test]
     async fn handshake_converges_server_and_client_both_ways() {
-        let server = CollabSync::new();
+        let server = sync();
         let topic = Topic::new("collab:doc").unwrap();
 
         // Seed the server with prior shared state (an earlier peer's edit).
@@ -297,7 +375,7 @@ mod tests {
 
     #[tokio::test]
     async fn topics_are_isolated() {
-        let server = CollabSync::new();
+        let server = sync();
         let a = Topic::new("collab:a").unwrap();
         let b = Topic::new("collab:b").unwrap();
 
@@ -328,7 +406,7 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_a_malformed_payload() {
-        let server = CollabSync::new();
+        let server = sync();
         let topic = Topic::new("collab:doc").unwrap();
         let empty = Bytes::new();
         let err = server
@@ -344,7 +422,7 @@ mod tests {
 
     #[tokio::test]
     async fn read_only_connection_can_sync_down_but_not_write() {
-        let server = CollabSync::new();
+        let server = sync();
         let topic = Topic::new("collab:doc").unwrap();
 
         // Seed the server with some state (via a writer).
@@ -386,5 +464,62 @@ mod tests {
         .await
         .unwrap_err();
         assert!(matches!(err, WsError::Forbidden(_)));
+    }
+
+    /// Read a handler's current document text by running a fresh SyncStep1
+    /// against it (the same way a brand-new client would catch up).
+    async fn handler_text(server: &CollabSync, topic: &Topic, field: &str) -> String {
+        let probe = CollabDocument::new();
+        let reaction = feed(
+            server,
+            topic,
+            CollabMessage::SyncStep1(Bytes::from(probe.state_vector())),
+        )
+        .await;
+        if let CollabMessage::SyncStep2(update) = decode(&reaction.replies()[0]) {
+            probe.apply_update(&update).unwrap();
+        }
+        probe.text(field)
+    }
+
+    #[tokio::test]
+    async fn peer_updates_converge_through_a_shared_fanout() {
+        // Two handlers sharing ONE fan-out simulate two web processes on one
+        // Redis bus (the gateway publishes each Reaction.broadcast to it).
+        let fanout: Arc<dyn Fanout> = Arc::new(LocalFanout::new());
+        let process_a = CollabSync::new(fanout.clone());
+        let process_b = CollabSync::new(fanout.clone());
+        let topic = Topic::new("collab:doc").unwrap();
+
+        // A client edits on process A; the gateway publishes A's broadcast.
+        let edit = CollabDocument::new();
+        edit.insert_text("body", 0, "from-A");
+        let reaction = feed(
+            &process_a,
+            &topic,
+            CollabMessage::Update(Bytes::from(edit.full_update())),
+        )
+        .await;
+        for payload in reaction.broadcasts() {
+            fanout.publish(&topic, payload.clone()).await.unwrap();
+        }
+
+        // Process B never saw a client for this topic, yet its apply loop folds
+        // A's edit in. Poll until converged (bounded; in-process is near-instant).
+        let mut converged = false;
+        for _ in 0..200 {
+            if handler_text(&process_b, &topic, "body")
+                .await
+                .contains("from-A")
+            {
+                converged = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        }
+        assert!(
+            converged,
+            "process B should converge to A's edit via the shared fan-out"
+        );
     }
 }

--- a/crates/pocopine-collab/src/server/mod.rs
+++ b/crates/pocopine-collab/src/server/mod.rs
@@ -6,10 +6,14 @@
 
 mod doc;
 mod error;
+mod handler;
+mod protocol;
 mod store;
 mod sync;
 
 pub use doc::{CollabAccess, CollabDoc};
 pub use error::{CollabError, CollabResult};
+pub use handler::CollabSync;
+pub use protocol::{COLLAB_SUBPROTOCOL, CollabMessage};
 pub use store::{CollabSnapshot, CollabStore, MemoryCollabStore};
 pub use sync::CollabDocument;

--- a/crates/pocopine-collab/src/server/mod.rs
+++ b/crates/pocopine-collab/src/server/mod.rs
@@ -1,0 +1,15 @@
+//! Host-side collab implementation (RFC 073 Part II).
+//!
+//! A single `#[cfg(not(target_arch = "wasm32"))]` gate at the crate root covers
+//! everything here; submodules carry no `cfg` (the `client-server-modules`
+//! skill).
+
+mod doc;
+mod error;
+mod store;
+mod sync;
+
+pub use doc::{CollabAccess, CollabDoc};
+pub use error::{CollabError, CollabResult};
+pub use store::{CollabSnapshot, CollabStore, MemoryCollabStore};
+pub use sync::CollabDocument;

--- a/crates/pocopine-collab/src/server/protocol.rs
+++ b/crates/pocopine-collab/src/server/protocol.rs
@@ -1,0 +1,115 @@
+//! The collab sub-protocol carried inside `pocopine-realtime` Data frames
+//! (RFC 073 Part II, the wire shape of the Yjs sync handshake).
+//!
+//! Each Data frame payload is exactly one [`CollabMessage`]: a single tag byte
+//! followed by the raw body (a yrs state vector or update, both already
+//! self-delimiting because they run to the end of the frame). This mirrors
+//! y-protocols' `messageSync` sub-types, minus the redundant length prefix the
+//! frame envelope already makes unnecessary.
+//!
+//! ```text
+//! message := u8(tag) body
+//!   tag 0  SyncStep1   body = state vector   ("what I have")
+//!   tag 1  SyncStep2   body = update diff    ("what you were missing")
+//!   tag 2  Update      body = update         (a live edit to converge)
+//! ```
+
+use bytes::Bytes;
+
+use super::error::{CollabError, CollabResult};
+
+/// The conventional `subprotocol_id` apps register the collab handler under and
+/// tag collab Data frames with. Apps may choose another id; this is the default
+/// both [`crate::CollabSync`] consumers and the client SDK assume.
+pub const COLLAB_SUBPROTOCOL: u64 = 1;
+
+const TAG_SYNC_STEP1: u8 = 0;
+const TAG_SYNC_STEP2: u8 = 1;
+const TAG_UPDATE: u8 = 2;
+
+/// One collab sub-protocol message (the body of a single Data frame).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum CollabMessage {
+    /// A peer's state vector — "here is what I already have" (SyncStep1).
+    SyncStep1(Bytes),
+    /// The update a peer was missing, computed from its SyncStep1 (SyncStep2).
+    SyncStep2(Bytes),
+    /// A live document update to merge and converge everywhere (Update).
+    Update(Bytes),
+}
+
+impl CollabMessage {
+    /// Encode as `tag || body`.
+    pub fn encode(&self) -> Bytes {
+        let (tag, body) = match self {
+            Self::SyncStep1(body) => (TAG_SYNC_STEP1, body),
+            Self::SyncStep2(body) => (TAG_SYNC_STEP2, body),
+            Self::Update(body) => (TAG_UPDATE, body),
+        };
+        let mut out = Vec::with_capacity(body.len() + 1);
+        out.push(tag);
+        out.extend_from_slice(body);
+        Bytes::from(out)
+    }
+
+    /// Decode a frame payload into a message, or `CollabError::Decode` on an
+    /// empty payload / unknown tag.
+    pub fn decode(payload: &[u8]) -> CollabResult<Self> {
+        let (&tag, body) = payload
+            .split_first()
+            .ok_or_else(|| CollabError::Decode("empty collab message".into()))?;
+        let body = Bytes::copy_from_slice(body);
+        match tag {
+            TAG_SYNC_STEP1 => Ok(Self::SyncStep1(body)),
+            TAG_SYNC_STEP2 => Ok(Self::SyncStep2(body)),
+            TAG_UPDATE => Ok(Self::Update(body)),
+            other => Err(CollabError::Decode(format!(
+                "unknown collab message tag {other}"
+            ))),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn roundtrip(msg: CollabMessage) {
+        let encoded = msg.encode();
+        assert_eq!(CollabMessage::decode(&encoded).unwrap(), msg);
+    }
+
+    #[test]
+    fn roundtrips_every_variant() {
+        roundtrip(CollabMessage::SyncStep1(Bytes::from_static(b"\x00\x01sv")));
+        roundtrip(CollabMessage::SyncStep2(Bytes::from_static(b"diff")));
+        roundtrip(CollabMessage::Update(Bytes::from_static(b"update")));
+    }
+
+    #[test]
+    fn empty_body_roundtrips() {
+        // An empty state vector (a brand-new peer) is a one-byte message.
+        let encoded = CollabMessage::SyncStep1(Bytes::new()).encode();
+        assert_eq!(encoded.len(), 1);
+        assert_eq!(
+            CollabMessage::decode(&encoded).unwrap(),
+            CollabMessage::SyncStep1(Bytes::new())
+        );
+    }
+
+    #[test]
+    fn empty_payload_is_a_decode_error() {
+        assert!(matches!(
+            CollabMessage::decode(&[]),
+            Err(CollabError::Decode(_))
+        ));
+    }
+
+    #[test]
+    fn unknown_tag_is_a_decode_error() {
+        assert!(matches!(
+            CollabMessage::decode(&[9, 1, 2, 3]),
+            Err(CollabError::Decode(_))
+        ));
+    }
+}

--- a/crates/pocopine-collab/src/server/store.rs
+++ b/crates/pocopine-collab/src/server/store.rs
@@ -50,7 +50,13 @@ pub trait CollabStore: Send + Sync + 'static {
     /// Load a document's latest snapshot, or `None` if it has never been saved.
     async fn load_snapshot(&self, doc_key: &str) -> CollabResult<Option<CollabSnapshot>>;
 
-    /// Persist a document's compacted snapshot (overwriting any prior one).
+    /// Persist a document's compacted snapshot — but ONLY if it is fresher than
+    /// the stored one (`snapshot.last_seq` strictly greater). The cursor must be
+    /// monotonic: replicas share one fan-out cursor and a lagging process can
+    /// otherwise overwrite a newer checkpoint with an older blob, rolling
+    /// `last_seq` backward so a restart resumes into an already-evicted gap. A
+    /// SQL adapter expresses this as a conditional upsert
+    /// (`... ON CONFLICT DO UPDATE WHERE excluded.last_seq > last_seq`).
     async fn save_snapshot(&self, doc_key: &str, snapshot: CollabSnapshot) -> CollabResult<()>;
 }
 
@@ -83,7 +89,13 @@ impl CollabStore for MemoryCollabStore {
             .snapshots
             .lock()
             .map_err(|_| CollabError::store("memory store mutex poisoned"))?;
-        map.insert(doc_key.to_string(), snapshot);
+        // Monotonic: ignore a checkpoint that does not advance the cursor.
+        match map.get(doc_key) {
+            Some(existing) if existing.last_seq >= snapshot.last_seq => {}
+            _ => {
+                map.insert(doc_key.to_string(), snapshot);
+            }
+        }
         Ok(())
     }
 }
@@ -136,6 +148,45 @@ mod tests {
                 .unwrap()
                 .last_seq,
             1
+        );
+    }
+
+    #[tokio::test]
+    async fn ignores_a_stale_or_equal_checkpoint() {
+        let store = MemoryCollabStore::new();
+        let key = "collab:doc";
+        store
+            .save_snapshot(key, snapshot(b"fresh", 10))
+            .await
+            .unwrap();
+
+        // A lagging replica writing an OLDER cursor must not roll it back.
+        store
+            .save_snapshot(key, snapshot(b"stale", 5))
+            .await
+            .unwrap();
+        let got = store.load_snapshot(key).await.unwrap().unwrap();
+        assert_eq!(got.last_seq, 10);
+        assert_eq!(got.blob, Bytes::from_static(b"fresh"));
+
+        // An equal cursor is also ignored (no churn).
+        store
+            .save_snapshot(key, snapshot(b"equal", 10))
+            .await
+            .unwrap();
+        assert_eq!(
+            store.load_snapshot(key).await.unwrap().unwrap().blob,
+            Bytes::from_static(b"fresh")
+        );
+
+        // A newer cursor still advances.
+        store
+            .save_snapshot(key, snapshot(b"newer", 11))
+            .await
+            .unwrap();
+        assert_eq!(
+            store.load_snapshot(key).await.unwrap().unwrap().last_seq,
+            11
         );
     }
 }

--- a/crates/pocopine-collab/src/server/store.rs
+++ b/crates/pocopine-collab/src/server/store.rs
@@ -7,6 +7,12 @@
 //! state vector, and the fan-out cursor; the document registry, ownership, and
 //! permissions belong to the app's own database. See
 //! `docs/internal/collab-persistence.md`.
+//!
+//! The key is the document's **topic string** (`collab:{doc_hash}`, via
+//! [`CollabDoc::topic`](super::doc::CollabDoc::topic)). The topic — not the full
+//! [`CollabDoc`](super::doc::CollabDoc) — is what both the convergence apply
+//! loop and the compaction path actually hold (the hash is one-way), so the
+//! store keys by it directly.
 
 use std::collections::HashMap;
 use std::sync::Mutex;
@@ -14,7 +20,6 @@ use std::sync::Mutex;
 use async_trait::async_trait;
 use bytes::Bytes;
 
-use super::doc::CollabDoc;
 use super::error::{CollabError, CollabResult};
 
 /// The persisted state of a document.
@@ -31,20 +36,22 @@ pub struct CollabSnapshot {
     pub last_seq: u64,
 }
 
-/// Durable, DB-agnostic blob-by-document persistence.
+/// Durable, DB-agnostic blob-by-document persistence, keyed by the document's
+/// topic string (`collab:{doc_hash}`).
 ///
 /// Implement this for your database; the framework ships [`MemoryCollabStore`]
-/// plus reference adapters, and never forces a specific engine. The store is
-/// keyed by the document — it does not expose registry/list queries (those
-/// belong to the app's own schema). The compaction worker is the only writer;
-/// the `web` process is a reader (loading a snapshot to serve a join).
+/// plus reference adapters, and never forces a specific engine. The store does
+/// not expose registry/list queries (those belong to the app's own schema). A
+/// process loads a snapshot when it first opens a topic and checkpoints the
+/// folded document back periodically, so the durable base survives restart and
+/// fan-out retention eviction.
 #[async_trait]
 pub trait CollabStore: Send + Sync + 'static {
     /// Load a document's latest snapshot, or `None` if it has never been saved.
-    async fn load_snapshot(&self, doc: &CollabDoc) -> CollabResult<Option<CollabSnapshot>>;
+    async fn load_snapshot(&self, doc_key: &str) -> CollabResult<Option<CollabSnapshot>>;
 
     /// Persist a document's compacted snapshot (overwriting any prior one).
-    async fn save_snapshot(&self, doc: &CollabDoc, snapshot: CollabSnapshot) -> CollabResult<()>;
+    async fn save_snapshot(&self, doc_key: &str, snapshot: CollabSnapshot) -> CollabResult<()>;
 }
 
 /// In-process [`CollabStore`] for tests and single-node dev (no database).
@@ -62,21 +69,21 @@ impl MemoryCollabStore {
 
 #[async_trait]
 impl CollabStore for MemoryCollabStore {
-    async fn load_snapshot(&self, doc: &CollabDoc) -> CollabResult<Option<CollabSnapshot>> {
+    async fn load_snapshot(&self, doc_key: &str) -> CollabResult<Option<CollabSnapshot>> {
         // std::Mutex held without crossing an .await — safe in async.
         let map = self
             .snapshots
             .lock()
             .map_err(|_| CollabError::store("memory store mutex poisoned"))?;
-        Ok(map.get(&doc.doc_hash()).cloned())
+        Ok(map.get(doc_key).cloned())
     }
 
-    async fn save_snapshot(&self, doc: &CollabDoc, snapshot: CollabSnapshot) -> CollabResult<()> {
+    async fn save_snapshot(&self, doc_key: &str, snapshot: CollabSnapshot) -> CollabResult<()> {
         let mut map = self
             .snapshots
             .lock()
             .map_err(|_| CollabError::store("memory store mutex poisoned"))?;
-        map.insert(doc.doc_hash(), snapshot);
+        map.insert(doc_key.to_string(), snapshot);
         Ok(())
     }
 }
@@ -96,19 +103,19 @@ mod tests {
     #[tokio::test]
     async fn round_trips_and_overwrites() {
         let store = MemoryCollabStore::new();
-        let doc = CollabDoc::new("app", "docs", "1", "main");
+        let key = "collab:doc1";
 
-        assert_eq!(store.load_snapshot(&doc).await.unwrap(), None);
+        assert_eq!(store.load_snapshot(key).await.unwrap(), None);
 
-        store.save_snapshot(&doc, snapshot(b"v1", 3)).await.unwrap();
+        store.save_snapshot(key, snapshot(b"v1", 3)).await.unwrap();
         assert_eq!(
-            store.load_snapshot(&doc).await.unwrap(),
+            store.load_snapshot(key).await.unwrap(),
             Some(snapshot(b"v1", 3))
         );
 
-        store.save_snapshot(&doc, snapshot(b"v2", 7)).await.unwrap();
+        store.save_snapshot(key, snapshot(b"v2", 7)).await.unwrap();
         assert_eq!(
-            store.load_snapshot(&doc).await.unwrap(),
+            store.load_snapshot(key).await.unwrap(),
             Some(snapshot(b"v2", 7))
         );
     }
@@ -116,10 +123,19 @@ mod tests {
     #[tokio::test]
     async fn documents_are_isolated() {
         let store = MemoryCollabStore::new();
-        let a = CollabDoc::new("app", "docs", "a", "main");
-        let b = CollabDoc::new("app", "docs", "b", "main");
-        store.save_snapshot(&a, snapshot(b"a", 1)).await.unwrap();
-        assert_eq!(store.load_snapshot(&b).await.unwrap(), None);
-        assert_eq!(store.load_snapshot(&a).await.unwrap().unwrap().last_seq, 1);
+        store
+            .save_snapshot("collab:a", snapshot(b"a", 1))
+            .await
+            .unwrap();
+        assert_eq!(store.load_snapshot("collab:b").await.unwrap(), None);
+        assert_eq!(
+            store
+                .load_snapshot("collab:a")
+                .await
+                .unwrap()
+                .unwrap()
+                .last_seq,
+            1
+        );
     }
 }

--- a/crates/pocopine-collab/src/server/store.rs
+++ b/crates/pocopine-collab/src/server/store.rs
@@ -1,0 +1,125 @@
+//! Durable persistence: the `CollabStore` trait and an in-memory reference
+//! implementation.
+//!
+//! The durable database is the user's preference, so the contract is
+//! deliberately DB-agnostic — a pure versioned blob-by-document store that
+//! assumes nothing SQL-specific. It stores only the compacted snapshot, its
+//! state vector, and the fan-out cursor; the document registry, ownership, and
+//! permissions belong to the app's own database. See
+//! `docs/internal/collab-persistence.md`.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+
+use super::doc::CollabDoc;
+use super::error::{CollabError, CollabResult};
+
+/// The persisted state of a document.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct CollabSnapshot {
+    /// The compacted document as a yrs full-state update
+    /// (`CollabDocument::full_update`).
+    pub blob: Bytes,
+    /// The yrs state vector of `blob` (small; lets the server reason about the
+    /// snapshot without decoding the whole blob).
+    pub state_vector: Bytes,
+    /// The `pocopine-realtime` topic cursor this snapshot is current to (where
+    /// the compaction worker resumes folding the live update log).
+    pub last_seq: u64,
+}
+
+/// Durable, DB-agnostic blob-by-document persistence.
+///
+/// Implement this for your database; the framework ships [`MemoryCollabStore`]
+/// plus reference adapters, and never forces a specific engine. The store is
+/// keyed by the document — it does not expose registry/list queries (those
+/// belong to the app's own schema). The compaction worker is the only writer;
+/// the `web` process is a reader (loading a snapshot to serve a join).
+#[async_trait]
+pub trait CollabStore: Send + Sync + 'static {
+    /// Load a document's latest snapshot, or `None` if it has never been saved.
+    async fn load_snapshot(&self, doc: &CollabDoc) -> CollabResult<Option<CollabSnapshot>>;
+
+    /// Persist a document's compacted snapshot (overwriting any prior one).
+    async fn save_snapshot(&self, doc: &CollabDoc, snapshot: CollabSnapshot) -> CollabResult<()>;
+}
+
+/// In-process [`CollabStore`] for tests and single-node dev (no database).
+#[derive(Default)]
+pub struct MemoryCollabStore {
+    snapshots: Mutex<HashMap<String, CollabSnapshot>>,
+}
+
+impl MemoryCollabStore {
+    /// An empty in-memory store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl CollabStore for MemoryCollabStore {
+    async fn load_snapshot(&self, doc: &CollabDoc) -> CollabResult<Option<CollabSnapshot>> {
+        // std::Mutex held without crossing an .await — safe in async.
+        let map = self
+            .snapshots
+            .lock()
+            .map_err(|_| CollabError::store("memory store mutex poisoned"))?;
+        Ok(map.get(&doc.doc_hash()).cloned())
+    }
+
+    async fn save_snapshot(&self, doc: &CollabDoc, snapshot: CollabSnapshot) -> CollabResult<()> {
+        let mut map = self
+            .snapshots
+            .lock()
+            .map_err(|_| CollabError::store("memory store mutex poisoned"))?;
+        map.insert(doc.doc_hash(), snapshot);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snapshot(blob: &[u8], seq: u64) -> CollabSnapshot {
+        CollabSnapshot {
+            blob: Bytes::copy_from_slice(blob),
+            state_vector: Bytes::from_static(b"sv"),
+            last_seq: seq,
+        }
+    }
+
+    #[tokio::test]
+    async fn round_trips_and_overwrites() {
+        let store = MemoryCollabStore::new();
+        let doc = CollabDoc::new("app", "docs", "1", "main");
+
+        assert_eq!(store.load_snapshot(&doc).await.unwrap(), None);
+
+        store.save_snapshot(&doc, snapshot(b"v1", 3)).await.unwrap();
+        assert_eq!(
+            store.load_snapshot(&doc).await.unwrap(),
+            Some(snapshot(b"v1", 3))
+        );
+
+        store.save_snapshot(&doc, snapshot(b"v2", 7)).await.unwrap();
+        assert_eq!(
+            store.load_snapshot(&doc).await.unwrap(),
+            Some(snapshot(b"v2", 7))
+        );
+    }
+
+    #[tokio::test]
+    async fn documents_are_isolated() {
+        let store = MemoryCollabStore::new();
+        let a = CollabDoc::new("app", "docs", "a", "main");
+        let b = CollabDoc::new("app", "docs", "b", "main");
+        store.save_snapshot(&a, snapshot(b"a", 1)).await.unwrap();
+        assert_eq!(store.load_snapshot(&b).await.unwrap(), None);
+        assert_eq!(store.load_snapshot(&a).await.unwrap().unwrap().last_seq, 1);
+    }
+}

--- a/crates/pocopine-collab/src/server/sync.rs
+++ b/crates/pocopine-collab/src/server/sync.rs
@@ -1,0 +1,171 @@
+//! The Yjs sync primitives over a `yrs` document (RFC 073, the collab wire
+//! protocol). These are the server-side half of the handshake:
+//!
+//! - `state_vector()` → SyncStep1 payload ("what I have")
+//! - `diff(remote_sv)` → SyncStep2 payload ("what you're missing")
+//! - `apply_update()` → merge a remote Update (idempotent, commutative)
+//! - `full_update()` → the whole doc as one update (a snapshot blob, or the
+//!   catch-up for a brand-new peer)
+//!
+//! CRDT merges are order-independent: applying updates in any order, even
+//! twice, converges. So the per-topic `seq` from the gateway is only for
+//! replay/resume bookkeeping, never for merge correctness.
+
+use yrs::updates::decoder::Decode;
+use yrs::updates::encoder::Encode;
+use yrs::{Doc, GetString, ReadTxn, StateVector, Text, Transact, Update};
+
+use super::error::{CollabError, CollabResult};
+
+/// A collaborative document: a thin wrapper over `yrs::Doc` exposing the sync
+/// handshake primitives.
+pub struct CollabDocument {
+    doc: Doc,
+}
+
+impl CollabDocument {
+    /// A fresh, empty document.
+    pub fn new() -> Self {
+        Self { doc: Doc::new() }
+    }
+
+    /// Reconstruct a document from a persisted full-state update (a snapshot
+    /// blob from the `CollabStore`).
+    pub fn from_snapshot(blob: &[u8]) -> CollabResult<Self> {
+        let doc = Self::new();
+        doc.apply_update(blob)?;
+        Ok(doc)
+    }
+
+    /// Borrow the underlying `yrs` document (to attach observers, drive edits,
+    /// or read shared types directly).
+    pub fn doc(&self) -> &Doc {
+        &self.doc
+    }
+
+    /// Apply a remote update — a CRDT delta, a SyncStep2 catch-up, or a full
+    /// snapshot. Idempotent: re-applying a known update is a no-op.
+    pub fn apply_update(&self, bytes: &[u8]) -> CollabResult<()> {
+        let update =
+            Update::decode_v1(bytes).map_err(|err| CollabError::Decode(err.to_string()))?;
+        self.doc
+            .transact_mut()
+            .apply_update(update)
+            .map_err(|err| CollabError::Apply(err.to_string()))?;
+        Ok(())
+    }
+
+    /// This document's state vector (the SyncStep1 payload), encoded.
+    pub fn state_vector(&self) -> Vec<u8> {
+        self.doc.transact().state_vector().encode_v1()
+    }
+
+    /// The update a peer whose state vector is `remote_sv` is missing (the
+    /// SyncStep2 payload).
+    pub fn diff(&self, remote_sv: &[u8]) -> CollabResult<Vec<u8>> {
+        let sv = StateVector::decode_v1(remote_sv)
+            .map_err(|err| CollabError::Decode(err.to_string()))?;
+        Ok(self.doc.transact().encode_state_as_update_v1(&sv))
+    }
+
+    /// The whole document as a single update (a snapshot blob, equivalently the
+    /// diff a brand-new peer with an empty state vector is missing).
+    pub fn full_update(&self) -> Vec<u8> {
+        self.doc
+            .transact()
+            .encode_state_as_update_v1(&StateVector::default())
+    }
+
+    // --- convenience for tests / simple text docs ---
+
+    /// Insert `content` into a root text field at `index`.
+    pub fn insert_text(&self, field: &str, index: u32, content: &str) {
+        let text = self.doc.get_or_insert_text(field);
+        let mut txn = self.doc.transact_mut();
+        text.insert(&mut txn, index, content);
+    }
+
+    /// Read a root text field as a string.
+    pub fn text(&self, field: &str) -> String {
+        let text = self.doc.get_or_insert_text(field);
+        text.get_string(&self.doc.transact())
+    }
+}
+
+impl Default for CollabDocument {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn two_documents_converge_via_diff_exchange() {
+        let a = CollabDocument::new();
+        let b = CollabDocument::new();
+        a.insert_text("body", 0, "hello");
+        b.insert_text("body", 0, "world");
+
+        // Each side computes what the other is missing from its state vector.
+        let a_missing = b.diff(&a.state_vector()).unwrap();
+        let b_missing = a.diff(&b.state_vector()).unwrap();
+        a.apply_update(&a_missing).unwrap();
+        b.apply_update(&b_missing).unwrap();
+
+        // CRDT convergence: identical result on both sides...
+        assert_eq!(a.text("body"), b.text("body"));
+        // ...containing both concurrent edits.
+        let merged = a.text("body");
+        assert!(merged.contains("hello") && merged.contains("world"));
+    }
+
+    #[test]
+    fn fresh_peer_catches_up_from_full_diff() {
+        let server = CollabDocument::new();
+        server.insert_text("body", 0, "shared state");
+
+        // A brand-new peer sends its (empty) state vector; the server replies
+        // with the diff (SyncStep1 -> SyncStep2).
+        let fresh = CollabDocument::new();
+        let catch_up = server.diff(&fresh.state_vector()).unwrap();
+        fresh.apply_update(&catch_up).unwrap();
+
+        assert_eq!(fresh.text("body"), "shared state");
+    }
+
+    #[test]
+    fn apply_is_idempotent_and_order_independent() {
+        let source = CollabDocument::new();
+        source.insert_text("body", 0, "abc");
+        let u1 = source.full_update();
+        source.insert_text("body", 3, "def");
+        let u2 = source
+            .diff(&{
+                let d = CollabDocument::new();
+                d.apply_update(&u1).unwrap();
+                d.state_vector()
+            })
+            .unwrap();
+
+        // Apply out of order and twice; still converges to the source.
+        let target = CollabDocument::new();
+        target.apply_update(&u2).unwrap(); // the later delta first
+        target.apply_update(&u1).unwrap();
+        target.apply_update(&u1).unwrap(); // duplicate
+        assert_eq!(target.text("body"), source.text("body"));
+        assert_eq!(target.text("body"), "abcdef");
+    }
+
+    #[test]
+    fn state_vector_round_trips_through_a_snapshot() {
+        let doc = CollabDocument::new();
+        doc.insert_text("body", 0, "persist me");
+        let blob = doc.full_update();
+
+        let restored = CollabDocument::from_snapshot(&blob).unwrap();
+        assert_eq!(restored.text("body"), "persist me");
+    }
+}

--- a/crates/pocopine-collab/src/server/sync.rs
+++ b/crates/pocopine-collab/src/server/sync.rs
@@ -85,6 +85,14 @@ impl CollabDocument {
         text.insert(&mut txn, index, content);
     }
 
+    /// Remove `len` characters from a root text field at `index`. A delete is
+    /// recorded in the delete-set, not the state vector.
+    pub fn delete_text(&self, field: &str, index: u32, len: u32) {
+        let text = self.doc.get_or_insert_text(field);
+        let mut txn = self.doc.transact_mut();
+        text.remove_range(&mut txn, index, len);
+    }
+
     /// Read a root text field as a string.
     pub fn text(&self, field: &str) -> String {
         let text = self.doc.get_or_insert_text(field);

--- a/crates/pocopine-collab/tests/gateway.rs
+++ b/crates/pocopine-collab/tests/gateway.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use futures_util::{SinkExt, Stream, StreamExt};
 use pocopine_collab::{COLLAB_SUBPROTOCOL, CollabDocument, CollabMessage, CollabSync};
-use pocopine_realtime::{Control, Frame, FrameKind, WsGateway, routes};
+use pocopine_realtime::{Control, Fanout, Frame, FrameKind, LocalFanout, WsGateway, routes};
 use tokio::time::timeout;
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::{Error as TungError, Message as WsMessage};
@@ -15,11 +15,13 @@ use tokio_tungstenite::tungstenite::{Error as TungError, Message as WsMessage};
 /// Quiet window after which the handshake/broadcast chatter is considered drained.
 const IDLE: Duration = Duration::from_millis(400);
 
-/// Boot a collab-enabled gateway on a random port; return its ws:// URL.
+/// Boot a collab-enabled gateway on a random port; return its ws:// URL. The
+/// handler and gateway share one fan-out (required for the apply loop).
 async fn spawn() -> String {
-    let gateway = WsGateway::local()
+    let fanout: Arc<dyn Fanout> = Arc::new(LocalFanout::new());
+    let gateway = WsGateway::new(fanout.clone())
         .allow_all_topics()
-        .with_handler(COLLAB_SUBPROTOCOL, Arc::new(CollabSync::new()));
+        .with_handler(COLLAB_SUBPROTOCOL, Arc::new(CollabSync::new(fanout)));
     let app = routes(gateway);
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();

--- a/crates/pocopine-collab/tests/gateway.rs
+++ b/crates/pocopine-collab/tests/gateway.rs
@@ -1,0 +1,165 @@
+//! End-to-end collab over the realtime gateway: boot the axum router with a
+//! [`CollabSync`] handler registered, connect real WebSocket clients, and prove
+//! the Yjs sync handshake catches a fresh peer up and live edits converge.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures_util::{SinkExt, Stream, StreamExt};
+use pocopine_collab::{COLLAB_SUBPROTOCOL, CollabDocument, CollabMessage, CollabSync};
+use pocopine_realtime::{Control, Frame, FrameKind, WsGateway, routes};
+use tokio::time::timeout;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::{Error as TungError, Message as WsMessage};
+
+/// Quiet window after which the handshake/broadcast chatter is considered drained.
+const IDLE: Duration = Duration::from_millis(400);
+
+/// Boot a collab-enabled gateway on a random port; return its ws:// URL.
+async fn spawn() -> String {
+    let gateway = WsGateway::local()
+        .allow_all_topics()
+        .with_handler(COLLAB_SUBPROTOCOL, Arc::new(CollabSync::new()));
+    let app = routes(gateway);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("ws://{addr}/__pocopine/ws/v1")
+}
+
+type Ws =
+    tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>>;
+
+async fn next_frame<S>(ws: &mut S) -> Frame
+where
+    S: Stream<Item = Result<WsMessage, TungError>> + Unpin,
+{
+    loop {
+        match ws
+            .next()
+            .await
+            .expect("stream ended")
+            .expect("transport error")
+        {
+            WsMessage::Binary(data) => return Frame::decode(&data).expect("decode frame"),
+            WsMessage::Close(_) => panic!("server closed unexpectedly"),
+            _ => {}
+        }
+    }
+}
+
+fn send(frame: Frame) -> WsMessage {
+    WsMessage::Binary(frame.encode())
+}
+
+/// Read the Hello and subscribe to `topic`, returning the assigned topic_ref.
+async fn join(ws: &mut Ws, topic: &str) -> u64 {
+    match next_frame(ws).await {
+        f if f.kind == FrameKind::Control => {
+            assert!(matches!(
+                Control::decode(&f.payload).unwrap(),
+                Control::Hello { .. }
+            ));
+        }
+        other => panic!("expected Hello, got {other:?}"),
+    }
+    ws.send(send(Frame::subscribe(COLLAB_SUBPROTOCOL, topic)))
+        .await
+        .unwrap();
+    let frame = next_frame(ws).await;
+    match Control::decode(&frame.payload).unwrap() {
+        Control::SubscribeAck { topic_ref, .. } => topic_ref,
+        other => panic!("expected SubscribeAck, got {other:?}"),
+    }
+}
+
+/// Send the opening SyncStep1 (this peer's state vector).
+async fn open_sync(ws: &mut Ws, topic_ref: u64, doc: &CollabDocument) {
+    let msg = CollabMessage::SyncStep1(doc.state_vector().into());
+    ws.send(send(Frame::data(
+        COLLAB_SUBPROTOCOL,
+        topic_ref,
+        0,
+        msg.encode(),
+    )))
+    .await
+    .unwrap();
+}
+
+/// Process every inbound collab Data frame — exactly as a real client would —
+/// until the connection is quiet for [`IDLE`]: reply to the server's SyncStep1
+/// with the diff it is missing, and apply SyncStep2/Update messages locally.
+/// CRDT idempotency makes the replayed/echoed duplicates harmless.
+async fn drive(ws: &mut Ws, topic_ref: u64, doc: &CollabDocument) {
+    while let Ok(frame) = timeout(IDLE, next_frame(ws)).await {
+        if frame.kind != FrameKind::Data {
+            continue;
+        }
+        match CollabMessage::decode(&frame.payload).unwrap() {
+            CollabMessage::SyncStep1(sv) => {
+                let diff = doc.diff(&sv).unwrap();
+                let reply = CollabMessage::SyncStep2(diff.into());
+                ws.send(send(Frame::data(
+                    COLLAB_SUBPROTOCOL,
+                    topic_ref,
+                    0,
+                    reply.encode(),
+                )))
+                .await
+                .unwrap();
+            }
+            CollabMessage::SyncStep2(update) | CollabMessage::Update(update) => {
+                doc.apply_update(&update).unwrap();
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn two_clients_converge_over_the_gateway() {
+    let url = spawn().await;
+    let topic = "collab:doc1";
+
+    // Client A joins with a local edit and syncs it up to the server.
+    let (mut a, _) = connect_async(&url).await.unwrap();
+    let a_ref = join(&mut a, topic).await;
+    let doc_a = CollabDocument::new();
+    doc_a.insert_text("body", 0, "alpha ");
+    open_sync(&mut a, a_ref, &doc_a).await;
+    drive(&mut a, a_ref, &doc_a).await;
+
+    // Client B joins fresh; the handshake catches it up to A's edit.
+    let (mut b, _) = connect_async(&url).await.unwrap();
+    let b_ref = join(&mut b, topic).await;
+    let doc_b = CollabDocument::new();
+    open_sync(&mut b, b_ref, &doc_b).await;
+    drive(&mut b, b_ref, &doc_b).await;
+    assert!(
+        doc_b.text("body").contains("alpha"),
+        "B should catch up to A's edit, got {:?}",
+        doc_b.text("body")
+    );
+
+    // A makes a further edit and broadcasts just the delta; B receives it live.
+    let before = doc_a.state_vector();
+    let end = doc_a.text("body").chars().count() as u32;
+    doc_a.insert_text("body", end, "beta");
+    let delta = doc_a.diff(&before).unwrap();
+    a.send(send(Frame::data(
+        COLLAB_SUBPROTOCOL,
+        a_ref,
+        0,
+        CollabMessage::Update(delta.into()).encode(),
+    )))
+    .await
+    .unwrap();
+
+    drive(&mut b, b_ref, &doc_b).await;
+    assert!(
+        doc_b.text("body").contains("beta"),
+        "B should receive A's live update, got {:?}",
+        doc_b.text("body")
+    );
+}

--- a/crates/pocopine-core/src/router.rs
+++ b/crates/pocopine-core/src/router.rs
@@ -1669,7 +1669,7 @@ fn route_navigation_key_from_query(path: &str, query: &HashMap<String, String>) 
         return path.to_string();
     }
     let mut pairs: Vec<_> = query.iter().collect();
-    pairs.sort_by(|(left, _), (right, _)| left.cmp(right));
+    pairs.sort_by_key(|(left, _)| *left);
     let mut out = path.to_string();
     out.push('?');
     for (idx, (key, value)) in pairs.into_iter().enumerate() {

--- a/crates/pocopine-realtime/Cargo.toml
+++ b/crates/pocopine-realtime/Cargo.toml
@@ -45,4 +45,5 @@ tokio-tungstenite = "0.24"
 futures-util = "0.3"
 redis = { version = "0.27", features = ["tokio-comp"] }
 bytes = "1"
+async-trait = "0.1"
 pocopine-events = { workspace = true }

--- a/crates/pocopine-realtime/src/server/gateway.rs
+++ b/crates/pocopine-realtime/src/server/gateway.rs
@@ -1,6 +1,7 @@
 //! The gateway hub: configuration, topic policy/resolver, and shared state
 //! (RFC 073 §10–§11).
 
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
@@ -9,6 +10,7 @@ use pocopine_events::Topic;
 
 use super::error::WsError;
 use super::fanout::{Fanout, LocalFanout};
+use super::handler::SubprotocolHandler;
 
 /// WebSocket sub-protocol identifier advertised in `Sec-WebSocket-Protocol`
 /// and the [`crate::Control::Hello`] frame.
@@ -77,6 +79,9 @@ pub struct WsGateway {
     resolver: TopicResolver,
     config: GatewayConfig,
     sessions: Arc<AtomicU64>,
+    /// Stateful inbound handlers keyed by `subprotocol_id`. A sub-protocol with
+    /// no entry uses the default publish-to-fan-out relay.
+    handlers: Arc<HashMap<u64, Arc<dyn SubprotocolHandler>>>,
 }
 
 impl WsGateway {
@@ -93,6 +98,7 @@ impl WsGateway {
             resolver: Arc::new(|topic| Topic::new(topic).map_err(WsError::from)),
             config: GatewayConfig::default(),
             sessions: Arc::new(AtomicU64::new(0)),
+            handlers: Arc::new(HashMap::new()),
         }
     }
 
@@ -156,6 +162,21 @@ impl WsGateway {
         self
     }
 
+    /// Register a stateful inbound [`SubprotocolHandler`] for `subprotocol_id`.
+    ///
+    /// Data frames tagged with that id are routed to the handler instead of the
+    /// default publish-to-fan-out relay; every other sub-protocol still relays.
+    /// Registering twice for the same id replaces the earlier handler.
+    pub fn with_handler(
+        mut self,
+        subprotocol_id: u64,
+        handler: Arc<dyn SubprotocolHandler>,
+    ) -> Self {
+        // Uniquely owned during the builder chain, so this never deep-clones.
+        Arc::make_mut(&mut self.handlers).insert(subprotocol_id, handler);
+        self
+    }
+
     // --- internal accessors used by the route/session machinery ---
 
     pub(crate) fn fanout(&self) -> &Arc<dyn Fanout> {
@@ -172,6 +193,10 @@ impl WsGateway {
 
     pub(crate) fn authorize(&self, ctx: &RequestContext, topic: &Topic) -> bool {
         (self.policy)(ctx, topic)
+    }
+
+    pub(crate) fn handler(&self, subprotocol_id: u64) -> Option<&Arc<dyn SubprotocolHandler>> {
+        self.handlers.get(&subprotocol_id)
     }
 
     pub(crate) fn next_session_id(&self) -> String {

--- a/crates/pocopine-realtime/src/server/gateway.rs
+++ b/crates/pocopine-realtime/src/server/gateway.rs
@@ -76,6 +76,10 @@ impl Default for GatewayConfig {
 pub struct WsGateway {
     fanout: Arc<dyn Fanout>,
     policy: TopicPolicy,
+    /// Per-topic *publish* authorization, layered on top of the join `policy`.
+    /// Defaults to allow, so any connection that may join may also publish
+    /// (the relay's historical behavior); set it to express read-only access.
+    write_policy: TopicPolicy,
     resolver: TopicResolver,
     config: GatewayConfig,
     sessions: Arc<AtomicU64>,
@@ -95,6 +99,7 @@ impl WsGateway {
         Self {
             fanout,
             policy: Arc::new(|_, _| false),
+            write_policy: Arc::new(|_, _| true),
             resolver: Arc::new(|topic| Topic::new(topic).map_err(WsError::from)),
             config: GatewayConfig::default(),
             sessions: Arc::new(AtomicU64::new(0)),
@@ -126,12 +131,25 @@ impl WsGateway {
         )))
     }
 
-    /// Replace the per-topic authorization policy.
+    /// Replace the per-topic join authorization policy.
     pub fn with_topic_policy(
         mut self,
         policy: impl Fn(&RequestContext, &Topic) -> bool + Send + Sync + 'static,
     ) -> Self {
         self.policy = Arc::new(policy);
+        self
+    }
+
+    /// Replace the per-topic *publish* policy (layered on top of the join
+    /// policy). Returning `false` makes the connection read-only for that
+    /// topic: inbound Data frames are refused by the relay, and handlers see
+    /// [`InboundData::can_write`](super::handler::InboundData) `= false`. The
+    /// default allows any joiner to publish.
+    pub fn with_write_policy(
+        mut self,
+        policy: impl Fn(&RequestContext, &Topic) -> bool + Send + Sync + 'static,
+    ) -> Self {
+        self.write_policy = Arc::new(policy);
         self
     }
 
@@ -193,6 +211,10 @@ impl WsGateway {
 
     pub(crate) fn authorize(&self, ctx: &RequestContext, topic: &Topic) -> bool {
         (self.policy)(ctx, topic)
+    }
+
+    pub(crate) fn authorize_write(&self, ctx: &RequestContext, topic: &Topic) -> bool {
+        (self.write_policy)(ctx, topic)
     }
 
     pub(crate) fn handler(&self, subprotocol_id: u64) -> Option<&Arc<dyn SubprotocolHandler>> {

--- a/crates/pocopine-realtime/src/server/gateway.rs
+++ b/crates/pocopine-realtime/src/server/gateway.rs
@@ -2,8 +2,8 @@
 //! (RFC 073 §10–§11).
 
 use std::collections::HashMap;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 
 use pocopine_auth::RequestContext;
 use pocopine_events::Topic;
@@ -86,6 +86,9 @@ pub struct WsGateway {
     /// Stateful inbound handlers keyed by `subprotocol_id`. A sub-protocol with
     /// no entry uses the default publish-to-fan-out relay.
     handlers: Arc<HashMap<u64, Arc<dyn SubprotocolHandler>>>,
+    /// Per-topic count of live subscriptions across all of this process's
+    /// connections. Drives the handler's topic active/idle lifecycle (0↔1).
+    subscriber_counts: Arc<Mutex<HashMap<Topic, usize>>>,
 }
 
 impl WsGateway {
@@ -104,6 +107,7 @@ impl WsGateway {
             config: GatewayConfig::default(),
             sessions: Arc::new(AtomicU64::new(0)),
             handlers: Arc::new(HashMap::new()),
+            subscriber_counts: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
@@ -219,6 +223,43 @@ impl WsGateway {
 
     pub(crate) fn handler(&self, subprotocol_id: u64) -> Option<&Arc<dyn SubprotocolHandler>> {
         self.handlers.get(&subprotocol_id)
+    }
+
+    /// Record a new subscription to `topic`; notify the sub-protocol's handler
+    /// if this is the topic's first live subscriber on this process (0→1).
+    pub(crate) fn topic_subscribed(&self, topic: &Topic, subprotocol_id: u64) {
+        let first = {
+            let mut counts = self.subscriber_counts.lock().expect("counts poisoned");
+            let n = counts.entry(topic.clone()).or_insert(0);
+            *n += 1;
+            *n == 1
+        };
+        if first && let Some(handler) = self.handler(subprotocol_id) {
+            handler.on_topic_active(topic);
+        }
+    }
+
+    /// Record a dropped subscription to `topic`; notify the sub-protocol's
+    /// handler if that was the topic's last live subscriber on this process
+    /// (1→0). Idempotent for an unknown topic.
+    pub(crate) fn topic_unsubscribed(&self, topic: &Topic, subprotocol_id: u64) {
+        let last = {
+            let mut counts = self.subscriber_counts.lock().expect("counts poisoned");
+            match counts.get_mut(topic) {
+                Some(n) => {
+                    *n = n.saturating_sub(1);
+                    let drained = *n == 0;
+                    if drained {
+                        counts.remove(topic);
+                    }
+                    drained
+                }
+                None => false,
+            }
+        };
+        if last && let Some(handler) = self.handler(subprotocol_id) {
+            handler.on_topic_idle(topic);
+        }
     }
 
     pub(crate) fn next_session_id(&self) -> String {

--- a/crates/pocopine-realtime/src/server/gateway.rs
+++ b/crates/pocopine-realtime/src/server/gateway.rs
@@ -86,9 +86,10 @@ pub struct WsGateway {
     /// Stateful inbound handlers keyed by `subprotocol_id`. A sub-protocol with
     /// no entry uses the default publish-to-fan-out relay.
     handlers: Arc<HashMap<u64, Arc<dyn SubprotocolHandler>>>,
-    /// Per-topic count of live subscriptions across all of this process's
-    /// connections. Drives the handler's topic active/idle lifecycle (0↔1).
-    subscriber_counts: Arc<Mutex<HashMap<Topic, usize>>>,
+    /// Live subscription count per `(topic, subprotocol_id)` across all of this
+    /// process's connections. Keyed by sub-protocol too, so the active/idle
+    /// lifecycle (0↔1) always reaches the handler that owns that sub-protocol.
+    subscriber_counts: Arc<Mutex<HashMap<(Topic, u64), usize>>>,
 }
 
 impl WsGateway {
@@ -225,40 +226,46 @@ impl WsGateway {
         self.handlers.get(&subprotocol_id)
     }
 
-    /// Record a new subscription to `topic`; notify the sub-protocol's handler
-    /// if this is the topic's first live subscriber on this process (0→1).
+    /// Record a new subscription to `(topic, subprotocol_id)`; notify the
+    /// sub-protocol's handler if this is its first live subscriber on this
+    /// process (0→1).
+    ///
+    /// The handler is notified WHILE the count lock is held: the lock orders the
+    /// 0→1 / 1→0 transitions, and notifying inside it makes the active/idle
+    /// callbacks arrive in that same order. Otherwise a concurrent unsubscribe
+    /// (1→0) and subscribe (0→1) on one topic could deliver idle-after-active
+    /// and leave a live topic with no handler state. (Lock order is always
+    /// counts → handler's own lock; nothing takes them the other way, so no
+    /// deadlock.)
     pub(crate) fn topic_subscribed(&self, topic: &Topic, subprotocol_id: u64) {
-        let first = {
-            let mut counts = self.subscriber_counts.lock().expect("counts poisoned");
-            let n = counts.entry(topic.clone()).or_insert(0);
-            *n += 1;
-            *n == 1
-        };
-        if first && let Some(handler) = self.handler(subprotocol_id) {
+        let mut counts = self.subscriber_counts.lock().expect("counts poisoned");
+        let n = counts.entry((topic.clone(), subprotocol_id)).or_insert(0);
+        *n += 1;
+        if *n == 1
+            && let Some(handler) = self.handler(subprotocol_id)
+        {
             handler.on_topic_active(topic);
         }
     }
 
-    /// Record a dropped subscription to `topic`; notify the sub-protocol's
-    /// handler if that was the topic's last live subscriber on this process
-    /// (1→0). Idempotent for an unknown topic.
+    /// Record a dropped subscription to `(topic, subprotocol_id)`; notify the
+    /// sub-protocol's handler (under the lock) if that was its last live
+    /// subscriber on this process (1→0). Idempotent for an unknown key.
     pub(crate) fn topic_unsubscribed(&self, topic: &Topic, subprotocol_id: u64) {
-        let last = {
-            let mut counts = self.subscriber_counts.lock().expect("counts poisoned");
-            match counts.get_mut(topic) {
-                Some(n) => {
-                    *n = n.saturating_sub(1);
-                    let drained = *n == 0;
-                    if drained {
-                        counts.remove(topic);
-                    }
-                    drained
-                }
-                None => false,
+        let mut counts = self.subscriber_counts.lock().expect("counts poisoned");
+        let key = (topic.clone(), subprotocol_id);
+        let drained = match counts.get_mut(&key) {
+            Some(n) => {
+                *n = n.saturating_sub(1);
+                *n == 0
             }
+            None => return,
         };
-        if last && let Some(handler) = self.handler(subprotocol_id) {
-            handler.on_topic_idle(topic);
+        if drained {
+            counts.remove(&key);
+            if let Some(handler) = self.handler(subprotocol_id) {
+                handler.on_topic_idle(topic);
+            }
         }
     }
 

--- a/crates/pocopine-realtime/src/server/handler.rs
+++ b/crates/pocopine-realtime/src/server/handler.rs
@@ -1,0 +1,101 @@
+//! Per-sub-protocol inbound handlers (RFC 073 §7, the stateful-server seam).
+//!
+//! By default a Data frame is a pure relay: the gateway re-checks write
+//! authorization and publishes the payload to the topic's [`Fanout`], so every
+//! subscriber (including other processes) receives it verbatim. That is all a
+//! presence/broadcast sub-protocol needs.
+//!
+//! A CRDT sub-protocol needs more: the *server* must answer a peer's
+//! `SyncStep1` with a computed diff (a reply to that one connection), while
+//! document updates still broadcast to everyone. Registering a
+//! [`SubprotocolHandler`] on the gateway for a `subprotocol_id` replaces the
+//! relay for that sub-protocol with stateful server logic. The handler reacts
+//! to each inbound Data frame with a [`Reaction`]: `reply` bytes go back to the
+//! originating connection only, `broadcast` bytes go through the fan-out to
+//! every subscriber. `pocopine-collab` is the canonical implementor.
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use pocopine_events::Topic;
+
+use super::error::WsError;
+
+/// One inbound Data frame, handed to a [`SubprotocolHandler`].
+///
+/// The connection has already passed the gateway's topic authorization, so the
+/// handler only sees frames it is allowed to act on. The payload is the opaque
+/// sub-protocol body (the frame envelope has been stripped).
+pub struct InboundData<'a> {
+    /// The resolved topic the frame targets.
+    pub topic: &'a Topic,
+    /// The opaque sub-protocol payload (the Data frame body).
+    pub payload: &'a Bytes,
+}
+
+/// What the gateway should emit after a [`SubprotocolHandler`] processes a
+/// frame: direct replies to the originating connection and/or broadcasts to the
+/// whole topic.
+///
+/// Replies and broadcasts are independent: a CRDT `SyncStep1` produces only
+/// replies (the catch-up diff), a document update produces only a broadcast,
+/// and the server's own `SyncStep1` rides along as a reply during the initial
+/// handshake. Order between a reply and a concurrently-pumped broadcast is not
+/// guaranteed — CRDT merges are commutative and idempotent, so it does not need
+/// to be.
+#[derive(Debug, Default)]
+pub struct Reaction {
+    pub(crate) replies: Vec<Bytes>,
+    pub(crate) broadcasts: Vec<Bytes>,
+}
+
+impl Reaction {
+    /// An empty reaction (no replies, no broadcasts).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Queue `payload` as a Data frame sent back to the originating connection
+    /// only (never fanned out). Used for the sync handshake.
+    pub fn reply(&mut self, payload: impl Into<Bytes>) -> &mut Self {
+        self.replies.push(payload.into());
+        self
+    }
+
+    /// Queue `payload` to publish to the topic's fan-out, reaching every
+    /// subscriber (including peers on other processes). Used for document
+    /// updates that must converge everywhere.
+    pub fn broadcast(&mut self, payload: impl Into<Bytes>) -> &mut Self {
+        self.broadcasts.push(payload.into());
+        self
+    }
+
+    /// The queued direct replies, in order (lets a handler's author assert its
+    /// output in tests).
+    pub fn replies(&self) -> &[Bytes] {
+        &self.replies
+    }
+
+    /// The queued broadcasts, in order.
+    pub fn broadcasts(&self) -> &[Bytes] {
+        &self.broadcasts
+    }
+}
+
+/// Server-side handler for one sub-protocol's inbound Data frames.
+///
+/// Registered on the gateway by `subprotocol_id` via
+/// [`WsGateway::with_handler`](super::gateway::WsGateway::with_handler). When a
+/// Data frame for that sub-protocol arrives, the gateway calls [`Self::on_data`]
+/// *instead of* the default publish-to-fan-out relay and then executes the
+/// returned [`Reaction`].
+///
+/// Implementors are shared across every connection and topic (held behind an
+/// `Arc`), so they must be `Send + Sync` and own any per-topic state behind
+/// interior synchronization.
+#[async_trait]
+pub trait SubprotocolHandler: Send + Sync + 'static {
+    /// React to one inbound Data frame. Returning `Err` rejects the frame (the
+    /// gateway logs it and sends the peer a `bad_frame` control error) without
+    /// tearing down the connection.
+    async fn on_data(&self, inbound: InboundData<'_>) -> Result<Reaction, WsError>;
+}

--- a/crates/pocopine-realtime/src/server/handler.rs
+++ b/crates/pocopine-realtime/src/server/handler.rs
@@ -22,14 +22,19 @@ use super::error::WsError;
 
 /// One inbound Data frame, handed to a [`SubprotocolHandler`].
 ///
-/// The connection has already passed the gateway's topic authorization, so the
-/// handler only sees frames it is allowed to act on. The payload is the opaque
-/// sub-protocol body (the frame envelope has been stripped).
+/// The connection has already passed the gateway's topic (join) authorization,
+/// so the handler only sees frames on topics it may read. The payload is the
+/// opaque sub-protocol body (the frame envelope has been stripped).
 pub struct InboundData<'a> {
     /// The resolved topic the frame targets.
     pub topic: &'a Topic,
     /// The opaque sub-protocol payload (the Data frame body).
     pub payload: &'a Bytes,
+    /// Whether this connection is authorized to *publish* on the topic
+    /// (the gateway's write policy; defaults to allow). A handler that
+    /// distinguishes read-only from read-write access (e.g. collab) gates
+    /// its mutating messages on this; pure relays ignore it.
+    pub can_write: bool,
 }
 
 /// What the gateway should emit after a [`SubprotocolHandler`] processes a

--- a/crates/pocopine-realtime/src/server/handler.rs
+++ b/crates/pocopine-realtime/src/server/handler.rs
@@ -103,4 +103,17 @@ pub trait SubprotocolHandler: Send + Sync + 'static {
     /// gateway logs it and sends the peer a `bad_frame` control error) without
     /// tearing down the connection.
     async fn on_data(&self, inbound: InboundData<'_>) -> Result<Reaction, WsError>;
+
+    /// `topic` gained its first local subscriber on this process (the gateway's
+    /// per-topic subscriber count went 0→1). A stateful handler spins up
+    /// per-topic resources here — collab starts the convergence apply loop.
+    /// Default: no-op (pure relays keep no per-topic state). Called
+    /// synchronously from the session loop, so do not block.
+    fn on_topic_active(&self, _topic: &Topic) {}
+
+    /// `topic` lost its last local subscriber on this process (the count went
+    /// 1→0). A stateful handler frees per-topic resources here — collab aborts
+    /// the apply loop and drops the document (which reloads from the store on
+    /// the next subscriber). Default: no-op.
+    fn on_topic_idle(&self, _topic: &Topic) {}
 }

--- a/crates/pocopine-realtime/src/server/mod.rs
+++ b/crates/pocopine-realtime/src/server/mod.rs
@@ -10,6 +10,7 @@ mod error;
 mod fanout;
 mod frame;
 mod gateway;
+mod handler;
 #[cfg(feature = "redis")]
 mod redis_fanout;
 mod route;
@@ -22,6 +23,7 @@ pub use fanout::{
 };
 pub use frame::{Frame, FrameKind};
 pub use gateway::{GatewayConfig, TopicPolicy, TopicResolver, WS_PROTOCOL_V1, WsGateway};
+pub use handler::{InboundData, Reaction, SubprotocolHandler};
 #[cfg(feature = "redis")]
 pub use redis_fanout::{DEFAULT_REDIS_MAX_LEN, RedisFanout};
 pub use route::{WS_STREAM_PATH, routes};

--- a/crates/pocopine-realtime/src/server/route.rs
+++ b/crates/pocopine-realtime/src/server/route.rs
@@ -82,6 +82,9 @@ async fn upgrade_handler(State(gateway): State<WsGateway>, request: Request<Body
 struct TopicEntry {
     topic: Topic,
     name: String,
+    /// The sub-protocol this topic was joined under (to notify the right
+    /// handler on the topic's active/idle lifecycle).
+    subprotocol_id: u64,
     pump: JoinHandle<()>,
 }
 
@@ -271,6 +274,8 @@ impl Session {
         if let Some(entry) = self.topics.remove(&frame.topic_ref) {
             entry.pump.abort();
             self.topic_by_name.remove(&entry.name);
+            self.gateway
+                .topic_unsubscribed(&entry.topic, entry.subprotocol_id);
             self.send(&Control::Unsubscribed { topic: entry.name });
         }
         Ok(())
@@ -408,11 +413,18 @@ impl Session {
             topic_ref,
             topic_name.to_string(),
         ));
+        // A genuinely new subscription (not a re-subscribe of a topic this
+        // connection already holds) bumps the process-wide count, which fires
+        // the handler's topic-active lifecycle on 0→1.
+        if !already_subscribed {
+            self.gateway.topic_subscribed(&topic, subprotocol_id);
+        }
         self.topics.insert(
             topic_ref,
             TopicEntry {
                 topic,
                 name: topic_name.to_string(),
+                subprotocol_id,
                 pump,
             },
         );
@@ -434,6 +446,8 @@ impl Session {
     fn shutdown(&mut self) {
         for (_, entry) in self.topics.drain() {
             entry.pump.abort();
+            self.gateway
+                .topic_unsubscribed(&entry.topic, entry.subprotocol_id);
         }
         self.topic_by_name.clear();
     }

--- a/crates/pocopine-realtime/src/server/route.rs
+++ b/crates/pocopine-realtime/src/server/route.rs
@@ -396,11 +396,28 @@ impl Session {
             return;
         }
 
-        // Commit: replace any existing subscription to this topic.
-        if let Some(old_ref) = self.topic_by_name.remove(topic_name)
+        // Commit: replace any existing subscription to this topic, capturing the
+        // sub-protocol it was joined under so the lifecycle counts rebalance.
+        let replaced = if let Some(old_ref) = self.topic_by_name.remove(topic_name)
             && let Some(entry) = self.topics.remove(&old_ref)
         {
             entry.pump.abort();
+            Some(entry.subprotocol_id)
+        } else {
+            None
+        };
+
+        // Rebalance the per-(topic, sub-protocol) subscriber count and fire the
+        // active/idle lifecycle. A re-subscribe under the SAME sub-protocol
+        // leaves the count untouched; switching sub-protocols releases the old
+        // and acquires the new (so neither handler is left unbalanced).
+        match replaced {
+            Some(old) if old == subprotocol_id => {}
+            Some(old) => {
+                self.gateway.topic_unsubscribed(&topic, old);
+                self.gateway.topic_subscribed(&topic, subprotocol_id);
+            }
+            None => self.gateway.topic_subscribed(&topic, subprotocol_id),
         }
 
         let topic_ref = self.next_topic_ref;
@@ -413,12 +430,6 @@ impl Session {
             topic_ref,
             topic_name.to_string(),
         ));
-        // A genuinely new subscription (not a re-subscribe of a topic this
-        // connection already holds) bumps the process-wide count, which fires
-        // the handler's topic-active lifecycle on 0→1.
-        if !already_subscribed {
-            self.gateway.topic_subscribed(&topic, subprotocol_id);
-        }
         self.topics.insert(
             topic_ref,
             TopicEntry {

--- a/crates/pocopine-realtime/src/server/route.rs
+++ b/crates/pocopine-realtime/src/server/route.rs
@@ -286,10 +286,13 @@ impl Session {
                 )));
             }
         };
-        // Re-check write authorization on every inbound write (RFC 073 §10.1).
+        // Re-check join authorization on every inbound frame (RFC 073 §10.1).
         if !self.gateway.authorize(&self.ctx, &topic) {
             return Err(WsError::forbidden(name));
         }
+        // Publish authorization is a second, finer gate (read-only connections
+        // may join but not write); handlers receive it, the relay enforces it.
+        let can_write = self.gateway.authorize_write(&self.ctx, &topic);
 
         // A registered sub-protocol handler (e.g. collab) intercepts the frame
         // and runs stateful server logic; every other sub-protocol is a pure
@@ -299,6 +302,7 @@ impl Session {
                 .on_data(InboundData {
                     topic: &topic,
                     payload: &frame.payload,
+                    can_write,
                 })
                 .await?;
             for payload in reaction.replies {
@@ -317,6 +321,11 @@ impl Session {
             return Ok(());
         }
 
+        // Default relay: a Data frame IS a publish, so it requires write
+        // authorization (the handler path delegates this gate to the handler).
+        if !can_write {
+            return Err(WsError::forbidden(name));
+        }
         self.gateway
             .fanout()
             .publish(&topic, frame.payload.clone())

--- a/crates/pocopine-realtime/src/server/route.rs
+++ b/crates/pocopine-realtime/src/server/route.rs
@@ -38,6 +38,7 @@ use super::error::WsError;
 use super::fanout::TopicStream;
 use super::frame::{Frame, FrameKind};
 use super::gateway::{GatewayConfig, WS_PROTOCOL_V1, WsGateway};
+use super::handler::InboundData;
 
 /// Mount path for the gateway upgrade endpoint.
 pub const WS_STREAM_PATH: &str = "/__pocopine/ws/v1";
@@ -289,6 +290,33 @@ impl Session {
         if !self.gateway.authorize(&self.ctx, &topic) {
             return Err(WsError::forbidden(name));
         }
+
+        // A registered sub-protocol handler (e.g. collab) intercepts the frame
+        // and runs stateful server logic; every other sub-protocol is a pure
+        // publish-to-fan-out relay.
+        if let Some(handler) = self.gateway.handler(frame.subprotocol_id) {
+            let reaction = handler
+                .on_data(InboundData {
+                    topic: &topic,
+                    payload: &frame.payload,
+                })
+                .await?;
+            for payload in reaction.replies {
+                // Out-of-band reply to THIS connection only (seq 0; the
+                // per-subscription seq is reserved for fanned-out Data frames).
+                // Non-blocking enqueue keeps the heartbeat watchdog live.
+                let reply = Frame::data(frame.subprotocol_id, frame.topic_ref, 0, payload);
+                if self.out.try_send(Message::Binary(reply.encode())).is_err() {
+                    self.should_close = true;
+                    break;
+                }
+            }
+            for payload in reaction.broadcasts {
+                self.gateway.fanout().publish(&topic, payload).await?;
+            }
+            return Ok(());
+        }
+
         self.gateway
             .fanout()
             .publish(&topic, frame.payload.clone())

--- a/crates/pocopine-realtime/tests/gateway.rs
+++ b/crates/pocopine-realtime/tests/gateway.rs
@@ -1,8 +1,13 @@
 //! End-to-end gateway tests: boot the axum router on an ephemeral port and
 //! drive it with a real WebSocket client (tokio-tungstenite).
 
+use std::sync::Arc;
+
 use futures_util::{SinkExt, Stream, StreamExt};
-use pocopine_realtime::{Control, Frame, FrameKind, GatewayConfig, TopicSeq, WsGateway, routes};
+use pocopine_realtime::{
+    Control, Frame, FrameKind, GatewayConfig, InboundData, Reaction, SubprotocolHandler, TopicSeq,
+    WsGateway, routes,
+};
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::{Error as TungError, Message as WsMessage};
 
@@ -202,4 +207,63 @@ async fn subscription_cap_rejects_extra_topics() {
         Control::Error { code, .. } => assert_eq!(code, "too_many_subscriptions"),
         other => panic!("expected too_many_subscriptions, got {other:?}"),
     }
+}
+
+/// A toy handler proving both [`Reaction`] paths: a `reply:`-prefixed echo back
+/// to the sender and a `bcast:`-prefixed message fanned out to every subscriber.
+struct PrefixHandler;
+
+#[async_trait::async_trait]
+impl SubprotocolHandler for PrefixHandler {
+    async fn on_data(
+        &self,
+        inbound: InboundData<'_>,
+    ) -> Result<Reaction, pocopine_realtime::WsError> {
+        let mut reaction = Reaction::new();
+        reaction.reply([b"reply:", &inbound.payload[..]].concat());
+        reaction.broadcast([b"bcast:", &inbound.payload[..]].concat());
+        Ok(reaction)
+    }
+}
+
+#[tokio::test]
+async fn handler_replies_to_sender_and_broadcasts_to_all() {
+    const SUB: u64 = 7;
+    let gateway = WsGateway::local()
+        .allow_all_topics()
+        .with_handler(SUB, Arc::new(PrefixHandler));
+    let url = spawn(gateway).await;
+
+    // Two clients on the same topic.
+    let (mut a, _ra) = connect_async(url.clone()).await.unwrap();
+    let (mut b, _rb) = connect_async(url).await.unwrap();
+    assert!(matches!(next_control(&mut a).await, Control::Hello { .. }));
+    assert!(matches!(next_control(&mut b).await, Control::Hello { .. }));
+    for ws in [&mut a, &mut b] {
+        ws.send(send_bytes(Frame::subscribe(SUB, "room:1")))
+            .await
+            .unwrap();
+        assert!(matches!(
+            next_control(ws).await,
+            Control::SubscribeAck { .. }
+        ));
+    }
+
+    // A sends one Data frame; the handler intercepts it (no raw relay).
+    a.send(send_bytes(Frame::data(SUB, 1, 0, &b"hi"[..])))
+        .await
+        .unwrap();
+
+    // A sees BOTH its direct reply (seq 0) and the broadcast (seq 1), in either
+    // order; B sees only the broadcast.
+    let f1 = next_data(&mut a).await;
+    let f2 = next_data(&mut a).await;
+    let mut a_payloads = [f1.payload_str().unwrap(), f2.payload_str().unwrap()];
+    a_payloads.sort_unstable();
+    assert_eq!(a_payloads, ["bcast:hi", "reply:hi"]);
+
+    let on_b = next_data(&mut b).await;
+    assert_eq!(on_b.payload_str().unwrap(), "bcast:hi");
+    assert_eq!(on_b.seq, 1, "broadcast is a normal sequenced Data frame");
+    assert_eq!(on_b.subprotocol_id, SUB);
 }

--- a/crates/pocopine-realtime/tests/gateway.rs
+++ b/crates/pocopine-realtime/tests/gateway.rs
@@ -209,6 +209,39 @@ async fn subscription_cap_rejects_extra_topics() {
     }
 }
 
+#[tokio::test]
+async fn write_policy_allows_subscribe_but_denies_publish() {
+    // Read-only: any topic may be joined, none may be published to.
+    let gateway = WsGateway::local()
+        .allow_all_topics()
+        .with_write_policy(|_, _| false);
+    let url = spawn(gateway).await;
+    let (mut ws, _resp) = connect_async(url).await.unwrap();
+    assert!(matches!(next_control(&mut ws).await, Control::Hello { .. }));
+
+    // Joining is allowed by the (separate) topic policy.
+    ws.send(send_bytes(Frame::subscribe(1, "topic:1")))
+        .await
+        .unwrap();
+    let topic_ref = match next_control(&mut ws).await {
+        Control::SubscribeAck { topic_ref, .. } => topic_ref,
+        other => panic!("expected SubscribeAck, got {other:?}"),
+    };
+
+    // Publishing is refused by the write policy — the relay returns an error
+    // instead of echoing the frame back.
+    ws.send(send_bytes(Frame::data(1, topic_ref, 0, &b"x"[..])))
+        .await
+        .unwrap();
+    match next_control(&mut ws).await {
+        Control::Error { message, .. } => assert!(
+            message.contains("forbidden"),
+            "expected a forbidden write, got {message:?}"
+        ),
+        other => panic!("expected a forbidden error, got {other:?}"),
+    }
+}
+
 /// A toy handler proving both [`Reaction`] paths: a `reply:`-prefixed echo back
 /// to the sender and a `bcast:`-prefixed message fanned out to every subscriber.
 struct PrefixHandler;

--- a/crates/pocopine-realtime/tests/gateway.rs
+++ b/crates/pocopine-realtime/tests/gateway.rs
@@ -1,9 +1,10 @@
 //! End-to-end gateway tests: boot the axum router on an ephemeral port and
 //! drive it with a real WebSocket client (tokio-tungstenite).
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use futures_util::{SinkExt, Stream, StreamExt};
+use pocopine_events::Topic;
 use pocopine_realtime::{
     Control, Frame, FrameKind, GatewayConfig, InboundData, Reaction, SubprotocolHandler, TopicSeq,
     WsGateway, routes,
@@ -299,4 +300,87 @@ async fn handler_replies_to_sender_and_broadcasts_to_all() {
     assert_eq!(on_b.payload_str().unwrap(), "bcast:hi");
     assert_eq!(on_b.seq, 1, "broadcast is a normal sequenced Data frame");
     assert_eq!(on_b.subprotocol_id, SUB);
+}
+
+/// Records topic active/idle lifecycle transitions; `on_data` is a no-op.
+struct LifecycleRecorder {
+    events: Arc<Mutex<Vec<String>>>,
+}
+
+#[async_trait::async_trait]
+impl SubprotocolHandler for LifecycleRecorder {
+    async fn on_data(
+        &self,
+        _inbound: InboundData<'_>,
+    ) -> Result<Reaction, pocopine_realtime::WsError> {
+        Ok(Reaction::new())
+    }
+
+    fn on_topic_active(&self, topic: &Topic) {
+        self.events
+            .lock()
+            .unwrap()
+            .push(format!("active:{}", topic.as_str()));
+    }
+
+    fn on_topic_idle(&self, topic: &Topic) {
+        self.events
+            .lock()
+            .unwrap()
+            .push(format!("idle:{}", topic.as_str()));
+    }
+}
+
+#[tokio::test]
+async fn topic_active_idle_fires_on_first_and_last_subscriber() {
+    const SUB: u64 = 5;
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let gateway = WsGateway::local().allow_all_topics().with_handler(
+        SUB,
+        Arc::new(LifecycleRecorder {
+            events: events.clone(),
+        }),
+    );
+    let url = spawn(gateway).await;
+
+    // Two clients join the same topic; active fires once (0→1), not per client.
+    let (mut a, _ra) = connect_async(url.clone()).await.unwrap();
+    let (mut b, _rb) = connect_async(url).await.unwrap();
+    assert!(matches!(next_control(&mut a).await, Control::Hello { .. }));
+    assert!(matches!(next_control(&mut b).await, Control::Hello { .. }));
+    let mut refs = Vec::new();
+    for ws in [&mut a, &mut b] {
+        ws.send(send_bytes(Frame::subscribe(SUB, "room:1")))
+            .await
+            .unwrap();
+        match next_control(ws).await {
+            Control::SubscribeAck { topic_ref, .. } => refs.push(topic_ref),
+            other => panic!("expected SubscribeAck, got {other:?}"),
+        }
+    }
+    // The lifecycle hook fires before the ack is sent, so by now it has run.
+    assert_eq!(*events.lock().unwrap(), vec!["active:room:1"]);
+
+    // A unsubscribes (2→1): no idle yet.
+    a.send(send_bytes(Frame::unsubscribe(refs[0])))
+        .await
+        .unwrap();
+    assert!(matches!(
+        next_control(&mut a).await,
+        Control::Unsubscribed { .. }
+    ));
+    assert_eq!(*events.lock().unwrap(), vec!["active:room:1"]);
+
+    // B unsubscribes (1→0): idle fires.
+    b.send(send_bytes(Frame::unsubscribe(refs[1])))
+        .await
+        .unwrap();
+    assert!(matches!(
+        next_control(&mut b).await,
+        Control::Unsubscribed { .. }
+    ));
+    assert_eq!(
+        *events.lock().unwrap(),
+        vec!["active:room:1", "idle:room:1"]
+    );
 }

--- a/examples/layout/src/lib.rs
+++ b/examples/layout/src/lib.rs
@@ -39,7 +39,7 @@ impl LayoutDemo {
 
 #[cfg(target_arch = "wasm32")]
 fn slide_drawer(open: bool) {
-    use pine_motion::{animate, AnimationHandle, Tween};
+    use pine_motion::{AnimationHandle, Tween, animate};
     use std::cell::RefCell;
 
     // Retain the latest handle past this call (dropping it would cancel

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,7 +2,10 @@
 # `proc_macro::Span` at expansion time, which still requires the
 # `proc_macro_span` feature gate. Pin the workspace to a known-good
 # nightly so contributors and CI use the same rustc.
+#
+# 2026-02-21 is the first pin past Rust 1.95 (Feb 2026), which stabilized
+# `if let` match guards — needed by yrs 0.27 (pocopine-collab).
 [toolchain]
-channel = "nightly-2025-12-18"
+channel = "nightly-2026-02-21"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
## What

`pocopine-collab` (RFC 073 Part II): server-side CRDT collaboration (yrs) running the Yjs sync handshake over the `pocopine-realtime` gateway — built to be **correct under a multi-process Redis fan-out**, not just single-process.

Adds the gateway hooks collab needs (a stateful inbound handler + a topic lifecycle), the collab handler itself, convergence across replicas, durable snapshots, and idle-topic eviction. Also bumps the pinned nightly to `2026-02-21` so yrs 0.27 (`if let` guards, stable in Rust 1.95) builds.

## Why — the bug this is designed around

A naive port mutates the document **only** on inbound client frames, while peer-process broadcasts go straight to client sockets. With ≥2 web replicas each process holds a *partial* document, and edits aged past the Redis stream window are lost. The single-process `LocalFanout` used in tests masks it entirely.

## Architecture

The document becomes a **materialized view of the shared ordered log**: every process self-subscribes to the fan-out and folds in *all* updates (its own + peers'), with a durable checkpoint so history outlives restarts and retention eviction.

```mermaid
flowchart TB
  subgraph web["WEB × N replicas (share ONE Fanout with the gateway)"]
    OD["on_data: apply + publish (+ reply for SyncStep1)"]
    AL["run_apply_loop (per topic):<br/>fold EVERY fanned-out Update → Doc"]
  end
  subgraph worker_future["(future) WORKER"]
    J["compaction job — dedup checkpoints"]
  end
  S[("CollabStore<br/>snapshot{blob, state_vector, last_seq}")]
  R[("Fanout / Redis stream<br/>MAXLEN ~1024")]
  OD -- publish --> R
  R -- "subscribe (peers' edits too)" --> AL
  AL -- apply --> D[("local Doc")]
  S -- "load on first subscriber" --> D
  AL -- "checkpoint every 64 (monotonic)" --> S
```

- **Convergence** — `CollabSync::new(fanout)` shares the gateway's fan-out and spawns one apply loop per topic. yrs idempotency makes re-applying our own publishes a no-op; peers' updates are folded the same way. Proven by two `CollabSync` over one `LocalFanout` (two simulated processes) converging.
- **Durability** — `.with_store(store)` loads the snapshot on the first subscriber (resuming the fan-out at `last_seq`) and checkpoints the folded doc every N updates (default 64, well under retention). `CollabStore` is keyed by topic string and is **monotonic** (a stale checkpoint can't roll `last_seq` back). `MemoryCollabStore` is dev-only; apps implement the trait for their DB.
- **Eviction** — a gateway per-`(topic, subprotocol)` subscriber refcount fires `on_topic_active` (0→1) / `on_topic_idle` (1→0); collab starts the loop on the first local subscriber and drops the doc on the last (reloads from the store next time). Memory is bounded to topics with active local clients.
- **Read-only access** — a gateway write policy → `InboundData.can_write`; the relay refuses writes and collab refuses `Update`/`SyncStep2` (and withholds the server's `SyncStep1`) for read-only connections.

## Commits

| Group | Commits |
| --- | --- |
| Toolchain | pin `nightly-2026-02-21` (if-let guards) + drift fixes; yrs `0.23→0.27` |
| Realtime hooks | per-sub-protocol inbound handler; subscriber-refcount topic lifecycle; read-only write policy |
| Collab core | sync handshake (increment 1+2); convergence apply loop; durable snapshots |
| Review fixes | broadcast every edit; monotonic cursor; abort loops on drop; atomic + sub-protocol-keyed lifecycle counts |

## Reviewed adversarially (`/code-review` xhigh) — 5 bugs caught + fixed

| # | Bug | Fix |
| --- | --- | --- |
| 1 | **Data-loss regression**: a "no-op" broadcast guard gated on the yrs state vector, but **deletes** (delete-set, not SV) and **out-of-order** updates (buffered pending) were applied locally yet never fanned out | Broadcast unconditionally after apply |
| 2 | Lifecycle race — handler notified *after* releasing the count lock → a live topic could be left with no apply loop | Notify inside the lock |
| 3 | Refcount keyed by `Topic` only → same topic under two sub-protocols leaked an apply loop | Key by `(Topic, subprotocol_id)` + rebalance |
| 4 | Durable cursor could regress (recovery replay / lagging replica) → restart into an evicted gap | Highest-seq checkpoint + monotonic `save_snapshot` |
| 5 | Apply loop leaked on non-eviction drop (detached, not aborted) | `impl Drop for TopicState` |

## Testing

- realtime: 33 unit + 8 e2e (handler interception, write policy, topic lifecycle).
- collab: 25 lib (handshake, both-ways convergence, **delete + out-of-order broadcast** regression guards, monotonic store, eviction reload) + 1 e2e over a real gateway.
- Gates: `cargo fmt --check`, the full `clippy --target wasm32` CI gate, and host clippy — all clean.

## Notes / follow-ups

- **Wire level unchanged** — the endpoint stays `/__pocopine/ws/v1`, sub-protocol `pocopine.ws.v1`.
- **Toolchain bump is workspace-wide** (`rust-toolchain.toml`) — needed for yrs 0.27; carries two mechanical rustfmt/clippy drift fixes.
- Open (not data loss): `#6` chunking (a single >1 MiB update), and per-process checkpoints are redundant — a worker compaction job behind the jobs `SETNX` lock would dedup + offload from web.
- **Next**: live-blocks document model + `pine-richtext` integration (separate PR after merge).
