### PR TITLE
fix(pine-richtext): delete inline atoms on backspace without collapsing the paragraph (#243)

### DIFF
--- a/crates/pine-richtext/src/commands.rs
+++ b/crates/pine-richtext/src/commands.rs
@@ -747,6 +747,73 @@ pub fn select_node_forward() -> BoxedCommand {
     })
 }
 
+/// Backspace with a collapsed caret sitting immediately **after** an
+/// inline atom (a mention, emoji, pill — `inline().atom()`) in the same
+/// textblock: delete that atom at the model level, leaving the parent
+/// paragraph intact.
+///
+/// ProseMirror lets the browser delete inline atoms and reconciles via
+/// its DOM mutation observer; pine has no such observer, so without a
+/// model command the native backspace deletes the atom **and** collapses
+/// the now-empty paragraph into a block-less, invalid doc (#243). The
+/// block-boundary cases (caret at block start, a selectable atom in the
+/// *previous* block) stay with `join_backward` / `select_node_backward`
+/// — this only covers the within-textblock inline-atom case those miss
+/// because the caret is at block *end*, not block start.
+pub fn delete_node_backward() -> BoxedCommand {
+    boxed(|state| {
+        let cursor = collapsed_cursor(state)?;
+        // Block-start cases belong to join/select_node_backward.
+        if cursor.parent_offset() == 0 {
+            return None;
+        }
+        let before = cursor.node_before()?;
+        let before_type = state.schema().node_type(before.type_name()).ok()?;
+        if !before_type.is_inline() || !before_type.is_atom() {
+            return None;
+        }
+        let pos = cursor.pos();
+        let mut tr = state.tr();
+        tr.delete(pos.saturating_sub(before.node_size()), pos)
+            .ok()?;
+        Some(tr)
+    })
+}
+
+/// Forward-delete counterpart of [`delete_node_backward`]: a collapsed
+/// caret immediately **before** an inline atom deletes that atom,
+/// preserving the parent paragraph.
+pub fn delete_node_forward() -> BoxedCommand {
+    boxed(|state| {
+        let cursor = collapsed_cursor(state)?;
+        // Block-end cases belong to join/select_node_forward.
+        if cursor.parent_offset() == cursor.parent().content_size() {
+            return None;
+        }
+        let after = cursor.node_after()?;
+        let after_type = state.schema().node_type(after.type_name()).ok()?;
+        if !after_type.is_inline() || !after_type.is_atom() {
+            return None;
+        }
+        let pos = cursor.pos();
+        let mut tr = state.tr();
+        tr.delete(pos, pos + after.node_size()).ok()?;
+        Some(tr)
+    })
+}
+
+/// The resolved position of a collapsed caret, or `None` when the
+/// selection is a range. Shared by the inline-atom delete commands.
+fn collapsed_cursor(state: &EditorState) -> Option<ResolvedPos> {
+    if !state.selection().is_empty(state.doc()) {
+        return None;
+    }
+    state
+        .doc()
+        .resolve(state.selection().from(state.doc()))
+        .ok()
+}
+
 // ====================================================================
 // Wrap / setBlockType / toggleMark
 // ====================================================================

--- a/crates/pine-richtext/src/view/input.rs
+++ b/crates/pine-richtext/src/view/input.rs
@@ -114,6 +114,10 @@ fn base_keymap() -> KeyMap {
                 inputrules_plugin::undo_input_rule(),
                 commands::delete_selection(),
                 commands::join_backward(),
+                // Inline-atom-after-caret: delete it at the model level
+                // so the native backspace can't collapse the paragraph
+                // into an invalid block-less doc (#243).
+                commands::delete_node_backward(),
                 commands::select_node_backward(),
             ]),
         )
@@ -122,6 +126,7 @@ fn base_keymap() -> KeyMap {
             commands::chain_commands(vec![
                 commands::delete_selection(),
                 commands::join_forward(),
+                commands::delete_node_forward(),
                 commands::select_node_forward(),
             ]),
         )

--- a/crates/pine-richtext/tests/parity_commands.rs
+++ b/crates/pine-richtext/tests/parity_commands.rs
@@ -634,6 +634,70 @@ fn commands_select_node_forward_selects_following_atom() {
     }
 }
 
