### PR TITLE
Collab durability & robustness follow-ups (B/E/D/J from #234)

### DIFF
--- a/crates/pine-richtext-collab/src/binder.rs
+++ b/crates/pine-richtext-collab/src/binder.rs
@@ -55,6 +55,10 @@ pub enum BindError {
     Protocol(String),
     /// The realtime transport failed to connect (bad URL / WebSocket error).
     Connect(String),
+    /// A second editor was bound to a connection that already drives one. A
+    /// `CollabConnection` drives exactly one editor; open a separate connection
+    /// per editor.
+    AlreadyBound,
 }
 
 impl From<RichTextError> for BindError {
@@ -70,6 +74,10 @@ impl fmt::Display for BindError {
             Self::Model(err) => write!(f, "collab model error: {err}"),
             Self::Protocol(msg) => write!(f, "collab protocol error: {msg}"),
             Self::Connect(msg) => write!(f, "collab connect error: {msg}"),
+            Self::AlreadyBound => write!(
+                f,
+                "collab connection already drives an editor; open a separate connection per editor"
+            ),
         }
     }
 }

--- a/crates/pine-richtext-collab/src/client/connection.rs
+++ b/crates/pine-richtext-collab/src/client/connection.rs
@@ -141,20 +141,17 @@ impl CollabConnection {
     /// is merged — wire it to load the document into the view editor. A no-op
     /// apply (the gateway echoing your own edit, or a duplicate) does NOT fire it.
     ///
-    /// A connection drives ONE editor: this REPLACES any previously registered
-    /// handler (so a second [`bind`](Self::bind) silently detaches the first
-    /// editor). The replacement is logged so the footgun is not silent; open a
-    /// separate [`CollabConnection`] per editor instead.
-    pub fn on_change(&self, callback: impl Fn(&Node) + 'static) {
+    /// A connection drives exactly ONE editor, so registering a second handler
+    /// (e.g. a second [`bind`](Self::bind)) is a [`BindError::AlreadyBound`]
+    /// error rather than a silent detach of the first — open a separate
+    /// [`CollabConnection`] per editor.
+    pub fn on_change(&self, callback: impl Fn(&Node) + 'static) -> Result<(), BindError> {
         let mut slot = self.on_change.borrow_mut();
         if slot.is_some() {
-            tracing::warn!(
-                target: "pocopine.log",
-                "collab: on_change handler replaced — a CollabConnection drives one editor; \
-                 a second bind()/on_change detaches the previous one"
-            );
+            return Err(BindError::AlreadyBound);
         }
         *slot = Some(Rc::new(callback));
+        Ok(())
     }
 
     /// Commit a local edit coarsely (a whole-document rebuild) and broadcast it.
@@ -217,12 +214,23 @@ impl CollabConnection {
     /// APIs that don't exist yet, so a remote edit currently reloads the doc; the
     /// [`point_at`](Self::point_at) / [`resolve_point`](Self::resolve_point)
     /// primitives are exposed for callers wiring it by hand in the meantime.
+    ///
+    /// Errors with [`BindError::AlreadyBound`] if this connection already drives
+    /// an editor (one connection ↔ one editor).
     #[cfg(target_arch = "wasm32")]
     pub fn bind(
         self: &Rc<Self>,
         editor: &pine_richtext::view::Editor,
-    ) -> pine_richtext::view::DocChangeSubscription {
+    ) -> Result<pine_richtext::view::DocChangeSubscription, BindError> {
         use pine_richtext::view::DocNode;
+
+        // Remote edits → load the converged doc back into the editor. Registered
+        // FIRST so a double-bind errors out *before* we attach the editor's
+        // update subscription (nothing to unwind on the error path).
+        let editor_remote = editor.clone();
+        self.on_change(move |node| {
+            let _ = editor_remote.set::<DocNode>(node);
+        })?;
 
         // Local edits → a fine-grained incremental write.
         let weak = Rc::downgrade(self);
@@ -233,13 +241,7 @@ impl CollabConnection {
                 tracing::warn!(target: "pocopine.log", error = %err, "collab: local push failed");
             }
         });
-
-        // Remote edits → load the converged doc back into the editor.
-        let editor = editor.clone();
-        self.on_change(move |node| {
-            let _ = editor.set::<DocNode>(node);
-        });
-        sub
+        Ok(sub)
     }
 }
 
