### PR TITLE
fix(auth-oauth): send Accept: application/json on token exchange (GitHub returns form-encoded by default)

### DIFF
--- a/crates/pocopine-auth-oauth/src/lib.rs
+++ b/crates/pocopine-auth-oauth/src/lib.rs
@@ -228,8 +228,13 @@ pub async fn refresh(
 /// collapsed to a stable error — the body (which can echo a code/secret) is never
 /// surfaced (§D10).
 async fn post_token(config: &OAuthConfig, form: &[(&str, String)]) -> OAuthResult<OAuthToken> {
+    // Negotiate a JSON token response. Spec-compliant providers already return
+    // JSON, but GitHub's token endpoint defaults to `application/x-www-form-
+    // urlencoded` and only returns JSON when `Accept: application/json` is sent —
+    // without this, `.json()` below fails with "error decoding response body".
     let response = reqwest::Client::new()
         .post(&config.token_url)
+        .header(reqwest::header::ACCEPT, "application/json")
         .form(form)
         .send()
         .await

--- a/crates/pocopine-auth-oauth/tests/flow.rs
+++ b/crates/pocopine-auth-oauth/tests/flow.rs
@@ -5,7 +5,7 @@
 use pocopine_auth_oauth::{OAuthConfig, complete_authorization, refresh};
 use pocopine_crypto::SecretString;
 use serde_json::json;
-use wiremock::matchers::{body_string_contains, method, path};
+use wiremock::matchers::{body_string_contains, header, method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
 
 fn config(server: &MockServer) -> OAuthConfig {
@@ -22,6 +22,9 @@ async fn complete_authorization_exchanges_the_code_with_pkce() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path("/token"))
+        // Require JSON negotiation — GitHub's token endpoint defaults to
+        // form-urlencoded and only returns JSON when this header is sent.
+        .and(header("accept", "application/json"))
         .and(body_string_contains("grant_type=authorization_code"))
         .and(body_string_contains("code=auth-code-xyz"))
         .and(body_string_contains("code_verifier=the-verifier"))
@@ -54,6 +57,7 @@ async fn refresh_exchanges_the_refresh_token_and_retains_an_omitted_one() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path("/token"))
+        .and(header("accept", "application/json"))
         .and(body_string_contains("grant_type=refresh_token"))
         .and(body_string_contains("refresh_token=refresh-1"))
         .respond_with(ResponseTemplate::new(200).set_body_json(json!({


### PR DESCRIPTION
## Problem
`complete_authorization` / `refresh` fail against GitHub with:

> `oauth token endpoint: invalid response: error decoding response body`

`post_token` parses the token response with `.json()` but never sets an `Accept` header. Per the current GitHub docs, the token endpoint **returns `application/x-www-form-urlencoded` by default** and only returns JSON when the request sends `Accept: application/json`:

> "By default, the response takes the following form: `access_token=…&scope=…&token_type=bearer`. You can also receive the response in different formats if you provide the format in the `Accept` header. For example, `Accept: application/json`…"

So the JSON decode fails. This affects both OAuth Apps and GitHub Apps (user-to-server tokens).

## Fix
Add `Accept: application/json` to the token-endpoint request. Spec-compliant providers already return JSON (or ignore the header); GitHub requires it.

## Tests
The `wiremock` flow tests (code exchange + refresh) now include a `header("accept", "application/json")` matcher, so the request is verified to send it — drop the header and the mock no longer matches and the tests fail. `pocopine-auth-oauth` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTij2YPhragJ7gJgrnHXhF