### PR TITLE
fix server auth layer finalization

### DIFF
--- a/crates/pocopine-agenkit/src/server/plugin.rs
+++ b/crates/pocopine-agenkit/src/server/plugin.rs
@@ -35,8 +35,10 @@ use super::agenkit::{Agenkit, with_principal};
 
 /// A tower layer that scopes the Agenkit caller-principal task-local for each
 /// request, reading the [`Principal`] from request extensions (anonymous when
-/// absent). Install it *after* `Server::with_auth(..)` populates the principal —
-/// or get it for free from [`agenkit_server_plugin`].
+/// absent). `Server::with_auth(..)` is applied during server finalization, so it
+/// runs before this layer when both are installed on a [`Server`]. For raw axum
+/// routers, install the auth middleware so it runs before this layer — or get
+/// this layer for free from [`agenkit_server_plugin`].
 #[derive(Clone, Copy, Default, Debug)]
 pub struct PrincipalLayer;
 

--- a/crates/pocopine-server/src/lib.rs
+++ b/crates/pocopine-server/src/lib.rs
@@ -218,10 +218,10 @@ async fn auth_middleware(
 /// [`Router`] in one line.
 ///
 /// Normal applications should prefer [`Server::with_auth`], because
-/// [`Server::new`] first installs all linked `#[server]` routes and
-/// then the builder method wraps them. This raw-router extension is
-/// still useful for tests and custom routers that manually install
-/// routes.
+/// the [`Server`] builder defers auth installation until finalization
+/// and therefore wraps routes added by later plugins. This raw-router
+/// extension is still useful for tests and custom routers that
+/// manually install routes.
 ///
 /// **Install after routes.** `Router::layer` (which this calls under
 /// the hood) only wraps the routes that exist at the call site —

--- a/crates/pocopine-server/src/server.rs
+++ b/crates/pocopine-server/src/server.rs
@@ -85,6 +85,7 @@ pub struct Server {
     router: Router,
     plugins: PluginRegistry,
     installing_plugin: Option<&'static str>,
+    auth_providers: Vec<SharedAuthProvider>,
     server_function_conflicts: Vec<ServerFunctionRouteConflict>,
 }
 
@@ -107,6 +108,7 @@ impl Server {
             router,
             plugins: PluginRegistry::default(),
             installing_plugin: None,
+            auth_providers: Vec::new(),
             server_function_conflicts,
         }
     }
@@ -136,21 +138,19 @@ impl Server {
 
     /// Install an [`AuthProvider`] as request middleware.
     ///
-    /// This is the preferred auth entry point for normal apps because
-    /// [`Self::new`] has already installed all linked `#[server]`
-    /// routes. The middleware therefore wraps server-function routes
-    /// and lets guarded functions read authenticated principals from
-    /// `RequestContext`.
+    /// This is the preferred auth entry point for normal apps. The
+    /// provider is recorded on the builder and applied during
+    /// [`Self::try_finalize`], after plugins have had a chance to add
+    /// routes. That means routes installed by later plugins are still
+    /// wrapped, and guarded handlers can read authenticated principals
+    /// from `RequestContext` regardless of builder-call order.
     pub fn with_auth<P: AuthProvider + 'static>(self, provider: P) -> Self {
         self.with_auth_arc(Arc::new(provider))
     }
 
     /// Install a pre-`Arc`'d auth provider.
     pub fn with_auth_arc(mut self, provider: SharedAuthProvider) -> Self {
-        self.router = self.router.layer(axum::middleware::from_fn_with_state(
-            provider,
-            auth_middleware,
-        ));
+        self.auth_providers.push(provider);
         self
     }
 
