### PR TITLE
add storage object read API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7553,6 +7553,7 @@ name = "pocopine-storage-gcs"
 version = "0.1.1"
 dependencies = [
  "bytes",
+ "futures-util",
  "google-cloud-auth",
  "google-cloud-gax",
  "google-cloud-storage",

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Full guides and tutorials live under [`docs/`](./docs). Start here:
 - [Server functions](./docs/guides/server/server-functions.md) — `#[server]` policies, guards, request context, and middleware extractors.
 - [App plugins](./docs/guides/plugins/app-plugins.md) / [Server plugins](./docs/guides/server/server-plugins.md) — install-time setup and lifecycle ordering.
 - [Sync (client)](./docs/guides/data/sync-client.md) / [Sync (server)](./docs/guides/data/sync-server.md) — the query data layer, end to end.
-- [Object-storage uploads](./docs/guides/data/storage-uploads.md) — the server-mediated upload path.
+- [Object-storage uploads and reads](./docs/guides/data/storage-uploads.md) — server-mediated upload and short-lived read paths.
 - [Logging, tracing & observers](./docs/guides/observability/logging-tracing.md) — structured events, sinks, and privacy labels.
 - [Charts](./docs/guides/styling/charts/) · [Icons](./docs/guides/styling/icons.md) · [Client modules](./docs/guides/server/client-modules.md) · [Browser storage](./docs/guides/data/browser-storage.md)
 

--- a/crates/pocopine-storage-azure/src/state.rs
+++ b/crates/pocopine-storage-azure/src/state.rs
@@ -92,6 +92,7 @@ pub(crate) struct AzureObjectBytes {
 pub(crate) struct AzureObjectMetadata {
     pub(crate) size: Option<u64>,
     pub(crate) etag: Option<String>,
+    pub(crate) content_type: Option<String>,
 }
 
 pub(crate) struct AzureObjectWrite {

--- a/crates/pocopine-storage-azure/src/storage.rs
+++ b/crates/pocopine-storage-azure/src/storage.rs
@@ -1531,6 +1531,7 @@ impl StorageBackend for AzureBlobStorageBackend {
                     visibility: ObjectVisibility::Private,
                     metadata: Default::default(),
                 },
+                content_length: Some(size),
                 body: ObjectBody::from_stream_with_limit(stream, max_bytes),
             })
         })

--- a/crates/pocopine-storage-azure/src/storage.rs
+++ b/crates/pocopine-storage-azure/src/storage.rs
@@ -22,10 +22,10 @@ use pocopine_storage::checksum::{
     precheck_checksum, validate_complete_checksum_precomputed,
 };
 use pocopine_storage::{
-    BackendCapabilities, ChecksumAlgorithm, CompleteUpload, InitiateUpload, ObjectChecksum,
-    ObjectRead, ObjectRef, ObjectVisibility, SafeObjectKey, StorageActor, StorageBackend,
-    StorageBoxFuture, StorageContext, StorageError, StorageResult, TransferPlan, UploadBody,
-    UploadSession, UploadSessionId, UploadSessionStatus, UploadStrategy,
+    BackendCapabilities, ChecksumAlgorithm, CompleteUpload, InitiateUpload, ObjectBody,
+    ObjectChecksum, ObjectRead, ObjectRef, ObjectVisibility, SafeObjectKey, StorageActor,
+    StorageBackend, StorageBoxFuture, StorageContext, StorageError, StorageResult, TransferPlan,
+    UploadBody, UploadSession, UploadSessionId, UploadSessionStatus, UploadStrategy,
 };
 use time::OffsetDateTime;
 use uuid::Uuid;
@@ -399,7 +399,14 @@ impl AzureBlobStorageBackend {
             .etag()
             .map_err(|err| azure_error("read blob etag", err))?
             .map(|etag| etag.to_string());
-        Ok(AzureObjectMetadata { size, etag })
+        let content_type = response
+            .content_type()
+            .map_err(|err| azure_error("read blob content type", err))?;
+        Ok(AzureObjectMetadata {
+            size,
+            etag,
+            content_type,
+        })
     }
 
     async fn put_object_bytes(
@@ -1478,36 +1485,53 @@ impl StorageBackend for AzureBlobStorageBackend {
                     })?;
             let declared_size = metadata.size;
             let metadata_etag = metadata.etag.clone();
-            if let Some(size) = declared_size
-                && size > max_bytes
-            {
+            let metadata_content_type = metadata.content_type.clone();
+            let size = declared_size
+                .ok_or_else(|| StorageError::backend("Azure blob size is unavailable"))?;
+            if size > max_bytes {
                 return Err(StorageError::payload_too_large(max_bytes));
             }
-            let read = self
-                .download_object_bytes_with_limit(&object_key, max_bytes, metadata)
+            let mut options = BlobClientDownloadOptions::default();
+            if let Some(etag) = &metadata.etag {
+                options.if_match = Some(Etag::from(etag.clone()));
+            }
+            let response = self
+                .container
+                .blob_client(&object_key)
+                .download(Some(options))
                 .await
-                .map_err(|err| match err {
-                    StorageError::UnknownUploadSession { .. } => {
+                .map_err(|err| {
+                    if is_azure_not_found(&err) {
                         StorageError::unknown_object(key.to_string())
+                    } else if is_azure_precondition_failed(&err) {
+                        StorageError::conflict("Azure blob changed while reading")
+                    } else {
+                        azure_error("download completed blob", err)
                     }
-                    err => err,
                 })?;
-            let size = declared_size.unwrap_or(read.bytes.len() as u64);
+            let etag = response
+                .properties
+                .etag
+                .map(|etag| etag.to_string())
+                .or(metadata_etag);
+            let content_type = response.properties.content_type.or(metadata_content_type);
+            let stream = response.body.map(|chunk| {
+                chunk.map_err(|err| std::io::Error::other(format!("Azure read blob body: {err}")))
+            });
             Ok(ObjectRead {
                 object: ObjectRef {
                     backend: self.name.to_string(),
                     scope: scope.to_string(),
                     key: key.to_string(),
                     version: None,
-                    etag: read.etag.or(metadata_etag),
+                    etag,
                     checksum: None,
-                    content_type: None,
+                    content_type,
                     size,
                     visibility: ObjectVisibility::Private,
                     metadata: Default::default(),
                 },
-                bytes: read.bytes,
-                truncated: false,
+                body: ObjectBody::from_stream_with_limit(stream, max_bytes),
             })
         })
     }

--- a/crates/pocopine-storage-azure/src/storage.rs
+++ b/crates/pocopine-storage-azure/src/storage.rs
@@ -23,9 +23,9 @@ use pocopine_storage::checksum::{
 };
 use pocopine_storage::{
     BackendCapabilities, ChecksumAlgorithm, CompleteUpload, InitiateUpload, ObjectChecksum,
-    ObjectRef, StorageActor, StorageBackend, StorageBoxFuture, StorageContext, StorageError,
-    StorageResult, TransferPlan, UploadBody, UploadSession, UploadSessionId, UploadSessionStatus,
-    UploadStrategy,
+    ObjectRead, ObjectRef, ObjectVisibility, SafeObjectKey, StorageActor, StorageBackend,
+    StorageBoxFuture, StorageContext, StorageError, StorageResult, TransferPlan, UploadBody,
+    UploadSession, UploadSessionId, UploadSessionStatus, UploadStrategy,
 };
 use time::OffsetDateTime;
 use uuid::Uuid;
@@ -1455,6 +1455,71 @@ impl StorageBackend for AzureBlobStorageBackend {
                 self.part_concurrency.forget(&session);
             }
             result
+        })
+    }
+
+    fn read_object<'a>(
+        &'a self,
+        _ctx: &'a StorageContext,
+        scope: &'a str,
+        key: SafeObjectKey,
+        max_bytes: u64,
+    ) -> StorageBoxFuture<'a, ObjectRead> {
+        Box::pin(async move {
+            let object_key = self.layout.object_key(key.as_str());
+            let metadata =
+                self.get_object_metadata(&object_key)
+                    .await
+                    .map_err(|err| match err {
+                        StorageError::UnknownUploadSession { .. } => {
+                            StorageError::unknown_object(key.to_string())
+                        }
+                        err => err,
+                    })?;
+            let declared_size = metadata.size;
+            let metadata_etag = metadata.etag.clone();
+            if let Some(size) = declared_size
+                && size > max_bytes
+            {
+                return Err(StorageError::payload_too_large(max_bytes));
+            }
+            let read = self
+                .download_object_bytes_with_limit(&object_key, max_bytes, metadata)
+                .await
+                .map_err(|err| match err {
+                    StorageError::UnknownUploadSession { .. } => {
+                        StorageError::unknown_object(key.to_string())
+                    }
+                    err => err,
+                })?;
+            let size = declared_size.unwrap_or(read.bytes.len() as u64);
+            Ok(ObjectRead {
+                object: ObjectRef {
+                    backend: self.name.to_string(),
+                    scope: scope.to_string(),
+                    key: key.to_string(),
+                    version: None,
+                    etag: read.etag.or(metadata_etag),
+                    checksum: None,
+                    content_type: None,
+                    size,
+                    visibility: ObjectVisibility::Private,
+                    metadata: Default::default(),
+                },
+                bytes: read.bytes,
+                truncated: false,
+            })
+        })
+    }
+
+    fn delete_completed_object<'a>(
+        &'a self,
+        _ctx: &'a StorageContext,
+        key: SafeObjectKey,
+    ) -> StorageBoxFuture<'a, ()> {
+        Box::pin(async move {
+            self.delete_object_if_exists(&self.layout.object_key(key.as_str()))
+                .await
         })
     }
 

--- a/crates/pocopine-storage-gcs/Cargo.toml
+++ b/crates/pocopine-storage-gcs/Cargo.toml
@@ -8,6 +8,7 @@ description = "Google Cloud Storage backend adapter for pocopine-storage."
 
 [dependencies]
 bytes = "1"
+futures-util = { version = "0.3", default-features = false }
 google-cloud-storage = "1"
 google-cloud-gax = "1"
 pocopine-codec = { workspace = true }

--- a/crates/pocopine-storage-gcs/src/storage.rs
+++ b/crates/pocopine-storage-gcs/src/storage.rs
@@ -11,9 +11,9 @@ use pocopine_storage::checksum::{
 };
 use pocopine_storage::{
     BackendCapabilities, ChecksumAlgorithm, ChecksumPolicy, CompleteUpload, InitiateUpload,
-    ObjectChecksum, ObjectRead, ObjectRef, ObjectVisibility, SafeObjectKey, StorageActor,
-    StorageBackend, StorageBoxFuture, StorageContext, StorageError, StorageResult, TransferPlan,
-    UploadBody, UploadSession, UploadSessionId, UploadSessionStatus, UploadStrategy,
+    ObjectBody, ObjectChecksum, ObjectRead, ObjectRef, ObjectVisibility, SafeObjectKey,
+    StorageActor, StorageBackend, StorageBoxFuture, StorageContext, StorageError, StorageResult,
+    TransferPlan, UploadBody, UploadSession, UploadSessionId, UploadSessionStatus, UploadStrategy,
 };
 use time::OffsetDateTime;
 use uuid::Uuid;
@@ -1621,34 +1621,57 @@ impl StorageBackend for GcsStorageBackend {
     ) -> StorageBoxFuture<'a, ObjectRead> {
         Box::pin(async move {
             let object_key = self.layout.object_key(key.as_str());
-            let read = self
-                .get_object_bytes_with_limit(&object_key, max_bytes)
+            let response = self
+                .storage
+                .read_object(self.layout.bucket_resource(), &object_key)
+                .send()
                 .await
                 .map_err(|err| match err {
-                    StorageError::UnknownUploadSession { .. } => {
-                        StorageError::unknown_object(key.to_string())
-                    }
-                    err => err,
+                    err if is_gcs_not_found(&err) => StorageError::unknown_object(key.to_string()),
+                    err => gcs_error("read completed object", err),
                 })?;
-            if read.truncated {
+            let object = response.object();
+            if object.size < 0 {
+                return Err(StorageError::backend("GCS object size is unavailable"));
+            }
+            let size = object.size as u64;
+            if size > max_bytes {
                 return Err(StorageError::payload_too_large(max_bytes));
             }
-            let size = read.bytes.len() as u64;
+            let generation = if object.generation > 0 {
+                Some(object.generation.to_string())
+            } else {
+                None
+            };
+            let etag = non_empty(object.etag.clone());
+            let content_type = non_empty(object.content_type.clone());
+            let stream = futures_util::stream::unfold(Some(response), |state| async move {
+                let mut response = state?;
+                match response.next().await.transpose() {
+                    Ok(Some(chunk)) => Some((Ok(chunk), Some(response))),
+                    Ok(None) => None,
+                    Err(err) => Some((
+                        Err(std::io::Error::other(format!(
+                            "GCS read object body: {err}"
+                        ))),
+                        None,
+                    )),
+                }
+            });
             Ok(ObjectRead {
                 object: ObjectRef {
                     backend: self.name.to_string(),
                     scope: scope.to_string(),
                     key: key.to_string(),
-                    version: read.generation,
-                    etag: read.etag,
+                    version: generation,
+                    etag,
                     checksum: None,
-                    content_type: None,
+                    content_type,
                     size,
                     visibility: ObjectVisibility::Private,
                     metadata: Default::default(),
                 },
-                bytes: read.bytes,
-                truncated: false,
+                body: ObjectBody::from_stream_with_limit(stream, max_bytes),
             })
         })
     }

--- a/crates/pocopine-storage-gcs/src/storage.rs
+++ b/crates/pocopine-storage-gcs/src/storage.rs
@@ -1671,6 +1671,7 @@ impl StorageBackend for GcsStorageBackend {
                     visibility: ObjectVisibility::Private,
                     metadata: Default::default(),
                 },