+// ─── #243 — inline-atom delete keeps the parent paragraph ──────────
+//
+// `image` is `inline().atom()` in the basic schema, the same shape as
+// the `mention` node from the issue. Backspacing one that is a
+// paragraph's sole content must leave an empty paragraph, never an
+// empty, block-less doc.
+
+#[test]
+fn commands_delete_node_backward_removes_inline_atom_keeps_paragraph() {
+    // doc(p(image)) with the caret right AFTER the inline atom (pos 2).
+    let state = state_with_doc(doc(vec![paragraph(vec![image("x.png")])]));
+    let mut tr = state.tr();
+    tr.set_selection(Selection::text(2)).unwrap();
+    let state = state.apply(tr).unwrap();
+
+    let state = run(&*commands::delete_node_backward(), state);
+    assert_eq!(state.doc(), &doc(vec![empty_paragraph()]));
+}
+
+#[test]
+fn commands_delete_node_forward_removes_inline_atom_keeps_paragraph() {
+    // doc(p(image)) with the caret right BEFORE the inline atom (pos 1).
+    let state = state_with_doc(doc(vec![paragraph(vec![image("x.png")])]));
+    let mut tr = state.tr();
+    tr.set_selection(Selection::text(1)).unwrap();
+    let state = state.apply(tr).unwrap();
+
+    let state = run(&*commands::delete_node_forward(), state);
+    assert_eq!(state.doc(), &doc(vec![empty_paragraph()]));
+}
+
+#[test]
+fn commands_delete_node_backward_ignores_text_caret() {
+    // A caret after plain text is NOT this command's job (text deletion
+    // is the browser / beforeinput path) — it bows out so the chain
+    // falls through.
+    let state = state_with_doc(doc(vec![paragraph_text("ab")]));
+    let mut tr = state.tr();
+    tr.set_selection(Selection::text(3)).unwrap();
+    let state = state.apply(tr).unwrap();
+
+    assert!(commands::delete_node_backward().apply(&state).is_none());
+}
+
+#[test]
+fn commands_backspace_chain_deletes_inline_atom_not_paragraph() {
+    // End-to-end: the Backspace chain (sans undo_input_rule, which is
+    // a no-op with no fired rule) on a sole inline atom leaves an empty
+    // paragraph — the regression #243 guards against.
+    let chain = chain_commands(vec![
+        delete_selection(),
+        join_backward(),
+        commands::delete_node_backward(),
+        select_node_backward(),
+    ]);
+    let state = state_with_doc(doc(vec![paragraph(vec![image("x.png")])]));
+    let mut tr = state.tr();
+    tr.set_selection(Selection::text(2)).unwrap();
+    let state = state.apply(tr).unwrap();
+
+    let state = run(&*chain, state);
+    assert_eq!(state.doc(), &doc(vec![empty_paragraph()]));
+}
+
 // Silence the `use commands::self` warning if it ever shows up — keeps the
 // import block tidy for the next wave.
 #[allow(unused_imports)]


### PR DESCRIPTION
## Summary

Backspacing an inline **atom** (mention, emoji, pill — `inline().atom()`) that is the sole content of its paragraph deleted the **paragraph itself**, leaving an empty, block-less contentEditable (`innerHTML === ""`) — an invalid doc with nowhere for the caret. Closes #243.

| Action | innerHTML (before) | innerHTML (after) |
| --- | --- | --- |
| type "ab", Backspace ×2 | `<p><br></p>` ✅ | `<p><br></p>` ✅ |
| insert inline atom, Backspace | `""` ❌ paragraph removed | `<p><br></p>` ✅ |

## Root cause

With a collapsed caret right **after** an inline atom (the paragraph's **end**, not its start):

- `delete_selection` → `None` (collapsed).
- `join_backward` → `None` (guards on `at_block_start`).
- `select_node_backward` → `None` (also guards on `at_block_start`; the caret is at block *end*).

So no command applied, `preventDefault` was never called, and the browser's native backspace ran — deleting the atom **and** collapsing the now-empty `<p>`. pine then re-parsed a block-less doc.

ProseMirror survives the native path because its DOM mutation observer reconciles the browser edit back into the model. pine has no such observer (it has a text-only `beforeinput` delete path that bows out for a caret sitting after a `contenteditable="false"` atom), so it needs a deterministic **model-level** command.

## Fix

Add `delete_node_backward` / `delete_node_forward` (`commands.rs`): a collapsed caret immediately after/before an inline atom in the same textblock deletes that atom at the model level in one press, leaving an empty paragraph and a valid caret. Wired into the Backspace/Delete keymap chains after the join commands (`view/input.rs`).

```
Backspace: [undo_input_rule, delete_selection, join_backward, delete_node_backward, select_node_backward]
Delete:    [delete_selection, join_forward, delete_node_forward, select_node_forward]
```

The commands guard on `is_inline() && is_atom()` and on the caret not being at block start/end, so:
- **block-boundary** atom selection (`join_backward` / `select_node_backward` at block start — the two-press image/hr behavior) is untouched;
- **plain text** carets fall through to the existing text-deletion path.

## Tests

4 new tests in `parity_commands.rs` (`image` is `inline().atom()` in the basic schema — same shape as the issue's `mention`):
- backward/forward delete of a sole inline atom → empty paragraph (not empty doc);
- text caret is ignored (command bows out → chain falls through);
- end-to-end Backspace **chain** on an inline atom → empty paragraph.

The fix is deterministic at the model+keymap layer; the model-level tests cover the exact transition the bug corrupted.

## Verification

- new tests: **4/4**; `parity_commands`: **39/0**; full pine-richtext host suite: **183 + others, 0 failed**.
- `cargo fmt` clean; clippy clean on **host + wasm32**.