### PR TITLE
feat(store): support #[computed] readonly fields on #[store] singletons

### DIFF
--- a/crates/pine/tests/store_computed.rs
+++ b/crates/pine/tests/store_computed.rs
@@ -1,0 +1,222 @@
+//! Issue #260 — `#[computed]` readonly fields on `#[store]` singletons.
+//!
+//! Components already expose `#[computed]` synthetic fields; a `#[store]`
+//! is just a singleton component scope, so the same machinery applies —
+//! the only missing wire was installing the store's computed entries at
+//! registration (stores have no DOM `setup` lifecycle) and making the
+//! store's `ComponentState` computed-aware.
+//!
+//! These are the runtime halves of the acceptance criteria:
+//! * `$store.<name>.<computed>` resolves in a template.
+//! * it re-derives when a *source* field changes through
+//!   `store::<T>().update(...)`.
+//! * a computed can depend on another computed (`filtered_len` reads
+//!   `filtered`).
+//! * an *unrelated* field write does not re-run the computed body
+//!   (lazy memoization) and does not serve a stale projection-cache
+//!   value.
+//! * the synthetic field is readonly through the `$store` proxy.
+//! * the value is available immediately after `App::store::<T>()`.
+
+#![cfg(target_arch = "wasm32")]
+
+use std::cell::Cell;
+
+use pocopine::prelude::*;
+use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+use web_sys::{Element, HtmlElement, window};
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+fn doc() -> web_sys::Document {
+    window().unwrap().document().unwrap()
+}
+
+async fn tick() {
+    for _ in 0..3 {
+        let p = js_sys::Promise::resolve(&JsValue::NULL);
+        let _ = wasm_bindgen_futures::JsFuture::from(p).await;
+    }
+}
+
+fn text_of(el: &Element) -> String {
+    el.clone()
+        .dyn_into::<HtmlElement>()
+        .unwrap()
+        .inner_text()
+        .trim()
+        .to_string()
+}
+
+thread_local! {
+    /// How many times the `filtered` computed *body* has run. Proves
+    /// memoization: an unrelated store write must leave this untouched.
+    static FILTERED_RUNS: Cell<u32> = const { Cell::new(0) };
+}
+
+fn filtered_runs() -> u32 {
+    FILTERED_RUNS.with(Cell::get)
+}
+
+// ── the store under test ───────────────────────────────────────────
+
+#[derive(Default, serde::Serialize, serde::Deserialize)]
+#[store(name = "demo")]
+struct DemoStore {
+    items: Vec<String>,
+    filter: String,
+    /// Not read by any computed — writing it must not recompute.
+    note: String,
+}
+
+#[handlers]
+impl DemoStore {
+    /// Raw-field computed: depends on `items` + `filter` by parameter.
+    #[computed]
+    fn filtered(items: &[String], filter: &str) -> Vec<String> {
+        FILTERED_RUNS.with(|c| c.set(c.get() + 1));
+        let q = filter.trim().to_lowercase();
+        items
+            .iter()
+            .filter(|i| q.is_empty() || i.to_lowercase().contains(&q))
+            .cloned()
+            .collect()
+    }
+
+    /// Computed-on-computed: depends on the `filtered` computed field.
+    #[computed]
+    fn filtered_len(filtered: Vec<String>) -> usize {
+        filtered.len()
+    }
+}
+
+// ── host component that binds the store computed ───────────────────
+
+#[derive(Default, serde::Serialize, serde::Deserialize)]
+#[component(template_inline = r#"
+<div class="demo-host">
+  <span class="d-len" pp-text="$store.demo.filtered_len"></span>
+</div>
+"#)]
+struct DemoHost {}
+
+#[handlers]
+impl DemoHost {}
+
+/// Register the store (installing its computed entries), reset it to a
+/// known-clean slate — the singleton persists across tests in the same
+/// wasm module — and mount a host that binds `$store.demo.filtered_len`.
+fn mount_host() -> Element {
+    <DemoHost as pocopine::__private::Component>::register();
+    // `App::store::<T>()` is the acceptance path — registration installs
+    // the computed nodes before any read.
+    let _ = App::new().store::<DemoStore>();
+    store::<DemoStore>().update(|s| *s = DemoStore::default());
+    pocopine_core::animate::disable_transitions();
+
+    let body = doc().body().unwrap();
+    let host = doc().create_element("div").unwrap();
+    let root = doc()
+        .create_element(<DemoHost as pocopine::__private::Component>::NAME)
+        .unwrap();
+    host.append_child(&root).unwrap();
+    body.append_child(&host).unwrap();
+    let mounted = pocopine::App::mount_subtree::<DemoHost>(&root);
+    pocopine_core::mount::finalize_compiled_subtree(&root);
+    mounted.leak();
+    host
+}
+
+#[wasm_bindgen_test]
+async fn store_computed_available_immediately_and_updates() {
+    let host = mount_host();
+    tick().await;
+
+    let len = host.query_selector(".d-len").unwrap().expect("len span");
+    // Available immediately after `App::store::<Demo>()` — the empty
+    // store derives a length of 0 on the very first render.
+    assert_eq!(text_of(&len), "0", "initial filtered_len for empty store");
+
+    // A source-field write re-derives the (chained) computed.
+    store::<DemoStore>().update(|s| {
+        s.items = vec!["alpha".into(), "beta".into(), "gamma".into()];
+    });
+    tick().await;
+    tick().await;
+    assert_eq!(text_of(&len), "3", "filtered_len after items set");
+
+    // Narrowing the other source field re-derives too. All three
+    // contain 'a'.
+    store::<DemoStore>().update(|s| s.filter = "a".into());
+    tick().await;
+    tick().await;
+    assert_eq!(text_of(&len), "3", "filter 'a' matches all three");
+
+    // Only "alpha" contains "al".
+    store::<DemoStore>().update(|s| s.filter = "al".into());
+    tick().await;
+    tick().await;
+    assert_eq!(text_of(&len), "1", "filter 'al' matches only alpha");
+
+    host.remove();
+}
+
+#[wasm_bindgen_test]
+async fn store_computed_skips_recompute_for_unrelated_writes() {
+    let host = mount_host();
+    tick().await;
+
+    let len = host.query_selector(".d-len").unwrap().expect("len span");
+    // Seed a source change so the computed has run and is memoized.
+    store::<DemoStore>().update(|s| s.items = vec!["one".into(), "two".into()]);
+    tick().await;
+    tick().await;
+    assert_eq!(text_of(&len), "2", "filtered_len after seeding items");
+    let runs_before = filtered_runs();
+
+    // Writing an unrelated field must NOT re-run the computed body...
+    store::<DemoStore>().update(|s| s.note = "hello".into());
+    tick().await;
+    tick().await;
+    assert_eq!(
+        filtered_runs(),
+        runs_before,
+        "unrelated store write must not recompute the body",
+    );
+    // ...and the value stays correct (no stale projection cache served).
+    assert_eq!(text_of(&len), "2", "value stable after unrelated write");
+
+    host.remove();
+}
+
+#[wasm_bindgen_test]
+async fn store_computed_is_readonly_through_proxy() {
+    let host = mount_host();
+    tick().await;
+
+    store::<DemoStore>().update(|s| s.items = vec!["x".into(), "y".into()]);
+    tick().await;
+    tick().await;
+
+    // Reach the `demo` proxy through the `$store` container and try to
+    // overwrite the synthetic field directly.
+    let stores = pocopine_core::store::stores_object();
+    let demo = js_sys::Reflect::get(&stores, &JsValue::from_str("demo")).unwrap();
+    let before = js_sys::Reflect::get(&demo, &JsValue::from_str("filtered_len")).unwrap();
+    assert_eq!(before.as_f64(), Some(2.0), "computed reads through proxy");
+
+    let _ = js_sys::Reflect::set(
+        &demo,
+        &JsValue::from_str("filtered_len"),
+        &JsValue::from_f64(999.0),
+    );
+    let after = js_sys::Reflect::get(&demo, &JsValue::from_str("filtered_len")).unwrap();
+    assert_eq!(
+        after.as_f64(),
+        Some(2.0),
+        "computed field is readonly — the proxy write is a no-op",
+    );
+
+    host.remove();
+}

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -4435,17 +4435,44 @@ pub fn store(attr: TokenStream, item: TokenStream) -> TokenStream {
             fn get(&self, key: &str) -> ::pocopine::__private::JsValue {
                 match key {
                     #(#get_arms)*
-                    _ => ::pocopine::__private::JsValue::UNDEFINED,
+                    // Not a real field — fall through to a `#[computed]`
+                    // synthetic field. Same resolution order as
+                    // `#[component]`: real fields first, then computed.
+                    _ => <Self as ::pocopine::__private::HandlerDispatch>::computed_get(self, key)
+                        .unwrap_or(::pocopine::__private::JsValue::UNDEFINED),
                 }
             }
             fn set(&mut self, key: &str, value: ::pocopine::__private::JsValue) {
                 match key {
                     #(#set_arms)*
-                    _ => {}
+                    // Computed keys never match a real field arm, so
+                    // they land here and stay read-only: a proxy write
+                    // to `$store.<name>.<computed>` is a silent no-op.
+                    _ => { let _ = value; }
                 }
             }
             fn keys(&self) -> &'static [&'static str] {
-                &[#(#keys_arr),*]
+                // Real field keys plus `#[computed]` synthetic keys.
+                // `computed_keys()` is empty for stores with no
+                // computed methods, so this degrades to the raw list.
+                static __POCOPINE_STORE_KEYS: ::std::sync::OnceLock<&'static [&'static str]> =
+                    ::std::sync::OnceLock::new();
+                *__POCOPINE_STORE_KEYS.get_or_init(|| {
+                    let mut __keys = ::std::vec![#(#keys_arr),*];
+                    __keys.extend_from_slice(
+                        <Self as ::pocopine::__private::HandlerDispatch>::computed_keys(),
+                    );
+                    let __boxed: ::std::boxed::Box<[&'static str]> = __keys.into_boxed_slice();
+                    ::std::boxed::Box::leak(__boxed)
+                })
+            }
+            fn is_computed_field(&self, key: &str) -> bool {
+                // Drives the projection-cache skip in `read_field_tracked`:
+                // a computed carries its own `Computed<JsValue>` memo, so
+                // it must not also be frozen in the per-field projection
+                // cache (which only invalidates on a direct write).
+                <Self as ::pocopine::__private::HandlerDispatch>::computed_keys()
+                    .contains(&key)
             }
             fn field_fingerprint(&self, key: &str) -> ::core::option::Option<u64> {
                 match key {
@@ -4489,7 +4516,27 @@ pub fn store(attr: TokenStream, item: TokenStream) -> TokenStream {
                     ::std::rc::Rc::new(::std::cell::RefCell::new(
                         <#struct_ident as ::core::default::Default>::default()
                     ));
-                let scope = ::pocopine::__private::Scope::new(instance);
+                // Pointer used to key this store's `#[computed]` entries.
+                // It must equal the pointer `computed_get` derives on a
+                // read — both borrow the same `RefCell`, whose contents
+                // never move — so compute it here and drop the borrow
+                // before the `Rc` is shared. No-op for stores without
+                // computed methods.
+                let __state_ptr = ::pocopine::__private::component_computed::state_ptr(
+                    &*instance.borrow(),
+                );
+                let scope = ::pocopine::__private::Scope::new(instance.clone());
+                let __scope_id = scope.id;
+                // Stores have no DOM lifecycle, so `setup` never runs.
+                // Install computed entries here instead, before the scope
+                // is registered — so the first `$store.<name>.<computed>`
+                // read resolves. `Handle` keeps the singleton alive for
+                // the computed closures.
+                <#struct_ident>::__pocopine_computed_install(
+                    __scope_id,
+                    __state_ptr,
+                    ::pocopine::__private::Handle::new(instance, __scope_id),
+                );
                 ::pocopine::__private::register_store_scope(#name_str, scope);
             }
 

--- a/crates/pocopine/tests/store_computed_ui.rs
+++ b/crates/pocopine/tests/store_computed_ui.rs
@@ -1,0 +1,29 @@
+//! Issue #260 — compile-time contract for `#[computed]` on `#[store]`
+//! singletons. Store computed reuses the shared `#[handlers]` computed
+//! machinery, so the positive case is pinned on a real `#[store]` while
+//! the rejections are pinned on the shared path they inherit.
+//!
+//! Following the `field_handles_ui` convention, the committed `.stderr`
+//! snapshots pin our own `compile_error!` text (regenerate with
+//! `TRYBUILD=overwrite` if rustc framing drifts). The reject fixtures use
+//! a bare `#[handlers]` impl on purpose: it isolates the snapshot to our
+//! `compile_error!`, which is stable across the CI (`nightly-2025-12-18`)
+//! and workspace (`rust-toolchain.toml`) nightlies. A `#[store]` target
+//! for the same rejection additionally cascades a rustc
+//! `HandlerDispatch`-not-implemented error whose framing differs between
+//! those two nightlies, which no single snapshot can satisfy.
+//!
+//! Host-only: trybuild shells out to cargo and isn't a wasm target.
+#![cfg(not(target_arch = "wasm32"))]
+
+#[test]
+fn store_computed_contract() {
+    let cases = trybuild::TestCases::new();
+    // A `#[store]` may declare a raw-field computed and a computed that
+    // depends on another computed.
+    cases.pass("tests/ui/store_computed_pass.rs");
+    // `#[computed]` must not read through `self` (shared contract).
+    cases.compile_fail("tests/ui/store_computed_self.rs");
+    // A computed cycle is rejected at compile time (shared contract).
+    cases.compile_fail("tests/ui/store_computed_cycle.rs");
+}

--- a/crates/pocopine/tests/ui/store_computed_cycle.rs
+++ b/crates/pocopine/tests/ui/store_computed_cycle.rs
@@ -1,0 +1,25 @@
+// Issue #260 — compile-fail: computed-to-computed dependencies form a
+// static graph; a cycle is rejected at compile time. Store computed
+// reuses this exact `#[handlers]` topological check, so the contract is
+// pinned on a bare `#[handlers]` impl to keep the snapshot to our own
+// `compile_error!` (see store_computed_self.rs for why).
+use pocopine::prelude::*;
+
+struct Derived {
+    seed: usize,
+}
+
+#[handlers]
+impl Derived {
+    #[computed]
+    fn a(b: usize) -> usize {
+        b
+    }
+
+    #[computed]
+    fn b(a: usize) -> usize {
+        a
+    }
+}
+
+fn main() {}

--- a/crates/pocopine/tests/ui/store_computed_cycle.stderr
+++ b/crates/pocopine/tests/ui/store_computed_cycle.stderr
@@ -1,0 +1,5 @@
+error: #[computed] dependency graph contains a cycle
+  --> tests/ui/store_computed_cycle.rs:15:8
+   |
+15 |     fn a(b: usize) -> usize {
+   |        ^

--- a/crates/pocopine/tests/ui/store_computed_pass.rs
+++ b/crates/pocopine/tests/ui/store_computed_pass.rs
@@ -1,0 +1,32 @@
+// Issue #260 — compile-pass: a `#[store]` may declare `#[computed]`
+// synthetic fields in its `#[handlers]` impl, including a computed that
+// depends on another computed.
+use pocopine::prelude::*;
+
+#[derive(Default, serde::Serialize, serde::Deserialize)]
+#[store(name = "demo")]
+struct DemoStore {
+    items: Vec<String>,
+    filter: String,
+}
+
+#[handlers]
+impl DemoStore {
+    // raw-field computed
+    #[computed]
+    fn filtered(items: &[String], filter: &str) -> Vec<String> {
+        items
+            .iter()
+            .filter(|i| i.contains(filter))
+            .cloned()
+            .collect()
+    }
+
+    // computed-on-computed
+    #[computed]
+    fn filtered_len(filtered: Vec<String>) -> usize {
+        filtered.len()
+    }
+}
+
+fn main() {}

--- a/crates/pocopine/tests/ui/store_computed_self.rs
+++ b/crates/pocopine/tests/ui/store_computed_self.rs
@@ -1,0 +1,22 @@
+// Issue #260 — compile-fail: `#[computed]` must declare its dependencies
+// as parameters, never read through `self`. Store computed reuses this
+// exact `#[handlers]` rejection, so the contract is pinned on a bare
+// `#[handlers]` impl: that keeps the snapshot to our own `compile_error!`
+// (toolchain-stable), whereas a `#[store]`/`#[component]` target would
+// also cascade a rustc "HandlerDispatch not implemented" error whose
+// framing drifts between the CI and workspace nightlies.
+use pocopine::prelude::*;
+
+struct Derived {
+    items: Vec<String>,
+}
+
+#[handlers]
+impl Derived {
+    #[computed]
+    fn bad(&self) -> usize {
+        self.items.len()
+    }
+}
+
+fn main() {}

--- a/crates/pocopine/tests/ui/store_computed_self.stderr
+++ b/crates/pocopine/tests/ui/store_computed_self.stderr
@@ -1,0 +1,5 @@
+error: #[computed] methods must not take self; declare dependencies as parameters
+  --> tests/ui/store_computed_self.rs:17:8
+   |
+17 |     fn bad(&self) -> usize {
+   |        ^^^

--- a/docs/guides/components/02-state.md
+++ b/docs/guides/components/02-state.md
@@ -221,6 +221,60 @@ should stay local-state only. A store is for genuinely shared state.
 **Don't:** create "global singletons" by hand (`static CART:
 OnceCell<...>`). Use `#[store]` so reactivity just works.
 
+### Derived store fields — `#[computed]`
+
+Stores get the same `#[computed]` synthetic fields as components. Declare
+a readonly derivation in the store's `#[handlers]` impl; its dependencies
+are its parameters (no `self`, so there are no hidden reads), and the
+function name is the field key templates bind to:
+
+```rust
+#[derive(Default, Serialize, Deserialize)]
+#[store(name = "ws")]
+pub struct WorkspaceStore {
+    pub active_channel: String,
+    pub messages: Vec<Message>,
+    pub unread_by_channel: HashMap<String, usize>,
+}
+
+#[handlers]
+impl WorkspaceStore {
+    #[computed]
+    fn visible_messages(active_channel: &str, messages: &[Message]) -> Vec<MessageVm> {
+        build_visible_messages(active_channel, messages)
+    }
+
+    // A computed may depend on another computed by naming it.
+    #[computed]
+    fn visible_count(visible_messages: Vec<MessageVm>) -> usize {
+        visible_messages.len()
+    }
+
+    // Actions stay ordinary business logic — no rebuild, no invalidation.
+    pub fn select_channel(&mut self, id: String) {
+        self.active_channel = id;
+    }
+}
+```
+
+Bind them field-like through the `$store` path:
+
+```poco
+<tt-message-list pp-bind:items="$store.ws.visible_messages"></tt-message-list>
+<span pp-text="$store.ws.visible_count"></span>
+```
+
+The value is installed when the store is registered (`App::store::<T>()`),
+so the first `$store.ws.visible_messages` read already resolves. It is
+lazily memoized: it re-derives only when a *source* field it names
+changes through `store::<T>().update(...)`, a proxy write, or a field
+handle — an unrelated field write does not recompute it. It is a
+**readonly** synthetic field: writing `$store.ws.visible_count` through
+the proxy is a no-op, and a `&self` parameter or a dependency cycle is
+rejected at compile time. This is what lets you delete manually-rebuilt
+"label" fields from a store — see the
+[storage-browser refactor recipe](../recipes/storage-browser-state-refactor.md).
+
 ---
 
 ## Async data / server functions
@@ -356,8 +410,10 @@ need a long one:
 4. **Derived state stored as a field you manually keep in sync.**
    Don't write `progress_label` updates into every handler that
    touches `progress`. Use `#[computed]` for pure derivations and
-   `#[watch(field)]` for side-effecting reactions. The framework
+   `#[watch(field)]` for side-effecting reactions — this holds for
+   `#[store]` singletons too, not just components. The framework
    keeps the derived value up to date for you. Templates bind by
-   name (`pp-text="progress_label"`). See
+   name (`pp-text="progress_label"` or `$store.name.progress_label`).
+   See
    [`docs/guides/poco/04-expressions.md`](../poco/04-expressions.md) for
    the full pattern and the canonical examples.


### PR DESCRIPTION
Closes #260.

## What

Extends `#[computed]` readonly synthetic fields from `#[component]` to `#[store]` singletons, so app-level stores expose derived fields (`$store.ws.visible_messages`) without manually rebuilding cache fields from every action.

```rust
#[store(name = "ws")]
pub struct WorkspaceStore { active_channel: String, messages: Vec<Message>, /* … */ }

#[handlers]
impl WorkspaceStore {
    #[computed]
    fn visible_messages(active_channel: &str, messages: &[Message]) -> Vec<MessageVm> { … }

    #[computed]                       // computed-on-computed
    fn visible_count(visible_messages: Vec<MessageVm>) -> usize { visible_messages.len() }

    pub fn select_channel(&mut self, id: String) { self.active_channel = id; } // no rebuild call
}
```
```poco
<span pp-text="$store.ws.visible_count"></span>
```

## Why the change is tiny

`#[handlers]` is shared between components and stores, so a store with `#[computed]` **already** generated `__pocopine_computed_install`, `computed_keys()`, and `computed_get()`. Only two wires were missing:

1. **The store's `ComponentState` wasn't computed-aware** — `get` didn't fall through to `computed_get`, `keys()` omitted computed keys, and `is_computed_field` was never overridden (so `read_field_tracked` couldn't skip the projection cache for a store computed and could serve a stale value). Now mirrors the `#[component]` impl exactly.
2. **Stores have no DOM `setup` lifecycle**, so the computed entries were never installed. They're now installed in `__register_store`, keyed by the same state pointer `computed_get` derives on a read, before the scope is registered — so the first `$store.<name>.<computed>` read resolves.

Both wires degrade to no-ops for stores without computed methods (`computed_keys()` is empty; the install is empty), so existing stores are unchanged — verified: keep + file-browser build for wasm identically.

## Behavior (matches component computed)

Lazy `Computed<JsValue>` memoization · parameter-declared dependencies (no `self`, no hidden reads) · computed-on-computed · compile-time cycle rejection · readonly through the proxy · source tracking that re-derives on `store::<T>().update(...)` / proxy writes / field handles while leaving unrelated writes un-recomputed.

## Design note

An ecosystem survey (Pinia/Vuex getters, Vue/Solid/Svelte/MobX/Angular auto-tracking, Reselect/NgRx selectors, Ember's `@computed` → autotracking migration, Knockout, Jotai/Recoil/Nanostores) supports the issue's params-as-dependencies model: runtime frameworks converge on auto-tracking, but a **compiled** framework that wants **compile-time cycle detection** structurally cannot use auto-tracking (the dep graph isn't known until runtime). The **no-`self`** rule makes params-as-deps strictly better than Ember's explicit keys — it converts "the dep list can drift from the body" from a convention footgun into a compiler-enforced impossibility.

## Tests

- `crates/pine/tests/store_computed.rs` (headless Firefox): immediate availability after registration · re-derive on source change · computed-on-computed · no recompute on unrelated writes (no stale projection cache) · readonly through the `$store` proxy.
- `crates/pocopine/tests/store_computed_ui.rs` (trybuild): compile-**pass** on a real `#[store]` (raw-field computed + computed-on-computed). The `&self` and cycle compile-**fail** cases are pinned on the shared `#[handlers]` path so the `.stderr` stays toolchain-stable — a `#[store]` reject cascades a rustc trait error whose framing differs between the CI (`nightly-2025-12-18`) and workspace (`nightly-2026-02-21`) nightlies, which no single snapshot can satisfy (verified). Documented in the harness.
- Docs: new "Derived store fields" section in `guides/components/02-state.md`.

## Gates

`cargo fmt --all --check` · wasm clippy `-D warnings` · host example builds (keep + file-browser) · trybuild on both nightlies · browser runtime (store 3/3, existing component computed 5/5, no regression). Reviewed by `codex exec review --base main` — zero findings.