### PR TITLE
feat(sync-query): QueryClient::apply_external_changes — ingest realtime deltas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9792,6 +9792,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync-external-e2e"
+version = "0.1.1"
+dependencies = [
+ "pocopine-sync",
+ "pocopine-sync-indexdb",
+ "pocopine-sync-query",
+ "pocopine-sync-query-macros",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,6 +83,7 @@ members = [
     "examples/richtext",
     "examples/site",
     "examples/spa",
+    "examples/sync-external-e2e",
     "examples/tailwind",
     "examples/todo",
     "examples/workspace",

--- a/crates/pocopine-sync-query/src/client.rs
+++ b/crates/pocopine-sync-query/src/client.rs
@@ -988,6 +988,91 @@ impl QueryClient {
         Ok(crate::MutationOutcome::Accepted(canonical_changes))
     }
 
+    /// Apply externally-sourced **canonical** row changes (e.g. a realtime /
+    /// WebSocket delta) into the sync client, WITHOUT a server pull or a client
+    /// mutation.
+    ///
+    /// Each change is routed into every matching live subscription on `stream`
+    /// (predicate-evaluated, with exactly the semantics of a `/pull` result — see
+    /// [`route_canonical_pull`](Self::route_canonical_pull)) **and** persisted to
+    /// the durable local store, so the delta survives an offline reload. The row
+    /// must already carry its **canonical** id: this is not an optimistic overlay,
+    /// so no [`MutationId`] is involved and pending optimistic overlays are left
+    /// untouched (a delivered row reconciles against canonical; a still-pending
+    /// local mutation keeps winning until its own `mutate()` confirms).
+    ///
+    /// This is the bridge that lets a realtime transport — which delivers rows out
+    /// of band from the sync `/pull` cycle — feed the offline-first cache as the
+    /// single source of truth, instead of maintaining a parallel in-memory store.
+    /// Best-effort persistence: a local-store write failure is logged, not
+    /// returned (the in-memory routing already succeeded and stays authoritative).
+    pub async fn apply_external_changes<Row>(
+        &self,
+        stream: &SyncStreamName,
+        changes: Vec<RowChange<Row>>,
+    ) where
+        Row: Clone + serde::Serialize + 'static,
+    {
+        // 1. Route into matching subscriptions — canonical semantics, no mutation
+        //    overlay to dequeue (the row is already final).
+        Self::route_canonical_pull::<Row>(&self.inner, stream, &changes);
+
+        // 2. Persist each affected subscription's canonical snapshot to the durable
+        //    store, keyed by its params-scoped compartment — the same key the
+        //    subscription hydrates from on reload (mirrors driver `persist_snapshot`).
+        let Some(config) = self.inner.config.as_ref() else {
+            return;
+        };
+        let Some(store) = config.local_store.clone() else {
+            return;
+        };
+        for sub in self.collect_subscriptions_on_stream::<Row>(stream) {
+            let (compartment, canonical, cursor, app_version) = {
+                let state = sub.state().borrow();
+                let sub_stream = sub.query().stream().clone();
+                let canonical: Vec<SyncRow<Value>> = state
+                    .canonical_rows()
+                    .filter_map(|row| {
+                        Some(SyncRow {
+                            key: row.key.clone(),
+                            version: row.version.clone(),
+                            value: serde_json::to_value(&row.value).ok()?,
+                            pending: false,
+                            conflict: false,
+                        })
+                    })
+                    .collect();
+                (
+                    pocopine_sync::local_stream_key(&sub_stream, sub.query().params()),
+                    canonical,
+                    state.cursor.clone(),
+                    state.application_schema_version,
+                )
+            };
+            // sync-query has no separate "collection" surface; reuse the
+            // compartment as the collection token (informational on the store).
+            let Ok(collection) = pocopine_sync::SyncCollectionName::new(compartment.as_str())
+            else {
+                continue;
+            };
+            let batch = pocopine_sync::LocalSnapshotBatch::new(
+                compartment.clone(),
+                collection,
+                canonical,
+                cursor,
+            )
+            .with_application_schema_version(app_version);
+            if let Err(err) = store.save_snapshot(batch).await {
+                tracing::warn!(
+                    target: "pocopine.log",
+                    stream = compartment.as_str(),
+                    error = %err,
+                    "sync-query: apply_external_changes persist failed; in-memory state still authoritative",
+                );
+            }
+        }
+    }
+
     /// Clear a durable pending mutation across every compartment
     /// of `stream` after the canonical reconcile confirmed it.
     /// Uses `mark_push_result` (which the store contract guarantees

--- a/crates/pocopine-sync-query/tests/persistence.rs
+++ b/crates/pocopine-sync-query/tests/persistence.rs
@@ -669,3 +669,160 @@ async fn no_local_store_keeps_in_memory_only_behavior() {
         })
         .await;
 }
