### PR TITLE
feat(agenkit): full-fidelity durable transcripts (deeper persistence P1–P5)

### DIFF
--- a/crates/pocopine-agenkit/Cargo.toml
+++ b/crates/pocopine-agenkit/Cargo.toml
@@ -32,6 +32,9 @@ pocopine-agenkit-macros = { workspace = true }
 # AI events ride the existing observability stack: TraceEvent -> ObservedEvent
 # -> emit_tracing. No parallel telemetry runtime (§D12).
 pocopine-observe = { workspace = true }
+# Framework logging (RFC-069): `tracing::warn!(target: "pocopine.log", …)` for
+# best-effort paths (e.g. a swallowed usage-provenance write) that must surface.
+tracing = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 # Provider runtime + bounded parallel branches (JoinSet/abort) + timeouts;

--- a/crates/pocopine-agenkit/src/server/agent.rs
+++ b/crates/pocopine-agenkit/src/server/agent.rs
@@ -9,8 +9,8 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use pocopine_agenkit_core::{
-    AgenkitError, AgenkitResult, Message, ModelRef, StepId, StepKind, StepStatus, ToolDescriptor,
-    events,
+    AgenkitError, AgenkitResult, Message, ModelRef, Role, StepId, StepKind, StepStatus,
+    ToolDescriptor, events,
 };
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -405,13 +405,27 @@ pub(crate) async fn compact_thread(
     }
 
     // Keep the recent tail verbatim (token-bounded — see `recent_keep_count`),
-    // fold the older prefix into the summary.
+    // fold the older prefix into the summary, snapping the boundary so the tail
+    // stays protocol-valid (no orphan tool result).
     let keep = recent_keep_count(&history, KEEP_RECENT_VERBATIM_TOKENS);
-    let (older, recent) = history.split_at(history.len() - keep);
+    let (older, recent) = history.split_at(compaction_split(&history, keep));
 
+    // Render the folded prefix for summarization. A tool-call turn carries its
+    // signal in `tool_calls` (not text), so spell the calls out — otherwise the
+    // summary silently forgets which tools were used (and `as_text()` of such a
+    // turn is empty).
     let transcript = older
         .iter()
-        .map(|m| format!("[{:?}] {}", m.role, m.content.as_text()))
+        .map(|m| {
+            let mut line = format!("[{:?}] {}", m.role, m.content.as_text());
+            for call in &m.tool_calls {
+                line.push_str(&format!(
+                    "\n  ↳ tool call `{}`({})",
+                    call.tool_id, call.args
+                ));
+            }
+            line
+        })
         .collect::<Vec<_>>()
         .join("\n");
     let summary = summarize(transcript, model, provider, cx).await?;
@@ -452,6 +466,20 @@ fn recent_keep_count(messages: &[Message], budget: u64) -> usize {
     keep
 }
 