+                content_length: Some(size),
                 body: ObjectBody::from_stream_with_limit(stream, max_bytes),
             })
         })

--- a/crates/pocopine-storage-gcs/src/storage.rs
+++ b/crates/pocopine-storage-gcs/src/storage.rs
@@ -11,9 +11,9 @@ use pocopine_storage::checksum::{
 };
 use pocopine_storage::{
     BackendCapabilities, ChecksumAlgorithm, ChecksumPolicy, CompleteUpload, InitiateUpload,
-    ObjectChecksum, ObjectRef, StorageActor, StorageBackend, StorageBoxFuture, StorageContext,
-    StorageError, StorageResult, TransferPlan, UploadBody, UploadSession, UploadSessionId,
-    UploadSessionStatus, UploadStrategy,
+    ObjectChecksum, ObjectRead, ObjectRef, ObjectVisibility, SafeObjectKey, StorageActor,
+    StorageBackend, StorageBoxFuture, StorageContext, StorageError, StorageResult, TransferPlan,
+    UploadBody, UploadSession, UploadSessionId, UploadSessionStatus, UploadStrategy,
 };
 use time::OffsetDateTime;
 use uuid::Uuid;
@@ -1609,6 +1609,58 @@ impl StorageBackend for GcsStorageBackend {
                 self.part_concurrency.forget(&session);
             }
             result
+        })
+    }
+
+    fn read_object<'a>(
+        &'a self,
+        _ctx: &'a StorageContext,
+        scope: &'a str,
+        key: SafeObjectKey,
+        max_bytes: u64,
+    ) -> StorageBoxFuture<'a, ObjectRead> {
+        Box::pin(async move {
+            let object_key = self.layout.object_key(key.as_str());
+            let read = self
+                .get_object_bytes_with_limit(&object_key, max_bytes)
+                .await
+                .map_err(|err| match err {
+                    StorageError::UnknownUploadSession { .. } => {
+                        StorageError::unknown_object(key.to_string())
+                    }
+                    err => err,
+                })?;
+            if read.truncated {
+                return Err(StorageError::payload_too_large(max_bytes));
+            }
+            let size = read.bytes.len() as u64;
+            Ok(ObjectRead {
+                object: ObjectRef {
+                    backend: self.name.to_string(),
+                    scope: scope.to_string(),
+                    key: key.to_string(),
+                    version: read.generation,
+                    etag: read.etag,
+                    checksum: None,
+                    content_type: None,
+                    size,
+                    visibility: ObjectVisibility::Private,
+                    metadata: Default::default(),
+                },
+                bytes: read.bytes,
+                truncated: false,
+            })
+        })
+    }
+
+    fn delete_completed_object<'a>(
+        &'a self,
+        _ctx: &'a StorageContext,
+        key: SafeObjectKey,
+    ) -> StorageBoxFuture<'a, ()> {
+        Box::pin(async move {
+            self.delete_object_if_exists(&self.layout.object_key(key.as_str()))
+                .await
         })
     }
 

--- a/crates/pocopine-storage-s3/src/storage.rs
+++ b/crates/pocopine-storage-s3/src/storage.rs
@@ -306,13 +306,15 @@ impl S3StorageBackend {
                     s3_error("get completed object", err)
                 }
             })?;
-        let declared_size = output.content_length.unwrap_or_default().max(0) as u64;
-        if declared_size > max_bytes {
+        let declared_size = output
+            .content_length
+            .and_then(|size| u64::try_from(size).ok());
+        if declared_size.is_some_and(|size| size > max_bytes) {
             return Err(StorageError::payload_too_large(max_bytes));
         }
         let etag = output.e_tag.map(normalize_etag);
         let content_type = output.content_type;
-        let size = declared_size;
+        let size = declared_size.unwrap_or_default();
         let stream =
             futures_util::stream::unfold(Some(output.body.into_async_read()), |state| async move {
                 let mut reader = state?;
@@ -339,6 +341,7 @@ impl S3StorageBackend {
                 visibility: ObjectVisibility::Private,
                 metadata: Default::default(),
             },
+            content_length: declared_size,
             body: ObjectBody::from_stream_with_limit(stream, max_bytes),
         })
     }

--- a/crates/pocopine-storage-s3/src/storage.rs
+++ b/crates/pocopine-storage-s3/src/storage.rs
@@ -17,11 +17,13 @@ use pocopine_storage::checksum::{
 };
 use pocopine_storage::{
     BackendCapabilities, ChecksumAlgorithm, ChecksumPolicy, CompleteUpload, InitiateUpload,
-    ObjectChecksum, ObjectRef, StorageBackend, StorageBoxFuture, StorageContext, StorageError,
-    StorageResult, TransferPlan, UploadBody, UploadSession, UploadSessionId, UploadSessionStatus,
-    UploadStrategy, UploadedPartStatus, UploadedPartView,
+    ObjectChecksum, ObjectRead, ObjectRef, ObjectVisibility, SafeObjectKey, StorageBackend,
+    StorageBoxFuture, StorageContext, StorageError, StorageResult, TransferPlan, UploadBody,
+    UploadSession, UploadSessionId, UploadSessionStatus, UploadStrategy, UploadedPartStatus,
+    UploadedPartView,
 };
 use time::OffsetDateTime;
+use tokio::io::AsyncReadExt as _;
 use tokio_stream::wrappers::ReceiverStream;
 use uuid::Uuid;
 
@@ -281,6 +283,79 @@ impl S3StorageBackend {
             .map_err(|err| s3_error("read object body", err))?
             .into_bytes();
         Ok((bytes.to_vec(), output.e_tag.map(normalize_etag)))
+    }
+
+    async fn get_completed_object(
+        &self,
+        scope: &str,
+        key: SafeObjectKey,
+        max_bytes: u64,
+    ) -> StorageResult<ObjectRead> {
+        let object_key = self.layout.object_key(key.as_str());
+        let output = self
+            .client
+            .get_object()
+            .bucket(&self.layout.bucket)
+            .key(&object_key)
+            .send()
+            .await
+            .map_err(|err| {
+                if is_get_object_not_found(&err) {
+                    StorageError::unknown_object(key.to_string())
+                } else {
+                    s3_error("get completed object", err)
+                }
+            })?;
+        let declared_size = output.content_length.unwrap_or_default().max(0) as u64;
+        if declared_size > max_bytes {
+            return Err(StorageError::payload_too_large(max_bytes));
+        }
+        let etag = output.e_tag.map(normalize_etag);
+        let content_type = output.content_type;
+        let max_len: usize = max_bytes.try_into().map_err(|_| {
+            StorageError::policy_rejected("S3 object read limit exceeds platform capacity")
+        })?;
+        let mut reader = output.body.into_async_read();
+        let mut buf = [0_u8; 64 * 1024];
+        let mut bytes = Vec::new();
+        loop {
+            let read = reader
+                .read(&mut buf)
+                .await
+                .map_err(|err| s3_error("read completed object body", err))?;
+            if read == 0 {
+                break;
+            }
+            if bytes
+                .len()
+                .checked_add(read)
+                .is_none_or(|len| len > max_len)
+            {
+                return Err(StorageError::payload_too_large(max_bytes));
+            }
+            bytes.extend_from_slice(&buf[..read]);
+        }
+        let size = if declared_size == 0 {
+            bytes.len() as u64
+        } else {
+            declared_size
+        };
+        Ok(ObjectRead {
+            object: ObjectRef {
+                backend: self.name.to_string(),
+                scope: scope.to_string(),
+                key: key.to_string(),
+                version: None,
+                etag,
+                checksum: None,
+                content_type,
+                size,
+                visibility: ObjectVisibility::Private,
+                metadata: Default::default(),
+            },
+            bytes,
+            truncated: false,
+        })
     }
 
     async fn put_object_bytes(
@@ -1607,6 +1682,27 @@ impl StorageBackend for S3StorageBackend {
                 self.part_concurrency.forget(&session);
             }
             result
+        })
+    }
+
+    fn read_object<'a>(
+        &'a self,
+        _ctx: &'a StorageContext,
+        scope: &'a str,
+        key: SafeObjectKey,
+        max_bytes: u64,
+    ) -> StorageBoxFuture<'a, ObjectRead> {
+        Box::pin(async move { self.get_completed_object(scope, key, max_bytes).await })
+    }
+
+    fn delete_completed_object<'a>(
+        &'a self,
+        _ctx: &'a StorageContext,
+        key: SafeObjectKey,
+    ) -> StorageBoxFuture<'a, ()> {
+        Box::pin(async move {
+            self.delete_object(&self.layout.object_key(key.as_str()))
+                .await
         })
     }
 

--- a/crates/pocopine-storage-s3/src/storage.rs
+++ b/crates/pocopine-storage-s3/src/storage.rs
@@ -17,10 +17,10 @@ use pocopine_storage::checksum::{
 };
 use pocopine_storage::{
     BackendCapabilities, ChecksumAlgorithm, ChecksumPolicy, CompleteUpload, InitiateUpload,
-    ObjectChecksum, ObjectRead, ObjectRef, ObjectVisibility, SafeObjectKey, StorageBackend,
-    StorageBoxFuture, StorageContext, StorageError, StorageResult, TransferPlan, UploadBody,
-    UploadSession, UploadSessionId, UploadSessionStatus, UploadStrategy, UploadedPartStatus,
-    UploadedPartView,
+    ObjectBody, ObjectChecksum, ObjectRead, ObjectRef, ObjectVisibility, SafeObjectKey,
+    StorageBackend, StorageBoxFuture, StorageContext, StorageError, StorageResult, TransferPlan,
+    UploadBody, UploadSession, UploadSessionId, UploadSessionStatus, UploadStrategy,
+    UploadedPartStatus, UploadedPartView,
 };
 use time::OffsetDateTime;
 use tokio::io::AsyncReadExt as _;
@@ -312,34 +312,20 @@ impl S3StorageBackend {
         }
         let etag = output.e_tag.map(normalize_etag);
         let content_type = output.content_type;
-        let max_len: usize = max_bytes.try_into().map_err(|_| {
-            StorageError::policy_rejected("S3 object read limit exceeds platform capacity")
-        })?;
-        let mut reader = output.body.into_async_read();
-        let mut buf = [0_u8; 64 * 1024];
-        let mut bytes = Vec::new();
-        loop {
-            let read = reader
-                .read(&mut buf)
-                .await
-                .map_err(|err| s3_error("read completed object body", err))?;
-            if read == 0 {
-                break;
-            }
-            if bytes
-                .len()
-                .checked_add(read)
-                .is_none_or(|len| len > max_len)
-            {
-                return Err(StorageError::payload_too_large(max_bytes));
-            }
-            bytes.extend_from_slice(&buf[..read]);
-        }
-        let size = if declared_size == 0 {
-            bytes.len() as u64
-        } else {
-            declared_size
-        };
+        let size = declared_size;
+        let stream =
+            futures_util::stream::unfold(Some(output.body.into_async_read()), |state| async move {
+                let mut reader = state?;
+                let mut buf = vec![0_u8; 64 * 1024];
+                match reader.read(&mut buf).await {
+                    Ok(0) => None,
+                    Ok(read) => {
+                        buf.truncate(read);
+                        Some((Ok(Bytes::from(buf)), Some(reader)))
+                    }
+                    Err(err) => Some((Err(std::io::Error::other(err)), None)),
+                }
+            });
         Ok(ObjectRead {
             object: ObjectRef {
                 backend: self.name.to_string(),
@@ -353,8 +339,7 @@ impl S3StorageBackend {
                 visibility: ObjectVisibility::Private,
                 metadata: Default::default(),
             },
-            bytes,
-            truncated: false,
+            body: ObjectBody::from_stream_with_limit(stream, max_bytes),
         })
     }
 

--- a/crates/pocopine-storage/src/client.rs
+++ b/crates/pocopine-storage/src/client.rs
@@ -1,8 +1,8 @@
 use pocopine_core::{App, AppPlugin};
 
 use crate::{
-    STORAGE_ENDPOINT_PREFIX, STORAGE_TUS_ENDPOINT_PREFIX, StorageError, StorageResult,
-    UploadPolicyDescriptor, UploadSession, UploadSessionId,
+    STORAGE_ENDPOINT_PREFIX, STORAGE_TUS_ENDPOINT_PREFIX, SignedRead, StorageError,
+    StorageObjectScope, StorageResult, UploadPolicyDescriptor, UploadSession, UploadSessionId,
 };
 
 /// App plugin that provides [`StorageClient`] to components.
@@ -150,6 +150,14 @@ impl StorageClient {
             scope: scope.into(),
         }
     }
+
+    /// Bind this client to a typed storage object scope.
+    pub fn object_scope<S>(&self) -> StorageScopeClient
+    where
+        S: StorageObjectScope,
+    {
+        self.scope(S::NAME)
+    }
 }
 
 /// Runtime browser upload client service installed by [`upload_plugin`].
@@ -191,6 +199,14 @@ impl UploadClient {
             scope: scope.into(),
         }
     }
+
+    /// Bind this upload client to a typed storage object scope.
+    pub fn object_scope<S>(&self) -> UploadScopeClient
+    where
+        S: StorageObjectScope,
+    {
+        self.scope(S::NAME)
+    }
 }
 
 /// Scope-bound browser upload client.
@@ -217,6 +233,27 @@ pub struct StorageScopeClient {
     scope: String,
 }
 