+
+// ─── Test: external (e.g. WebSocket-delivered) changes route + persist ──
+
+#[tokio::test]
+async fn apply_external_changes_routes_into_view_and_persists() {
+    let local = LocalSet::new();
+    local
+        .run_until(async {
+            reset_middleware();
+            // Empty /open + /pull: the subscription opens with no rows, so the only
+            // row that can appear is the externally-applied one.
+            install_middleware(|req: FetchRequest, _next: FetchNext| async move {
+                match req.url.as_str() {
+                    SYNC_OPEN_PATH => Ok(json_response(&open_response(1, None))),
+                    SYNC_PULL_PATH => Ok(json_response(&snapshot_response(vec![]))),
+                    other => Err(ServerError::Network(format!("unexpected {other}"))),
+                }
+            });
+
+            let store = Rc::new(MemoryLocalStore::new());
+            let store_handle: Rc<dyn SyncLocalStore> = store.clone();
+            // Long poll so a periodic /pull snapshot can't wipe the external row
+            // before we assert (snapshot pulls are authoritative).
+            let config = QueryClientConfig {
+                poll_interval: Some(Duration::from_secs(3600)),
+                disable_live: true,
+                ..QueryClientConfig::default()
+            }
+            .with_local_store(store_handle);
+            let client = query_client_plugin().config(config).into_client();
+
+            let view = client.observe(Issue::query().eq(issues::field::workspace_id, "W1").build());
+            settle(3).await; // initial /open + empty /pull
+            assert_eq!(view.rows().len(), 0, "no rows before the external change");
+
+            // Inject a WS-style external delta (row already carries its canonical id).
+            let stream = SyncStreamName::new(STREAM).unwrap();
+            let row = Issue {
+                id: "issue_ws".into(),
+                workspace_id: "W1".into(),
+                title: "delivered over WS".into(),
+            };
+            client
+                .apply_external_changes(&stream, vec![RowChange::Upsert(row.clone())])
+                .await;
+
+            // 1. Routed into the live observing view.
+            let rows = view.rows();
+            assert_eq!(
+                rows.len(),
+                1,
+                "external change routed into the observing view"
+            );
+            assert_eq!(rows[0].id, "issue_ws");
+
+            // 2. Persisted to the durable store under the query's params-scoped
+            //    compartment — so it survives an offline reload (the realtime path
+            //    is otherwise in-memory only).
+            let params = {
+                let mut p = StreamParams::new();
+                p.insert("workspace_id".into(), serde_json::json!("W1"));
+                p
+            };
+            let compartment = local_stream_key(&stream, &params);
+            let persisted = store.hydrate_stream(&compartment).await.unwrap();
+            assert_eq!(
+                persisted.rows.len(),
+                1,
+                "external change persisted to the local store"
+            );
+            assert_eq!(persisted.rows[0].key.as_str(), "issue_ws");
+
+            // 3. A non-matching predicate departure is a no-op for this view.
+            let other = Issue {
+                id: "issue_other_ws".into(),
+                workspace_id: "W2".into(),
+                title: "different workspace".into(),
+            };
+            client
+                .apply_external_changes(&stream, vec![RowChange::Upsert(other)])
+                .await;
+            assert_eq!(
+                view.rows().len(),
+                1,
+                "a change for a non-matching param doesn't enter the view"
+            );
+        })
+        .await;
+}
+
+// ─── Test: an external (WS) change survives an OFFLINE reload ────────
+
+#[tokio::test]
+async fn external_change_survives_offline_reload() {
+    let local = LocalSet::new();
+    local
+        .run_until(async {
+            let store = Rc::new(MemoryLocalStore::new());
+            let stream = SyncStreamName::new(STREAM).unwrap();
+            let row = Issue {
+                id: "issue_ws".into(),
+                workspace_id: "W1".into(),
+                title: "delivered over WS".into(),
+            };
+            let query = || Issue::query().eq(issues::field::workspace_id, "W1").build();
+            let config = || QueryClientConfig {
+                poll_interval: Some(Duration::from_secs(3600)),
+                disable_live: true,
+                ..QueryClientConfig::default()
+            };
+
+            // Session 1 (online): a WS delta arrives → routed + persisted to the store.
+            {
+                reset_middleware();
+                install_middleware(|req: FetchRequest, _next: FetchNext| async move {
+                    match req.url.as_str() {
+                        SYNC_OPEN_PATH => Ok(json_response(&open_response(1, None))),
+                        SYNC_PULL_PATH => Ok(json_response(&snapshot_response(vec![]))),
+                        other => Err(ServerError::Network(format!("unexpected {other}"))),
+                    }
+                });
+                let s: Rc<dyn SyncLocalStore> = store.clone();
+                let c1 = query_client_plugin()
+                    .config(config().with_local_store(s))
+                    .into_client();
+                let _v1 = c1.observe(query());
+                settle(3).await;
+                c1.apply_external_changes(&stream, vec![RowChange::Upsert(row.clone())])
+                    .await;
+                settle(1).await;
+            }
+
+            // Session 2 (reload while OFFLINE): every sync call fails, so the durable
+            // cache is the only source — the WS delta must still be visible.
+            {
+                reset_middleware();
+                install_middleware(|req: FetchRequest, _next: FetchNext| async move {
+                    Err(ServerError::Network(format!("offline: {}", req.url)))
+                });
+                let s: Rc<dyn SyncLocalStore> = store.clone();
+                let c2 = query_client_plugin()
+                    .config(config().with_local_store(s))
+                    .into_client();
+                let v2 = c2.observe(query());
+                settle(4).await; // hydrate from cache; /open + /pull fail (offline)
+                let rows = v2.rows();
+                assert_eq!(
+                    rows.len(),
+                    1,
+                    "the WS-delivered change survived an offline reload (served from cache)"
+                );
+                assert_eq!(rows[0].id, "issue_ws");
+                assert_eq!(rows[0].title, "delivered over WS");
+            }
+        })
+        .await;
+}