+/// Where the kept-verbatim tail begins, given `keep` recent messages. Starts at
+/// `len - keep`, then advances past any leading tool-result messages so the tail
+/// never begins with an orphan `Role::Tool` whose assistant tool-call turn was
+/// folded into the summary — which a model API would reject (a tool result with
+/// no matching tool call) on the next request after a resume/compaction. Those
+/// orphaned results fold into the summary instead.
+fn compaction_split(history: &[Message], keep: usize) -> usize {
+    let mut split = history.len() - keep;
+    while split < history.len() && history[split].role == Role::Tool {
+        split += 1;
+    }
+    split
+}
+
 /// Summarize a conversation transcript into a single compaction summary via a
 /// plain-text model call (no tools, no schema).
 async fn summarize(
@@ -484,10 +512,33 @@ async fn summarize(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pocopine_agenkit_core::Role;
+    use pocopine_agenkit_core::{Content, Role, ToolCall};
 
     fn msg(text: &str) -> Message {
         Message::new(Role::User, text)
+    }
+
+    #[test]
+    fn compaction_split_never_orphans_a_tool_result() {
+        // A full-fidelity tool turn: user, assistant tool-call, tool result, answer.
+        let history = vec![
+            Message::user("q"),
+            Message::assistant_tool_calls(
+                Content::default(),
+                vec![ToolCall::new("c1", "echo", serde_json::json!({}))],
+            ),
+            Message::tool_result("c1", "out"),
+            Message::assistant("a"),
+        ];
+        // Naively keeping the last 2 would start the tail at the tool result (index
+        // 2) — an orphan once its assistant tool-call turn is summarized. The split
+        // must advance past it so the kept tail begins at the answer (index 3).
+        assert_eq!(compaction_split(&history, 2), 3);
+        assert_ne!(history[compaction_split(&history, 2)].role, Role::Tool);
+
+        // A boundary that already lands on a non-tool message is unchanged.
+        assert_eq!(compaction_split(&history, 1), 3); // tail = [answer]
+        assert_eq!(compaction_split(&history, 4), 0); // keep all → start at 0
     }
 
     #[test]

--- a/crates/pocopine-agenkit/src/server/agent.rs
+++ b/crates/pocopine-agenkit/src/server/agent.rs
@@ -244,11 +244,13 @@ async fn run_loop<A: AiAgent>(
         // `Vec<Message>`, so it carries any persisted tool-call linkage verbatim.
         messages.extend(thread.active_history().await?);
     }
-    // Serialize the input once (reused when persisting the turn). A failure is a
-    // real error, not an empty prompt sent to the model.
+    // Serialize the input. A failure is a real error, not an empty prompt sent to
+    // the model. `persist_from` marks where this turn's new records begin — the
+    // seeded history before it is already stored, so only the suffix is persisted.
     let input_json = serde_json::to_string(input)
         .map_err(|e| AgenkitError::internal(format!("agent `{}` input encode: {e}", A::ID)))?;
-    messages.push(Message::user(input_json.clone()));
+    let persist_from = messages.len();
+    messages.push(Message::user(input_json));
 
     // Resolve the provider credential once (W6): the principal and provider are
     // fixed across the agent loop, so the per-request context is too.
@@ -303,16 +305,15 @@ async fn run_loop<A: AiAgent>(
                 let output_json = serde_json::to_string(&output).map_err(|e| {
                     AgenkitError::internal(format!("agent `{}` output encode: {e}", A::ID))
                 })?;
+                // Full fidelity: the user input + every tool turn the loop produced
+                // (in `messages` from `persist_from`) + the final structured answer.
+                // So a resumed thread replays the tool calls/results, not just the
+                // question and answer.
+                let mut records = messages[persist_from..].to_vec();
+                records.push(Message::assistant(output_json));
                 thread
                     .store
-                    .append(
-                        &thread.id,
-                        thread.owner(),
-                        vec![
-                            Message::user(input_json.clone()),
-                            Message::assistant(output_json),
-                        ],
-                    )
+                    .append(&thread.id, thread.owner(), records)
                     .await?;
                 maybe_compact::<A>(run, config, model, provider, &cx, thread).await?;
             }

--- a/crates/pocopine-agenkit/src/server/agent.rs
+++ b/crates/pocopine-agenkit/src/server/agent.rs
@@ -9,8 +9,8 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 use pocopine_agenkit_core::{
-    AgenkitError, AgenkitResult, Message, ModelRef, Role, StepId, StepKind, StepStatus,
-    ThreadMessage, ToolDescriptor, events,
+    AgenkitError, AgenkitResult, Message, ModelRef, StepId, StepKind, StepStatus, ToolDescriptor,
+    events,
 };
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -240,10 +240,9 @@ async fn run_loop<A: AiAgent>(
     let mut messages = Vec::new();
     if let Some(thread) = thread {
         // The compacted view (from the last checkpoint) — keeps a long-running
-        // thread inside the model's context window (W7 compaction).
-        for message in thread.active_history().await? {
-            messages.push(Message::new(message.role, message.content));
-        }
+        // thread inside the model's context window (W7 compaction). Already
+        // `Vec<Message>`, so it carries any persisted tool-call linkage verbatim.
+        messages.extend(thread.active_history().await?);
     }
     // Serialize the input once (reused when persisting the turn). A failure is a
     // real error, not an empty prompt sent to the model.
@@ -310,8 +309,8 @@ async fn run_loop<A: AiAgent>(
                         &thread.id,
                         thread.owner(),
                         vec![
-                            ThreadMessage::new(Role::User, input_json.clone()),
-                            ThreadMessage::new(Role::Assistant, output_json),
+                            Message::user(input_json.clone()),
+                            Message::assistant(output_json),
                         ],
                     )
                     .await?;
@@ -397,17 +396,16 @@ pub(crate) async fn compact_thread(
     if history.len() < 4 {
         return Ok(None); // nothing meaningful to summarize yet
     }
-    let messages: Vec<Message> = history
-        .iter()
-        .map(|m| Message::new(m.role, m.content.clone()))
-        .collect();
-    if !context_headroom(catalog_model, &messages, max_output).over {
+    // `active_history` is already `Vec<Message>` (full fidelity), so size and
+    // split it directly — no lossy reconstruction, and the kept tail retains any
+    // tool-call linkage verbatim.
+    if !context_headroom(catalog_model, &history, max_output).over {
         return Ok(None); // still fits — no compaction
     }
 
     // Keep the recent tail verbatim (token-bounded — see `recent_keep_count`),
     // fold the older prefix into the summary.
-    let keep = recent_keep_count(&messages, KEEP_RECENT_VERBATIM_TOKENS);
+    let keep = recent_keep_count(&history, KEEP_RECENT_VERBATIM_TOKENS);
     let (older, recent) = history.split_at(history.len() - keep);
 
     let transcript = older
@@ -418,7 +416,7 @@ pub(crate) async fn compact_thread(
     let summary = summarize(transcript, model, provider, cx).await?;
     let (folded, kept) = (older.len() as u64, recent.len() as u64);
     thread
-        .checkpoint(ThreadMessage::new(Role::System, summary), recent.to_vec())
+        .checkpoint(Message::system(summary), recent.to_vec())
         .await?;
     Ok(Some((folded, kept)))
 }

--- a/crates/pocopine-agenkit/src/server/mod.rs
+++ b/crates/pocopine-agenkit/src/server/mod.rs
@@ -68,8 +68,8 @@ pub use provider::{
 pub use reduce::ReduceBuilder;
 pub use retrieval::{AiRetriever, DynRetriever, RetrieverRegistry, retriever_as_tool};
 pub use runtime::{
-    AbortHandle, AgentConfig, AgentEvent, AgentSession, AgentSessionBuilder, StopReason,
-    ToolDecision,
+    AbortHandle, AgentConfig, AgentEvent, AgentSession, AgentSessionBuilder, CapturePolicy,
+    StopReason, ToolDecision,
 };
 pub use thread::{
     AgentThreadHandle, AgentThreadStore, SessionThreadStore, ThreadBuilder, ThreadOwner,

--- a/crates/pocopine-agenkit/src/server/overflow.rs
+++ b/crates/pocopine-agenkit/src/server/overflow.rs
@@ -78,6 +78,18 @@ pub fn estimate_input_tokens(messages: &[Message]) -> u64 {
                     ContentPart::Media(_) => PER_MEDIA,
                 });
             }
+            // A tool-call turn carries its payload in `tool_calls` (the serialized
+            // args), and a tool result links by `tool_call_id` — neither rides in
+            // `content.parts`. With full-fidelity transcripts these are now in the
+            // history, so count them or a tool-heavy thread under-counts and never
+            // trips proactive compaction (overflowing at generate instead).
+            for call in &m.tool_calls {
+                let args_len = serde_json::to_string(&call.args).map_or(0, |s| s.len());
+                tokens = tokens.saturating_add((call.tool_id.len() + args_len) as u64 / 4);
+            }
+            if let Some(id) = &m.tool_call_id {
+                tokens = tokens.saturating_add(id.len() as u64 / 4);
+            }
             tokens
         })
         .sum()
@@ -175,6 +187,21 @@ mod tests {
             (990..=1010).contains(&est),
             "reasoning under-counted: {est}"
         );
+    }
+
+    #[test]
+    fn estimate_counts_tool_call_args_not_just_content() {
+        use pocopine_agenkit_core::{Content, ToolCall};
+        // A tool-call turn with empty text content but a large args payload must
+        // count toward the input — otherwise a tool-heavy history under-counts and
+        // never trips proactive compaction.
+        let big_args = serde_json::json!({ "blob": "z".repeat(4000) });
+        let call = Message::assistant_tool_calls(
+            Content::default(),
+            vec![ToolCall::new("c1", "echo", big_args)],
+        );
+        let est = estimate_input_tokens(&[call]);
+        assert!(est >= 1000, "tool-call args under-counted: {est}");
     }
 
     #[test]

--- a/crates/pocopine-agenkit/src/server/runtime.rs
+++ b/crates/pocopine-agenkit/src/server/runtime.rs
@@ -27,7 +27,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use pocopine_agenkit_core::{
     AgenkitError, AgenkitResult, AgentThreadId, Message, ModelRef, Role, RunId, StepId, StepKind,
-    StepStatus, ThreadMessage, ThreadRetention, ToolCall, ToolDescriptor, TraceId, Usage, events,
+    StepStatus, ThreadRetention, ToolCall, ToolDescriptor, TraceId, Usage, events,
 };
 use pocopine_auth::Principal;
 use tokio::sync::mpsc::{UnboundedSender, unbounded_channel};
@@ -538,7 +538,7 @@ impl AgentSession {
     }
 
     /// The full stored conversation (every turn, pre-compaction view).
-    pub async fn history(&self) -> AgenkitResult<Vec<ThreadMessage>> {
+    pub async fn history(&self) -> AgenkitResult<Vec<Message>> {
         self.thread.history().await
     }
 
@@ -623,14 +623,10 @@ impl AgentSession {
         text: String,
         events: &UnboundedSender<AgentEvent>,
     ) -> AgenkitResult<StopReason> {
-        // Seed the model context from the compacted history (W7), then the prompt.
-        let mut messages: Vec<Message> = self
-            .thread
-            .active_history()
-            .await?
-            .into_iter()
-            .map(|m| Message::new(m.role, m.content))
-            .collect();
+        // Seed the model context from the compacted history (W7) — already
+        // `Vec<Message>` (full fidelity), so any persisted tool turns replay
+        // verbatim — then append the new prompt.
+        let mut messages: Vec<Message> = self.thread.active_history().await?;
         let persist_from = messages.len();
         messages.push(Message::user(text.clone()));
 
@@ -642,7 +638,7 @@ impl AgentSession {
             .append(
                 &self.thread.id,
                 self.thread.owner(),
-                vec![ThreadMessage::new(Role::User, text)],
+                vec![Message::user(text)],
             )
             .await?;
 
@@ -662,12 +658,12 @@ impl AgentSession {
         // assistant messages with NO tool calls. Narration that rides a tool call,
         // and tool results, are NOT stored, so resume replays a clean alternating
         // Q&A rather than a transcript referencing tool calls that are gone.
-        let to_persist: Vec<ThreadMessage> = messages[persist_from + 1..]
+        let to_persist: Vec<Message> = messages[persist_from + 1..]
             .iter()
             .filter_map(|m| match m.role {
-                Role::User => Some(ThreadMessage::new(Role::User, m.content.as_text())),
+                Role::User => Some(Message::user(m.content.as_text())),
                 Role::Assistant if m.tool_calls.is_empty() && !m.content.as_text().is_empty() => {
-                    Some(ThreadMessage::new(Role::Assistant, m.content.as_text()))
+                    Some(Message::assistant(m.content.as_text()))
                 }
                 _ => None,
             })

--- a/crates/pocopine-agenkit/src/server/runtime.rs
+++ b/crates/pocopine-agenkit/src/server/runtime.rs
@@ -206,6 +206,10 @@ impl AgentConfig {
 /// tool payloads from disk. Large payloads are already kept out-of-line by the
 /// `ExternalizingSessionStore`; this is the orthogonal "don't store the bytes at
 /// all" knob.
+///
+/// Scope: this governs the conversational [`AgentSession`] runtime only. The
+/// single-shot typed loop (`ctx.agent::<A>()`) has no session-level policy and
+/// persists its tool turns verbatim.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum CapturePolicy {
@@ -227,8 +231,15 @@ fn redact_tool_payloads(messages: Vec<Message>) -> Vec<Message> {
     messages
         .into_iter()
         .map(|mut m| {
-            for call in &mut m.tool_calls {
-                call.args = serde_json::json!({ "redacted": true });
+            if !m.tool_calls.is_empty() {
+                // Redact the call arguments AND the assistant turn's own content:
+                // the narration that rides a tool call can echo the same secret,
+                // and a reasoning part carries the provider thinking signature —
+                // both would otherwise persist in the clear.
+                for call in &mut m.tool_calls {
+                    call.args = serde_json::json!({ "redacted": true });
+                }
+                m.content = Content::text("[redacted]");
             }
             if m.tool_call_id.is_some() {
                 m.content = Content::text("[redacted]");
@@ -1431,6 +1442,45 @@ mod tests {
         // The question and the answer are untouched (not tool payloads).
         assert_eq!(history[0].content.as_text(), "weather?");
         assert_eq!(history[3].content.as_text(), "it's sunny");
+    }
+
+    #[test]
+    fn redact_tool_payloads_strips_narration_and_signature_too() {
+        use pocopine_agenkit_core::{Content, ContentPart, ToolCall};
+        // An assistant tool-call turn whose narration AND reasoning signature echo
+        // the secret — both must be scrubbed, not just the args (review #4).
+        let messages = vec![
+            Message::assistant_tool_calls(
+                Content::from_parts(vec![
+                    ContentPart::text("calling echo with key-123"),
+                    ContentPart::thinking("the key is key-123", Some("sig-123".to_string())),
+                ]),
+                vec![ToolCall::new(
+                    "c1",
+                    "echo",
+                    serde_json::json!({ "text": "key-123" }),
+                )],
+            ),
+            Message::tool_result("c1", "{\"echoed\":\"key-123\"}"),
+        ];
+        let redacted = redact_tool_payloads(messages);
+
+        // The tool-call turn: args redacted AND the content (narration + signature)
+        // gone — but the call structure stays for replay coherence.
+        assert_eq!(redacted[0].tool_calls.len(), 1);
+        assert!(
+            redacted[0].tool_calls[0]
+                .args
+                .to_string()
+                .contains("redacted")
+        );
+        let turn0 = format!("{:?}", redacted[0].content);
+        assert!(!turn0.contains("key-123"), "narration leaked: {turn0}");
+        assert!(!turn0.contains("sig-123"), "signature leaked: {turn0}");
+
+        // The tool result: payload gone, linkage kept.
+        assert_eq!(redacted[1].tool_call_id.as_deref(), Some("c1"));
+        assert!(!redacted[1].content.as_text().contains("key-123"));
     }
 
     #[test]

--- a/crates/pocopine-agenkit/src/server/runtime.rs
+++ b/crates/pocopine-agenkit/src/server/runtime.rs
@@ -26,7 +26,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use pocopine_agenkit_core::{
-    AgenkitError, AgenkitResult, AgentThreadId, Message, ModelRef, Role, RunId, StepId, StepKind,
+    AgenkitError, AgenkitResult, AgentThreadId, Message, ModelRef, RunId, StepId, StepKind,
     StepStatus, ThreadRetention, ToolCall, ToolDescriptor, TraceId, Usage, events,
 };
 use pocopine_auth::Principal;
@@ -369,13 +369,15 @@ impl AgentLoop {
 
                 let text = response.text_output();
                 if !text.is_empty() {
-                    let _ = events.send(AgentEvent::AssistantText { text: text.clone() });
+                    let _ = events.send(AgentEvent::AssistantText { text });
                 }
 
                 if response.tool_calls.is_empty() {
-                    // The model answered. Persist the assistant text so the
-                    // conversation replays on resume.
-                    messages.push(Message::new(Role::Assistant, text));
+                    // The model answered. Push the assistant's FULL content (text
+                    // plus any reasoning + provider signature), not just the
+                    // flattened text, so an extended-thinking turn replays
+                    // losslessly on resume (the signature must be replayed verbatim).
+                    messages.push(Message::assistant(response.content.clone()));
                     // Steering: a queued follow-up message continues the turn
                     // ("talk to it mid-run"); otherwise the turn ends.
                     match controls.next_steer() {
@@ -617,7 +619,7 @@ impl AgentSession {
     }
 
     /// One prompt's work: load history → persist the prompt → run the turn →
-    /// persist the answer → compact.
+    /// persist the full turn transcript → compact.
     async fn run_one_prompt(
         &self,
         text: String,
@@ -653,21 +655,20 @@ impl AgentSession {
             .run_turn(&mut messages, events, &self.controls)
             .await?;
 
-        // Persist what the turn produced (everything after the already-stored
-        // prompt): any steered follow-up prompts + the assistant **answers** —
-        // assistant messages with NO tool calls. Narration that rides a tool call,
-        // and tool results, are NOT stored, so resume replays a clean alternating
-        // Q&A rather than a transcript referencing tool calls that are gone.
-        let to_persist: Vec<Message> = messages[persist_from + 1..]
-            .iter()
-            .filter_map(|m| match m.role {
-                Role::User => Some(Message::user(m.content.as_text())),
-                Role::Assistant if m.tool_calls.is_empty() && !m.content.as_text().is_empty() => {
-                    Some(Message::assistant(m.content.as_text()))
-                }
-                _ => None,
-            })
-            .collect();
+        // Persist the FULL turn transcript — everything the turn produced after
+        // the already-stored prompt: the assistant tool-call turns, the tool
+        // results (with their `tool_call_id` linkage), any steered follow-up
+        // prompts, and the final answer (reasoning + signature intact). So resume
+        // replays the exact `Vec<Message>` the model saw, not a lossy Q&A.
+        //
+        // All-or-nothing per turn: this runs only on `run_turn` success, and
+        // `run_turn` only returns `Ok` with a well-formed transcript (every
+        // assistant tool-call is followed by its results). On a turn error nothing
+        // here runs (the pre-stored prompt still survives), so resume never sees a
+        // half-open tool call. (Per-step streaming durability — surviving a crash
+        // *mid-turn* — would need a transactional batch append; tracked as a
+        // follow-up.)
+        let to_persist = messages[persist_from + 1..].to_vec();
         if !to_persist.is_empty() {
             self.thread
                 .store
@@ -784,7 +785,7 @@ mod tests {
     use super::*;
     use crate::server::{Agenkit, AiTool, AiToolContext, BoxFuture, MockProvider};
     use futures::StreamExt;
-    use pocopine_agenkit_core::{ModelRef, ToolDescriptor as Td};
+    use pocopine_agenkit_core::{ModelRef, Role, ToolDescriptor as Td};
     use serde::{Deserialize, Serialize};
     use tokio::sync::mpsc::unbounded_channel;
 
@@ -1140,7 +1141,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn a_tool_using_turn_persists_only_the_question_and_final_answer() {
+    async fn a_tool_using_turn_persists_the_full_transcript() {
         let agenkit = Agenkit::builder()
             .provider(
                 MockProvider::new("local")
@@ -1157,12 +1158,26 @@ mod tests {
             .await
             .unwrap();
         let _ = session.prompt("weather?").collect::<Vec<_>>().await;
-        // The assistant tool-call turn and the tool result are NOT persisted —
-        // only the user question and the final answer (a clean alternating Q&A).
+        // Full fidelity (P2): the user question, the assistant tool-call turn, the
+        // tool result (with its linkage), and the final answer all persist — so
+        // resume replays the exact transcript the model saw, not a lossy Q&A.
         let history = session.history().await.unwrap();
-        assert_eq!(history.len(), 2, "{history:?}");
+        assert_eq!(history.len(), 4, "{history:?}");
+        assert_eq!(history[0].role, Role::User);
         assert_eq!(history[0].content.as_text(), "weather?");
-        assert_eq!(history[1].content.as_text(), "it's sunny");
+        // The assistant's tool-call turn, with the call recorded (linkage intact).
+        assert_eq!(history[1].role, Role::Assistant);
+        assert_eq!(history[1].tool_calls.len(), 1);
+        assert_eq!(history[1].tool_calls[0].tool_id, "echo");
+        // The tool result, answering that call by id.
+        assert_eq!(history[2].role, Role::Tool);
+        assert_eq!(
+            history[2].tool_call_id.as_deref(),
+            Some(history[1].tool_calls[0].id.as_str())
+        );
+        // The final answer.
+        assert_eq!(history[3].role, Role::Assistant);
+        assert_eq!(history[3].content.as_text(), "it's sunny");
     }
 
     #[test]

--- a/crates/pocopine-agenkit/src/server/runtime.rs
+++ b/crates/pocopine-agenkit/src/server/runtime.rs
@@ -249,6 +249,29 @@ fn redact_tool_payloads(messages: Vec<Message>) -> Vec<Message> {
         .collect()
 }
 
+/// A per-turn usage/cost provenance entry — a typed [`RecordKind::StateChange`]
+/// payload. Typed (not hand-built JSON) so the write site and the `usage()`/`cost()`
+/// readers share one schema: a renamed/missing field is a compile error, not a
+/// silent zero. The `kind` discriminator distinguishes this from any future
+/// state-change payload that also rides `RecordKind::StateChange`.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct UsageRecord {
+    /// Discriminator within `RecordKind::StateChange` — always `"usage"` here.
+    kind: String,
+    /// The model the turn used.
+    model: String,
+    /// The turn's aggregate token usage.
+    usage: Usage,
+    /// The catalog-derived cost, if the model had pricing.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    cost: Option<CostEstimate>,
+}
+
+impl UsageRecord {
+    /// The discriminator value for a usage entry.
+    const KIND: &'static str = "usage";
+}
+
 /// Typed steering hooks (L3) — host-side closures that *steer* the loop. The
 /// shapes pre-image the WIT extension world so extensions later supply the same
 /// decisions across the component boundary.
@@ -613,37 +636,48 @@ impl AgentSession {
         self.thread.history().await
     }
 
+    /// The durable usage provenance entries for this thread (this thread's own
+    /// turns only — a fork reports its own usage, not the inherited prefix's).
+    /// Empty if the backing store doesn't record provenance.
+    async fn usage_records(&self) -> AgenkitResult<Vec<UsageRecord>> {
+        Ok(self
+            .thread
+            .state_changes()
+            .await?
+            .into_iter()
+            // Typed decode also filters: a non-usage state-change payload fails to
+            // deserialize into `UsageRecord` and is skipped.
+            .filter_map(|v| serde_json::from_value::<UsageRecord>(v).ok())
+            .filter(|r| r.kind == UsageRecord::KIND)
+            .collect())
+    }
+
     /// Aggregate token [`Usage`] across this conversation's turns, summed from the
     /// durable usage provenance (P5). Zero if the backing store doesn't record
     /// provenance (e.g. a custom store that no-ops `append_state_change`).
     pub async fn usage(&self) -> AgenkitResult<Usage> {
-        let mut total = Usage::default();
-        for entry in self.thread.state_changes().await? {
-            if entry.get("kind").and_then(serde_json::Value::as_str) == Some("usage")
-                && let Some(u) = entry
-                    .get("usage")
-                    .and_then(|u| serde_json::from_value::<Usage>(u.clone()).ok())
-            {
-                total = total.merge(u);
-            }
-        }
-        Ok(total)
+        Ok(self
+            .usage_records()
+            .await?
+            .into_iter()
+            .fold(Usage::default(), |acc, r| acc.merge(r.usage)))
     }
 
     /// Aggregate estimated cost across this conversation's turns, summed from the
     /// durable usage provenance (P5). `None` if no turn recorded a cost (no
-    /// provenance, or no catalog pricing for the model).
+    /// provenance, or no catalog pricing for the model). Entries in a currency
+    /// other than the first seen are skipped rather than summed as if fungible.
     pub async fn cost(&self) -> AgenkitResult<Option<CostEstimate>> {
         let mut amount = 0.0;
         let mut currency: Option<String> = None;
-        for entry in self.thread.state_changes().await? {
-            if let Some(cost) = entry
-                .get("cost")
-                .filter(|c| !c.is_null())
-                .and_then(|c| serde_json::from_value::<CostEstimate>(c.clone()).ok())
-            {
-                currency.get_or_insert(cost.currency);
-                amount += cost.amount;
+        for record in self.usage_records().await? {
+            let Some(cost) = record.cost else { continue };
+            match &currency {
+                Some(seen) if *seen != cost.currency => continue, // don't add a different currency
+                _ => {
+                    currency.get_or_insert(cost.currency);
+                    amount += cost.amount;
+                }
             }
         }
         Ok(currency.map(|currency| CostEstimate::new(currency, amount)))
@@ -774,7 +808,17 @@ impl AgentSession {
         // half-open tool call. (Per-step streaming durability — surviving a crash
         // *mid-turn* — would need a transactional batch append; tracked as a
         // follow-up.)
-        let to_persist = messages[persist_from + 1..].to_vec();
+        // Drop any truly-empty message (no content parts, no tool calls, no
+        // result linkage) — e.g. an empty completion — so resume doesn't replay a
+        // contentless turn that some providers reject. A thinking-only or
+        // tool-call turn has parts/tool_calls and is kept.
+        let to_persist: Vec<Message> = messages[persist_from + 1..]
+            .iter()
+            .filter(|m| {
+                !m.content.is_empty() || !m.tool_calls.is_empty() || m.tool_call_id.is_some()
+            })
+            .cloned()
+            .collect();
         // §D10 capture policy: optionally redact tool payloads before they hit disk
         // (the linkage is kept, so resume stays coherent — see `CapturePolicy`).
         let to_persist = match self.capture {
@@ -802,18 +846,32 @@ impl AgentSession {
         // Record this turn's usage + catalog cost as a provenance entry (P5) — a
         // `StateChange` outside the conversation history (it never reaches the
         // model), so a session's running cost is auditable from its durable log.
-        // Best-effort: a provenance write must not fail the prompt.
+        // Best-effort: a provenance write must not fail the prompt, but a failure
+        // is logged (not silently swallowed) so a divergence is observable.
         if usage.total() > 0 {
-            let cost = super::catalog::lookup(&model).map(|m| m.estimate_cost(&usage));
-            let _ = self
-                .thread
-                .append_state_change(serde_json::json!({
-                    "kind": "usage",
-                    "model": model.as_str(),
-                    "usage": usage,
-                    "cost": cost,
-                }))
-                .await;
+            let record = UsageRecord {
+                kind: UsageRecord::KIND.to_string(),
+                model: model.as_str().to_string(),
+                usage,
+                cost: super::catalog::lookup(&model).map(|m| m.estimate_cost(&usage)),
+            };
+            match serde_json::to_value(&record) {
+                Ok(data) => {
+                    if let Err(error) = self.thread.append_state_change(data).await {
+                        tracing::warn!(
+                            target: "pocopine.log",
+                            thread_id = self.thread.id().as_str(),
+                            error = %error,
+                            "failed to record turn usage provenance",
+                        );
+                    }
+                }
+                Err(error) => tracing::warn!(
+                    target: "pocopine.log",
+                    error = %error,
+                    "failed to encode turn usage provenance",
+                ),
+            }
         }
 
         let max_output = self.config.max_tokens.unwrap_or(1024);
@@ -1391,6 +1449,37 @@ mod tests {
             "expected ~{}, got {cost:?}",
             per_turn * 2.0
         );
+    }
+
+    #[tokio::test]
+    async fn fork_usage_is_local_not_double_counted() {
+        // A fork inherits the parent's MESSAGES for replay, but usage()/cost()
+        // report only this thread's OWN turns — so summing across the tree never
+        // double-counts the shared prefix (review #5).
+        let agenkit = Agenkit::builder()
+            .provider(
+                MockProvider::new("anthropic")
+                    .default_text("hi")
+                    .with_usage(pocopine_agenkit_core::Usage::new(1_000, 500)),
+            )
+            .default_model(ModelRef::new("anthropic/claude-sonnet-4-6"))
+            .build()
+            .unwrap();
+        let session = AgentSession::builder(&agenkit).open(None).await.unwrap();
+        let _ = session.prompt("first").collect::<Vec<_>>().await; // parent: 1 turn
+
+        let forked = session.fork().await.unwrap().expect("store can branch");
+        let _ = forked.prompt("second").collect::<Vec<_>>().await; // fork: 1 turn
+
+        // The fork reports ONLY its own turn (1000/500), not the parent's too.
+        let fork_usage = forked.usage().await.unwrap();
+        assert_eq!(
+            fork_usage.input_tokens, 1_000,
+            "fork double-counted the parent"
+        );
+        assert_eq!(fork_usage.output_tokens, 500);
+        // The parent still reports its own single turn.
+        assert_eq!(session.usage().await.unwrap().input_tokens, 1_000);
     }
 
     #[tokio::test]

--- a/crates/pocopine-agenkit/src/server/runtime.rs
+++ b/crates/pocopine-agenkit/src/server/runtime.rs
@@ -1180,6 +1180,48 @@ mod tests {
         assert_eq!(history[3].content.as_text(), "it's sunny");
     }
 
+    #[tokio::test]
+    async fn a_resumed_session_replays_the_tool_transcript() {
+        // P4 end-to-end: persist a tool turn, reopen the session by id over the
+        // same store, and confirm the resumed history replays the tool call +
+        // result linkage — the agent remembers it used a tool.
+        let agenkit = Agenkit::builder()
+            .provider(
+                MockProvider::new("local")
+                    .on_prompt_tool("weather", "echo", serde_json::json!({ "text": "x" }))
+                    .default_text("it's sunny"),
+            )
+            .default_model(ModelRef::new("local/default"))
+            .tool(Echo)
+            .build()
+            .unwrap();
+        let id = {
+            let s = AgentSession::builder(&agenkit)
+                .config(AgentConfig::new().tools(["echo"]))
+                .open(None)
+                .await
+                .unwrap();
+            let _ = s.prompt("weather?").collect::<Vec<_>>().await;
+            s.id().clone()
+        };
+
+        // Reopen by id over the same (shared) store → the tool transcript replays.
+        let resumed = AgentSession::builder(&agenkit)
+            .config(AgentConfig::new().tools(["echo"]))
+            .open(Some(id))
+            .await
+            .unwrap();
+        let history = resumed.history().await.unwrap();
+        assert_eq!(history.len(), 4, "{history:?}");
+        assert_eq!(history[1].tool_calls[0].tool_id, "echo");
+        assert_eq!(history[2].role, Role::Tool);
+        assert_eq!(
+            history[2].tool_call_id.as_deref(),
+            Some(history[1].tool_calls[0].id.as_str())
+        );
+        assert_eq!(history[3].content.as_text(), "it's sunny");
+    }
+
     #[test]
     fn agent_config_default_has_a_nonzero_step_budget() {
         // Regression: the derived Default gave max_steps_per_turn = 0 (a no-op turn).

--- a/crates/pocopine-agenkit/src/server/runtime.rs
+++ b/crates/pocopine-agenkit/src/server/runtime.rs
@@ -26,8 +26,8 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use pocopine_agenkit_core::{
-    AgenkitError, AgenkitResult, AgentThreadId, Message, ModelRef, RunId, StepId, StepKind,
-    StepStatus, ThreadRetention, ToolCall, ToolDescriptor, TraceId, Usage, events,
+    AgenkitError, AgenkitResult, AgentThreadId, CostEstimate, Message, ModelRef, RunId, StepId,
+    StepKind, StepStatus, ThreadRetention, ToolCall, ToolDescriptor, TraceId, Usage, events,
 };
 use pocopine_auth::Principal;
 use tokio::sync::mpsc::{UnboundedSender, unbounded_channel};
@@ -275,15 +275,16 @@ impl AgentLoop {
     /// and stop when the model answers without tool calls or the step budget is
     /// hit. Appends every produced message (assistant text, tool-call turns, tool
     /// results) to `messages`, emits events, and returns the [`StopReason`].
-    /// Returns the stop reason and the resolved [`ProviderContext`] it used, so
-    /// the caller can reuse the (credential-resolved) context for compaction
-    /// instead of resolving the credential a second time.
+    /// Returns the stop reason, the resolved [`ProviderContext`] it used (so the
+    /// caller can reuse the credential for compaction instead of resolving it a
+    /// second time), and the turn's aggregate token [`Usage`] (summed across its
+    /// model calls, for cost provenance).
     pub(crate) async fn run_turn(
         &self,
         messages: &mut Vec<Message>,
         events: &UnboundedSender<AgentEvent>,
         controls: &TurnControls,
-    ) -> AgenkitResult<(StopReason, ProviderContext)> {
+    ) -> AgenkitResult<(StopReason, ProviderContext, Usage)> {
         let model = self.model()?;
         self.inner.check_model_allowed(&model)?;
         let provider = self.inner.providers.resolve(&model)?;
@@ -334,13 +335,15 @@ impl AgentLoop {
             .with_model(model.clone()),
         );
         // The runtime's observer: the `AgentEvent` firehose *and* (via the wrapped
-        // `TraceObserver`) the trace spans.
+        // `TraceObserver`) the trace spans, accumulating the turn's token usage.
+        let turn_usage = std::sync::Mutex::new(Usage::default());
         let observer = RuntimeObserver {
             trace: TraceObserver {
                 run: &run,
                 agent_step: agent_step.clone(),
             },
             events,
+            turn_usage: &turn_usage,
         };
         // Adapt the `Arc` hook into a borrowable `&dyn Fn` for the shared dispatcher.
         let before = controls.hooks.before_tool_call.as_deref();
@@ -427,7 +430,8 @@ impl AgentLoop {
             ),
         }
 
-        outcome.map(|reason| (reason, cx))
+        let usage = turn_usage.lock().map(|g| *g).unwrap_or_default();
+        outcome.map(|reason| (reason, cx, usage))
     }
 }
 
@@ -438,6 +442,9 @@ impl AgentLoop {
 struct RuntimeObserver<'a> {
     trace: TraceObserver<'a>,
     events: &'a UnboundedSender<AgentEvent>,
+    /// Accumulates token usage across the turn's model calls, so the turn can be
+    /// recorded as one usage provenance entry (P5 cost auditing).
+    turn_usage: &'a std::sync::Mutex<Usage>,
 }
 
 impl LoopObserver for RuntimeObserver<'_> {
@@ -446,6 +453,11 @@ impl LoopObserver for RuntimeObserver<'_> {
     }
 
     fn model_response(&self, step: Option<StepId>, model: &ModelRef, usage: Option<Usage>) {
+        if let Some(u) = usage
+            && let Ok(mut total) = self.turn_usage.lock()
+        {
+            *total = total.merge(u);
+        }
         self.trace.model_response(step, model, usage);
     }
 
@@ -542,6 +554,42 @@ impl AgentSession {
     /// The full stored conversation (every turn, pre-compaction view).
     pub async fn history(&self) -> AgenkitResult<Vec<Message>> {
         self.thread.history().await
+    }
+
+    /// Aggregate token [`Usage`] across this conversation's turns, summed from the
+    /// durable usage provenance (P5). Zero if the backing store doesn't record
+    /// provenance (e.g. a custom store that no-ops `append_state_change`).
+    pub async fn usage(&self) -> AgenkitResult<Usage> {
+        let mut total = Usage::default();
+        for entry in self.thread.state_changes().await? {
+            if entry.get("kind").and_then(serde_json::Value::as_str) == Some("usage")
+                && let Some(u) = entry
+                    .get("usage")
+                    .and_then(|u| serde_json::from_value::<Usage>(u.clone()).ok())
+            {
+                total = total.merge(u);
+            }
+        }
+        Ok(total)
+    }
+
+    /// Aggregate estimated cost across this conversation's turns, summed from the
+    /// durable usage provenance (P5). `None` if no turn recorded a cost (no
+    /// provenance, or no catalog pricing for the model).
+    pub async fn cost(&self) -> AgenkitResult<Option<CostEstimate>> {
+        let mut amount = 0.0;
+        let mut currency: Option<String> = None;
+        for entry in self.thread.state_changes().await? {
+            if let Some(cost) = entry
+                .get("cost")
+                .filter(|c| !c.is_null())
+                .and_then(|c| serde_json::from_value::<CostEstimate>(c.clone()).ok())
+            {
+                currency.get_or_insert(cost.currency);
+                amount += cost.amount;
+            }
+        }
+        Ok(currency.map(|currency| CostEstimate::new(currency, amount)))
     }
 
     /// Prompt the conversation: run one turn and stream its [`AgentEvent`]s. The
@@ -651,7 +699,7 @@ impl AgentSession {
         );
         // Reuse the credential-resolved context the turn already produced for
         // compaction, so a BYOK store isn't hit a second time per prompt.
-        let (reason, cx) = agent_loop
+        let (reason, cx, usage) = agent_loop
             .run_turn(&mut messages, events, &self.controls)
             .await?;
 
@@ -686,6 +734,24 @@ impl AgentSession {
             .or_else(|| self.inner.default_model.clone())
             .ok_or_else(|| AgenkitError::config("agent runtime has no model"))?;
         let provider = self.inner.providers.resolve(&model)?;
+
+        // Record this turn's usage + catalog cost as a provenance entry (P5) — a
+        // `StateChange` outside the conversation history (it never reaches the
+        // model), so a session's running cost is auditable from its durable log.
+        // Best-effort: a provenance write must not fail the prompt.
+        if usage.total() > 0 {
+            let cost = super::catalog::lookup(&model).map(|m| m.estimate_cost(&usage));
+            let _ = self
+                .thread
+                .append_state_change(serde_json::json!({
+                    "kind": "usage",
+                    "model": model.as_str(),
+                    "usage": usage,
+                    "cost": cost,
+                }))
+                .await;
+        }
+
         let max_output = self.config.max_tokens.unwrap_or(1024);
         if let Some((folded, _kept)) =
             super::agent::compact_thread(&self.thread, &model, &provider, &cx, max_output).await?
@@ -847,7 +913,7 @@ mod tests {
         let (tx, mut rx) = unbounded_channel();
         let mut messages = vec![Message::user("use the tool then answer")];
 
-        let (stop, _) = loop_
+        let (stop, _, _) = loop_
             .run_turn(&mut messages, &tx, &TurnControls::default())
             .await
             .unwrap();
@@ -904,7 +970,7 @@ mod tests {
         );
         let (tx, mut rx) = unbounded_channel();
         let mut messages = vec![Message::user("go")];
-        let (stop, _) = loop_
+        let (stop, _, _) = loop_
             .run_turn(&mut messages, &tx, &TurnControls::default())
             .await
             .unwrap();
@@ -1005,7 +1071,7 @@ mod tests {
         let (tx, mut rx) = unbounded_channel();
         let mut messages = vec![Message::user("hi")];
 
-        let (stop, _) = loop_.run_turn(&mut messages, &tx, &controls).await.unwrap();
+        let (stop, _, _) = loop_.run_turn(&mut messages, &tx, &controls).await.unwrap();
         drop(tx);
         assert_eq!(stop, StopReason::Aborted);
         // Aborted before the model call → no assistant text was produced.
@@ -1220,6 +1286,38 @@ mod tests {
             Some(history[1].tool_calls[0].id.as_str())
         );
         assert_eq!(history[3].content.as_text(), "it's sunny");
+    }
+
+    #[tokio::test]
+    async fn turn_usage_and_cost_are_recorded_as_provenance() {
+        // P5: each turn writes a usage `StateChange`; `usage()`/`cost()` aggregate
+        // them from the durable log (a catalog model so cost is resolvable).
+        let agenkit = Agenkit::builder()
+            .provider(
+                MockProvider::new("anthropic")
+                    .default_text("hi")
+                    .with_usage(pocopine_agenkit_core::Usage::new(1_000, 500)),
+            )
+            .default_model(ModelRef::new("anthropic/claude-sonnet-4-6"))
+            .build()
+            .unwrap();
+        let session = AgentSession::builder(&agenkit).open(None).await.unwrap();
+        let _ = session.prompt("first").collect::<Vec<_>>().await;
+        let _ = session.prompt("second").collect::<Vec<_>>().await;
+
+        // Two turns × (1000 in / 500 out) summed from the provenance log.
+        let usage = session.usage().await.unwrap();
+        assert_eq!(usage.input_tokens, 2_000);
+        assert_eq!(usage.output_tokens, 1_000);
+
+        // And the catalog cost, aggregated. sonnet-4-6: in 3.0, out 15.0 per 1e6.
+        let per_turn = (1_000.0 * 3.0 + 500.0 * 15.0) / 1_000_000.0;
+        let cost = session.cost().await.unwrap().expect("a cost was recorded");
+        assert!(
+            (cost.amount - per_turn * 2.0).abs() < 1e-9,
+            "expected ~{}, got {cost:?}",
+            per_turn * 2.0
+        );
     }
 
     #[test]

--- a/crates/pocopine-agenkit/src/server/runtime.rs
+++ b/crates/pocopine-agenkit/src/server/runtime.rs
@@ -26,8 +26,9 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use pocopine_agenkit_core::{
-    AgenkitError, AgenkitResult, AgentThreadId, CostEstimate, Message, ModelRef, RunId, StepId,
-    StepKind, StepStatus, ThreadRetention, ToolCall, ToolDescriptor, TraceId, Usage, events,
+    AgenkitError, AgenkitResult, AgentThreadId, Content, CostEstimate, Message, ModelRef, RunId,
+    StepId, StepKind, StepStatus, ThreadRetention, ToolCall, ToolDescriptor, TraceId, Usage,
+    events,
 };
 use pocopine_auth::Principal;
 use tokio::sync::mpsc::{UnboundedSender, unbounded_channel};
@@ -193,6 +194,48 @@ impl AgentConfig {
         self.max_steps_per_turn = steps.max(1);
         self
     }
+}
+
+/// What of a turn's tool activity is written to the durable session log (§D10).
+///
+/// The session log is the agent's **owner-scoped, host-side** working memory, so
+/// the default is full fidelity — tool arguments and results are stored verbatim,
+/// which a faithful resume requires. Switch to
+/// [`RedactToolPayloads`](CapturePolicy::RedactToolPayloads) to keep the transcript
+/// *structure* (so resume stays coherent) while dropping the potentially-sensitive
+/// tool payloads from disk. Large payloads are already kept out-of-line by the
+/// `ExternalizingSessionStore`; this is the orthogonal "don't store the bytes at
+/// all" knob.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CapturePolicy {
+    /// Persist tool-call arguments and tool results verbatim (default).
+    #[default]
+    Full,
+    /// Persist the tool-call turns and results — keeping the call↔result linkage
+    /// so resume never sees a half-open call — but replace the call arguments and
+    /// the result payload with a redaction marker. Resume stays structurally
+    /// coherent; the model just no longer re-reads the (possibly sensitive) tool
+    /// data on a later turn.
+    RedactToolPayloads,
+}
+
+/// Apply [`CapturePolicy::RedactToolPayloads`]: strip tool-call arguments and tool
+/// result payloads from `messages`, keeping roles and the `tool_call_id` linkage
+/// so the persisted transcript stays replay-coherent (no half-open calls).
+fn redact_tool_payloads(messages: Vec<Message>) -> Vec<Message> {
+    messages
+        .into_iter()
+        .map(|mut m| {
+            for call in &mut m.tool_calls {
+                call.args = serde_json::json!({ "redacted": true });
+            }
+            if m.tool_call_id.is_some() {
+                m.content = Content::text("[redacted]");
+            }
+            m
+        })
+        .collect()
 }
 
 /// Typed steering hooks (L3) — host-side closures that *steer* the loop. The
@@ -516,6 +559,8 @@ pub struct AgentSession {
     /// its duration so a concurrent `prompt` is rejected rather than corrupting
     /// the shared thread/queue/abort.
     busy: Arc<AtomicBool>,
+    /// What of each turn's tool activity is written to the durable log (§D10).
+    capture: CapturePolicy,
 }
 
 impl AgentSession {
@@ -527,6 +572,7 @@ impl AgentSession {
             config: AgentConfig::new(),
             agent_id: "kitty".to_string(),
             hooks: Hooks::default(),
+            capture: CapturePolicy::default(),
         }
     }
 
@@ -663,6 +709,7 @@ impl AgentSession {
                 ..TurnControls::default()
             },
             busy: Arc::new(AtomicBool::new(false)),
+            capture: self.capture,
         }))
     }
 
@@ -717,6 +764,12 @@ impl AgentSession {
         // *mid-turn* — would need a transactional batch append; tracked as a
         // follow-up.)
         let to_persist = messages[persist_from + 1..].to_vec();
+        // §D10 capture policy: optionally redact tool payloads before they hit disk
+        // (the linkage is kept, so resume stays coherent — see `CapturePolicy`).
+        let to_persist = match self.capture {
+            CapturePolicy::Full => to_persist,
+            CapturePolicy::RedactToolPayloads => redact_tool_payloads(to_persist),
+        };
         if !to_persist.is_empty() {
             self.thread
                 .store
@@ -769,6 +822,7 @@ pub struct AgentSessionBuilder {
     config: AgentConfig,
     agent_id: String,
     hooks: Hooks,
+    capture: CapturePolicy,
 }
 
 impl AgentSessionBuilder {
@@ -801,6 +855,13 @@ impl AgentSessionBuilder {
     /// Set the agent id stored on the thread (default `"kitty"`).
     pub fn agent_id(mut self, agent_id: impl Into<String>) -> Self {
         self.agent_id = agent_id.into();
+        self
+    }
+
+    /// Set the §D10 [`CapturePolicy`] — what of each turn's tool activity reaches
+    /// the durable log (default [`CapturePolicy::Full`]).
+    pub fn capture_policy(mut self, capture: CapturePolicy) -> Self {
+        self.capture = capture;
         self
     }
 
@@ -842,6 +903,7 @@ impl AgentSessionBuilder {
                 ..TurnControls::default()
             },
             busy: Arc::new(AtomicBool::new(false)),
+            capture: self.capture,
         })
     }
 }
@@ -1318,6 +1380,57 @@ mod tests {
             "expected ~{}, got {cost:?}",
             per_turn * 2.0
         );
+    }
+
+    #[tokio::test]
+    async fn redact_tool_payloads_policy_keeps_structure_but_drops_payloads() {
+        // P5b §D10 knob: a tool's args + result carry a secret. Under
+        // `RedactToolPayloads` the transcript STRUCTURE persists (so resume stays
+        // coherent) but the secret never reaches disk.
+        let agenkit = Agenkit::builder()
+            .provider(
+                MockProvider::new("local")
+                    .on_prompt_tool("weather", "echo", serde_json::json!({ "text": "key-123" }))
+                    .default_text("it's sunny"),
+            )
+            .default_model(ModelRef::new("local/default"))
+            .tool(Echo)
+            .build()
+            .unwrap();
+        let session = AgentSession::builder(&agenkit)
+            .config(AgentConfig::new().tools(["echo"]))
+            .capture_policy(CapturePolicy::RedactToolPayloads)
+            .open(None)
+            .await
+            .unwrap();
+        let _ = session.prompt("weather?").collect::<Vec<_>>().await;
+
+        let history = session.history().await.unwrap();
+        // Structure + linkage preserved (4 records, call ↔ result still keyed).
+        assert_eq!(history.len(), 4, "{history:?}");
+        assert_eq!(history[1].tool_calls[0].tool_id, "echo");
+        assert_eq!(history[2].role, Role::Tool);
+        assert_eq!(
+            history[2].tool_call_id.as_deref(),
+            Some(history[1].tool_calls[0].id.as_str())
+        );
+        // ...but the secret is gone from both the call args and the result payload.
+        assert!(
+            !history[1].tool_calls[0]
+                .args
+                .to_string()
+                .contains("key-123"),
+            "tool args should be redacted: {:?}",
+            history[1].tool_calls[0].args
+        );
+        assert!(
+            !history[2].content.as_text().contains("key-123"),
+            "tool result should be redacted: {:?}",
+            history[2].content.as_text()
+        );
+        // The question and the answer are untouched (not tool payloads).
+        assert_eq!(history[0].content.as_text(), "weather?");
+        assert_eq!(history[3].content.as_text(), "it's sunny");
     }
 
     #[test]

--- a/crates/pocopine-agenkit/src/server/thread.rs
+++ b/crates/pocopine-agenkit/src/server/thread.rs
@@ -148,6 +148,33 @@ pub trait AgentThreadStore: Send + Sync + 'static {
         let _ = (id, owner);
         Box::pin(async move { Ok(None) })
     }
+
+    /// Record a `state-change` provenance entry (model / usage / cost) alongside
+    /// the messages, *without* placing it in the conversation history (it never
+    /// reaches the model). The default is a no-op — provenance is best-effort, so
+    /// a store that doesn't model it simply drops it. A session-backed store writes
+    /// a [`RecordKind::StateChange`] record.
+    fn append_state_change(
+        &self,
+        id: &AgentThreadId,
+        owner: ThreadOwner<'_>,
+        data: serde_json::Value,
+    ) -> BoxFuture<'_, AgenkitResult<()>> {
+        let _ = (id, owner, data);
+        Box::pin(async move { Ok(()) })
+    }
+
+    /// The `state-change` provenance entries for a thread, in order (the inverse of
+    /// [`append_state_change`](AgentThreadStore::append_state_change)). The default
+    /// is empty — a store that doesn't record provenance has none to return.
+    fn state_changes(
+        &self,
+        id: &AgentThreadId,
+        owner: ThreadOwner<'_>,
+    ) -> BoxFuture<'_, AgenkitResult<Vec<serde_json::Value>>> {
+        let _ = (id, owner);
+        Box::pin(async move { Ok(Vec::new()) })
+    }
 }
 
 /// The default agent-thread store: agent threads run **on the durable session
@@ -417,6 +444,60 @@ impl AgentThreadStore for SessionThreadStore {
             Ok(Some(AgentThreadId::new(child.id().as_str())))
         })
     }
+
+    fn append_state_change(
+        &self,
+        id: &AgentThreadId,
+        owner: ThreadOwner<'_>,
+        data: serde_json::Value,
+    ) -> BoxFuture<'_, AgenkitResult<()>> {
+        let sessions = self.sessions.clone();
+        let tid = session::ThreadId::new(id.as_str());
+        let want = owner.key().map(str::to_string);
+        Box::pin(async move {
+            // Owner-scoped, like every other mutation (no existence oracle).
+            if owner_checked_meta(sessions.as_ref(), &tid, want.as_deref())
+                .await?
+                .is_none()
+            {
+                return Err(AgenkitError::not_found("thread not found"));
+            }
+            sessions
+                .append(&tid, RecordKind::StateChange, data)
+                .await
+                .map_err(session_err)?;
+            Ok(())
+        })
+    }
+
+    fn state_changes(
+        &self,
+        id: &AgentThreadId,
+        owner: ThreadOwner<'_>,
+    ) -> BoxFuture<'_, AgenkitResult<Vec<serde_json::Value>>> {
+        let sessions = self.sessions.clone();
+        let tid = session::ThreadId::new(id.as_str());
+        let want = owner.key().map(str::to_string);
+        Box::pin(async move {
+            if owner_checked_meta(sessions.as_ref(), &tid, want.as_deref())
+                .await?
+                .is_none()
+            {
+                return Ok(Vec::new()); // missing/foreign reads as empty
+            }
+            // The materialized log (a fork includes its inherited prefix), keeping
+            // only the `StateChange` payloads.
+            let records = session::Session::open(sessions.clone(), tid)
+                .history()
+                .await
+                .map_err(session_err)?;
+            Ok(records
+                .into_iter()
+                .filter(|r| r.kind == RecordKind::StateChange)
+                .map(|r| r.data)
+                .collect())
+        })
+    }
 }
 
 /// A handle to a thread within a flow run: its id, the store to reach it, and
@@ -480,6 +561,19 @@ impl AgentThreadHandle {
                 store: self.store.clone(),
                 owner,
             }))
+    }
+
+    /// Record a provenance entry (model / usage / cost) outside the conversation
+    /// history (see [`AgentThreadStore::append_state_change`]).
+    pub async fn append_state_change(&self, data: serde_json::Value) -> AgenkitResult<()> {
+        self.store
+            .append_state_change(&self.id, self.owner(), data)
+            .await
+    }
+
+    /// The provenance entries recorded for this thread, in order.
+    pub async fn state_changes(&self) -> AgenkitResult<Vec<serde_json::Value>> {
+        self.store.state_changes(&self.id, self.owner()).await
     }
 }
 

--- a/crates/pocopine-agenkit/src/server/thread.rs
+++ b/crates/pocopine-agenkit/src/server/thread.rs
@@ -15,8 +15,8 @@
 use std::sync::Arc;
 
 use pocopine_agenkit_core::{
-    AgenkitError, AgenkitResult, AgentThreadId, StepKind, StepStatus, ThreadMessage,
-    ThreadRetention, events,
+    AgenkitError, AgenkitResult, AgentThreadId, Message, StepKind, StepStatus, ThreadRetention,
+    events,
 };
 use pocopine_auth::Principal;
 
@@ -88,14 +88,14 @@ pub trait AgentThreadStore: Send + Sync + 'static {
         &self,
         id: &AgentThreadId,
         owner: ThreadOwner<'_>,
-    ) -> BoxFuture<'_, AgenkitResult<Option<Vec<ThreadMessage>>>>;
+    ) -> BoxFuture<'_, AgenkitResult<Option<Vec<Message>>>>;
 
     /// Append messages to a thread owned by `owner`.
     fn append(
         &self,
         id: &AgentThreadId,
         owner: ThreadOwner<'_>,
-        messages: Vec<ThreadMessage>,
+        messages: Vec<Message>,
     ) -> BoxFuture<'_, AgenkitResult<()>>;
 
     /// Delete a thread and its state if it is owned by `owner`. A missing or
@@ -119,8 +119,8 @@ pub trait AgentThreadStore: Send + Sync + 'static {
         &self,
         id: &AgentThreadId,
         owner: ThreadOwner<'_>,
-        summary: ThreadMessage,
-        kept: Vec<ThreadMessage>,
+        summary: Message,
+        kept: Vec<Message>,
     ) -> BoxFuture<'_, AgenkitResult<()>> {
         let _ = kept;
         self.append(id, owner, vec![summary])
@@ -133,7 +133,7 @@ pub trait AgentThreadStore: Send + Sync + 'static {
         &self,
         id: &AgentThreadId,
         owner: ThreadOwner<'_>,
-    ) -> BoxFuture<'_, AgenkitResult<Option<Vec<ThreadMessage>>>> {
+    ) -> BoxFuture<'_, AgenkitResult<Option<Vec<Message>>>> {
         self.load(id, owner)
     }
 
@@ -187,7 +187,7 @@ impl SessionThreadStore {
         id: &AgentThreadId,
         owner: ThreadOwner<'_>,
         compacted: bool,
-    ) -> BoxFuture<'_, AgenkitResult<Option<Vec<ThreadMessage>>>> {
+    ) -> BoxFuture<'_, AgenkitResult<Option<Vec<Message>>>> {
         let sessions = self.sessions.clone();
         let tid = session::ThreadId::new(id.as_str());
         let want = owner.key().map(str::to_string);
@@ -210,7 +210,7 @@ impl SessionThreadStore {
                 match record.kind {
                     // Full view = Message records only.
                     RecordKind::Message => {
-                        let message: ThreadMessage =
+                        let message: Message =
                             serde_json::from_value(record.data).map_err(|e| {
                                 AgenkitError::internal(format!("thread message decode: {e}"))
                             })?;
@@ -259,9 +259,9 @@ fn session_err(err: session::SessionError) -> AgenkitError {
 /// `[summary, ...kept]`.
 #[derive(serde::Serialize, serde::Deserialize)]
 struct CheckpointPayload {
-    summary: ThreadMessage,
+    summary: Message,
     #[serde(default)]
-    kept: Vec<ThreadMessage>,
+    kept: Vec<Message>,
 }
 
 impl CheckpointPayload {
@@ -297,7 +297,7 @@ impl AgentThreadStore for SessionThreadStore {
         &self,
         id: &AgentThreadId,
         owner: ThreadOwner<'_>,
-    ) -> BoxFuture<'_, AgenkitResult<Option<Vec<ThreadMessage>>>> {
+    ) -> BoxFuture<'_, AgenkitResult<Option<Vec<Message>>>> {
         // The full message history (a foreign owner reads as not-found).
         self.read(id, owner, false)
     }
@@ -306,7 +306,7 @@ impl AgentThreadStore for SessionThreadStore {
         &self,
         id: &AgentThreadId,
         owner: ThreadOwner<'_>,
-    ) -> BoxFuture<'_, AgenkitResult<Option<Vec<ThreadMessage>>>> {
+    ) -> BoxFuture<'_, AgenkitResult<Option<Vec<Message>>>> {
         // The compacted view: from the last checkpoint (its summary leads).
         self.read(id, owner, true)
     }
@@ -315,7 +315,7 @@ impl AgentThreadStore for SessionThreadStore {
         &self,
         id: &AgentThreadId,
         owner: ThreadOwner<'_>,
-        messages: Vec<ThreadMessage>,
+        messages: Vec<Message>,
     ) -> BoxFuture<'_, AgenkitResult<()>> {
         let sessions = self.sessions.clone();
         let tid = session::ThreadId::new(id.as_str());
@@ -365,8 +365,8 @@ impl AgentThreadStore for SessionThreadStore {
         &self,
         id: &AgentThreadId,
         owner: ThreadOwner<'_>,
-        summary: ThreadMessage,
-        kept: Vec<ThreadMessage>,
+        summary: Message,
+        kept: Vec<Message>,
     ) -> BoxFuture<'_, AgenkitResult<()>> {
         let sessions = self.sessions.clone();
         let tid = session::ThreadId::new(id.as_str());
@@ -442,7 +442,7 @@ impl AgentThreadHandle {
     }
 
     /// Load the full message history.
-    pub async fn history(&self) -> AgenkitResult<Vec<ThreadMessage>> {
+    pub async fn history(&self) -> AgenkitResult<Vec<Message>> {
         Ok(self
             .store
             .load(&self.id, self.owner())
@@ -451,7 +451,7 @@ impl AgentThreadHandle {
     }
 
     /// The compacted history to send the model (from the last checkpoint).
-    pub async fn active_history(&self) -> AgenkitResult<Vec<ThreadMessage>> {
+    pub async fn active_history(&self) -> AgenkitResult<Vec<Message>> {
         Ok(self
             .store
             .active_history(&self.id, self.owner())
@@ -461,11 +461,7 @@ impl AgentThreadHandle {
 
     /// Append a compaction checkpoint: the summary of the folded prefix plus
     /// `kept`, the recent messages retained verbatim in the active context.
-    pub async fn checkpoint(
-        &self,
-        summary: ThreadMessage,
-        kept: Vec<ThreadMessage>,
-    ) -> AgenkitResult<()> {
+    pub async fn checkpoint(&self, summary: Message, kept: Vec<Message>) -> AgenkitResult<()> {
         self.store
             .checkpoint(&self.id, self.owner(), summary, kept)
             .await
@@ -590,7 +586,7 @@ mod tests {
             .append(
                 &id,
                 owner,
-                vec![ThreadMessage::new(Role::User, "why did it fail?")],
+                vec![Message::new(Role::User, "why did it fail?")],
             )
             .await
             .unwrap();
@@ -613,7 +609,7 @@ mod tests {
             .await
             .unwrap();
         store
-            .append(&id, alice, vec![ThreadMessage::new(Role::User, "secret")])
+            .append(&id, alice, vec![Message::new(Role::User, "secret")])
             .await
             .unwrap();
 
@@ -622,7 +618,7 @@ mod tests {
         // Bob cannot append to it.
         assert!(
             store
-                .append(&id, bob, vec![ThreadMessage::new(Role::User, "inject")])
+                .append(&id, bob, vec![Message::new(Role::User, "inject")])
                 .await
                 .is_err()
         );
@@ -667,11 +663,7 @@ mod tests {
                 .await
                 .unwrap();
             store
-                .append(
-                    &id,
-                    alice,
-                    vec![ThreadMessage::new(Role::User, "remembered")],
-                )
+                .append(&id, alice, vec![Message::new(Role::User, "remembered")])
                 .await
                 .unwrap();
             id
@@ -700,8 +692,8 @@ mod tests {
                 &id,
                 owner,
                 vec![
-                    ThreadMessage::new(Role::User, "q1"),
-                    ThreadMessage::new(Role::Assistant, "a1"),
+                    Message::new(Role::User, "q1"),
+                    Message::new(Role::Assistant, "a1"),
                 ],
             )
             .await
@@ -711,13 +703,13 @@ mod tests {
             .checkpoint(
                 &id,
                 owner,
-                ThreadMessage::new(Role::System, "summary of q1"),
-                vec![ThreadMessage::new(Role::Assistant, "a1")],
+                Message::new(Role::System, "summary of q1"),
+                vec![Message::new(Role::Assistant, "a1")],
             )
             .await
             .unwrap();
         store
-            .append(&id, owner, vec![ThreadMessage::new(Role::User, "q2")])
+            .append(&id, owner, vec![Message::new(Role::User, "q2")])
             .await
             .unwrap();
 
@@ -754,8 +746,8 @@ mod tests {
                 &id,
                 alice,
                 vec![
-                    ThreadMessage::new(Role::User, "shared"),
-                    ThreadMessage::new(Role::Assistant, "shared-reply"),
+                    Message::new(Role::User, "shared"),
+                    Message::new(Role::Assistant, "shared-reply"),
                 ],
             )
             .await
@@ -771,7 +763,7 @@ mod tests {
             .append(
                 &branch_id,
                 alice,
-                vec![ThreadMessage::new(Role::User, "branch-only")],
+                vec![Message::new(Role::User, "branch-only")],
             )
             .await
             .unwrap();

--- a/crates/pocopine-agenkit/src/server/thread.rs
+++ b/crates/pocopine-agenkit/src/server/thread.rs
@@ -563,7 +563,7 @@ impl ThreadBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pocopine_agenkit_core::Role;
+    use pocopine_agenkit_core::{Content, ContentPart, Role, ToolCall};
     use pocopine_auth::AuthUser;
 
     fn alice() -> Principal {
@@ -595,6 +595,79 @@ mod tests {
         assert_eq!(history[0].role, Role::User);
         store.delete(&id, owner).await.unwrap();
         assert!(store.load(&id, owner).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn full_fidelity_messages_round_trip_through_the_store() {
+        // The P4 resume-fidelity guard: a complete tool turn survives a store
+        // round trip byte-for-byte — tool_calls, the tool_call_id linkage, AND a
+        // reasoning signature (all of which the old lossy `ThreadMessage` dropped).
+        let store = SessionThreadStore::in_memory();
+        let owner = ThreadOwner::anonymous();
+        let id = store
+            .create("a", owner, ThreadRetention::Session)
+            .await
+            .unwrap();
+
+        let original = vec![
+            Message::user("weather?"),
+            // An assistant tool-call turn carrying reasoning + a provider signature.
+            Message::assistant_tool_calls(
+                Content::from_parts(vec![
+                    ContentPart::thinking("let me check the tool", Some("sig-xyz".to_string())),
+                    ContentPart::text("calling echo"),
+                ]),
+                vec![ToolCall::new(
+                    "call-1",
+                    "echo",
+                    serde_json::json!({ "text": "x" }),
+                )],
+            ),
+            // A tool result, linked to the call by id.
+            Message::tool_result("call-1", "{\"echoed\":\"x\"}"),
+            Message::assistant("it's sunny"),
+        ];
+        store.append(&id, owner, original.clone()).await.unwrap();
+
+        // Reload via the resume path → byte-equal to what was stored.
+        let reloaded = store.load(&id, owner).await.unwrap().unwrap();
+        assert_eq!(reloaded, original);
+    }
+
+    #[tokio::test]
+    async fn legacy_thread_message_records_decode_into_message() {
+        // Forward-compat: records written before this work (old `ThreadMessage`
+        // shape — role + content + ts_ms, no tool fields) still decode into
+        // `Message`, with the new fields defaulting. No data migration needed.
+        let sessions: Arc<dyn SessionStore> = Arc::new(session::MemorySessionStore::new());
+        let store = SessionThreadStore::new(sessions.clone());
+        let owner = ThreadOwner::anonymous();
+        let id = store
+            .create("a", owner, ThreadRetention::Session)
+            .await
+            .unwrap();
+
+        // Append a raw legacy-shaped record straight to the underlying log.
+        let tid = session::ThreadId::new(id.as_str());
+        sessions
+            .append(
+                &tid,
+                RecordKind::Message,
+                serde_json::json!({
+                    "role": "user",
+                    "content": [{ "type": "text", "text": "legacy hi" }],
+                    "ts_ms": 1_700_000_000_000u64,
+                }),
+            )
+            .await
+            .unwrap();
+
+        let history = store.load(&id, owner).await.unwrap().unwrap();
+        assert_eq!(history.len(), 1);
+        assert_eq!(history[0].role, Role::User);
+        assert_eq!(history[0].content.as_text(), "legacy hi");
+        assert!(history[0].tool_calls.is_empty());
+        assert!(history[0].tool_call_id.is_none());
     }
 
     #[tokio::test]

--- a/crates/pocopine-agenkit/src/server/thread.rs
+++ b/crates/pocopine-agenkit/src/server/thread.rs
@@ -485,12 +485,13 @@ impl AgentThreadStore for SessionThreadStore {
             {
                 return Ok(Vec::new()); // missing/foreign reads as empty
             }
-            // The materialized log (a fork includes its inherited prefix), keeping
-            // only the `StateChange` payloads.
-            let records = session::Session::open(sessions.clone(), tid)
-                .history()
-                .await
-                .map_err(session_err)?;
+            // This thread's OWN records, NOT the materialized parent chain. Each
+            // turn's provenance is recorded on exactly one thread, so a fork reports
+            // only its own usage — summing across the tree never double-counts the
+            // shared prefix (a fork inherits the parent's *messages* for replay, but
+            // not its already-counted usage). It also avoids materializing the full
+            // ancestor log just to keep a handful of provenance rows.
+            let records = sessions.records(&tid).await.map_err(session_err)?;
             Ok(records
                 .into_iter()
                 .filter(|r| r.kind == RecordKind::StateChange)

--- a/crates/pocopine-agenkit/tests/agent_session.rs
+++ b/crates/pocopine-agenkit/tests/agent_session.rs
@@ -8,7 +8,7 @@ use pocopine_agenkit::server::session::{
     JsonlSessionStore, Session, SessionStore, SqliteSessionStore, ThreadId,
 };
 use pocopine_agenkit::server::{AgentThreadStore, AuthUser, Principal, SessionThreadStore};
-use pocopine_agenkit_core::{Role, ThreadMessage, ThreadRetention};
+use pocopine_agenkit_core::{Message, ThreadRetention};
 
 #[tokio::test]
 async fn jsonl_store_survives_a_reopen() {
@@ -167,11 +167,7 @@ async fn sqlite_thread_store_keeps_owner_scope_across_a_reopen() {
             .await
             .unwrap();
         store
-            .append(
-                &id,
-                alice,
-                vec![ThreadMessage::new(Role::User, "remembered")],
-            )
+            .append(&id, alice, vec![Message::user("remembered")])
             .await
             .unwrap();
         id

--- a/crates/pocopine-agenkit/tests/agent_thread_reduce.rs
+++ b/crates/pocopine-agenkit/tests/agent_thread_reduce.rs
@@ -75,14 +75,26 @@ async fn research_flow(input: Question, ctx: AiFlowContext) -> AgenkitResult<Age
     ctx.agent::<Researcher>().input(input).run().await
 }
 
-async fn threaded_flow(input: Question, ctx: AiFlowContext) -> AgenkitResult<usize> {
+/// Run the tool-using `Researcher` on a thread and return a compact shape of each
+/// persisted record (`role` + tool-call / tool-result marker), so a test can
+/// assert the FULL transcript was stored, not a lossy Q&A.
+async fn threaded_flow(input: Question, ctx: AiFlowContext) -> AgenkitResult<Vec<String>> {
     let thread = ctx.thread::<Researcher>().create().await?;
     ctx.agent::<Researcher>()
         .thread(thread.clone())
         .input(input)
         .run()
         .await?;
-    Ok(thread.history().await?.len())
+    Ok(thread
+        .history()
+        .await?
+        .iter()
+        .map(|m| match (&m.tool_calls.first(), &m.tool_call_id) {
+            (Some(call), _) => format!("{:?}+call:{}", m.role, call.tool_id),
+            (None, Some(_)) => format!("{:?}+result", m.role),
+            (None, None) => format!("{:?}", m.role),
+        })
+        .collect())
 }
 
 async fn reduce_fold_flow(_input: (), ctx: AiFlowContext) -> AgenkitResult<u32> {
@@ -162,8 +174,8 @@ fn agent_runs_tool_loop_then_answers() {
 }
 
 #[test]
-fn threaded_agent_persists_exchange() {
-    let count: usize = block_on(
+fn threaded_agent_persists_the_full_tool_transcript() {
+    let shape: Vec<String> = block_on(
         runtime()
             .flow("threaded")
             .input(Question {
@@ -172,8 +184,19 @@ fn threaded_agent_persists_exchange() {
             .run(),
     )
     .unwrap();
-    // The run appends one user + one assistant message to the thread.
-    assert_eq!(count, 2);
+    // P3: the single-shot agent loop persists the WHOLE transcript — the question,
+    // the assistant tool-call turn, the tool result (linked to the call), and the
+    // final structured answer — so a resumed thread replays the tool use.
+    assert_eq!(
+        shape,
+        vec![
+            "User".to_string(),
+            "Assistant+call:lookup".to_string(),
+            "Tool+result".to_string(),
+            "Assistant".to_string(),
+        ],
+        "expected the full tool transcript, got {shape:?}"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What

Closes the agent runtime's one remaining shallow spot. A resumed `AgentSession` used to replay a **lossy text Q&A that had forgotten every tool call, tool result, and reasoning block** — for a coding agent, the difference between "resumes mid-task" and "starts over."

The key insight reframed the work: **the durable session log was always lossless** (`Record.data` is opaque JSON) — the loss was a *projection*, `ThreadMessage { role, content, ts_ms }`, which can't model `tool_calls` / `tool_call_id`. So the fix was to retire the projection, not rebuild storage.

```mermaid
flowchart TB
  turn["in-memory turn<br/>Message { content, tool_calls, tool_call_id }"]
  subgraph before["BEFORE — two lossy layers"]
    f1["run_one_prompt filter:<br/>keep only User + no-tool Assistant text"]
    f2["ThreadMessage { role, content }<br/>can't hold tool_calls / tool_call_id"]
  end
  log["SessionStore Record { kind, data: opaque JSON } — already lossless"]
  turn --> before --> log
  turn -. "AFTER (P1–P3)" .-> after["persist Message directly<br/>full transcript, tool linkage intact"] --> log
```

## Phases

| | What |
|---|---|
| **P1** | Thread layer (`AgentThreadStore`/`SessionThreadStore`/`AgentThreadHandle`/`CheckpointPayload`) carries core **`Message`**, not the lossy `ThreadMessage`. Old records decode forward via serde defaults — **no migration**. |
| **P2** | Runtime persists the **full turn transcript** (tool-call turns, tool results with linkage, steers, answer with reasoning + signature). All-or-nothing per turn ⇒ resume never sees a half-open tool call. |
| **P3** | Single-shot `ctx.agent` loop persists its tool turns too (was `[user, output]` only). Both loops lossless via the shared shape. |
| **P4** | Resume-fidelity guards: byte-equal store round-trip (incl. Thinking signature + linkage), legacy-record decode, end-to-end reopen-and-replay. |
| **P5** | Per-turn **usage + cost** as `StateChange` provenance → `AgentSession::usage()`/`cost()`; **`CapturePolicy`** knob (`Full` default / `RedactToolPayloads`). |

## Review fixes (this branch was self-reviewed before opening)

A 9-angle review found that **P2 put tool turns into stored history for the first time, and three pieces of infrastructure that only ever saw text Q&A mishandled them.** All fixed:

- **Compaction split → unresumable thread (highest severity).** The kept-tail boundary could land between an assistant tool-call turn (folded into the summary) and its tool result (kept), so `active_history` began with an orphan tool result → provider **400** on the next prompt. New `compaction_split` snaps the boundary past leading tool results.
- **Compaction summary forgot tool use** — it was built from `as_text()` (empty for a tool-call turn); now spells out each `tool call \`id\`(args)`.
- **Token estimator ignored `tool_calls`** → tool-heavy turns under-counted → compaction never fired → overflow at generate. Now counts args + `tool_call_id`.
- **`RedactToolPayloads` leaked narration + thinking signature** — only args/result were scrubbed; the assistant tool-call turn's own content (which can echo the secret + carries the signature) now is too.
- **Fork double-counted usage** — `state_changes()` materialized the parent chain; now reads this thread's own records, so summing across the tree never double-counts the shared prefix.
- **Provenance hardening** — stringly-typed `{kind,usage,cost}` → typed `UsageRecord` (a key typo no longer silently reads $0; `cost()` now gates on kind); mixed-currency guard; failed writes `tracing::warn` instead of `let _`; empty completions no longer persist a contentless turn.

## Decisions locked
Full-fidelity by default in the **owner-scoped, host-side** session log (Codex/pi-style working memory; the wire stays redacted via `bridge`). `CapturePolicy` governs the conversational runtime only. Atomicity = all-or-nothing-per-turn.

## Tests & gates
New: `compaction_split_never_orphans_a_tool_result`, `estimate_counts_tool_call_args_not_just_content`, `redact_tool_payloads_strips_narration_and_signature_too`, `fork_usage_is_local_not_double_counted`, plus P1–P5's round-trip/legacy/reopen guards. **160 tests pass**, clippy host + wasm clean, fmt clean. Nothing outside the agenkit crate depends on the changed surface.

## Follow-ups (not in this PR)
- Batch/transactional `append` (`SessionThreadStore::append` is per-record) — enables per-step streaming durability (surviving a crash *mid-turn*).
- `ThreadMessage` stays in core, now unused — kept for a possible future redacted wire-history view.