+impl StorageScopeClient {
+    /// Bind this scope client to a completed object key.
+    pub fn object(&self, key: impl Into<String>) -> StorageObjectClient {
+        StorageObjectClient {
+            endpoint: self.endpoint.clone(),
+            with_credentials: self.with_credentials,
+            scope: self.scope.clone(),
+            key: key.into(),
+        }
+    }
+}
+
+/// Client for a completed object inside a storage scope.
+#[derive(Clone, Debug)]
+pub struct StorageObjectClient {
+    endpoint: String,
+    with_credentials: bool,
+    scope: String,
+    key: String,
+}
+
 #[cfg(not(target_arch = "wasm32"))]
 impl StorageScopeClient {
     /// Host compile stub. Browser fetch support is only available on wasm32.
@@ -230,6 +267,40 @@ impl StorageScopeClient {
     /// Host compile stub. Browser fetch support is only available on wasm32.
     pub async fn session(&self, id: UploadSessionId) -> StorageResult<UploadSession> {
         let _ = (&self.endpoint, self.with_credentials, &self.scope, id);
+        Err(StorageError::unsupported(
+            "storage client HTTP calls are only available in the browser runtime",
+        ))
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl StorageObjectClient {
+    /// Host compile stub. Browser fetch support is only available on wasm32.
+    pub async fn signed_read(&self) -> StorageResult<SignedRead> {
+        let _ = (
+            &self.endpoint,
+            self.with_credentials,
+            &self.scope,
+            &self.key,
+        );
+        Err(StorageError::unsupported(
+            "storage client HTTP calls are only available in the browser runtime",
+        ))
+    }
+
+    /// Host compile stub. Browser fetch support is only available on wasm32.
+    pub async fn download_url(&self) -> StorageResult<String> {
+        Ok(self.signed_read().await?.url)
+    }
+
+    /// Host compile stub. Browser fetch support is only available on wasm32.
+    pub async fn delete(&self) -> StorageResult<()> {
+        let _ = (
+            &self.endpoint,
+            self.with_credentials,
+            &self.scope,
+            &self.key,
+        );
         Err(StorageError::unsupported(
             "storage client HTTP calls are only available in the browser runtime",
         ))
@@ -266,8 +337,9 @@ mod wasm {
 
     use super::*;
     use crate::{
-        CompleteUploadRequest, InitiateUploadRequest, ObjectRef, PartSpec, STORAGE_PROTOCOL_V1,
-        StorageResponse, UploadPhase, UploadProgress, UploadStrategy, plan_parts,
+        CompleteUploadRequest, InitiateUploadRequest, ObjectRef, PartSpec, ReadUrlRequest,
+        STORAGE_PROTOCOL_V1, StorageResponse, UploadPhase, UploadProgress, UploadStrategy,
+        plan_parts,
     };
 
     const DEFAULT_CHUNK_SIZE: u64 = 1024 * 1024;
@@ -422,6 +494,40 @@ mod wasm {
                 resume_session: None,
                 auto_resume: false,
             }
+        }
+    }
+
+    impl super::StorageObjectClient {
+        /// Ask the server for a short-lived URL that reads this object.
+        pub async fn signed_read(&self) -> StorageResult<SignedRead> {
+            fetch_json(
+                BrowserStorageRequest::post_json(
+                    object_read_url(&self.endpoint, &self.scope, &self.key),
+                    &ReadUrlRequest::default(),
+                    self.with_credentials,
+                    None,
+                )?,
+                "object read url",
+            )
+            .await
+        }
+
+        /// Return the URL portion of [`Self::signed_read`].
+        pub async fn download_url(&self) -> StorageResult<String> {
+            Ok(self.signed_read().await?.url)
+        }
+
+        /// Delete this completed object.
+        pub async fn delete(&self) -> StorageResult<()> {
+            fetch_no_content(
+                BrowserStorageRequest::delete(
+                    object_url(&self.endpoint, &self.scope, &self.key),
+                    self.with_credentials,
+                    None,
+                ),
+                "delete object",
+            )
+            .await
         }
     }
 
@@ -1775,6 +1881,35 @@ mod wasm {
             endpoint.trim_end_matches('/'),
             pocopine_codec::percent_encode(scope)
         )
+    }
+
+    fn object_url(endpoint: &str, scope: &str, key: &str) -> String {
+        format!(
+            "{}/scopes/{}/objects/{}",
+            endpoint.trim_end_matches('/'),
+            pocopine_codec::percent_encode(scope),
+            encode_object_key_path(key)
+        )
+    }
+
+    fn object_read_url(endpoint: &str, scope: &str, key: &str) -> String {
+        format!(
+            "{}/scopes/{}/objects/read-url/{}",
+            endpoint.trim_end_matches('/'),
+            pocopine_codec::percent_encode(scope),
+            encode_object_key_path(key)
+        )
+    }
+
+    fn encode_object_key_path(key: &str) -> String {
+        let mut encoded = String::new();
+        for (index, segment) in key.split('/').enumerate() {
+            if index > 0 {
+                encoded.push('/');
+            }
+            encoded.push_str(&pocopine_codec::percent_encode(segment));
+        }
+        encoded
     }
 
     fn upload_url(endpoint: &str, session: &str) -> String {

--- a/crates/pocopine-storage/src/error.rs
+++ b/crates/pocopine-storage/src/error.rs
@@ -16,6 +16,8 @@ pub enum StorageError {
     UnknownBackend { backend: String },
     /// A requested upload session is unknown or no longer retained.
     UnknownUploadSession { session: String },
+    /// A requested completed object is unknown or no longer retained.
+    UnknownObject { key: String },
     /// Authentication is required for this storage operation.
     Unauthorized { message: String },
     /// Authentication succeeded, but this actor cannot perform the operation.
@@ -64,6 +66,10 @@ impl StorageError {
         Self::UnknownUploadSession {
             session: session.into(),
         }
+    }
+
+    pub fn unknown_object(key: impl Into<String>) -> Self {
+        Self::UnknownObject { key: key.into() }
     }
 
     pub fn unauthorized(message: impl Into<String>) -> Self {
@@ -132,6 +138,7 @@ impl fmt::Display for StorageError {
             Self::UnknownUploadSession { session } => {
                 write!(f, "unknown upload session: {session}")
             }
+            Self::UnknownObject { key } => write!(f, "unknown storage object: {key}"),
             Self::Unauthorized { message } => write!(f, "unauthorized storage request: {message}"),
             Self::Forbidden { message } => write!(f, "forbidden storage request: {message}"),
             Self::PolicyRejected { reason } => {

--- a/crates/pocopine-storage/src/lib.rs
+++ b/crates/pocopine-storage/src/lib.rs
@@ -1,7 +1,9 @@
 //! Storage protocol, browser client, and server plugin extension for Pocopine.
 //!
 //! This crate is an explicit extension. Apps opt in by installing the browser
-//! app plugin and the host server plugin.
+//! app plugin and the host server plugin. Uploads and reads are organized by
+//! named scopes; [`StorageObjectScope`] lets apps define one typed contract for
+//! the browser scope name, server upload policy, and durable object key layout.
 
 #[cfg(not(target_arch = "wasm32"))]
 #[doc(hidden)]
@@ -25,8 +27,8 @@ mod server;
 pub use client::{BrowserStorageRequest, BrowserStorageResponse, BrowserStorageTransport};
 pub use client::{
     ResumableUpload, ResumableUploadBuilder, StorageClient, StorageClientPlugin,
-    StorageScopeClient, UploadBuilder, UploadClient, UploadClientPlugin, UploadScopeClient,
-    storage_plugin, upload_plugin,
+    StorageObjectClient, StorageScopeClient, UploadBuilder, UploadClient, UploadClientPlugin,
+    UploadScopeClient, storage_plugin, upload_plugin,
 };
 
 #[cfg(all(target_arch = "wasm32", any(test, feature = "test-utils")))]
@@ -36,13 +38,14 @@ pub use error::{StorageError, StorageResult};
 pub use protocol::{
     AnonymousUploadBinding, BackendCapabilities, ChecksumAlgorithm, ChecksumPolicy, CompleteUpload,
     CompleteUploadRequest, InitiateUpload, InitiateUploadRequest, MAX_STORAGE_TOKEN_LEN,
-    MetadataSchema, ObjectChecksum, ObjectMetadata, ObjectOwnerRef, ObjectRef, ObjectVisibility,
-    PartSpec, PrincipalRef, STORAGE_ANON_COOKIE, STORAGE_ENDPOINT_PREFIX, STORAGE_PROTOCOL_V1,
-    STORAGE_SCOPES_PREFIX, STORAGE_TUS_ENDPOINT_PREFIX, STORAGE_UPLOADS_PATH,
-    STORAGE_UPLOADS_PREFIX, SafeObjectKey, SignedRead, StorageBackendName, StorageKey,
-    StorageResponse, TransferPlan, UploadIntent, UploadPhase, UploadPolicy, UploadPolicyDescriptor,
-    UploadProgress, UploadSession, UploadSessionId, UploadSessionStatus, UploadStrategy,
-    UploadTarget, UploadedPartStatus, UploadedPartView, plan_parts,
+    MetadataSchema, ObjectChecksum, ObjectMetadata, ObjectOwnerRef, ObjectRead, ObjectRef,
+    ObjectVisibility, PartSpec, PrincipalRef, ReadDisposition, ReadUrlRequest, STORAGE_ANON_COOKIE,
+    STORAGE_ENDPOINT_PREFIX, STORAGE_OBJECTS_PREFIX, STORAGE_PROTOCOL_V1, STORAGE_SCOPES_PREFIX,
+    STORAGE_TUS_ENDPOINT_PREFIX, STORAGE_UPLOADS_PATH, STORAGE_UPLOADS_PREFIX, SafeObjectKey,
+    SignedRead, StorageBackendName, StorageKey, StorageObjectScope, StorageResponse, TransferPlan,
+    UploadIntent, UploadPhase, UploadPolicy, UploadPolicyDescriptor, UploadProgress, UploadSession,
+    UploadSessionId, UploadSessionStatus, UploadStrategy, UploadTarget, UploadedPartStatus,
+    UploadedPartView, plan_parts,
 };
 
 #[cfg(not(target_arch = "wasm32"))]

--- a/crates/pocopine-storage/src/lib.rs
+++ b/crates/pocopine-storage/src/lib.rs
@@ -38,8 +38,8 @@ pub use error::{StorageError, StorageResult};
 pub use protocol::{
     AnonymousUploadBinding, BackendCapabilities, ChecksumAlgorithm, ChecksumPolicy, CompleteUpload,
     CompleteUploadRequest, InitiateUpload, InitiateUploadRequest, MAX_STORAGE_TOKEN_LEN,
-    MetadataSchema, ObjectChecksum, ObjectMetadata, ObjectOwnerRef, ObjectRead, ObjectRef,
-    ObjectVisibility, PartSpec, PrincipalRef, ReadDisposition, ReadUrlRequest, STORAGE_ANON_COOKIE,
+    MetadataSchema, ObjectChecksum, ObjectMetadata, ObjectOwnerRef, ObjectRef, ObjectVisibility,
+    PartSpec, PrincipalRef, ReadDisposition, ReadUrlRequest, STORAGE_ANON_COOKIE,
     STORAGE_ENDPOINT_PREFIX, STORAGE_OBJECTS_PREFIX, STORAGE_PROTOCOL_V1, STORAGE_SCOPES_PREFIX,
     STORAGE_TUS_ENDPOINT_PREFIX, STORAGE_UPLOADS_PATH, STORAGE_UPLOADS_PREFIX, SafeObjectKey,
     SignedRead, StorageBackendName, StorageKey, StorageObjectScope, StorageResponse, TransferPlan,
@@ -56,8 +56,9 @@ pub use memory::MemoryStorageBackend;
 
 #[cfg(not(target_arch = "wasm32"))]
 pub use server::{
-    StorageActor, StorageBackend, StorageBoxFuture, StorageContext, StorageGuardFuture,
-    StorageKeyFuture, StorageKeyResolver, StorageScope, StorageScopeBuilder, StorageScopeGuard,
-    StorageServer, StorageServerBuilder, StorageServerPlugin, StorageTusServerPlugin, UploadBody,
-    UploadByteStream, storage_server_plugin, storage_tus_server_plugin,
+    ObjectBody, ObjectRead, StorageActor, StorageBackend, StorageBoxFuture, StorageContext,
+    StorageGuardFuture, StorageKeyFuture, StorageKeyResolver, StorageScope, StorageScopeBuilder,
+    StorageScopeGuard, StorageServer, StorageServerBuilder, StorageServerPlugin,
+    StorageTusServerPlugin, UploadBody, UploadByteStream, storage_server_plugin,
+    storage_tus_server_plugin,
 };

--- a/crates/pocopine-storage/src/local_fs.rs
+++ b/crates/pocopine-storage/src/local_fs.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::fs::{self, File, OpenOptions};
-use std::io::Write;
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex as StdMutex};
 
@@ -13,7 +13,7 @@ use crate::backend_common::{
     ensure_upload_length_can_be_set, expires_at, object_ref, refresh_expired, select_upload_mode,
 };
 use crate::checksum::{ensure_supported_checksum_policy, validate_complete_checksum};
-use crate::server::{StorageActor, StorageBackend, StorageBoxFuture, StorageContext};
+use crate::server::{ObjectBody, StorageActor, StorageBackend, StorageBoxFuture, StorageContext};
 use crate::{
     ChecksumPolicy, CompleteUpload, InitiateUpload, ObjectRead, ObjectRef, SafeObjectKey,
     StorageError, StorageKey, StorageResult, TransferPlan, UploadSession, UploadSessionId,
@@ -516,7 +516,7 @@ impl LocalFsStorageBackend {
         if metadata.len() > max_bytes {
             return Err(StorageError::payload_too_large(max_bytes));
         }
-        let bytes = fs::read(&path)
+        let file = File::open(&path)
             .map_err(|err| map_not_found(err, || StorageError::unknown_object(key.to_string())))?;
         Ok(ObjectRead {
             object: ObjectRef {
@@ -531,8 +531,7 @@ impl LocalFsStorageBackend {
                 visibility: crate::ObjectVisibility::Private,
                 metadata: Default::default(),
             },
-            bytes,
-            truncated: false,
+            body: file_body(file, max_bytes),
         })
     }
 
@@ -540,6 +539,34 @@ impl LocalFsStorageBackend {
         fs::remove_file(self.object_path(&key))
             .map_err(|err| map_not_found(err, || StorageError::unknown_object(key.to_string())))
     }
+}
+
+fn file_body(file: File, max_bytes: u64) -> ObjectBody {
+    let stream = futures_util::stream::unfold(Some(file), |state| async move {
+        let file = state?;
+        let result = tokio::task::spawn_blocking(move || {
+            let mut file = file;
+            let mut buf = vec![0_u8; 64 * 1024];
+            let result = file.read(&mut buf).map(|read| {
+                buf.truncate(read);
+                buf
+            });
+            (file, result)
+        })
+        .await;
+        match result {
+            Ok((_file, Ok(buf))) if buf.is_empty() => None,
+            Ok((file, Ok(buf))) => Some((Ok(Bytes::from(buf)), Some(file))),
+            Ok((_file, Err(err))) => Some((Err(err), None)),
+            Err(err) => Some((
+                Err(std::io::Error::other(format!(
+                    "blocking file read failed: {err}"
+                ))),
+                None,
+            )),
+        }
+    });
+    ObjectBody::from_stream_with_limit(stream, max_bytes)
 }
 
 async fn run_blocking<F, T>(f: F) -> StorageResult<T>

--- a/crates/pocopine-storage/src/local_fs.rs
+++ b/crates/pocopine-storage/src/local_fs.rs
@@ -15,9 +15,9 @@ use crate::backend_common::{
 use crate::checksum::{ensure_supported_checksum_policy, validate_complete_checksum};
 use crate::server::{StorageActor, StorageBackend, StorageBoxFuture, StorageContext};
 use crate::{
-    ChecksumPolicy, CompleteUpload, InitiateUpload, ObjectRef, SafeObjectKey, StorageError,
-    StorageKey, StorageResult, TransferPlan, UploadSession, UploadSessionId, UploadSessionStatus,
-    UploadStrategy,
+    ChecksumPolicy, CompleteUpload, InitiateUpload, ObjectRead, ObjectRef, SafeObjectKey,
+    StorageError, StorageKey, StorageResult, TransferPlan, UploadSession, UploadSessionId,
+    UploadSessionStatus, UploadStrategy,
 };
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -298,6 +298,29 @@ impl StorageBackend for LocalFsStorageBackend {
             outcome
         })
     }
+
+    fn read_object<'a>(
+        &'a self,
+        _ctx: &'a StorageContext,
+        scope: &'a str,
+        key: SafeObjectKey,
+        max_bytes: u64,
+    ) -> StorageBoxFuture<'a, ObjectRead> {
+        let backend = self.clone();
+        let scope = scope.to_string();
+        Box::pin(async move {
+            run_blocking(move || backend.read_object_blocking(&scope, key, max_bytes)).await
+        })
+    }
+
+    fn delete_completed_object<'a>(
+        &'a self,
+        _ctx: &'a StorageContext,
+        key: SafeObjectKey,
+    ) -> StorageBoxFuture<'a, ()> {
+        let backend = self.clone();
+        Box::pin(async move { run_blocking(move || backend.delete_object_blocking(key)).await })
+    }
 }
 
 impl LocalFsStorageBackend {
@@ -479,6 +502,43 @@ impl LocalFsStorageBackend {
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
             Err(err) => Err(local_io_error("remove upload session", err)),
         }
+    }
+
+    fn read_object_blocking(
+        &self,
+        scope: &str,
+        key: SafeObjectKey,
+        max_bytes: u64,
+    ) -> StorageResult<ObjectRead> {
+        let path = self.object_path(&key);
+        let metadata = fs::metadata(&path)
+            .map_err(|err| map_not_found(err, || StorageError::unknown_object(key.to_string())))?;
+        if metadata.len() > max_bytes {
+            return Err(StorageError::payload_too_large(max_bytes));
+        }
+        let bytes = fs::read(&path)
+            .map_err(|err| map_not_found(err, || StorageError::unknown_object(key.to_string())))?;
+        Ok(ObjectRead {
+            object: ObjectRef {
+                backend: self.name.to_string(),
+                scope: scope.to_string(),
+                key: key.to_string(),
+                version: None,
+                etag: None,
+                checksum: None,
+                content_type: None,
+                size: metadata.len(),
+                visibility: crate::ObjectVisibility::Private,
+                metadata: Default::default(),
+            },
+            bytes,
+            truncated: false,
+        })
+    }
+
+    fn delete_object_blocking(&self, key: SafeObjectKey) -> StorageResult<()> {
+        fs::remove_file(self.object_path(&key))
+            .map_err(|err| map_not_found(err, || StorageError::unknown_object(key.to_string())))
     }
 }
 

--- a/crates/pocopine-storage/src/local_fs.rs
+++ b/crates/pocopine-storage/src/local_fs.rs
@@ -511,13 +511,15 @@ impl LocalFsStorageBackend {
         max_bytes: u64,
     ) -> StorageResult<ObjectRead> {
         let path = self.object_path(&key);
-        let metadata = fs::metadata(&path)
+        let file = File::open(&path)
+            .map_err(|err| map_not_found(err, || StorageError::unknown_object(key.to_string())))?;
+        let metadata = file
+            .metadata()
             .map_err(|err| map_not_found(err, || StorageError::unknown_object(key.to_string())))?;
         if metadata.len() > max_bytes {
             return Err(StorageError::payload_too_large(max_bytes));
         }
-        let file = File::open(&path)
-            .map_err(|err| map_not_found(err, || StorageError::unknown_object(key.to_string())))?;
+        let size = metadata.len();
         Ok(ObjectRead {
             object: ObjectRef {
                 backend: self.name.to_string(),
@@ -527,11 +529,12 @@ impl LocalFsStorageBackend {
                 etag: None,
                 checksum: None,
                 content_type: None,
-                size: metadata.len(),
+                size,
                 visibility: crate::ObjectVisibility::Private,
                 metadata: Default::default(),
             },
-            body: file_body(file, max_bytes),
+            content_length: Some(size),
+            body: file_body(file, size, max_bytes),
         })
     }
 
@@ -541,22 +544,29 @@ impl LocalFsStorageBackend {
     }
 }
 
-fn file_body(file: File, max_bytes: u64) -> ObjectBody {
-    let stream = futures_util::stream::unfold(Some(file), |state| async move {
-        let file = state?;
+fn file_body(file: File, content_length: u64, max_bytes: u64) -> ObjectBody {
+    let stream = futures_util::stream::unfold(Some((file, content_length)), |state| async move {
+        let (file, remaining) = state?;
+        if remaining == 0 {
+            return None;
+        }
+        let chunk_len = remaining.min(64 * 1024) as usize;
         let result = tokio::task::spawn_blocking(move || {
             let mut file = file;
-            let mut buf = vec![0_u8; 64 * 1024];
+            let mut buf = vec![0_u8; chunk_len];
             let result = file.read(&mut buf).map(|read| {
                 buf.truncate(read);
-                buf
+                (read, buf)
             });
             (file, result)
         })
         .await;
         match result {
-            Ok((_file, Ok(buf))) if buf.is_empty() => None,
-            Ok((file, Ok(buf))) => Some((Ok(Bytes::from(buf)), Some(file))),
+            Ok((_file, Ok((_read, buf)))) if buf.is_empty() => None,
+            Ok((file, Ok((read, buf)))) => Some((
+                Ok(Bytes::from(buf)),
+                Some((file, remaining.saturating_sub(read as u64))),
+            )),
             Ok((_file, Err(err))) => Some((Err(err), None)),
             Err(err) => Some((
                 Err(std::io::Error::other(format!(

--- a/crates/pocopine-storage/src/memory.rs
+++ b/crates/pocopine-storage/src/memory.rs
@@ -343,6 +343,7 @@ impl StorageBackend for MemoryStorageBackend {
             }
             Ok(ObjectRead {
                 object: stored.object.clone(),
+                content_length: Some(stored.object.size),
                 body: ObjectBody::from_bytes(Bytes::from(stored.bytes.clone())),
             })
         })

--- a/crates/pocopine-storage/src/memory.rs
+++ b/crates/pocopine-storage/src/memory.rs
@@ -9,7 +9,7 @@ use crate::backend_common::{
     ensure_upload_length_can_be_set, expires_at, object_ref, refresh_expired, select_upload_mode,
 };
 use crate::checksum::{ensure_supported_checksum_policy, validate_complete_checksum};
-use crate::server::{StorageActor, StorageBackend, StorageBoxFuture, StorageContext};
+use crate::server::{ObjectBody, StorageActor, StorageBackend, StorageBoxFuture, StorageContext};
 use crate::{
     ChecksumPolicy, CompleteUpload, InitiateUpload, ObjectRead, ObjectRef, SafeObjectKey,
     StorageError, StorageKey, StorageResult, TransferPlan, UploadSession, UploadSessionId,
@@ -343,8 +343,7 @@ impl StorageBackend for MemoryStorageBackend {
             }
             Ok(ObjectRead {
                 object: stored.object.clone(),
-                bytes: stored.bytes.clone(),
-                truncated: false,
+                body: ObjectBody::from_bytes(Bytes::from(stored.bytes.clone())),
             })
         })
     }

--- a/crates/pocopine-storage/src/memory.rs
+++ b/crates/pocopine-storage/src/memory.rs
@@ -11,9 +11,9 @@ use crate::backend_common::{
 use crate::checksum::{ensure_supported_checksum_policy, validate_complete_checksum};
 use crate::server::{StorageActor, StorageBackend, StorageBoxFuture, StorageContext};
 use crate::{
-    ChecksumPolicy, CompleteUpload, InitiateUpload, ObjectRef, StorageError, StorageKey,
-    StorageResult, TransferPlan, UploadSession, UploadSessionId, UploadSessionStatus,
-    UploadStrategy,
+    ChecksumPolicy, CompleteUpload, InitiateUpload, ObjectRead, ObjectRef, SafeObjectKey,
+    StorageError, StorageKey, StorageResult, TransferPlan, UploadSession, UploadSessionId,
+    UploadSessionStatus, UploadStrategy,
 };
 
 #[derive(Clone, Debug)]
@@ -29,10 +29,16 @@ struct StoredUpload {
     object: Option<ObjectRef>,
 }
 
+#[derive(Clone, Debug)]
+struct StoredObject {
+    bytes: Vec<u8>,
+    object: ObjectRef,
+}
+
 #[derive(Default, Debug)]
 struct Inner {
     sessions: HashMap<String, StoredUpload>,
-    objects: HashMap<String, Vec<u8>>,
+    objects: HashMap<String, StoredObject>,
 }
 
 /// In-memory storage backend for tests, demos, and single-process examples.
@@ -72,7 +78,11 @@ impl MemoryStorageBackend {
     }
 
     pub fn object_bytes(&self, key: &str) -> StorageResult<Option<Vec<u8>>> {
-        Ok(self.lock()?.objects.get(key).cloned())
+        Ok(self
+            .lock()?
+            .objects
+            .get(key)
+            .map(|object| object.bytes.clone()))
     }
 
     /// Remove expired in-memory upload sessions.
@@ -287,7 +297,13 @@ impl StorageBackend for MemoryStorageBackend {
                 stored.object = Some(object.clone());
                 (key, stored.bytes.clone(), object)
             };
-            inner.objects.insert(key, bytes);
+            inner.objects.insert(
+                key,
+                StoredObject {
+                    bytes,
+                    object: object.clone(),
+                },
+            );
             Ok(object)
         })
     }
@@ -307,6 +323,45 @@ impl StorageBackend for MemoryStorageBackend {
             Ok(())
         })
     }
+
+    fn read_object<'a>(
+        &'a self,
+        _ctx: &'a StorageContext,
+        _scope: &'a str,
+        key: SafeObjectKey,
+        max_bytes: u64,
+    ) -> StorageBoxFuture<'a, ObjectRead> {
+        Box::pin(async move {
+            let key_string = key.to_string();
+            let inner = self.lock()?;
+            let stored = inner
+                .objects
+                .get(key.as_str())
+                .ok_or_else(|| StorageError::unknown_object(key_string))?;
+            if stored.bytes.len() as u64 > max_bytes {
+                return Err(StorageError::payload_too_large(max_bytes));
+            }
+            Ok(ObjectRead {
+                object: stored.object.clone(),
+                bytes: stored.bytes.clone(),
+                truncated: false,
+            })
+        })
+    }
+
+    fn delete_completed_object<'a>(
+        &'a self,
+        _ctx: &'a StorageContext,
+        key: SafeObjectKey,
+    ) -> StorageBoxFuture<'a, ()> {
+        Box::pin(async move {
+            let removed = self.lock()?.objects.remove(key.as_str());
+            if removed.is_none() {
+                return Err(StorageError::unknown_object(key.to_string()));
+            }
+            Ok(())
+        })
+    }
 }
 
 fn refresh_expired_public(stored: &mut StoredUpload) {
@@ -322,12 +377,24 @@ mod tests {
     #[test]
     fn debug_does_not_dump_in_memory_objects() {
         let backend = MemoryStorageBackend::new();
-        backend
-            .inner
-            .lock()
-            .unwrap()
-            .objects
-            .insert("secret-key".to_string(), b"secret-bytes".to_vec());
+        backend.inner.lock().unwrap().objects.insert(
+            "secret-key".to_string(),
+            StoredObject {
+                bytes: b"secret-bytes".to_vec(),
+                object: ObjectRef {
+                    backend: "memory".to_string(),
+                    scope: "test".to_string(),
+                    key: "secret-key".to_string(),
+                    version: None,
+                    etag: None,
+                    checksum: None,
+                    content_type: None,
+                    size: 12,
+                    visibility: crate::ObjectVisibility::Private,
+                    metadata: Default::default(),
+                },
+            },
+        );
 
         let debug = format!("{backend:?}");
 

--- a/crates/pocopine-storage/src/protocol.rs
+++ b/crates/pocopine-storage/src/protocol.rs
@@ -965,15 +965,6 @@ impl Default for ReadUrlRequest {
     }
 }
 
-/// Completed object bytes returned by a backend read.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct ObjectRead {
-    pub object: ObjectRef,
-    #[serde(with = "pocopine_codec::base64_bytes")]
-    pub bytes: Vec<u8>,
-    pub truncated: bool,
-}
-
 /// Browser upload creation request.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct InitiateUploadRequest {

--- a/crates/pocopine-storage/src/protocol.rs
+++ b/crates/pocopine-storage/src/protocol.rs
@@ -26,6 +26,8 @@ pub const STORAGE_SCOPES_PREFIX: &str = storage_path!("/scopes");
 pub const STORAGE_UPLOADS_PREFIX: &str = storage_path!("/uploads");
 /// Upload creation route.
 pub const STORAGE_UPLOADS_PATH: &str = storage_path!("/uploads");
+/// Object read/delete route prefix.
+pub const STORAGE_OBJECTS_PREFIX: &str = storage_path!("/scopes");
 /// Default tus 1.0 endpoint prefix mounted by the tus server plugin.
 pub const STORAGE_TUS_ENDPOINT_PREFIX: &str = "/__pocopine/storage/tus/v1";
 /// Anonymous upload binding cookie read by the storage server.
@@ -933,6 +935,45 @@ pub struct SignedRead {
     pub expires_at: OffsetDateTime,
 }
 
+/// How a browser should present a generated read URL.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ReadDisposition {
+    #[default]
+    Inline,
+    Attachment {
+        filename: String,
+    },
+}
+
+/// Request body for creating a short-lived object read URL.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ReadUrlRequest {
+    #[serde(default)]
+    pub disposition: ReadDisposition,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub expires_seconds: Option<u64>,
+}
+
+impl Default for ReadUrlRequest {
+    fn default() -> Self {
+        Self {
+            disposition: ReadDisposition::Inline,
+            expires_seconds: None,
+        }
+    }
+}
+
+/// Completed object bytes returned by a backend read.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ObjectRead {
+    pub object: ObjectRef,
+    #[serde(with = "pocopine_codec::base64_bytes")]
+    pub bytes: Vec<u8>,
+    pub truncated: bool,
+}
+
 /// Browser upload creation request.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct InitiateUploadRequest {
