### PR TITLE
fix(pine-richtext): white-space: pre-wrap on the editor surface

### DIFF
--- a/crates/pine-richtext/src/view/PineRichTextRoot.poco
+++ b/crates/pine-richtext/src/view/PineRichTextRoot.poco
@@ -1,5 +1,6 @@
 <root class="pine-rich-text"
       contenteditable="true"
+      style="white-space: pre-wrap;"
       pp-ref="surface"
       :data-empty="state == null">
   <!-- TODO: doc renderer goes here. Today the surface is empty and


### PR DESCRIPTION
## Summary

Set `white-space: pre-wrap` on the `.pine-rich-text` contenteditable surface.

A rich-text editing surface needs `pre-wrap` so the browser **preserves consecutive spaces and authored newlines** while still **wrapping long lines**. The default `white-space: normal` collapses runs of whitespace and drops hard line breaks during editing, which is wrong for an editor.

## Why inline

Pine ships no CSS files (headless, "ready to style"), and functional defaults for this component are already declared inline / via the macro — `contenteditable="true"` on the same element and `display = "block"` on the component. `white-space: pre-wrap` is in that same functional-default category (it governs editing behaviour, not theming), so it lives inline on the editable root next to `contenteditable`.

- `pine-richtext/src/view/PineRichTextRoot.poco`

## Verification

- `pine-richtext` builds for `wasm32-unknown-unknown`.
- richtext test suites green (parity/core/runtime, 180+ tests); no view-markup test asserts the root's attribute set.