### PR TITLE
fix realtime browser websocket auth

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7465,6 +7465,7 @@ dependencies = [
  "futures-util",
  "js-sys",
  "pocopine-auth",
+ "pocopine-codec",
  "pocopine-core",
  "pocopine-crypto",
  "pocopine-events",

--- a/crates/pocopine-auth-oauth/src/lib.rs
+++ b/crates/pocopine-auth-oauth/src/lib.rs
@@ -162,18 +162,18 @@ pub fn begin_authorization(config: &OAuthConfig) -> OAuthResult<Authorization> {
     let challenge = pocopine_codec::base64url_encode(&pocopine_crypto::sha256(verifier.as_bytes()));
     let state = random_url_token(16)?;
 
-    let mut url = format!(
-        "{}?response_type=code&client_id={}&redirect_uri={}&code_challenge={}&code_challenge_method=S256&state={}",
-        config.authorize_url,
-        pocopine_codec::percent_encode(&config.client_id),
-        pocopine_codec::percent_encode(&config.redirect_uri),
-        challenge,
-        state,
-    );
+    let mut params = pocopine_codec::QueryParams::new()
+        .pair("response_type", "code")
+        .pair("client_id", &config.client_id)
+        .pair("redirect_uri", &config.redirect_uri)
+        .pair("code_challenge", &challenge)
+        .pair("code_challenge_method", "S256")
+        .pair("state", &state);
     if !config.scopes.is_empty() {
-        url.push_str("&scope=");
-        url.push_str(&pocopine_codec::percent_encode(&config.scopes.join(" ")));
+        params = params.pair("scope", config.scopes.join(" "));
     }
+    let mut url = config.authorize_url.clone();
+    params.append_to(&mut url);
 
     Ok(Authorization {
         authorize_url: url,
@@ -334,6 +334,29 @@ mod tests {
         );
         assert!(!auth.pkce_verifier.expose().is_empty());
         assert!(!auth.state.is_empty());
+    }
+
+    #[test]
+    fn begin_authorization_appends_query_before_fragment() {
+        let cfg = OAuthConfig::public(
+            "https://auth.example.com/authorize?prompt=select#login",
+            "https://auth.example.com/token",
+            "client 123",
+            "https://app.example.com/callback?from=oauth",
+        );
+
+        let auth = begin_authorization(&cfg).unwrap();
+
+        assert!(
+            auth.authorize_url
+                .starts_with("https://auth.example.com/authorize?prompt=select&response_type=code")
+        );
+        assert!(auth.authorize_url.ends_with("#login"));
+        assert!(auth.authorize_url.contains("client_id=client%201"));
+        assert!(
+            auth.authorize_url
+                .contains("redirect_uri=https%3A%2F%2Fapp.example.com%2Fcallback%3Ffrom%3Doauth")
+        );
     }
 
     #[test]

--- a/crates/pocopine-codec/src/lib.rs
+++ b/crates/pocopine-codec/src/lib.rs
@@ -23,6 +23,17 @@
 //! assert_eq!(percent_decode("a%20b+c", true), "a b c");
 //! ```
 //!
+//! Query strings use the same component encoder:
+//!
+//! ```
+//! use pocopine_codec::append_query_param;
+//!
+//! assert_eq!(
+//!     append_query_param("wss://example/ws?room=1#top", "access token", "a b"),
+//!     "wss://example/ws?room=1&access%20token=a%20b#top"
+//! );
+//! ```
+//!
 //! For a `Vec<u8>` struct field that should serialize as a base64 string, use the
 //! [`base64_bytes`] serde adapter:
 //!
@@ -131,6 +142,90 @@ pub fn percent_decode(s: &str, plus_as_space: bool) -> String {
     } else {
         percent_decode_str(s).decode_utf8_lossy().into_owned()
     }
+}
+
+/// Owned query pairs that can be appended to an existing URL or path.
+///
+/// This is intentionally not a URL parser. It only handles the common safe
+/// operation Pocopine crates need: append RFC 3986 component-encoded query
+/// pairs before any existing `#fragment`.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct QueryParams {
+    pairs: Vec<(String, String)>,
+}
+
+impl QueryParams {
+    /// Create an empty query parameter builder.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add one query key/value pair.
+    pub fn pair(mut self, key: impl AsRef<str>, value: impl AsRef<str>) -> Self {
+        self.pairs
+            .push((key.as_ref().to_string(), value.as_ref().to_string()));
+        self
+    }
+
+    /// Return whether this builder contains no pairs.
+    pub fn is_empty(&self) -> bool {
+        self.pairs.is_empty()
+    }
+
+    /// Append the query pairs to `url`, preserving any existing `#fragment`.
+    pub fn append_to(&self, url: &mut String) {
+        if self.pairs.is_empty() {
+            return;
+        }
+
+        let fragment = url.find('#').map(|idx| url.split_off(idx));
+        push_query_separator(url);
+        for (index, (key, value)) in self.pairs.iter().enumerate() {
+            if index > 0 {
+                url.push('&');
+            }
+            push_encoded_query_pair(url, key, value);
+        }
+        if let Some(fragment) = fragment {
+            url.push_str(&fragment);
+        }
+    }
+}
+
+/// Return `url` with one percent-encoded query pair appended.
+///
+/// Existing queries are preserved, trailing `?`/`&` separators are reused, and
+/// the new pair is inserted before any existing `#fragment`.
+pub fn append_query_param(url: &str, key: &str, value: &str) -> String {
+    let mut out = url.to_string();
+    append_query_param_into(&mut out, key, value);
+    out
+}
+
+/// Append one percent-encoded query pair to `url` in place.
+pub fn append_query_param_into(url: &mut String, key: &str, value: &str) {
+    let fragment = url.find('#').map(|idx| url.split_off(idx));
+    push_query_separator(url);
+    push_encoded_query_pair(url, key, value);
+    if let Some(fragment) = fragment {
+        url.push_str(&fragment);
+    }
+}
+
+fn push_query_separator(url: &mut String) {
+    if url.contains('?') {
+        if !url.ends_with('?') && !url.ends_with('&') {
+            url.push('&');
+        }
+    } else {
+        url.push('?');
+    }
+}
+
+fn push_encoded_query_pair(out: &mut String, key: &str, value: &str) {
+    percent_encode_into(out, key);
+    out.push('=');
+    percent_encode_into(out, value);
 }
 
 /// Serde adapter for a `Vec<u8>` field encoded as a base64 string.
@@ -242,6 +337,63 @@ mod tests {
         assert_eq!(percent_decode("%FF", false), "\u{FFFD}");
         // A `%` not followed by two hex digits is left verbatim.
         assert_eq!(percent_decode("100%zz", false), "100%zz");
+    }
+
+    #[test]
+    fn append_query_param_adds_and_encodes_pair() {
+        assert_eq!(
+            append_query_param("wss://example/ws", "access token", "a b/c"),
+            "wss://example/ws?access%20token=a%20b%2Fc"
+        );
+    }
+
+    #[test]
+    fn append_query_param_reuses_existing_query_separator() {
+        assert_eq!(
+            append_query_param("wss://example/ws?room=1", "token", "a+b"),
+            "wss://example/ws?room=1&token=a%2Bb"
+        );
+        assert_eq!(
+            append_query_param("wss://example/ws?", "token", "a"),
+            "wss://example/ws?token=a"
+        );
+        assert_eq!(
+            append_query_param("wss://example/ws?room=1&", "token", "a"),
+            "wss://example/ws?room=1&token=a"
+        );
+    }
+
+    #[test]
+    fn append_query_param_inserts_before_fragment() {
+        assert_eq!(
+            append_query_param("wss://example/ws#top", "token", "a"),
+            "wss://example/ws?token=a#top"
+        );
+        assert_eq!(
+            append_query_param("wss://example/ws?room=1#top", "token", "a"),
+            "wss://example/ws?room=1&token=a#top"
+        );
+    }
+
+    #[test]
+    fn query_params_appends_multiple_pairs() {
+        let mut url = String::from("/callback?existing=1#done");
+        QueryParams::new()
+            .pair("client_id", "client 1")
+            .pair("redirect_uri", "/auth/cb?x=1")
+            .append_to(&mut url);
+
+        assert_eq!(
+            url,
+            "/callback?existing=1&client_id=client%201&redirect_uri=%2Fauth%2Fcb%3Fx%3D1#done"
+        );
+    }
+
+    #[test]
+    fn empty_query_params_do_not_touch_url() {
+        let mut url = String::from("/callback#done");
+        QueryParams::new().append_to(&mut url);
+        assert_eq!(url, "/callback#done");
     }
 
     #[test]

--- a/crates/pocopine-realtime/Cargo.toml
+++ b/crates/pocopine-realtime/Cargo.toml
@@ -15,6 +15,7 @@ redis = ["dep:redis"]
 # is shared too — the wasm transport logs dropped frames per the logging rule.
 [dependencies]
 bytes = "1"
+pocopine-codec = { workspace = true }
 serde = { workspace = true }
 serde_json = "1"
 tracing = { workspace = true }

--- a/crates/pocopine-realtime/src/client/mod.rs
+++ b/crates/pocopine-realtime/src/client/mod.rs
@@ -4,6 +4,8 @@
 //! the wasm WebSocket I/O shell, but host-testable on its own. The shell itself
 //! is `wasm32`-only.
 
+use crate::protocol::WS_ACCESS_TOKEN_QUERY_PARAM;
+
 mod session;
 pub use session::{ClientSession, ConnectionStatus, SessionEvent, reconnect_delay_ms};
 
@@ -11,3 +13,48 @@ pub use session::{ClientSession, ConnectionStatus, SessionEvent, reconnect_delay
 mod transport;
 #[cfg(target_arch = "wasm32")]
 pub use transport::RealtimeClient;
+
+/// Return `url` with `access_token=<token>` appended as a query parameter.
+///
+/// Browser WebSocket constructors cannot set an `Authorization` header during
+/// the upgrade. Pair this with `routes_with_auth` on the server, which verifies
+/// the query token through the configured `AuthProvider`.
+pub fn url_with_access_token(url: &str, token: &str) -> String {
+    append_query_param(url, WS_ACCESS_TOKEN_QUERY_PARAM, token)
+}
+
+fn append_query_param(url: &str, key: &str, value: &str) -> String {
+    let separator = if url.contains('?') {
+        if url.ends_with('?') || url.ends_with('&') {
+            ""
+        } else {
+            "&"
+        }
+    } else {
+        "?"
+    };
+    format!(
+        "{}{}{}={}",
+        url,
+        separator,
+        pocopine_codec::percent_encode(key),
+        pocopine_codec::percent_encode(value)
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn access_token_url_appends_and_encodes_query_value() {
+        assert_eq!(
+            url_with_access_token("ws://localhost/__pocopine/ws/v1", "a b/c"),
+            "ws://localhost/__pocopine/ws/v1?access_token=a%20b%2Fc"
+        );
+        assert_eq!(
+            url_with_access_token("wss://example/ws?room=1", "tok+en"),
+            "wss://example/ws?room=1&access_token=tok%2Ben"
+        );
+    }
+}

--- a/crates/pocopine-realtime/src/client/mod.rs
+++ b/crates/pocopine-realtime/src/client/mod.rs
@@ -20,26 +20,7 @@ pub use transport::RealtimeClient;
 /// the upgrade. Pair this with `routes_with_auth` on the server, which verifies
 /// the query token through the configured `AuthProvider`.
 pub fn url_with_access_token(url: &str, token: &str) -> String {
-    append_query_param(url, WS_ACCESS_TOKEN_QUERY_PARAM, token)
-}
-
-fn append_query_param(url: &str, key: &str, value: &str) -> String {
-    let separator = if url.contains('?') {
-        if url.ends_with('?') || url.ends_with('&') {
-            ""
-        } else {
-            "&"
-        }
-    } else {
-        "?"
-    };
-    format!(
-        "{}{}{}={}",
-        url,
-        separator,
-        pocopine_codec::percent_encode(key),
-        pocopine_codec::percent_encode(value)
-    )
+    pocopine_codec::append_query_param(url, WS_ACCESS_TOKEN_QUERY_PARAM, token)
 }
 
 #[cfg(test)]
@@ -55,6 +36,10 @@ mod tests {
         assert_eq!(
             url_with_access_token("wss://example/ws?room=1", "tok+en"),
             "wss://example/ws?room=1&access_token=tok%2Ben"
+        );
+        assert_eq!(
+            url_with_access_token("wss://example/ws#frag", "tok"),
+            "wss://example/ws?access_token=tok#frag"
         );
     }
 }

--- a/crates/pocopine-realtime/src/client/session.rs
+++ b/crates/pocopine-realtime/src/client/session.rs
@@ -56,6 +56,8 @@ pub enum SessionEvent {
     Data { topic: String, payload: Bytes },
     /// A subscription must be re-established fresh (unreplayable cursor / lag).
     Gap { topic: String, reason: String },
+    /// A subscribe was rejected by the gateway's topic authorizer.
+    SubscribeDenied { topic: String, reason: String },
     /// The server reported a typed error.
     Error { code: String, message: String },
     /// A heartbeat was acknowledged.
@@ -177,6 +179,12 @@ impl ClientSession {
                 }
                 SessionEvent::Gap { topic, reason }
             }
+            Control::SubscribeDenied { topic, reason } => {
+                if let Some(topic_ref) = self.topic_ref.remove(&topic) {
+                    self.topic_name.remove(&topic_ref);
+                }
+                SessionEvent::SubscribeDenied { topic, reason }
+            }
             Control::Error { code, message } => SessionEvent::Error { code, message },
             Control::HeartbeatAck {} => SessionEvent::HeartbeatAck,
             // Heartbeat / Resume are client→server; the client never receives them.
@@ -293,6 +301,31 @@ mod tests {
         );
         // No bogus ref leaked into the maps.
         assert!(s.data("t", 1, Bytes::from_static(b"x")).is_none());
+    }
+
+    #[test]
+    fn subscribe_denied_is_visible_and_drops_any_stale_ref() {
+        let mut s = ClientSession::new();
+        let ack = Control::SubscribeAck {
+            topic: "private".into(),
+            topic_ref: 8,
+        }
+        .into_frame()
+        .unwrap();
+        s.on_frame(&ack).unwrap();
+        assert!(s.data("private", 1, Bytes::from_static(b"x")).is_some());
+
+        let denied = Control::subscribe_denied("private", "forbidden")
+            .into_frame()
+            .unwrap();
+        assert_eq!(
+            s.on_frame(&denied).unwrap(),
+            Some(SessionEvent::SubscribeDenied {
+                topic: "private".into(),
+                reason: "forbidden".into(),
+            })
+        );
+        assert!(s.data("private", 1, Bytes::from_static(b"x")).is_none());
     }
 
     #[test]

--- a/crates/pocopine-realtime/src/client/transport.rs
+++ b/crates/pocopine-realtime/src/client/transport.rs
@@ -262,6 +262,15 @@ impl RealtimeClient {
         Ok(Self { inner })
     }
 
+    /// Open a connection with a browser-safe bearer token query parameter.
+    ///
+    /// Browsers cannot set arbitrary WebSocket upgrade headers. This appends an
+    /// `access_token` query parameter and expects the server to mount
+    /// `routes_with_auth` with a compatible `AuthProvider`.
+    pub fn connect_with_token(url: &str, token: &str) -> Result<Self, JsValue> {
+        Self::connect(&super::url_with_access_token(url, token))
+    }
+
     /// Build the four reusable socket-event closures (each holding a `Weak`).
     fn build_handlers(inner: &Rc<RefCell<Inner>>) -> SocketHandlers {
         let on_open = {

--- a/crates/pocopine-realtime/src/lib.rs
+++ b/crates/pocopine-realtime/src/lib.rs
@@ -32,6 +32,28 @@
 //! # }
 //! ```
 //!
+//! ## Browser WebSocket auth
+//!
+//! Browsers cannot attach arbitrary headers to a WebSocket upgrade, so bearer
+//! tokens that work for `fetch` do not automatically reach this transport. Use
+//! `RealtimeClient::connect_with_token` on wasm and [`routes_with_auth`] on the
+//! server to pass a bearer token through the
+//! `access_token` query parameter and verify it with the same `AuthProvider`
+//! used by HTTP routes:
+//!
+//! ```ignore
+//! // wasm
+//! let client = RealtimeClient::connect_with_token("/__pocopine/ws/v1", token)?;
+//!
+//! // host
+//! let router = pocopine_realtime::routes_with_auth(gateway, jwt_verifier);
+//! ```
+//!
+//! A denied subscribe is surfaced as
+//! [`client::SessionEvent::SubscribeDenied`] instead of looking like an idle
+//! topic. Consumers that need UI feedback should register
+//! `RealtimeClient::on_event` and handle that event.
+//!
 //! ## Module layout
 //!
 //! This crate is host-only. Following the `client-server-modules` convention,
@@ -51,7 +73,8 @@
 // The wire protocol is target-agnostic — shared by the server and the client.
 pub mod protocol;
 pub use protocol::{
-    Control, Frame, FrameKind, ProtocolError, TopicSeq, WS_PROTOCOL_V1, WS_STREAM_PATH,
+    Control, Frame, FrameKind, ProtocolError, TopicSeq, WS_ACCESS_TOKEN_QUERY_PARAM,
+    WS_PROTOCOL_V1, WS_STREAM_PATH,
 };
 
 // The browser client. Its session state machine is target-agnostic

--- a/crates/pocopine-realtime/src/protocol/control.rs
+++ b/crates/pocopine-realtime/src/protocol/control.rs
@@ -58,6 +58,8 @@ pub enum Control {
     /// Server → client: a resume cursor is unreplayable or the subscription
     /// lagged; the client must re-subscribe fresh.
     Gap { topic: String, reason: String },
+    /// Server → client: a Subscribe was denied by the topic authorizer.
+    SubscribeDenied { topic: String, reason: String },
     /// Server → client: a typed error (forbidden topic, oversized frame, ...).
     Error { code: String, message: String },
 }
@@ -91,6 +93,14 @@ impl Control {
     /// Convenience constructor for an [`Control::Gap`].
     pub fn gap(topic: impl Into<String>, reason: impl Into<String>) -> Self {
         Self::Gap {
+            topic: topic.into(),
+            reason: reason.into(),
+        }
+    }
+
+    /// Convenience constructor for [`Control::SubscribeDenied`].
+    pub fn subscribe_denied(topic: impl Into<String>, reason: impl Into<String>) -> Self {
+        Self::SubscribeDenied {
             topic: topic.into(),
             reason: reason.into(),
         }
@@ -142,6 +152,7 @@ mod tests {
             topic: "collab:abc".into(),
         });
         roundtrip(Control::gap("collab:abc", "cursor_not_replayable"));
+        roundtrip(Control::subscribe_denied("collab:abc", "forbidden"));
         roundtrip(Control::error("forbidden_topic", "denied"));
     }
 

--- a/crates/pocopine-realtime/src/protocol/mod.rs
+++ b/crates/pocopine-realtime/src/protocol/mod.rs
@@ -23,3 +23,9 @@ pub const WS_PROTOCOL_V1: &str = "pocopine.ws.v1";
 
 /// Mount path for the gateway upgrade endpoint (the URL a client connects to).
 pub const WS_STREAM_PATH: &str = "/__pocopine/ws/v1";
+
+/// Query parameter used by browser clients to carry a bearer token on the
+/// WebSocket upgrade. Browsers cannot set arbitrary upgrade headers, so
+/// `routes_with_auth` accepts this parameter and authenticates it through the
+/// configured `AuthProvider`.
+pub const WS_ACCESS_TOKEN_QUERY_PARAM: &str = "access_token";

--- a/crates/pocopine-realtime/src/server/gateway.rs
+++ b/crates/pocopine-realtime/src/server/gateway.rs
@@ -129,7 +129,7 @@ where
 /// [`WsGateway::with_write_policy`].
 struct WriteClamp {
     inner: Arc<dyn TopicAuthorizer>,
-    write: Arc<dyn Fn(&RequestContext, &Topic) -> bool + Send + Sync>,
+    write: TopicPolicy,
 }
 
 impl TopicAuthorizer for WriteClamp {

--- a/crates/pocopine-realtime/src/server/mod.rs
+++ b/crates/pocopine-realtime/src/server/mod.rs
@@ -24,4 +24,4 @@ pub use gateway::{
 pub use handler::{InboundData, Reaction, SubprotocolHandler};
 #[cfg(feature = "redis")]
 pub use redis_fanout::{DEFAULT_REDIS_MAX_LEN, RedisFanout};
-pub use route::routes;
+pub use route::{routes, routes_with_auth, routes_with_auth_arc};

--- a/crates/pocopine-realtime/src/server/route.rs
+++ b/crates/pocopine-realtime/src/server/route.rs
@@ -16,17 +16,20 @@
 //! reaped.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 use axum::Router;
 use axum::body::Body;
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::extract::{FromRequestParts, State};
-use axum::http::Request;
+use axum::http::header::AUTHORIZATION;
+use axum::http::{HeaderValue, Request, Uri};
+use axum::middleware::Next;
 use axum::response::{IntoResponse, Response};
 use axum::routing::get;
 use futures_util::{SinkExt, StreamExt};
-use pocopine_auth::RequestAuthExt;
+use pocopine_auth::{AuthProvider, Principal, RequestAuthExt};
 use pocopine_core::server::RequestContext;
 use pocopine_events::Topic;
 use pocopine_observe::LOG_TARGET;
@@ -34,12 +37,16 @@ use tokio::sync::mpsc;
 use tokio::task::JoinHandle;
 use tokio::time::{Instant, MissedTickBehavior, interval};
 
-use crate::protocol::{Control, Frame, FrameKind, WS_PROTOCOL_V1, WS_STREAM_PATH};
+use crate::protocol::{
+    Control, Frame, FrameKind, WS_ACCESS_TOKEN_QUERY_PARAM, WS_PROTOCOL_V1, WS_STREAM_PATH,
+};
 
 use super::error::WsError;
 use super::fanout::TopicStream;
 use super::gateway::{GatewayConfig, WsGateway};
 use super::handler::InboundData;
+
+type SharedAuthProvider = Arc<dyn AuthProvider>;
 
 /// Build the axum router for the gateway. Mirrors `pocopine_live::routes`:
 /// the [`WsGateway`] is the router state, reachable in the handler via
@@ -48,6 +55,102 @@ pub fn routes(gateway: WsGateway) -> Router {
     Router::new()
         .route(WS_STREAM_PATH, get(upgrade_handler))
         .with_state(gateway)
+}
+
+/// Build the gateway router and authenticate browser-safe `access_token` query
+/// values through an [`AuthProvider`].
+///
+/// Browsers cannot set an `Authorization` header on a WebSocket upgrade.
+/// `RealtimeClient::connect_with_token` appends the token as a query parameter;
+/// this route helper converts it into the bearer shape existing providers
+/// understand, inserts the resulting [`Principal`] into request extensions, and
+/// scrubs the token from the URI before the gateway builds its
+/// [`RequestContext`].
+pub fn routes_with_auth<P: AuthProvider + 'static>(gateway: WsGateway, provider: P) -> Router {
+    routes_with_auth_arc(gateway, Arc::new(provider))
+}
+
+/// Pre-`Arc`'d variant of [`routes_with_auth`].
+pub fn routes_with_auth_arc(gateway: WsGateway, provider: Arc<dyn AuthProvider>) -> Router {
+    routes(gateway).layer(axum::middleware::from_fn_with_state(
+        provider,
+        websocket_auth_middleware,
+    ))
+}
+
+async fn websocket_auth_middleware(
+    State(provider): State<SharedAuthProvider>,
+    mut req: Request<Body>,
+    next: Next,
+) -> Response {
+    let token = access_token(req.uri());
+    let mut headers = req.headers().clone();
+    if headers.get(AUTHORIZATION).is_none()
+        && let Some(token) = &token
+        && let Ok(value) = HeaderValue::from_str(&format!("Bearer {token}"))
+    {
+        headers.insert(AUTHORIZATION, value);
+    }
+    if token.is_some()
+        && let Some(uri) = uri_without_access_token(req.uri())
+    {
+        *req.uri_mut() = uri;
+    }
+
+    let ctx = RequestContext::from_parts(
+        req.method().clone(),
+        req.uri().clone(),
+        headers,
+        req.extensions().clone(),
+    );
+    match provider.authenticate(&ctx).await {
+        Ok(Some(user)) => {
+            req.extensions_mut().insert(Principal::from_user(user));
+        }
+        Ok(None) => {}
+        Err(err) => {
+            tracing::warn!(
+                target: LOG_TARGET,
+                error = %err,
+                "realtime websocket auth provider failed; treating request as anonymous"
+            );
+        }
+    }
+
+    next.run(req).await
+}
+
+fn access_token(uri: &Uri) -> Option<String> {
+    query_value(uri.query()?, WS_ACCESS_TOKEN_QUERY_PARAM)
+}
+
+fn query_value(query: &str, key: &str) -> Option<String> {
+    query.split('&').find_map(|part| {
+        let (raw_key, raw_value) = part.split_once('=')?;
+        (pocopine_codec::percent_decode(raw_key, true) == key)
+            .then(|| pocopine_codec::percent_decode(raw_value, true))
+    })
+}
+
+fn uri_without_access_token(uri: &Uri) -> Option<Uri> {
+    let query = uri.query()?;
+    let mut parts = uri.clone().into_parts();
+    let mut filtered = query
+        .split('&')
+        .filter(|part| decoded_query_key(part) != WS_ACCESS_TOKEN_QUERY_PARAM)
+        .peekable();
+    let mut path_and_query = uri.path().to_string();
+    if filtered.peek().is_some() {
+        path_and_query.push('?');
+        path_and_query.push_str(&filtered.collect::<Vec<_>>().join("&"));
+    }
+    parts.path_and_query = Some(path_and_query.parse().ok()?);
+    Uri::from_parts(parts).ok()
+}
+
+fn decoded_query_key(part: &str) -> String {
+    let raw_key = part.split_once('=').map(|(key, _)| key).unwrap_or(part);
+    pocopine_codec::percent_decode(raw_key, true)
 }
 
 async fn upgrade_handler(State(gateway): State<WsGateway>, request: Request<Body>) -> Response {
@@ -364,10 +467,7 @@ impl Session {
             }
         };
         if !self.gateway.authorize(&self.ctx, &topic).await.can_join() {
-            self.send(&Control::error(
-                "forbidden_topic",
-                format!("topic '{topic_name}' denied"),
-            ));
+            self.send(&Control::subscribe_denied(topic_name, "forbidden"));
             return;
         }
 
@@ -505,5 +605,31 @@ async fn send_control(out: &mpsc::Sender<Message>, control: &Control) -> bool {
     match control.into_frame() {
         Ok(frame) => out.send(Message::Binary(frame.encode())).await.is_ok(),
         Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn uri_without_access_token_scrubs_value_bare_and_encoded_keys() {
+        let uri: Uri =
+            "/__pocopine/ws/v1?room=1&access_token=secret&access_token&access%5Ftoken=secret2&flag"
+                .parse()
+                .unwrap();
+
+        let scrubbed = uri_without_access_token(&uri).unwrap();
+
+        assert_eq!(scrubbed.to_string(), "/__pocopine/ws/v1?room=1&flag");
+    }
+
+    #[test]
+    fn uri_without_access_token_removes_empty_query_when_only_token_was_present() {
+        let uri: Uri = "/__pocopine/ws/v1?access_token=secret".parse().unwrap();
+
+        let scrubbed = uri_without_access_token(&uri).unwrap();
+
+        assert_eq!(scrubbed.to_string(), "/__pocopine/ws/v1");
     }
 }

--- a/crates/pocopine-realtime/tests/gateway.rs
+++ b/crates/pocopine-realtime/tests/gateway.rs
@@ -8,24 +8,39 @@ use std::sync::{Arc, Mutex};
 
 use bytes::Bytes;
 use futures_util::{SinkExt, Stream, StreamExt};
+use pocopine_auth::{AuthFuture, AuthProvider, AuthUser, RequestAuthExt};
+use pocopine_core::server::RequestContext;
 use pocopine_events::Topic;
 use pocopine_realtime::client::{ClientSession, SessionEvent};
 use pocopine_realtime::{
     Control, Frame, FrameKind, GatewayConfig, InboundData, Reaction, SubprotocolHandler, TopicSeq,
-    WsGateway, routes,
+    WsGateway, routes, routes_with_auth,
 };
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::{Error as TungError, Message as WsMessage};
 
 /// Boot `gateway` on a random local port; return the ws:// URL.
 async fn spawn(gateway: WsGateway) -> String {
-    let app = routes(gateway);
+    spawn_app(routes(gateway)).await
+}
+
+async fn spawn_app(app: axum::Router) -> String {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     tokio::spawn(async move {
         axum::serve(listener, app).await.unwrap();
     });
     format!("ws://{addr}/__pocopine/ws/v1")
+}
+
+struct QueryTokenAuth;
+
+impl AuthProvider for QueryTokenAuth {
+    fn authenticate<'a>(&'a self, ctx: &'a RequestContext) -> AuthFuture<'a, Option<AuthUser>> {
+        Box::pin(async move {
+            Ok((ctx.bearer_token() == Some("ok token")).then(|| AuthUser::new("u1")))
+        })
+    }
 }
 
 /// Read the next binary frame, skipping ping/pong/text. Each read is bounded by
@@ -130,9 +145,65 @@ async fn default_deny_rejects_subscribe() {
         .await
         .unwrap();
     match next_control(&mut ws).await {
-        Control::Error { code, .. } => assert_eq!(code, "forbidden_topic"),
-        other => panic!("expected forbidden error, got {other:?}"),
+        Control::SubscribeDenied { topic, reason } => {
+            assert_eq!(topic, "topic:1");
+            assert_eq!(reason, "forbidden");
+        }
+        other => panic!("expected SubscribeDenied, got {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn routes_with_auth_accepts_browser_access_token_query() {
+    let gateway = WsGateway::local().with_access(|ctx, _topic| {
+        assert!(
+            !ctx.uri()
+                .query()
+                .unwrap_or_default()
+                .contains("access_token"),
+            "route helper must scrub the bearer token from downstream context"
+        );
+        if ctx.require_user().is_ok() {
+            pocopine_realtime::TopicAccess::ReadWrite
+        } else {
+            pocopine_realtime::TopicAccess::Denied
+        }
+    });
+    let url = spawn_app(routes_with_auth(gateway, QueryTokenAuth)).await;
+    let (mut ws, _resp) = connect_async(format!("{url}?room=1&access_token=ok%20token"))
+        .await
+        .unwrap();
+    assert!(matches!(next_control(&mut ws).await, Control::Hello { .. }));
+
+    ws.send(send_bytes(Frame::subscribe(1, "topic:1")))
+        .await
+        .unwrap();
+    assert!(matches!(
+        next_control(&mut ws).await,
+        Control::SubscribeAck { .. }
+    ));
+}
+
+#[tokio::test]
+async fn routes_with_auth_denies_when_browser_access_token_is_missing() {
+    let gateway = WsGateway::local().with_access(|ctx, _topic| {
+        if ctx.require_user().is_ok() {
+            pocopine_realtime::TopicAccess::ReadWrite
+        } else {
+            pocopine_realtime::TopicAccess::Denied
+        }
+    });
+    let url = spawn_app(routes_with_auth(gateway, QueryTokenAuth)).await;
+    let (mut ws, _resp) = connect_async(url).await.unwrap();
+    assert!(matches!(next_control(&mut ws).await, Control::Hello { .. }));
+
+    ws.send(send_bytes(Frame::subscribe(1, "topic:1")))
+        .await
+        .unwrap();
+    assert!(matches!(
+        next_control(&mut ws).await,
+        Control::SubscribeDenied { .. }
+    ));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes #253.

- Adds browser-safe WebSocket bearer helpers: `RealtimeClient::connect_with_token(...)` on wasm and `client::url_with_access_token(...)` for testable URL construction.
- Adds `routes_with_auth(...)` / `routes_with_auth_arc(...)` so realtime routes can verify an `access_token` query value through an existing `AuthProvider` and populate the upgrade `Principal`.
- Scrubs `access_token` from the downstream request URI before the gateway builds its `RequestContext`.
- Replaces silent/generic denied subscribes with a typed `Control::SubscribeDenied` and `SessionEvent::SubscribeDenied { topic, reason }`.
- Adds reusable query-string helpers in `pocopine-codec` (`QueryParams`, `append_query_param`, `append_query_param_into`) and uses them from realtime and OAuth URL construction.
- Documents the browser WebSocket auth path in `pocopine-realtime` crate docs.

## Root Cause

Browser WebSocket upgrades cannot set an `Authorization` header, while the realtime gateway authorizer reads identity from the upgrade request context. Apps using bearer tokens outside cookies had to hand-roll query-token middleware. When authorization denied a subscribe, clients only observed no data unless they were watching generic control errors.

## Validation

- `cargo test -p pocopine-codec -p pocopine-auth-oauth -p pocopine-realtime`
- `cargo fmt --all -- --check`
- `cargo clippy -p pocopine-codec -p pocopine-auth-oauth -p pocopine-realtime --all-targets -- -D warnings`
- `cargo clippy -p pocopine-codec -p pocopine-realtime --target wasm32-unknown-unknown --all-targets -- -D warnings`
- `git diff --check`

Note: Claude external review was not run because execution policy blocked sending unpublished branch diff/code to Claude. This PR remains draft until the external review gate can be satisfied.