@@ -1011,6 +1052,28 @@ pub struct CompleteUploadRequest {
 pub struct CompleteUpload {
     pub session: UploadSessionId,
     pub checksum: Option<ObjectChecksum>,
+}
+
+/// App-defined object scope contract.
+///
+/// `StorageObjectScope` describes a typed storage scope such as avatars,
+/// message attachments, exports, or documents. The trait is target-neutral so
+/// wasm clients can use its `NAME`; host-only policy and key resolution methods
+/// wire the same type into [`StorageServer`](crate::StorageServer).
+pub trait StorageObjectScope: Send + Sync + 'static {
+    /// Runtime storage scope name.
+    const NAME: &'static str;
+
+    /// Upload/read policy for this object scope.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn policy() -> StorageResult<UploadPolicy>;
+
+    /// Resolve an upload intent to a durable object key.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn resolve_key<'a>(
+        ctx: &'a crate::server::StorageContext,
+        intent: &'a UploadIntent,
+    ) -> crate::server::StorageKeyFuture<'a>;
 }
 
 /// Direct and multipart target modes are protocol variants in PR 1, but the

--- a/crates/pocopine-storage/src/server.rs
+++ b/crates/pocopine-storage/src/server.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use bytes::Bytes;
 use futures_core::Stream;
-use futures_util::TryStreamExt;
+use futures_util::{StreamExt as _, TryStreamExt};
 use pocopine_codec::{base64_decode, base64_encode, percent_encode};
 use pocopine_core::{ServerError, ServerResult};
 use pocopine_crypto::{SecretString, hmac_sha256};