--- a/examples/sync-external-e2e/Cargo.toml
+++ b/examples/sync-external-e2e/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "sync-external-e2e"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+publish = false
+
+# A tiny wasm app that drives `QueryClient::apply_external_changes` against the
+# REAL `IndexedDbLocalStore`, so a Playwright test can prove a realtime-style
+# delta routes into a live view AND survives a page reload (offline). No server,
+# no UI framework — just the sync client + three wasm-bindgen hooks.
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+pocopine-sync = { workspace = true }
+pocopine-sync-query = { workspace = true }
+pocopine-sync-query-macros = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+wasm-bindgen = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+pocopine-sync-indexdb = { workspace = true }
+wasm-bindgen-futures = { workspace = true }

--- a/examples/sync-external-e2e/index.html
+++ b/examples/sync-external-e2e/index.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>sync-external e2e</title>
+    <link rel="icon" href="data:," />
+  </head>
+  <body>
+    <div id="app">loading…</div>
+    <script type="module">
+      import init, { inject, view_rows } from './pkg/sync_external_e2e.js';
+      await init();
+      // Expose the wasm hooks so the Playwright spec can drive them.
+      window.inject = inject;
+      window.view_rows = view_rows;
+      document.getElementById('app').textContent = 'ready';
+    </script>
+  </body>
+</html>

