### PR TITLE
fix(pine-layout): silence dead-code on resolve_size in host non-test builds

### DIFF
--- a/crates/pine-layout/src/workspace/resize.rs
+++ b/crates/pine-layout/src/workspace/resize.rs
@@ -19,6 +19,11 @@ pub enum Axis {
 /// Pure resize math (host-testable): apply a pointer `delta` to a starting
 /// size, flip it for end-anchored handles (`invert`), clamp to `[min, max]`,
 /// and snap to `min` when the result falls below `collapse_at`.
+///
+/// Its callers are the `wasm32`-only drag handler below and the host unit tests,
+/// so a plain host (non-test) lib build sees no caller — allow it there rather
+/// than gate the function out of the build it is documented to be tested in.
+#[cfg_attr(not(any(target_arch = "wasm32", test)), allow(dead_code))]
 pub(crate) fn resolve_size(
     start: f64,
     delta: f64,


### PR DESCRIPTION
## What
`pine-layout::workspace::resize::resolve_size` is pure resize math whose only callers are the `#[cfg(target_arch = "wasm32")]` drag handler and the `#[cfg(test)]` host unit tests. A plain **host, non-test** `cargo clippy --workspace --all-targets -- -D warnings` therefore compiles the lib target with neither caller active and fails:

```
error: function `resolve_size` is never used
```

## Why CI didn't catch it
- `clippy (wasm32)` includes pine-layout, but on wasm the drag-handler caller exists → clean.
- `clippy (host)` only lints `pocopine-cli`, so it never compiles pine-layout's lib for linting.
- `cargo test … --tests` builds with `cfg(test)` active, where the tests use it → clean.

So it's latent — only a workspace-wide host clippy surfaces it. Pre-existing on `main`.

## Fix
`#[cfg_attr(not(any(target_arch = "wasm32", test)), allow(dead_code))]` on the function — allow dead_code **only** in the host non-test config, keeping the lint live everywhere the function is actually compiled-and-used. Preferred over `#[cfg]`-gating it out, which would remove it from a build it's documented to be host-tested in.

Host clippy `--all-targets -D warnings`, wasm clippy `-D warnings`, and fmt all clean.