@@ -272,8 +274,13 @@ mod tests {
         conn.push_local(&schema_basic::doc(vec![para("hi")]).unwrap())
             .expect("push_local queues without error");
 
-        // Registering a change handler must not panic.
-        conn.on_change(|_| {});
+        // The first change handler registers; a second is refused (one editor
+        // per connection).
+        conn.on_change(|_| {}).expect("first on_change registers");
+        assert!(
+            matches!(conn.on_change(|_| {}), Err(BindError::AlreadyBound)),
+            "a second on_change must be AlreadyBound, not a silent replace"
+        );
 
         // Drop clears the (absent in node) heartbeat + detaches handlers.
         drop(conn);

--- a/crates/pocopine-collab/src/server/handler.rs
+++ b/crates/pocopine-collab/src/server/handler.rs
@@ -23,10 +23,23 @@
 //!
 //! Every process **self-subscribes** to each topic's fan-out and folds peer
 //! updates into its local document, so replicas behind a multi-process fan-out
-//! (Redis) converge — not just the clients of one process. This closes the gap
-//! where the document was only ever mutated by inbound frames on the local
-//! connection. Durable load/compaction through
-//! [`CollabStore`](super::store::CollabStore) is the next step.
+//! (Redis) converge — not just the clients of one process. Durable load and
+//! checkpointing run through [`CollabStore`](super::store::CollabStore).
+//!
+//! ## Durability window (at-least-once *through the client*)
+//!
+//! [`on_data`](CollabSync::on_data) applies an inbound edit to the in-memory
+//! document and RETURNS a broadcast; the gateway then publishes that broadcast
+//! to the fan-out (and so, durably, toward the store). If the process crashes in
+//! that window — after the optimistic apply, before the gateway publishes — the
+//! edit reached neither the fan-out nor the store. It is not lost outright: the
+//! originating client re-runs the sync handshake on reconnect (its SyncStep1
+//! re-uploads exactly what the server lacks), so the edit returns as long as
+//! that client reconnects. The server is thus at-least-once *through the client*,
+//! not server-durable the instant it acks; the gap is only real if the client
+//! also disappears in that window. Closing it fully would have the handler
+//! publish to the fan-out itself before acking (a realtime↔collab contract
+//! change deferred as its own piece).
 
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -350,7 +363,10 @@ async fn run_apply_loop(
     // durable cursor only ever moves forward.
     let mut highest_seq = after.unwrap_or(0);
     last_folded.store(highest_seq, Ordering::Relaxed);
+    // The cursor a checkpoint was last INITIATED for. Checkpoints are detached
+    // (below) so a slow store never blocks folding; at most one runs at a time.
     let mut last_checkpointed = after.unwrap_or(0);
+    let mut checkpoint: Option<JoinHandle<()>> = None;
     let mut folded = 0u64;
     loop {
         match stream.next().await {
@@ -365,15 +381,30 @@ async fn run_apply_loop(
                 highest_seq = highest_seq.max(seq);
                 last_folded.store(highest_seq, Ordering::Relaxed);
                 folded += 1;
+                // Spawn a checkpoint without awaiting it, so the loop keeps
+                // folding while the store writes. Only one at a time (skip if the
+                // previous is still running) and only when there is new state to
+                // save; the store's monotonic guard + CRDT idempotency make an
+                // out-of-order or redundant detached save harmless. The save is
+                // still bounded by CHECKPOINT_TIMEOUT inside `checkpoint_and_trim`,
+                // so a wedged store frees the slot rather than blocking forever.
                 if let Some(store) = &store
                     && folded >= checkpoint_every
                 {
                     folded = 0;
-                    if highest_seq > last_checkpointed
-                        && checkpoint_and_trim(store.as_ref(), &fanout, &topic, &doc, highest_seq)
-                            .await
-                    {
+                    let idle = checkpoint.as_ref().is_none_or(|h| h.is_finished());
+                    if idle && highest_seq > last_checkpointed {
                         last_checkpointed = highest_seq;
+                        let (store, fanout, topic, doc, seq) = (
+                            store.clone(),
+                            fanout.clone(),
+                            topic.clone(),
+                            doc.clone(),
+                            highest_seq,
+                        );
+                        checkpoint = Some(tokio::spawn(async move {
+                            checkpoint_and_trim(store.as_ref(), &fanout, &topic, &doc, seq).await;
+                        }));
                     }
                 }
             }

--- a/crates/pocopine-collab/src/server/sqlite_store.rs
+++ b/crates/pocopine-collab/src/server/sqlite_store.rs
@@ -34,6 +34,15 @@ impl SqliteCollabStore {
         // so only file-backed connections enable it.
         conn.pragma_update(None, "journal_mode", "WAL")
             .map_err(|err| CollabError::store(err.to_string()))?;
+        // synchronous = FULL fsyncs every commit, NOT just at WAL-checkpoint
+        // boundaries (NORMAL's default). This matters because the apply loop
+        // trims the fan-out to a cursor as soon as `save_snapshot` returns Ok:
+        // under NORMAL a power loss could revert that not-yet-fsynced snapshot
+        // while the fan-out stayed trimmed past it, opening an evicted gap. FULL
+        // makes the save durable BEFORE the trim. The cost — one fsync per
+        // checkpoint — is negligible at the checkpoint cadence (every N updates).
+        conn.pragma_update(None, "synchronous", "FULL")
+            .map_err(|err| CollabError::store(err.to_string()))?;
         Self::from_connection(conn)
     }
 


### PR DESCRIPTION
## Collab durability & robustness follow-ups

The known-limitation follow-ups from #234, addressed. All four are small, targeted hardening of the durable apply-loop and the client binding.

| # | Fix | What it closes |
|---|-----|----------------|
| **B** | `SqliteCollabStore` sets `synchronous = FULL` | The apply loop trims the fan-out as soon as `save_snapshot` returns Ok; under WAL's default `NORMAL` a power loss could revert a not-yet-fsynced snapshot while the stream stayed trimmed past it (an evicted gap). FULL makes the save durable **before** the trim. One fsync per checkpoint — negligible at the cadence. |
| **E** | Detach the apply-loop checkpoint | A slow/remote store no longer stalls convergence — the loop keeps folding while the save runs. One checkpoint in flight at a time, only when there's new state; the monotonic store guard + CRDT idempotency make a detached/out-of-order save harmless, and the 5s timeout frees a wedged slot. |
| **D** | A second `bind()` is `BindError::AlreadyBound` | `CollabConnection` drives exactly one editor; `on_change`/`bind` now return `Result` and hard-error instead of silently overwriting (which detached the first editor from remote updates). |
| **J** | Document the `on_data` → publish durability window | An edit applied in `on_data` but lost before the gateway publishes to the fan-out is recoverable via the client's re-`hello()` on reconnect (at-least-once *through the client*), not server-durable at ack. Documented in the handler. |

### Deliberately not done

- **I (topic-shape guard)** — *skipped on purpose.* A hard `collab:{64-hex}` check in the handler would break the `collab-canvas` example, which registers `CollabSync` under a **`canvas:demo`** topic. The handler is intentionally topic-agnostic; the `collab:{hash}` shape is a `CollabDoc` convention, not a handler requirement. Defense-in-depth belongs in the gateway's `TopicResolver`.
- **#6 (>1 MiB update chunking)** and **worker-dedup (single designated compactor)** — left as separate efforts; each is a real protocol / distributed-systems change (frame fragmentation + reassembly; a `pocopine-jobs` SETNX-locked compaction worker), not a quick fix. Both are correctness-neutral today (the frame cap blocks oversized updates cleanly; per-replica checkpoints are redundant-but-correct via the monotonic guard).

### Testing

`pocopine-collab` 37 unit + 2 integration, `pine-richtext-collab` 28 host + wasm (node 24, incl. the new `AlreadyBound` assertion); `fmt` + `clippy` clean on host **and** `wasm32`.