--- a/examples/sync-external-e2e/src/lib.rs
+++ b/examples/sync-external-e2e/src/lib.rs
@@ -1,0 +1,84 @@
+//! Minimal browser harness for `QueryClient::apply_external_changes`.
+//!
+//! `start()` builds a `QueryClient` over the real `IndexedDbLocalStore` and
+//! observes `notes` for board `b1`. `inject(id, body)` feeds a row in as if it
+//! arrived over a realtime transport (no server, no mutation). `view_rows()`
+//! returns the live view's rows as JSON. The Playwright spec drives these to
+//! prove the delta routes into the view AND survives a reload (served from the
+//! durable IndexedDB cache).
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use pocopine_sync::SyncStreamName;
+use pocopine_sync_query::{QueryClient, QueryView, RowChange};
+use pocopine_sync_query_macros::query_resource;
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::prelude::*;
+
+#[query_resource(name = "notes", schema_version = 1)]
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct Note {
+    pub id: String,
+    #[query_param(required)]
+    pub board: String,
+    pub body: String,
+}
+
+const BOARD: &str = "b1";
+
+thread_local! {
+    static CLIENT: RefCell<Option<Rc<QueryClient>>> = const { RefCell::new(None) };
+    static VIEW: RefCell<Option<QueryView<Note>>> = const { RefCell::new(None) };
+}
+
+#[wasm_bindgen(start)]
+pub fn start() {
+    let store: Rc<dyn pocopine_sync::SyncLocalStore> = Rc::new(
+        pocopine_sync_indexdb::IndexedDbLocalStore::with_database_name("sync_external_e2e")
+            .unwrap_or_else(|_| pocopine_sync_indexdb::IndexedDbLocalStore::new()),
+    );
+    // `disable_live`: no SSE; there's no server, so the only writes are external
+    // injects + the durable-cache hydrate (the /open + /pull fetches just fail and
+    // leave the hydrated cache visible — exactly the "offline" scenario we test).
+    let config = pocopine_sync_query::QueryClientConfig {
+        disable_live: true,
+        ..Default::default()
+    }
+    .with_local_store(store);
+    let client = Rc::new(pocopine_sync_query::query_client_plugin().config(config).into_client());
+    let view = client.observe(Note::query().eq(notes::field::board, BOARD).build());
+    CLIENT.with(|c| *c.borrow_mut() = Some(client));
+    VIEW.with(|v| *v.borrow_mut() = Some(view));
+}
+
+/// Inject a row as if a realtime transport delivered it — routes into the live
+/// view and persists to IndexedDB, with no server round-trip.
+#[wasm_bindgen]
+pub async fn inject(id: String, body: String) {
+    let Some(client) = CLIENT.with(|c| c.borrow().clone()) else {
+        return;
+    };
+    let stream = SyncStreamName::new("notes").unwrap();
+    client
+        .apply_external_changes(
+            &stream,
+            vec![RowChange::Upsert(Note {
+                id,
+                board: BOARD.to_string(),
+                body,
+            })],
+        )
+        .await;
+}
+
+/// The live view's current rows, as a JSON array (what the test asserts on).
+#[wasm_bindgen]
+pub fn view_rows() -> String {
+    VIEW.with(|v| {
+        v.borrow()
+            .as_ref()
+            .map(|view| serde_json::to_string(&view.rows()).unwrap_or_default())
+            .unwrap_or_else(|| "[]".to_string())
+    })
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
     "build:richtext": "wasm-pack build examples/richtext --target web --out-dir pkg",
     "test:richtext-smoke": "npm run build:richtext && playwright test richtext.spec.mjs",
     "test:richtext-perf": "npm run build:richtext && playwright test richtext.perf.spec.mjs",
+    "build:sync-external": "wasm-pack build examples/sync-external-e2e --target web --out-dir pkg",
+    "test:sync-external": "npm run build:sync-external && PLAYWRIGHT_SERVE_DIR=examples/sync-external-e2e playwright test sync-external.spec.mjs",
     "test:storage-tus-e2e": "cargo test -p pocopine-storage --test tus_js_client_e2e -- --ignored --nocapture"
   },
   "devDependencies": {

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -4,6 +4,9 @@ const browserChannel = process.env.PLAYWRIGHT_BROWSER_CHANNEL
   ?? (process.env.CI ? undefined : 'chrome');
 const richtextSmokePort = process.env.RICHTEXT_SMOKE_PORT ?? '5245';
 const richtextSmokeUrl = `http://127.0.0.1:${richtextSmokePort}`;
+// Which example directory the static server serves. Defaults to the richtext
+// smoke; set PLAYWRIGHT_SERVE_DIR=examples/<other> to run another example's spec.
+const serveDir = process.env.PLAYWRIGHT_SERVE_DIR ?? 'examples/richtext';
 
 export default defineConfig({
   testDir: './tests/playwright',
@@ -26,7 +29,7 @@ export default defineConfig({
     },
   ],
   webServer: {
-    command: `python3 -m http.server ${richtextSmokePort} --bind 127.0.0.1 --directory examples/richtext`,
+    command: `python3 -m http.server ${richtextSmokePort} --bind 127.0.0.1 --directory ${serveDir}`,
     url: richtextSmokeUrl,
     reuseExistingServer: !process.env.CI,
     timeout: 10_000,

--- a/tests/playwright/sync-external.spec.mjs
+++ b/tests/playwright/sync-external.spec.mjs
@@ -1,0 +1,35 @@
+import { expect, test } from '@playwright/test';
+
+// Serve with: PLAYWRIGHT_SERVE_DIR=examples/sync-external-e2e (see playwright.config.mjs).
+// Proves QueryClient::apply_external_changes in a REAL browser: a realtime-style
+// delta routes into the live view AND survives a reload, served from IndexedDB.
+
+const rows = (page) => page.evaluate(() => JSON.parse(window.view_rows()));
+
+test('apply_external_changes routes into the view and survives an offline reload', async ({ page }) => {
+  await page.goto('/');
+  await expect(page.locator('#app')).toHaveText('ready');
+
+  // Start with a clean IndexedDB so a prior run can't leak in.
+  await page.evaluate(
+    () => new Promise((resolve) => {
+      const req = indexedDB.deleteDatabase('sync_external_e2e');
+      req.onsuccess = req.onerror = req.onblocked = () => resolve();
+    }),
+  );
+  await page.reload();
+  await expect(page.locator('#app')).toHaveText('ready');
+  expect(await rows(page)).toHaveLength(0);
+
+  // Inject a row as if a WebSocket delivered it (no server, no mutation).
+  await page.evaluate(() => window.inject('n1', 'delivered over WS'));
+  await expect.poll(async () => (await rows(page)).length).toBe(1);
+  expect((await rows(page))[0]).toMatchObject({ id: 'n1', body: 'delivered over WS' });
+
+  // Reload (there is no server → /open + /pull fail): the row must still be here,
+  // hydrated from the durable IndexedDB cache. This is the offline-survival guarantee.
+  await page.reload();
+  await expect(page.locator('#app')).toHaveText('ready');
+  await expect.poll(async () => (await rows(page)).length, { timeout: 10_000 }).toBe(1);
+  expect((await rows(page))[0]).toMatchObject({ id: 'n1', body: 'delivered over WS' });
+});


### PR DESCRIPTION
## What