@@ -31,7 +31,7 @@ use uuid::Uuid;
 use crate::backend_common::expires_at;
 use crate::{
     AnonymousUploadBinding, CompleteUpload, CompleteUploadRequest, InitiateUpload,
-    InitiateUploadRequest, ObjectMetadata, ObjectRead, PrincipalRef, ReadDisposition,
+    InitiateUploadRequest, ObjectMetadata, ObjectRef, PrincipalRef, ReadDisposition,
     ReadUrlRequest, STORAGE_ANON_COOKIE, STORAGE_PROTOCOL_V1, STORAGE_UPLOADS_PATH, SafeObjectKey,
     SignedRead, StorageBackendName, StorageError, StorageKey, StorageObjectScope, StorageResponse,
     StorageResult, UploadIntent, UploadPolicy, UploadPolicyDescriptor, UploadSession,
@@ -320,6 +320,75 @@ impl Stream for UploadByteStream {
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.inner.as_mut().poll_next(cx)
     }
+}
+
+/// A `Send` byte stream for completed object reads.
+///
+/// Backends return this instead of `Vec<u8>` so object downloads can move
+/// provider bytes through the HTTP response under backpressure.
+pub struct ObjectBody {
+    inner: Pin<Box<dyn Stream<Item = Result<Bytes, std::io::Error>> + Send>>,
+}
+
+impl ObjectBody {
+    /// Wrap a stream of object bytes.
+    pub fn from_stream<S>(stream: S) -> Self
+    where
+        S: Stream<Item = Result<Bytes, std::io::Error>> + Send + 'static,
+    {
+        Self {
+            inner: Box::pin(stream),
+        }
+    }
+
+    /// Wrap a stream of object bytes and fail the body if more than
+    /// `max_bytes` are yielded. Metadata checks should reject oversized objects
+    /// before headers are sent when possible; this is a final guard for stores
+    /// whose body exceeds metadata or lacks a trusted size.
+    pub fn from_stream_with_limit<S>(stream: S, max_bytes: u64) -> Self
+    where
+        S: Stream<Item = Result<Bytes, std::io::Error>> + Send + 'static,
+    {
+        let mut seen = 0_u64;
+        Self::from_stream(stream.map(move |chunk| {
+            let bytes = chunk?;
+            seen = seen
+                .checked_add(bytes.len() as u64)
+                .ok_or_else(|| std::io::Error::other("storage object read size overflowed"))?;
+            if seen > max_bytes {
+                return Err(std::io::Error::other(format!(
+                    "storage object exceeded maximum read size of {max_bytes} bytes"
+                )));
+            }
+            Ok(bytes)
+        }))
+    }
+
+    /// Build a read body from bytes already held in memory.
+    pub fn from_bytes(bytes: Bytes) -> Self {
+        Self::from_stream(futures_util::stream::once(async move { Ok(bytes) }))
+    }
+}
+
+impl std::fmt::Debug for ObjectBody {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ObjectBody").finish_non_exhaustive()
+    }
+}
+
+impl Stream for ObjectBody {
+    type Item = Result<Bytes, std::io::Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.inner.as_mut().poll_next(cx)
+    }
+}
+
+/// Completed object metadata plus a streaming read body.
+#[derive(Debug)]
+pub struct ObjectRead {
+    pub object: ObjectRef,
+    pub body: ObjectBody,
 }
 
 /// Server-side backend contract for storage engines.
@@ -2397,12 +2466,13 @@ fn object_read_response(
 ) -> Response {
     match result {
         Ok((read, disposition)) => {
+            let ObjectRead { object, body } = read;
             let mut response = if head_only {
                 Body::empty().into_response()
             } else {
-                Body::from(read.bytes).into_response()
+                Body::from_stream(body).into_response()
             };
-            if let Some(content_type) = &read.object.content_type
+            if let Some(content_type) = &object.content_type
                 && let Ok(value) = HeaderValue::from_str(content_type)
             {
                 response.headers_mut().insert(CONTENT_TYPE, value);
@@ -2412,10 +2482,10 @@ fn object_read_response(
                     HeaderValue::from_static("application/octet-stream"),
                 );
             }
-            if let Ok(value) = HeaderValue::from_str(&read.object.size.to_string()) {
+            if let Ok(value) = HeaderValue::from_str(&object.size.to_string()) {
                 response.headers_mut().insert(CONTENT_LENGTH, value);
             }
-            if let Some(etag) = &read.object.etag
+            if let Some(etag) = &object.etag
                 && let Ok(value) = HeaderValue::from_str(etag)
             {
                 response.headers_mut().insert(ETAG, value);

--- a/crates/pocopine-storage/src/server.rs
+++ b/crates/pocopine-storage/src/server.rs
@@ -1,36 +1,47 @@
 use std::collections::{BTreeMap, HashMap};
 use std::future::Future;
+use std::marker::PhantomData;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::task::{Context, Poll};
+use std::time::Duration;
 
 use bytes::Bytes;
 use futures_core::Stream;
 use futures_util::TryStreamExt;
+use pocopine_codec::{base64_decode, base64_encode, percent_encode};
 use pocopine_core::{ServerError, ServerResult};
+use pocopine_crypto::{SecretString, hmac_sha256};
 use pocopine_server::RequestContext;
 use pocopine_server::auth::{Decision, DenyReason, Predicate, RequestAuthExt};
 use pocopine_server::axum::body::{Body, to_bytes};
-use pocopine_server::axum::extract::{Path, State};
+use pocopine_server::axum::extract::{Path, Query, State};
 use pocopine_server::axum::http::{
-    HeaderMap, HeaderValue, Request, StatusCode,
-    header::{CACHE_CONTROL, CONTENT_LENGTH, SET_COOKIE, VARY},
+    HeaderMap, HeaderName, HeaderValue, Request, StatusCode,
+    header::{
+        CACHE_CONTROL, CONTENT_DISPOSITION, CONTENT_LENGTH, CONTENT_TYPE, ETAG, SET_COOKIE, VARY,
+    },
 };
 use pocopine_server::axum::response::{IntoResponse, Json, Response};
 use pocopine_server::axum::routing::{get, head, options, post};
 use pocopine_server::{Server, ServerPlugin};
+use time::OffsetDateTime;
 use uuid::Uuid;
 
+use crate::backend_common::expires_at;
 use crate::{
     AnonymousUploadBinding, CompleteUpload, CompleteUploadRequest, InitiateUpload,
-    InitiateUploadRequest, ObjectMetadata, PrincipalRef, STORAGE_ANON_COOKIE, STORAGE_PROTOCOL_V1,
-    STORAGE_UPLOADS_PATH, SafeObjectKey, StorageBackendName, StorageError, StorageKey,
-    StorageResponse, StorageResult, UploadIntent, UploadPolicy, UploadPolicyDescriptor,
-    UploadSession, UploadSessionId, UploadStrategy,
+    InitiateUploadRequest, ObjectMetadata, ObjectRead, PrincipalRef, ReadDisposition,
+    ReadUrlRequest, STORAGE_ANON_COOKIE, STORAGE_PROTOCOL_V1, STORAGE_UPLOADS_PATH, SafeObjectKey,
+    SignedRead, StorageBackendName, StorageError, StorageKey, StorageObjectScope, StorageResponse,
+    StorageResult, UploadIntent, UploadPolicy, UploadPolicyDescriptor, UploadSession,
+    UploadSessionId, UploadStrategy,
 };
 
 const MAX_PROXY_PATCH_BYTES: u64 = 64 * 1024 * 1024;
 const MAX_JSON_CONTROL_BYTES: usize = 64 * 1024;
+const DEFAULT_READ_URL_EXPIRES: Duration = Duration::from_secs(5 * 60);
+const MAX_READ_URL_EXPIRES: Duration = Duration::from_secs(60 * 60);
 /// Request header carrying the 1-based multipart part number on a part `PUT`,
 /// the multipart twin of the sequential path's `Upload-Offset`.
 const UPLOAD_PART_HEADER: &str = "Upload-Part";
@@ -384,6 +395,55 @@ pub trait StorageBackend: Send + Sync + 'static {
         ctx: &'a StorageContext,
         session: UploadSessionId,
     ) -> StorageBoxFuture<'a, ()>;
+
+    /// Read a completed object, capped by the caller's scope policy.
+    fn read_object<'a>(
+        &'a self,
+        _ctx: &'a StorageContext,
+        _scope: &'a str,
+        _key: SafeObjectKey,
+        _max_bytes: u64,
+    ) -> StorageBoxFuture<'a, ObjectRead> {
+        Box::pin(async move {
+            Err(StorageError::unsupported(
+                "storage backend does not support object reads",
+            ))
+        })
+    }
+
+    /// Delete a completed object.
+    fn delete_completed_object<'a>(
+        &'a self,
+        _ctx: &'a StorageContext,
+        _key: SafeObjectKey,
+    ) -> StorageBoxFuture<'a, ()> {
+        Box::pin(async move {
+            Err(StorageError::unsupported(
+                "storage backend does not support object deletes",
+            ))
+        })
+    }
+}
+
+struct StorageObjectScopeKeyResolver<S>(PhantomData<S>);
+
+impl<S> Default for StorageObjectScopeKeyResolver<S> {
+    fn default() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<S> StorageKeyResolver for StorageObjectScopeKeyResolver<S>
+where
+    S: StorageObjectScope,
+{
+    fn resolve_key<'a>(
+        &'a self,
+        ctx: &'a StorageContext,
+        intent: &'a UploadIntent,
+    ) -> StorageKeyFuture<'a> {
+        S::resolve_key(ctx, intent)
+    }
 }
 
 #[derive(Clone)]
