### PR TITLE
Add storage image variants and object guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,13 @@ jobs:
           --target wasm32-unknown-unknown
           --all-targets
           -- -D warnings
+      - name: pocopine-storage image compression wasm clippy
+        run: >
+          cargo clippy -p pocopine-storage
+          --target wasm32-unknown-unknown
+          --features image-compression
+          --all-targets
+          -- -D warnings
 
   clippy-host:
     name: clippy (host — pocopine-cli)
@@ -288,6 +295,8 @@ jobs:
         run: cargo test -p pocopine-sync-query-macros --tests
         env:
           CARGO_TARGET_DIR: target/sync-query-macros-host
+      - name: pocopine-storage image compression tests
+        run: cargo test -p pocopine-storage --features image-compression
       - name: workspace host tests
         run: cargo test --workspace --exclude pine --exclude observability-smoke --exclude pocopine-sync-query-macros --tests
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2690,6 +2690,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fast_image_resize"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12dd43e5011e8d8411a3215a0d57a2ec5c68282fb90eb5d7221fab0113442174"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "num-traits",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4958,6 +4970,12 @@ dependencies = [
  "getrandom 0.3.4",
  "libc",
 ]
+
+[[package]]
+name = "jpeg-encoder"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b0b36cbb4e6704f12f5b5d7b01dac593982c6550859ebd5a66fb15c9ea27fd5"
 
 [[package]]
 name = "js-sys"
@@ -7505,9 +7523,11 @@ version = "0.1.1"
 dependencies = [
  "bytes",
  "criterion",
+ "fast_image_resize",
  "futures-core",
  "futures-util",
  "http-body-util",
+ "jpeg-encoder",
  "js-sys",
  "pocopine",
  "pocopine-codec",
@@ -7526,6 +7546,9 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-bindgen-test",
  "web-sys",
+ "zune-core",
+ "zune-jpeg",
+ "zune-png",
 ]
 
 [[package]]
@@ -12662,3 +12685,37 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]
+
+[[package]]
+name = "zune-png"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a321146329f7617ba0a5b26982cba45b7ce78163135aba78be25850aefcea80"
+dependencies = [
+ "zune-core",
+ "zune-inflate",
+]

--- a/crates/pocopine-storage/Cargo.toml
+++ b/crates/pocopine-storage/Cargo.toml
@@ -7,6 +7,13 @@ repository.workspace = true
 description = "Storage protocol, browser client, and server plugin extension for Pocopine apps."
 
 [features]
+image-compression = [
+    "dep:fast_image_resize",
+    "dep:jpeg-encoder",
+    "dep:zune-core",
+    "dep:zune-jpeg",
+    "dep:zune-png",
+]
 # Exposes the browser transport override hook used by `tests/client_browser.rs`
 # (and any downstream tus client harness). Gated to keep the MITM-capable
 # `__set_browser_transport_for_test` setter out of production wasm bundles —
@@ -16,12 +23,17 @@ test-utils = []
 
 [dependencies]
 bytes = "1"
+fast_image_resize = { version = "6", default-features = false, features = ["no_std"], optional = true }
+jpeg-encoder = { version = "0.7", default-features = false, optional = true }
 pocopine-codec = { workspace = true }
 pocopine-core = { workspace = true, default-features = false }
 serde = { workspace = true }
 serde_json = { workspace = true }
 time = { version = "0.3", features = ["serde", "formatting"] }
 uuid = { version = "1", features = ["v4", "js"] }
