### PR TITLE
feat(agenkit): long-lived conversational agent runtime (kitty Layer 2)

### DIFF
--- a/crates/pocopine-agenkit/src/server/agent.rs
+++ b/crates/pocopine-agenkit/src/server/agent.rs
@@ -404,21 +404,51 @@ async fn maybe_compact<A: AiAgent>(
     cx: &ProviderContext,
     thread: &AgentThreadHandle,
 ) -> AgenkitResult<()> {
+    let max_output = config.max_tokens.unwrap_or(1024);
+    if let Some((folded, kept)) = compact_thread(thread, model, provider, cx, max_output).await? {
+        run.emit(
+            run.event(
+                events::AI_THREAD_CHECKPOINTED,
+                StepKind::Custom,
+                StepStatus::Completed,
+            )
+            .with_field("thread_id", thread.id().as_str())
+            .with_field("agent_id", A::ID)
+            .with_field("compacted_messages", folded)
+            .with_field("kept_verbatim", kept),
+        );
+    }
+    Ok(())
+}
+
+/// Compact a thread if its active history would overflow the model's window
+/// (consumes the W3 headroom signal → writes a W7 checkpoint). Keeps the recent
+/// tail verbatim (token-bounded) and folds the older prefix into one summary.
+/// Returns `Some((folded, kept))` when it summarized, `None` otherwise.
+///
+/// Shared by the single-shot agent loop ([`maybe_compact`]) and the long-lived
+/// runtime ([`super::runtime`]); the caller emits its own checkpoint event.
+pub(crate) async fn compact_thread(
+    thread: &AgentThreadHandle,
+    model: &ModelRef,
+    provider: &Arc<dyn Provider>,
+    cx: &ProviderContext,
+    max_output: u32,
+) -> AgenkitResult<Option<(u64, u64)>> {
     // Without catalog metadata we can't size the window — skip (degrade, no error).
     let Some(catalog_model) = super::catalog::lookup(model) else {
-        return Ok(());
+        return Ok(None);
     };
     let history = thread.active_history().await?;
     if history.len() < 4 {
-        return Ok(()); // nothing meaningful to summarize yet
+        return Ok(None); // nothing meaningful to summarize yet
     }
     let messages: Vec<Message> = history
         .iter()
         .map(|m| Message::new(m.role, m.content.clone()))
         .collect();
-    let max_output = config.max_tokens.unwrap_or(1024);
     if !context_headroom(catalog_model, &messages, max_output).over {
-        return Ok(()); // still fits — no compaction
+        return Ok(None); // still fits — no compaction
     }
 
     // Keep the recent tail verbatim (token-bounded — see `recent_keep_count`),
@@ -432,21 +462,11 @@ async fn maybe_compact<A: AiAgent>(
         .collect::<Vec<_>>()
         .join("\n");
     let summary = summarize(transcript, model, provider, cx).await?;
+    let (folded, kept) = (older.len() as u64, recent.len() as u64);
     thread
         .checkpoint(ThreadMessage::new(Role::System, summary), recent.to_vec())
         .await?;
-    run.emit(
-        run.event(
-            events::AI_THREAD_CHECKPOINTED,
-            StepKind::Custom,
-            StepStatus::Completed,
-        )
-        .with_field("thread_id", thread.id().as_str())
-        .with_field("agent_id", A::ID)
-        .with_field("compacted_messages", older.len() as u64)
-        .with_field("kept_verbatim", recent.len() as u64),
-    );
-    Ok(())
+    Ok(Some((folded, kept)))
 }
 
 /// The token budget for the recent tail [`maybe_compact`] keeps verbatim. Older

--- a/crates/pocopine-agenkit/src/server/agent.rs
+++ b/crates/pocopine-agenkit/src/server/agent.rs
@@ -16,6 +16,7 @@ use serde::Serialize;
 use serde::de::DeserializeOwned;
 
 use super::context::AiContext;
+use super::loop_core::{self, ToolErrorMode};
 use super::overflow::{context_headroom, estimate_input_tokens};
 use super::provider::{GenerateRequest, Provider, ProviderContext};
 use super::run::RunState;
@@ -261,6 +262,15 @@ async fn run_loop<A: AiAgent>(
         super::provider::ProviderContext::for_request(credential)
     };
 
+    // The shared loop core projects each step onto a `LoopObserver`; for the
+    // typed run that's the trace projection (model request/response + usage, tool
+    // spans), all parented to this agent step.
+    let observer = loop_core::TraceObserver {
+        run,
+        agent_step: agent_step.clone(),
+    };
+    let agent_label = format!("agent `{}`", A::ID);
+
     for _ in 0..config.max_steps {
         let request = GenerateRequest {
             model: model.clone(),
@@ -273,37 +283,7 @@ async fn run_loop<A: AiAgent>(
             // generate builder); defaults to `ThinkingLevel::Off`.
             thinking: Default::default(),
         };
-
-        let model_step = run.next_step_id();
-        run.emit(
-            run.event(
-                events::AI_MODEL_REQUEST,
-                StepKind::Generation,
-                StepStatus::Started,
-            )
-            .with_step(model_step.clone())
-            .with_parent(agent_step.clone())
-            .with_model(model.clone()),
-        );
-        // Reclassify an "input too long" provider error as ContextOverflow (W3),
-        // so callers/UI can branch on the kind — parity with the `Ai` paths.
-        let response = provider
-            .generate(request, &cx)
-            .await
-            .map_err(super::generate::reclassify_overflow)?;
-        let mut completed = run
-            .event(
-                events::AI_MODEL_RESPONSE,
-                StepKind::Generation,
-                StepStatus::Completed,
-            )
-            .with_step(model_step)
-            .with_parent(agent_step.clone())
-            .with_model(model.clone());
-        if let Some(usage) = response.usage {
-            completed = completed.with_usage(usage);
-        }
-        run.emit(completed);
+        let response = loop_core::run_model_step(provider, request, &cx, model, &observer).await?;
 
         if response.tool_calls.is_empty() {
             let value = response
@@ -340,49 +320,23 @@ async fn run_loop<A: AiAgent>(
             return Ok(output);
         }
 
-        // Record the assistant's tool-request turn so the next request carries
-        // the protocol linkage real providers (OpenAI, ...) require — keeping
-        // any text the model emitted alongside the calls.
-        messages.push(Message::assistant_tool_calls(
-            response.content.clone(),
-            response.tool_calls.clone(),
-        ));
-
-        for call in &response.tool_calls {
-            // Enforce the agent's explicit tool allowlist (§D5/§D10).
-            if !config.tool_ids.iter().any(|id| id == &call.tool_id) {
-                return Err(AgenkitError::tool_policy(format!(
-                    "agent `{}` called non-allowlisted tool `{}`",
-                    A::ID,
-                    call.tool_id
-                )));
-            }
-            let tool = run.inner.tools.get(&call.tool_id).ok_or_else(|| {
-                AgenkitError::tool_policy(format!("tool `{}` is not registered", call.tool_id))
-            })?;
-            let tool_step = run.next_step_id();
-            run.emit(
-                run.event(events::AI_TOOL_STARTED, StepKind::Tool, StepStatus::Started)
-                    .with_step(tool_step.clone())
-                    .with_parent(agent_step.clone())
-                    .with_field("tool_id", call.tool_id.clone()),
-            );
-            let output = tool.call_json(call.args.clone(), ctx.clone()).await?;
-            run.emit(
-                run.event(
-                    events::AI_TOOL_COMPLETED,
-                    StepKind::Tool,
-                    StepStatus::Completed,
-                )
-                .with_step(tool_step)
-                .with_parent(agent_step.clone())
-                .with_field("tool_id", call.tool_id.clone()),
-            );
-            let output_json = serde_json::to_string(&output).map_err(|e| {
-                AgenkitError::internal(format!("tool `{}` output encode: {e}", call.tool_id))
-            })?;
-            messages.push(Message::tool_result(call.id.clone(), output_json));
-        }
+        // Run the tool batch via the shared dispatcher. A tool error propagates
+        // (a typed run fails as a whole); no `before_tool_call` hook on this path.
+        messages.extend(
+            loop_core::dispatch_tool_calls(
+                &run.inner,
+                &config.tool_ids,
+                &ctx,
+                &response,
+                &agent_label,
+                // No steering hook on the typed run; `+ Sync` keeps the loop's
+                // future `Send` (it runs inside Send flow handlers).
+                None::<&(dyn Fn(&str, &serde_json::Value) -> loop_core::ToolDecision + Sync)>,
+                ToolErrorMode::Propagate,
+                &observer,
+            )
+            .await?,
+        );
     }
 
     Err(AgenkitError::budget_exhausted(format!(

--- a/crates/pocopine-agenkit/src/server/loop_core.rs
+++ b/crates/pocopine-agenkit/src/server/loop_core.rs
@@ -1,0 +1,271 @@
+//! Shared model↔tool **loop primitives** used by BOTH the single-shot typed
+//! agent loop ([`run_loop`](super::agent)) and the long-lived conversational
+//! runtime ([`AgentLoop`](super::runtime)).
+//!
+//! The two loops differ in *lifecycle* (one typed `input → output` run vs. a
+//! persistent conversation) and in *termination* (structured output vs. idle /
+//! steering) — but a single **step** is identical: build the request, call the
+//! model (emitting the request/response trace + token usage), then dispatch the
+//! tool batch (allowlist, `before_tool_call` hook, execute, feed back). Those
+//! mechanics live here once, parameterized by a [`LoopObserver`] so each loop
+//! projects the same step onto its own surface: the typed run emits only
+//! `pocopine.trace` events ([`TraceObserver`]); the runtime emits the
+//! [`AgentEvent`](super::runtime::AgentEvent) firehose *and* the same trace (its
+//! observer wraps a [`TraceObserver`]) — which is how conversational turns get
+//! cost/usage metering, closing the formerly-duplicated loops.
+
+use std::sync::Arc;
+
+use pocopine_agenkit_core::{
+    AgenkitError, AgenkitResult, Message, ModelRef, StepId, StepKind, StepStatus, ToolCall, Usage,
+    events,
+};
+
+use super::agenkit::AgenkitInner;
+use super::context::AiContext;
+use super::provider::{GenerateRequest, GenerateResponse, Provider, ProviderContext};
+use super::run::RunState;
+
+/// A `before_tool_call` hook's decision for one tool call (L3). Mirrors the
+/// (parked) WIT `hook-decision` so the extension world projects onto it.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub enum ToolDecision {
+    /// Run the tool with its requested arguments.
+    Proceed,
+    /// Don't run the tool; feed `reason` back to the model (an approval/trust
+    /// gate, or a policy block).
+    Block {
+        /// Why the call is blocked.
+        reason: String,
+    },
+    /// Run the tool, but with these arguments instead (e.g. inject a sandbox
+    /// path, redact a field).
+    ReplaceArgs {
+        /// The arguments to use.
+        args: serde_json::Value,
+    },
+}
+
+/// How the loop reacts to a tool returning an error.
+#[derive(Clone, Copy)]
+pub(crate) enum ToolErrorMode {
+    /// Propagate it — aborts the loop. The single-shot typed run uses this: a
+    /// tool error means the run as a whole failed.
+    Propagate,
+    /// Feed the error back to the model as the tool result so it can recover.
+    /// The conversational runtime uses this: one bad call shouldn't kill a long
+    /// session (it's bounded by the per-turn step budget).
+    FeedBack,
+}
+
+/// The observable points of one model↔tool step. Each loop implements only the
+/// surface it has — the default no-ops let the typed run skip the
+/// firehose-specific points (it propagates tool errors and has no hooks, so
+/// `tool_failed`/`tool_blocked` never fire). The [`StepId`] returned by
+/// `model_request`/`tool_started` is paired back into the matching
+/// `model_response`/`tool_completed` so a tracer can span the call.
+pub(crate) trait LoopObserver {
+    /// A model request is about to go out; returns the trace step it opened.
+    fn model_request(&self, _model: &ModelRef) -> Option<StepId> {
+        None
+    }
+    /// The model responded (`usage` = token accounting, if the provider gave it).
+    fn model_response(&self, _step: Option<StepId>, _model: &ModelRef, _usage: Option<Usage>) {}
+    /// A tool is about to run; returns the trace step it opened.
+    fn tool_started(&self, _call: &ToolCall) -> Option<StepId> {
+        None
+    }
+    /// A tool returned successfully.
+    fn tool_completed(&self, _step: Option<StepId>, _call: &ToolCall, _output: &serde_json::Value) {
+    }
+    /// A tool failed (its error is fed back to the model under [`ToolErrorMode::FeedBack`]).
+    fn tool_failed(&self, _call: &ToolCall, _error: &str) {}
+    /// A `before_tool_call` hook blocked a tool (its reason replaces the result).
+    fn tool_blocked(&self, _call: &ToolCall, _reason: &str) {}
+}
+
+/// Call the model for one step: emit the request span, generate (reclassifying an
+/// "input too long" provider error as `ContextOverflow`, W3), then emit the
+/// response span with token usage. Returns the raw response; the *caller* decides
+/// termination (structured output vs. idle/steer) and surfaces any assistant text.
+pub(crate) async fn run_model_step(
+    provider: &Arc<dyn Provider>,
+    request: GenerateRequest,
+    cx: &ProviderContext,
+    model: &ModelRef,
+    // `+ Sync`: the reference is held across the model `.await` inside a turn that
+    // runs on a spawned (Send) task, so the observer must be shareable.
+    observer: &(dyn LoopObserver + Sync),
+) -> AgenkitResult<GenerateResponse> {
+    let step = observer.model_request(model);
+    let response = provider
+        .generate(request, cx)
+        .await
+        .map_err(super::generate::reclassify_overflow)?;
+    observer.model_response(step, model, response.usage);
+    Ok(response)
+}
+
+/// Dispatch one assistant turn's tool calls. Records the assistant tool-request
+/// message (keeping the provider protocol linkage real providers require on the
+/// next request), then for each call: enforce the allowlist, run the
+/// `before_tool_call` hook (block / replace), and execute — appending each tool
+/// result. Returns the messages to append to the transcript. A tool error follows
+/// `error_mode`. `agent_label` prefixes the allowlist-violation error (e.g.
+/// ``agent `weather` `` for the typed run, `agent` for the runtime).
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn dispatch_tool_calls<H>(
+    inner: &Arc<AgenkitInner>,
+    allowlist: &[String],
+    ctx: &AiContext,
+    response: &GenerateResponse,
+    agent_label: &str,
+    before_tool_call: Option<&H>,
+    error_mode: ToolErrorMode,
+    observer: &(dyn LoopObserver + Sync),
+) -> AgenkitResult<Vec<Message>>
+where
+    H: Fn(&str, &serde_json::Value) -> ToolDecision + ?Sized,
+{
+    let mut out = Vec::with_capacity(response.tool_calls.len() + 1);
+    // The assistant's tool-request turn — kept (with any text the model emitted
+    // alongside the calls) so the next request carries the protocol linkage.
+    out.push(Message::assistant_tool_calls(
+        response.content.clone(),
+        response.tool_calls.clone(),
+    ));
+
+    for call in &response.tool_calls {
+        // Enforce the explicit tool allowlist (§D5/§D10).
+        if !allowlist.iter().any(|id| id == &call.tool_id) {
+            return Err(AgenkitError::tool_policy(format!(
+                "{agent_label} called non-allowlisted tool `{}`",
+                call.tool_id
+            )));
+        }
+        let tool = inner.tools.get(&call.tool_id).ok_or_else(|| {
+            AgenkitError::tool_policy(format!("tool `{}` is not registered", call.tool_id))
+        })?;
+        let step = observer.tool_started(call);
+
+        // `before_tool_call` hook (L3): block (approval/trust gate) or replace the
+        // arguments before running. Absent on the typed run (`None`).
+        let decision = before_tool_call
+            .map(|hook| hook(&call.tool_id, &call.args))
+            .unwrap_or(ToolDecision::Proceed);
+
+        let result_text = match decision {
+            ToolDecision::Block { reason } => {
+                observer.tool_blocked(call, &reason);
+                serde_json::json!({ "blocked": reason }).to_string()
+            }
+            decision => {
+                let args = match decision {
+                    ToolDecision::ReplaceArgs { args } => args,
+                    _ => call.args.clone(),
+                };
+                match tool.call_json(args, ctx.clone()).await {
+                    Ok(output) => {
+                        observer.tool_completed(step, call, &output);
+                        serde_json::to_string(&output).map_err(|e| {
+                            AgenkitError::internal(format!(
+                                "tool `{}` output encode: {e}",
+                                call.tool_id
+                            ))
+                        })?
+                    }
+                    Err(error) => match error_mode {
+                        ToolErrorMode::Propagate => return Err(error),
+                        ToolErrorMode::FeedBack => {
+                            let kind = error.to_string();
+                            observer.tool_failed(call, &kind);
+                            serde_json::json!({ "error": kind }).to_string()
+                        }
+                    },
+                }
+            }
+        };
+        out.push(Message::tool_result(call.id.clone(), result_text));
+    }
+    Ok(out)
+}
+
+/// A [`LoopObserver`] that emits the `pocopine.trace` step events for one agent
+/// step — the model request/response (with token usage) and tool start/complete
+/// spans, all parented to the enclosing agent step. Shared by the typed run and
+/// (wrapped) the runtime, so trace emission lives in exactly one place.
+pub(crate) struct TraceObserver<'a> {
+    pub(crate) run: &'a Arc<RunState>,
+    pub(crate) agent_step: StepId,
+}
+
+impl LoopObserver for TraceObserver<'_> {
+    fn model_request(&self, model: &ModelRef) -> Option<StepId> {
+        let step = self.run.next_step_id();
+        self.run.emit(
+            self.run
+                .event(
+                    events::AI_MODEL_REQUEST,
+                    StepKind::Generation,
+                    StepStatus::Started,
+                )
+                .with_step(step.clone())
+                .with_parent(self.agent_step.clone())
+                .with_model(model.clone()),
+        );
+        Some(step)
+    }
+
+    fn model_response(&self, step: Option<StepId>, model: &ModelRef, usage: Option<Usage>) {
+        let mut completed = self
+            .run
+            .event(
+                events::AI_MODEL_RESPONSE,
+                StepKind::Generation,
+                StepStatus::Completed,
+            )
+            .with_parent(self.agent_step.clone())
+            .with_model(model.clone());
+        if let Some(step) = step {
+            completed = completed.with_step(step);
+        }
+        if let Some(usage) = usage {
+            completed = completed.with_usage(usage);
+            // Resolve the catalog-derived cost (W2) so agent/conversational turns
+            // are *metered*, not just token-counted — parity with the `Ai` path.
+            if let Some(meta) = super::catalog::lookup(model) {
+                completed = completed.with_cost(meta.estimate_cost(&usage));
+            }
+        }
+        self.run.emit(completed);
+    }
+
+    fn tool_started(&self, call: &ToolCall) -> Option<StepId> {
+        let step = self.run.next_step_id();
+        self.run.emit(
+            self.run
+                .event(events::AI_TOOL_STARTED, StepKind::Tool, StepStatus::Started)
+                .with_step(step.clone())
+                .with_parent(self.agent_step.clone())
+                .with_field("tool_id", call.tool_id.clone()),
+        );
+        Some(step)
+    }
+
+    fn tool_completed(&self, step: Option<StepId>, call: &ToolCall, _output: &serde_json::Value) {
+        let mut completed = self
+            .run
+            .event(
+                events::AI_TOOL_COMPLETED,
+                StepKind::Tool,
+                StepStatus::Completed,
+            )
+            .with_parent(self.agent_step.clone())
+            .with_field("tool_id", call.tool_id.clone());
+        if let Some(step) = step {
+            completed = completed.with_step(step);
+        }
+        self.run.emit(completed);
+    }
+}

--- a/crates/pocopine-agenkit/src/server/mod.rs
+++ b/crates/pocopine-agenkit/src/server/mod.rs
@@ -64,7 +64,7 @@ pub use provider::{
 pub use reduce::ReduceBuilder;
 pub use retrieval::{AiRetriever, DynRetriever, RetrieverRegistry, retriever_as_tool};
 pub use runtime::{
-    AbortHandle, AgentConfig, AgentEvent, AgentLoop, AgentSession, AgentSessionBuilder, StopReason,
+    AbortHandle, AgentConfig, AgentEvent, AgentSession, AgentSessionBuilder, StopReason,
     ToolDecision,
 };
 pub use thread::{

--- a/crates/pocopine-agenkit/src/server/mod.rs
+++ b/crates/pocopine-agenkit/src/server/mod.rs
@@ -64,7 +64,8 @@ pub use provider::{
 pub use reduce::ReduceBuilder;
 pub use retrieval::{AiRetriever, DynRetriever, RetrieverRegistry, retriever_as_tool};
 pub use runtime::{
-    AgentConfig, AgentEvent, AgentLoop, AgentSession, AgentSessionBuilder, StopReason,
+    AbortHandle, AgentConfig, AgentEvent, AgentLoop, AgentSession, AgentSessionBuilder, StopReason,
+    ToolDecision,
 };
 pub use thread::{
     AgentThreadHandle, AgentThreadStore, SessionThreadStore, ThreadBuilder, ThreadOwner,

--- a/crates/pocopine-agenkit/src/server/mod.rs
+++ b/crates/pocopine-agenkit/src/server/mod.rs
@@ -25,6 +25,10 @@ pub mod provider;
 pub mod reduce;
 pub mod retrieval;
 pub mod run;
+/// The long-lived, multi-turn agent runtime (Layer 2): a conversational
+/// `AgentSession` over the W7 session layer, with a typed event firehose and
+/// (L3) steering hooks.
+pub mod runtime;
 mod schema;
 /// Durable, branchable conversation sessions (roadmap W7) — a single-writer
 /// append-only event log with parent-pointer forks and compaction checkpoints.
@@ -59,6 +63,9 @@ pub use provider::{
 };
 pub use reduce::ReduceBuilder;
 pub use retrieval::{AiRetriever, DynRetriever, RetrieverRegistry, retriever_as_tool};
+pub use runtime::{
+    AgentConfig, AgentEvent, AgentLoop, AgentSession, AgentSessionBuilder, StopReason,
+};
 pub use thread::{
     AgentThreadHandle, AgentThreadStore, SessionThreadStore, ThreadBuilder, ThreadOwner,
 };

--- a/crates/pocopine-agenkit/src/server/mod.rs
+++ b/crates/pocopine-agenkit/src/server/mod.rs
@@ -15,6 +15,10 @@ pub mod credentials;
 pub mod embed;
 pub mod flow;
 pub mod generate;
+/// Shared model↔tool loop primitives (the model call + tool dispatch + a trace
+/// observer) used by both the single-shot typed agent loop and the long-lived
+/// runtime, so the engine lives once and both lifecycles emit the same trace.
+mod loop_core;
 pub mod oauth;
 pub mod observe;
 pub mod overflow;

--- a/crates/pocopine-agenkit/src/server/runtime.rs
+++ b/crates/pocopine-agenkit/src/server/runtime.rs
@@ -1,0 +1,709 @@
+//! The long-lived, multi-turn **agent runtime** (the `kitty` runtime — Layer 2 /
+//! pi's `pi-agent-core`).
+//!
+//! agenkit's [`AgentRun`](super::agent::AgentRun) is a *single-shot, flow-scoped*
+//! loop: typed `input → run → typed output`, inside one request. This module is
+//! the **conversational** counterpart: an [`AgentSession`] you `open` once and
+//! [`prompt`](AgentSession::prompt) over time, watching a typed [`AgentEvent`]
+//! stream and (L3) steering it with hooks. It runs on the **W7 session layer**
+//! ([`super::session`]) for durability, branching, and resume.
+//!
+//! Layering of this build: **L1** = the loop core ([`AgentLoop`]) + the event
+//! firehose; **L2** = durable [`AgentSession`] (resume / branch / compaction);
+//! **L3** = steering queue + typed hooks + abort. The event/decision types are
+//! shaped to **pre-image the WASM/WIT extension world** (parked) so extensions
+//! later plug into a contract that already exists here.
+
+use std::sync::Arc;
+
+use pocopine_agenkit_core::{
+    AgenkitError, AgenkitResult, AgentThreadId, Message, ModelRef, Role, ThreadMessage,
+    ThreadRetention, ToolDescriptor,
+};
+use pocopine_auth::Principal;
+use tokio::sync::mpsc::{UnboundedSender, unbounded_channel};
+use tokio_stream::wrappers::UnboundedReceiverStream;
+
+use super::agenkit::{Agenkit, AgenkitInner};
+use super::context::AiContext;
+use super::provider::{GenerateRequest, ProviderContext};
+use super::thread::{AgentThreadHandle, ThreadOwner};
+
+/// How a [`prompt`](AgentSession::prompt) turn ended.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum StopReason {
+    /// The model answered with no tool calls (and no queued follow-up) — the
+    /// conversation is idle, waiting for the next prompt.
+    Idle,
+    /// The per-turn model↔tool step budget was hit.
+    MaxSteps,
+    // L3 adds: `Terminated` (a tool requested stop) and `Aborted`.
+}
+
+/// A host-side firehose event from a running turn. Richer than the redacted
+/// wire [`FlowStreamEvent`](pocopine_agenkit_core::FlowStreamEvent) — this is the
+/// **trusted, in-process** view (a dev observing the agent). The variants mirror
+/// the (parked) `pocopine:agent/extension` WIT `agent-event` so the extension
+/// world is a projection of this contract.
+#[derive(Clone, Debug)]
+pub enum AgentEvent {
+    /// A prompt was accepted; the loop begins.
+    Started,
+    /// A model text response within the turn (may precede tool calls).
+    AssistantText {
+        /// The assistant's text.
+        text: String,
+    },
+    /// A tool call is about to run.
+    ToolStarted {
+        /// The provider's call id.
+        id: String,
+        /// The tool's registry id.
+        tool: String,
+        /// The call arguments.
+        args: serde_json::Value,
+    },
+    /// A tool call returned.
+    ToolCompleted {
+        /// The provider's call id.
+        id: String,
+        /// The tool's registry id.
+        tool: String,
+        /// The tool's output.
+        output: serde_json::Value,
+    },
+    /// A tool call failed; the error is fed back to the model (the loop
+    /// continues) rather than aborting the conversation.
+    ToolFailed {
+        /// The provider's call id.
+        id: String,
+        /// The tool's registry id.
+        tool: String,
+        /// The error (stable kind/text — no provider internals).
+        error: String,
+    },
+    /// The thread was compacted (L2): `folded` older messages → one summary.
+    Compacted {
+        /// How many messages were folded into the summary.
+        folded: u64,
+    },
+    /// Terminal: the turn finished successfully.
+    Stopped {
+        /// Why the turn ended.
+        reason: StopReason,
+    },
+    /// Terminal: the turn failed.
+    Failed {
+        /// The error kind/message.
+        error: String,
+    },
+}
+
+/// Configuration for a conversational agent: the same knobs as
+/// [`AiAgentBuilder`](super::agent::AiAgentBuilder) minus typed I/O (the runtime
+/// is a free-text conversation, not a typed flow unit).
+#[derive(Clone, Debug, Default)]
+pub struct AgentConfig {
+    pub(crate) model: Option<ModelRef>,
+    pub(crate) system: Option<String>,
+    pub(crate) tool_ids: Vec<String>,
+    pub(crate) max_tokens: Option<u32>,
+    pub(crate) max_steps_per_turn: u32,
+}
+
+impl AgentConfig {
+    /// A config with the default per-turn step budget (8).
+    pub fn new() -> Self {
+        Self {
+            max_steps_per_turn: 8,
+            ..Self::default()
+        }
+    }
+
+    /// Set the model (defaults to the runtime default).
+    pub fn model(mut self, model: impl Into<ModelRef>) -> Self {
+        self.model = Some(model.into());
+        self
+    }
+
+    /// Set the system prompt.
+    pub fn system(mut self, system: impl Into<String>) -> Self {
+        self.system = Some(system.into());
+        self
+    }
+
+    /// Allow several tools (by registry id).
+    pub fn tools<I, S>(mut self, ids: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.tool_ids.extend(ids.into_iter().map(Into::into));
+        self
+    }
+
+    /// Cap output tokens per model call.
+    pub fn max_tokens(mut self, max_tokens: u32) -> Self {
+        self.max_tokens = Some(max_tokens);
+        self
+    }
+
+    /// Bound the model↔tool steps *within one turn* (default 8). A turn ends
+    /// early when the model stops calling tools; this is the runaway guard.
+    pub fn max_steps_per_turn(mut self, steps: u32) -> Self {
+        self.max_steps_per_turn = steps.max(1);
+        self
+    }
+}
+
+/// The in-memory conversational loop core (L1). It owns no durable state — it
+/// runs one model↔tool turn over a `messages` transcript, emitting
+/// [`AgentEvent`]s, and returns where it stopped. [`AgentSession`] (L2) wraps it
+/// with a W7 session; [`AgentLoop`] is reusable on its own for tests / embedding.
+pub struct AgentLoop {
+    inner: Arc<AgenkitInner>,
+    principal: Principal,
+    config: AgentConfig,
+}
+
+impl AgentLoop {
+    pub(crate) fn new(inner: Arc<AgenkitInner>, principal: Principal, config: AgentConfig) -> Self {
+        Self {
+            inner,
+            principal,
+            config,
+        }
+    }
+
+    /// The resolved model for this loop (config override, else runtime default).
+    fn model(&self) -> AgenkitResult<ModelRef> {
+        self.config
+            .model
+            .clone()
+            .or_else(|| self.inner.default_model.clone())
+            .ok_or_else(|| AgenkitError::config("agent runtime has no model"))
+    }
+
+    /// Run one turn over `messages` (which must already include the new user
+    /// prompt as its last message): call the model, run any tool calls, re-enter,
+    /// and stop when the model answers without tool calls or the step budget is
+    /// hit. Appends every produced message (assistant text, tool-call turns, tool
+    /// results) to `messages`, emits events, and returns the [`StopReason`].
+    pub(crate) async fn run_turn(
+        &self,
+        messages: &mut Vec<Message>,
+        events: &UnboundedSender<AgentEvent>,
+    ) -> AgenkitResult<StopReason> {
+        let model = self.model()?;
+        self.inner.check_model_allowed(&model)?;
+        let provider = self.inner.providers.resolve(&model)?;
+
+        let tools: Vec<ToolDescriptor> = self
+            .config
+            .tool_ids
+            .iter()
+            .filter_map(|id| self.inner.tools.get(id).map(|t| t.descriptor()))
+            .collect();
+        if !tools.is_empty() && !provider.capabilities().tools {
+            return Err(AgenkitError::config(format!(
+                "provider `{}` does not support tool calling",
+                provider.id()
+            )));
+        }
+
+        // Tool-execution context + a credential resolved once for the turn (W6).
+        let ctx = AiContext::with_principal(self.inner.state.clone(), self.principal.clone());
+        let cx = {
+            let credential = self
+                .inner
+                .credentials
+                .resolve(provider.id(), &self.principal)
+                .await?;
+            ProviderContext::for_request(credential)
+        };
+
+        for _ in 0..self.config.max_steps_per_turn {
+            let request = GenerateRequest {
+                model: model.clone(),
+                system: self.config.system.clone(),
+                messages: messages.clone(),
+                tools: tools.clone(),
+                json_schema: None, // conversational: free text, not structured output
+                max_tokens: self.config.max_tokens,
+                thinking: Default::default(),
+            };
+            let response = provider
+                .generate(request, &cx)
+                .await
+                .map_err(super::generate::reclassify_overflow)?;
+
+            let text = response.text_output();
+            if !text.is_empty() {
+                let _ = events.send(AgentEvent::AssistantText { text: text.clone() });
+            }
+
+            if response.tool_calls.is_empty() {
+                // The model answered — the turn is done. Persist the assistant's
+                // text so the conversation replays on resume.
+                messages.push(Message::new(Role::Assistant, text));
+                return Ok(StopReason::Idle);
+            }
+
+            // Record the assistant's tool-request turn (keeps the provider's
+            // protocol linkage that real providers require on the next request).
+            messages.push(Message::assistant_tool_calls(
+                response.content.clone(),
+                response.tool_calls.clone(),
+            ));
+
+            for call in &response.tool_calls {
+                if !self.config.tool_ids.iter().any(|id| id == &call.tool_id) {
+                    return Err(AgenkitError::tool_policy(format!(
+                        "agent called non-allowlisted tool `{}`",
+                        call.tool_id
+                    )));
+                }
+                let tool = self.inner.tools.get(&call.tool_id).ok_or_else(|| {
+                    AgenkitError::tool_policy(format!("tool `{}` is not registered", call.tool_id))
+                })?;
+                let _ = events.send(AgentEvent::ToolStarted {
+                    id: call.id.clone(),
+                    tool: call.tool_id.clone(),
+                    args: call.args.clone(),
+                });
+                // A tool failure is fed back to the model (so it can recover),
+                // not propagated — a long conversation shouldn't die on one bad
+                // tool call. The runaway case is bounded by `max_steps_per_turn`.
+                let result_text = match tool.call_json(call.args.clone(), ctx.clone()).await {
+                    Ok(output) => {
+                        let _ = events.send(AgentEvent::ToolCompleted {
+                            id: call.id.clone(),
+                            tool: call.tool_id.clone(),
+                            output: output.clone(),
+                        });
+                        serde_json::to_string(&output).map_err(|e| {
+                            AgenkitError::internal(format!(
+                                "tool `{}` output encode: {e}",
+                                call.tool_id
+                            ))
+                        })?
+                    }
+                    Err(error) => {
+                        let kind = error.to_string();
+                        let _ = events.send(AgentEvent::ToolFailed {
+                            id: call.id.clone(),
+                            tool: call.tool_id.clone(),
+                            error: kind.clone(),
+                        });
+                        serde_json::json!({ "error": kind }).to_string()
+                    }
+                };
+                messages.push(Message::tool_result(call.id.clone(), result_text));
+            }
+        }
+
+        Ok(StopReason::MaxSteps)
+    }
+}
+
+/// A long-lived, durable conversational agent (L2). Built on the W7 session
+/// layer: `open` (or resume) once, then [`prompt`](AgentSession::prompt) over
+/// time. Each prompt loads the compacted history, runs one turn via
+/// [`AgentLoop`], persists the user + assistant messages, and compacts if the
+/// window would overflow — all owner-scoped, durable, and forkable.
+#[derive(Clone)]
+pub struct AgentSession {
+    inner: Arc<AgenkitInner>,
+    principal: Principal,
+    config: AgentConfig,
+    thread: AgentThreadHandle,
+    agent_id: String,
+}
+
+impl AgentSession {
+    /// Begin building a session over `agenkit`'s runtime.
+    pub fn builder(agenkit: &Agenkit) -> AgentSessionBuilder {
+        AgentSessionBuilder {
+            inner: agenkit.inner.clone(),
+            principal: Principal::anonymous(),
+            config: AgentConfig::new(),
+            agent_id: "kitty".to_string(),
+        }
+    }
+
+    /// The durable thread id (persist this to resume the conversation later).
+    pub fn id(&self) -> &AgentThreadId {
+        self.thread.id()
+    }
+
+    /// The full stored conversation (every turn, pre-compaction view).
+    pub async fn history(&self) -> AgenkitResult<Vec<ThreadMessage>> {
+        self.thread.history().await
+    }
+
+    /// Prompt the conversation: run one turn and stream its [`AgentEvent`]s. The
+    /// turn runs on a spawned task; drain the returned stream to observe it. The
+    /// terminal event is [`AgentEvent::Stopped`] (success) or
+    /// [`AgentEvent::Failed`].
+    pub fn prompt(&self, text: impl Into<String>) -> UnboundedReceiverStream<AgentEvent> {
+        let (tx, rx) = unbounded_channel();
+        let session = self.clone();
+        let text = text.into();
+        tokio::spawn(async move {
+            let _ = tx.send(AgentEvent::Started);
+            match session.run_one_prompt(text, &tx).await {
+                Ok(reason) => {
+                    let _ = tx.send(AgentEvent::Stopped { reason });
+                }
+                Err(error) => {
+                    let _ = tx.send(AgentEvent::Failed {
+                        error: error.to_string(),
+                    });
+                }
+            }
+        });
+        UnboundedReceiverStream::new(rx)
+    }
+
+    /// Fork the conversation into an independent branch (a `/fork`): a new
+    /// session over a forked thread that inherits the full history; the original
+    /// is untouched. `None` if the store can't branch.
+    pub async fn fork(&self) -> AgenkitResult<Option<AgentSession>> {
+        Ok(self.thread.fork().await?.map(|thread| AgentSession {
+            inner: self.inner.clone(),
+            principal: self.principal.clone(),
+            config: self.config.clone(),
+            thread,
+            agent_id: self.agent_id.clone(),
+        }))
+    }
+
+    /// One prompt's work: load history → run the turn → persist → compact.
+    async fn run_one_prompt(
+        &self,
+        text: String,
+        events: &UnboundedSender<AgentEvent>,
+    ) -> AgenkitResult<StopReason> {
+        // Seed the model context from the compacted history (W7), then the prompt.
+        let mut messages: Vec<Message> = self
+            .thread
+            .active_history()
+            .await?
+            .into_iter()
+            .map(|m| Message::new(m.role, m.content))
+            .collect();
+        messages.push(Message::user(text.clone()));
+
+        let agent_loop = AgentLoop::new(
+            self.inner.clone(),
+            self.principal.clone(),
+            self.config.clone(),
+        );
+        let reason = agent_loop.run_turn(&mut messages, events).await?;
+
+        // Persist the turn (user prompt + the assistant's final answer) so the
+        // conversation replays on resume. Tool detail is transient/re-derivable.
+        let answer = messages
+            .iter()
+            .rev()
+            .find(|m| m.role == Role::Assistant)
+            .map(|m| m.content.as_text())
+            .unwrap_or_default();
+        self.thread
+            .store
+            .append(
+                &self.thread.id,
+                self.thread.owner(),
+                vec![
+                    ThreadMessage::new(Role::User, text),
+                    ThreadMessage::new(Role::Assistant, answer),
+                ],
+            )
+            .await?;
+
+        // Compact if the (now longer) history would overflow the window.
+        let model = self
+            .config
+            .model
+            .clone()
+            .or_else(|| self.inner.default_model.clone())
+            .ok_or_else(|| AgenkitError::config("agent runtime has no model"))?;
+        let provider = self.inner.providers.resolve(&model)?;
+        let cx = {
+            let credential = self
+                .inner
+                .credentials
+                .resolve(provider.id(), &self.principal)
+                .await?;
+            ProviderContext::for_request(credential)
+        };
+        let max_output = self.config.max_tokens.unwrap_or(1024);
+        if let Some((folded, _kept)) =
+            super::agent::compact_thread(&self.thread, &model, &provider, &cx, max_output).await?
+        {
+            let _ = events.send(AgentEvent::Compacted { folded });
+        }
+        Ok(reason)
+    }
+}
+
+/// Builder for [`AgentSession`].
+pub struct AgentSessionBuilder {
+    inner: Arc<AgenkitInner>,
+    principal: Principal,
+    config: AgentConfig,
+    agent_id: String,
+}
+
+impl AgentSessionBuilder {
+    /// Run the conversation under `principal` (owner-scopes the durable thread).
+    /// Defaults to anonymous.
+    pub fn principal(mut self, principal: Principal) -> Self {
+        self.principal = principal;
+        self
+    }
+
+    /// Set the agent config (model, system prompt, tools, limits).
+    pub fn config(mut self, config: AgentConfig) -> Self {
+        self.config = config;
+        self
+    }
+
+    /// Set the agent id stored on the thread (default `"kitty"`).
+    pub fn agent_id(mut self, agent_id: impl Into<String>) -> Self {
+        self.agent_id = agent_id.into();
+        self
+    }
+
+    /// Open the session: resume the thread `id` if it exists **and** is owned by
+    /// the principal, otherwise create a fresh durable thread.
+    pub async fn open(self, id: Option<AgentThreadId>) -> AgenkitResult<AgentSession> {
+        let store = self.inner.thread_store.clone();
+        let owner = ThreadOwner::from_principal(&self.principal);
+        let owner_key = owner.key().map(str::to_string);
+
+        let thread_id = match id {
+            Some(id) if store.load(&id, owner).await?.is_some() => id,
+            _ => {
+                store
+                    .create(&self.agent_id, owner, ThreadRetention::Durable)
+                    .await?
+            }
+        };
+        let thread = AgentThreadHandle {
+            id: thread_id,
+            store,
+            owner: owner_key,
+        };
+        Ok(AgentSession {
+            inner: self.inner,
+            principal: self.principal,
+            config: self.config,
+            thread,
+            agent_id: self.agent_id,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::server::{Agenkit, AiTool, AiToolContext, BoxFuture, MockProvider};
+    use futures::StreamExt;
+    use pocopine_agenkit_core::{ModelRef, ToolDescriptor as Td};
+    use serde::{Deserialize, Serialize};
+    use tokio::sync::mpsc::unbounded_channel;
+
+    fn chat(answer: &str) -> Agenkit {
+        Agenkit::builder()
+            .provider(MockProvider::new("local").default_text(answer))
+            .default_model(ModelRef::new("local/default"))
+            .build()
+            .unwrap()
+    }
+
+    #[derive(Deserialize, schemars::JsonSchema)]
+    struct EchoIn {
+        text: String,
+    }
+    #[derive(Serialize, schemars::JsonSchema)]
+    struct EchoOut {
+        echoed: String,
+    }
+    struct Echo;
+    impl AiTool for Echo {
+        const ID: &'static str = "echo";
+        type Input = EchoIn;
+        type Output = EchoOut;
+        fn descriptor() -> Td {
+            Td::new("echo", "Echo the input")
+        }
+        fn call(
+            &self,
+            input: EchoIn,
+            _ctx: AiToolContext,
+        ) -> BoxFuture<'_, AgenkitResult<EchoOut>> {
+            Box::pin(async move { Ok(EchoOut { echoed: input.text }) })
+        }
+    }
+
+    fn runtime() -> Agenkit {
+        Agenkit::builder()
+            .provider(
+                MockProvider::new("local")
+                    // First model call → a tool call; second → a plain answer.
+                    .on_prompt_tool("use the tool", "echo", serde_json::json!({ "text": "hi" }))
+                    .default_text("all done"),
+            )
+            .default_model(ModelRef::new("local/default"))
+            .tool(Echo)
+            .build()
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn run_turn_loops_through_a_tool_then_answers() {
+        let agenkit = runtime();
+        let loop_ = AgentLoop::new(
+            agenkit.inner.clone(),
+            Principal::anonymous(),
+            AgentConfig::new().tools(["echo"]),
+        );
+        let (tx, mut rx) = unbounded_channel();
+        let mut messages = vec![Message::user("use the tool then answer")];
+
+        let stop = loop_.run_turn(&mut messages, &tx).await.unwrap();
+        drop(tx);
+        assert_eq!(stop, StopReason::Idle);
+
+        let mut kinds = Vec::new();
+        while let Ok(ev) = rx.try_recv() {
+            kinds.push(match ev {
+                AgentEvent::AssistantText { .. } => "text",
+                AgentEvent::ToolStarted { tool, .. } if tool == "echo" => "tool_start",
+                AgentEvent::ToolCompleted { .. } => "tool_done",
+                AgentEvent::ToolFailed { .. } => "tool_fail",
+                _ => "other",
+            });
+        }
+        // tool runs, then the model answers (the answer text crosses too).
+        assert!(kinds.contains(&"tool_start"), "events: {kinds:?}");
+        assert!(kinds.contains(&"tool_done"), "events: {kinds:?}");
+        assert!(kinds.contains(&"text"), "events: {kinds:?}");
+        // The transcript grew: user + assistant(tool-call) + tool result + final assistant.
+        assert!(messages.len() >= 4, "messages: {}", messages.len());
+        assert_eq!(messages.last().unwrap().role, Role::Assistant);
+    }
+
+    #[tokio::test]
+    async fn tool_failure_is_fed_back_not_fatal() {
+        struct Boom;
+        impl AiTool for Boom {
+            const ID: &'static str = "boom";
+            type Input = EchoIn;
+            type Output = EchoOut;
+            fn descriptor() -> Td {
+                Td::new("boom", "Always fails")
+            }
+            fn call(&self, _i: EchoIn, _c: AiToolContext) -> BoxFuture<'_, AgenkitResult<EchoOut>> {
+                Box::pin(async move { Err(AgenkitError::internal("kaboom")) })
+            }
+        }
+        let agenkit = Agenkit::builder()
+            .provider(
+                MockProvider::new("local")
+                    .on_prompt_tool("go", "boom", serde_json::json!({ "text": "x" }))
+                    .default_text("recovered"),
+            )
+            .default_model(ModelRef::new("local/default"))
+            .tool(Boom)
+            .build()
+            .unwrap();
+        let loop_ = AgentLoop::new(
+            agenkit.inner.clone(),
+            Principal::anonymous(),
+            AgentConfig::new().tools(["boom"]),
+        );
+        let (tx, mut rx) = unbounded_channel();
+        let mut messages = vec![Message::user("go")];
+        let stop = loop_.run_turn(&mut messages, &tx).await.unwrap();
+        drop(tx);
+        // The failed tool did NOT abort the turn — the model recovered and answered.
+        assert_eq!(stop, StopReason::Idle);
+        let mut saw_fail = false;
+        while let Ok(ev) = rx.try_recv() {
+            if matches!(ev, AgentEvent::ToolFailed { .. }) {
+                saw_fail = true;
+            }
+        }
+        assert!(saw_fail, "should have emitted ToolFailed");
+    }
+
+    // ── L2: durable AgentSession ─────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn session_prompt_streams_events_and_persists_the_turn() {
+        let agenkit = chat("hello back");
+        let session = AgentSession::builder(&agenkit).open(None).await.unwrap();
+
+        let events: Vec<AgentEvent> = session.prompt("hi").collect().await;
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, AgentEvent::AssistantText { text } if text == "hello back")),
+            "{events:?}"
+        );
+        assert!(
+            matches!(
+                events.last(),
+                Some(AgentEvent::Stopped {
+                    reason: StopReason::Idle
+                })
+            ),
+            "{events:?}"
+        );
+
+        // The turn persisted: user + assistant.
+        let history = session.history().await.unwrap();
+        assert_eq!(history.len(), 2);
+        assert_eq!(history[0].role, Role::User);
+        assert_eq!(history[1].content.as_text(), "hello back");
+
+        // A second prompt appends another turn (multi-turn conversation).
+        let _ = session.prompt("again").collect::<Vec<_>>().await;
+        assert_eq!(session.history().await.unwrap().len(), 4);
+    }
+
+    #[tokio::test]
+    async fn session_resumes_by_thread_id() {
+        let agenkit = chat("ok");
+        let id = {
+            let s = AgentSession::builder(&agenkit).open(None).await.unwrap();
+            let _ = s.prompt("remember this").collect::<Vec<_>>().await;
+            s.id().clone()
+        };
+        // Reopen by id over the same store → the conversation resumes.
+        let resumed = AgentSession::builder(&agenkit)
+            .open(Some(id))
+            .await
+            .unwrap();
+        let history = resumed.history().await.unwrap();
+        assert_eq!(history.len(), 2);
+        assert_eq!(history[0].content.as_text(), "remember this");
+    }
+
+    #[tokio::test]
+    async fn session_forks_into_an_independent_branch() {
+        let agenkit = chat("done");
+        let session = AgentSession::builder(&agenkit).open(None).await.unwrap();
+        let _ = session.prompt("first").collect::<Vec<_>>().await;
+
+        let forked = session.fork().await.unwrap().expect("store can branch");
+        assert_ne!(forked.id().as_str(), session.id().as_str());
+        // The fork inherits the parent's history; the parent is untouched.
+        assert_eq!(forked.history().await.unwrap().len(), 2);
+        let _ = forked.prompt("second").collect::<Vec<_>>().await;
+        assert_eq!(forked.history().await.unwrap().len(), 4);
+        assert_eq!(session.history().await.unwrap().len(), 2);
+    }
+}

--- a/crates/pocopine-agenkit/src/server/runtime.rs
+++ b/crates/pocopine-agenkit/src/server/runtime.rs
@@ -31,13 +31,15 @@ use super::thread::{AgentThreadHandle, ThreadOwner};
 
 /// How a [`prompt`](AgentSession::prompt) turn ended.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum StopReason {
     /// The model answered with no tool calls (and no queued follow-up) — the
     /// conversation is idle, waiting for the next prompt.
     Idle,
     /// The per-turn model↔tool step budget was hit.
     MaxSteps,
-    // L3 adds: `Terminated` (a tool requested stop) and `Aborted`.
+    /// An [`AbortHandle`] cancelled the turn (checked between steps).
+    Aborted,
 }
 
 /// A host-side firehose event from a running turn. Richer than the redacted
@@ -46,6 +48,7 @@ pub enum StopReason {
 /// the (parked) `pocopine:agent/extension` WIT `agent-event` so the extension
 /// world is a projection of this contract.
 #[derive(Clone, Debug)]
+#[non_exhaustive]
 pub enum AgentEvent {
     /// A prompt was accepted; the loop begins.
     Started,
@@ -81,6 +84,16 @@ pub enum AgentEvent {
         tool: String,
         /// The error (stable kind/text — no provider internals).
         error: String,
+    },
+    /// A `before_tool_call` hook blocked a tool (e.g. an approval/trust gate);
+    /// the block reason is fed back to the model instead of running the tool.
+    ToolBlocked {
+        /// The provider's call id.
+        id: String,
+        /// The tool's registry id.
+        tool: String,
+        /// Why the hook blocked it.
+        reason: String,
     },
     /// The thread was compacted (L2): `folded` older messages → one summary.
     Compacted {
@@ -156,6 +169,74 @@ impl AgentConfig {
     }
 }
 
+/// A `before_tool_call` hook's decision for one tool call (L3). Mirrors the
+/// (parked) WIT `hook-decision` so the extension world projects onto it.
+#[derive(Clone, Debug)]
+#[non_exhaustive]
+pub enum ToolDecision {
+    /// Run the tool with its requested arguments.
+    Proceed,
+    /// Don't run the tool; feed `reason` back to the model (an approval/trust
+    /// gate, or a policy block).
+    Block {
+        /// Why the call is blocked.
+        reason: String,
+    },
+    /// Run the tool, but with these arguments instead (e.g. inject a sandbox
+    /// path, redact a field).
+    ReplaceArgs {
+        /// The arguments to use.
+        args: serde_json::Value,
+    },
+}
+
+/// Typed steering hooks (L3) — host-side closures that *steer* the loop. The
+/// shapes pre-image the WIT extension world so extensions later supply the same
+/// decisions across the component boundary.
+#[derive(Clone, Default)]
+pub(crate) struct Hooks {
+    #[allow(clippy::type_complexity)]
+    before_tool_call: Option<Arc<dyn Fn(&str, &serde_json::Value) -> ToolDecision + Send + Sync>>,
+}
+
+/// A handle to cancel a running turn. Cloneable; calling [`abort`](AbortHandle::abort)
+/// stops the loop at the next step boundary (between model/tool calls).
+#[derive(Clone)]
+pub struct AbortHandle(Arc<std::sync::atomic::AtomicBool>);
+
+impl AbortHandle {
+    /// Request cancellation of the in-flight turn.
+    pub fn abort(&self) {
+        self.0.store(true, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    /// Whether cancellation has been requested.
+    pub fn is_aborted(&self) -> bool {
+        self.0.load(std::sync::atomic::Ordering::Relaxed)
+    }
+}
+
+/// Per-turn steering controls passed into [`AgentLoop::run_turn`]: the mid-run
+/// message queue, the abort flag, and the hooks. [`Default`] is the inert form
+/// (empty queue, never aborted, no hooks) — the plain L1 loop.
+#[derive(Clone, Default)]
+pub(crate) struct TurnControls {
+    queue: Arc<std::sync::Mutex<std::collections::VecDeque<String>>>,
+    abort: Arc<std::sync::atomic::AtomicBool>,
+    hooks: Hooks,
+}
+
+impl TurnControls {
+    fn aborted(&self) -> bool {
+        self.abort.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    /// Pop the next steered follow-up message, if any.
+    fn next_steer(&self) -> Option<String> {
+        self.queue.lock().ok().and_then(|mut q| q.pop_front())
+    }
+}
+
 /// The in-memory conversational loop core (L1). It owns no durable state — it
 /// runs one model↔tool turn over a `messages` transcript, emitting
 /// [`AgentEvent`]s, and returns where it stopped. [`AgentSession`] (L2) wraps it
@@ -193,6 +274,7 @@ impl AgentLoop {
         &self,
         messages: &mut Vec<Message>,
         events: &UnboundedSender<AgentEvent>,
+        controls: &TurnControls,
     ) -> AgenkitResult<StopReason> {
         let model = self.model()?;
         self.inner.check_model_allowed(&model)?;
@@ -223,6 +305,11 @@ impl AgentLoop {
         };
 
         for _ in 0..self.config.max_steps_per_turn {
+            // Abort is checked between steps (cancels after the current call).
+            if controls.aborted() {
+                return Ok(StopReason::Aborted);
+            }
+
             let request = GenerateRequest {
                 model: model.clone(),
                 system: self.config.system.clone(),
@@ -243,10 +330,18 @@ impl AgentLoop {
             }
 
             if response.tool_calls.is_empty() {
-                // The model answered — the turn is done. Persist the assistant's
-                // text so the conversation replays on resume.
+                // The model answered. Persist the assistant text so the
+                // conversation replays on resume.
                 messages.push(Message::new(Role::Assistant, text));
-                return Ok(StopReason::Idle);
+                // Steering: a queued follow-up message continues the turn instead
+                // of going idle ("talk to it mid-run"); otherwise the turn ends.
+                match controls.next_steer() {
+                    Some(steer) => {
+                        messages.push(Message::user(steer));
+                        continue;
+                    }
+                    None => return Ok(StopReason::Idle),
+                }
             }
 
             // Record the assistant's tool-request turn (keeps the provider's
@@ -271,31 +366,57 @@ impl AgentLoop {
                     tool: call.tool_id.clone(),
                     args: call.args.clone(),
                 });
-                // A tool failure is fed back to the model (so it can recover),
-                // not propagated — a long conversation shouldn't die on one bad
-                // tool call. The runaway case is bounded by `max_steps_per_turn`.
-                let result_text = match tool.call_json(call.args.clone(), ctx.clone()).await {
-                    Ok(output) => {
-                        let _ = events.send(AgentEvent::ToolCompleted {
+
+                // `before_tool_call` hook (L3): block (approval/trust gate) or
+                // replace the arguments before running.
+                let decision = controls
+                    .hooks
+                    .before_tool_call
+                    .as_ref()
+                    .map(|hook| hook(&call.tool_id, &call.args))
+                    .unwrap_or(ToolDecision::Proceed);
+
+                let result_text = match decision {
+                    ToolDecision::Block { reason } => {
+                        let _ = events.send(AgentEvent::ToolBlocked {
                             id: call.id.clone(),
                             tool: call.tool_id.clone(),
-                            output: output.clone(),
+                            reason: reason.clone(),
                         });
-                        serde_json::to_string(&output).map_err(|e| {
-                            AgenkitError::internal(format!(
-                                "tool `{}` output encode: {e}",
-                                call.tool_id
-                            ))
-                        })?
+                        serde_json::json!({ "blocked": reason }).to_string()
                     }
-                    Err(error) => {
-                        let kind = error.to_string();
-                        let _ = events.send(AgentEvent::ToolFailed {
-                            id: call.id.clone(),
-                            tool: call.tool_id.clone(),
-                            error: kind.clone(),
-                        });
-                        serde_json::json!({ "error": kind }).to_string()
+                    decision => {
+                        let args = match decision {
+                            ToolDecision::ReplaceArgs { args } => args,
+                            _ => call.args.clone(),
+                        };
+                        // A tool failure is fed back to the model (so it can
+                        // recover), not propagated — a long conversation shouldn't
+                        // die on one bad tool call (bounded by max_steps_per_turn).
+                        match tool.call_json(args, ctx.clone()).await {
+                            Ok(output) => {
+                                let _ = events.send(AgentEvent::ToolCompleted {
+                                    id: call.id.clone(),
+                                    tool: call.tool_id.clone(),
+                                    output: output.clone(),
+                                });
+                                serde_json::to_string(&output).map_err(|e| {
+                                    AgenkitError::internal(format!(
+                                        "tool `{}` output encode: {e}",
+                                        call.tool_id
+                                    ))
+                                })?
+                            }
+                            Err(error) => {
+                                let kind = error.to_string();
+                                let _ = events.send(AgentEvent::ToolFailed {
+                                    id: call.id.clone(),
+                                    tool: call.tool_id.clone(),
+                                    error: kind.clone(),
+                                });
+                                serde_json::json!({ "error": kind }).to_string()
+                            }
+                        }
                     }
                 };
                 messages.push(Message::tool_result(call.id.clone(), result_text));
@@ -318,6 +439,9 @@ pub struct AgentSession {
     config: AgentConfig,
     thread: AgentThreadHandle,
     agent_id: String,
+    /// Shared steering controls (queue + abort + hooks). Cloning the session
+    /// shares these (Arc-backed), so `steer`/`abort` reach the running turn.
+    controls: TurnControls,
 }
 
 impl AgentSession {
@@ -328,7 +452,23 @@ impl AgentSession {
             principal: Principal::anonymous(),
             config: AgentConfig::new(),
             agent_id: "kitty".to_string(),
+            hooks: Hooks::default(),
         }
+    }
+
+    /// Inject a follow-up message into the **currently running** turn: instead of
+    /// going idle when the model next answers, the loop continues with this
+    /// message (the "talk to it mid-run" steering). If no turn is running it is
+    /// picked up by the next [`prompt`](AgentSession::prompt).
+    pub fn steer(&self, text: impl Into<String>) {
+        if let Ok(mut queue) = self.controls.queue.lock() {
+            queue.push_back(text.into());
+        }
+    }
+
+    /// A handle to cancel the running turn (stops at the next step boundary).
+    pub fn abort_handle(&self) -> AbortHandle {
+        AbortHandle(self.controls.abort.clone())
     }
 
     /// The durable thread id (persist this to resume the conversation later).
@@ -375,6 +515,12 @@ impl AgentSession {
             config: self.config.clone(),
             thread,
             agent_id: self.agent_id.clone(),
+            // The branch is an independent conversation: same hooks, fresh
+            // queue + abort.
+            controls: TurnControls {
+                hooks: self.controls.hooks.clone(),
+                ..TurnControls::default()
+            },
         }))
     }
 
@@ -384,6 +530,11 @@ impl AgentSession {
         text: String,
         events: &UnboundedSender<AgentEvent>,
     ) -> AgenkitResult<StopReason> {
+        // A fresh prompt clears any stale abort from a previous turn.
+        self.controls
+            .abort
+            .store(false, std::sync::atomic::Ordering::Relaxed);
+
         // Seed the model context from the compacted history (W7), then the prompt.
         let mut messages: Vec<Message> = self
             .thread
@@ -392,33 +543,34 @@ impl AgentSession {
             .into_iter()
             .map(|m| Message::new(m.role, m.content))
             .collect();
-        messages.push(Message::user(text.clone()));
+        let persist_from = messages.len();
+        messages.push(Message::user(text));
 
         let agent_loop = AgentLoop::new(
             self.inner.clone(),
             self.principal.clone(),
             self.config.clone(),
         );
-        let reason = agent_loop.run_turn(&mut messages, events).await?;
+        let reason = agent_loop
+            .run_turn(&mut messages, events, &self.controls)
+            .await?;
 
-        // Persist the turn (user prompt + the assistant's final answer) so the
-        // conversation replays on resume. Tool detail is transient/re-derivable.
-        let answer = messages
+        // Persist the turn's user + assistant *text* messages (the initial prompt,
+        // any steered follow-ups, and the answers) so the conversation replays on
+        // resume. Tool calls/results are transient and re-derivable.
+        let to_persist: Vec<ThreadMessage> = messages[persist_from..]
             .iter()
-            .rev()
-            .find(|m| m.role == Role::Assistant)
-            .map(|m| m.content.as_text())
-            .unwrap_or_default();
+            .filter_map(|m| match m.role {
+                Role::User => Some(ThreadMessage::new(Role::User, m.content.as_text())),
+                Role::Assistant if !m.content.as_text().is_empty() => {
+                    Some(ThreadMessage::new(Role::Assistant, m.content.as_text()))
+                }
+                _ => None,
+            })
+            .collect();
         self.thread
             .store
-            .append(
-                &self.thread.id,
-                self.thread.owner(),
-                vec![
-                    ThreadMessage::new(Role::User, text),
-                    ThreadMessage::new(Role::Assistant, answer),
-                ],
-            )
+            .append(&self.thread.id, self.thread.owner(), to_persist)
             .await?;
 
         // Compact if the (now longer) history would overflow the window.
@@ -453,6 +605,7 @@ pub struct AgentSessionBuilder {
     principal: Principal,
     config: AgentConfig,
     agent_id: String,
+    hooks: Hooks,
 }
 
 impl AgentSessionBuilder {
@@ -460,6 +613,19 @@ impl AgentSessionBuilder {
     /// Defaults to anonymous.
     pub fn principal(mut self, principal: Principal) -> Self {
         self.principal = principal;
+        self
+    }
+
+    /// Set a `before_tool_call` steering hook (L3): called with the tool id and
+    /// arguments before every tool runs, returning a [`ToolDecision`] to proceed,
+    /// **block** it (an approval/trust gate — the reason is fed back to the
+    /// model), or **replace** its arguments. This is the host-side mirror of the
+    /// (parked) WIT extension hook.
+    pub fn before_tool_call<F>(mut self, hook: F) -> Self
+    where
+        F: Fn(&str, &serde_json::Value) -> ToolDecision + Send + Sync + 'static,
+    {
+        self.hooks.before_tool_call = Some(Arc::new(hook));
         self
     }
 
@@ -501,6 +667,10 @@ impl AgentSessionBuilder {
             config: self.config,
             thread,
             agent_id: self.agent_id,
+            controls: TurnControls {
+                hooks: self.hooks,
+                ..TurnControls::default()
+            },
         })
     }
 }
@@ -572,7 +742,10 @@ mod tests {
         let (tx, mut rx) = unbounded_channel();
         let mut messages = vec![Message::user("use the tool then answer")];
 
-        let stop = loop_.run_turn(&mut messages, &tx).await.unwrap();
+        let stop = loop_
+            .run_turn(&mut messages, &tx, &TurnControls::default())
+            .await
+            .unwrap();
         drop(tx);
         assert_eq!(stop, StopReason::Idle);
 
@@ -626,7 +799,10 @@ mod tests {
         );
         let (tx, mut rx) = unbounded_channel();
         let mut messages = vec![Message::user("go")];
-        let stop = loop_.run_turn(&mut messages, &tx).await.unwrap();
+        let stop = loop_
+            .run_turn(&mut messages, &tx, &TurnControls::default())
+            .await
+            .unwrap();
         drop(tx);
         // The failed tool did NOT abort the turn — the model recovered and answered.
         assert_eq!(stop, StopReason::Idle);
@@ -705,5 +881,108 @@ mod tests {
         let _ = forked.prompt("second").collect::<Vec<_>>().await;
         assert_eq!(forked.history().await.unwrap().len(), 4);
         assert_eq!(session.history().await.unwrap().len(), 2);
+    }
+
+    // ── L3: steering queue + typed hooks + abort ─────────────────────────────
+
+    #[tokio::test]
+    async fn pre_set_abort_stops_the_turn_immediately() {
+        let agenkit = chat("won't run");
+        let loop_ = AgentLoop::new(
+            agenkit.inner.clone(),
+            Principal::anonymous(),
+            AgentConfig::new(),
+        );
+        let controls = TurnControls::default();
+        controls
+            .abort
+            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let (tx, mut rx) = unbounded_channel();
+        let mut messages = vec![Message::user("hi")];
+
+        let stop = loop_.run_turn(&mut messages, &tx, &controls).await.unwrap();
+        drop(tx);
+        assert_eq!(stop, StopReason::Aborted);
+        // Aborted before the model call → no assistant text was produced.
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn before_tool_call_block_prevents_execution() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        struct Recorder(Arc<AtomicBool>);
+        impl AiTool for Recorder {
+            const ID: &'static str = "recorder";
+            type Input = EchoIn;
+            type Output = EchoOut;
+            fn descriptor() -> Td {
+                Td::new("recorder", "Records that it ran")
+            }
+            fn call(
+                &self,
+                input: EchoIn,
+                _c: AiToolContext,
+            ) -> BoxFuture<'_, AgenkitResult<EchoOut>> {
+                self.0.store(true, Ordering::Relaxed);
+                Box::pin(async move { Ok(EchoOut { echoed: input.text }) })
+            }
+        }
+        let ran = Arc::new(AtomicBool::new(false));
+        let agenkit = Agenkit::builder()
+            .provider(
+                MockProvider::new("local")
+                    .on_prompt_tool("go", "recorder", serde_json::json!({ "text": "x" }))
+                    .default_text("after block"),
+            )
+            .default_model(ModelRef::new("local/default"))
+            .tool(Recorder(ran.clone()))
+            .build()
+            .unwrap();
+        let loop_ = AgentLoop::new(
+            agenkit.inner.clone(),
+            Principal::anonymous(),
+            AgentConfig::new().tools(["recorder"]),
+        );
+        let controls = TurnControls {
+            hooks: Hooks {
+                before_tool_call: Some(Arc::new(|_tool, _args| ToolDecision::Block {
+                    reason: "needs approval".to_string(),
+                })),
+            },
+            ..TurnControls::default()
+        };
+        let (tx, mut rx) = unbounded_channel();
+        let mut messages = vec![Message::user("go")];
+        let _ = loop_.run_turn(&mut messages, &tx, &controls).await.unwrap();
+        drop(tx);
+
+        // The hook blocked the call → the tool never executed, and a ToolBlocked
+        // event was emitted instead.
+        assert!(
+            !ran.load(Ordering::Relaxed),
+            "the blocked tool must not run"
+        );
+        let mut saw_block = false;
+        while let Ok(ev) = rx.try_recv() {
+            if matches!(ev, AgentEvent::ToolBlocked { .. }) {
+                saw_block = true;
+            }
+        }
+        assert!(saw_block, "should have emitted ToolBlocked");
+    }
+
+    #[tokio::test]
+    async fn steered_follow_up_continues_the_same_turn() {
+        let agenkit = chat("answer");
+        let session = AgentSession::builder(&agenkit).open(None).await.unwrap();
+        // Queue a follow-up *before* prompting: when the model answers the first
+        // prompt and would go idle, the steered message continues the turn.
+        session.steer("and another thing");
+        let _ = session.prompt("first").collect::<Vec<_>>().await;
+        // One prompt processed two exchanges: user/assistant ×2 = 4 messages.
+        assert_eq!(session.history().await.unwrap().len(), 4);
+        let history = session.history().await.unwrap();
+        assert_eq!(history[0].content.as_text(), "first");
+        assert_eq!(history[2].content.as_text(), "and another thing");
     }
 }

--- a/crates/pocopine-agenkit/src/server/runtime.rs
+++ b/crates/pocopine-agenkit/src/server/runtime.rs
@@ -14,21 +14,20 @@
 //! shaped to **pre-image the WASM/WIT extension world** (parked) so extensions
 //! later plug into a contract that already exists here.
 //!
-//! Known follow-up (deferred — a focused refactor, not a quick fix): this loop
-//! ([`AgentLoop::run_turn`]) and the single-shot [`run_loop`](super::agent) share
-//! only `compact_thread` — the model↔tool core is duplicated, and this runtime
-//! emits the [`AgentEvent`] firehose but **not** the `pocopine.trace` events /
-//! usage that `run_loop` feeds (no cost metering for conversational turns yet).
-//! The fix is to unify them behind one observer (RunState-emit vs AgentEvent
-//! sink), which also brings trace + usage here — done carefully so the merged
-//! single-shot path isn't regressed.
+//! The model↔tool engine is **not** duplicated: both this loop
+//! ([`AgentLoop::run_turn`]) and the single-shot [`run_loop`](super::agent) drive
+//! the shared [`loop_core`](super::loop_core) (model call + tool dispatch),
+//! differing only in lifecycle and termination. A conversational turn opens its
+//! own trace run and emits the same `pocopine.trace` events + token usage as the
+//! typed run (its observer wraps the shared `TraceObserver`), so conversational
+//! turns are metered too — alongside the [`AgentEvent`] firehose.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use pocopine_agenkit_core::{
-    AgenkitError, AgenkitResult, AgentThreadId, Message, ModelRef, Role, ThreadMessage,
-    ThreadRetention, ToolDescriptor,
+    AgenkitError, AgenkitResult, AgentThreadId, Message, ModelRef, Role, RunId, StepId, StepKind,
+    StepStatus, ThreadMessage, ThreadRetention, ToolCall, ToolDescriptor, TraceId, Usage, events,
 };
 use pocopine_auth::Principal;
 use tokio::sync::mpsc::{UnboundedSender, unbounded_channel};
@@ -36,7 +35,12 @@ use tokio_stream::wrappers::UnboundedReceiverStream;
 
 use super::agenkit::{Agenkit, AgenkitInner};
 use super::context::AiContext;
+pub use super::loop_core::ToolDecision;
+use super::loop_core::{
+    LoopObserver, ToolErrorMode, TraceObserver, dispatch_tool_calls, run_model_step,
+};
 use super::provider::{GenerateRequest, ProviderContext};
+use super::run::RunState;
 use super::thread::{AgentThreadHandle, ThreadOwner};
 
 /// How a [`prompt`](AgentSession::prompt) turn ended.
@@ -191,27 +195,6 @@ impl AgentConfig {
     }
 }
 
-/// A `before_tool_call` hook's decision for one tool call (L3). Mirrors the
-/// (parked) WIT `hook-decision` so the extension world projects onto it.
-#[derive(Clone, Debug)]
-#[non_exhaustive]
-pub enum ToolDecision {
-    /// Run the tool with its requested arguments.
-    Proceed,
-    /// Don't run the tool; feed `reason` back to the model (an approval/trust
-    /// gate, or a policy block).
-    Block {
-        /// Why the call is blocked.
-        reason: String,
-    },
-    /// Run the tool, but with these arguments instead (e.g. inject a sandbox
-    /// path, redact a field).
-    ReplaceArgs {
-        /// The arguments to use.
-        args: serde_json::Value,
-    },
-}
-
 /// Typed steering hooks (L3) — host-side closures that *steer* the loop. The
 /// shapes pre-image the WIT extension world so extensions later supply the same
 /// decisions across the component boundary.
@@ -329,128 +312,173 @@ impl AgentLoop {
             ProviderContext::for_request(credential)
         };
 
-        for _ in 0..self.config.max_steps_per_turn.max(1) {
-            // Abort is checked between steps (cancels after the current call).
-            // A dropped event receiver is treated the same: the consumer left, so
-            // stop rather than keep making paid model/tool calls nobody reads.
-            if controls.aborted() || events.is_closed() {
-                return Ok((StopReason::Aborted, cx.clone()));
-            }
+        // Open a trace run for this turn: mint correlation ids and an agent step
+        // that parents the model/tool spans, so a conversational turn emits the
+        // same `pocopine.trace` events + token usage the single-shot loop does.
+        let seq = self.inner.run_seq.fetch_add(1, Ordering::Relaxed);
+        let run = RunState::new(
+            self.inner.clone(),
+            RunId::new(format!("run-{seq}")),
+            TraceId::new(format!("trace-{seq}")),
+            self.principal.clone(),
+            None,
+        );
+        let agent_step = run.next_step_id();
+        run.emit(
+            run.event(
+                events::AI_STEP_STARTED,
+                StepKind::Agent,
+                StepStatus::Started,
+            )
+            .with_step(agent_step.clone())
+            .with_model(model.clone()),
+        );
+        // The runtime's observer: the `AgentEvent` firehose *and* (via the wrapped
+        // `TraceObserver`) the trace spans.
+        let observer = RuntimeObserver {
+            trace: TraceObserver {
+                run: &run,
+                agent_step: agent_step.clone(),
+            },
+            events,
+        };
+        // Adapt the `Arc` hook into a borrowable `&dyn Fn` for the shared dispatcher.
+        let before = controls.hooks.before_tool_call.as_deref();
 
-            let request = GenerateRequest {
-                model: model.clone(),
-                system: self.config.system.clone(),
-                messages: messages.clone(),
-                tools: tools.clone(),
-                json_schema: None, // conversational: free text, not structured output
-                max_tokens: self.config.max_tokens,
-                thinking: Default::default(),
-            };
-            let response = provider
-                .generate(request, &cx)
-                .await
-                .map_err(super::generate::reclassify_overflow)?;
-
-            let text = response.text_output();
-            if !text.is_empty() {
-                let _ = events.send(AgentEvent::AssistantText { text: text.clone() });
-            }
-
-            if response.tool_calls.is_empty() {
-                // The model answered. Persist the assistant text so the
-                // conversation replays on resume.
-                messages.push(Message::new(Role::Assistant, text));
-                // Steering: a queued follow-up message continues the turn instead
-                // of going idle ("talk to it mid-run"); otherwise the turn ends.
-                match controls.next_steer() {
-                    Some(steer) => {
-                        messages.push(Message::user(steer));
-                        continue;
-                    }
-                    None => return Ok((StopReason::Idle, cx.clone())),
+        // The model↔tool steps, with the agent step closed afterwards so the trace
+        // run is balanced on every exit (idle / steered / max-steps / error).
+        let outcome: AgenkitResult<StopReason> = async {
+            for _ in 0..self.config.max_steps_per_turn.max(1) {
+                // Abort is checked between steps (cancels after the current call).
+                // A dropped event receiver is treated the same: the consumer left,
+                // so stop rather than make paid model/tool calls nobody reads.
+                if controls.aborted() || events.is_closed() {
+                    return Ok(StopReason::Aborted);
                 }
-            }
 
-            // Record the assistant's tool-request turn (keeps the provider's
-            // protocol linkage that real providers require on the next request).
-            messages.push(Message::assistant_tool_calls(
-                response.content.clone(),
-                response.tool_calls.clone(),
-            ));
-
-            for call in &response.tool_calls {
-                if !self.config.tool_ids.iter().any(|id| id == &call.tool_id) {
-                    return Err(AgenkitError::tool_policy(format!(
-                        "agent called non-allowlisted tool `{}`",
-                        call.tool_id
-                    )));
-                }
-                let tool = self.inner.tools.get(&call.tool_id).ok_or_else(|| {
-                    AgenkitError::tool_policy(format!("tool `{}` is not registered", call.tool_id))
-                })?;
-                let _ = events.send(AgentEvent::ToolStarted {
-                    id: call.id.clone(),
-                    tool: call.tool_id.clone(),
-                    args: call.args.clone(),
-                });
-
-                // `before_tool_call` hook (L3): block (approval/trust gate) or
-                // replace the arguments before running.
-                let decision = controls
-                    .hooks
-                    .before_tool_call
-                    .as_ref()
-                    .map(|hook| hook(&call.tool_id, &call.args))
-                    .unwrap_or(ToolDecision::Proceed);
-
-                let result_text = match decision {
-                    ToolDecision::Block { reason } => {
-                        let _ = events.send(AgentEvent::ToolBlocked {
-                            id: call.id.clone(),
-                            tool: call.tool_id.clone(),
-                            reason: reason.clone(),
-                        });
-                        serde_json::json!({ "blocked": reason }).to_string()
-                    }
-                    decision => {
-                        let args = match decision {
-                            ToolDecision::ReplaceArgs { args } => args,
-                            _ => call.args.clone(),
-                        };
-                        // A tool failure is fed back to the model (so it can
-                        // recover), not propagated — a long conversation shouldn't
-                        // die on one bad tool call (bounded by max_steps_per_turn).
-                        match tool.call_json(args, ctx.clone()).await {
-                            Ok(output) => {
-                                let _ = events.send(AgentEvent::ToolCompleted {
-                                    id: call.id.clone(),
-                                    tool: call.tool_id.clone(),
-                                    output: output.clone(),
-                                });
-                                serde_json::to_string(&output).map_err(|e| {
-                                    AgenkitError::internal(format!(
-                                        "tool `{}` output encode: {e}",
-                                        call.tool_id
-                                    ))
-                                })?
-                            }
-                            Err(error) => {
-                                let kind = error.to_string();
-                                let _ = events.send(AgentEvent::ToolFailed {
-                                    id: call.id.clone(),
-                                    tool: call.tool_id.clone(),
-                                    error: kind.clone(),
-                                });
-                                serde_json::json!({ "error": kind }).to_string()
-                            }
-                        }
-                    }
+                let request = GenerateRequest {
+                    model: model.clone(),
+                    system: self.config.system.clone(),
+                    messages: messages.clone(),
+                    tools: tools.clone(),
+                    json_schema: None, // conversational: free text, not structured output
+                    max_tokens: self.config.max_tokens,
+                    thinking: Default::default(),
                 };
-                messages.push(Message::tool_result(call.id.clone(), result_text));
+                let response = run_model_step(&provider, request, &cx, &model, &observer).await?;
+
+                let text = response.text_output();
+                if !text.is_empty() {
+                    let _ = events.send(AgentEvent::AssistantText { text: text.clone() });
+                }
+
+                if response.tool_calls.is_empty() {
+                    // The model answered. Persist the assistant text so the
+                    // conversation replays on resume.
+                    messages.push(Message::new(Role::Assistant, text));
+                    // Steering: a queued follow-up message continues the turn
+                    // ("talk to it mid-run"); otherwise the turn ends.
+                    match controls.next_steer() {
+                        Some(steer) => {
+                            messages.push(Message::user(steer));
+                            continue;
+                        }
+                        None => return Ok(StopReason::Idle),
+                    }
+                }
+
+                // Run the tool batch via the shared dispatcher; a tool failure is
+                // fed back to the model (a long conversation shouldn't die on one
+                // bad call — bounded by `max_steps_per_turn`), and the
+                // `before_tool_call` hook can block / replace each call.
+                messages.extend(
+                    dispatch_tool_calls(
+                        &self.inner,
+                        &self.config.tool_ids,
+                        &ctx,
+                        &response,
+                        "agent",
+                        before,
+                        ToolErrorMode::FeedBack,
+                        &observer,
+                    )
+                    .await?,
+                );
             }
+            Ok(StopReason::MaxSteps)
+        }
+        .await;
+
+        match &outcome {
+            Ok(_) => run.emit(
+                run.event(
+                    events::AI_STEP_COMPLETED,
+                    StepKind::Agent,
+                    StepStatus::Completed,
+                )
+                .with_step(agent_step.clone()),
+            ),
+            Err(error) => run.emit(
+                run.event(events::AI_STEP_FAILED, StepKind::Agent, StepStatus::Failed)
+                    .with_step(agent_step.clone())
+                    .with_error(error.clone()),
+            ),
         }
 
-        Ok((StopReason::MaxSteps, cx))
+        outcome.map(|reason| (reason, cx))
+    }
+}
+
+/// The runtime's [`LoopObserver`]: emits the [`AgentEvent`] firehose for a turn
+/// **and** the `pocopine.trace` spans (by delegating to the wrapped
+/// [`TraceObserver`]), so a conversational turn is both observable live and
+/// metered like the typed run.
+struct RuntimeObserver<'a> {
+    trace: TraceObserver<'a>,
+    events: &'a UnboundedSender<AgentEvent>,
+}
+
+impl LoopObserver for RuntimeObserver<'_> {
+    fn model_request(&self, model: &ModelRef) -> Option<StepId> {
+        self.trace.model_request(model)
+    }
+
+    fn model_response(&self, step: Option<StepId>, model: &ModelRef, usage: Option<Usage>) {
+        self.trace.model_response(step, model, usage);
+    }
+
+    fn tool_started(&self, call: &ToolCall) -> Option<StepId> {
+        let _ = self.events.send(AgentEvent::ToolStarted {
+            id: call.id.clone(),
+            tool: call.tool_id.clone(),
+            args: call.args.clone(),
+        });
+        self.trace.tool_started(call)
+    }
+
+    fn tool_completed(&self, step: Option<StepId>, call: &ToolCall, output: &serde_json::Value) {
+        let _ = self.events.send(AgentEvent::ToolCompleted {
+            id: call.id.clone(),
+            tool: call.tool_id.clone(),
+            output: output.clone(),
+        });
+        self.trace.tool_completed(step, call, output);
+    }
+
+    fn tool_failed(&self, call: &ToolCall, error: &str) {
+        let _ = self.events.send(AgentEvent::ToolFailed {
+            id: call.id.clone(),
+            tool: call.tool_id.clone(),
+            error: error.to_string(),
+        });
+    }
+
+    fn tool_blocked(&self, call: &ToolCall, reason: &str) {
+        let _ = self.events.send(AgentEvent::ToolBlocked {
+            id: call.id.clone(),
+            tool: call.tool_id.clone(),
+            reason: reason.to_string(),
+        });
     }
 }
 

--- a/crates/pocopine-agenkit/src/server/runtime.rs
+++ b/crates/pocopine-agenkit/src/server/runtime.rs
@@ -13,6 +13,15 @@
 //! **L3** = steering queue + typed hooks + abort. The event/decision types are
 //! shaped to **pre-image the WASM/WIT extension world** (parked) so extensions
 //! later plug into a contract that already exists here.
+//!
+//! Known follow-up (deferred — a focused refactor, not a quick fix): this loop
+//! ([`AgentLoop::run_turn`]) and the single-shot [`run_loop`](super::agent) share
+//! only `compact_thread` — the model↔tool core is duplicated, and this runtime
+//! emits the [`AgentEvent`] firehose but **not** the `pocopine.trace` events /
+//! usage that `run_loop` feeds (no cost metering for conversational turns yet).
+//! The fix is to unify them behind one observer (RunState-emit vs AgentEvent
+//! sink), which also brings trace + usage here — done carefully so the merged
+//! single-shot path isn't regressed.
 
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -283,12 +292,15 @@ impl AgentLoop {
     /// and stop when the model answers without tool calls or the step budget is
     /// hit. Appends every produced message (assistant text, tool-call turns, tool
     /// results) to `messages`, emits events, and returns the [`StopReason`].
+    /// Returns the stop reason and the resolved [`ProviderContext`] it used, so
+    /// the caller can reuse the (credential-resolved) context for compaction
+    /// instead of resolving the credential a second time.
     pub(crate) async fn run_turn(
         &self,
         messages: &mut Vec<Message>,
         events: &UnboundedSender<AgentEvent>,
         controls: &TurnControls,
-    ) -> AgenkitResult<StopReason> {
+    ) -> AgenkitResult<(StopReason, ProviderContext)> {
         let model = self.model()?;
         self.inner.check_model_allowed(&model)?;
         let provider = self.inner.providers.resolve(&model)?;
@@ -322,7 +334,7 @@ impl AgentLoop {
             // A dropped event receiver is treated the same: the consumer left, so
             // stop rather than keep making paid model/tool calls nobody reads.
             if controls.aborted() || events.is_closed() {
-                return Ok(StopReason::Aborted);
+                return Ok((StopReason::Aborted, cx.clone()));
             }
 
             let request = GenerateRequest {
@@ -355,7 +367,7 @@ impl AgentLoop {
                         messages.push(Message::user(steer));
                         continue;
                     }
-                    None => return Ok(StopReason::Idle),
+                    None => return Ok((StopReason::Idle, cx.clone())),
                 }
             }
 
@@ -438,7 +450,7 @@ impl AgentLoop {
             }
         }
 
-        Ok(StopReason::MaxSteps)
+        Ok((StopReason::MaxSteps, cx))
     }
 }
 
@@ -611,7 +623,9 @@ impl AgentSession {
             self.principal.clone(),
             self.config.clone(),
         );
-        let reason = agent_loop
+        // Reuse the credential-resolved context the turn already produced for
+        // compaction, so a BYOK store isn't hit a second time per prompt.
+        let (reason, cx) = agent_loop
             .run_turn(&mut messages, events, &self.controls)
             .await?;
 
@@ -637,7 +651,9 @@ impl AgentSession {
                 .await?;
         }
 
-        // Compact if the (now longer) history would overflow the window.
+        // Compact if the (now longer) history would overflow the window. Model +
+        // provider re-resolution is a cheap registry lookup (no IO); the credential
+        // (the costly part) is reused from `cx` above.
         let model = self
             .config
             .model
@@ -645,14 +661,6 @@ impl AgentSession {
             .or_else(|| self.inner.default_model.clone())
             .ok_or_else(|| AgenkitError::config("agent runtime has no model"))?;
         let provider = self.inner.providers.resolve(&model)?;
-        let cx = {
-            let credential = self
-                .inner
-                .credentials
-                .resolve(provider.id(), &self.principal)
-                .await?;
-            ProviderContext::for_request(credential)
-        };
         let max_output = self.config.max_tokens.unwrap_or(1024);
         if let Some((folded, _kept)) =
             super::agent::compact_thread(&self.thread, &model, &provider, &cx, max_output).await?
@@ -814,7 +822,7 @@ mod tests {
         let (tx, mut rx) = unbounded_channel();
         let mut messages = vec![Message::user("use the tool then answer")];
 
-        let stop = loop_
+        let (stop, _) = loop_
             .run_turn(&mut messages, &tx, &TurnControls::default())
             .await
             .unwrap();
@@ -871,7 +879,7 @@ mod tests {
         );
         let (tx, mut rx) = unbounded_channel();
         let mut messages = vec![Message::user("go")];
-        let stop = loop_
+        let (stop, _) = loop_
             .run_turn(&mut messages, &tx, &TurnControls::default())
             .await
             .unwrap();
@@ -972,7 +980,7 @@ mod tests {
         let (tx, mut rx) = unbounded_channel();
         let mut messages = vec![Message::user("hi")];
 
-        let stop = loop_.run_turn(&mut messages, &tx, &controls).await.unwrap();
+        let (stop, _) = loop_.run_turn(&mut messages, &tx, &controls).await.unwrap();
         drop(tx);
         assert_eq!(stop, StopReason::Aborted);
         // Aborted before the model call → no assistant text was produced.

--- a/crates/pocopine-agenkit/src/server/runtime.rs
+++ b/crates/pocopine-agenkit/src/server/runtime.rs
@@ -15,6 +15,7 @@
 //! later plug into a contract that already exists here.
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 
 use pocopine_agenkit_core::{
     AgenkitError, AgenkitResult, AgentThreadId, Message, ModelRef, Role, ThreadMessage,
@@ -115,7 +116,7 @@ pub enum AgentEvent {
 /// Configuration for a conversational agent: the same knobs as
 /// [`AiAgentBuilder`](super::agent::AiAgentBuilder) minus typed I/O (the runtime
 /// is a free-text conversation, not a typed flow unit).
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct AgentConfig {
     pub(crate) model: Option<ModelRef>,
     pub(crate) system: Option<String>,
@@ -124,13 +125,25 @@ pub struct AgentConfig {
     pub(crate) max_steps_per_turn: u32,
 }
 
+impl Default for AgentConfig {
+    /// No model/system/tools, an 8-step per-turn budget. Hand-written (not
+    /// derived) so the step budget defaults to 8, not 0 — a derived `0` would
+    /// make a loop run zero model calls and silently "succeed".
+    fn default() -> Self {
+        Self {
+            model: None,
+            system: None,
+            tool_ids: Vec::new(),
+            max_tokens: None,
+            max_steps_per_turn: 8,
+        }
+    }
+}
+
 impl AgentConfig {
     /// A config with the default per-turn step budget (8).
     pub fn new() -> Self {
-        Self {
-            max_steps_per_turn: 8,
-            ..Self::default()
-        }
+        Self::default()
     }
 
     /// Set the model (defaults to the runtime default).
@@ -304,9 +317,11 @@ impl AgentLoop {
             ProviderContext::for_request(credential)
         };
 
-        for _ in 0..self.config.max_steps_per_turn {
+        for _ in 0..self.config.max_steps_per_turn.max(1) {
             // Abort is checked between steps (cancels after the current call).
-            if controls.aborted() {
+            // A dropped event receiver is treated the same: the consumer left, so
+            // stop rather than keep making paid model/tool calls nobody reads.
+            if controls.aborted() || events.is_closed() {
                 return Ok(StopReason::Aborted);
             }
 
@@ -431,7 +446,8 @@ impl AgentLoop {
 /// layer: `open` (or resume) once, then [`prompt`](AgentSession::prompt) over
 /// time. Each prompt loads the compacted history, runs one turn via
 /// [`AgentLoop`], persists the user + assistant messages, and compacts if the
-/// window would overflow — all owner-scoped, durable, and forkable.
+/// window would overflow — all owner-scoped and forkable. Persistence is the
+/// configured store's (the default is in-memory; see [`open`](AgentSessionBuilder::open)).
 #[derive(Clone)]
 pub struct AgentSession {
     inner: Arc<AgenkitInner>,
@@ -442,6 +458,10 @@ pub struct AgentSession {
     /// Shared steering controls (queue + abort + hooks). Cloning the session
     /// shares these (Arc-backed), so `steer`/`abort` reach the running turn.
     controls: TurnControls,
+    /// Single-active-turn guard (Arc-shared across clones): a turn holds it for
+    /// its duration so a concurrent `prompt` is rejected rather than corrupting
+    /// the shared thread/queue/abort.
+    busy: Arc<AtomicBool>,
 }
 
 impl AgentSession {
@@ -458,8 +478,9 @@ impl AgentSession {
 
     /// Inject a follow-up message into the **currently running** turn: instead of
     /// going idle when the model next answers, the loop continues with this
-    /// message (the "talk to it mid-run" steering). If no turn is running it is
-    /// picked up by the next [`prompt`](AgentSession::prompt).
+    /// message (the "talk to it mid-run" steering). A steer queued just before a
+    /// `prompt` is picked up by that turn; anything left unconsumed is cleared
+    /// when the turn ends (it never leaks into a later prompt).
     pub fn steer(&self, text: impl Into<String>) {
         if let Ok(mut queue) = self.controls.queue.lock() {
             queue.push_back(text.into());
@@ -482,16 +503,46 @@ impl AgentSession {
     }
 
     /// Prompt the conversation: run one turn and stream its [`AgentEvent`]s. The
-    /// turn runs on a spawned task; drain the returned stream to observe it. The
-    /// terminal event is [`AgentEvent::Stopped`] (success) or
-    /// [`AgentEvent::Failed`].
+    /// turn runs on a spawned task (so this **requires a Tokio runtime** — it
+    /// panics otherwise); drain the returned stream to observe it. The terminal
+    /// event is [`AgentEvent::Stopped`] (success) or [`AgentEvent::Failed`].
+    ///
+    /// **One turn at a time:** if a turn is already running on this session (or a
+    /// clone of it), the prompt is rejected with a `Failed` event rather than run
+    /// concurrently — concurrent turns would corrupt the shared thread and
+    /// steering state. Await the stream to completion (or `abort`) before the
+    /// next prompt.
     pub fn prompt(&self, text: impl Into<String>) -> UnboundedReceiverStream<AgentEvent> {
         let (tx, rx) = unbounded_channel();
-        let session = self.clone();
         let text = text.into();
+
+        // Single-active-turn guard: claim the turn lock, or reject.
+        if self
+            .busy
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            let _ = tx.send(AgentEvent::Failed {
+                error: "a turn is already running on this session".to_string(),
+            });
+            return UnboundedReceiverStream::new(rx);
+        }
+        // Reset abort SYNCHRONOUSLY (before the task is spawned), so an `abort()`
+        // the caller issues right after `prompt()` targets THIS turn and can't be
+        // clobbered by a reset inside the spawned task.
+        self.controls.abort.store(false, Ordering::Relaxed);
+
+        let session = self.clone();
         tokio::spawn(async move {
             let _ = tx.send(AgentEvent::Started);
-            match session.run_one_prompt(text, &tx).await {
+            let result = session.run_one_prompt(text, &tx).await;
+            // Release the turn lock and drop any steer left unconsumed, so it
+            // can't leak into the next prompt.
+            if let Ok(mut queue) = session.controls.queue.lock() {
+                queue.clear();
+            }
+            session.busy.store(false, Ordering::Release);
+            match result {
                 Ok(reason) => {
                     let _ = tx.send(AgentEvent::Stopped { reason });
                 }
@@ -516,25 +567,22 @@ impl AgentSession {
             thread,
             agent_id: self.agent_id.clone(),
             // The branch is an independent conversation: same hooks, fresh
-            // queue + abort.
+            // queue + abort + turn lock.
             controls: TurnControls {
                 hooks: self.controls.hooks.clone(),
                 ..TurnControls::default()
             },
+            busy: Arc::new(AtomicBool::new(false)),
         }))
     }
 
-    /// One prompt's work: load history → run the turn → persist → compact.
+    /// One prompt's work: load history → persist the prompt → run the turn →
+    /// persist the answer → compact.
     async fn run_one_prompt(
         &self,
         text: String,
         events: &UnboundedSender<AgentEvent>,
     ) -> AgenkitResult<StopReason> {
-        // A fresh prompt clears any stale abort from a previous turn.
-        self.controls
-            .abort
-            .store(false, std::sync::atomic::Ordering::Relaxed);
-
         // Seed the model context from the compacted history (W7), then the prompt.
         let mut messages: Vec<Message> = self
             .thread
@@ -544,7 +592,19 @@ impl AgentSession {
             .map(|m| Message::new(m.role, m.content))
             .collect();
         let persist_from = messages.len();
-        messages.push(Message::user(text));
+        messages.push(Message::user(text.clone()));
+
+        // Persist the prompt UP FRONT so it survives a mid-turn error (the turn
+        // below may fail before producing an answer — the question must not be
+        // lost from a "durable, resumable" session).
+        self.thread
+            .store
+            .append(
+                &self.thread.id,
+                self.thread.owner(),
+                vec![ThreadMessage::new(Role::User, text)],
+            )
+            .await?;
 
         let agent_loop = AgentLoop::new(
             self.inner.clone(),
@@ -555,23 +615,27 @@ impl AgentSession {
             .run_turn(&mut messages, events, &self.controls)
             .await?;
 
-        // Persist the turn's user + assistant *text* messages (the initial prompt,
-        // any steered follow-ups, and the answers) so the conversation replays on
-        // resume. Tool calls/results are transient and re-derivable.
-        let to_persist: Vec<ThreadMessage> = messages[persist_from..]
+        // Persist what the turn produced (everything after the already-stored
+        // prompt): any steered follow-up prompts + the assistant **answers** —
+        // assistant messages with NO tool calls. Narration that rides a tool call,
+        // and tool results, are NOT stored, so resume replays a clean alternating
+        // Q&A rather than a transcript referencing tool calls that are gone.
+        let to_persist: Vec<ThreadMessage> = messages[persist_from + 1..]
             .iter()
             .filter_map(|m| match m.role {
                 Role::User => Some(ThreadMessage::new(Role::User, m.content.as_text())),
-                Role::Assistant if !m.content.as_text().is_empty() => {
+                Role::Assistant if m.tool_calls.is_empty() && !m.content.as_text().is_empty() => {
                     Some(ThreadMessage::new(Role::Assistant, m.content.as_text()))
                 }
                 _ => None,
             })
             .collect();
-        self.thread
-            .store
-            .append(&self.thread.id, self.thread.owner(), to_persist)
-            .await?;
+        if !to_persist.is_empty() {
+            self.thread
+                .store
+                .append(&self.thread.id, self.thread.owner(), to_persist)
+                .await?;
+        }
 
         // Compact if the (now longer) history would overflow the window.
         let model = self
@@ -642,7 +706,14 @@ impl AgentSessionBuilder {
     }
 
     /// Open the session: resume the thread `id` if it exists **and** is owned by
-    /// the principal, otherwise create a fresh durable thread.
+    /// the principal, otherwise create a fresh thread.
+    ///
+    /// Persistence is the configured store's: the runtime's **default**
+    /// `thread_store` is in-memory (process-local — resume works within the
+    /// process, but the thread is lost on restart). For across-restart durability,
+    /// build the runtime with a durable store, e.g.
+    /// `Agenkit::builder().thread_store(SessionThreadStore::new(Arc::new(
+    /// SqliteSessionStore::open(path)?)))`.
     pub async fn open(self, id: Option<AgentThreadId>) -> AgenkitResult<AgentSession> {
         let store = self.inner.thread_store.clone();
         let owner = ThreadOwner::from_principal(&self.principal);
@@ -671,6 +742,7 @@ impl AgentSessionBuilder {
                 hooks: self.hooks,
                 ..TurnControls::default()
             },
+            busy: Arc::new(AtomicBool::new(false)),
         })
     }
 }
@@ -984,5 +1056,87 @@ mod tests {
         let history = session.history().await.unwrap();
         assert_eq!(history[0].content.as_text(), "first");
         assert_eq!(history[2].content.as_text(), "and another thing");
+    }
+
+    // ── review fixes ─────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn a_concurrent_prompt_is_rejected_not_run() {
+        // current-thread runtime: the two prompt() calls run synchronously before
+        // either spawned turn does, so the second sees the turn lock held.
+        let agenkit = chat("ok");
+        let session = AgentSession::builder(&agenkit).open(None).await.unwrap();
+        let a = session.prompt("A"); // claims the turn lock (sync), spawns the turn
+        let b: Vec<AgentEvent> = session.prompt("B").collect().await; // rejected
+        assert!(
+            matches!(b.as_slice(), [AgentEvent::Failed { .. }]),
+            "second concurrent prompt must be rejected: {b:?}"
+        );
+        let _ = a.collect::<Vec<_>>().await; // let A finish, releasing the lock
+        // A fresh prompt works once the lock is free.
+        let c: Vec<AgentEvent> = session.prompt("C").collect().await;
+        assert!(
+            matches!(c.last(), Some(AgentEvent::Stopped { .. })),
+            "{c:?}"
+        );
+        // A persisted (prompt+answer); B persisted nothing; C persisted.
+        assert_eq!(session.history().await.unwrap().len(), 4);
+    }
+
+    #[tokio::test]
+    async fn the_prompt_is_persisted_even_when_the_turn_errors() {
+        // The model calls a tool the agent never allow-listed → run_turn errors.
+        let agenkit = Agenkit::builder()
+            .provider(MockProvider::new("local").on_prompt_tool(
+                "go",
+                "ghost",
+                serde_json::json!({}),
+            ))
+            .default_model(ModelRef::new("local/default"))
+            .build()
+            .unwrap();
+        let session = AgentSession::builder(&agenkit).open(None).await.unwrap();
+        let events: Vec<AgentEvent> = session.prompt("go").collect().await;
+        assert!(
+            matches!(events.last(), Some(AgentEvent::Failed { .. })),
+            "{events:?}"
+        );
+        // The question survived the error (persisted up front), so resume isn't blank.
+        let history = session.history().await.unwrap();
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].content.as_text(), "go");
+    }
+
+    #[tokio::test]
+    async fn a_tool_using_turn_persists_only_the_question_and_final_answer() {
+        let agenkit = Agenkit::builder()
+            .provider(
+                MockProvider::new("local")
+                    .on_prompt_tool("weather", "echo", serde_json::json!({ "text": "x" }))
+                    .default_text("it's sunny"),
+            )
+            .default_model(ModelRef::new("local/default"))
+            .tool(Echo)
+            .build()
+            .unwrap();
+        let session = AgentSession::builder(&agenkit)
+            .config(AgentConfig::new().tools(["echo"]))
+            .open(None)
+            .await
+            .unwrap();
+        let _ = session.prompt("weather?").collect::<Vec<_>>().await;
+        // The assistant tool-call turn and the tool result are NOT persisted —
+        // only the user question and the final answer (a clean alternating Q&A).
+        let history = session.history().await.unwrap();
+        assert_eq!(history.len(), 2, "{history:?}");
+        assert_eq!(history[0].content.as_text(), "weather?");
+        assert_eq!(history[1].content.as_text(), "it's sunny");
+    }
+
+    #[test]
+    fn agent_config_default_has_a_nonzero_step_budget() {
+        // Regression: the derived Default gave max_steps_per_turn = 0 (a no-op turn).
+        assert_eq!(AgentConfig::default().max_steps_per_turn, 8);
+        assert_eq!(AgentConfig::new().max_steps_per_turn, 8);
     }
 }

--- a/crates/pocopine-agenkit/tests/runtime_trace.rs
+++ b/crates/pocopine-agenkit/tests/runtime_trace.rs
@@ -1,0 +1,75 @@
+#![cfg(not(target_arch = "wasm32"))]
+//! The long-lived conversational runtime emits `pocopine.trace` for its turns —
+//! the same agent/model spans (with token [`Usage`] → catalog cost) the
+//! single-shot agent loop does, now that both drive the shared loop core. This is
+//! the regression guard for "conversational turns are metered": before the loop
+//! unification the runtime emitted only its `AgentEvent` firehose and no trace.
+//!
+//! Reads emitted events through a thread-local subscriber, so keep this binary to
+//! one trace-driving test (a parallel one would race the capture).
+
+mod common;
+
+use common::{block_on, capture};
+use pocopine_agenkit::server::{Agenkit, AgentEvent, AgentSession, MockProvider};
+use pocopine_agenkit_core::{ModelRef, Usage};
+use tokio_stream::StreamExt;
+
+/// A catalog model so cost is resolvable from usage.
+const MODEL: &str = "anthropic/claude-sonnet-4-6";
+
+fn runtime() -> Agenkit {
+    Agenkit::builder()
+        .provider(
+            MockProvider::new("anthropic")
+                .default_text("hi there")
+                // Explicit usage so the cost is deterministic (not prompt-derived).
+                .with_usage(Usage::new(1_000, 500)),
+        )
+        .default_model(ModelRef::new(MODEL))
+        .build()
+        .unwrap()
+}
+
+#[test]
+fn a_conversational_turn_emits_model_trace_with_cost() {
+    // claude-sonnet-4-6 rates: in 3.0, out 15.0 per 1e6 tokens.
+    // (1000*3.0 + 500*15.0) / 1e6 = 10500 / 1e6 = 0.0105
+    let expected = (1_000.0 * 3.0 + 500.0 * 15.0) / 1_000_000.0;
+
+    let cap = capture(|| {
+        let agenkit = runtime();
+        block_on(async {
+            let session = AgentSession::builder(&agenkit).open(None).await.unwrap();
+            // Drain the turn to completion so the spawned task (which emits the
+            // trace) runs on this current-thread runtime, under the subscriber.
+            let mut stream = session.prompt("hi");
+            let mut last = None;
+            while let Some(ev) = stream.next().await {
+                last = Some(ev);
+            }
+            assert!(
+                matches!(last, Some(AgentEvent::Stopped { .. })),
+                "turn should finish cleanly: {last:?}"
+            );
+        });
+    });
+
+    // The turn opened a trace run (an agent step) and emitted a model response...
+    assert!(
+        cap.contains("ai_step_started"),
+        "the turn should open an agent step: {:?}",
+        cap.names()
+    );
+    assert!(
+        cap.contains("ai_model_response"),
+        "the turn should emit a model response: {:?}",
+        cap.names()
+    );
+    // ...carrying the catalog-derived cost — conversational turns are now metered.
+    assert!(
+        cap.costs().iter().any(|c| (c - expected).abs() < 1e-9),
+        "expected a model-response cost ~{expected}, captured {:?}",
+        cap.costs()
+    );
+}


### PR DESCRIPTION
## What

The long-lived, multi-turn **agent runtime** for agenkit (the *kitty* runtime — Layer 2 / pi's `pi-agent-core`). agenkit's `ctx.agent::<A>()` is a single-shot, flow-scoped loop (`typed input → run → typed output`, inside one request). This adds its **conversational** counterpart: an `AgentSession` you `open` once and `prompt()` over time, watching a typed `AgentEvent` stream and steering it with hooks — running on the **W7 session layer** for durability, branching, and resume.

Built in three phases (L1–L3), then hardened against a code review, then the two loops were **unified behind one engine**.

```mermaid
flowchart TB
  subgraph public["public surface"]
    session["AgentSession (L2, durable)<br/>open · prompt · fork · resume"]
  end
  subgraph steer["steering (L3)"]
    queue["steer() — mid-run queue"]
    hook["before_tool_call → Proceed / Block / ReplaceArgs"]
    abort["abort_handle() → StopReason::Aborted"]
  end
  loopcore["server::loop_core (shared engine)<br/>run_model_step · dispatch_tool_calls · LoopObserver"]
  single["ctx.agent (single-shot)<br/>TraceObserver"]
  runtimeobs["runtime turn<br/>RuntimeObserver = trace + firehose"]
  store["W7 SessionStore — append · fork · checkpoint"]
  fire["AgentEvent firehose"]
  trace["pocopine.trace — usage + catalog cost"]

  session --> runtimeobs
  steer --> runtimeobs
  runtimeobs --> loopcore
  single --> loopcore
  session --> store
  runtimeobs --> fire
  runtimeobs --> trace
  single --> trace
```

## The phases

| | what |
|---|---|
| **L1** | `AgentLoop` — the in-memory conversational model↔tool core, emitting a typed `AgentEvent` firehose (`Started` / `AssistantText` / `ToolStarted` / `ToolCompleted` / `ToolFailed` / `ToolBlocked` / `Compacted` / `Stopped` / `Failed`). Tool failures feed back to the model instead of aborting. |
| **L2** | `AgentSession` — durable on the W7 session layer. `builder(&agenkit).open(id?)` (owner-checked resume or a fresh durable thread); `prompt(text) -> Stream<AgentEvent>` (load compacted history → run a turn on a spawned task → persist → compact); `fork()` branches an independent conversation. |
| **L3** | Steering — `steer(text)` mid-run queue ("talk to it mid-run"); a `before_tool_call -> ToolDecision` hook (`Proceed` / `Block{reason}` / `ReplaceArgs{args}`) with a `ToolBlocked` event; `abort_handle()` → `StopReason::Aborted`. Types are `#[non_exhaustive]` and shaped to pre-image the (parked) WASM/WIT extension world. |

## Review fixes (15 findings, all resolved)

A code review of L1–L3 surfaced 15 findings — all addressed across the last three commits:

- **Concurrency & lifecycle** — single-active-turn guard (a concurrent `prompt` is rejected, not run); abort reset is synchronous (no race with a just-issued `abort()`); a dropped event receiver stops the turn (no detached paid work); steer queue cleared at turn end (no leak into the next prompt).
- **Persistence fidelity** — the user prompt is persisted *up front* (survives a mid-turn error); only the question + final answer are stored (clean alternating Q&A; resume never references vanished tool calls); `AgentConfig::default()` has a non-zero step budget.
- **Dedup** — `run_turn` returns its resolved `ProviderContext` so compaction reuses the credential (no second BYOK resolve per prompt); `AgentLoop` dropped from the public re-export.

## Loop unification + tracing (the altitude fix)

The single-shot loop and the runtime duplicated the model↔tool engine, and the runtime was **trace-blind** — it emitted only its `AgentEvent` firehose, no `pocopine.trace`, no usage, no cost. These were one problem: the runtime lacked tracing *because* it was a second loop.

Both are now fixed by extracting **`server::loop_core`**:

- a `LoopObserver` trait + `run_model_step` (model call + request/response trace + usage) + `dispatch_tool_calls` (allowlist · `before_tool_call` hook · execute · feed-back), driven by **both** loops;
- the loops now differ only in **lifecycle and termination** (structured output vs. idle/steer), via their own observer — `ctx.agent` uses a `TraceObserver` (trace only); the runtime uses a `RuntimeObserver` wrapping `TraceObserver` + the firehose;
- each conversational turn opens its own trace run (an agent step parenting the model/tool spans) and emits the same `ai_model_response` + token usage as the typed run;
- `TraceObserver` now also resolves the **catalog-derived cost** (W2) on every model response — so *both* loops are **metered**, not just token-counted (the single-shot loop never emitted cost before either; this is a net gain on both paths).

`ToolDecision` moved to `loop_core` (re-exported from `runtime`); the public path `server::ToolDecision` is unchanged.

## API shape

```rust
let session = AgentSession::builder(&agenkit)
    .config(AgentConfig::new().system("…").tools(["read", "edit"]))
    .before_tool_call(|tool, args| { /* approval/trust gate → Proceed | Block | ReplaceArgs */ })
    .open(thread_id_or_none).await?;

let mut events = session.prompt("refactor the auth module");   // Stream<AgentEvent>
while let Some(ev) = events.next().await { /* render / telemetry */ }
session.steer("also add tests");      // enqueues into the running turn
let forked = session.fork().await?;   // branch an independent conversation
```

## Tests & gates

- New `runtime_trace` integration test: a conversational turn emits the agent step, `ai_model_response`, and a non-zero catalog cost (~\$0.0105 for 1000-in / 500-out on sonnet-4-6).
- Runtime unit tests cover the tool loop, tool-failure feed-back, durable persistence / resume / fork, steering, abort, single-active-turn rejection, persist-on-error, and the clean Q&A persistence.
- All `pocopine-agenkit` tests (106 lib + every integration binary), `clippy` (host + wasm), and `fmt` are green.

## Follow-ups (not in this PR)
- L4 modes — `print` (`-p`) and `rpc` (LF-JSONL over stdio); the SDK/embed surface (`AgentSession`) is what this PR ships.
- Deeper persistence — store the full event log (needs `ThreadMessage` to model `tool_calls`); current model is the same lossy-text view as the single-shot loop.
- The parked WASM/WIT extension world plugs into these (now-existing) hook/event contracts.