@@ -436,6 +496,15 @@ impl StorageScope {
             delete_guard: None,
             key_resolver: Arc::new(GeneratedStorageKeyResolver),
         }
+    }
+
+    pub fn object_scope<S>() -> StorageResult<Self>
+    where
+        S: StorageObjectScope,
+    {
+        Ok(Self::builder(S::policy()?)
+            .key_resolver(StorageObjectScopeKeyResolver::<S>::default())
+            .build())
     }
 }
 
@@ -500,6 +569,7 @@ struct StorageServerInner {
     scopes: Arc<HashMap<String, Arc<RegisteredStorageScope>>>,
     trusted_origins: Arc<Vec<TrustedOrigin>>,
     secure_anonymous_cookies: bool,
+    read_token_secret: Arc<SecretString>,
 }
 
 /// Host-side storage server service.
@@ -684,6 +754,83 @@ impl StorageServer {
         backend.abort_upload(&ctx, session).await
     }
 
+    pub async fn signed_read(
+        &self,
+        ctx: StorageContext,
+        scope_name: String,
+        key: SafeObjectKey,
+        request: ReadUrlRequest,
+    ) -> StorageResult<SignedRead> {
+        let scope = self.scope(&scope_name)?;
+        scope
+            .authorize_read(ctx)
+            .await
+            .map_err(storage_auth_error)?;
+        let expires_after = request
+            .expires_seconds
+            .map(Duration::from_secs)
+            .unwrap_or(DEFAULT_READ_URL_EXPIRES)
+            .min(MAX_READ_URL_EXPIRES);
+        let expires_at = expires_at(expires_after);
+        let claims = ReadTokenClaims {
+            scope: scope_name.clone(),
+            key: key.to_string(),
+            disposition: request.disposition,
+            expires_at,
+        };
+        let token = self.sign_read_token(&claims)?;
+        Ok(SignedRead {
+            url: object_read_url(&scope_name, key.as_str(), Some(&token)),
+            headers: Vec::new(),
+            expires_at,
+        })
+    }
+
+    pub async fn read_object(
+        &self,
+        ctx: StorageContext,
+        scope_name: String,
+        key: SafeObjectKey,
+        token: Option<String>,
+    ) -> StorageResult<(ObjectRead, ReadDisposition)> {
+        let scope = self.scope(&scope_name)?;
+        let disposition = if let Some(token) = token {
+            let claims = self.verify_read_token(&token)?;
+            if claims.scope != scope_name || claims.key != key.as_str() {
+                return Err(StorageError::forbidden(
+                    "storage read token does not match object",
+                ));
+            }
+            claims.disposition
+        } else {
+            scope
+                .authorize_read(ctx.clone())
+                .await
+                .map_err(storage_auth_error)?;
+            ReadDisposition::Inline
+        };
+        let backend = self.backend(scope.policy.backend.as_str())?;
+        let object = backend
+            .read_object(&ctx, &scope_name, key, scope.policy.max_bytes)
+            .await?;
+        Ok((object, disposition))
+    }
+
+    pub async fn delete_object(
+        &self,
+        ctx: StorageContext,
+        scope_name: String,
+        key: SafeObjectKey,
+    ) -> StorageResult<()> {
+        let scope = self.scope(&scope_name)?;
+        scope
+            .authorize_delete(ctx.clone())
+            .await
+            .map_err(storage_auth_error)?;
+        let backend = self.backend(scope.policy.backend.as_str())?;
+        backend.delete_completed_object(&ctx, key).await
+    }
+
     fn scope(&self, scope: &str) -> StorageResult<Arc<RegisteredStorageScope>> {
         self.inner
             .scopes
@@ -729,6 +876,49 @@ impl StorageServer {
     fn secure_anonymous_cookies(&self) -> bool {
         self.inner.secure_anonymous_cookies
     }
+
+    fn sign_read_token(&self, claims: &ReadTokenClaims) -> StorageResult<String> {
+        let payload = serde_json::to_vec(claims)
+            .map_err(|err| StorageError::backend(format!("encode storage read token: {err}")))?;
+        let payload = base64_encode(&payload);
+        let signature = hmac_sha256(
+            self.inner.read_token_secret.expose().as_bytes(),
+            payload.as_bytes(),
+        );
+        Ok(format!("{}.{}", payload, base64_encode(&signature)))
+    }
+
+    fn verify_read_token(&self, token: &str) -> StorageResult<ReadTokenClaims> {
+        let (payload, signature) = token
+            .split_once('.')
+            .ok_or_else(|| StorageError::invalid_value("read token", "<malformed>"))?;
+        let provided = base64_decode(signature)
+            .map_err(|_| StorageError::invalid_value("read token", "<signature>"))?;
+        let expected = hmac_sha256(
+            self.inner.read_token_secret.expose().as_bytes(),
+            payload.as_bytes(),
+        );
+        if provided.as_slice() != expected.as_slice() {
+            return Err(StorageError::forbidden("invalid storage read token"));
+        }
+        let payload = base64_decode(payload)
+            .map_err(|_| StorageError::invalid_value("read token", "<payload>"))?;
+        let claims: ReadTokenClaims = serde_json::from_slice(&payload)
+            .map_err(|_| StorageError::invalid_value("read token", "<payload>"))?;
+        if OffsetDateTime::now_utc() >= claims.expires_at {
+            return Err(StorageError::forbidden("storage read token expired"));
+        }
+        SafeObjectKey::parse(&claims.key)?;
+        Ok(claims)
+    }
+}
+
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+struct ReadTokenClaims {
+    scope: String,
+    key: String,
+    disposition: ReadDisposition,
+    expires_at: OffsetDateTime,
 }
 
 /// Builder for [`StorageServer`].
@@ -737,6 +927,7 @@ pub struct StorageServerBuilder {
     scopes: HashMap<String, Arc<RegisteredStorageScope>>,
     trusted_origins: Vec<TrustedOrigin>,
     secure_anonymous_cookies: bool,
+    read_token_secret: Option<SecretString>,
 }
 
 impl Default for StorageServerBuilder {
@@ -746,6 +937,7 @@ impl Default for StorageServerBuilder {
             scopes: HashMap::new(),
             trusted_origins: Vec::new(),
             secure_anonymous_cookies: true,
+            read_token_secret: None,
         }
     }
 }
