### PR TITLE
feat(website): render Mermaid diagrams in the docs

### DIFF
--- a/examples/website/build.rs
+++ b/examples/website/build.rs
@@ -1323,10 +1323,22 @@ fn render(hl: &Hl, md: &str, page_path: &str) -> (String, Vec<(u8, String, Strin
                 i += 1;
             }
             i += 1; // skip End(CodeBlock)
-            let inner = hl.code(src.trim_end_matches('\n'), &lang);
-            out_events.push(Event::Html(CowStr::from(format!(
-                "<pre><code>{inner}</code></pre>"
-            ))));
+            let body = src.trim_end_matches('\n');
+            if lang.eq_ignore_ascii_case("mermaid") {
+                // Hand the raw diagram source to the client-side mermaid.js
+                // (see index.html). Escape it so `<br/>`, `-->`, `&` survive as
+                // text — mermaid reads `textContent`, which the browser
+                // un-escapes back to the literal source.
+                out_events.push(Event::Html(CowStr::from(format!(
+                    "<pre class=\"mermaid\">{}</pre>",
+                    esc(body)
+                ))));
+            } else {
+                let inner = hl.code(body, &lang);
+                out_events.push(Event::Html(CowStr::from(format!(
+                    "<pre><code>{inner}</code></pre>"
+                ))));
+            }
         } else {
             out_events.push(events[i].clone());
             i += 1;

--- a/examples/website/index.html
+++ b/examples/website/index.html
@@ -36,5 +36,68 @@
     import init from "/pkg/website.js";
     init();
   </script>
+
+  <!-- Mermaid diagram rendering for docs. The build emits fenced ```mermaid
+       blocks as <pre class="mermaid">…raw source…</pre> (see build.rs); this
+       renders them client-side. The SPA injects doc fragments after navigation,
+       so a MutationObserver re-renders whenever new diagrams appear, and a
+       second observer re-themes them when the site theme toggles. -->
+  <script type="module">
+    import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+
+    const mermaidTheme = () =>
+      document.documentElement.dataset.theme === "light" ? "neutral" : "dark";
+    const config = () => ({
+      startOnLoad: false,
+      securityLevel: "strict",
+      theme: mermaidTheme(),
+      fontFamily: "inherit",
+    });
+    mermaid.initialize(config());
+
+    // Render every not-yet-processed .mermaid node. Stash the raw source the
+    // first time so a theme change can re-render (mermaid replaces the text
+    // with an SVG once processed).
+    function render() {
+      const pending = [];
+      document.querySelectorAll("pre.mermaid").forEach((n) => {
+        if (n.dataset.src === undefined) n.dataset.src = n.textContent;
+        if (n.dataset.processed === undefined) pending.push(n);
+      });
+      if (pending.length) {
+        mermaid.run({ nodes: pending }).catch(() => {});
+      }
+    }
+
+    // Coalesce DOM mutations (SPA renders + mermaid's own SVG writes) to one
+    // render per frame.
+    let scheduled = false;
+    function schedule() {
+      if (scheduled) return;
+      scheduled = true;
+      requestAnimationFrame(() => {
+        scheduled = false;
+        render();
+      });
+    }
+    new MutationObserver(schedule).observe(document.body, { childList: true, subtree: true });
+
+    // Re-theme rendered diagrams when the site toggles light/dark: restore the
+    // stashed source, clear the processed flag, and re-run under the new theme.
+    new MutationObserver(() => {
+      mermaid.initialize(config());
+      document.querySelectorAll("pre.mermaid[data-processed]").forEach((n) => {
+        if (n.dataset.src !== undefined) {
+          n.removeAttribute("data-processed");
+          n.removeAttribute("aria-roledescription");
+          n.innerHTML = "";
+          n.textContent = n.dataset.src;
+        }
+      });
+      schedule();
+    }).observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] });
+
+    schedule();
+  </script>
 </body>
 </html>

--- a/examples/website/styles.css
+++ b/examples/website/styles.css
@@ -202,6 +202,27 @@ section {
   font-size: 0.82rem;
   line-height: 1.6;
 }
+/* Mermaid diagrams (rendered client-side from <pre class="mermaid">). Drop the
+   code-panel chrome and center the SVG; the panel surface fits the theme. */
+.doc-body pre.mermaid {
+  background: var(--bg-subtle);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  text-align: center;
+  line-height: normal;
+}
+.doc-body pre.mermaid svg {
+  max-width: 100%;
+  height: auto;
+}
+/* Before mermaid.js processes it, keep the raw source from flashing as a wall
+   of monospace text (it still renders if scripts are blocked, just plainer). */
+.doc-body pre.mermaid:not([data-processed]) {
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  color: var(--fg-muted, var(--fg));
+  white-space: pre-wrap;
+}
 .doc-body table {
   width: 100%;
   border-collapse: collapse;


### PR DESCRIPTION
Renders fenced ```mermaid blocks as diagrams across the docs site — the new agenkit guide plus existing jobs / sync / storage / layout pages that already authored mermaid but were showing it as highlighted code.

- **build.rs** — emit a `mermaid` fence as `<pre class="mermaid">` (HTML-escaped source) instead of syntect-highlighting it. Escaping is chosen so `<br/>`, `-->`, and `&lt;`/`&gt;` reach mermaid intact via `textContent`.
- **index.html** — load mermaid (ESM, pinned `@11`) and render `pre.mermaid` nodes via a MutationObserver, so the SPA-injected doc fragments render on navigation; a second observer re-themes diagrams (stashing the source) when the site toggles light/dark. `securityLevel: strict`, `fontFamily: inherit`.
- **styles.css** — drop the code-panel chrome for `.mermaid` and center the SVG.

`static-docs/` is a gitignored build artifact (regenerated by `build.rs`), so only source is committed. Regenerated fragments verified to carry one `<pre class="mermaid">` per diagram with correct escaping; the injected JS was syntax-checked.