### PR TITLE
feat(realtime): capability-based topic authorization (TopicAuthorizer/TopicAccess) + InboundData.principal

### DIFF
--- a/crates/pocopine-collab/src/server/handler.rs
+++ b/crates/pocopine-collab/src/server/handler.rs
@@ -573,11 +573,13 @@ mod tests {
         can_write: bool,
     ) -> Result<Reaction, WsError> {
         let payload = message.encode();
+        let principal = pocopine_realtime::Principal::anonymous();
         server
             .on_data(InboundData {
                 topic,
                 payload: &payload,
                 can_write,
+                principal: &principal,
             })
             .await
     }
@@ -811,11 +813,13 @@ mod tests {
         let server = sync();
         let topic = Topic::new("collab:doc").unwrap();
         let empty = Bytes::new();
+        let principal = pocopine_realtime::Principal::anonymous();
         let err = server
             .on_data(InboundData {
                 topic: &topic,
                 payload: &empty,
                 can_write: true,
+                principal: &principal,
             })
             .await
             .unwrap_err();

--- a/crates/pocopine-realtime/src/lib.rs
+++ b/crates/pocopine-realtime/src/lib.rs
@@ -64,3 +64,10 @@ pub mod client;
 pub mod server;
 #[cfg(not(target_arch = "wasm32"))]
 pub use server::*;
+
+// Re-export the auth types that appear in the gateway's public API —
+// `InboundData::principal` and the topic-policy signatures — so consumers (and
+// the crates that construct `InboundData` in tests) can name them without taking
+// a direct `pocopine-auth` dependency.
+#[cfg(not(target_arch = "wasm32"))]
+pub use pocopine_auth::{Principal, RequestContext};

--- a/crates/pocopine-realtime/src/server/gateway.rs
+++ b/crates/pocopine-realtime/src/server/gateway.rs
@@ -1,7 +1,9 @@
-//! The gateway hub: configuration, topic policy/resolver, and shared state
-//! (RFC 073 §10–§11).
+//! The gateway hub: configuration, topic authorization/resolver, and shared
+//! state (RFC 073 §10–§11).
 
 use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
 
@@ -26,15 +28,122 @@ const DEFAULT_MAX_SUBSCRIPTIONS: usize = 256;
 /// Default cap on a topic-name string (bytes).
 const DEFAULT_MAX_TOPIC_BYTES: usize = 512;
 
-/// Per-topic authorization policy: may this `RequestContext` join this `Topic`?
+/// What a connection may do on a topic — the whole authorization outcome of one
+/// [`TopicAuthorizer`] decision.
 ///
-/// Mirrors `LiveHub::with_topic_policy`'s synchronous bool shape (RFC 073
-/// §10.1). Capability-bearing consumers (e.g. collab read-only vs read-write)
-/// layer a richer async authorizer on top in their own crates.
+/// `ReadWrite` permits join + publish; `ReadOnly` permits join only; `Denied`
+/// permits neither. Write-without-join is unrepresentable.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum TopicAccess {
+    /// May neither subscribe nor publish.
+    #[default]
+    Denied,
+    /// May subscribe (read) but not publish.
+    ReadOnly,
+    /// May subscribe and publish.
+    ReadWrite,
+}
+
+impl TopicAccess {
+    /// Whether the connection may subscribe to the topic.
+    pub fn can_join(self) -> bool {
+        !matches!(self, Self::Denied)
+    }
+
+    /// Whether the connection may publish to the topic.
+    pub fn can_write(self) -> bool {
+        matches!(self, Self::ReadWrite)
+    }
+
+    /// Downgrade `ReadWrite` to `ReadOnly` when `writable` is false; otherwise
+    /// unchanged. Used by the [`WsGateway::with_write_policy`] clamp.
+    fn clamp_write(self, writable: bool) -> Self {
+        match self {
+            Self::ReadWrite if !writable => Self::ReadOnly,
+            other => other,
+        }
+    }
+}
+
+/// Decides what a connection may do on a topic — join (read) AND publish (write)
+/// in one **async** decision, so the check can hit a store (e.g. a
+/// channel-membership lookup). The single authorization seam on the
+/// [`WsGateway`]: it is awaited at subscribe time and re-checked on every inbound
+/// frame (RFC 073 §10.1).
+///
+/// Most apps don't implement this directly — the closure builders
+/// ([`WsGateway::with_access`], [`WsGateway::with_async_access`]) and the
+/// back-compat [`WsGateway::with_topic_policy`] cover the common cases. Implement
+/// it for a stateful, testable authorizer (one that carries a DB pool, a cache,
+/// or capability tokens).
+pub trait TopicAuthorizer: Send + Sync + 'static {
+    fn authorize<'a>(
+        &'a self,
+        ctx: &'a RequestContext,
+        topic: &'a Topic,
+    ) -> Pin<Box<dyn Future<Output = TopicAccess> + Send + 'a>>;
+}
+
+/// Back-compat alias for the synchronous bool join-policy closure shape.
 pub type TopicPolicy = Arc<dyn Fn(&RequestContext, &Topic) -> bool + Send + Sync>;
 
 /// Resolves a client-supplied topic string to a canonical `Topic`.
 pub type TopicResolver = Arc<dyn Fn(&str) -> Result<Topic, WsError> + Send + Sync>;