@@ -791,6 +983,17 @@ impl StorageServerBuilder {
     /// local HTTP development where browsers cannot persist `Secure` cookies.
     pub fn secure_anonymous_cookies(mut self, secure: bool) -> Self {
         self.secure_anonymous_cookies = secure;
+        self
+    }
+
+    /// Override the HMAC secret used for short-lived object read URLs.
+    ///
+    /// If omitted, the server generates an in-memory secret on startup. That is
+    /// convenient for local development, but invalidates read URLs on restart;
+    /// production apps should set a stable secret when read URLs need to survive
+    /// rolling restarts.
+    pub fn read_token_secret(mut self, secret: SecretString) -> Self {
+        self.read_token_secret = Some(secret);
         self
     }
 
@@ -842,6 +1045,14 @@ impl StorageServerBuilder {
         Ok(self)
     }
 
+    pub fn object_scope<S>(mut self) -> StorageResult<Self>
+    where
+        S: StorageObjectScope,
+    {
+        self.insert_scope(S::NAME.to_string(), StorageScope::object_scope::<S>()?)?;
+        Ok(self)
+    }
+
     pub fn build(self) -> StorageServer {
         StorageServer {
             inner: Arc::new(StorageServerInner {
@@ -849,6 +1060,13 @@ impl StorageServerBuilder {
                 scopes: Arc::new(self.scopes),
                 trusted_origins: Arc::new(self.trusted_origins),
                 secure_anonymous_cookies: self.secure_anonymous_cookies,
+                read_token_secret: Arc::new(self.read_token_secret.unwrap_or_else(|| {
+                    SecretString::new(format!(
+                        "{}{}",
+                        Uuid::new_v4().simple(),
+                        Uuid::new_v4().simple()
+                    ))
+                })),
             }),
         }
     }
@@ -900,6 +1118,17 @@ impl ServerPlugin for StorageServerPlugin {
             .route(
                 "/__pocopine/storage/v1/scopes/:scope",
                 get(scope_handler).with_state(storage.clone()),
+            )
+            .route(
+                "/__pocopine/storage/v1/scopes/:scope/objects/read-url/*key",
+                post(object_read_url_handler).with_state(storage.clone()),
+            )
+            .route(
+                "/__pocopine/storage/v1/scopes/:scope/objects/*key",
+                get(object_read_handler)
+                    .head(object_head_handler)
+                    .delete(object_delete_handler)
+                    .with_state(storage.clone()),
             )
             .route(
                 STORAGE_UPLOADS_PATH,
@@ -962,6 +1191,95 @@ async fn scope_handler(
         storage.descriptor(request.ctx, &scope).await,
         request.set_cookie,
     )
+}
+
+#[derive(serde::Deserialize)]
+struct ObjectReadQuery {
+    token: Option<String>,
+}
+
+async fn object_read_url_handler(
+    State(storage): State<StorageServer>,
+    Path((scope, key)): Path<(String, String)>,
+    request: Request<Body>,
+) -> Response {
+    match parse_optional_json_request::<ReadUrlRequest>(request, &storage).await {
+        Ok(request) => {
+            let set_cookie = request.set_cookie;
+            storage_response(
+                async {
+                    let key = SafeObjectKey::parse(key)?;
+                    storage
+                        .signed_read(request.ctx, scope, key, request.payload)
+                        .await
+                }
+                .await,
+                set_cookie,
+            )
+        }
+        Err(err) => storage_response::<SignedRead>(Err(err), None),
+    }
+}
+
+async fn object_read_handler(
+    State(storage): State<StorageServer>,
+    Path((scope, key)): Path<(String, String)>,
+    Query(query): Query<ObjectReadQuery>,
+    request: Request<Body>,
+) -> Response {
+    let request = context_from_request(request, &storage);
+    object_read_response(
+        async {
+            let key = SafeObjectKey::parse(key)?;
+            storage
+                .read_object(request.ctx, scope, key, query.token)
+                .await
+        }
+        .await,
+        false,
+        request.set_cookie,
+    )
+}
+
+async fn object_head_handler(
+    State(storage): State<StorageServer>,
+    Path((scope, key)): Path<(String, String)>,
+    Query(query): Query<ObjectReadQuery>,
+    request: Request<Body>,
+) -> Response {
+    let request = context_from_request(request, &storage);
+    object_read_response(
+        async {
+            let key = SafeObjectKey::parse(key)?;
+            storage
+                .read_object(request.ctx, scope, key, query.token)
+                .await
+        }
+        .await,
+        true,
+        request.set_cookie,
+    )
+}
+
+async fn object_delete_handler(
+    State(storage): State<StorageServer>,
+    Path((scope, key)): Path<(String, String)>,
+    request: Request<Body>,
+) -> Response {
+    match mutation_context_from_request(request, &storage) {
+        Ok(request) => {
+            let set_cookie = request.set_cookie;
+            storage_response(
+                async {
+                    let key = SafeObjectKey::parse(key)?;
+                    storage.delete_object(request.ctx, scope, key).await
+                }
+                .await,
+                set_cookie,
+            )
+        }
+        Err(err) => storage_response::<()>(Err(err), None),
+    }
 }
 
 async fn initiate_handler(
@@ -2072,6 +2390,124 @@ where
     response
 }
 
+fn object_read_response(
+    result: StorageResult<(ObjectRead, ReadDisposition)>,
+    head_only: bool,
+    set_cookie: Option<String>,
+) -> Response {
+    match result {
+        Ok((read, disposition)) => {
+            let mut response = if head_only {
+                Body::empty().into_response()
+            } else {
+                Body::from(read.bytes).into_response()
+            };
+            if let Some(content_type) = &read.object.content_type
+                && let Ok(value) = HeaderValue::from_str(content_type)
+            {
+                response.headers_mut().insert(CONTENT_TYPE, value);
+            } else {
+                response.headers_mut().insert(
+                    CONTENT_TYPE,
+                    HeaderValue::from_static("application/octet-stream"),
+                );
+            }
+            if let Ok(value) = HeaderValue::from_str(&read.object.size.to_string()) {
+                response.headers_mut().insert(CONTENT_LENGTH, value);
+            }
+            if let Some(etag) = &read.object.etag
+                && let Ok(value) = HeaderValue::from_str(etag)
+            {
+                response.headers_mut().insert(ETAG, value);
+            }
+            response.headers_mut().insert(
+                CACHE_CONTROL,
+                HeaderValue::from_static("private, max-age=60"),
+            );
+            response
+                .headers_mut()
+                .insert(VARY, HeaderValue::from_static("Cookie"));
+            response.headers_mut().insert(
+                HeaderName::from_static("x-content-type-options"),
+                HeaderValue::from_static("nosniff"),
+            );
+            if let Ok(value) = HeaderValue::from_str(&content_disposition(&disposition)) {
+                response.headers_mut().insert(CONTENT_DISPOSITION, value);
+            }
+            if let Some(set_cookie) = set_cookie
+                && let Ok(value) = HeaderValue::from_str(&set_cookie)
+            {
+                response.headers_mut().insert(SET_COOKIE, value);
+            }
+            response
+        }
+        Err(err) => {
+            let status = storage_error_status(&err);
+            let mut response = (status, Json(StorageResponse::<()>::err(err))).into_response();
+            response = no_store_response(response);
+            if let Some(set_cookie) = set_cookie
+                && let Ok(value) = HeaderValue::from_str(&set_cookie)
+            {
+                response.headers_mut().insert(SET_COOKIE, value);
+            }
+            response
+        }
+    }
+}
+
+fn content_disposition(disposition: &ReadDisposition) -> String {
+    match disposition {
+        ReadDisposition::Inline => "inline".to_string(),
+        ReadDisposition::Attachment { filename } => {
+            format!(
+                "attachment; filename=\"{}\"",
+                sanitize_header_filename(filename)
+            )
+        }
+    }
+}
+
+fn sanitize_header_filename(filename: &str) -> String {
+    let sanitized: String = filename
+        .chars()
+        .map(|ch| match ch {
+            '"' | '\\' | '\r' | '\n' => '_',
+            ch if ch.is_control() => '_',
+            ch => ch,
+        })
+        .take(255)
+        .collect();
+    if sanitized.trim().is_empty() {
+        "download".to_string()
+    } else {
+        sanitized
+    }
+}
+
+fn object_read_url(scope: &str, key: &str, token: Option<&str>) -> String {
+    let mut url = format!(
+        "/__pocopine/storage/v1/scopes/{}/objects/{}",
+        percent_encode(scope),
+        encode_object_key_path(key)
+    );
+    if let Some(token) = token {
+        url.push_str("?token=");
+        url.push_str(&percent_encode(token));
+    }
+    url
+}
+
+fn encode_object_key_path(key: &str) -> String {
+    let mut encoded = String::new();
+    for (index, segment) in key.split('/').enumerate() {
+        if index > 0 {
+            encoded.push('/');
+        }
+        encoded.push_str(&percent_encode(segment));
+    }
+    encoded
+}
+
 fn no_store_response(mut response: Response) -> Response {
     response
         .headers_mut()
@@ -2087,7 +2523,8 @@ fn storage_error_status(error: &StorageError) -> StatusCode {
         StorageError::InvalidValue { .. } => StatusCode::BAD_REQUEST,
         StorageError::UnknownScope { .. }
         | StorageError::UnknownBackend { .. }
-        | StorageError::UnknownUploadSession { .. } => StatusCode::NOT_FOUND,
+        | StorageError::UnknownUploadSession { .. }
+        | StorageError::UnknownObject { .. } => StatusCode::NOT_FOUND,
         StorageError::Unauthorized { .. } => StatusCode::UNAUTHORIZED,
         StorageError::Forbidden { .. } => StatusCode::FORBIDDEN,
         StorageError::PayloadTooLarge { .. } => StatusCode::PAYLOAD_TOO_LARGE,

--- a/crates/pocopine-storage/src/server.rs
+++ b/crates/pocopine-storage/src/server.rs
@@ -388,6 +388,9 @@ impl Stream for ObjectBody {
 #[derive(Debug)]
 pub struct ObjectRead {
     pub object: ObjectRef,
+    /// HTTP `Content-Length` for the read body when the backend has a trusted
+    /// length. `None` lets the response stream use transfer encoding instead.
+    pub content_length: Option<u64>,
     pub body: ObjectBody,
 }
 
@@ -2466,7 +2469,11 @@ fn object_read_response(
 ) -> Response {
     match result {
         Ok((read, disposition)) => {
-            let ObjectRead { object, body } = read;
+            let ObjectRead {
+                object,
+                content_length,
+                body,
+            } = read;
             let mut response = if head_only {
                 Body::empty().into_response()
             } else {
@@ -2482,7 +2489,9 @@ fn object_read_response(
                     HeaderValue::from_static("application/octet-stream"),
                 );
             }
-            if let Ok(value) = HeaderValue::from_str(&object.size.to_string()) {
+            if let Some(content_length) = content_length
+                && let Ok(value) = HeaderValue::from_str(&content_length.to_string())
+            {
                 response.headers_mut().insert(CONTENT_LENGTH, value);
             }
             if let Some(etag) = &object.etag

--- a/crates/pocopine-storage/tests/client_browser.rs
+++ b/crates/pocopine-storage/tests/client_browser.rs
@@ -14,9 +14,9 @@ use js_sys::{Array, Promise};
 use pocopine::prelude::*;
 use pocopine_storage::{
     BrowserStorageRequest, BrowserStorageResponse, BrowserStorageTransport, ObjectRef,
-    ObjectVisibility, StorageClient, StorageError, StorageResponse, StorageResult, TransferPlan,
-    UploadClient, UploadPhase, UploadProgress, UploadSession, UploadSessionId, UploadSessionStatus,
-    UploadStrategy, storage_plugin, upload_plugin,
+    ObjectVisibility, SignedRead, StorageClient, StorageError, StorageObjectScope, StorageResponse,
+    StorageResult, TransferPlan, UploadClient, UploadPhase, UploadProgress, UploadSession,
+    UploadSessionId, UploadSessionStatus, UploadStrategy, storage_plugin, upload_plugin,
 };
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
@@ -30,6 +30,12 @@ wasm_bindgen_test_configure!(run_in_browser);
 thread_local! {
     static PLUGIN_RESOLVED: RefCell<bool> = const { RefCell::new(false) };
     static UPLOAD_PLUGIN_RESOLVED: RefCell<bool> = const { RefCell::new(false) };
+}
+
+struct AvatarObjects;
+
+impl StorageObjectScope for AvatarObjects {
+    const NAME: &'static str = "avatars";
 }
 
 #[derive(Default, Serialize, Deserialize)]
@@ -141,6 +147,49 @@ async fn upload_blob_sends_initiate_chunks_and_complete_with_progress() {
     assert_eq!(
         progress.borrow().last().unwrap().phase,
         UploadPhase::Complete
+    );
+    pocopine_storage::__reset_browser_transport_for_test();
+}
+
+#[wasm_bindgen_test(async)]
+async fn object_chain_requests_download_url_and_delete() {
+    pocopine_storage::__reset_browser_transport_for_test();
+    let fake = FakeStorageTransport::default();
+    let state = fake.state.clone();
+    pocopine_storage::__set_browser_transport_for_test(fake);
+
+    let object = StorageClient::new()
+        .object_scope::<AvatarObjects>()
+        .object("avatars/user-1/photo.txt");
+    let url = object.download_url().await.unwrap();
+    object.delete().await.unwrap();
+
+    assert_eq!(
+        url,
+        "/__pocopine/storage/v1/scopes/avatars/objects/avatars/user-1/photo.txt?token=read-token"
+    );
+    let state = state.borrow();
+    assert_eq!(
+        state
+            .requests
+            .iter()
+            .map(|request| request.method.as_str())
+            .collect::<Vec<_>>(),
+        ["POST", "DELETE"]
+    );
+    assert_eq!(
+        state.requests[0].url,
+        "/__pocopine/storage/v1/scopes/avatars/objects/read-url/avatars/user-1/photo.txt"
+    );
+    assert!(
+        state.requests[0]
+            .headers
+            .iter()
+            .any(|(name, value)| name == "content-type" && value == "application/json")
+    );
+    assert_eq!(
+        state.requests[1].url,
+        "/__pocopine/storage/v1/scopes/avatars/objects/avatars/user-1/photo.txt"
     );
     pocopine_storage::__reset_browser_transport_for_test();
 }
@@ -668,6 +717,23 @@ impl BrowserStorageTransport for FakeStorageTransport {
                 ("POST", "/__pocopine/storage/v1/uploads/session-1/complete") => {
                     Ok(json_response(Ok(object_ref(state.offset))))
                 }
+                (
+                    "POST",
+                    "/__pocopine/storage/v1/scopes/avatars/objects/read-url/avatars/user-1/photo.txt",
+                ) => Ok(json_response(Ok(SignedRead {
+                    url: "/__pocopine/storage/v1/scopes/avatars/objects/avatars/user-1/photo.txt?token=read-token"
+                        .to_string(),
+                    headers: Vec::new(),
+                    expires_at: OffsetDateTime::UNIX_EPOCH + time::Duration::days(1),
+                }))),
+                (
+                    "DELETE",
+                    "/__pocopine/storage/v1/scopes/avatars/objects/avatars/user-1/photo.txt",
+                ) => Ok(BrowserStorageResponse {
+                    status: 204,
+                    headers: Vec::new(),
+                    body: String::new(),
+                }),
                 ("POST", "/__pocopine/storage/tus/v1/avatars/uploads") => {
                     state.tus_offset = 0;
                     Ok(tus_response(
@@ -805,7 +871,7 @@ fn json_response<T: Serialize>(result: StorageResult<T>) -> BrowserStorageRespon
         Err(StorageError::OffsetMismatch { .. } | StorageError::Conflict { .. }) => 409,
         Err(StorageError::Unauthorized { .. }) => 401,
         Err(StorageError::Forbidden { .. }) => 403,
-        Err(StorageError::UnknownUploadSession { .. }) => 404,
+        Err(StorageError::UnknownUploadSession { .. } | StorageError::UnknownObject { .. }) => 404,
         Err(StorageError::PayloadTooLarge { .. }) => 413,
         Err(StorageError::PolicyRejected { .. }) => 422,
         Err(_) => 500,

--- a/crates/pocopine-storage/tests/storage_host.rs
+++ b/crates/pocopine-storage/tests/storage_host.rs
@@ -15,12 +15,12 @@ use pocopine_server::axum::body::Body;
 use pocopine_server::axum::http::{HeaderMap, HeaderValue, Method, Request, StatusCode, Uri};
 use pocopine_storage::{
     ChecksumAlgorithm, ChecksumPolicy, CompleteUpload, InitiateUpload, InitiateUploadRequest,
-    LocalFsStorageBackend, MemoryStorageBackend, ObjectChecksum, ObjectMetadata, ObjectOwnerRef,
-    ReadUrlRequest, STORAGE_ANON_COOKIE, STORAGE_UPLOADS_PATH, SafeObjectKey, SignedRead,
-    StorageBackend, StorageContext, StorageError, StorageKey, StorageKeyFuture, StorageKeyResolver,
-    StorageResponse, StorageResult, StorageScope, StorageServer, UploadIntent, UploadPolicy,
-    UploadSession, UploadSessionId, UploadSessionStatus, UploadStrategy, storage_server_plugin,
-    storage_tus_server_plugin,
+    LocalFsStorageBackend, MemoryStorageBackend, ObjectBody, ObjectChecksum, ObjectMetadata,
+    ObjectOwnerRef, ReadUrlRequest, STORAGE_ANON_COOKIE, STORAGE_UPLOADS_PATH, SafeObjectKey,
+    SignedRead, StorageBackend, StorageContext, StorageError, StorageKey, StorageKeyFuture,
+    StorageKeyResolver, StorageResponse, StorageResult, StorageScope, StorageServer, UploadIntent,
+    UploadPolicy, UploadSession, UploadSessionId, UploadSessionStatus, UploadStrategy,
+    storage_server_plugin, storage_tus_server_plugin,
 };
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -90,6 +90,19 @@ async fn route_mints_anonymous_binding_cookie_for_public_uploads() -> StorageRes
     let session = outer.into_result()?;
     assert_eq!(session.status, UploadSessionStatus::Open);
     Ok(())
+}
+
+#[tokio::test]
+async fn object_body_stream_limit_fails_when_stream_exceeds_policy() {
+    let chunks = futures_util::stream::iter([
+        Ok(Bytes::from_static(b"abc")),
+        Ok(Bytes::from_static(b"def")),
+    ]);
+    let body = ObjectBody::from_stream_with_limit(chunks, 5);
+
+    let result = Body::from_stream(body).collect().await;
+
+    assert!(result.is_err());
 }
 
 #[tokio::test]

--- a/crates/pocopine-storage/tests/storage_host.rs
+++ b/crates/pocopine-storage/tests/storage_host.rs
@@ -16,10 +16,11 @@ use pocopine_server::axum::http::{HeaderMap, HeaderValue, Method, Request, Statu
 use pocopine_storage::{
     ChecksumAlgorithm, ChecksumPolicy, CompleteUpload, InitiateUpload, InitiateUploadRequest,
     LocalFsStorageBackend, MemoryStorageBackend, ObjectChecksum, ObjectMetadata, ObjectOwnerRef,
-    STORAGE_ANON_COOKIE, STORAGE_UPLOADS_PATH, SafeObjectKey, StorageBackend, StorageContext,
-    StorageError, StorageKey, StorageKeyFuture, StorageKeyResolver, StorageResponse, StorageResult,
-    StorageScope, StorageServer, UploadIntent, UploadPolicy, UploadSession, UploadSessionId,
-    UploadSessionStatus, UploadStrategy, storage_server_plugin, storage_tus_server_plugin,
+    ReadUrlRequest, STORAGE_ANON_COOKIE, STORAGE_UPLOADS_PATH, SafeObjectKey, SignedRead,
+    StorageBackend, StorageContext, StorageError, StorageKey, StorageKeyFuture, StorageKeyResolver,
+    StorageResponse, StorageResult, StorageScope, StorageServer, UploadIntent, UploadPolicy,
+    UploadSession, UploadSessionId, UploadSessionStatus, UploadStrategy, storage_server_plugin,
+    storage_tus_server_plugin,
 };
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -260,6 +261,131 @@ async fn route_accepts_configured_trusted_origin() -> StorageResult<()> {
 
     assert_eq!(status, StatusCode::OK);
     assert_eq!(session?.status, UploadSessionStatus::Open);
+    Ok(())
+}
+
+#[tokio::test]
+async fn object_read_url_serves_completed_object_and_delete_removes_it() -> StorageResult<()> {
+    let storage = memory_storage()?;
+    let actor = anon_ctx();
+    let session = storage
+        .initiate_upload(
+            actor.clone(),
+            initiate_request("avatars", UploadStrategy::Auto),
+        )
+        .await?;
+    storage
+        .append_upload_bytes(
+            actor.clone(),
+            session.id.clone(),
+            0,
+            Bytes::from_static(b"hello"),
+        )
+        .await?;
+    let object = storage
+        .complete_upload(
+            actor,
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await?;
+    let router = finalize(storage);
+    let read_url = format!(
+        "/__pocopine/storage/v1/scopes/avatars/objects/read-url/{}",
+        object.key
+    );
+    let signed: SignedRead =
+        post_json(router.clone(), &read_url, &ReadUrlRequest::default()).await?;
+
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(&signed.url)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get("content-type").unwrap(),
+        "text/plain"
+    );
+    assert_eq!(response.headers().get("content-length").unwrap(), "5");
+    assert_eq!(
+        response.headers().get("content-disposition").unwrap(),
+        "inline"
+    );
+    let bytes = response.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(&bytes[..], b"hello");
+
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("HEAD")
+                .uri(&signed.url)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(response.headers().get("content-length").unwrap(), "5");
+    assert!(
+        response
+            .into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes()
+            .is_empty()
+    );
+
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!(
+                    "/__pocopine/storage/v1/scopes/avatars/objects/{}",
+                    object.key
+                ))
+                .header("cookie", anon_cookie())
+                .header("sec-fetch-site", "same-origin")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = String::from_utf8(
+        response
+            .into_body()
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes()
+            .to_vec(),
+    )
+    .unwrap();
+    assert!(body.contains(r#""ok":true"#));
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(&signed.url)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
     Ok(())
 }
 

--- a/crates/pocopine-storage/tests/storage_host.rs
+++ b/crates/pocopine-storage/tests/storage_host.rs
@@ -403,6 +403,83 @@ async fn object_read_url_serves_completed_object_and_delete_removes_it() -> Stor
 }
 
 #[tokio::test]
+async fn local_fs_read_streams_multichunk_object_with_matching_content_length() -> StorageResult<()>
+{
+    let tmp = tempdir().unwrap();
+    let size = 70 * 1024 + 17;
+    let bytes: Vec<u8> = (0..size).map(|index| (index % 251) as u8).collect();
+    let policy = UploadPolicy::new("local")?
+        .max_bytes(bytes.len() as u64 + 1)
+        .allowed_content_types(["text/plain"])
+        .allowed_extensions(["txt"])
+        .preferred_chunk_size(32 * 1024);
+    let storage = StorageServer::builder()
+        .backend("local", LocalFsStorageBackend::new(tmp.path()))?
+        .public_scope("avatars", policy)?
+        .build();
+    let actor = anon_ctx();
+    let session = storage
+        .initiate_upload(
+            actor.clone(),
+            InitiateUploadRequest {
+                protocol: pocopine_storage::STORAGE_PROTOCOL_V1.to_string(),
+                scope: "avatars".to_string(),
+                file_name: "large.txt".to_string(),
+                size: Some(bytes.len() as u64),
+                content_type: Some("text/plain".to_string()),
+                metadata: Default::default(),
+                requested_strategy: UploadStrategy::Sequential,
+            },
+        )
+        .await?;
+    storage
+        .append_upload_bytes(
+            actor.clone(),
+            session.id.clone(),
+            0,
+            Bytes::from(bytes.clone()),
+        )
+        .await?;
+    let object = storage
+        .complete_upload(
+            actor,
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await?;
+    let router = finalize(storage);
+    let read_url = format!(
+        "/__pocopine/storage/v1/scopes/avatars/objects/read-url/{}",
+        object.key
+    );
+    let signed: SignedRead =
+        post_json(router.clone(), &read_url, &ReadUrlRequest::default()).await?;
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(&signed.url)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get("content-length").unwrap(),
+        &HeaderValue::from_str(&bytes.len().to_string()).unwrap()
+    );
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(body.len(), bytes.len());
+    assert_eq!(&body[..], bytes.as_slice());
+    Ok(())
+}
+
+#[tokio::test]
 async fn tus_options_advertises_creation_resume_and_termination() -> StorageResult<()> {
     let router = finalize_tus(memory_storage()?);
     let response = router

--- a/docs/guides/data/storage-uploads.md
+++ b/docs/guides/data/storage-uploads.md
@@ -139,6 +139,11 @@ metadata plus an `ObjectBody` byte stream, and the HTTP route forwards that
 stream with backpressure instead of collecting the full object into memory.
 The scope's `max_bytes` is still enforced before streaming when provider
 metadata exposes the object size, with a streaming cap as a final guard.
+Backends only send `Content-Length` when the provider length is trusted; if a
+provider does not expose a reliable size the route uses a streamed response
+without asserting a length. Once response headers have been sent, provider
+read errors surface as an interrupted download, so callers that manually fetch
+the URL should treat a short or failed body as a failed read.
 
 ## Two transports
 

--- a/docs/guides/data/storage-uploads.md
+++ b/docs/guides/data/storage-uploads.md
@@ -1,9 +1,9 @@
 ---
-title: "Object storage uploads"
-description: "Server-mediated object-storage uploads into S3, GCS, and Azure native multipart."
+title: "Object storage uploads and reads"
+description: "Server-mediated object-storage uploads and short-lived object reads for S3, GCS, and Azure."
 ---
 
-# Object storage uploads
+# Object storage uploads and reads
 
 How `pocopine-storage` moves bytes from a browser into S3, GCS, or Azure
 Blob Storage: a **server-mediated, proxy-like** upload path that streams
@@ -40,13 +40,15 @@ falls over under load. The whole upload runtime is built to avoid that:
      PUT    /uploads/:s              multipart part     (Upload-Part header)
      POST   /uploads/:s/complete     assemble
      GET/DELETE /uploads/:s          inspect / abort
+     POST   /scopes/:x/objects/read-url/:key
+     GET/HEAD/DELETE /scopes/:x/objects/:key
         ▼
   StorageServer                                 ← auth, scope policy, ownership
-     require_bound_actor · authorize_write · scope policy
+     require_bound_actor · authorize_* · scope policy
         ▼
   StorageBackend trait                          ← one impl per provider
      capabilities() · initiate · append_upload_bytes(Bytes)
-     upload_part(UploadBody) · complete · abort
+     upload_part(UploadBody) · complete · abort · read_object · delete_completed_object
         ▼
   S3 / GCS / Azure                              ← native multipart assembly
      (memory + local-fs backends for tests/dev)
@@ -56,6 +58,81 @@ Everything above `StorageBackend` is provider-neutral. Each backend
 crate (`pocopine-storage-s3`, `-gcs`, `-azure`) maps the contract onto
 one provider; shared session bookkeeping lives in
 `pocopine-storage/src/backend_common.rs`.
+
+## Typed object scopes
+
+Use `StorageObjectScope` when a bucket area has a stable contract: maximum
+object size, accepted content types/extensions, key layout, and later
+scope-level encryption settings. The same type gives the browser the scope
+name and gives the server the policy plus key resolver.
+
+```rust
+use pocopine_storage::{
+    SafeObjectKey, StorageContext, StorageKey, StorageKeyFuture, StorageObjectScope,
+    StorageResult, UploadIntent, UploadPolicy,
+};
+
+struct AvatarObjects;
+
+impl StorageObjectScope for AvatarObjects {
+    const NAME: &'static str = "avatars";
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn policy() -> StorageResult<UploadPolicy> {
+        Ok(UploadPolicy::new("s3")?
+            .max_bytes(2 * 1024 * 1024)
+            .allowed_content_types(["image/png", "image/jpeg"])
+            .allowed_extensions(["png", "jpg", "jpeg"]))
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn resolve_key<'a>(
+        _ctx: &'a StorageContext,
+        intent: &'a UploadIntent,
+    ) -> StorageKeyFuture<'a> {
+        Box::pin(async move {
+            let ext = intent.extension().unwrap_or("bin");
+            Ok(StorageKey::new(SafeObjectKey::parse(format!(
+                "avatars/{}/original.{ext}",
+                intent.generated_object_id()
+            ))?))
+        })
+    }
+}
+```
+
+Register the scope once on the server:
+
+```rust
+let storage = pocopine_storage::StorageServer::builder()
+    .backend("s3", s3_backend)?
+    .object_scope::<AvatarObjects>()?
+    .build();
+```
+
+The browser can use the same scope type for both upload and read chains:
+
+```rust
+let storage = pocopine_storage::StorageClient::new();
+
+let object = storage
+    .object_scope::<AvatarObjects>()
+    .upload_blob(file, "avatar.png")
+    .send()
+    .await?;
+
+let url = storage
+    .object_scope::<AvatarObjects>()
+    .object(object.key)
+    .download_url()
+    .await?;
+```
+
+`download_url()` currently returns a short-lived Pocopine URL. The browser
+fetches that URL from the app origin; provider credentials still stay on the
+server. `signed_read()` returns the full `SignedRead` response when callers
+need the expiry or future provider-specific headers, and `delete()` removes
+the completed object through the same scope authorization.
 
 ## Two transports
 
@@ -273,7 +350,8 @@ provider exactly once.
 ## Source map
 
 - `pocopine-storage/src/protocol.rs` — `UploadStrategy`,
-  `BackendCapabilities`, `TransferPlan`, `UploadSession`, `UploadPolicy`.
+  `BackendCapabilities`, `TransferPlan`, `UploadSession`, `UploadPolicy`,
+  `StorageObjectScope`, `ReadUrlRequest`, `SignedRead`.
 - `pocopine-storage/src/server.rs` — routes, `StorageServer`,
   `StorageBackend` trait, `UploadBody` / `UploadByteStream`.
 - `pocopine-storage/src/backend_common.rs` — `select_upload_mode`,
@@ -281,7 +359,8 @@ provider exactly once.
   size/owner/open guards.
 - `pocopine-storage-{s3,gcs,azure}/src/storage.rs` — per-provider
   `initiate` / `append_upload_bytes` / `upload_part` / `complete` /
-  `abort`, plus native helpers and emulator-backed integration tests.
+  `abort` / `read_object` / `delete_completed_object`, plus native helpers
+  and emulator-backed integration tests.
 
 ## Roadmap
 

--- a/docs/guides/data/storage-uploads.md
+++ b/docs/guides/data/storage-uploads.md
@@ -134,6 +134,12 @@ server. `signed_read()` returns the full `SignedRead` response when callers
 need the expiry or future provider-specific headers, and `delete()` removes
 the completed object through the same scope authorization.
 
+Object reads are streamed. `StorageBackend::read_object` returns object
+metadata plus an `ObjectBody` byte stream, and the HTTP route forwards that
+stream with backpressure instead of collecting the full object into memory.
+The scope's `max_bytes` is still enforced before streaming when provider
+metadata exposes the object size, with a streaming cap as a final guard.
+
 ## Two transports
 
 A scope's backend advertises which transports it can serve, and the

--- a/docs/site.toml
+++ b/docs/site.toml
@@ -116,7 +116,7 @@ title = "Data & Sync"
 pages = [
   { title = "Sync (client)",          path = "guides/data/sync-client.md" },
   { title = "Sync (server)",          path = "guides/data/sync-server.md" },
-  { title = "Object-storage uploads", path = "guides/data/storage-uploads.md" },
+  { title = "Object-storage uploads and reads", path = "guides/data/storage-uploads.md" },
   { title = "Browser storage",        path = "guides/data/browser-storage.md" },
 ]
 

--- a/examples/sync-external-e2e/Cargo.toml
+++ b/examples/sync-external-e2e/Cargo.toml
@@ -15,12 +15,10 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 pocopine-sync = { workspace = true }
+pocopine-sync-indexdb = { workspace = true }
 pocopine-sync-query = { workspace = true }
 pocopine-sync-query-macros = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 wasm-bindgen = { workspace = true }
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-pocopine-sync-indexdb = { workspace = true }
 wasm-bindgen-futures = { workspace = true }


### PR DESCRIPTION
## Summary

Adds the read side for `pocopine-storage` completed objects and introduces the typed `StorageObjectScope` contract for scope policy, key resolution, and browser client binding.

- Adds short-lived signed object read URLs plus `GET`, `HEAD`, and `DELETE` object routes.
- Adds `StorageClient::object_scope::<T>().object(key).download_url()` / `signed_read()` / `delete()` chain.
- Changes backend reads to return metadata plus a streaming `ObjectBody`, so object downloads are forwarded with backpressure instead of buffering full files in memory.
- Implements completed-object reads/deletes for memory, local-fs, S3, GCS, and Azure backends, including streaming provider bodies for S3/GCS/Azure and chunked local-fs reads.
- Updates storage docs and navigation from upload-only to upload/read usage.

## Impact

Apps can now upload through the existing storage flow and later ask the framework for a short-lived app-origin download URL without exposing provider credentials to the browser. The typed scope gives us a place to hang max object size, allowed file shape, key layout, and future scope-level encryption settings. Large object reads no longer require the server to collect the full object before sending the response.

## Validation

- `cargo fmt --all -- --check`
- `cargo check -p pocopine-storage -p pocopine-storage-s3 -p pocopine-storage-gcs -p pocopine-storage-azure`
- `cargo clippy -p pocopine-storage -p pocopine-storage-s3 -p pocopine-storage-gcs -p pocopine-storage-azure --all-targets -- -D warnings`
- `cargo clippy -p pocopine-storage --target wasm32-unknown-unknown --all-targets --features test-utils -- -D warnings`
- `cargo test -p pocopine-storage`
- `cargo test -p pocopine-storage-s3 -p pocopine-storage-gcs -p pocopine-storage-azure`
- `wasm-pack test --firefox --headless crates/pocopine-storage --test client_browser --features test-utils`

Note: `gh auth status` is currently invalid locally, so this PR was created and updated via the GitHub connector after pushing the branch.