@@ -188,7 +188,9 @@ impl Server {
     ///
     /// The same caveat applies to plugins that compose internally:
     /// install layers in their `install` fn after any `route`/
-    /// `router_mut` calls.
+    /// `router_mut` calls. [`Self::with_auth`] is the exception:
+    /// the builder records auth providers and applies them during
+    /// finalization so plugin routes added later are still wrapped.
     pub fn layer<L>(mut self, layer: L) -> Self
     where
         L: Layer<axum::routing::Route> + Clone + Send + Sync + 'static,
@@ -272,8 +274,9 @@ impl Server {
     #[doc(hidden)]
     pub fn try_finalize(self) -> std::io::Result<Router> {
         let Self {
-            router,
+            mut router,
             plugins,
+            auth_providers,
             server_function_conflicts,
             ..
         } = self;
@@ -293,6 +296,12 @@ impl Server {
         }
 
         plugin::activate(plugins);
+        for provider in auth_providers {
+            router = router.layer(axum::middleware::from_fn_with_state(
+                provider,
+                auth_middleware,
+            ));
+        }
         Ok(router)
     }
 

--- a/crates/pocopine-server/tests/auth_layer_ordering.rs
+++ b/crates/pocopine-server/tests/auth_layer_ordering.rs
@@ -1,0 +1,138 @@
+//! Auth installed through `Server::with_auth` is builder-global: plugin routes
+//! added later must still receive the principal-populating middleware.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use pocopine_auth::{AuthFuture, AuthProvider, AuthUser, Principal};
+use pocopine_server::axum::body::Body;
+use pocopine_server::axum::extract::Request as AxumRequest;
+use pocopine_server::axum::http::{Request, StatusCode};
+use pocopine_server::axum::response::Response;
+use pocopine_server::axum::routing::get;
+use pocopine_server::axum::{Extension, Router};
+use pocopine_server::tower::{Layer, Service, ServiceExt};
+use pocopine_server::{RequestContext, Server, ServerPlugin};
+
+struct AlwaysAuth;
+
+impl AuthProvider for AlwaysAuth {
+    fn authenticate<'a>(&'a self, _ctx: &'a RequestContext) -> AuthFuture<'a, Option<AuthUser>> {
+        Box::pin(async { Ok(Some(AuthUser::new("u1"))) })
+    }
+}
+
+async fn probe(principal: Option<Extension<Principal>>) -> StatusCode {
+    if principal.is_some() {
+        StatusCode::OK
+    } else {
+        StatusCode::UNAUTHORIZED
+    }
+}
+
+async fn status(router: Router, path: &str) -> StatusCode {
+    router
+        .oneshot(Request::builder().uri(path).body(Body::empty()).unwrap())
+        .await
+        .unwrap()
+        .status()
+}
+
+struct AddsProbeRoute;
+
+impl ServerPlugin for AddsProbeRoute {
+    fn install(self, server: Server) -> Server {
+        server.route("/plugin", get(probe))
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct SawPrincipal(bool);
+
+#[derive(Clone, Copy, Debug)]
+struct CapturePrincipalLayer;
+
+#[derive(Clone)]
+struct CapturePrincipalService<S> {
+    inner: S,
+}
+
+impl<S> Layer<S> for CapturePrincipalLayer {
+    type Service = CapturePrincipalService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        CapturePrincipalService { inner }
+    }
+}
+
+impl<S> Service<AxumRequest> for CapturePrincipalService<S>
+where
+    S: Service<AxumRequest, Response = Response> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, mut req: AxumRequest) -> Self::Future {
+        let saw = req.extensions().get::<Principal>().is_some();
+        req.extensions_mut().insert(SawPrincipal(saw));
+        let clone = self.inner.clone();
+        let mut inner = std::mem::replace(&mut self.inner, clone);
+        Box::pin(async move { inner.call(req).await })
+    }
+}
+
+async fn captured_probe(Extension(SawPrincipal(saw)): Extension<SawPrincipal>) -> StatusCode {
+    if saw {
+        StatusCode::OK
+    } else {
+        StatusCode::UNAUTHORIZED
+    }
+}
+
+#[tokio::test]
+async fn server_with_auth_wraps_routes_added_afterward() {
+    pocopine_server::__reset_for_test();
+
+    let direct = Server::new(Router::new())
+        .with_auth(AlwaysAuth)
+        .route("/direct", get(probe))
+        .try_finalize()
+        .unwrap();
+
+    assert_eq!(status(direct, "/direct").await, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn server_with_auth_wraps_later_plugin_routes() {
+    pocopine_server::__reset_for_test();
+
+    let plugin = Server::new(Router::new())
+        .with_auth(AlwaysAuth)
+        .plugin(AddsProbeRoute)
+        .try_finalize()
+        .unwrap();
+
+    assert_eq!(status(plugin, "/plugin").await, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn server_with_auth_runs_before_deferred_layers_that_read_principal() {
+    pocopine_server::__reset_for_test();
+
+    let layered = Server::new(Router::new().route("/layered", get(captured_probe)))
+        .with_auth(AlwaysAuth)
+        .layer(CapturePrincipalLayer)
+        .try_finalize()
+        .unwrap();
+
+    assert_eq!(status(layered, "/layered").await, StatusCode::OK);
+}

--- a/crates/pocopine/tests/auth_middleware.rs
+++ b/crates/pocopine/tests/auth_middleware.rs
@@ -67,11 +67,11 @@ async fn whoami_with_extension(
 }
 
 fn build_router() -> Router {
-    // axum's `Router::layer` only wraps routes that exist at the
-    // call site, so `with_auth` must run AFTER the server-function
-    // route helpers have registered their routes. Get this order
-    // wrong and the middleware silently no-ops on the unwrapped
-    // routes.
+    // This uses the raw `RouterAuthExt::with_auth` extension. axum's
+    // `Router::layer` only wraps routes that exist at the call site,
+    // so the raw router extension must run AFTER the server-function
+    // route helpers have registered their routes. `Server::with_auth`
+    // is builder-global and does not have this ordering footgun.
     let router = pocopine_server::axum::Router::new();
     let router = __whoami_route(router);
     let router = __whoami_with_request_context_route(router);

--- a/docs/guides/auth/credentials.md
+++ b/docs/guides/auth/credentials.md
@@ -473,10 +473,9 @@ async fn main() -> std::io::Result<()> {
     let verifier =
         JwtVerifier::custom(creds.verifier_config()).expect("verifier from credentials config");
 
-    // Important: install the verifier middleware on the router
-    // BEFORE installing the credentials plugin, otherwise the
-    // signup/login routes added by the plugin would be wrapped in
-    // the auth middleware and reject anonymous requests.
+    // Server::with_auth is builder-global: it is applied after plugins
+    // register routes, so protected app routes and plugin routes see
+    // the same Principal-populating middleware.
     Server::new(Router::new())
         .with_auth(verifier)
         .plugin(creds)

--- a/docs/guides/server/server-plugins.md
+++ b/docs/guides/server/server-plugins.md
@@ -188,7 +188,10 @@ Server::new(Router::new())
 Within a single plugin's `install` fn, the same rule applies: call
 `route` / `router_mut` first, then `layer`. The `RouterAuthExt::with_auth`
 extension on `axum::Router` has the identical caveat documented in
-its rustdoc — same axum constraint.
+its rustdoc — same axum constraint. `Server::with_auth` is intentionally
+different: the builder records auth providers and applies them during
+finalization, after plugins have registered routes, so auth behaves like a
+global server feature instead of a call-site-only route layer.
 
 ## active_plugin cost
 


### PR DESCRIPTION
## Summary

Fixes #251.

- Defers `Server::with_auth` providers until `Server::try_finalize`, after plugins and later `Server::route` calls have registered routes.
- Keeps raw `RouterAuthExt::with_auth` as an immediate axum layer and clarifies the separate ordering caveat.
- Adds regression coverage for routes added after `with_auth`, plugin-added routes, and middleware that reads `Principal` from request extensions.
- Updates server/auth docs and Agenkit principal-layer rustdoc to match the new builder-global auth behavior.

## Root Cause

`Server::with_auth` previously called `Router::layer` immediately. axum only applies that layer to routes present at the call site, so routes added by later plugins bypassed auth middleware and never received a `Principal`.

## Validation

- `cargo test -p pocopine-server --test auth_layer_ordering`
- `cargo test -p pocopine-server`
- `cargo clippy -p pocopine-server --all-targets -- -D warnings`
- `cargo test -p pocopine --test auth_middleware`
- `cargo test -p pocopine-agenkit`
- `cargo fmt --all -- --check`
- `cargo clippy -p pocopine-agenkit --all-targets -- -D warnings`