### PR TITLE
Smooth pie and radial chart tweens

### DIFF
--- a/crates/pine-charts/src/animation.rs
+++ b/crates/pine-charts/src/animation.rs
@@ -1,6 +1,7 @@
 pub(crate) const DEFAULT_ANIMATION_DURATION_MS: f64 = 160.0;
 pub(crate) const DEFAULT_ANIMATION_EASING: &str = "ease";
 const EXIT_ANIMATION_BUFFER_MS: u32 = 40;
+const CUBIC_BEZIER_SOLVE_EPSILON: f64 = 1e-6;
 
 pub(crate) fn animation_duration_ms(duration_ms: f64) -> u32 {
     if duration_ms.is_finite() && duration_ms >= 0.0 {
@@ -28,6 +29,107 @@ pub(crate) fn animation_style(duration_ms: f64, easing: &str) -> String {
     )
 }
 
+pub(crate) fn easing_progress(progress: f64, easing: &str) -> f64 {
+    let progress = progress.clamp(0.0, 1.0);
+    let easing = easing.trim();
+    match easing {
+        "linear" => progress,
+        "ease" => cubic_bezier_progress(progress, 0.25, 0.1, 0.25, 1.0),
+        "ease-in" => cubic_bezier_progress(progress, 0.42, 0.0, 1.0, 1.0),
+        "ease-out" => cubic_bezier_progress(progress, 0.0, 0.0, 0.58, 1.0),
+        "ease-in-out" => cubic_bezier_progress(progress, 0.42, 0.0, 0.58, 1.0),
+        _ => parse_cubic_bezier(easing)
+            .map(|[x1, y1, x2, y2]| cubic_bezier_progress(progress, x1, y1, x2, y2))
+            .unwrap_or_else(|| cubic_bezier_progress(progress, 0.25, 0.1, 0.25, 1.0)),
+    }
+}
+
+fn parse_cubic_bezier(easing: &str) -> Option<[f64; 4]> {
+    let inner = easing
+        .strip_prefix("cubic-bezier(")?
+        .strip_suffix(')')?
+        .trim();
+    let mut values = [0.0; 4];
+    let mut count = 0;
+    for part in inner.split(',') {
+        if count == values.len() {
+            return None;
+        }
+        let value = part.trim().parse::<f64>().ok()?;
+        if !value.is_finite() {
+            return None;
+        }
+        values[count] = value;
+        count += 1;
+    }
+    if count != values.len()
+        || !(0.0..=1.0).contains(&values[0])
+        || !(0.0..=1.0).contains(&values[2])
+    {
+        return None;
+    }
+    Some(values)
+}
+
+fn cubic_bezier_progress(progress: f64, x1: f64, y1: f64, x2: f64, y2: f64) -> f64 {
+    if progress <= 0.0 {
+        return 0.0;
+    }
+    if progress >= 1.0 {
+        return 1.0;
+    }
+
+    let t = solve_cubic_bezier_t(progress, x1, x2);
+    cubic_bezier_sample(t, y1, y2).clamp(0.0, 1.0)
+}
+
+fn solve_cubic_bezier_t(progress: f64, x1: f64, x2: f64) -> f64 {
+    let mut t = progress;
+    for _ in 0..8 {
+        let x = cubic_bezier_sample(t, x1, x2) - progress;
+        if x.abs() <= CUBIC_BEZIER_SOLVE_EPSILON {
+            return t.clamp(0.0, 1.0);
+        }
+        let derivative = cubic_bezier_derivative(t, x1, x2);
+        if derivative.abs() < CUBIC_BEZIER_SOLVE_EPSILON {
+            break;
+        }
+        let next = t - x / derivative;
+        if !(0.0..=1.0).contains(&next) {
+            break;
+        }
+        t = next;
+    }
+
+    let mut lo = 0.0;
+    let mut hi = 1.0;
+    for _ in 0..20 {
+        t = (lo + hi) * 0.5;
+        let x = cubic_bezier_sample(t, x1, x2);
+        if (x - progress).abs() <= CUBIC_BEZIER_SOLVE_EPSILON {
+            break;
+        }
+        if x < progress {
+            lo = t;
+        } else {
+            hi = t;
+        }
+    }
+    t
+}
+
+fn cubic_bezier_sample(t: f64, p1: f64, p2: f64) -> f64 {
+    let one_minus_t = 1.0 - t;
+    3.0 * one_minus_t * one_minus_t * t * p1 + 3.0 * one_minus_t * t * t * p2 + t * t * t
+}
+
+fn cubic_bezier_derivative(t: f64, p1: f64, p2: f64) -> f64 {
+    let one_minus_t = 1.0 - t;
+    3.0 * one_minus_t * one_minus_t * p1
+        + 6.0 * one_minus_t * t * (p2 - p1)
+        + 3.0 * t * t * (1.0 - p2)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -52,5 +154,28 @@ mod tests {
     fn exit_animation_delay_adds_cleanup_buffer() {
         assert_eq!(exit_animation_delay_ms(120.0), 160);
         assert_eq!(exit_animation_delay_ms(f64::NAN), 200);
+    }
+
+    #[test]
+    fn easing_progress_matches_css_named_curves() {
+        assert_eq!(easing_progress(0.5, "linear"), 0.5);
+        assert!(easing_progress(0.5, "ease-in") < 0.35);
+        assert!(easing_progress(0.5, "ease-out") > 0.65);
+        assert!((easing_progress(0.5, "ease-in-out") - 0.5).abs() <= 0.001);
+    }
+
+    #[test]
+    fn easing_progress_parses_css_cubic_bezier() {
+        let progress = easing_progress(0.5, "cubic-bezier(0, 0, 0.58, 1)");
+
+        assert!((progress - easing_progress(0.5, "ease-out")).abs() <= 0.001);
+    }
+
+    #[test]
+    fn easing_progress_falls_back_to_css_ease() {
+        assert_eq!(
+            easing_progress(0.5, "not-an-easing"),
+            easing_progress(0.5, "ease")
+        );
     }
 }

--- a/crates/pine-charts/src/pie/PinePieChart.poco
+++ b/crates/pine-charts/src/pie/PinePieChart.poco
@@ -44,12 +44,12 @@
                 :data-label="slice.label"
                 :data-value="slice.value"
                 :data-percentage="slice.percentage"
-                :data-hovered="slice.key == hover_key && animating_slices"
+                :data-hovered="slice.key == hover_key && !slice.leaving"
                 :data-focused="slice.key == focused_key"
                 :data-selected="slice.key == selected_key"
                 :data-entering="slice.entering ? 'true' : 'false'"
                 :data-leaving="slice.leaving ? 'true' : 'false'"
-                :style="slice.animation_style"
+                :style="slice.animation_style + slice.hover_style"
                 @click.stop="select_slice(slice.key)"></path>
         </g>
       </template>

--- a/crates/pine-charts/src/pie/mod.rs
+++ b/crates/pine-charts/src/pie/mod.rs
@@ -5,7 +5,8 @@ use pocopine::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::animation::{
-    DEFAULT_ANIMATION_DURATION_MS, DEFAULT_ANIMATION_EASING, animation_duration_ms, animation_style,
+    DEFAULT_ANIMATION_DURATION_MS, DEFAULT_ANIMATION_EASING, animation_duration_ms,
+    animation_style, easing_progress,
 };
 use crate::cartesian::{
     CartesianHoverPlacement, ChartStateFields, DEFAULT_EMPTY_MESSAGE, pointer_event_svg_point,
@@ -23,6 +24,7 @@ use crate::svg::format_tick;
 const FULL_CIRCLE_DEGREES: f64 = 360.0;
 const PIE_SLICE_DELAY_MS: u32 = 28;
 const PIE_LEAVING_PRUNE_PROGRESS: f64 = 0.995;
+const PIE_HOVER_OFFSET_PX: f64 = 4.0;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ChartPieSlice {
@@ -153,6 +155,7 @@ impl PieChartGeometry {
                     label_x: label_point.x,
                     label_y: label_point.y,
                     animation_style: slice_animation_style(index),
+                    hover_style: slice_hover_style(center, outer_radius, slice_start, slice_end),
                     center_x: center.x,
                     center_y: center.y,
                     outer_radius,
@@ -208,6 +211,7 @@ pub struct SvgPieSlice {
     pub label_x: f64,
     pub label_y: f64,
     pub animation_style: String,
+    pub hover_style: String,
     pub center_x: f64,
     pub center_y: f64,
     pub outer_radius: f64,
@@ -706,12 +710,11 @@ impl PinePieChart {
                 let entering = previous.entering;
                 slice.entering = entering;
                 slice.leaving = false;
-                let delay_ms = if entering { slice_delay_ms(index) } else { 0 };
                 animations.push(PieSliceAnimation {
                     key: slice.key.clone(),
                     from: from.clone(),
                     to,
-                    delay_ms,
+                    delay_ms: 0,
                     duration_ms,
                     entering,
                     leaving: false,
@@ -734,7 +737,7 @@ impl PinePieChart {
                 key: slice.key.clone(),
                 from: from.clone(),
                 to,
-                delay_ms: slice_delay_ms(index),
+                delay_ms: 0,
                 duration_ms,
                 entering: true,
                 leaving: false,
@@ -1082,7 +1085,7 @@ impl PinePieChart {
     }
 
     fn update_hover_overlay_visibility(&mut self) {
-        self.hover_overlay_visible = self.hover_visible && !self.animating_slices;
+        self.hover_overlay_visible = false;
     }
 
     fn reconcile_selection(&mut self) {
@@ -1341,6 +1344,12 @@ fn apply_slice_frame(slice: &mut SvgPieSlice, frame: &PieSliceFrame) {
     );
     slice.label_x = label_point.x;
     slice.label_y = label_point.y;
+    slice.hover_style = slice_hover_style(
+        center,
+        frame.outer_radius,
+        frame.start_angle,
+        frame.end_angle,
+    );
 }
 
 fn interpolate_slice_frame(
@@ -1379,29 +1388,22 @@ fn slice_animation_progress(animation: &PieSliceAnimation, elapsed_ms: f64) -> f
     (elapsed_ms / animation.duration_ms as f64).clamp(0.0, 1.0)
 }
 
-fn easing_progress(progress: f64, easing: &str) -> f64 {
-    let progress = progress.clamp(0.0, 1.0);
-    match easing.trim() {
-        "linear" => progress,
-        "ease-in" => progress * progress,
-        "ease-out" => 1.0 - (1.0 - progress).powi(2),
-        "ease-in-out" => {
-            if progress < 0.5 {
-                2.0 * progress * progress
-            } else {
-                1.0 - (-2.0 * progress + 2.0).powi(2) * 0.5
-            }
-        }
-        _ => progress * progress * (3.0 - 2.0 * progress),
-    }
-}
-
 fn lerp(from: f64, to: f64, progress: f64) -> f64 {
     clean(from + (to - from) * progress)
 }
 
 fn slice_animation_style(index: usize) -> String {
     format!("--pine-chart-slice-delay: {}ms;", slice_delay_ms(index))
+}
+
+fn slice_hover_style(center: Point, outer_radius: f64, start_angle: f64, end_angle: f64) -> String {
+    let offset = PIE_HOVER_OFFSET_PX.min(outer_radius * 0.08);
+    let midpoint = polar_point(center, offset, (start_angle + end_angle) * 0.5);
+    format!(
+        "--pine-chart-slice-hover-x:{}px;--pine-chart-slice-hover-y:{}px;",
+        clean(midpoint.x - center.x),
+        clean(midpoint.y - center.y)
+    )
 }
 
 fn slice_delay_ms(index: usize) -> u32 {

--- a/crates/pine-charts/src/radial/PineRadialBarChart.poco
+++ b/crates/pine-charts/src/radial/PineRadialBarChart.poco
@@ -7,6 +7,7 @@
       :data-hover="hover_visible"
       :data-tooltip="tooltip_mode"
       :data-animate="animate"
+      :data-ring-animating="animating_bars"
       :data-animation-duration="animation_duration"
       :data-animation-easing="animation_easing"
       :style="animation_style"
@@ -39,6 +40,8 @@
               :data-value="bar.value"
               :data-max="bar.max"
               :data-percentage="bar.percentage"
+              :data-leaving="bar.leaving ? 'true' : 'false'"
+              :style="bar.leaving ? 'display: none;' : bar.track_style"
               @click.stop="select_bar(bar.key)"></path>
       </template>
     </g>
@@ -53,6 +56,7 @@
               :aria-selected="bar.key == selected_key ? 'true' : 'false'"
               :stroke-width="bar.stroke_width"
               :stroke-dasharray="bar.stroke_dasharray"
+              :opacity="bar.opacity"
               :data-key="bar.key"
               :data-label="bar.label"
               :data-value="bar.value"
@@ -62,6 +66,8 @@
               :data-hovered="bar.key == hover_key"
               :data-focused="bar.key == focused_key"
               :data-selected="bar.key == selected_key"
+              :data-entering="bar.entering ? 'true' : 'false'"
+              :data-leaving="bar.leaving ? 'true' : 'false'"
               @click.stop="select_bar(bar.key)"></path>
       </template>
     </g>

--- a/crates/pine-charts/src/radial/mod.rs
+++ b/crates/pine-charts/src/radial/mod.rs
@@ -4,7 +4,10 @@ use core::fmt::Write;
 use pocopine::prelude::*;
 use serde::{Deserialize, Serialize};
 
-use crate::animation::{DEFAULT_ANIMATION_DURATION_MS, DEFAULT_ANIMATION_EASING, animation_style};
+use crate::animation::{
+    DEFAULT_ANIMATION_DURATION_MS, DEFAULT_ANIMATION_EASING, animation_duration_ms,
+    animation_style, easing_progress,
+};
 use crate::cartesian::{
     CartesianChartState, CartesianHoverPlacement, ChartStateFields, DEFAULT_EMPTY_MESSAGE,
     pointer_event_svg_point, step_key, sync_tooltip_fields,
@@ -19,6 +22,7 @@ use crate::legend::LegendItem;
 use crate::svg::format_tick;
 
 const FULL_CIRCLE_DEGREES: f64 = 360.0;
+const RADIAL_LEAVING_PRUNE_PROGRESS: f64 = 0.995;
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ChartRadialBar {
@@ -162,6 +166,8 @@ impl RadialBarChartGeometry {
                     percentage_label,
                     aria_label,
                     track_d,
+                    track_opacity: 1.0,
+                    track_style: radial_track_style(1.0),
                     value_d,
                     value_visible: bar.value > 0.0,
                     stroke_dasharray: stroke_dasharray(progress),
@@ -169,11 +175,16 @@ impl RadialBarChartGeometry {
                     inner_radius: inner,
                     outer_radius: outer,
                     stroke_width: thickness,
+                    opacity: 1.0,
+                    center_x: center.x,
+                    center_y: center.y,
                     start_angle,
                     end_angle,
                     value_end_angle,
                     label_x: label_point.x,
                     label_y: label_point.y,
+                    entering: false,
+                    leaving: false,
                 })
             })
             .collect::<ChartResult<Vec<_>>>()?;
@@ -219,6 +230,8 @@ pub struct SvgRadialBar {
     pub percentage_label: String,
     pub aria_label: String,
     pub track_d: String,
+    pub track_opacity: f64,
+    pub track_style: String,
     pub value_d: String,
     pub value_visible: bool,
     pub stroke_dasharray: String,
@@ -226,11 +239,16 @@ pub struct SvgRadialBar {
     pub inner_radius: f64,
     pub outer_radius: f64,
     pub stroke_width: f64,
+    pub opacity: f64,
+    pub center_x: f64,
+    pub center_y: f64,
     pub start_angle: f64,
     pub end_angle: f64,
     pub value_end_angle: f64,
     pub label_x: f64,
     pub label_y: f64,
+    pub entering: bool,
+    pub leaving: bool,
 }
 
 impl SvgRadialBar {
@@ -247,9 +265,9 @@ impl SvgRadialBar {
         )
     }
 
-    fn contains(&self, point: Point, center: Point) -> bool {
-        let dx = point.x - center.x;
-        let dy = point.y - center.y;
+    fn contains(&self, point: Point) -> bool {
+        let dx = point.x - self.center_x;
+        let dy = point.y - self.center_y;
         let radius = (dx * dx + dy * dy).sqrt();
         if radius < self.inner_radius || radius > self.outer_radius {
             return false;
@@ -286,6 +304,31 @@ struct NormalizedRadialBar {
     label: String,
     value: f64,
     max: f64,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+struct RadialBarFrame {
+    center_x: f64,
+    center_y: f64,
+    radius: f64,
+    inner_radius: f64,
+    outer_radius: f64,
+    stroke_width: f64,
+    opacity: f64,
+    track_opacity: f64,
+    start_angle: f64,
+    end_angle: f64,
+    progress: f64,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize)]
+struct RadialBarAnimation {
+    key: String,
+    from: RadialBarFrame,
+    to: RadialBarFrame,
+    duration_ms: u32,
+    entering: bool,
+    leaving: bool,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -344,6 +387,10 @@ pub struct PineRadialBarChart {
     pub tooltip_mode: String,
     pub tooltip_aria_hidden: String,
     pub animation_style: String,
+    pub animation_generation: u32,
+    pub animating_bars: bool,
+    bar_animations: Vec<RadialBarAnimation>,
+    animation_started_at_ms: f64,
     pub state: String,
     pub view_box: String,
     pub bars: Vec<SvgRadialBar>,
@@ -406,6 +453,10 @@ impl Default for PineRadialBarChart {
                 DEFAULT_ANIMATION_DURATION_MS,
                 DEFAULT_ANIMATION_EASING,
             ),
+            animation_generation: 0,
+            animating_bars: false,
+            bar_animations: Vec::new(),
+            animation_started_at_ms: 0.0,
             state: "empty".into(),
             view_box: format!("0 0 {} {}", options.width, options.height),
             bars: Vec::new(),
@@ -608,7 +659,13 @@ impl PineRadialBarChart {
         match RadialBarChartGeometry::new(&self.data, &self.options()) {
             Ok(geometry) => {
                 self.view_box = geometry.view_box;
-                self.bars = geometry.bars;
+                let mut bars = geometry.bars;
+                if self.animate {
+                    self.prepare_bar_animations(&mut bars);
+                } else {
+                    self.clear_bar_animations();
+                }
+                self.bars = bars;
                 self.legend_items = geometry.legend_items;
                 self.center_x = geometry.center.x;
                 self.center_y = geometry.center.y;
@@ -621,6 +678,18 @@ impl PineRadialBarChart {
                 self.clear_hover();
             }
             Err(ChartError::EmptySeries) => {
+                if self.animate
+                    && !self.bars.is_empty()
+                    && animation_duration_ms(self.animation_duration) > 0
+                {
+                    self.prepare_empty_bar_exit();
+                    self.legend_items = radial_bar_legend_items(&self.data);
+                    self.clear_hover();
+                    self.clear_selection();
+                    self.error.clear();
+                    self.state_fields().apply(CartesianChartState::Ready);
+                    return;
+                }
                 self.clear_geometry();
                 self.clear_hover();
                 self.clear_selection();
@@ -634,6 +703,194 @@ impl PineRadialBarChart {
                 self.error = error.to_string();
                 self.state_fields().apply(CartesianChartState::Invalid);
             }
+        }
+    }
+
+    fn prepare_bar_animations(&mut self, next: &mut Vec<SvgRadialBar>) {
+        let duration_ms = animation_duration_ms(self.animation_duration);
+        if duration_ms == 0 {
+            self.clear_bar_animations();
+            return;
+        }
+
+        let mut animations = Vec::new();
+        for bar in next.iter_mut() {
+            if let Some(previous) = self
+                .bars
+                .iter()
+                .find(|previous| !previous.leaving && previous.key == bar.key)
+            {
+                let from = bar_frame(previous);
+                let to = bar_frame(bar);
+                if radial_frames_match(&from, &to) && !previous.entering {
+                    configure_static_bar(bar);
+                    continue;
+                }
+                let entering = previous.entering;
+                bar.entering = entering;
+                bar.leaving = false;
+                animations.push(RadialBarAnimation {
+                    key: bar.key.clone(),
+                    from: from.clone(),
+                    to,
+                    duration_ms,
+                    entering,
+                    leaving: false,
+                });
+                apply_bar_frame(bar, &from);
+                continue;
+            }
+
+            let to = bar_frame(bar);
+            let from = radial_zero_frame(&to);
+            bar.entering = true;
+            bar.leaving = false;
+            animations.push(RadialBarAnimation {
+                key: bar.key.clone(),
+                from: from.clone(),
+                to,
+                duration_ms,
+                entering: true,
+                leaving: false,
+            });
+            apply_bar_frame(bar, &from);
+        }
+
+        for previous in self.bars.iter().filter(|previous| !previous.leaving) {
+            if next.iter().any(|bar| bar.key == previous.key) {
+                continue;
+            }
+            let mut leaving = previous.clone();
+            let from = bar_frame(previous);
+            let to = radial_zero_frame(&from);
+            leaving.entering = false;
+            leaving.leaving = true;
+            apply_bar_frame(&mut leaving, &from);
+            animations.push(RadialBarAnimation {
+                key: leaving.key.clone(),
+                from,
+                to,
+                duration_ms,
+                entering: false,
+                leaving: true,
+            });
+            next.push(leaving);
+        }
+
+        if animations.is_empty() {
+            self.clear_bar_animations();
+            return;
+        }
+        self.bar_animations = animations;
+        self.animating_bars = true;
+        self.animation_started_at_ms = now_ms();
+        self.start_bar_animation_loop();
+    }
+
+    fn prepare_empty_bar_exit(&mut self) {
+        let duration_ms = animation_duration_ms(self.animation_duration);
+        if duration_ms == 0 || self.bars.is_empty() {
+            self.clear_bar_animations();
+            return;
+        }
+        let mut animations = Vec::new();
+        for bar in &mut self.bars {
+            let from = bar_frame(bar);
+            let to = radial_zero_frame(&from);
+            bar.entering = false;
+            bar.leaving = true;
+            animations.push(RadialBarAnimation {
+                key: bar.key.clone(),
+                from,
+                to,
+                duration_ms,
+                entering: false,
+                leaving: true,
+            });
+        }
+        self.bar_animations = animations;
+        self.animating_bars = true;
+        self.animation_started_at_ms = now_ms();
+        self.start_bar_animation_loop();
+    }
+
+    fn clear_bar_animations(&mut self) {
+        self.bar_animations.clear();
+        self.animating_bars = false;
+    }
+
+    fn start_bar_animation_loop(&mut self) {
+        self.animation_generation = self.animation_generation.wrapping_add(1);
+        let generation = self.animation_generation;
+        let me = pocopine::this::<Self>();
+        pocopine::spawn_scoped(async move {
+            loop {
+                let now = pocopine::timers::next_frame().await;
+                if me.update(|chart| chart.tick_bar_animations(generation, now)) {
+                    break;
+                }
+            }
+        });
+    }
+
+    fn tick_bar_animations(&mut self, generation: u32, now_ms: f64) -> bool {
+        if generation != self.animation_generation || self.bar_animations.is_empty() {
+            return true;
+        }
+
+        let animations = self.bar_animations.clone();
+        let elapsed_ms = (now_ms - self.animation_started_at_ms).max(0.0);
+        let easing = self.animation_easing.clone();
+        let complete = animations
+            .iter()
+            .all(|animation| bar_animation_progress(animation, elapsed_ms) >= 1.0);
+        let mut prune_leaving_keys = Vec::new();
+
+        for bar in &mut self.bars {
+            let Some(animation) = animations.iter().find(|animation| animation.key == bar.key)
+            else {
+                configure_static_bar(bar);
+                continue;
+            };
+
+            let progress = bar_animation_progress(animation, elapsed_ms);
+            if animation.leaving && progress >= RADIAL_LEAVING_PRUNE_PROGRESS {
+                prune_leaving_keys.push(bar.key.clone());
+                continue;
+            }
+            let eased_progress = easing_progress(progress, &easing);
+            let mut frame = interpolate_bar_frame(&animation.from, &animation.to, eased_progress);
+            frame.opacity = radial_animation_opacity(animation, eased_progress);
+            apply_bar_frame(bar, &frame);
+            bar.entering = animation.entering && progress < 1.0;
+            bar.leaving = animation.leaving;
+        }
+
+        if !prune_leaving_keys.is_empty() {
+            self.bars.retain(|bar| {
+                !bar.leaving || !prune_leaving_keys.iter().any(|key| key == &bar.key)
+            });
+        }
+        self.sync_hover_bar();
+
+        if complete {
+            self.finish_bar_animations(generation);
+            return true;
+        }
+        false
+    }
+
+    fn finish_bar_animations(&mut self, generation: u32) {
+        if generation != self.animation_generation {
+            return;
+        }
+        self.clear_bar_animations();
+        self.bars.retain(|bar| !bar.leaving);
+        self.bars.iter_mut().for_each(configure_static_bar);
+        self.sync_hover_bar();
+        if self.bars.is_empty() {
+            self.clear_geometry();
+            self.state_fields().apply(CartesianChartState::Empty);
         }
     }
 
@@ -664,15 +921,12 @@ impl PineRadialBarChart {
             return;
         }
 
-        let center = Point {
-            x: self.center_x,
-            y: self.center_y,
-        };
         let plot = self.plot_rect();
         let Some(update) = self
             .bars
             .iter()
-            .find(|bar| bar.contains(point, center))
+            .filter(|bar| !bar.leaving)
+            .find(|bar| bar.contains(point))
             .map(|bar| bar.hover_update(plot, self.width, self.height))
         else {
             self.clear_hover();
@@ -684,7 +938,10 @@ impl PineRadialBarChart {
 
     fn step_bar_focus(&mut self, step: isize) {
         if let Some(key) = step_key(
-            self.bars.iter().map(|bar| bar.key.as_str()),
+            self.bars
+                .iter()
+                .filter(|bar| !bar.leaving)
+                .map(|bar| bar.key.as_str()),
             &self.focused_key,
             step,
         ) {
@@ -693,18 +950,19 @@ impl PineRadialBarChart {
     }
 
     fn has_bar_key(&self, key: &str) -> bool {
-        self.bars.iter().any(|bar| bar.key == key)
+        self.bars.iter().any(|bar| !bar.leaving && bar.key == key)
     }
 
     fn selection_for_bar(&self, key: &str) -> Option<ChartSelection> {
         self.bars
             .iter()
-            .find(|bar| bar.key == key)
+            .find(|bar| !bar.leaving && bar.key == key)
             .map(SvgRadialBar::selection)
     }
 
     fn clear_geometry(&mut self) {
         self.bars.clear();
+        self.clear_bar_animations();
         self.hover_bar = SvgRadialBar::default();
         self.legend_items.clear();
         self.center_x = 0.0;
@@ -788,7 +1046,7 @@ impl PineRadialBarChart {
         self.hover_bar = self
             .bars
             .iter()
-            .find(|bar| bar.key == self.hover_key)
+            .find(|bar| !bar.leaving && bar.key == self.hover_key)
             .cloned()
             .unwrap_or_default();
     }
@@ -949,6 +1207,173 @@ fn stroke_dasharray(progress: f64) -> String {
     format!("{} 1", clean(progress.clamp(0.0, 1.0)))
 }
 
+fn configure_static_bar(bar: &mut SvgRadialBar) {
+    bar.entering = false;
+    bar.leaving = false;
+    bar.opacity = 1.0;
+    set_radial_track_opacity(bar, 1.0);
+}
+
+fn bar_frame(bar: &SvgRadialBar) -> RadialBarFrame {
+    RadialBarFrame {
+        center_x: bar.center_x,
+        center_y: bar.center_y,
+        radius: bar.radius,
+        inner_radius: bar.inner_radius,
+        outer_radius: bar.outer_radius,
+        stroke_width: bar.stroke_width,
+        opacity: bar.opacity,
+        track_opacity: bar.track_opacity,
+        start_angle: bar.start_angle,
+        end_angle: bar.end_angle,
+        progress: radial_bar_progress(bar),
+    }
+}
+
+fn radial_bar_progress(bar: &SvgRadialBar) -> f64 {
+    bar.stroke_dasharray
+        .split_whitespace()
+        .next()
+        .and_then(|value| value.parse::<f64>().ok())
+        .filter(|value| value.is_finite())
+        .unwrap_or_else(|| {
+            if bar.max > 0.0 {
+                bar.value / bar.max
+            } else {
+                0.0
+            }
+        })
+        .clamp(0.0, 1.0)
+}
+
+fn radial_zero_frame(frame: &RadialBarFrame) -> RadialBarFrame {
+    RadialBarFrame {
+        progress: 0.0,
+        opacity: 0.0,
+        track_opacity: 0.0,
+        ..frame.clone()
+    }
+}
+
+fn apply_bar_frame(bar: &mut SvgRadialBar, frame: &RadialBarFrame) {
+    let center = Point {
+        x: frame.center_x,
+        y: frame.center_y,
+    };
+    if let Ok(path) = arc_path(center, frame.radius, frame.start_angle, frame.end_angle) {
+        bar.track_d = path.clone();
+        bar.value_d = if frame.progress > 0.0 {
+            path
+        } else {
+            String::new()
+        };
+    }
+    let progress = frame.progress.clamp(0.0, 1.0);
+    bar.value_visible = progress > 0.0;
+    bar.stroke_dasharray = stroke_dasharray(progress);
+    bar.radius = frame.radius;
+    bar.inner_radius = frame.inner_radius;
+    bar.outer_radius = frame.outer_radius;
+    bar.stroke_width = frame.stroke_width;
+    bar.opacity = frame.opacity.clamp(0.0, 1.0);
+    set_radial_track_opacity(bar, frame.track_opacity);
+    bar.center_x = frame.center_x;
+    bar.center_y = frame.center_y;
+    bar.start_angle = frame.start_angle;
+    bar.end_angle = frame.end_angle;
+    bar.value_end_angle = frame.start_angle + (frame.end_angle - frame.start_angle) * progress;
+    let label_angle = if progress > 0.0 {
+        frame.start_angle + (bar.value_end_angle - frame.start_angle) * 0.5
+    } else {
+        frame.start_angle
+    };
+    let label_point = polar_point(center, frame.radius, label_angle);
+    bar.label_x = label_point.x;
+    bar.label_y = label_point.y;
+}
+
+fn interpolate_bar_frame(
+    from: &RadialBarFrame,
+    to: &RadialBarFrame,
+    progress: f64,
+) -> RadialBarFrame {
+    RadialBarFrame {
+        center_x: lerp(from.center_x, to.center_x, progress),
+        center_y: lerp(from.center_y, to.center_y, progress),
+        radius: lerp(from.radius, to.radius, progress),
+        inner_radius: lerp(from.inner_radius, to.inner_radius, progress),
+        outer_radius: lerp(from.outer_radius, to.outer_radius, progress),
+        stroke_width: lerp(from.stroke_width, to.stroke_width, progress),
+        opacity: lerp(from.opacity, to.opacity, progress),
+        track_opacity: lerp(from.track_opacity, to.track_opacity, progress),
+        start_angle: lerp(from.start_angle, to.start_angle, progress),
+        end_angle: lerp(from.end_angle, to.end_angle, progress),
+        progress: lerp(from.progress, to.progress, progress),
+    }
+}
+
+fn radial_frames_match(left: &RadialBarFrame, right: &RadialBarFrame) -> bool {
+    const EPSILON: f64 = 0.001;
+    (left.center_x - right.center_x).abs() <= EPSILON
+        && (left.center_y - right.center_y).abs() <= EPSILON
+        && (left.radius - right.radius).abs() <= EPSILON
+        && (left.inner_radius - right.inner_radius).abs() <= EPSILON
+        && (left.outer_radius - right.outer_radius).abs() <= EPSILON
+        && (left.stroke_width - right.stroke_width).abs() <= EPSILON
+        && (left.opacity - right.opacity).abs() <= EPSILON
+        && (left.track_opacity - right.track_opacity).abs() <= EPSILON
+        && (left.start_angle - right.start_angle).abs() <= EPSILON
+        && (left.end_angle - right.end_angle).abs() <= EPSILON
+        && (left.progress - right.progress).abs() <= EPSILON
+}
+
+fn bar_animation_progress(animation: &RadialBarAnimation, elapsed_ms: f64) -> f64 {
+    if elapsed_ms <= 0.0 {
+        return 0.0;
+    }
+    if animation.duration_ms == 0 {
+        return 1.0;
+    }
+    (elapsed_ms / animation.duration_ms as f64).clamp(0.0, 1.0)
+}
+
+fn radial_animation_opacity(animation: &RadialBarAnimation, eased_progress: f64) -> f64 {
+    const EXIT_FADE_COMPLETE: f64 = 0.68;
+    const ENTER_FADE_COMPLETE: f64 = 0.45;
+
+    if animation.leaving {
+        let fade = (eased_progress / EXIT_FADE_COMPLETE).clamp(0.0, 1.0);
+        return clean(1.0 - fade);
+    }
+    if animation.entering {
+        return clean((eased_progress / ENTER_FADE_COMPLETE).clamp(0.0, 1.0));
+    }
+    clean(lerp(animation.from.opacity, animation.to.opacity, eased_progress).clamp(0.0, 1.0))
+}
+
+fn radial_track_style(opacity: f64) -> String {
+    format!(
+        "--pine-chart-radial-track-opacity:{};",
+        clean(opacity.clamp(0.0, 1.0))
+    )
+}
+
+fn set_radial_track_opacity(bar: &mut SvgRadialBar, opacity: f64) {
+    bar.track_opacity = opacity.clamp(0.0, 1.0);
+    bar.track_style = radial_track_style(bar.track_opacity);
+}
+
+fn lerp(from: f64, to: f64, progress: f64) -> f64 {
+    clean(from + (to - from) * progress)
+}
+
+fn now_ms() -> f64 {
+    web_sys::window()
+        .and_then(|window| window.performance())
+        .map(|performance| performance.now())
+        .unwrap_or_else(js_sys::Date::now)
+}
+
 fn is_full_arc(start_angle: f64, end_angle: f64) -> bool {
     (end_angle - start_angle).abs() >= FULL_CIRCLE_DEGREES
 }
@@ -1106,9 +1531,9 @@ mod tests {
                 .unwrap();
         let bar = &geometry.bars[0];
 
-        assert!(bar.contains(Point { x: 50.0, y: 20.0 }, geometry.center));
-        assert!(!bar.contains(Point { x: 50.0, y: 50.0 }, geometry.center));
-        assert!(!bar.contains(Point { x: 50.0, y: -5.0 }, geometry.center));
+        assert!(bar.contains(Point { x: 50.0, y: 20.0 }));
+        assert!(!bar.contains(Point { x: 50.0, y: 50.0 }));
+        assert!(!bar.contains(Point { x: 50.0, y: -5.0 }));
     }
 
     #[test]

--- a/crates/pine-charts/tests/charts.rs
+++ b/crates/pine-charts/tests/charts.rs
@@ -123,6 +123,35 @@ fn first_arc_radius(path: &str) -> f64 {
     radius.parse().expect("expected numeric SVG arc radius")
 }
 
+fn first_dash_progress(value: &str) -> f64 {
+    value
+        .split_whitespace()
+        .next()
+        .expect("expected SVG dash progress")
+        .parse()
+        .expect("expected numeric SVG dash progress")
+}
+
+fn svg_opacity(element: &Element) -> f64 {
+    element
+        .get_attribute("opacity")
+        .expect("expected SVG opacity")
+        .parse()
+        .expect("expected numeric SVG opacity")
+}
+
+fn css_variable_number(element: &Element, name: &str) -> f64 {
+    element
+        .get_attribute("style")
+        .unwrap_or_default()
+        .split(';')
+        .find_map(|declaration| declaration.trim().strip_prefix(name))
+        .and_then(|value| value.strip_prefix(':'))
+        .expect("expected CSS variable")
+        .parse()
+        .expect("expected numeric CSS variable")
+}
+
 fn direct_svg_layers(svg: &Element) -> Vec<String> {
     let groups = svg.query_selector_all(":scope > g[data-layer]").unwrap();
     (0..groups.length())
@@ -897,7 +926,7 @@ async fn pie_chart_morphs_shape_without_svg_animate_nodes() {
 }
 
 #[wasm_bindgen_test]
-async fn pie_chart_prunes_finished_leaving_slices_before_delayed_entries_finish() {
+async fn pie_chart_prunes_finished_leaving_slices_while_new_entries_settle() {
     let host = mount_fixture::<PieChartFixture>();
     settle().await;
 
@@ -932,7 +961,15 @@ async fn pie_chart_prunes_finished_leaving_slices_before_delayed_entries_finish(
             .unwrap()
             .get_attribute("data-entering")
             .as_deref(),
-        Some("true")
+        Some("false")
+    );
+    assert!(
+        !host
+            .query_selector(".pine-pie-chart")
+            .unwrap()
+            .unwrap()
+            .has_attribute("data-slice-animating"),
+        "new entries should settle with the same coherent tween as removed slices"
     );
 
     host.remove();
@@ -2389,7 +2426,10 @@ async fn pie_chart_renders_donut_slices_and_selection() {
     dispatch_pointer_move(&svg, 50.0, 10.0);
     settle().await;
 
-    assert!(!first.has_attribute("data-hovered"));
+    assert!(first.has_attribute("data-hovered"));
+    let first_style = first.get_attribute("style").unwrap_or_default();
+    assert!(first_style.contains("--pine-chart-slice-hover-x:"));
+    assert!(first_style.contains("--pine-chart-slice-hover-y:"));
     let hovered_key = first.get_attribute("data-key").unwrap();
     let hover_slice = host
         .query_selector(".pine-chart-pie-hover .pine-chart-pie-slice")
@@ -2402,6 +2442,17 @@ async fn pie_chart_renders_donut_slices_and_selection() {
         Some(hovered_key.as_str())
     );
     assert!(hover_slice.has_attribute("data-hovered"));
+    let hover_layer = host
+        .query_selector(".pine-chart-pie-hover")
+        .unwrap()
+        .unwrap();
+    assert!(
+        hover_layer
+            .get_attribute("style")
+            .unwrap_or_default()
+            .contains("display: none"),
+        "expected pie hover to style the canonical slice, not stack a duplicate hover arc"
+    );
     let tooltip = host
         .query_selector(".pine-chart-pie-tooltip")
         .unwrap()
@@ -2478,6 +2529,52 @@ impl Default for RadialBarChartFixture {
 #[handlers]
 impl RadialBarChartFixture {}
 
+#[derive(serde::Serialize, serde::Deserialize)]
+#[component(template_inline = r#"
+<div>
+  <button class="swap-radial" @click="swap">Swap</button>
+  <pine-radial-bar-chart class="animated-rings"
+                         label="Rings"
+                         width="120"
+                         height="120"
+                         margin_top="0"
+                         margin_right="0"
+                         margin_bottom="0"
+                         margin_left="0"
+                         inner_radius="0.3"
+                         ring_gap="4"
+                         animate="true"
+                         animation_duration="80"
+                         animation_easing="cubic-bezier(0.22, 1, 0.36, 1)"
+                         pp-bind:data="data"></pine-radial-bar-chart>
+</div>
+"#)]
+struct RadialAnimationFixture {
+    data: Vec<ChartRadialBar>,
+}
+
+impl Default for RadialAnimationFixture {
+    fn default() -> Self {
+        Self {
+            data: vec![
+                ChartRadialBar::new("Activation", 84.0, 100.0),
+                ChartRadialBar::new("Retention", 68.0, 100.0),
+            ],
+        }
+    }
+}
+
+#[handlers]
+impl RadialAnimationFixture {
+    pub fn swap(&mut self) {
+        self.data = vec![
+            ChartRadialBar::new("API", 74.0, 100.0),
+            ChartRadialBar::new("Render", 62.0, 100.0),
+            ChartRadialBar::new("Network", 58.0, 100.0),
+        ];
+    }
+}
+
 #[wasm_bindgen_test]
 async fn radial_bar_chart_renders_rings_hover_and_selection() {
     let host = mount_fixture::<RadialBarChartFixture>();
@@ -2495,6 +2592,7 @@ async fn radial_bar_chart_renders_rings_hover_and_selection() {
     assert_eq!(chart.get_attribute("data-state").as_deref(), Some("ready"));
     assert_eq!(chart.get_attribute("tabindex").as_deref(), Some("0"));
     assert!(!chart.has_attribute("data-hover"));
+    assert!(!chart.has_attribute("data-ring-animating"));
 
     let svg = host.query_selector("svg.pine-chart-svg").unwrap().unwrap();
     assert_eq!(
@@ -2602,6 +2700,159 @@ async fn radial_bar_chart_renders_rings_hover_and_selection() {
 }
 
 #[wasm_bindgen_test]
+async fn radial_bar_chart_tweens_ring_swaps_with_enter_and_exit_state() {
+    let host = mount_fixture::<RadialAnimationFixture>();
+    settle().await;
+
+    let chart = host.query_selector(".animated-rings").unwrap().unwrap();
+    assert!(chart.has_attribute("data-ring-animating"));
+    let activation_entering = host
+        .query_selector(".pine-chart-radial-bar[data-label='Activation']")
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        activation_entering
+            .get_attribute("data-entering")
+            .as_deref(),
+        Some("true")
+    );
+    assert!(
+        first_dash_progress(
+            &activation_entering
+                .get_attribute("stroke-dasharray")
+                .unwrap()
+        ) < 0.84,
+        "initial radial entry should be driven by the renderer tween"
+    );
+    assert!(
+        svg_opacity(&activation_entering) < 1.0,
+        "initial radial entry should fade in on the renderer tween"
+    );
+
+    sleep_ms(100).await;
+    settle().await;
+
+    assert!(!chart.has_attribute("data-ring-animating"));
+    let activation_before = host
+        .query_selector(".pine-chart-radial-bar[data-label='Activation']")
+        .unwrap()
+        .unwrap()
+        .get_attribute("stroke-dasharray")
+        .unwrap();
+
+    host.query_selector(".swap-radial")
+        .unwrap()
+        .unwrap()
+        .dyn_into::<HtmlElement>()
+        .unwrap()
+        .click();
+    settle().await;
+
+    assert!(chart.has_attribute("data-ring-animating"));
+    assert_eq!(
+        host.query_selector(".pine-chart-radial-bar[data-label='Activation']")
+            .unwrap()
+            .unwrap()
+            .get_attribute("data-leaving")
+            .as_deref(),
+        Some("true")
+    );
+    let activation_track = host
+        .query_selector(".pine-chart-radial-track[data-label='Activation']")
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        activation_track.get_attribute("data-leaving").as_deref(),
+        Some("true")
+    );
+    assert!(
+        activation_track
+            .get_attribute("style")
+            .unwrap_or_default()
+            .contains("display: none"),
+        "leaving radial tracks should not leave a gray exit ghost"
+    );
+    assert_eq!(
+        host.query_selector(".pine-chart-radial-bar[data-label='API']")
+            .unwrap()
+            .unwrap()
+            .get_attribute("data-entering")
+            .as_deref(),
+        Some("true")
+    );
+    let api_track = host
+        .query_selector(".pine-chart-radial-track[data-label='API']")
+        .unwrap()
+        .unwrap()
+        .dyn_into::<Element>()
+        .unwrap();
+    assert!(
+        css_variable_number(&api_track, "--pine-chart-radial-track-opacity") < 1.0,
+        "entering radial tracks should fade in instead of popping as full gray rings"
+    );
+
+    sleep_ms(24).await;
+    settle().await;
+
+    let activation_mid = host
+        .query_selector(".pine-chart-radial-bar[data-label='Activation']")
+        .unwrap()
+        .unwrap()
+        .dyn_into::<Element>()
+        .unwrap();
+    let activation_mid_dash = activation_mid.get_attribute("stroke-dasharray").unwrap();
+    let api_mid = host
+        .query_selector(".pine-chart-radial-bar[data-label='API']")
+        .unwrap()
+        .unwrap()
+        .dyn_into::<Element>()
+        .unwrap();
+    let api_mid_dash = api_mid.get_attribute("stroke-dasharray").unwrap();
+    assert!(
+        first_dash_progress(&activation_mid_dash) < first_dash_progress(&activation_before),
+        "leaving ring should shrink instead of disappearing"
+    );
+    assert!(
+        svg_opacity(&activation_mid) < 1.0,
+        "leaving ring should fade before the tiny final sweep"
+    );
+    assert!(
+        first_dash_progress(&api_mid_dash) > 0.0 && first_dash_progress(&api_mid_dash) < 0.74,
+        "entering ring should fill from zero during the renderer-owned tween"
+    );
+    assert!(
+        svg_opacity(&api_mid) > 0.0,
+        "entering ring should fade in on the renderer-owned tween"
+    );
+
+    sleep_ms(120).await;
+    settle().await;
+
+    assert!(
+        host.query_selector(".pine-chart-radial-bar[data-label='Activation']")
+            .unwrap()
+            .is_none(),
+        "leaving ring pruned after the tween"
+    );
+    let api_done = host
+        .query_selector(".pine-chart-radial-bar[data-label='API']")
+        .unwrap()
+        .unwrap();
+    assert_eq!(
+        api_done.get_attribute("data-entering").as_deref(),
+        Some("false")
+    );
+    assert_eq!(
+        api_done.get_attribute("stroke-dasharray").as_deref(),
+        Some("0.74 1")
+    );
+    assert_eq!(api_done.get_attribute("opacity").as_deref(), Some("1"));
+    assert!(!chart.has_attribute("data-ring-animating"));
+
+    host.remove();
+}
+
+#[wasm_bindgen_test]
 async fn pie_chart_marks_added_slice_as_entering_without_blocking_geometry_updates() {
     let host = mount_fixture::<PieChartFixture>();
     settle().await;
@@ -2655,6 +2906,10 @@ async fn pie_chart_marks_added_slice_as_entering_without_blocking_geometry_updat
     assert!(
         first_arc_radius(&paid_animating_path) > 1.0,
         "expected entering slice to keep chart radius while the arc grows, got {paid_animating_path}"
+    );
+    assert_ne!(
+        paid_animating_path, "M50,100 A50,50 0 0 1 50,100 L50,75 A25,25 0 0 0 50,75 Z",
+        "entering slices should start their sector tween immediately, not wait for the CSS delay hook"
     );
     let chart = host.query_selector(".pine-pie-chart").unwrap().unwrap();
     let svg = host.query_selector("svg.pine-chart-svg").unwrap().unwrap();
@@ -2767,7 +3022,7 @@ async fn pie_chart_marks_removed_slice_as_leaving_before_pruning() {
             .is_none()
     );
 
-    sleep_ms(34).await;
+    sleep_ms(12).await;
     settle().await;
 
     let shrinking_referral = host

--- a/docs/guides/styling/charts/components.md
+++ b/docs/guides/styling/charts/components.md
@@ -418,13 +418,19 @@ Chart animation is opt-in. Set `animate="true"` on a chart root to emit
 `data-animate="true"`, `data-animation-duration`, `data-animation-easing`, and
 CSS variables
 `--pine-chart-animation-duration` / `--pine-chart-animation-easing`.
+For pie, donut, and radial bar charts, the same easing value drives the
+renderer-owned geometry tween. CSS named easing values and `cubic-bezier(...)`
+curves are supported, so a prop such as
+`animation_easing="cubic-bezier(0.22, 1, 0.36, 1)"` affects SVG path or
+`stroke-dasharray` interpolation instead of only the surrounding CSS hooks.
 The renderer keeps marks keyed by series, slice, or point identity. Application
 CSS can keyframe newly inserted marks while existing marks remain stable during
 add/remove updates. If an application wants an existing mark to replay an entry
 animation after a data change, change that mark's key deliberately or use CSS
 transitions for the changed property.
-Area series and pie/donut slices also retain removed marks for one animation
-window and expose `data-leaving="true"` before pruning them from the DOM.
+Area series, pie/donut slices, and radial rings also retain removed marks for
+one animation window and expose `data-leaving="true"` before pruning them from
+the DOM.
 
 ## Styling Hooks
 
@@ -499,20 +505,26 @@ The component emits stable hooks:
 - `data-selected`
 - `data-entering="true|false"`
 - `data-leaving="true|false"`
+- `data-ring-animating`
 - `data-active`
 - `data-empty`
 - `data-invalid`
 - `--pine-chart-animation-duration`
 - `--pine-chart-animation-easing`
+- `--pine-chart-radial-track-opacity`
 - `--pine-chart-slice-delay`
 
 The default line paths use `stroke="currentColor"` and `fill="none"`, while bars
 use `fill="currentColor"`. Application CSS should own the final visual
-treatment. Pie/donut slices expose `data-entering` and `data-leaving` so CSS
-can style keyed mark changes. The chart owns pie/donut animation by
-interpolating sector geometry in component state, following the same broad
-model as Recharts' animated pie sectors. That keeps the rendered `d` attribute
-authoritative for interaction, donut radius changes, and half-donut morphs.
+treatment. Pie/donut slices and radial rings expose `data-entering` and
+`data-leaving` so CSS can style keyed mark changes. The chart owns pie/donut
+animation by interpolating sector geometry in component state, using the
+chart's `animation_easing` curve for the same path tween that moves slice
+start/end angles and donut radii. Radial charts use the same curve for ring
+radius, stroke width, and progress interpolation, and expose
+`data-ring-animating` on the root while that renderer-owned tween is active.
+That keeps rendered SVG geometry authoritative for interaction, donut radius
+changes, half-donut morphs, initial ring entry, and ring swaps.
 
 ```css
 .pine-chart-root {
@@ -658,7 +670,10 @@ authoritative for interaction, donut radius changes, and half-donut morphs.
 }
 
 .pine-chart-pie-slice[data-hovered] {
-  transform: scale(1.03);
+  transform: translate(
+    var(--pine-chart-slice-hover-x, 0),
+    var(--pine-chart-slice-hover-y, 0)
+  );
 }
 
 .pine-chart-root[data-empty] .pine-chart-svg {

--- a/docs/guides/styling/charts/interaction.md
+++ b/docs/guides/styling/charts/interaction.md
@@ -208,12 +208,16 @@ animation variables. Keyframe entry animations should target keyed marks as they
 enter the DOM; add/remove updates then animate only the new line, area, bar,
 point, or pie segment instead of restarting the whole chart.
 
-Pie/donut slices expose `data-entering="true"` during entry. Area series and
-pie/donut slices expose `data-leaving="true"` during exit so CSS or
-renderer-owned animation can show removal before the renderer prunes the mark.
-Pie/donut enter, exit, and shape changes are rendered by interpolating sector
-geometry in component state, so the visible path itself sweeps between sector
-angles and radii.
+Pie/donut slices and radial rings expose `data-entering="true"` during entry.
+Area series, pie/donut slices, and radial rings expose `data-leaving="true"`
+during exit so CSS or renderer-owned animation can show removal before the
+renderer prunes the mark. Pie/donut enter, exit, and shape changes are rendered
+by interpolating sector geometry in component state, so the visible path itself
+sweeps between sector angles and radii. Radial initial entry and ring swaps
+interpolate radius, stroke width, and `stroke-dasharray` in component state, with
+`data-ring-animating` on the root while the tween is active. CSS named easing
+values and `cubic-bezier(...)` values in `animation_easing` are applied to
+those renderer-owned tweens.
 
 ## Styling
 
@@ -258,6 +262,13 @@ angles and radii.
 .pine-chart-pie-slice[data-hovered] {
   opacity: 1;
   stroke: currentColor;
+}
+
+.pine-chart-pie-slice[data-hovered] {
+  transform: translate(
+    var(--pine-chart-slice-hover-x, 0),
+    var(--pine-chart-slice-hover-y, 0)
+  );
 }
 
 .pine-chart-marker[data-focused],

--- a/examples/charts/index.html
+++ b/examples/charts/index.html
@@ -347,7 +347,12 @@
     }
 
     .pine-chart-root[data-animate="true"] .pine-chart-radial-bar {
-      animation: pine-chart-radial-fill var(--pine-chart-animation-duration) var(--pine-chart-animation-easing);
+      transition-property: transform;
+    }
+
+    .pine-chart-root[data-animate="true"][data-ring-animating] .pine-chart-radial-bar {
+      animation: none;
+      transition-property: transform;
     }
 
     .pine-chart-root[data-animate="true"] .pine-chart-area[data-leaving="true"],
@@ -364,6 +369,10 @@
     }
 
     .pine-chart-root[data-animate="true"] .pine-chart-pie-slice[data-leaving="true"] {
+      pointer-events: none;
+    }
+
+    .pine-chart-root[data-animate="true"] .pine-chart-radial-bar[data-leaving="true"] {
       pointer-events: none;
     }
 
@@ -396,12 +405,6 @@
       from {
         opacity: 0;
         transform: scaleY(0);
-      }
-    }
-
-    @keyframes pine-chart-radial-fill {
-      from {
-        stroke-dasharray: 0 1;
       }
     }
 
@@ -633,8 +636,8 @@
     }
 
     .pine-chart-pie-slice[data-hovered] {
-      opacity: 0.92;
-      transform: scale(1.035);
+      opacity: 0.96;
+      transform: translate(var(--pine-chart-slice-hover-x, 0), var(--pine-chart-slice-hover-y, 0));
     }
 
     .pine-chart-pie-slice[data-label="Organic"],
@@ -658,7 +661,7 @@
     }
 
     .pine-chart-radial-track {
-      opacity: 0.14;
+      opacity: calc(0.14 * var(--pine-chart-radial-track-opacity, 1));
       stroke: #526173;
       stroke-linecap: round;
       vector-effect: non-scaling-stroke;

--- a/examples/charts/src/ChartDemo.poco
+++ b/examples/charts/src/ChartDemo.poco
@@ -338,8 +338,8 @@
                         pp-bind:end_angle="pie_end_angle"
                         pp-bind:center_label="pie_center_label"
                         animate="true"
-                        animation_duration="180"
-                        animation_easing="ease-out"
+                        animation_duration="320"
+                        animation_easing="cubic-bezier(0.22, 1, 0.36, 1)"
                         pp-bind:center_value="pie_center_value"></pine-pie-chart>
       </pine-chart-responsive>
 
@@ -375,8 +375,8 @@
                                pp-bind:center_label="radial_center_label"
                                pp-bind:center_value="radial_center_value"
                                animate="true"
-                               animation_duration="900"
-                               animation_easing="ease"></pine-radial-bar-chart>
+                               animation_duration="420"
+                               animation_easing="cubic-bezier(0.22, 1, 0.36, 1)"></pine-radial-bar-chart>
       </pine-chart-responsive>
 
       <pine-chart-legend class="chart-card-legend"

--- a/examples/website/src/components/charts_page/ChartsPage.poco
+++ b/examples/website/src/components/charts_page/ChartsPage.poco
@@ -70,8 +70,8 @@
               <pine-chart-responsive aspect_ratio="1" min_height="240" width="min(300px, 100%)">
                 <pine-pie-chart label="Channel share"
                                 pp-bind:data="pie_data"
-                                animate="true" animation_duration="180"
-                                animation_easing="ease-out"></pine-pie-chart>
+                                animate="true" animation_duration="320"
+                                animation_easing="cubic-bezier(0.22, 1, 0.36, 1)"></pine-pie-chart>
               </pine-chart-responsive>
               <pine-chart-legend label="Pie legend" pp-bind:items="pie_legend"></pine-chart-legend>
             </div>
@@ -109,8 +109,8 @@
                                 pp-bind:data="pie_data"
                                 inner_radius="0.6"
                                 center_label="Channels" center_value="4"
-                                animate="true" animation_duration="180"
-                                animation_easing="ease-out"></pine-pie-chart>
+                                animate="true" animation_duration="320"
+                                animation_easing="cubic-bezier(0.22, 1, 0.36, 1)"></pine-pie-chart>
               </pine-chart-responsive>
               <pine-chart-legend label="Donut legend" pp-bind:items="pie_legend"></pine-chart-legend>
             </div>
@@ -122,8 +122,8 @@
                                        pp-bind:data="radial_data"
                                        inner_radius="0.34" ring_gap="7"
                                        center_label="Avg" pp-bind:center_value="radial_center"
-                                       animate="true" animation_duration="900"
-                                       animation_easing="ease"></pine-radial-bar-chart>
+                                       animate="true" animation_duration="420"
+                                       animation_easing="cubic-bezier(0.22, 1, 0.36, 1)"></pine-radial-bar-chart>
               </pine-chart-responsive>
               <pine-chart-legend label="Radial legend" pp-bind:items="radial_legend"></pine-chart-legend>
             </div>

--- a/examples/website/styles.css
+++ b/examples/website/styles.css
@@ -666,7 +666,7 @@ html { scroll-behavior: smooth; }
 .pine-chart-legend-marker[data-series="Segment B"] { background: #d96c2c; }
 
 .pine-chart-radial-track {
-  opacity: 0.14;
+  opacity: calc(0.14 * var(--pine-chart-radial-track-opacity, 1));
   stroke: var(--fg-muted);
   stroke-linecap: round;
   vector-effect: non-scaling-stroke;
@@ -844,4 +844,3 @@ html { scroll-behavior: smooth; }
   background: var(--bg-hover);
   outline: none;
 }
-


### PR DESCRIPTION
## Summary
- add shared cubic-bezier easing for renderer-owned chart tweens
- smooth pie/donut slice morphs and hover the canonical slice instead of stacking a duplicate arc
- move radial rings to renderer-owned entry, swap, and exit tweens with track fade handling
- update chart docs and examples for the new animation hooks

## Review follow-up
- fixed radial hover hit-testing to use each bar per-frame center during animated geometry changes
- updated website radial track CSS to honor --pine-chart-radial-track-opacity

## Validation
- cargo fmt --all -- --check
- cargo test -p pine-charts
- cargo clippy -p pine-charts --target wasm32-unknown-unknown --all-targets -- -D warnings
- cargo clippy -p charts -p website --target wasm32-unknown-unknown --all-targets -- -D warnings
- wasm-pack test --firefox --headless crates/pine-charts
- git diff --check