+
+/// Adapts a synchronous capability closure into a [`TopicAuthorizer`].
+struct FnAuthorizer<F>(F);
+
+impl<F> TopicAuthorizer for FnAuthorizer<F>
+where
+    F: Fn(&RequestContext, &Topic) -> TopicAccess + Send + Sync + 'static,
+{
+    fn authorize<'a>(
+        &'a self,
+        ctx: &'a RequestContext,
+        topic: &'a Topic,
+    ) -> Pin<Box<dyn Future<Output = TopicAccess> + Send + 'a>> {
+        let access = (self.0)(ctx, topic);
+        Box::pin(std::future::ready(access))
+    }
+}
+
+/// Adapts an async capability closure into a [`TopicAuthorizer`].
+struct AsyncFnAuthorizer<F>(F);
+
+impl<F, Fut> TopicAuthorizer for AsyncFnAuthorizer<F>
+where
+    F: Fn(RequestContext, Topic) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = TopicAccess> + Send + 'static,
+{
+    fn authorize<'a>(
+        &'a self,
+        ctx: &'a RequestContext,
+        topic: &'a Topic,
+    ) -> Pin<Box<dyn Future<Output = TopicAccess> + Send + 'a>> {
+        Box::pin((self.0)(ctx.clone(), topic.clone()))
+    }
+}
+
+/// Wraps an authorizer with a synchronous **write clamp**: a `ReadWrite` decision
+/// is downgraded to `ReadOnly` when `write` returns false. Back-compat seam for
+/// [`WsGateway::with_write_policy`].
+struct WriteClamp {
+    inner: Arc<dyn TopicAuthorizer>,
+    write: Arc<dyn Fn(&RequestContext, &Topic) -> bool + Send + Sync>,
+}
+
+impl TopicAuthorizer for WriteClamp {
+    fn authorize<'a>(
+        &'a self,
+        ctx: &'a RequestContext,
+        topic: &'a Topic,
+    ) -> Pin<Box<dyn Future<Output = TopicAccess> + Send + 'a>> {
+        Box::pin(async move {
+            let access = self.inner.authorize(ctx, topic).await;
+            access.clamp_write((self.write)(ctx, topic))
+        })
+    }
+}
 
 /// Tunable connection limits and liveness timings.
 #[derive(Clone, Copy, Debug)]