+zune-core = { version = "0.5", default-features = false, optional = true }
+zune-jpeg = { version = "0.5", default-features = false, optional = true }
+zune-png = { version = "0.5", default-features = false, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 pocopine-server = { workspace = true }
@@ -64,6 +76,7 @@ web-sys = { version = "0.3", features = [
     "AbortController",
     "AbortSignal",
     "Blob",
+    "BlobPropertyBag",
     "File",
     "Headers",
     "Request",

--- a/crates/pocopine-storage/src/client.rs
+++ b/crates/pocopine-storage/src/client.rs
@@ -241,6 +241,7 @@ impl StorageScopeClient {
             with_credentials: self.with_credentials,
             scope: self.scope.clone(),
             key: key.into(),
+            variant: None,
         }
     }
 }
@@ -252,6 +253,15 @@ pub struct StorageObjectClient {
     with_credentials: bool,
     scope: String,
     key: String,
+    variant: Option<String>,
+}
+
+impl StorageObjectClient {
+    /// Address a deterministic image variant sibling of this canonical object.
+    pub fn variant(mut self, variant: impl Into<String>) -> Self {
+        self.variant = Some(variant.into());
+        self
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -282,6 +292,7 @@ impl StorageObjectClient {
             self.with_credentials,
             &self.scope,
             &self.key,
+            &self.variant,
         );
         Err(StorageError::unsupported(
             "storage client HTTP calls are only available in the browser runtime",
@@ -300,6 +311,7 @@ impl StorageObjectClient {
             self.with_credentials,
             &self.scope,
             &self.key,
+            &self.variant,
         );
         Err(StorageError::unsupported(
             "storage client HTTP calls are only available in the browser runtime",
@@ -315,6 +327,10 @@ pub struct UploadBuilder;
 #[derive(Debug)]
 pub struct ResumableUploadBuilder;
 
+#[cfg(all(not(target_arch = "wasm32"), feature = "image-compression"))]
+#[derive(Debug)]
+pub struct ImageUploadBuilder;
+
 #[cfg(target_arch = "wasm32")]
 mod wasm {
     use std::cell::Cell;
@@ -327,10 +343,14 @@ mod wasm {
 
     use futures_util::stream::{FuturesUnordered, StreamExt as _};
     use js_sys::Promise;
+    #[cfg(feature = "image-compression")]
+    use js_sys::{Array, ArrayBuffer, Uint8Array};
     use serde::de::DeserializeOwned;
     use wasm_bindgen::JsCast;
     use wasm_bindgen::prelude::*;
     use wasm_bindgen_futures::JsFuture;
+    #[cfg(feature = "image-compression")]
+    use web_sys::BlobPropertyBag;
     use web_sys::{
         AbortSignal, Blob, File, Headers, Request, RequestCredentials, RequestInit, Response,
     };
@@ -340,6 +360,12 @@ mod wasm {
         CompleteUploadRequest, InitiateUploadRequest, ObjectRef, PartSpec, ReadUrlRequest,
         STORAGE_PROTOCOL_V1, StorageResponse, UploadPhase, UploadProgress, UploadStrategy,
         plan_parts,
+    };
+    #[cfg(feature = "image-compression")]
+    use crate::{
+        IMAGE_VARIANT_BASE_KEY_METADATA_KEY, IMAGE_VARIANT_HEIGHT_METADATA_KEY,
+        IMAGE_VARIANT_METADATA_KEY, IMAGE_VARIANT_ORIGINAL, IMAGE_VARIANT_WIDTH_METADATA_KEY,
+        ImageUploadManifest, ImageVariantObject, ImageVariantPolicy, compress_image_variants,
     };
 
     const DEFAULT_CHUNK_SIZE: u64 = 1024 * 1024;
@@ -420,6 +446,18 @@ mod wasm {
         });
     }
 
+    #[cfg(feature = "image-compression")]
+    impl super::StorageClient {
+        /// Start a client-side compressed image upload for a typed object scope.
+        pub fn upload_image_scope<S>(&self, file: File) -> ImageUploadBuilder
+        where
+            S: StorageObjectScope,
+        {
+            self.object_scope::<S>()
+                .upload_image_with_policy(file, S::image_variants())
+        }
+    }
+
     impl super::StorageScopeClient {
         /// Fetch the safe upload policy descriptor for this scope.
         pub async fn descriptor(&self) -> StorageResult<UploadPolicyDescriptor> {
@@ -474,6 +512,36 @@ mod wasm {
             })
         }
 
+        /// Start a client-side compressed image upload from a browser [`File`].
+        #[cfg(feature = "image-compression")]
+        pub fn upload_image(&self, file: File) -> ImageUploadBuilder {
+            self.upload_image_with_policy(file, ImageVariantPolicy::default())
+        }
+
+        /// Start a client-side compressed image upload with an explicit variant policy.
+        #[cfg(feature = "image-compression")]
+        pub fn upload_image_with_policy(
+            &self,
+            file: File,
+            policy: ImageVariantPolicy,
+        ) -> ImageUploadBuilder {
+            let name = file.name();
+            let size = file.size() as u64;
+            let content_type = empty_to_none(file.type_());
+            let last_modified = Some(file.last_modified() as i64);
+            let blob: Blob = file.unchecked_into();
+            self.image_upload_source(
+                UploadSource {
+                    blob,
+                    name,
+                    size,
+                    content_type,
+                    last_modified,
+                },
+                policy,
+            )
+        }
+
         /// Resume an existing browser-safe upload session.
         pub fn resume(&self, file: File, session: UploadSession) -> UploadBuilder {
             self.upload(file).session(session)
@@ -495,15 +563,40 @@ mod wasm {
                 auto_resume: false,
             }
         }
+
+        #[cfg(feature = "image-compression")]
+        fn image_upload_source(
+            &self,
+            source: UploadSource,
+            policy: ImageVariantPolicy,
+        ) -> ImageUploadBuilder {
+            ImageUploadBuilder {
+                endpoint: self.endpoint.clone(),
+                with_credentials: self.with_credentials,
+                scope: self.scope.clone(),
+                source,
+                policy,
+                strategy: UploadStrategy::Auto,
+                metadata: BTreeMap::new(),
+                progress: None,
+                retry_limit: 2,
+                retry_base_delay_ms: 100,
+                abort_signal: None,
+            }
+        }
     }
 
     impl super::StorageObjectClient {
         /// Ask the server for a short-lived URL that reads this object.
         pub async fn signed_read(&self) -> StorageResult<SignedRead> {
+            let request = ReadUrlRequest {
+                variant: self.variant.clone(),
+                ..ReadUrlRequest::default()
+            };
             fetch_json(
                 BrowserStorageRequest::post_json(
                     object_read_url(&self.endpoint, &self.scope, &self.key),
-                    &ReadUrlRequest::default(),
+                    &request,
                     self.with_credentials,
                     None,
                 )?,
@@ -521,7 +614,12 @@ mod wasm {
         pub async fn delete(&self) -> StorageResult<()> {
             fetch_no_content(
                 BrowserStorageRequest::delete(
-                    object_url(&self.endpoint, &self.scope, &self.key),
+                    object_url(
+                        &self.endpoint,
+                        &self.scope,
+                        &self.key,
+                        self.variant.as_deref(),
+                    ),
                     self.with_credentials,
                     None,
                 ),
@@ -591,6 +689,233 @@ mod wasm {
         size: u64,
         content_type: Option<String>,
         last_modified: Option<i64>,
+    }
+
+    /// Browser image upload builder with client-side Rust compression.
+    #[cfg(feature = "image-compression")]
+    #[must_use]
+    pub struct ImageUploadBuilder {
+        endpoint: String,
+        with_credentials: bool,
+        scope: String,
+        source: UploadSource,
+        policy: ImageVariantPolicy,
+        strategy: UploadStrategy,
+        metadata: BTreeMap<String, String>,
+        progress: Option<Rc<dyn Fn(String, UploadProgress)>>,
+        retry_limit: u32,
+        retry_base_delay_ms: u32,
+        abort_signal: Option<AbortSignal>,
+    }
+
+    #[cfg(feature = "image-compression")]
+    impl ImageUploadBuilder {
+        /// Replace the image variant policy.
+        pub fn policy(mut self, policy: ImageVariantPolicy) -> Self {
+            self.policy = policy;
+            self
+        }
+
+        /// Add one generated image variant.
+        pub fn variant(mut self, variant: crate::ImageVariantSpec) -> Self {
+            self.policy.variants.push(variant);
+            self
+        }
+
+        /// Control whether the original file is uploaded alongside variants.
+        pub fn keep_original(mut self, keep_original: bool) -> Self {
+            self.policy.keep_original = keep_original;
+            self
+        }
+
+        /// Set the requested upload strategy for every object in the manifest.
+        pub fn strategy(mut self, strategy: UploadStrategy) -> Self {
+            self.strategy = strategy;
+            self
+        }
+
+        /// Add string metadata to every uploaded object in the image manifest.
+        pub fn metadata(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+            self.metadata.insert(key.into(), value.into());
+            self
+        }
+
+        /// Observe upload progress per manifest entry.
+        pub fn on_progress<F>(mut self, callback: F) -> Self
+        where
+            F: Fn(String, UploadProgress) + 'static,
+        {
+            self.progress = Some(Rc::new(callback));
+            self
+        }
+
+        /// Set the number of retries for transient browser transport errors.
+        pub fn retry_limit(mut self, retry_limit: u32) -> Self {
+            self.retry_limit = retry_limit;
+            self
+        }
+
+        /// Set the base retry backoff in milliseconds.
+        pub fn retry_base_delay_ms(mut self, retry_base_delay_ms: u32) -> Self {
+            self.retry_base_delay_ms = retry_base_delay_ms;
+            self
+        }
+
+        /// Attach a browser abort signal to every request in this image upload.
+        pub fn abort_signal(mut self, signal: AbortSignal) -> Self {
+            self.abort_signal = Some(signal);
+            self
+        }
+
+        /// Compress the configured variants and upload the resulting manifest.
+        pub async fn send(self) -> StorageResult<ImageUploadManifest> {
+            self.policy.validate()?;
+
+            let (source_info, variants) = if self.policy.variants.is_empty() {
+                (None, Vec::new())
+            } else {
+                let source_bytes = read_blob_bytes(&self.source.blob).await?;
+                let (source_info, variants) = compress_image_variants(
+                    &self.source.name,
+                    &source_bytes,
+                    self.policy.variants.clone(),
+                )?;
+                (Some(source_info), variants)
+            };
+
+            let mut manifest = ImageUploadManifest::default();
+            let mut base_key = None;
+            if self.policy.keep_original {
+                let mut source = self.source.clone();
+                if source.content_type.is_none() {
+                    source.content_type = source_info
+                        .as_ref()
+                        .map(|source_info| source_info.content_type.clone());
+                }
+                let original_width = source_info
+                    .as_ref()
+                    .map(|source_info| source_info.width)
+                    .unwrap_or_default();
+                let original_height = source_info
+                    .as_ref()
+                    .map(|source_info| source_info.height)
+                    .unwrap_or_default();
+                let original_content_type = source_info
+                    .as_ref()
+                    .map(|source_info| source_info.content_type.clone())
+                    .or_else(|| source.content_type.clone())
+                    .unwrap_or_else(|| "application/octet-stream".to_string());
+                let object = self
+                    .upload_one(
+                        source,
+                        IMAGE_VARIANT_ORIGINAL,
+                        source_info
+                            .as_ref()
+                            .map(|source_info| (source_info.width, source_info.height)),
+                        None,
+                    )
+                    .await?;
+                base_key = Some(object.key.clone());
+                manifest.original = Some(ImageVariantObject {
+                    name: IMAGE_VARIANT_ORIGINAL.to_string(),
+                    object,
+                    width: original_width,
+                    height: original_height,
+                    content_type: original_content_type,
+                });
+            }
+
+            for variant in variants {
+                let blob = blob_from_bytes(&variant.bytes, &variant.content_type)?;
+                let object = self
+                    .upload_one(
+                        UploadSource {
+                            blob,
+                            name: variant.file_name.clone(),
+                            size: variant.bytes.len() as u64,
+                            content_type: Some(variant.content_type.clone()),
+                            last_modified: self.source.last_modified,
+                        },
+                        &variant.name,
+                        Some((variant.width, variant.height)),
+                        base_key.as_deref(),
+                    )
+                    .await?;
+                manifest.variants.push(ImageVariantObject {
+                    name: variant.name,
+                    object,
+                    width: variant.width,
+                    height: variant.height,
+                    content_type: variant.content_type,
+                });
+            }
+
+            Ok(manifest)
+        }
+
+        async fn upload_one(
+            &self,
+            source: UploadSource,
+            variant_name: &str,
+            dimensions: Option<(u32, u32)>,
+            base_key: Option<&str>,
+        ) -> StorageResult<ObjectRef> {
+            UploadBuilder {
+                endpoint: self.endpoint.clone(),
+                with_credentials: self.with_credentials,
+                scope: self.scope.clone(),
+                source,
+                strategy: self.strategy,
+                metadata: self.variant_metadata(variant_name, dimensions, base_key),
+                progress: self.variant_progress(variant_name),
+                retry_limit: self.retry_limit,
+                retry_base_delay_ms: self.retry_base_delay_ms,
+                abort_signal: self.abort_signal.clone(),
+                resume_session: None,
+                auto_resume: false,
+            }
+            .send()
+            .await
+        }
+
+        fn variant_metadata(
+            &self,
+            variant_name: &str,
+            dimensions: Option<(u32, u32)>,
+            base_key: Option<&str>,
+        ) -> BTreeMap<String, String> {
+            let mut metadata = self.metadata.clone();
+            metadata.insert(
+                IMAGE_VARIANT_METADATA_KEY.to_string(),
+                variant_name.to_string(),
+            );
+            if let Some(base_key) = base_key {
+                metadata.insert(
+                    IMAGE_VARIANT_BASE_KEY_METADATA_KEY.to_string(),
+                    base_key.to_string(),
+                );
+            }
+            if let Some((width, height)) = dimensions {
+                metadata.insert(
+                    IMAGE_VARIANT_WIDTH_METADATA_KEY.to_string(),
+                    width.to_string(),
+                );
+                metadata.insert(
+                    IMAGE_VARIANT_HEIGHT_METADATA_KEY.to_string(),
+                    height.to_string(),
+                );
+            }
+            metadata
+        }
+
+        fn variant_progress(&self, variant_name: &str) -> Option<Rc<dyn Fn(UploadProgress)>> {
+            self.progress.as_ref().map(|callback| {
+                let callback = callback.clone();
+                let variant_name = variant_name.to_string();
+                Rc::new(move |progress| callback(variant_name.clone(), progress))
+                    as Rc<dyn Fn(UploadProgress)>
+            })
+        }
     }
 
     /// Browser upload builder.
@@ -1883,13 +2208,18 @@ mod wasm {
         )
     }
 
-    fn object_url(endpoint: &str, scope: &str, key: &str) -> String {
-        format!(
+    fn object_url(endpoint: &str, scope: &str, key: &str, variant: Option<&str>) -> String {
+        let mut url = format!(
             "{}/scopes/{}/objects/{}",
             endpoint.trim_end_matches('/'),
             pocopine_codec::percent_encode(scope),
             encode_object_key_path(key)
-        )
+        );
+        if let Some(variant) = variant {
+            url.push_str("?variant=");
+            url.push_str(&pocopine_codec::percent_encode(variant));
+        }
+        url
     }
 
     fn object_read_url(endpoint: &str, scope: &str, key: &str) -> String {
@@ -1924,6 +2254,28 @@ mod wasm {
         format!("{}/complete", upload_url(endpoint, session))
     }
 
+    #[cfg(feature = "image-compression")]
+    async fn read_blob_bytes(blob: &Blob) -> StorageResult<Vec<u8>> {
+        let value = JsFuture::from(blob.array_buffer())
+            .await
+            .map_err(|err| StorageError::client(format!("read image blob: {err:?}")))?;
+        let buffer: ArrayBuffer = value.dyn_into().map_err(|err| {
+            StorageError::client(format!("image blob was not ArrayBuffer: {err:?}"))
+        })?;
+        Ok(Uint8Array::new(&buffer).to_vec())
+    }
+
+    #[cfg(feature = "image-compression")]
+    fn blob_from_bytes(bytes: &[u8], content_type: &str) -> StorageResult<Blob> {
+        let array = Uint8Array::from(bytes);
+        let parts = Array::new();
+        parts.push(&array);
+        let options = BlobPropertyBag::new();
+        options.set_type(content_type);
+        Blob::new_with_u8_array_sequence_and_options(&parts, &options)
+            .map_err(|err| StorageError::client(format!("create image variant blob: {err:?}")))
+    }
+
     fn empty_to_none(value: String) -> Option<String> {
         (!value.is_empty()).then_some(value)
     }
@@ -1934,6 +2286,9 @@ pub use wasm::{
     BrowserStorageRequest, BrowserStorageResponse, BrowserStorageTransport, ResumableUploadBuilder,
     UploadBuilder,
 };
+
+#[cfg(all(target_arch = "wasm32", feature = "image-compression"))]
+pub use wasm::ImageUploadBuilder;
 
 #[cfg(all(target_arch = "wasm32", any(test, feature = "test-utils")))]
 pub use wasm::{__reset_browser_transport_for_test, __set_browser_transport_for_test};

--- a/crates/pocopine-storage/src/image_compression.rs
+++ b/crates/pocopine-storage/src/image_compression.rs
@@ -1,0 +1,363 @@
+use fast_image_resize::images::Image;
+use fast_image_resize::{PixelType, ResizeOptions, Resizer};
+use jpeg_encoder::{ColorType, Encoder};
+use zune_core::bytestream::ZCursor;
+use zune_core::colorspace::ColorSpace;
+use zune_core::options::DecoderOptions;
+use zune_jpeg::JpegDecoder;
+use zune_png::PngDecoder;
+
+use crate::{
+    ImageVariantFormat, ImageVariantResize, ImageVariantSpec, StorageError, StorageResult,
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ImageSourceInfo {
+    pub width: u32,
+    pub height: u32,
+    pub content_type: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CompressedImageVariant {
+    pub name: String,
+    pub file_name: String,
+    pub bytes: Vec<u8>,
+    pub width: u32,
+    pub height: u32,
+    pub content_type: String,
+}
+
+struct DecodedImage {
+    info: ImageSourceInfo,
+    pixels: Vec<u8>,
+}
+
+pub fn inspect_image(bytes: &[u8]) -> StorageResult<ImageSourceInfo> {
+    Ok(decode_image(bytes)?.info)
+}
+
+pub fn compress_image_variant(
+    source_name: &str,
+    bytes: &[u8],
+    variant: &ImageVariantSpec,
+) -> StorageResult<CompressedImageVariant> {
+    let (_, mut variants) = compress_image_variants(source_name, bytes, [variant.clone()])?;
+    variants
+        .pop()
+        .ok_or_else(|| StorageError::client("image compression produced no variant"))
+}
+
+pub fn compress_image_variants(
+    source_name: &str,
+    bytes: &[u8],
+    variants: impl IntoIterator<Item = ImageVariantSpec>,
+) -> StorageResult<(ImageSourceInfo, Vec<CompressedImageVariant>)> {
+    let decoded = decode_image(bytes)?;
+    let mut compressed = Vec::new();
+    for variant in variants {
+        variant.validate()?;
+        compressed.push(compress_decoded_image(source_name, &decoded, &variant)?);
+    }
+    Ok((decoded.info, compressed))
+}
+
+fn decode_image(bytes: &[u8]) -> StorageResult<DecodedImage> {
+    if bytes.starts_with(&[0xff, 0xd8, 0xff]) {
+        return decode_jpeg(bytes);
+    }
+    if bytes.starts_with(b"\x89PNG\r\n\x1a\n") {
+        return decode_png(bytes);
+    }
+    Err(StorageError::unsupported(
+        "image compression currently supports JPEG and PNG inputs",
+    ))
+}
+
+fn decode_jpeg(bytes: &[u8]) -> StorageResult<DecodedImage> {
+    let options = DecoderOptions::default().jpeg_set_out_colorspace(ColorSpace::RGB);
+    let mut decoder = JpegDecoder::new_with_options(ZCursor::new(bytes), options);
+    let pixels = decoder
+        .decode()
+        .map_err(|err| StorageError::client(format!("decode JPEG image: {err}")))?;
+    let info = decoder
+        .info()
+        .ok_or_else(|| StorageError::client("JPEG decoder omitted image info"))?;
+    let width = u32::from(info.width);
+    let height = u32::from(info.height);
+    validate_rgb_len(width, height, pixels.len())?;
+    Ok(DecodedImage {
+        info: ImageSourceInfo {
+            width,
+            height,
+            content_type: "image/jpeg".to_string(),
+        },
+        pixels,
+    })
+}
+
+fn decode_png(bytes: &[u8]) -> StorageResult<DecodedImage> {
+    let options = DecoderOptions::default().png_set_strip_to_8bit(true);
+    let mut decoder = PngDecoder::new_with_options(ZCursor::new(bytes), options);
+    decoder
+        .decode_headers()
+        .map_err(|err| StorageError::client(format!("decode PNG headers: {err}")))?;
+    let (width, height) = decoder
+        .dimensions()
+        .ok_or_else(|| StorageError::client("PNG decoder omitted dimensions"))?;
+    let colorspace = decoder
+        .colorspace()
+        .ok_or_else(|| StorageError::client("PNG decoder omitted colorspace"))?;
+    let decoded = decoder
+        .decode()
+        .map_err(|err| StorageError::client(format!("decode PNG image: {err}")))?;
+    let samples = decoded
+        .u8()
+        .ok_or_else(|| StorageError::unsupported("PNG decoder returned non-8-bit samples"))?;
+    let width =
+        u32::try_from(width).map_err(|_| StorageError::unsupported("PNG width is too large"))?;
+    let height =
+        u32::try_from(height).map_err(|_| StorageError::unsupported("PNG height is too large"))?;
+    let pixels = png_to_rgb(samples, colorspace)?;
+    validate_rgb_len(width, height, pixels.len())?;
+    Ok(DecodedImage {
+        info: ImageSourceInfo {
+            width,
+            height,
+            content_type: "image/png".to_string(),
+        },
+        pixels,
+    })
+}
+
+fn png_to_rgb(samples: Vec<u8>, colorspace: ColorSpace) -> StorageResult<Vec<u8>> {
+    match colorspace {
+        ColorSpace::RGB => Ok(samples),
+        ColorSpace::Luma => {
+            let mut out = Vec::with_capacity(samples.len() * 3);
+            for luma in samples {
+                out.extend_from_slice(&[luma, luma, luma]);
+            }
+            Ok(out)
+        }
+        ColorSpace::RGBA => {
+            let mut out = Vec::with_capacity(samples.len() / 4 * 3);
+            for pixel in samples.chunks_exact(4) {
+                push_matted_rgb(&mut out, pixel[0], pixel[1], pixel[2], pixel[3]);
+            }
+            Ok(out)
+        }
+        ColorSpace::LumaA => {
+            let mut out = Vec::with_capacity(samples.len() / 2 * 3);
+            for pixel in samples.chunks_exact(2) {
+                push_matted_rgb(&mut out, pixel[0], pixel[0], pixel[0], pixel[1]);
+            }
+            Ok(out)
+        }
+        ColorSpace::BGR => {
+            let mut out = Vec::with_capacity(samples.len());
+            for pixel in samples.chunks_exact(3) {
+                out.extend_from_slice(&[pixel[2], pixel[1], pixel[0]]);
+            }
+            Ok(out)
+        }
+        ColorSpace::BGRA => {
+            let mut out = Vec::with_capacity(samples.len() / 4 * 3);
+            for pixel in samples.chunks_exact(4) {
+                push_matted_rgb(&mut out, pixel[2], pixel[1], pixel[0], pixel[3]);
+            }
+            Ok(out)
+        }
+        ColorSpace::ARGB => {
+            let mut out = Vec::with_capacity(samples.len() / 4 * 3);
+            for pixel in samples.chunks_exact(4) {
+                push_matted_rgb(&mut out, pixel[1], pixel[2], pixel[3], pixel[0]);
+            }
+            Ok(out)
+        }
+        other => Err(StorageError::unsupported(format!(
+            "PNG colorspace is not supported for JPEG variants: {other:?}"
+        ))),
+    }
+}
+
+fn push_matted_rgb(out: &mut Vec<u8>, r: u8, g: u8, b: u8, alpha: u8) {
+    out.push(matte_over_white(r, alpha));
+    out.push(matte_over_white(g, alpha));
+    out.push(matte_over_white(b, alpha));
+}
+
+fn matte_over_white(channel: u8, alpha: u8) -> u8 {
+    let alpha = u16::from(alpha);
+    let channel = u16::from(channel);
+    ((channel * alpha + 255 * (255 - alpha) + 127) / 255) as u8
+}
+
+fn compress_decoded_image(
+    source_name: &str,
+    decoded: &DecodedImage,
+    variant: &ImageVariantSpec,
+) -> StorageResult<CompressedImageVariant> {
+    let ImageVariantFormat::Jpeg = variant.format;
+    let (width, height, resize_options) =
+        variant_dimensions(decoded.info.width, decoded.info.height, variant.resize)?;
+    ensure_jpeg_dimensions(width, height)?;
+
+    let src = Image::from_vec_u8(
+        decoded.info.width,
+        decoded.info.height,
+        decoded.pixels.clone(),
+        PixelType::U8x3,
+    )
+    .map_err(|err| StorageError::client(format!("prepare source image: {err}")))?;
+    let mut dst = Image::new(width, height, PixelType::U8x3);
+    let mut resizer = Resizer::new();
+    resizer
+        .resize(&src, &mut dst, Some(&resize_options))
+        .map_err(|err| StorageError::client(format!("resize image variant: {err}")))?;
+
+    let mut bytes = Vec::new();
+    Encoder::new(&mut bytes, variant.quality)
+        .encode(dst.buffer(), width as u16, height as u16, ColorType::Rgb)
+        .map_err(|err| StorageError::client(format!("encode JPEG variant: {err}")))?;
+
+    Ok(CompressedImageVariant {
+        name: variant.name.clone(),
+        file_name: variant.output_file_name(source_name),
+        bytes,
+        width,
+        height,
+        content_type: variant.format.content_type().to_string(),
+    })
+}
+
+fn variant_dimensions(
+    source_width: u32,
+    source_height: u32,
+    resize: ImageVariantResize,
+) -> StorageResult<(u32, u32, ResizeOptions)> {
+    if source_width == 0 || source_height == 0 {
+        return Err(StorageError::client("image dimensions must be non-zero"));
+    }
+    match resize {
+        ImageVariantResize::Fit {
+            max_width,
+            max_height,
+        } => {
+            resize.validate()?;
+            if source_width <= max_width && source_height <= max_height {
+                return Ok((source_width, source_height, ResizeOptions::new()));
+            }
+            let source_width = u64::from(source_width);
+            let source_height = u64::from(source_height);
+            let max_width = u64::from(max_width);
+            let max_height = u64::from(max_height);
+            let (width, height) = if source_width * max_height > source_height * max_width {
+                (
+                    max_width,
+                    ((source_height * max_width) + source_width / 2) / source_width,
+                )
+            } else {
+                (
+                    ((source_width * max_height) + source_height / 2) / source_height,
+                    max_height,
+                )
+            };
+            Ok((
+                u32::try_from(width.max(1))
+                    .map_err(|_| StorageError::unsupported("image variant width is too large"))?,
+                u32::try_from(height.max(1))
+                    .map_err(|_| StorageError::unsupported("image variant height is too large"))?,
+                ResizeOptions::new(),
+            ))
+        }
+        ImageVariantResize::Cover { width, height } => {
+            resize.validate()?;
+            Ok((
+                width,
+                height,
+                ResizeOptions::new().fit_into_destination(Some((0.5, 0.5))),
+            ))
+        }
+    }
+}
+
+fn validate_rgb_len(width: u32, height: u32, len: usize) -> StorageResult<()> {
+    let expected = usize::try_from(width)
+        .ok()
+        .and_then(|width| {
+            usize::try_from(height)
+                .ok()
+                .and_then(|height| width.checked_mul(height))
+        })
+        .and_then(|pixels| pixels.checked_mul(3))
+        .ok_or_else(|| StorageError::unsupported("image dimensions are too large"))?;
+    if len != expected {
+        return Err(StorageError::client(format!(
+            "decoded image length mismatch: expected {expected} bytes, got {len}"
+        )));
+    }
+    Ok(())
+}
+
+fn ensure_jpeg_dimensions(width: u32, height: u32) -> StorageResult<()> {
+    if width > u32::from(u16::MAX) || height > u32::from(u16::MAX) {
+        return Err(StorageError::unsupported(
+            "JPEG variants cannot exceed 65535 pixels on either axis",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn jpeg_fixture(width: u16, height: u16) -> Vec<u8> {
+        let mut pixels = Vec::with_capacity(usize::from(width) * usize::from(height) * 3);
+        for y in 0..height {
+            for x in 0..width {
+                pixels.push((x % 251) as u8);
+                pixels.push((y % 251) as u8);
+                pixels.push(((x + y) % 251) as u8);
+            }
+        }
+
+        let mut bytes = Vec::new();
+        Encoder::new(&mut bytes, 92)
+            .encode(&pixels, width, height, ColorType::Rgb)
+            .unwrap();
+        bytes
+    }
+
+    #[test]
+    fn fit_variant_downscales_without_upscaling() {
+        let image = jpeg_fixture(80, 40);
+        let small = ImageVariantSpec::fit("small", 20, 20);
+        let variant = compress_image_variant("avatar.jpeg", &image, &small).unwrap();
+        assert_eq!(variant.width, 20);
+        assert_eq!(variant.height, 10);
+        assert_eq!(variant.file_name, "avatar-small.jpg");
+
+        let large = ImageVariantSpec::fit("large", 200, 200);
+        let variant = compress_image_variant("avatar.jpeg", &image, &large).unwrap();
+        assert_eq!(variant.width, 80);
+        assert_eq!(variant.height, 40);
+    }
+
+    #[test]
+    fn cover_variant_uses_exact_target_dimensions() {
+        let image = jpeg_fixture(80, 40);
+        let variant = compress_image_variant(
+            "avatar.jpeg",
+            &image,
+            &ImageVariantSpec::cover("square", 24, 24).quality(76),
+        )
+        .unwrap();
+
+        assert_eq!(variant.width, 24);
+        assert_eq!(variant.height, 24);
+        assert_eq!(variant.content_type, "image/jpeg");
+        assert!(!variant.bytes.is_empty());
+    }
+}

--- a/crates/pocopine-storage/src/lib.rs
+++ b/crates/pocopine-storage/src/lib.rs
@@ -13,6 +13,8 @@ pub mod backend_common;
 pub mod checksum;
 mod client;
 mod error;
+#[cfg(feature = "image-compression")]
+mod image_compression;
 mod protocol;
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -22,6 +24,8 @@ mod memory;
 #[cfg(not(target_arch = "wasm32"))]
 mod server;
 
+#[cfg(feature = "image-compression")]
+pub use client::ImageUploadBuilder;
 #[cfg(target_arch = "wasm32")]
 #[doc(hidden)]
 pub use client::{BrowserStorageRequest, BrowserStorageResponse, BrowserStorageTransport};
@@ -35,17 +39,26 @@ pub use client::{
 #[doc(hidden)]
 pub use client::{__reset_browser_transport_for_test, __set_browser_transport_for_test};
 pub use error::{StorageError, StorageResult};
+#[cfg(feature = "image-compression")]
+pub use image_compression::{
+    CompressedImageVariant, ImageSourceInfo, compress_image_variant, compress_image_variants,
+    inspect_image,
+};
 pub use protocol::{
     AnonymousUploadBinding, BackendCapabilities, ChecksumAlgorithm, ChecksumPolicy, CompleteUpload,
-    CompleteUploadRequest, InitiateUpload, InitiateUploadRequest, MAX_STORAGE_TOKEN_LEN,
-    MetadataSchema, ObjectChecksum, ObjectMetadata, ObjectOwnerRef, ObjectRef, ObjectVisibility,
-    PartSpec, PrincipalRef, ReadDisposition, ReadUrlRequest, STORAGE_ANON_COOKIE,
-    STORAGE_ENDPOINT_PREFIX, STORAGE_OBJECTS_PREFIX, STORAGE_PROTOCOL_V1, STORAGE_SCOPES_PREFIX,
-    STORAGE_TUS_ENDPOINT_PREFIX, STORAGE_UPLOADS_PATH, STORAGE_UPLOADS_PREFIX, SafeObjectKey,
-    SignedRead, StorageBackendName, StorageKey, StorageObjectScope, StorageResponse, TransferPlan,
-    UploadIntent, UploadPhase, UploadPolicy, UploadPolicyDescriptor, UploadProgress, UploadSession,
-    UploadSessionId, UploadSessionStatus, UploadStrategy, UploadTarget, UploadedPartStatus,
-    UploadedPartView, plan_parts,
+    CompleteUploadRequest, IMAGE_VARIANT_BASE_KEY_METADATA_KEY, IMAGE_VARIANT_HEIGHT_METADATA_KEY,
+    IMAGE_VARIANT_METADATA_KEY, IMAGE_VARIANT_ORIGINAL, IMAGE_VARIANT_WIDTH_METADATA_KEY,
+    ImageUploadManifest, ImageVariantFormat, ImageVariantObject, ImageVariantPolicy,
+    ImageVariantResize, ImageVariantSpec, InitiateUpload, InitiateUploadRequest,
+    MAX_STORAGE_TOKEN_LEN, MetadataSchema, ObjectChecksum, ObjectMetadata, ObjectOwnerRef,
+    ObjectRef, ObjectVisibility, PartSpec, PrincipalRef, ReadDisposition, ReadUrlRequest,
+    STORAGE_ANON_COOKIE, STORAGE_ENDPOINT_PREFIX, STORAGE_OBJECTS_PREFIX, STORAGE_PROTOCOL_V1,
+    STORAGE_SCOPES_PREFIX, STORAGE_TUS_ENDPOINT_PREFIX, STORAGE_UPLOADS_PATH,
+    STORAGE_UPLOADS_PREFIX, SafeObjectKey, SignedRead, StorageBackendName, StorageKey,
+    StorageObjectScope, StorageResponse, TransferPlan, UploadIntent, UploadPhase, UploadPolicy,
+    UploadPolicyDescriptor, UploadProgress, UploadSession, UploadSessionId, UploadSessionStatus,
+    UploadStrategy, UploadTarget, UploadedPartStatus, UploadedPartView, image_variant_key,
+    plan_parts,
 };
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -57,8 +70,8 @@ pub use memory::MemoryStorageBackend;
 #[cfg(not(target_arch = "wasm32"))]
 pub use server::{
     ObjectBody, ObjectRead, StorageActor, StorageBackend, StorageBoxFuture, StorageContext,
-    StorageGuardFuture, StorageKeyFuture, StorageKeyResolver, StorageScope, StorageScopeBuilder,
-    StorageScopeGuard, StorageServer, StorageServerBuilder, StorageServerPlugin,
-    StorageTusServerPlugin, UploadBody, UploadByteStream, storage_server_plugin,
-    storage_tus_server_plugin,
+    StorageGuardFuture, StorageKeyFuture, StorageKeyResolver, StorageObjectAccess,
+    StorageObjectGuard, StorageScope, StorageScopeBuilder, StorageScopeGuard, StorageServer,
+    StorageServerBuilder, StorageServerPlugin, StorageTusServerPlugin, UploadBody,
+    UploadByteStream, storage_server_plugin, storage_tus_server_plugin,
 };

--- a/crates/pocopine-storage/src/protocol.rs
+++ b/crates/pocopine-storage/src/protocol.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 use std::time::Duration;
 
@@ -32,6 +32,16 @@ pub const STORAGE_OBJECTS_PREFIX: &str = storage_path!("/scopes");
 pub const STORAGE_TUS_ENDPOINT_PREFIX: &str = "/__pocopine/storage/tus/v1";
 /// Anonymous upload binding cookie read by the storage server.
 pub const STORAGE_ANON_COOKIE: &str = "pocopine_storage_anon";
+/// Metadata key attached to image variant uploads.
+pub const IMAGE_VARIANT_METADATA_KEY: &str = "pocopine.image.variant";
+/// Metadata value used when the original image is uploaded as part of a manifest.
+pub const IMAGE_VARIANT_ORIGINAL: &str = "original";
+/// Metadata key that links an uploaded variant to its canonical image object.
+pub const IMAGE_VARIANT_BASE_KEY_METADATA_KEY: &str = "pocopine.image.base_key";
+/// Metadata key attached to image uploads with the encoded width.
+pub const IMAGE_VARIANT_WIDTH_METADATA_KEY: &str = "pocopine.image.width";
+/// Metadata key attached to image uploads with the encoded height.
+pub const IMAGE_VARIANT_HEIGHT_METADATA_KEY: &str = "pocopine.image.height";
 
 /// Stable JSON envelope used by storage HTTP routes.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -81,6 +91,240 @@ impl<T> StorageResponse<T> {
 
 fn none<T>() -> Option<T> {
     None
+}
+
+/// Build the deterministic sibling key for an image variant.
+///
+/// `avatars/u/photo.png` + `thumb64` becomes
+/// `avatars/u/photo.thumb64.jpg`. Variants are currently JPEG outputs, so the
+/// suffix always uses `.jpg`.
+pub fn image_variant_key(
+    base_key: impl AsRef<str>,
+    variant: impl AsRef<str>,
+) -> StorageResult<SafeObjectKey> {
+    let base_key = base_key.as_ref();
+    let variant = variant.as_ref();
+    if variant == IMAGE_VARIANT_ORIGINAL {
+        return SafeObjectKey::parse(base_key);
+    }
+    validate_image_variant_name(variant)?;
+
+    let (dir, file_name) = base_key
+        .rsplit_once('/')
+        .map_or(("", base_key), |(dir, file_name)| (dir, file_name));
+    let stem = file_name
+        .rsplit_once('.')
+        .filter(|(stem, _)| !stem.is_empty())
+        .map_or(file_name, |(stem, _)| stem);
+    let file_name = format!("{stem}.{variant}.jpg");
+    if dir.is_empty() {
+        SafeObjectKey::parse(file_name)
+    } else {
+        SafeObjectKey::parse(format!("{dir}/{file_name}"))
+    }
+}
+
+/// Browser-side output codec for generated image variants.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ImageVariantFormat {
+    /// Lossy JPEG output. This is the first supported client-side compression
+    /// format because the Rust encoder path is `no_std + alloc` compatible.
+    Jpeg,
+}
+
+impl ImageVariantFormat {
+    pub fn content_type(self) -> &'static str {
+        match self {
+            Self::Jpeg => "image/jpeg",
+        }
+    }
+
+    pub fn extension(self) -> &'static str {
+        match self {
+            Self::Jpeg => "jpg",
+        }
+    }
+}
+
+/// Resize operation for a generated image variant.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ImageVariantResize {
+    /// Preserve aspect ratio and fit inside the requested bounds. Smaller
+    /// source images are not upscaled.
+    Fit { max_width: u32, max_height: u32 },
+    /// Center-crop to match the requested aspect ratio, then resize exactly.
+    Cover { width: u32, height: u32 },
+}
+
+impl ImageVariantResize {
+    pub(crate) fn validate(&self) -> StorageResult<()> {
+        match self {
+            Self::Fit {
+                max_width,
+                max_height,
+            } => {
+                if *max_width == 0 || *max_height == 0 {
+                    return Err(StorageError::policy_rejected(
+                        "image fit variant dimensions must be greater than zero",
+                    ));
+                }
+            }
+            Self::Cover { width, height } => {
+                if *width == 0 || *height == 0 {
+                    return Err(StorageError::policy_rejected(
+                        "image cover variant dimensions must be greater than zero",
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// One app-defined image variant emitted before upload.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ImageVariantSpec {
+    pub name: String,
+    pub resize: ImageVariantResize,
+    pub format: ImageVariantFormat,
+    /// JPEG quality in the inclusive 1..=100 range.
+    pub quality: u8,
+}
+
+impl ImageVariantSpec {
+    pub fn fit(name: impl Into<String>, max_width: u32, max_height: u32) -> Self {
+        Self {
+            name: name.into(),
+            resize: ImageVariantResize::Fit {
+                max_width,
+                max_height,
+            },
+            format: ImageVariantFormat::Jpeg,
+            quality: 82,
+        }
+    }
+
+    pub fn cover(name: impl Into<String>, width: u32, height: u32) -> Self {
+        Self {
+            name: name.into(),
+            resize: ImageVariantResize::Cover { width, height },
+            format: ImageVariantFormat::Jpeg,
+            quality: 82,
+        }
+    }
+
+    pub fn format(mut self, format: ImageVariantFormat) -> Self {
+        self.format = format;
+        self
+    }
+
+    pub fn quality(mut self, quality: u8) -> Self {
+        self.quality = quality.clamp(1, 100);
+        self
+    }
+
+    pub fn output_file_name(&self, source_name: &str) -> String {
+        let file_name = source_name.rsplit('/').next().unwrap_or(source_name);
+        let stem = file_name
+            .rsplit_once('.')
+            .filter(|(stem, _)| !stem.is_empty())
+            .map_or(file_name, |(stem, _)| stem);
+        format!("{stem}-{}.{}", self.name, self.format.extension())
+    }
+
+    pub(crate) fn validate(&self) -> StorageResult<()> {
+        validate_image_variant_name(&self.name)?;
+        if self.name == IMAGE_VARIANT_ORIGINAL {
+            return Err(StorageError::policy_rejected(
+                "image variant name 'original' is reserved",
+            ));
+        }
+        self.resize.validate()?;
+        if !(1..=100).contains(&self.quality) {
+            return Err(StorageError::policy_rejected(
+                "image variant quality must be between 1 and 100",
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Client-side image variant policy for a typed object scope.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ImageVariantPolicy {
+    pub keep_original: bool,
+    pub variants: Vec<ImageVariantSpec>,
+}
+
+impl Default for ImageVariantPolicy {
+    fn default() -> Self {
+        Self {
+            keep_original: true,
+            variants: Vec::new(),
+        }
+    }
+}
+
+impl ImageVariantPolicy {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Control whether the original object is uploaded.
+    ///
+    /// Linked variant uploads currently require this to remain `true` because
+    /// each variant key is derived from the resolved original object key.
+    pub fn keep_original(mut self, keep_original: bool) -> Self {
+        self.keep_original = keep_original;
+        self
+    }
+
+    pub fn variant(mut self, variant: ImageVariantSpec) -> Self {
+        self.variants.push(variant);
+        self
+    }
+
+    pub fn variants(mut self, variants: impl IntoIterator<Item = ImageVariantSpec>) -> Self {
+        self.variants.extend(variants);
+        self
+    }
+
+    pub fn validate(&self) -> StorageResult<()> {
+        if !self.keep_original {
+            return Err(StorageError::policy_rejected(
+                "linked image variants require keeping the original object",
+            ));
+        }
+        let mut names = BTreeSet::new();
+        for variant in &self.variants {
+            variant.validate()?;
+            if !names.insert(variant.name.as_str()) {
+                return Err(StorageError::policy_rejected(format!(
+                    "duplicate image variant name: {}",
+                    variant.name
+                )));
+            }
+        }
+        Ok(())
+    }
+}
+
+fn validate_image_variant_name(name: &str) -> StorageResult<()> {
+    let bytes = name.as_bytes();
+    let valid = !bytes.is_empty()
+        && bytes.len() <= 64
+        && bytes[0].is_ascii_alphanumeric()
+        && bytes
+            .iter()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.'));
+    if !valid {
+        return Err(StorageError::invalid_value("image variant name", name));
+    }
+    Ok(())
 }
 
 fn validate_token(field: &'static str, value: String) -> StorageResult<String> {
@@ -538,6 +782,11 @@ impl UploadPolicy {
         self
     }
 
+    pub fn metadata_schema(mut self, metadata_schema: MetadataSchema) -> Self {
+        self.metadata_schema = metadata_schema;
+        self
+    }
+
     #[cfg(not(target_arch = "wasm32"))]
     pub(crate) fn validate_configuration(&self) -> StorageResult<()> {
         if self.max_bytes == 0 {
@@ -686,6 +935,25 @@ impl Default for MetadataSchema {
 }
 
 impl MetadataSchema {
+    pub fn allowed_keys<I, S>(mut self, values: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.allowed_keys = values.into_iter().map(Into::into).collect();
+        self
+    }
+
+    pub fn max_key_bytes(mut self, max_key_bytes: usize) -> Self {
+        self.max_key_bytes = max_key_bytes;
+        self
+    }
+
+    pub fn max_value_bytes(mut self, max_value_bytes: usize) -> Self {
+        self.max_value_bytes = max_value_bytes;
+        self
+    }
+
     #[cfg(not(target_arch = "wasm32"))]
     fn validate(&self, metadata: &BTreeMap<String, String>) -> StorageResult<()> {
         for (key, value) in metadata {
@@ -796,6 +1064,63 @@ pub struct ObjectRef {
     pub size: u64,
     pub visibility: ObjectVisibility,
     pub metadata: BTreeMap<String, String>,
+}
+
+/// One uploaded object inside an image upload manifest.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ImageVariantObject {
+    pub name: String,
+    pub object: ObjectRef,
+    pub width: u32,
+    pub height: u32,
+    pub content_type: String,
+}
+
+impl ImageVariantObject {
+    pub fn key(&self) -> &str {
+        self.object.key.as_str()
+    }
+
+    pub fn object_ref(&self) -> &ObjectRef {
+        &self.object
+    }
+}
+
+/// Result returned by a client-side image variant upload.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ImageUploadManifest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub original: Option<ImageVariantObject>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub variants: Vec<ImageVariantObject>,
+}
+
+impl ImageUploadManifest {
+    pub fn original(&self) -> Option<&ImageVariantObject> {
+        self.original.as_ref()
+    }
+
+    pub fn variant(&self, name: impl AsRef<str>) -> Option<&ImageVariantObject> {
+        let name = name.as_ref();
+        self.variants.iter().find(|variant| variant.name == name)
+    }
+
+    pub fn entry(&self, name: impl AsRef<str>) -> Option<&ImageVariantObject> {
+        let name = name.as_ref();
+        if name == IMAGE_VARIANT_ORIGINAL {
+            self.original()
+        } else {
+            self.variant(name)
+        }
+    }
+
+    pub fn object_ref(&self, name: impl AsRef<str>) -> Option<&ObjectRef> {
+        self.entry(name).map(ImageVariantObject::object_ref)
+    }
+
+    pub fn key(&self, name: impl AsRef<str>) -> Option<&str> {
+        self.entry(name).map(ImageVariantObject::key)
+    }
 }
 
 /// Public upload session view.
@@ -954,6 +1279,8 @@ pub struct ReadUrlRequest {
     pub disposition: ReadDisposition,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expires_seconds: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub variant: Option<String>,
 }
 
 impl Default for ReadUrlRequest {
@@ -961,7 +1288,25 @@ impl Default for ReadUrlRequest {
         Self {
             disposition: ReadDisposition::Inline,
             expires_seconds: None,
+            variant: None,
         }
+    }
+}
+
+impl ReadUrlRequest {
+    pub fn variant(mut self, variant: impl Into<String>) -> Self {
+        self.variant = Some(variant.into());
+        self
+    }
+
+    pub fn expires_seconds(mut self, expires_seconds: u64) -> Self {
+        self.expires_seconds = Some(expires_seconds);
+        self
+    }
+
+    pub fn disposition(mut self, disposition: ReadDisposition) -> Self {
+        self.disposition = disposition;
+        self
     }
 }
 
@@ -1016,6 +1361,31 @@ impl UploadIntent {
     pub fn extension(&self) -> Option<&str> {
         file_extension(&self.file_name)
     }
+
+    pub fn image_variant_name(&self) -> Option<&str> {
+        self.metadata
+            .get(IMAGE_VARIANT_METADATA_KEY)
+            .map(String::as_str)
+    }
+
+    pub fn image_base_key(&self) -> Option<&str> {
+        self.metadata
+            .get(IMAGE_VARIANT_BASE_KEY_METADATA_KEY)
+            .map(String::as_str)
+    }
+
+    pub fn image_variant_object_key(&self) -> StorageResult<Option<SafeObjectKey>> {
+        let Some(variant) = self.image_variant_name() else {
+            return Ok(None);
+        };
+        if variant == IMAGE_VARIANT_ORIGINAL {
+            return Ok(None);
+        }
+        let Some(base_key) = self.image_base_key() else {
+            return Ok(None);
+        };
+        Ok(Some(image_variant_key(base_key, variant)?))
+    }
 }
 
 /// Backend upload initiation request.
@@ -1054,6 +1424,11 @@ pub struct CompleteUpload {
 pub trait StorageObjectScope: Send + Sync + 'static {
     /// Runtime storage scope name.
     const NAME: &'static str;
+
+    /// Client-side image variant policy for this scope.
+    fn image_variants() -> ImageVariantPolicy {
+        ImageVariantPolicy::default()
+    }
 
     /// Upload/read policy for this object scope.
     #[cfg(not(target_arch = "wasm32"))]
@@ -1210,5 +1585,141 @@ mod plan_parts_tests {
         // to allocate ~size parts; the absolute cap rejects it instead.
         let err = plan_parts(u64::MAX, &plan(1, 1, 1, None)).unwrap_err();
         assert!(matches!(err, StorageError::PolicyRejected { .. }));
+    }
+}
+
+#[cfg(test)]
+mod image_variant_policy_tests {
+    use super::*;
+
+    #[test]
+    fn validates_duplicate_variant_names() {
+        let policy = ImageVariantPolicy::new()
+            .variant(ImageVariantSpec::fit("avatar", 128, 128))
+            .variant(ImageVariantSpec::cover("avatar", 64, 64));
+
+        assert!(matches!(
+            policy.validate(),
+            Err(StorageError::PolicyRejected { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_reserved_original_variant_name() {
+        let policy = ImageVariantPolicy::new().variant(ImageVariantSpec::fit(
+            IMAGE_VARIANT_ORIGINAL,
+            128,
+            128,
+        ));
+
+        assert!(matches!(
+            policy.validate(),
+            Err(StorageError::PolicyRejected { .. })
+        ));
+    }
+
+    #[test]
+    fn linked_variants_must_keep_original() {
+        let policy = ImageVariantPolicy::new()
+            .keep_original(false)
+            .variant(ImageVariantSpec::fit("avatar", 128, 128));
+
+        assert!(matches!(
+            policy.validate(),
+            Err(StorageError::PolicyRejected { .. })
+        ));
+    }
+
+    #[test]
+    fn output_file_name_replaces_source_extension() {
+        let variant = ImageVariantSpec::fit("preview", 320, 320);
+
+        assert_eq!(
+            variant.output_file_name("avatars/profile.photo.png"),
+            "profile.photo-preview.jpg"
+        );
+    }
+
+    #[test]
+    fn variant_key_uses_suffix_before_jpeg_extension() {
+        assert_eq!(
+            image_variant_key("avatars/user-1/photo.png", "thumb64")
+                .unwrap()
+                .as_str(),
+            "avatars/user-1/photo.thumb64.jpg"
+        );
+    }
+
+    #[test]
+    fn upload_intent_derives_linked_variant_key() {
+        let intent = UploadIntent {
+            scope: "avatars".to_string(),
+            file_name: "photo.thumb64.jpg".to_string(),
+            size: Some(128),
+            content_type: Some("image/jpeg".to_string()),
+            metadata: [
+                (
+                    IMAGE_VARIANT_BASE_KEY_METADATA_KEY.to_string(),
+                    "avatars/user-1/photo.png".to_string(),
+                ),
+                (
+                    IMAGE_VARIANT_METADATA_KEY.to_string(),
+                    "thumb64".to_string(),
+                ),
+            ]
+            .into(),
+            requested_strategy: UploadStrategy::Auto,
+            generated_object_id: "generated".to_string(),
+        };
+
+        assert_eq!(
+            intent.image_variant_object_key().unwrap().unwrap().as_str(),
+            "avatars/user-1/photo.thumb64.jpg"
+        );
+    }
+
+    #[test]
+    fn manifest_looks_up_named_variants() {
+        let object = ObjectRef {
+            backend: "memory".to_string(),
+            scope: "avatars".to_string(),
+            key: "avatars/1/thumb64.jpg".to_string(),
+            version: None,
+            etag: None,
+            checksum: None,
+            content_type: Some("image/jpeg".to_string()),
+            size: 128,
+            visibility: ObjectVisibility::Private,
+            metadata: BTreeMap::new(),
+        };
+        let original = ImageVariantObject {
+            name: IMAGE_VARIANT_ORIGINAL.to_string(),
+            object: ObjectRef {
+                key: "avatars/1/original.jpg".to_string(),
+                ..object.clone()
+            },
+            width: 512,
+            height: 512,
+            content_type: "image/jpeg".to_string(),
+        };
+        let thumb = ImageVariantObject {
+            name: "thumb64".to_string(),
+            object,
+            width: 64,
+            height: 64,
+            content_type: "image/jpeg".to_string(),
+        };
+        let manifest = ImageUploadManifest {
+            original: Some(original),
+            variants: vec![thumb],
+        };
+
+        assert_eq!(manifest.variant("thumb64").unwrap().width, 64);
+        assert_eq!(manifest.key("thumb64"), Some("avatars/1/thumb64.jpg"));
+        assert_eq!(
+            manifest.key(IMAGE_VARIANT_ORIGINAL),
+            Some("avatars/1/original.jpg")
+        );
+        assert!(manifest.variant("missing").is_none());
     }
 }

--- a/crates/pocopine-storage/src/server.rs
+++ b/crates/pocopine-storage/src/server.rs
@@ -28,6 +28,7 @@ use pocopine_server::{Server, ServerPlugin};
 use time::OffsetDateTime;
 use uuid::Uuid;
 
+use crate::ObjectVisibility;
 use crate::backend_common::expires_at;
 use crate::{
     AnonymousUploadBinding, CompleteUpload, CompleteUploadRequest, InitiateUpload,
@@ -35,7 +36,7 @@ use crate::{
     ReadUrlRequest, STORAGE_ANON_COOKIE, STORAGE_PROTOCOL_V1, STORAGE_UPLOADS_PATH, SafeObjectKey,
     SignedRead, StorageBackendName, StorageError, StorageKey, StorageObjectScope, StorageResponse,
     StorageResult, UploadIntent, UploadPolicy, UploadPolicyDescriptor, UploadSession,
-    UploadSessionId, UploadStrategy,
+    UploadSessionId, UploadStrategy, image_variant_key,
 };
 
 const MAX_PROXY_PATCH_BYTES: u64 = 64 * 1024 * 1024;
@@ -184,6 +185,58 @@ where
             None => Decision::Deny(DenyReason::Unauthorized).into(),
         };
         Box::pin(async move { result })
+    }
+}
+
+/// Object-level operation passed to a key-aware storage guard.
+///
+/// Scope guards are intentionally coarse: they answer "may this actor use this
+/// scope?". Object guards answer "may this actor use this specific object key
+/// or upload intent?", which is required for private attachments and other
+/// per-object authorization rules.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum StorageObjectAccess {
+    Write { scope: String, intent: UploadIntent },
+    Read { scope: String, key: SafeObjectKey },
+    Delete { scope: String, key: SafeObjectKey },
+}
+
+impl StorageObjectAccess {
+    pub fn scope(&self) -> &str {
+        match self {
+            Self::Write { scope, .. } | Self::Read { scope, .. } | Self::Delete { scope, .. } => {
+                scope
+            }
+        }
+    }
+
+    pub fn key(&self) -> Option<&SafeObjectKey> {
+        match self {
+            Self::Read { key, .. } | Self::Delete { key, .. } => Some(key),
+            Self::Write { .. } => None,
+        }
+    }
+
+    pub fn intent(&self) -> Option<&UploadIntent> {
+        match self {
+            Self::Write { intent, .. } => Some(intent),
+            Self::Read { .. } | Self::Delete { .. } => None,
+        }
+    }
+}
+
+/// Server-side access check for a concrete storage object operation.
+pub trait StorageObjectGuard: Send + Sync + 'static {
+    fn check(&self, ctx: StorageContext, access: StorageObjectAccess) -> StorageGuardFuture<'_>;
+}
+
+impl<F, Fut> StorageObjectGuard for F
+where
+    F: Fn(StorageContext, StorageObjectAccess) -> Fut + Send + Sync + 'static,
+    Fut: Future<Output = ServerResult<()>> + Send + 'static,
+{
+    fn check(&self, ctx: StorageContext, access: StorageObjectAccess) -> StorageGuardFuture<'_> {
+        Box::pin((self)(ctx, access))
     }
 }
 
@@ -524,6 +577,7 @@ struct RegisteredStorageScope {
     write_guard: Option<Arc<dyn StorageScopeGuard>>,
     read_guard: Option<Arc<dyn StorageScopeGuard>>,
     delete_guard: Option<Arc<dyn StorageScopeGuard>>,
+    object_guard: Option<Arc<dyn StorageObjectGuard>>,
     key_resolver: Arc<dyn StorageKeyResolver>,
 }
 
@@ -551,6 +605,84 @@ impl RegisteredStorageScope {
             self.authorize_write(ctx).await
         }
     }
+
+    async fn authorize_object_write(
+        &self,
+        ctx: StorageContext,
+        scope: &str,
+        intent: &UploadIntent,
+    ) -> ServerResult<()> {
+        if let Some(guard) = &self.object_guard {
+            guard
+                .check(
+                    ctx,
+                    StorageObjectAccess::Write {
+                        scope: scope.to_string(),
+                        intent: intent.clone(),
+                    },
+                )
+                .await
+        } else {
+            Ok(())
+        }
+    }
+
+    async fn authorize_object_read(
+        &self,
+        ctx: StorageContext,
+        scope: &str,
+        key: &SafeObjectKey,
+    ) -> ServerResult<()> {
+        self.authorize_read(ctx.clone()).await?;
+        if let Some(guard) = &self.object_guard {
+            return guard
+                .check(
+                    ctx,
+                    StorageObjectAccess::Read {
+                        scope: scope.to_string(),
+                        key: key.clone(),
+                    },
+                )
+                .await;
+        }
+        self.allow_unguarded_object_access(&ctx, "read")
+    }
+
+    async fn authorize_object_delete(
+        &self,
+        ctx: StorageContext,
+        scope: &str,
+        key: &SafeObjectKey,
+    ) -> ServerResult<()> {
+        self.authorize_delete(ctx.clone()).await?;
+        if let Some(guard) = &self.object_guard {
+            return guard
+                .check(
+                    ctx,
+                    StorageObjectAccess::Delete {
+                        scope: scope.to_string(),
+                        key: key.clone(),
+                    },
+                )
+                .await;
+        }
+        self.allow_unguarded_object_access(&ctx, "delete")
+    }
+
+    fn allow_unguarded_object_access(
+        &self,
+        ctx: &StorageContext,
+        operation: &str,
+    ) -> ServerResult<()> {
+        if self.policy.visibility == ObjectVisibility::Public
+            || matches!(ctx.actor, StorageActor::System(_))
+        {
+            return Ok(());
+        }
+        Err(ServerError::forbidden(format!(
+            "private storage object {operation} requires a key-aware object guard or a signed read token"
+        )))
+    }
 }
 
 /// Server-registered storage scope.
@@ -566,6 +698,7 @@ impl StorageScope {
             write_guard: None,
             read_guard: None,
             delete_guard: None,
+            object_guard: None,
             key_resolver: Arc::new(GeneratedStorageKeyResolver),
         }
     }
@@ -586,6 +719,7 @@ pub struct StorageScopeBuilder {
     write_guard: Option<Arc<dyn StorageScopeGuard>>,
     read_guard: Option<Arc<dyn StorageScopeGuard>>,
     delete_guard: Option<Arc<dyn StorageScopeGuard>>,
+    object_guard: Option<Arc<dyn StorageObjectGuard>>,
     key_resolver: Arc<dyn StorageKeyResolver>,
 }
 
@@ -614,6 +748,14 @@ impl StorageScopeBuilder {
         self
     }
 
+    pub fn object_guard<G>(mut self, guard: G) -> Self
+    where
+        G: StorageObjectGuard,
+    {
+        self.object_guard = Some(Arc::new(guard));
+        self
+    }
+
     pub fn key_resolver<R>(mut self, resolver: R) -> Self
     where
         R: StorageKeyResolver,
@@ -629,6 +771,7 @@ impl StorageScopeBuilder {
                 write_guard: self.write_guard,
                 read_guard: self.read_guard,
                 delete_guard: self.delete_guard,
+                object_guard: self.object_guard,
                 key_resolver: self.key_resolver,
             },
         }
@@ -704,6 +847,10 @@ impl StorageServer {
             requested_strategy: request.requested_strategy,
             generated_object_id: Uuid::new_v4().to_string(),
         };
+        scope
+            .authorize_object_write(ctx.clone(), &request.scope, &intent)
+            .await
+            .map_err(storage_auth_error)?;
         let storage_key = scope.key_resolver.resolve_key(&ctx, &intent).await?;
         let backend = self.backend(scope.policy.backend.as_str())?;
         backend
@@ -834,8 +981,10 @@ impl StorageServer {
         request: ReadUrlRequest,
     ) -> StorageResult<SignedRead> {
         let scope = self.scope(&scope_name)?;
+        let variant = request.variant;
+        let effective_key = effective_read_key(&key, variant.as_deref())?;
         scope
-            .authorize_read(ctx)
+            .authorize_object_read(ctx, &scope_name, &effective_key)
             .await
             .map_err(storage_auth_error)?;
         let expires_after = request
@@ -847,12 +996,13 @@ impl StorageServer {
         let claims = ReadTokenClaims {
             scope: scope_name.clone(),
             key: key.to_string(),
+            variant: variant.clone(),
             disposition: request.disposition,
             expires_at,
         };
         let token = self.sign_read_token(&claims)?;
         Ok(SignedRead {
-            url: object_read_url(&scope_name, key.as_str(), Some(&token)),
+            url: object_read_url(&scope_name, key.as_str(), Some(&token), variant.as_deref()),
             headers: Vec::new(),
             expires_at,
         })
@@ -864,11 +1014,16 @@ impl StorageServer {
         scope_name: String,
         key: SafeObjectKey,
         token: Option<String>,
+        variant: Option<String>,
     ) -> StorageResult<(ObjectRead, ReadDisposition)> {
         let scope = self.scope(&scope_name)?;
+        let effective_key = effective_read_key(&key, variant.as_deref())?;
         let disposition = if let Some(token) = token {
             let claims = self.verify_read_token(&token)?;
-            if claims.scope != scope_name || claims.key != key.as_str() {
+            if claims.scope != scope_name
+                || claims.key != key.as_str()
+                || claims.variant.as_deref() != variant.as_deref()
+            {
                 return Err(StorageError::forbidden(
                     "storage read token does not match object",
                 ));
@@ -876,14 +1031,14 @@ impl StorageServer {
             claims.disposition
         } else {
             scope
-                .authorize_read(ctx.clone())
+                .authorize_object_read(ctx.clone(), &scope_name, &effective_key)
                 .await
                 .map_err(storage_auth_error)?;
             ReadDisposition::Inline
         };
         let backend = self.backend(scope.policy.backend.as_str())?;
         let object = backend
-            .read_object(&ctx, &scope_name, key, scope.policy.max_bytes)
+            .read_object(&ctx, &scope_name, effective_key, scope.policy.max_bytes)
             .await?;
         Ok((object, disposition))
     }
@@ -893,14 +1048,16 @@ impl StorageServer {
         ctx: StorageContext,
         scope_name: String,
         key: SafeObjectKey,
+        variant: Option<String>,
     ) -> StorageResult<()> {
         let scope = self.scope(&scope_name)?;
+        let effective_key = effective_read_key(&key, variant.as_deref())?;
         scope
-            .authorize_delete(ctx.clone())
+            .authorize_object_delete(ctx.clone(), &scope_name, &effective_key)
             .await
             .map_err(storage_auth_error)?;
         let backend = self.backend(scope.policy.backend.as_str())?;
-        backend.delete_completed_object(&ctx, key).await
+        backend.delete_completed_object(&ctx, effective_key).await
     }
 
     fn scope(&self, scope: &str) -> StorageResult<Arc<RegisteredStorageScope>> {
@@ -989,6 +1146,8 @@ impl StorageServer {
 struct ReadTokenClaims {
     scope: String,
     key: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    variant: Option<String>,
     disposition: ReadDisposition,
     expires_at: OffsetDateTime,
 }
@@ -1072,8 +1231,9 @@ impl StorageServerBuilder {
     pub fn public_scope(
         mut self,
         name: impl Into<String>,
-        policy: UploadPolicy,
+        mut policy: UploadPolicy,
     ) -> StorageResult<Self> {
+        policy = policy.visibility(ObjectVisibility::Public);
         self.insert_scope(name.into(), StorageScope::builder(policy).build())?;
         Ok(self)
     }
@@ -1122,6 +1282,19 @@ impl StorageServerBuilder {
         S: StorageObjectScope,
     {
         self.insert_scope(S::NAME.to_string(), StorageScope::object_scope::<S>()?)?;
+        Ok(self)
+    }
+
+    pub fn guarded_object_scope<S, G>(mut self, guard: G) -> StorageResult<Self>
+    where
+        S: StorageObjectScope,
+        G: StorageObjectGuard,
+    {
+        let scope = StorageScope::builder(S::policy()?)
+            .key_resolver(StorageObjectScopeKeyResolver::<S>::default())
+            .object_guard(guard)
+            .build();
+        self.insert_scope(S::NAME.to_string(), scope)?;
         Ok(self)
     }
 
@@ -1268,6 +1441,7 @@ async fn scope_handler(
 #[derive(serde::Deserialize)]
 struct ObjectReadQuery {
     token: Option<String>,
+    variant: Option<String>,
 }
 
 async fn object_read_url_handler(
@@ -1304,7 +1478,7 @@ async fn object_read_handler(
         async {
             let key = SafeObjectKey::parse(key)?;
             storage
-                .read_object(request.ctx, scope, key, query.token)
+                .read_object(request.ctx, scope, key, query.token, query.variant)
                 .await
         }
         .await,
@@ -1324,7 +1498,7 @@ async fn object_head_handler(
         async {
             let key = SafeObjectKey::parse(key)?;
             storage
-                .read_object(request.ctx, scope, key, query.token)
+                .read_object(request.ctx, scope, key, query.token, query.variant)
                 .await
         }
         .await,
@@ -1336,6 +1510,7 @@ async fn object_head_handler(
 async fn object_delete_handler(
     State(storage): State<StorageServer>,
     Path((scope, key)): Path<(String, String)>,
+    Query(query): Query<ObjectReadQuery>,
     request: Request<Body>,
 ) -> Response {
     match mutation_context_from_request(request, &storage) {
@@ -1344,7 +1519,9 @@ async fn object_delete_handler(
             storage_response(
                 async {
                     let key = SafeObjectKey::parse(key)?;
-                    storage.delete_object(request.ctx, scope, key).await
+                    storage
+                        .delete_object(request.ctx, scope, key, query.variant)
+                        .await
                 }
                 .await,
                 set_cookie,
@@ -2563,15 +2740,33 @@ fn sanitize_header_filename(filename: &str) -> String {
     }
 }
 
-fn object_read_url(scope: &str, key: &str, token: Option<&str>) -> String {
+fn effective_read_key(
+    base_key: &SafeObjectKey,
+    variant: Option<&str>,
+) -> StorageResult<SafeObjectKey> {
+    match variant {
+        Some(variant) => image_variant_key(base_key.as_str(), variant),
+        None => Ok(base_key.clone()),
+    }
+}
+
+fn object_read_url(scope: &str, key: &str, token: Option<&str>, variant: Option<&str>) -> String {
     let mut url = format!(
         "/__pocopine/storage/v1/scopes/{}/objects/{}",
         percent_encode(scope),
         encode_object_key_path(key)
     );
+    let mut separator = '?';
     if let Some(token) = token {
-        url.push_str("?token=");
+        url.push(separator);
+        separator = '&';
+        url.push_str("token=");
         url.push_str(&percent_encode(token));
+    }
+    if let Some(variant) = variant {
+        url.push(separator);
+        url.push_str("variant=");
+        url.push_str(&percent_encode(variant));
     }
     url
 }

--- a/crates/pocopine-storage/tests/client_browser.rs
+++ b/crates/pocopine-storage/tests/client_browser.rs
@@ -14,9 +14,10 @@ use js_sys::{Array, Promise};
 use pocopine::prelude::*;
 use pocopine_storage::{
     BrowserStorageRequest, BrowserStorageResponse, BrowserStorageTransport, ObjectRef,
-    ObjectVisibility, SignedRead, StorageClient, StorageError, StorageObjectScope, StorageResponse,
-    StorageResult, TransferPlan, UploadClient, UploadPhase, UploadProgress, UploadSession,
-    UploadSessionId, UploadSessionStatus, UploadStrategy, storage_plugin, upload_plugin,
+    ObjectVisibility, ReadUrlRequest, SignedRead, StorageClient, StorageError, StorageObjectScope,
+    StorageResponse, StorageResult, TransferPlan, UploadClient, UploadPhase, UploadProgress,
+    UploadSession, UploadSessionId, UploadSessionStatus, UploadStrategy, storage_plugin,
+    upload_plugin,
 };
 use serde::{Deserialize, Serialize};
 use time::OffsetDateTime;
@@ -190,6 +191,60 @@ async fn object_chain_requests_download_url_and_delete() {
     assert_eq!(
         state.requests[1].url,
         "/__pocopine/storage/v1/scopes/avatars/objects/avatars/user-1/photo.txt"
+    );
+    pocopine_storage::__reset_browser_transport_for_test();
+}
+
+#[wasm_bindgen_test(async)]
+async fn object_chain_requests_image_variant_download_url() {
+    pocopine_storage::__reset_browser_transport_for_test();
+    let fake = FakeStorageTransport::default();
+    let state = fake.state.clone();
+    pocopine_storage::__set_browser_transport_for_test(fake);
+
+    let url = StorageClient::new()
+        .object_scope::<AvatarObjects>()
+        .object("avatars/user-1/photo.txt")
+        .variant("thumb64")
+        .download_url()
+        .await
+        .unwrap();
+
+    assert_eq!(
+        url,
+        "/__pocopine/storage/v1/scopes/avatars/objects/avatars/user-1/photo.txt?token=read-token&variant=thumb64"
+    );
+    let state = state.borrow();
+    let request: ReadUrlRequest = serde_json::from_str(
+        state.requests[0]
+            .json_body
+            .as_deref()
+            .expect("read-url request should include JSON"),
+    )
+    .unwrap();
+    assert_eq!(request.variant.as_deref(), Some("thumb64"));
+    pocopine_storage::__reset_browser_transport_for_test();
+}
+
+#[wasm_bindgen_test(async)]
+async fn object_chain_deletes_image_variant_url() {
+    pocopine_storage::__reset_browser_transport_for_test();
+    let fake = FakeStorageTransport::default();
+    let state = fake.state.clone();
+    pocopine_storage::__set_browser_transport_for_test(fake);
+
+    StorageClient::new()
+        .object_scope::<AvatarObjects>()
+        .object("avatars/user-1/photo.txt")
+        .variant("thumb64")
+        .delete()
+        .await
+        .unwrap();
+
+    let state = state.borrow();
+    assert_eq!(
+        state.requests[0].url,
+        "/__pocopine/storage/v1/scopes/avatars/objects/avatars/user-1/photo.txt?variant=thumb64"
     );
     pocopine_storage::__reset_browser_transport_for_test();
 }
@@ -616,6 +671,7 @@ struct SeenRequest {
     method: String,
     url: String,
     headers: Vec<(String, String)>,
+    json_body: Option<String>,
 }
 
 impl BrowserStorageTransport for FakeStorageTransport {
@@ -638,6 +694,7 @@ impl BrowserStorageTransport for FakeStorageTransport {
                 method: request.method.clone(),
                 url: request.url.clone(),
                 headers: request.headers.clone(),
+                json_body: request.json_body.clone(),
             });
             match (request.method.as_str(), request.url.as_str()) {
                 ("POST", "/__pocopine/storage/v1/uploads") => {
@@ -720,15 +777,36 @@ impl BrowserStorageTransport for FakeStorageTransport {
                 (
                     "POST",
                     "/__pocopine/storage/v1/scopes/avatars/objects/read-url/avatars/user-1/photo.txt",
-                ) => Ok(json_response(Ok(SignedRead {
-                    url: "/__pocopine/storage/v1/scopes/avatars/objects/avatars/user-1/photo.txt?token=read-token"
-                        .to_string(),
-                    headers: Vec::new(),
-                    expires_at: OffsetDateTime::UNIX_EPOCH + time::Duration::days(1),
-                }))),
+                ) => {
+                    let variant = request
+                        .json_body
+                        .as_deref()
+                        .and_then(|body| serde_json::from_str::<ReadUrlRequest>(body).ok())
+                        .and_then(|body| body.variant);
+                    let mut url =
+                        "/__pocopine/storage/v1/scopes/avatars/objects/avatars/user-1/photo.txt?token=read-token"
+                            .to_string();
+                    if let Some(variant) = variant {
+                        url.push_str("&variant=");
+                        url.push_str(&variant);
+                    }
+                    Ok(json_response(Ok(SignedRead {
+                        url,
+                        headers: Vec::new(),
+                        expires_at: OffsetDateTime::UNIX_EPOCH + time::Duration::days(1),
+                    })))
+                }
                 (
                     "DELETE",
                     "/__pocopine/storage/v1/scopes/avatars/objects/avatars/user-1/photo.txt",
+                ) => Ok(BrowserStorageResponse {
+                    status: 204,
+                    headers: Vec::new(),
+                    body: String::new(),
+                }),
+                (
+                    "DELETE",
+                    "/__pocopine/storage/v1/scopes/avatars/objects/avatars/user-1/photo.txt?variant=thumb64",
                 ) => Ok(BrowserStorageResponse {
                     status: 204,
                     headers: Vec::new(),

--- a/crates/pocopine-storage/tests/storage_host.rs
+++ b/crates/pocopine-storage/tests/storage_host.rs
@@ -16,9 +16,10 @@ use pocopine_server::axum::http::{HeaderMap, HeaderValue, Method, Request, Statu
 use pocopine_storage::{
     ChecksumAlgorithm, ChecksumPolicy, CompleteUpload, InitiateUpload, InitiateUploadRequest,
     LocalFsStorageBackend, MemoryStorageBackend, ObjectBody, ObjectChecksum, ObjectMetadata,
-    ObjectOwnerRef, ReadUrlRequest, STORAGE_ANON_COOKIE, STORAGE_UPLOADS_PATH, SafeObjectKey,
-    SignedRead, StorageBackend, StorageContext, StorageError, StorageKey, StorageKeyFuture,
-    StorageKeyResolver, StorageResponse, StorageResult, StorageScope, StorageServer, UploadIntent,
+    ObjectOwnerRef, ObjectVisibility, ReadUrlRequest, STORAGE_ANON_COOKIE, STORAGE_UPLOADS_PATH,
+    SafeObjectKey, SignedRead, StorageActor, StorageBackend, StorageContext, StorageError,
+    StorageGuardFuture, StorageKey, StorageKeyFuture, StorageKeyResolver, StorageObjectAccess,
+    StorageObjectGuard, StorageResponse, StorageResult, StorageScope, StorageServer, UploadIntent,
     UploadPolicy, UploadSession, UploadSessionId, UploadSessionStatus, UploadStrategy,
     storage_server_plugin, storage_tus_server_plugin,
 };
@@ -399,6 +400,419 @@ async fn object_read_url_serves_completed_object_and_delete_removes_it() -> Stor
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    Ok(())
+}
+
+#[tokio::test]
+async fn object_read_url_variant_query_reads_suffix_object() -> StorageResult<()> {
+    let scope = StorageScope::builder(policy("memory")?.visibility(ObjectVisibility::Public))
+        .key_resolver(LinkedImageResolver)
+        .build();
+    let storage = StorageServer::builder()
+        .backend("memory", MemoryStorageBackend::new())?
+        .scope("avatars", scope)?
+        .build();
+    let actor = anon_ctx();
+
+    let original_session = storage
+        .initiate_upload(
+            actor.clone(),
+            initiate_request("avatars", UploadStrategy::Auto),
+        )
+        .await?;
+    storage
+        .append_upload_bytes(
+            actor.clone(),
+            original_session.id.clone(),
+            0,
+            Bytes::from_static(b"hello"),
+        )
+        .await?;
+    let original = storage
+        .complete_upload(
+            actor.clone(),
+            CompleteUpload {
+                session: original_session.id,
+                checksum: None,
+            },
+        )
+        .await?;
+
+    let mut variant_request = initiate_request("avatars", UploadStrategy::Auto);
+    variant_request.file_name = "photo.thumb64.txt".to_string();
+    variant_request.metadata = [
+        (
+            pocopine_storage::IMAGE_VARIANT_BASE_KEY_METADATA_KEY.to_string(),
+            original.key.clone(),
+        ),
+        (
+            pocopine_storage::IMAGE_VARIANT_METADATA_KEY.to_string(),
+            "thumb64".to_string(),
+        ),
+    ]
+    .into();
+    let variant_session = storage
+        .initiate_upload(actor.clone(), variant_request)
+        .await?;
+    storage
+        .append_upload_bytes(
+            actor,
+            variant_session.id.clone(),
+            0,
+            Bytes::from_static(b"small"),
+        )
+        .await?;
+    let variant = storage
+        .complete_upload(
+            anon_ctx(),
+            CompleteUpload {
+                session: variant_session.id,
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(variant.key, "avatars/user-1/photo.thumb64.jpg");
+
+    let router = finalize(storage);
+    let read_url = format!(
+        "/__pocopine/storage/v1/scopes/avatars/objects/read-url/{}",
+        original.key
+    );
+    let signed: SignedRead = post_json(
+        router.clone(),
+        &read_url,
+        &ReadUrlRequest::default().variant("thumb64"),
+    )
+    .await?;
+    assert!(signed.url.contains("variant=thumb64"));
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(&signed.url)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.into_body().collect().await.unwrap().to_bytes(),
+        Bytes::from_static(b"small")
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn object_delete_variant_query_removes_suffix_object_only() -> StorageResult<()> {
+    let scope = StorageScope::builder(policy("memory")?.visibility(ObjectVisibility::Public))
+        .key_resolver(LinkedImageResolver)
+        .build();
+    let storage = StorageServer::builder()
+        .backend("memory", MemoryStorageBackend::new())?
+        .scope("avatars", scope)?
+        .build();
+    let actor = anon_ctx();
+
+    let original_session = storage
+        .initiate_upload(
+            actor.clone(),
+            initiate_request("avatars", UploadStrategy::Auto),
+        )
+        .await?;
+    storage
+        .append_upload_bytes(
+            actor.clone(),
+            original_session.id.clone(),
+            0,
+            Bytes::from_static(b"hello"),
+        )
+        .await?;
+    let original = storage
+        .complete_upload(
+            actor.clone(),
+            CompleteUpload {
+                session: original_session.id,
+                checksum: None,
+            },
+        )
+        .await?;
+
+    let mut variant_request = initiate_request("avatars", UploadStrategy::Auto);
+    variant_request.file_name = "photo.thumb64.txt".to_string();
+    variant_request.metadata = [
+        (
+            pocopine_storage::IMAGE_VARIANT_BASE_KEY_METADATA_KEY.to_string(),
+            original.key.clone(),
+        ),
+        (
+            pocopine_storage::IMAGE_VARIANT_METADATA_KEY.to_string(),
+            "thumb64".to_string(),
+        ),
+    ]
+    .into();
+    let variant_session = storage
+        .initiate_upload(actor.clone(), variant_request)
+        .await?;
+    storage
+        .append_upload_bytes(
+            actor,
+            variant_session.id.clone(),
+            0,
+            Bytes::from_static(b"small"),
+        )
+        .await?;
+    storage
+        .complete_upload(
+            anon_ctx(),
+            CompleteUpload {
+                session: variant_session.id,
+                checksum: None,
+            },
+        )
+        .await?;
+
+    let router = finalize(storage.clone());
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!(
+                    "/__pocopine/storage/v1/scopes/avatars/objects/{}?variant=thumb64",
+                    original.key
+                ))
+                .header("cookie", anon_cookie())
+                .header("sec-fetch-site", "same-origin")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let (read, _) = storage
+        .read_object(
+            StorageContext::system("test"),
+            "avatars".to_string(),
+            SafeObjectKey::parse(&original.key)?,
+            None,
+            None,
+        )
+        .await?;
+    assert_eq!(
+        Body::from_stream(read.body)
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes(),
+        Bytes::from_static(b"hello")
+    );
+    let deleted_variant = storage
+        .read_object(
+            StorageContext::system("test"),
+            "avatars".to_string(),
+            SafeObjectKey::parse(&original.key)?,
+            None,
+            Some("thumb64".to_string()),
+        )
+        .await;
+    assert!(matches!(
+        deleted_variant,
+        Err(StorageError::UnknownObject { .. })
+    ));
+    Ok(())
+}
+
+#[tokio::test]
+async fn private_scope_rejects_browser_object_access_without_key_guard() -> StorageResult<()> {
+    let scope = StorageScope::builder(policy("memory")?)
+        .key_resolver(CountingResolver {
+            calls: Arc::new(AtomicUsize::new(0)),
+        })
+        .build();
+    let storage = StorageServer::builder()
+        .backend("memory", MemoryStorageBackend::new())?
+        .scope("avatars", scope)?
+        .build();
+    let actor = ctx();
+    let session = storage
+        .initiate_upload(
+            actor.clone(),
+            initiate_request("avatars", UploadStrategy::Auto),
+        )
+        .await?;
+    storage
+        .append_upload_bytes(
+            actor.clone(),
+            session.id.clone(),
+            0,
+            Bytes::from_static(b"hello"),
+        )
+        .await?;
+    let object = storage
+        .complete_upload(
+            actor,
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await?;
+
+    let router = finalize(storage.clone());
+    let object_uri = format!(
+        "/__pocopine/storage/v1/scopes/avatars/objects/{}",
+        object.key
+    );
+    let response = router
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(&object_uri)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+    let read_url = format!(
+        "/__pocopine/storage/v1/scopes/avatars/objects/read-url/{}",
+        object.key
+    );
+    let (status, signed): (StatusCode, StorageResult<SignedRead>) =
+        post_json_status(router.clone(), &read_url, &ReadUrlRequest::default(), true).await;
+    assert_eq!(status, StatusCode::FORBIDDEN);
+    assert!(matches!(signed, Err(StorageError::Forbidden { .. })));
+
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(&object_uri)
+                .header("cookie", anon_cookie())
+                .header("sec-fetch-site", "same-origin")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+    let (read, _) = storage
+        .read_object(
+            StorageContext::system("checked-storage-read"),
+            "avatars".to_string(),
+            SafeObjectKey::parse(&object.key)?,
+            None,
+            None,
+        )
+        .await?;
+    assert_eq!(
+        Body::from_stream(read.body)
+            .collect()
+            .await
+            .unwrap()
+            .to_bytes(),
+        Bytes::from_static(b"hello")
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn object_guard_authorizes_read_url_direct_read_and_delete_by_key() -> StorageResult<()> {
+    let scope = StorageScope::builder(policy("memory")?)
+        .key_resolver(PrincipalKeyResolver)
+        .object_guard(OwnerPrefixGuard)
+        .build();
+    let storage = StorageServer::builder()
+        .backend("memory", MemoryStorageBackend::new())?
+        .scope("attachments", scope)?
+        .build();
+    let owner = principal_ctx("user-1", "owner");
+    let other = principal_ctx("user-2", "other");
+    let session = storage
+        .initiate_upload(
+            owner.clone(),
+            initiate_request("attachments", UploadStrategy::Auto),
+        )
+        .await?;
+    storage
+        .append_upload_bytes(
+            owner.clone(),
+            session.id.clone(),
+            0,
+            Bytes::from_static(b"hello"),
+        )
+        .await?;
+    let object = storage
+        .complete_upload(
+            owner.clone(),
+            CompleteUpload {
+                session: session.id,
+                checksum: None,
+            },
+        )
+        .await?;
+    assert_eq!(object.key, "user-1/photo.txt");
+    let key = SafeObjectKey::parse(&object.key)?;
+
+    let denied_read = storage
+        .read_object(
+            other.clone(),
+            "attachments".to_string(),
+            key.clone(),
+            None,
+            None,
+        )
+        .await;
+    assert!(matches!(denied_read, Err(StorageError::Forbidden { .. })));
+
+    let denied_signed = storage
+        .signed_read(
+            other.clone(),
+            "attachments".to_string(),
+            key.clone(),
+            ReadUrlRequest::default(),
+        )
+        .await;
+    assert!(matches!(denied_signed, Err(StorageError::Forbidden { .. })));
+
+    let denied_delete = storage
+        .delete_object(other, "attachments".to_string(), key.clone(), None)
+        .await;
+    assert!(matches!(denied_delete, Err(StorageError::Forbidden { .. })));
+
+    let signed = storage
+        .signed_read(
+            owner.clone(),
+            "attachments".to_string(),
+            key.clone(),
+            ReadUrlRequest::default(),
+        )
+        .await?;
+    let router = finalize(storage.clone());
+    let response = router
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(&signed.url)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.into_body().collect().await.unwrap().to_bytes(),
+        Bytes::from_static(b"hello")
+    );
+
+    storage
+        .delete_object(owner, "attachments".to_string(), key, None)
+        .await?;
     Ok(())
 }
 
@@ -1949,6 +2363,42 @@ struct CountingResolver {
     calls: Arc<AtomicUsize>,
 }
 
+struct LinkedImageResolver;
+struct PrincipalKeyResolver;
+struct OwnerPrefixGuard;
+
+impl StorageKeyResolver for LinkedImageResolver {
+    fn resolve_key<'a>(
+        &'a self,
+        _ctx: &'a StorageContext,
+        intent: &'a UploadIntent,
+    ) -> StorageKeyFuture<'a> {
+        Box::pin(async move {
+            if let Some(key) = intent.image_variant_object_key()? {
+                return Ok(StorageKey::new(key));
+            }
+            storage_key()
+        })
+    }
+}
+
+impl StorageKeyResolver for PrincipalKeyResolver {
+    fn resolve_key<'a>(
+        &'a self,
+        ctx: &'a StorageContext,
+        intent: &'a UploadIntent,
+    ) -> StorageKeyFuture<'a> {
+        Box::pin(async move {
+            let principal = ctx.require_principal()?;
+            Ok(StorageKey::new(SafeObjectKey::parse(format!(
+                "{}/{}",
+                principal.subject,
+                intent.file_name()
+            ))?))
+        })
+    }
+}
+
 impl StorageKeyResolver for CountingResolver {
     fn resolve_key<'a>(
         &'a self,
@@ -1957,5 +2407,29 @@ impl StorageKeyResolver for CountingResolver {
     ) -> StorageKeyFuture<'a> {
         self.calls.fetch_add(1, Ordering::SeqCst);
         Box::pin(async { storage_key() })
+    }
+}
+
+impl StorageObjectGuard for OwnerPrefixGuard {
+    fn check(&self, ctx: StorageContext, access: StorageObjectAccess) -> StorageGuardFuture<'_> {
+        Box::pin(async move {
+            let subject = match ctx.actor {
+                StorageActor::Principal(principal) => principal.subject,
+                _ => return Err(ServerError::unauthorized("login required")),
+            };
+            let prefix = format!("{subject}/");
+            match access {
+                StorageObjectAccess::Write { .. } => Ok(()),
+                StorageObjectAccess::Read { key, .. } | StorageObjectAccess::Delete { key, .. } => {
+                    if key.as_str().starts_with(&prefix) {
+                        Ok(())
+                    } else {
+                        Err(ServerError::forbidden(
+                            "object belongs to another principal",
+                        ))
+                    }
+                }
+            }
+        })
     }
 }

--- a/docs/guides/data/storage-uploads.md
+++ b/docs/guides/data/storage-uploads.md
@@ -68,8 +68,8 @@ name and gives the server the policy plus key resolver.
 
 ```rust
 use pocopine_storage::{
-    SafeObjectKey, StorageContext, StorageKey, StorageKeyFuture, StorageObjectScope,
-    StorageResult, UploadIntent, UploadPolicy,
+    ObjectVisibility, SafeObjectKey, StorageContext, StorageKey, StorageKeyFuture,
+    StorageObjectScope, StorageResult, UploadIntent, UploadPolicy,
 };
 
 struct AvatarObjects;
@@ -82,7 +82,8 @@ impl StorageObjectScope for AvatarObjects {
         Ok(UploadPolicy::new("s3")?
             .max_bytes(2 * 1024 * 1024)
             .allowed_content_types(["image/png", "image/jpeg"])
-            .allowed_extensions(["png", "jpg", "jpeg"]))
+            .allowed_extensions(["png", "jpg", "jpeg"])
+            .visibility(ObjectVisibility::Public))
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -110,7 +111,7 @@ let storage = pocopine_storage::StorageServer::builder()
     .build();
 ```
 
-The browser can use the same scope type for both upload and read chains:
+The browser can use the same scope type for uploads:
 
 ```rust
 let storage = pocopine_storage::StorageClient::new();
@@ -120,19 +121,13 @@ let object = storage
     .upload_blob(file, "avatar.png")
     .send()
     .await?;
-
-let url = storage
-    .object_scope::<AvatarObjects>()
-    .object(object.key)
-    .download_url()
-    .await?;
 ```
 
-`download_url()` currently returns a short-lived Pocopine URL. The browser
-fetches that URL from the app origin; provider credentials still stay on the
-server. `signed_read()` returns the full `SignedRead` response when callers
-need the expiry or future provider-specific headers, and `delete()` removes
-the completed object through the same scope authorization.
+Public objects can be read from the storage object route, or through an
+app-owned route such as `/avatar/<user_id>?v=<hash>&s=<px>` when the client can
+compute a stable, cacheable address. Private objects should use
+`download_url()` / `signed_read()` with a key-aware object guard; that path is
+covered below. Provider credentials never reach the browser.
 
 Object reads are streamed. `StorageBackend::read_object` returns object
 metadata plus an `ObjectBody` byte stream, and the HTTP route forwards that
@@ -144,6 +139,227 @@ provider does not expose a reliable size the route uses a streamed response
 without asserting a length. Once response headers have been sent, provider
 read errors surface as an interrupted download, so callers that manually fetch
 the URL should treat a short or failed body as a failed read.
+
+## Private object guards
+
+Scope guards are coarse: they answer "may this actor use this scope?". Private
+per-object storage also needs a key-aware guard so the framework can answer
+"may this actor read or delete this object key?" before it serves bytes or
+mints a `download_url()` token.
+
+Private browser object reads are denied unless the request carries a valid
+signed read token or the registered scope has an object guard. Private browser
+deletes require an object guard. Public scopes can still be read or deleted
+directly through the storage object route. Server-mediated routes that already
+checked domain permissions may call `StorageServer::read_object` with a system
+`StorageContext`.
+
+Migration note: if an existing private scope relied on only `read_guard` /
+`delete_guard` for browser object routes, add an `object_guard` or move reads
+behind a server-mediated `signed_read` flow. Private no-token object access is
+deny-by-default without a key-aware guard.
+
+```rust
+use pocopine_core::ServerError;
+use pocopine_storage::{
+    SafeObjectKey, StorageActor, StorageContext, StorageGuardFuture, StorageObjectAccess,
+    StorageObjectGuard, StorageObjectScope,
+};
+
+struct MessageAttachmentObjects;
+
+impl StorageObjectScope for MessageAttachmentObjects {
+    const NAME: &'static str = "message-attachments";
+
+    // policy() and resolve_key() omitted: use a key shape such as
+    // "<channel_id>/<uuid>_<filename>".
+}
+
+struct AttachmentGuard {
+    pool: sqlx::PgPool,
+}
+
+impl StorageObjectGuard for AttachmentGuard {
+    fn check(
+        &self,
+        ctx: StorageContext,
+        access: StorageObjectAccess,
+    ) -> StorageGuardFuture<'_> {
+        Box::pin(async move {
+            let user_id = match ctx.actor {
+                StorageActor::Principal(principal) => principal.subject,
+                _ => return Err(ServerError::unauthorized("login required")),
+            };
+
+            let Some(key) = access.key() else {
+                // Upload authorization can check request metadata in access.intent().
+                return Ok(());
+            };
+            let channel_id = key
+                .as_str()
+                .split_once('/')
+                .map(|(channel_id, _)| channel_id)
+                .ok_or_else(|| ServerError::forbidden("invalid attachment key"))?;
+
+            if is_channel_member(&self.pool, &user_id, channel_id).await? {
+                Ok(())
+            } else {
+                Err(ServerError::forbidden("attachment is not visible to this user"))
+            }
+        })
+    }
+}
+
+let storage = pocopine_storage::StorageServer::builder()
+    .backend("s3", s3_backend)?
+    .guarded_object_scope::<MessageAttachmentObjects, _>(AttachmentGuard { pool })?
+    .build();
+```
+
+With that guard installed, `StorageClient::object_scope::<MessageAttachmentObjects>()
+.object(key).download_url().await?` is the right read path for private
+attachments: the server checks the concrete key, then returns a short-lived,
+key-bound capability URL.
+
+When reading or deleting an image variant, the guard receives the effective
+suffix key, such as `avatars/u/original.avatar.jpg`, not the canonical base key.
+Prefix and ownership-segment guards naturally handle this; guards that do exact
+DB lookups should either record variant keys or normalize them back to the base
+key before checking.
+
+For private image-variant scopes, the client-provided
+`pocopine.image.base_key` metadata determines the generated suffix key. Validate
+that base key in `StorageObjectAccess::Write { intent, .. }` or inside
+`resolve_key` before returning `intent.image_variant_object_key()?`; otherwise a
+caller could try to place a variant beside an object they do not own.
+
+For public avatars, prefer an app-owned deterministic route instead of
+`download_url()`. If the client already has the user id, content version, and
+display size, it can build the image URL synchronously:
+
+```text
+/avatar/<user_id>?v=<content_hash>&s=<px>
+```
+
+That route can map `s` to the nearest stored variant and answer with
+`Cache-Control: public, max-age=31536000, immutable`. Because `v` changes when
+the avatar bytes change, the same URL string can be cached across sidebars,
+message rows, popovers, and reloads. `download_url()` is intentionally
+short-lived and async, so it is useful for private objects but a poor fit for
+public, content-versioned avatars.
+
+## Client-side image compression
+
+Enable the optional `image-compression` feature when a browser client should
+generate bounded image variants before upload:
+
+```toml
+pocopine-storage = { version = "0.1", features = ["image-compression"] }
+```
+
+The implementation uses Rust codecs and resizing, not canvas or a JavaScript
+image package: JPEG/PNG inputs are decoded with the Zune codec crates, resized
+with `fast_image_resize` in its `no_std` mode, and encoded as JPEG with
+`jpeg-encoder` with default `std` features disabled. Transparent PNG pixels are
+flattened over white because generated variants are JPEG. The browser bridge
+only reads the selected `File` into bytes when variants are requested, then
+wraps generated bytes back into a `Blob` for the normal storage upload path.
+
+Define variants on the typed object scope:
+
+```rust
+use pocopine_storage::{
+    ImageVariantPolicy, ImageVariantSpec, ObjectVisibility, SafeObjectKey, StorageContext,
+    StorageKey, StorageKeyFuture, StorageObjectScope, StorageResult, UploadIntent, UploadPolicy,
+};
+
+struct AvatarObjects;
+
+impl StorageObjectScope for AvatarObjects {
+    const NAME: &'static str = "avatars";
+
+    fn image_variants() -> ImageVariantPolicy {
+        ImageVariantPolicy::new()
+            .keep_original(true)
+            .variant(ImageVariantSpec::cover("avatar", 256, 256).quality(82))
+            .variant(ImageVariantSpec::fit("preview", 768, 768).quality(78))
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn policy() -> StorageResult<UploadPolicy> {
+        Ok(UploadPolicy::new("s3")?
+            .max_bytes(2 * 1024 * 1024)
+            .allowed_content_types(["image/jpeg", "image/png"])
+            .allowed_extensions(["jpg", "jpeg", "png"])
+            .visibility(ObjectVisibility::Public)
+            .metadata_schema(
+                pocopine_storage::MetadataSchema::default().allowed_keys([
+                    "pocopine.image.variant",
+                    "pocopine.image.base_key",
+                    "pocopine.image.width",
+                    "pocopine.image.height",
+                    "usage",
+                ]),
+            ))
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn resolve_key<'a>(
+        _ctx: &'a StorageContext,
+        intent: &'a UploadIntent,
+    ) -> StorageKeyFuture<'a> {
+        Box::pin(async move {
+            if let Some(key) = intent.image_variant_object_key()? {
+                return Ok(StorageKey::new(key));
+            }
+
+            Ok(StorageKey::new(SafeObjectKey::parse(format!(
+                "avatars/{}/original.{}",
+                intent.generated_object_id(),
+                intent.extension().unwrap_or("jpg"),
+            ))?))
+        })
+    }
+}
+```
+
+Upload with the typed policy. Variants are uploaded as deterministic suffix
+objects linked to the original key. Linked variants currently require
+`keep_original(true)` because the server derives each suffix key from the
+resolved original object key.
+
+```rust
+let manifest = pocopine_storage::StorageClient::new()
+    .upload_image_scope::<AvatarObjects>(file)
+    .metadata("usage", "profile")
+    .send()
+    .await?;
+
+let original = manifest.original().unwrap();
+let original_key = original.key();
+let avatar_version = compute_or_store_content_hash(original).await?;
+
+store_profile_avatar_key_and_version(user_id, original_key, &avatar_version).await?;
+
+let avatar_url = format!("/avatar/{user_id}?v={avatar_version}&s=256");
+```
+
+Each uploaded object receives image metadata:
+`pocopine.image.variant` (`original`, `avatar`, `preview`, ...),
+`pocopine.image.width`, and `pocopine.image.height`. Generated variants also
+receive `pocopine.image.base_key`, which lets `intent.image_variant_object_key()`
+place them beside the original by suffix, for example
+`avatars/u/original.avatar.jpg`. If a scope uses a non-empty
+`MetadataSchema::allowed_keys`, include those framework keys plus any app
+metadata keys you attach with `.metadata(...)`.
+
+Client-side compression reads the selected image into wasm memory because
+decoding and resizing need random access to pixels. Use it for bounded media
+scopes such as avatars, thumbnails, and post images. If the image policy keeps
+only the original and defines no variants, the client skips decoding and uploads
+the raw file through the normal path; width/height metadata is omitted. Large
+arbitrary files should keep using `upload(file).send().await`, which streams
+through the server and provider without buffering the complete object.
 
 ## Two transports
 

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -232,6 +232,7 @@ run_lib_package pocopine-deploy-railway crates/pocopine-deploy-railway/tests
 run_lib_package pocopine-realtime crates/pocopine-realtime/tests
 run_lib_package pocopine-server crates/pocopine-server/tests
 run_lib_package pocopine-storage crates/pocopine-storage/tests
+run cargo test -p pocopine-storage --features image-compression --lib --test storage_host
 run_lib_package pocopine-storage-azure crates/pocopine-storage-azure/tests
 run_lib_package pocopine-storage-gcs crates/pocopine-storage-gcs/tests
 run_lib_package pocopine-storage-s3 crates/pocopine-storage-s3/tests


### PR DESCRIPTION
## Summary

- Adds `pocopine-storage` client-side image compression and linked image variants behind the `image-compression` feature.
- Adds variant-aware object read/delete URLs so clients can address deterministic suffix objects like `photo.thumb64.jpg`.
- Fixes #255 with key-aware `StorageObjectGuard` authorization for private per-object read/delete and signed read URL minting.
- Documents public avatar routes vs private attachment `download_url()` flows, private-scope migration notes, and image variant constraints.
- Adds CI and `scripts/runtests.sh` coverage for the new storage image-compression feature.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p pocopine-storage --features image-compression`
- `cargo clippy -p pocopine-storage --all-targets --features image-compression -- -D warnings`
- `cargo clippy -p pocopine-storage --target wasm32-unknown-unknown --features image-compression --all-targets -- -D warnings`
- `cargo clippy -p pocopine-storage --target wasm32-unknown-unknown --all-targets -- -D warnings`
- `wasm-pack test --firefox --headless crates/pocopine-storage --features test-utils,image-compression --test client_browser`

## Review

Claude Opus reviewed the branch twice. The initial findings were fixed, and the follow-up review reported no blockers.
