### PR TITLE
docs(sync): drop pocopine-sync-crud from user-facing docs; point to sync-query

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ members = [
     # pocopine-sync-sqlx (CRUD-specific) deleted. The Source/MutationLog
     # types in pocopine_sync_query::write supersede them; the macro-
     # emitted typed write API replaces hand-built CrudMutationPayload.
-    # See docs/sync-crud-to-query-migration.md (Phase 5) for the
+    # See docs/legacy-sync-to-query-migration.md (Phase 5) for the
     # migration path.
     "crates/pocopine-sync-indexdb",
     "crates/pocopine-sync-query",

--- a/crates/pocopine-sync-query/README.md
+++ b/crates/pocopine-sync-query/README.md
@@ -1,20 +1,14 @@
 # `pocopine-sync-query`
 
-**Status: 🚧 Work in progress (Phase 3 scaffold).** API surface is being built out; the runtime is not yet wired up. Use [`pocopine-sync-crud`](../pocopine-sync-crud/) for production today.
+Query-centric, local-first data layer for Pocopine. Filtered subscriptions, predicate-routed optimistic mutations, reactive selectors, and typed writes — built on the `pocopine-sync` wire protocol, durable local store, and live-wakeup channel.
 
-Query-centric local-first data layer for Pocopine sync. Parallel to `pocopine-sync-crud`; recommended for filtered multi-tenant apps once it ships.
+This is the framework's data-layer crate. One `Query` API spans the full range: simple single-shape entities (TodoMVC, settings, blog comments) **and** filtered multi-tenant shapes, where the same `Issues` table is observed under many filters at once (a workspace switcher, a status filter, an assignee filter). The `Source` trait plus the macro-emitted typed write builders cover every create/update/delete.
 
-## Why a second crate?
+## When to reach for it
 
-`pocopine-sync-crud` is designed to be **safe and rigid**:
-
-* One Resource = one logical entity type, one logical view.
-* No subscription parameters; one stream serves one shape.
-* Optimistic writes go to "the" Resource state.
-
-That design wins for TodoMVC, blog comments, settings pages. It does **not** win for multi-tenant SaaS apps where the same `Issues` table is observed under many filtered shapes (workspace switcher, status filter, assignee filter).
-
-Retrofitting shape subscriptions into CRUD violates its invariants. See [RFC 086](../../rfcs/rfc-086-sync-query.md) for the full reasoning. The short version: **CRUD stays simple; this crate is the home for shape-aware data flow.**
+* You want server data mirrored into reactive local state with optimistic writes.
+* You observe one entity type under more than one filtered shape and need each view to update independently.
+* You want derived values (counts, projections, dashboards) that recompute only when their inputs change.
 
 ## Design
 
@@ -24,31 +18,10 @@ Three primitives, drawn from the consensus across Replicache/Zero, ElectricSQL, 
 2. **`Mutator`** — a transactional function that produces row changes; the engine evaluates each change against every active query's predicate and routes it to the views that match.
 3. **`QueryClient`** — a refcounted registry that owns one `QuerySubscription` per distinct `Query`, with its own state, queue, and lifecycle.
 
-See RFC 086 (`rfcs/rfc-086-sync-query.md`) for the design rationale and
-RFC 090 (`rfcs/rfc-090-merge-crud-into-query.md`) for the merge that
-folded `pocopine-sync-crud` into this crate.
-
-## What ships in this branch
-
-| File                              | Status  | Notes                                                  |
-| --------------------------------- | ------- | ------------------------------------------------------ |
-| `src/lib.rs`                      | ✅      | Module declarations + re-exports                       |
-| `src/query.rs`                    | ✅      | `Query<Row>`, `QueryKey`, `OrderBy`, `Order` + builder, `MatchFn<Row>` |
-| `src/params.rs`                   | ✅      | Comparator wrappers (`InSet`, `Range`, `Contains`)     |
-| `src/predicate.rs`                | ✅      | Sealed comparator-trait gate + `range_contains` / `contains_matches` runtime helpers |
-| `src/mutator.rs`                  | ✅      | `Mutator` trait + `RowChange` + `MutationOutcome`      |
-| `src/state.rs`                    | ✅      | `QueryState<Row>` (per-query reactive state)           |
-| `src/client.rs`                   | ✅      | `QueryClient` + refcounted `QuerySubscription` registry + routing engine |
-| `src/wire.rs`                     | ✅      | Build `SyncOpenRequest` / `SyncPullRequest` / `SyncPushRequest` from typed queries |
-| `pocopine-sync-query-macros`      | ✅      | `#[query_resource]` + `#[query]` macros: query DSL builders, comparator-trait impls, predicate evaluator, selector memoization |
-| `src/selector.rs`                 | ✅      | `#[query]` runtime: tracking stack, `SelectorEntry`, `SelectorView`, `AnyTrackable`, `PartialEq` diff-suppression |
-| Background-task drivers (wasm)    | ⏳ next | spawn-aware `/open` + `/pull` flow; live wakeup; offline replay |
-| `examples/issue-tracker`          | ⏳ later| Linear-clone demo                                      |
-| `docs/sync-query-cookbook.md`     | ⏳ later| User-facing cookbook                                   |
-
-## Reference implementation
-
-The branch `wip/sync-shape-subs-batch-4` is a **reference implementation** of shape subscriptions integrated into `pocopine-sync-crud`. It demonstrates what NOT to do — see the design doc's architectural-tension analysis. The wire protocol and macro DSL from that branch carry over to this crate; the client-side machinery does not.
+See [RFC 086](../../rfcs/rfc-086-sync-query.md) for the design rationale,
+[RFC 087](../../rfcs/rfc-087-sync-query-driver.md) for the per-subscription
+driver lifecycle, and [RFC 088](../../rfcs/rfc-088-sync-query-production-parity.md)
+for the production-parity surface (typed writes, offline replay, live invalidation).
 
 ## Quickstart
 
@@ -209,8 +182,7 @@ Full picture, broker comparison, and topic-cardinality scaling notes in [`docs/t
 - [`docs/guides/data/sync-client.md`](../../docs/guides/data/sync-client.md) — `QueryClient` /
   `Query<Row>` DSL / typed writes reference.
 
-RFC 090 (merged) folded `pocopine-sync-crud` into this crate. The
-`Source` trait + `SourceResource` adapter cover both former CRUD and
-former Query use cases, with typed writes via the
+The `Source` trait + `SourceResource` adapter cover every server-side
+read/write shape, with typed writes via the
 `#[query_resource(draft = ...)]`-emitted
 `Issue::create/update/delete(...).optimistic(...).push_typed(...)` API.

--- a/docs/legacy-sync-to-query-migration.md
+++ b/docs/legacy-sync-to-query-migration.md
@@ -6,11 +6,10 @@ This guide walks the migration of an app off the legacy
 `QueryView` + the `Source` trait). The `examples/keep` app is the
 worked reference — every pattern below ships there.
 
-> **Context.** RFC-090 folded the old `pocopine-sync-crud` crate into
-> `pocopine-sync-query`; the legacy *collection* client in
-> `pocopine-sync` is the last thing apps still depend on. `pocopine-sync`
-> remains the shared protocol/foundation (wire types, `SyncServer`,
-> `SyncLocalStore`).
+> **Context.** `pocopine-sync-query` is the current data-layer crate; the
+> legacy *collection* client in `pocopine-sync` is the last thing apps
+> still depend on. `pocopine-sync` remains the shared protocol/foundation
+> (wire types, `SyncServer`, `SyncLocalStore`).
 
 ---
 

--- a/rfcs/rfc-072-offline-sync-protocol.md
+++ b/rfcs/rfc-072-offline-sync-protocol.md
@@ -58,8 +58,8 @@ The local-store implementation plan is documented in
 [`docs/sync-local-store-plan.md`](../docs/sync-local-store-plan.md):
 SQLite-first local storage, with SQLx kept as a later host/server
 adapter.
-The CRUD helper plan is documented in
-[`docs/sync-crud.md`](../docs/sync-crud.md).
+The data-layer client is documented in the sync guides
+([`docs/guides/data/sync-client.md`](../docs/guides/data/sync-client.md)).
 
 ## 1. Summary
 

--- a/rfcs/rfc-086-sync-query.md
+++ b/rfcs/rfc-086-sync-query.md
@@ -273,7 +273,7 @@ A separate PR on a new branch (`wip/revert-crud-shape-integration`) reverts the 
 * `pocopine-sync`: keeps the wire envelope changes (`SyncStreamSubscription`, `validate_params` / `validate_push_params` on `SyncStreamSource`, `local_stream_key`). These are wire-level and useful to Query.
 * `pocopine-sync`'s client-side: removes the bare-vs-composite split, `active_local_key`, `is_active_local_key`, `reconcile_local_key`. Restores the simple selector-keyed state model that CRUD's invariants need.
 
-After this revert, `pocopine-sync-crud` is back to its pre-RFC-085 simplicity. The wire protocol's shape envelope stays. Apps that depended on the interim shape DSL on CRUD switch to `pocopine-sync-query` once Phase 3 lands.
+After this revert, `pocopine-sync-crud` is back to its pre-RFC-085 simplicity. The wire protocol's shape envelope stays. Apps that depended on the interim shape DSL on CRUD switched to `pocopine-sync-query` when Phase 3 shipped.
 
 ### Phase 3 — Implement `pocopine-sync-query`
 
@@ -314,4 +314,4 @@ Draft. Awaiting design-doc-level detail in `docs/sync-query-design.md` and a tra
 
 * RFC 085 — Shape subscriptions. This RFC inherits its wire protocol and macro vocabulary, and supersedes its client-side model for shape-aware apps.
 * `docs/sync-design.md` — full sync framework design, including the architectural-tension analysis that motivated this RFC.
-* `docs/sync-shape-subscriptions.md` — the cookbook for the Batch 4 reference implementation. Will be superseded by `docs/sync-query-cookbook.md` once Phase 3 lands.
+* `docs/sync-shape-subscriptions.md` — the cookbook for the Batch 4 reference implementation; superseded by the `docs/guides/data/` sync guides when Phase 3 shipped.

--- a/rfcs/rfc-090-merge-crud-into-query.md
+++ b/rfcs/rfc-090-merge-crud-into-query.md
@@ -3,9 +3,8 @@
 * **Status:** Implemented
 * **Author:** sync framework working group
 * **Tracking branch:** `feat/rfc-090-merge-crud-into-query`
-* **Supersedes:** the dual-crate boundary documented in
-  [`sync-crud.md`](../docs/sync-crud.md) and
-  [`sync-crud-query-composition.md`](../docs/sync-crud-query-composition.md)
+* **Supersedes:** the dual-crate boundary documented in the
+  (now-removed) `sync-crud.md` and `sync-crud-query-composition.md`
 * **Related:** [RFC 086 (pocopine-sync-query)](./rfc-086-sync-query.md),
   [RFC 087 (driver lifecycle)](./rfc-087-sync-query-driver.md),
   [RFC 088 (production parity)](./rfc-088-sync-query-production-parity.md)


### PR DESCRIPTION
## What & why

`pocopine-sync-crud` was folded into `pocopine-sync-query` (RFC-090) and the crate no longer exists, yet several docs still referenced it — most importantly the crate README, which told users to **"use `pocopine-sync-crud` for production today."** This scrubs the dead crate from the user-facing docs and points everything at `pocopine-sync-query`.

## Changes

| File | Change |
|---|---|
| `crates/pocopine-sync-query/README.md` | Rewrote the header: removed the stale *"🚧 WIP scaffold / use sync-crud for production"* status, the "why a second crate?" dual-crate framing, the branch-progress table (which also over-promised the nonexistent `examples/issue-tracker` + `docs/sync-query-cookbook.md`), and the sync-crud "reference implementation" section. Presents sync-query as *the* data-layer crate. Technical sections kept verbatim. |
| `docs/sync-crud-to-query-migration.md` → `docs/legacy-sync-to-query-migration.md` | Renamed + cleaned the one sync-crud mention (the guide is about migrating off the *legacy collection client*, not sync-crud). |
| `Cargo.toml` | Updated the workspace comment's `See docs/…` path to the new filename (the rename would otherwise dangle it). |
| `rfcs/rfc-072`, `rfc-090` | Fixed the broken `docs/sync-crud.md` links (file deleted by RFC-090). |
| `rfcs/rfc-086` | De-WIP'd two "once Phase 3 lands" phrases → "when Phase 3 shipped". |

## Scope notes

- **RFCs are light-touch on purpose.** `sync-crud` is kept where it's accurate historical narrative (rfc-084/086/087/088/090 + the RFC index row, e.g. rfc-090 is titled "Merge sync-crud into sync-query"). Only broken links and stale WIP wording were fixed; the merge history stays intact.
- **User-facing docs (`README` + `docs/`) now contain zero `sync-crud` mentions**; all README relative links verified to resolve.
- Docs-only change (plus one `Cargo.toml` *comment*) — no code or build impact.
