### PR TITLE
docs(agenkit): fix Mermaid parse error in traceable-flows + entity co…

### DIFF
--- a/docs/guides/agenkit/README.md
+++ b/docs/guides/agenkit/README.md
@@ -14,13 +14,13 @@ principal-scoped tools.
 
 ```mermaid
 graph LR
-  app["#[server] fn<br/>(the endpoint)"] -->|active_plugin::&lt;Agenkit&gt;| AK["Agenkit"]
+  app["#[server] fn<br/>(the endpoint)"] -->|active_plugin::#lt;Agenkit#gt;| AK["Agenkit"]
   AK --> FL["flow(Marker)<br/>typed input/output"]
   FL --> CTX["AiFlowContext"]
   CTX --> AI["ctx.ai() · generate"]
   CTX --> ST["ctx.step() · custom work"]
-  CTX --> RT["ctx.retrieve::&lt;R&gt;()"]
-  CTX --> AG["ctx.agent::&lt;A&gt;() · tool loop"]
+  CTX --> RT["ctx.retrieve::#lt;R#gt;()"]
+  CTX --> AG["ctx.agent::#lt;A#gt;() · tool loop"]
   CTX --> PAR["ctx.parallel() · fan-out"]
   CTX --> RED["ctx.reduce() · fold/judge"]
   AK --> PV["Provider<br/>Anthropic · OpenAI"]

--- a/docs/guides/agenkit/retrieval.md
+++ b/docs/guides/agenkit/retrieval.md
@@ -16,7 +16,7 @@ A registered `AiRetriever` can be reached two ways, and the choice is about
 ```mermaid
 graph LR
   subgraph direct["Direct — flow decides"]
-    F["flow body"] -->|ctx.retrieve::&lt;Docs&gt;| R1["retrieve once,<br/>deterministic query"]
+    F["flow body"] -->|ctx.retrieve::#lt;Docs#gt;| R1["retrieve once,<br/>deterministic query"]
     R1 --> P["assemble prompt → ctx.ai()"]
   end
   subgraph tool["As a tool — model decides"]

--- a/docs/guides/agenkit/traceable-flows.md
+++ b/docs/guides/agenkit/traceable-flows.md
@@ -22,11 +22,11 @@ what it touches. This page is the contract (§D6).
 ```mermaid
 graph TB
   subgraph good["✅ through ctx — traced + principal-scoped"]
-    b1["ctx.retrieve::&lt;Docs&gt;()"] --> t1["ai_retrieval_started/completed"]
-    b2["ctx.state::&lt;Db&gt;(\"db\")"] --> t2["recorded vs manifest"]
+    b1["ctx.retrieve::#lt;Docs#gt;()"] --> t1["ai_retrieval_started/completed"]
+    b2["ctx.state::#lt;Db#gt;(#quot;db#quot;)"] --> t2["recorded vs manifest"]
   end
   subgraph bad["❌ raw read in the body — invisible"]
-    r1["sqlx::query(&amp;pool)"] -.->|no trace event| X1["not in the tree"]
+    r1["sqlx::query(#amp;pool)"] -.->|no trace event| X1["not in the tree"]
     r1 -.->|no identity| X2["not principal-scoped"]
   end
 ```

--- a/docs/guides/data/sync-server.md
+++ b/docs/guides/data/sync-server.md
@@ -442,7 +442,7 @@ shapes — pick the right one for your auth model:
 
 ```mermaid
 flowchart TD
-    Resource["SourceResource&lt;S, IdOf&gt;"]
+    Resource["SourceResource#lt;S, IdOf#gt;"]
     Public["SyncServerBuilder::public_stream(resource)"]
     Guarded["SyncServerBuilder::guarded_stream(resource, predicate)"]
     GuardedWith["SyncServerBuilder::guarded_stream_with(resource, guard)"]


### PR DESCRIPTION
…des in guides

The traceable-flows diagram used backslash-escaped quotes — ["...(\"db\")"] — but Mermaid has no \" escape, so the quoted label closed early and the whole diagram failed to parse.

Switch to Mermaid entity codes (#quot;), and across the agenkit guides + data/sync-server convert the HTML entities &lt;/&gt;/&amp; (which build.rs's esc() double-escapes into literal text) to #lt;/#gt;/#amp; so generics like <Docs> render correctly instead of showing the raw entity.

All 5 diagrams validated with mermaid-cli.