@@ -71,11 +180,8 @@ impl Default for GatewayConfig {
 #[derive(Clone)]
 pub struct WsGateway {
     fanout: Arc<dyn Fanout>,
-    policy: TopicPolicy,
-    /// Per-topic *publish* authorization, layered on top of the join `policy`.
-    /// Defaults to allow, so any connection that may join may also publish
-    /// (the relay's historical behavior); set it to express read-only access.
-    write_policy: TopicPolicy,
+    /// The single join + publish authorization seam. Defaults to deny-all.
+    authorizer: Arc<dyn TopicAuthorizer>,
     resolver: TopicResolver,
     config: GatewayConfig,
     sessions: Arc<AtomicU64>,
@@ -91,15 +197,18 @@ pub struct WsGateway {
 impl WsGateway {
     /// Build a gateway over an explicit [`Fanout`].
     ///
-    /// The default topic policy denies every topic (matching `LiveHub`'s safe
+    /// The default authorizer denies every topic (matching `LiveHub`'s safe
     /// default); open it with [`WsGateway::allow_all_topics`],
-    /// [`WsGateway::allow_topics`], or [`WsGateway::with_topic_policy`]. The
-    /// default resolver maps a topic string straight to a `Topic`.
+    /// [`WsGateway::allow_topics`], [`WsGateway::with_access`],
+    /// [`WsGateway::with_async_access`], [`WsGateway::with_authorizer`], or the
+    /// back-compat [`WsGateway::with_topic_policy`]. The default resolver maps a
+    /// topic string straight to a `Topic`.
     pub fn new(fanout: Arc<dyn Fanout>) -> Self {
         Self {
             fanout,
-            policy: Arc::new(|_, _| false),
-            write_policy: Arc::new(|_, _| true),
+            authorizer: Arc::new(FnAuthorizer(
+                |_: &RequestContext, _: &Topic| TopicAccess::Denied,
+            )),
             resolver: Arc::new(|topic| Topic::new(topic).map_err(WsError::from)),
             config: GatewayConfig::default(),
             sessions: Arc::new(AtomicU64::new(0)),
@@ -132,38 +241,83 @@ impl WsGateway {
         )))
     }
 
-    /// Replace the per-topic join authorization policy.
-    pub fn with_topic_policy(
-        mut self,
-        policy: impl Fn(&RequestContext, &Topic) -> bool + Send + Sync + 'static,
-    ) -> Self {
-        self.policy = Arc::new(policy);
+    /// Set the [`TopicAuthorizer`] — the join + publish decision for every topic.
+    /// Replaces any previously-set authorizer / policy.
+    pub fn with_authorizer(mut self, authorizer: impl TopicAuthorizer) -> Self {
+        self.authorizer = Arc::new(authorizer);
         self
     }
 
-    /// Replace the per-topic *publish* policy (layered on top of the join
-    /// policy). Returning `false` makes the connection read-only for that
-    /// topic: inbound Data frames are refused by the relay, and handlers see
-    /// [`InboundData::can_write`](super::handler::InboundData) `= false`. The
-    /// default allows any joiner to publish.
+    /// Set a **synchronous** capability policy: one closure returns the full
+    /// [`TopicAccess`] (join + write) for a connection/topic.
+    pub fn with_access(
+        self,
+        policy: impl Fn(&RequestContext, &Topic) -> TopicAccess + Send + Sync + 'static,
+    ) -> Self {
+        self.with_authorizer(FnAuthorizer(policy))
+    }
+
+    /// Set an **async** capability policy — the closure awaits (e.g. a DB
+    /// membership lookup) and returns the full [`TopicAccess`]. The closure
+    /// receives an owned [`RequestContext`] (it carries the principal) + the
+    /// resolved [`Topic`].
+    pub fn with_async_access<F, Fut>(self, policy: F) -> Self
+    where
+        F: Fn(RequestContext, Topic) -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = TopicAccess> + Send + 'static,
+    {
+        self.with_authorizer(AsyncFnAuthorizer(policy))
+    }
+
+    /// Replace the per-topic join policy (back-compat bool shape): `true` →
+    /// [`TopicAccess::ReadWrite`], `false` → [`TopicAccess::Denied`]. Prefer
+    /// [`with_access`](Self::with_access) / [`with_async_access`](Self::with_async_access)
+    /// to express read-only access or an async lookup directly.
+    pub fn with_topic_policy(
+        self,
+        policy: impl Fn(&RequestContext, &Topic) -> bool + Send + Sync + 'static,
+    ) -> Self {
+        self.with_access(move |ctx, topic| {
+            if policy(ctx, topic) {
+                TopicAccess::ReadWrite
+            } else {
+                TopicAccess::Denied
+            }
+        })
+    }
+
+    /// Layer a **publish** restriction on top of the current authorizer: when
+    /// `policy` returns false a `ReadWrite` decision is clamped to `ReadOnly` (the
+    /// connection may join but not publish), and handlers see
+    /// [`InboundData::can_write`](super::handler::InboundData) `= false`. Prefer
+    /// returning [`TopicAccess::ReadOnly`] from [`with_access`](Self::with_access).
     pub fn with_write_policy(
         mut self,
         policy: impl Fn(&RequestContext, &Topic) -> bool + Send + Sync + 'static,
     ) -> Self {
-        self.write_policy = Arc::new(policy);
+        self.authorizer = Arc::new(WriteClamp {
+            inner: self.authorizer.clone(),
+            write: Arc::new(policy),
+        });
         self
     }
 
-    /// Allow any connection to join any topic. Use only when topic access is
-    /// enforced elsewhere or is genuinely public.
+    /// Allow any connection to join and publish on any topic. Use only when topic
+    /// access is enforced elsewhere or is genuinely public.
     pub fn allow_all_topics(self) -> Self {
-        self.with_topic_policy(|_, _| true)
+        self.with_access(|_, _| TopicAccess::ReadWrite)
     }
 
-    /// Allow only the given set of `Topic`s.
+    /// Allow only the given set of `Topic`s (join + publish); deny the rest.
     pub fn allow_topics(self, topics: impl IntoIterator<Item = Topic>) -> Self {
         let allowed: Arc<Vec<Topic>> = Arc::new(topics.into_iter().collect());
-        self.with_topic_policy(move |_, topic| allowed.iter().any(|t| t == topic))
+        self.with_access(move |_, topic| {
+            if allowed.iter().any(|t| t == topic) {
+                TopicAccess::ReadWrite
+            } else {
+                TopicAccess::Denied
+            }
+        })
     }
 
     /// Replace the topic-string → `Topic` resolver.
@@ -214,12 +368,11 @@ impl WsGateway {
         (self.resolver)(topic)
     }
 
-    pub(crate) fn authorize(&self, ctx: &RequestContext, topic: &Topic) -> bool {
-        (self.policy)(ctx, topic)
-    }
-
-    pub(crate) fn authorize_write(&self, ctx: &RequestContext, topic: &Topic) -> bool {
-        (self.write_policy)(ctx, topic)
+    /// Authorize a connection against a topic — the single join + publish
+    /// decision, awaiting the [`TopicAuthorizer`]. Checked at subscribe time and
+    /// re-checked on every inbound frame.
+    pub(crate) async fn authorize(&self, ctx: &RequestContext, topic: &Topic) -> TopicAccess {
+        self.authorizer.authorize(ctx, topic).await
     }
 
     pub(crate) fn handler(&self, subprotocol_id: u64) -> Option<&Arc<dyn SubprotocolHandler>> {
@@ -288,20 +441,72 @@ mod tests {
         )
     }
 
-    #[test]
-    fn default_policy_denies_all_topics() {
+    #[tokio::test]
+    async fn default_authorizer_denies_all_topics() {
         let gateway = WsGateway::local();
         let topic = Topic::new("collab:abc").unwrap();
-        assert!(!gateway.authorize(&anon_ctx(), &topic));
+        assert_eq!(
+            gateway.authorize(&anon_ctx(), &topic).await,
+            TopicAccess::Denied
+        );
     }
 
-    #[test]
-    fn allow_topics_permits_only_listed() {
+    #[tokio::test]
+    async fn allow_topics_permits_only_listed_read_write() {
         let allowed = Topic::new("collab:abc").unwrap();
         let other = Topic::new("collab:xyz").unwrap();
         let gateway = WsGateway::local().allow_topics([allowed.clone()]);
-        assert!(gateway.authorize(&anon_ctx(), &allowed));
-        assert!(!gateway.authorize(&anon_ctx(), &other));
+        assert_eq!(
+            gateway.authorize(&anon_ctx(), &allowed).await,
+            TopicAccess::ReadWrite
+        );
+        assert_eq!(
+            gateway.authorize(&anon_ctx(), &other).await,
+            TopicAccess::Denied
+        );
+    }
+
+    #[tokio::test]
+    async fn write_policy_clamps_read_write_to_read_only() {
+        let topic = Topic::new("collab:abc").unwrap();
+        let gateway = WsGateway::local()
+            .allow_all_topics()
+            .with_write_policy(|_, _| false);
+        let access = gateway.authorize(&anon_ctx(), &topic).await;
+        assert!(access.can_join());
+        assert!(!access.can_write());
+        assert_eq!(access, TopicAccess::ReadOnly);
+    }
+
+    #[tokio::test]
+    async fn async_authorizer_decides_per_topic() {
+        let allowed = Topic::new("chat:abc").unwrap();
+        let denied = Topic::new("chat:xyz").unwrap();
+        // The authorizer can await (here a trivial future) and decide per topic.
+        let gateway = WsGateway::local().with_async_access(|_ctx, topic: Topic| async move {
+            if topic.as_str() == "chat:abc" {
+                TopicAccess::ReadWrite
+            } else {
+                TopicAccess::Denied
+            }
+        });
+        assert_eq!(
+            gateway.authorize(&anon_ctx(), &allowed).await,
+            TopicAccess::ReadWrite
+        );
+        assert_eq!(
+            gateway.authorize(&anon_ctx(), &denied).await,
+            TopicAccess::Denied
+        );
+    }
+
+    #[tokio::test]
+    async fn with_access_expresses_read_only() {
+        let topic = Topic::new("chat:abc").unwrap();
+        let gateway = WsGateway::local().with_access(|_, _| TopicAccess::ReadOnly);
+        let access = gateway.authorize(&anon_ctx(), &topic).await;
+        assert!(access.can_join());
+        assert!(!access.can_write());
     }
 
     #[test]

--- a/crates/pocopine-realtime/src/server/handler.rs
+++ b/crates/pocopine-realtime/src/server/handler.rs
@@ -16,6 +16,7 @@
 
 use async_trait::async_trait;
 use bytes::Bytes;
+use pocopine_auth::Principal;
 use pocopine_events::Topic;
 
 use super::error::WsError;
@@ -35,6 +36,10 @@ pub struct InboundData<'a> {
     /// distinguishes read-only from read-write access (e.g. collab) gates
     /// its mutating messages on this; pure relays ignore it.
     pub can_write: bool,
+    /// The server-trusted principal for this connection, from the upgrade
+    /// request's `RequestContext`. Lets a stateful handler (e.g. chat) stamp the
+    /// authenticated identity onto committed state instead of trusting the wire.
+    pub principal: &'a Principal,
 }
 
 /// What the gateway should emit after a [`SubprotocolHandler`] processes a

--- a/crates/pocopine-realtime/src/server/mod.rs
+++ b/crates/pocopine-realtime/src/server/mod.rs
@@ -18,7 +18,9 @@ pub use error::WsError;
 pub use fanout::{
     DEFAULT_TOPIC_CAPACITY, Fanout, LocalFanout, TopicMessage, TopicSource, TopicStream,
 };
-pub use gateway::{GatewayConfig, TopicPolicy, TopicResolver, WsGateway};
+pub use gateway::{
+    GatewayConfig, TopicAccess, TopicAuthorizer, TopicPolicy, TopicResolver, WsGateway,
+};
 pub use handler::{InboundData, Reaction, SubprotocolHandler};
 #[cfg(feature = "redis")]
 pub use redis_fanout::{DEFAULT_REDIS_MAX_LEN, RedisFanout};

--- a/crates/pocopine-realtime/src/server/route.rs
+++ b/crates/pocopine-realtime/src/server/route.rs
@@ -288,13 +288,14 @@ impl Session {
                 )));
             }
         };
-        // Re-check join authorization on every inbound frame (RFC 073 §10.1).
-        if !self.gateway.authorize(&self.ctx, &topic) {
+        // Re-authorize on every inbound frame (RFC 073 §10.1): one decision
+        // covers both join (read) and publish (write); read-only connections may
+        // join but not write (handlers receive `can_write`, the relay enforces it).
+        let access = self.gateway.authorize(&self.ctx, &topic).await;
+        if !access.can_join() {
             return Err(WsError::forbidden(name));
         }
-        // Publish authorization is a second, finer gate (read-only connections
-        // may join but not write); handlers receive it, the relay enforces it.
-        let can_write = self.gateway.authorize_write(&self.ctx, &topic);
+        let can_write = access.can_write();
 
         // A registered sub-protocol handler (e.g. collab) intercepts the frame
         // and runs stateful server logic; every other sub-protocol is a pure
@@ -305,6 +306,7 @@ impl Session {
                     topic: &topic,
                     payload: &frame.payload,
                     can_write,
+                    principal: &self.ctx.user,
                 })
                 .await?;
             for payload in reaction.replies {
@@ -359,7 +361,7 @@ impl Session {
                 return;
             }
         };
-        if !self.gateway.authorize(&self.ctx, &topic) {
+        if !self.gateway.authorize(&self.ctx, &topic).await.can_join() {
             self.send(&Control::error(
                 "forbidden_topic",
                 format!("topic '{topic_name}' denied"),


### PR DESCRIPTION
## What

Replaces the gateway's split authorization hooks with **one capability authorizer**, and hands the connection's principal to sub-protocol handlers.

### `TopicAuthorizer` / `TopicAccess`
```rust
trait TopicAuthorizer { async fn authorize(ctx, topic) -> TopicAccess }
enum TopicAccess { Denied, ReadOnly, ReadWrite }   // write-without-join unrepresentable
```
- **Async** — the check can hit a store (a channel-membership lookup), which a sync `Fn(&RequestContext, &Topic) -> bool` can't. This is what a realtime chat needs for per-channel read isolation.
- **One decision, both gates** — the per-frame path now does one `authorize` call (was `authorize` + `authorize_write`) and derives `can_write` from it.
- **Models read-only vs read-write** directly — the gateway's own stated goal for collab.

Ergonomic builders, all back-compat:
- `with_authorizer(impl TopicAuthorizer)` — stateful/testable named authorizer
- `with_access(|ctx,t| TopicAccess)` — sync capability closure
- `with_async_access(|ctx,t| async {..})` — async capability closure
- `with_topic_policy(|ctx,t| bool)` — legacy join policy (`true` → `ReadWrite`)
- `with_write_policy(|ctx,t| bool)` — legacy publish clamp (`ReadWrite` → `ReadOnly`)
- `allow_all_topics` / `allow_topics` — unchanged

The gateway holds one `authorizer: Arc<dyn TopicAuthorizer>` (default deny); `with_write_policy` wraps it in a clamp. `TopicAccess`, `TopicAuthorizer`, `Principal`, `RequestContext` are re-exported from the crate root.

### `InboundData.principal`
`SubprotocolHandler::on_data` now receives the server-trusted `Principal` from the upgrade `RequestContext`, so a handler (chat) can stamp the authenticated identity onto committed state instead of trusting the wire.

## Why
A realtime chat needs per-channel read isolation: a private channel's messages must fan out only to members. The topic is `chat:sha256(channel_id)`, so the gate must look up membership — an async DB call returning a capability (member → ReadWrite, guest → ReadOnly, stranger → Denied). The old sync `with_topic_policy` could only do coarse, bool, join-only checks.

## Compatibility
Additive. `allow_all_topics` / `allow_topics` / `with_topic_policy` / `with_write_policy` all keep working (now thin shims over the authorizer). `InboundData` gains a field — handlers *receive* it; only the gateway + tests construct it (collab's two test helpers updated).

## Tests
Capability + write-clamp + async-authorizer unit tests; `pocopine-realtime` (43) and `pocopine-collab` (34) suites green; full workspace builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTij2YPhragJ7gJgrnHXhF