### PR TITLE
Nested signals: PathAccess substrate + leaf-granular reactivity (RFC-112/113)

### DIFF
--- a/crates/pocopine-core/src/expr.rs
+++ b/crates/pocopine-core/src/expr.rs
@@ -157,6 +157,26 @@ pub fn parse_cached(src: &str) -> Result<Spanned<Expr>, ParseError> {
 pub trait ScopeAccess {
     fn read(&self, key: &str) -> Option<JsValue>;
     fn write(&self, key: &str, value: &JsValue) -> bool;
+
+    /// RFC-113 — nested read with leaf-granular tracking:
+    /// subscribe the running effect to `path.join(".")` instead of
+    /// the root field, so sibling-leaf changes don't re-run it.
+    /// `None` = not eligible (derived scope, `$`-root, numeric
+    /// segment, or no `PathAccess` fingerprint reach) — the caller
+    /// keeps the root-tracked walk.
+    fn read_path(&self, path: &[&str]) -> Option<JsValue> {
+        let _ = path;
+        None
+    }
+
+    /// RFC-112 — native nested write (`path` = `[field, nested…]`)
+    /// through the state's `set_path`. `false` = not natively
+    /// reachable; the caller falls back to the RFC-024 §7
+    /// snapshot round-trip.
+    fn write_path(&self, path: &[&str], value: &JsValue) -> bool {
+        let _ = (path, value);
+        false
+    }
 }
 
 pub type RootAccess = std::rc::Rc<dyn ScopeAccess>;

--- a/crates/pocopine-core/src/lib.rs
+++ b/crates/pocopine-core/src/lib.rs
@@ -39,6 +39,7 @@ pub mod model_runtime;
 pub mod mount;
 pub mod mutation_channel;
 pub mod path;
+pub mod path_access;
 pub mod payload_scope;
 pub mod plugin;
 pub mod profiler;

--- a/crates/pocopine-core/src/path.rs
+++ b/crates/pocopine-core/src/path.rs
@@ -47,8 +47,20 @@ pub fn resolve_path_with(
                 segments.next()
             };
             if let Some(field) = field {
+                // RFC-113 — leaf-granular subscription when the
+                // field's type has PathAccess reach; root-tracked
+                // walk otherwise.
+                let rest: Vec<&str> = segments.collect();
+                if !rest.is_empty() {
+                    let mut full = Vec::with_capacity(rest.len() + 1);
+                    full.push(field);
+                    full.extend_from_slice(&rest);
+                    if let Some(v) = access.read_path(&full) {
+                        return v;
+                    }
+                }
                 let mut cur = access.read(field).unwrap_or(JsValue::UNDEFINED);
-                for seg in segments {
+                for seg in rest {
                     cur = Reflect::get(&cur, &JsValue::from_str(seg)).unwrap_or(JsValue::UNDEFINED);
                 }
                 return cur;
@@ -65,11 +77,24 @@ pub fn resolve_path_with(
         }
         return cur;
     }
+    let rest: Vec<&str> = segments.collect();
+    if !rest.is_empty()
+        && let Some(a) = reader
+    {
+        let mut full = Vec::with_capacity(rest.len() + 1);
+        full.push(first);
+        full.extend_from_slice(&rest);
+        // RFC-113 — leaf-granular subscription (see the magic
+        // branch above).
+        if let Some(v) = a.read_path(&full) {
+            return v;
+        }
+    }
     let mut cur = match reader.and_then(|a| a.read(first)) {
         Some(v) => v,
         None => Reflect::get(root, &JsValue::from_str(first)).unwrap_or(JsValue::UNDEFINED),
     };
-    for segment in segments {
+    for segment in rest {
         cur = Reflect::get(&cur, &JsValue::from_str(segment)).unwrap_or(JsValue::UNDEFINED);
     }
     cur
@@ -116,6 +141,17 @@ pub(crate) fn write_segments_with(
             [] => false,
             [field] => macc.write(field, value),
             [field, rest @ ..] => {
+                // RFC-112 — native leaf write first: leaf-typed
+                // deserialize, no container round-trip, and the
+                // precise trigger lattice (sibling leaves stay
+                // quiet). Falls through when the path has no
+                // PathAccess reach.
+                let mut full = Vec::with_capacity(rest.len() + 1);
+                full.push(*field);
+                full.extend_from_slice(rest);
+                if macc.write_path(&full, value) {
+                    return true;
+                }
                 let container = macc.read(field).unwrap_or(JsValue::UNDEFINED);
                 if !set_leaf(&container, rest, value, segments) {
                     return false;
@@ -140,6 +176,14 @@ pub(crate) fn write_segments_with(
             Reflect::set(root, &JsValue::from_str(single), value).unwrap_or(false)
         }
         [first, rest @ ..] => {
+            // RFC-112 — native leaf write first (see the magic
+            // branch above). `$`-roots never resolve natively.
+            if !first.starts_with('$')
+                && let Some(a) = access
+                && a.write_path(segments, value)
+            {
+                return true;
+            }
             let container = match access.and_then(|a| a.read(first)) {
                 Some(v) => v,
                 None => Reflect::get(root, &JsValue::from_str(first)).unwrap_or(JsValue::UNDEFINED),

--- a/crates/pocopine-core/src/path_access.rs
+++ b/crates/pocopine-core/src/path_access.rs
@@ -1,0 +1,148 @@
+//! RFC-112 — typed nested-path access.
+//!
+//! The substrate for native deep writes and nested-signal
+//! fingerprinting. Templates address state by dotted string paths
+//! (`settings.theme`); the type that owns a path segment is only
+//! known one level at a time, so access composes serde-style: a
+//! `#[derive(PathAccess)]` on a struct handles ITS OWN fields and
+//! recurses into children through the autoref dispatch below —
+//! children that also derive keep descending, children that don't
+//! terminate the native path and the caller falls back to the
+//! RFC-024 §7 snapshot round-trip.
+//!
+//! Design points:
+//!
+//! * **Values are pushed down, not references pulled up.** A
+//!   `get_mut`-shaped API can't cross `dyn ComponentState` — the
+//!   leaf type varies per runtime path. Instead the `JsValue`
+//!   travels down the recursion and deserializes at the leaf arm,
+//!   where the concrete type is known.
+//! * **Empty path = the value itself.** `path_set(&[], v)`
+//!   replaces `self` (serde), which is what a `Vec` element hit
+//!   with an exhausted path needs.
+//! * **`Vec` traverses numeric segments; `Option` traverses
+//!   through `Some`.** A `None` on the way reports `false` — the
+//!   caller's fallback (and the runtime's dropped-write warning)
+//!   own that case.
+
+use wasm_bindgen::JsValue;
+
+/// Typed nested access, implemented by `#[derive(PathAccess)]`
+/// (in `pocopine-macros`) and the container impls below.
+pub trait PathAccess {
+    /// Write `value` at `path` relative to `self`. Empty path
+    /// replaces `self`. Returns `false` when the path doesn't
+    /// resolve or the value doesn't deserialize — callers fall
+    /// back to the snapshot round-trip.
+    fn path_set(&mut self, path: &[&str], value: &JsValue) -> bool;
+
+    /// RFC-113 — fingerprint of the value at `path` (the nested
+    /// analogue of `ComponentState::field_fingerprint`). Empty
+    /// path fingerprints `self`. `None` = unreachable path.
+    fn path_fingerprint(&self, path: &[&str]) -> Option<u64>;
+}
+
+impl<T: PathAccess + serde::Serialize + serde::de::DeserializeOwned> PathAccess for Vec<T> {
+    fn path_set(&mut self, path: &[&str], value: &JsValue) -> bool {
+        match path {
+            [] => set_leaf(self, value),
+            [idx, rest @ ..] => {
+                let Ok(i) = idx.parse::<usize>() else {
+                    return false;
+                };
+                match self.get_mut(i) {
+                    Some(el) => el.path_set(rest, value),
+                    None => false,
+                }
+            }
+        }
+    }
+
+    fn path_fingerprint(&self, path: &[&str]) -> Option<u64> {
+        match path {
+            [] => crate::fingerprint::fingerprint(self),
+            [idx, rest @ ..] => self.get(idx.parse::<usize>().ok()?)?.path_fingerprint(rest),
+        }
+    }
+}
+
+impl<T: PathAccess + serde::Serialize + serde::de::DeserializeOwned> PathAccess for Option<T> {
+    fn path_set(&mut self, path: &[&str], value: &JsValue) -> bool {
+        match path {
+            [] => set_leaf(self, value),
+            _ => match self {
+                Some(inner) => inner.path_set(path, value),
+                None => false,
+            },
+        }
+    }
+
+    fn path_fingerprint(&self, path: &[&str]) -> Option<u64> {
+        match path {
+            [] => crate::fingerprint::fingerprint(self),
+            _ => self.as_ref()?.path_fingerprint(path),
+        }
+    }
+}
+
+/// Deserialize `value` into `slot`. Mirrors the macro-generated
+/// `ComponentState::set` semantics, including the empty-string →
+/// `null` retry (inputs emit `""` where `Option` fields expect
+/// absence).
+pub fn set_leaf<T: serde::de::DeserializeOwned>(slot: &mut T, value: &JsValue) -> bool {
+    if let Ok(v) = serde_wasm_bindgen::from_value(value.clone()) {
+        *slot = v;
+        return true;
+    }
+    if value.as_string().as_deref() == Some("")
+        && let Ok(v) = serde_wasm_bindgen::from_value(JsValue::NULL)
+    {
+        *slot = v;
+        return true;
+    }
+    false
+}
+
+// ─── autoref dispatch (macro-generated call sites) ─────────────────
+//
+// The `#[component]` / `#[store]` / `#[derive(PathAccess)]` macros
+// emit descent calls without knowing whether the child type
+// implements `PathAccess`. Method resolution decides at compile
+// time: the by-value impl (bound on `PathAccess`) wins when the
+// bound holds; otherwise autoref finds the by-reference fallback,
+// which terminates the native path (`false` / `None`) so the
+// caller degrades to the snapshot round-trip.
+
+pub struct PathSetDispatch<'a, T: ?Sized>(pub &'a mut T);
+
+pub trait PathSetViaAccess {
+    fn __poc_dispatch_set(self, path: &[&str], value: &JsValue) -> bool;
+}
+impl<T: PathAccess + ?Sized> PathSetViaAccess for PathSetDispatch<'_, T> {
+    fn __poc_dispatch_set(self, path: &[&str], value: &JsValue) -> bool {
+        self.0.path_set(path, value)
+    }
+}
+pub trait PathSetNoAccess {
+    fn __poc_dispatch_set(&self, _path: &[&str], _value: &JsValue) -> bool {
+        false
+    }
+}
+impl<T: ?Sized> PathSetNoAccess for PathSetDispatch<'_, T> {}
+
+pub struct PathFpDispatch<'a, T: ?Sized>(pub &'a T);
+
+pub trait PathFpViaAccess {
+    fn __poc_dispatch_fp(self, path: &[&str]) -> Option<u64>;
+}
+impl<T: PathAccess + ?Sized> PathFpViaAccess for PathFpDispatch<'_, T> {
+    fn __poc_dispatch_fp(self, path: &[&str]) -> Option<u64> {
+        self.0.path_fingerprint(path)
+    }
+}
+pub trait PathFpNoAccess {
+    fn __poc_dispatch_fp(&self, _path: &[&str]) -> Option<u64> {
+        None
+    }
+}
+impl<T: ?Sized> PathFpNoAccess for PathFpDispatch<'_, T> {}

--- a/crates/pocopine-core/src/reactive.rs
+++ b/crates/pocopine-core/src/reactive.rs
@@ -436,11 +436,41 @@ fn field_signal(scope_id: ScopeId, key: &str, mint: bool) -> Option<SignalId> {
             return None;
         }
         let sid = next_signal_id();
+        // RFC-113 — remember which scopes minted dotted (nested)
+        // keys so the flat write path's down-fan can early-out
+        // without allocating (the neutrality gate: flat-only
+        // scopes pay one HashSet miss).
+        if key.contains('.') {
+            NESTED_KEY_SCOPES.with(|n| {
+                n.borrow_mut().insert(scope_id);
+            });
+        }
         map.entry(scope_id)
             .or_default()
             .insert(Cow::Owned(key.to_owned()), sid);
         Some(sid)
     })
+}
+
+thread_local! {
+    /// RFC-113 — scopes that interned at least one dotted key.
+    static NESTED_KEY_SCOPES: RefCell<std::collections::HashSet<ScopeId>> =
+        RefCell::new(std::collections::HashSet::new());
+}
+
+/// RFC-113 — does `scope_id` have any leaf-granular (dotted)
+/// tracked keys? The flat write path consults this before its
+/// down-fan scan.
+pub(crate) fn has_nested_keys(scope_id: ScopeId) -> bool {
+    NESTED_KEY_SCOPES.with(|n| n.borrow().contains(&scope_id))
+}
+
+/// RFC-113 — scope teardown for the nested-key marker. Called
+/// alongside the `FIELD_SIGNALS` purges.
+pub(crate) fn forget_nested_keys(scope_id: ScopeId) {
+    NESTED_KEY_SCOPES.with(|n| {
+        n.borrow_mut().remove(&scope_id);
+    });
 }
 
 /// RFC-096 S3 — resolve-or-mint the `SignalId` for `(scope, key)`
@@ -641,6 +671,7 @@ pub fn clear_scope(scope_id: ScopeId) {
             .map(|inner| inner.into_values().collect())
             .unwrap_or_default()
     });
+    forget_nested_keys(scope_id);
     release_field_signals(&sids);
 }
 
@@ -666,6 +697,9 @@ fn release_field_signals(sids: &[SignalId]) {
 pub fn clear_scopes(scope_ids: &[ScopeId]) {
     if scope_ids.is_empty() {
         return;
+    }
+    for sid in scope_ids {
+        forget_nested_keys(*sid);
     }
     let sids: Vec<SignalId> = FIELD_SIGNALS.with(|f| {
         let mut map = f.borrow_mut();

--- a/crates/pocopine-core/src/scope.rs
+++ b/crates/pocopine-core/src/scope.rs
@@ -98,6 +98,31 @@ pub trait ComponentState: 'static {
         None
     }
 
+    /// RFC-112 — native nested write: `path` is
+    /// `[field, nested…]`; the value deserializes at the leaf via
+    /// the field type's [`crate::path_access::PathAccess`] chain.
+    /// `false` = the path doesn't resolve natively (no derive on
+    /// the way, bad segment, failed deserialize) — callers fall
+    /// back to the RFC-024 §7 snapshot round-trip. The
+    /// `#[component]` / `#[store]` macros override this with
+    /// per-field dispatch arms.
+    fn set_path(&mut self, path: &[&str], value: &JsValue) -> bool {
+        let _ = (path, value);
+        false
+    }
+
+    /// RFC-113 — fingerprint of a nested location, `path` =
+    /// `[field, nested…]`. The dirty sweep uses this for dotted
+    /// tracked keys exactly as it uses [`Self::field_fingerprint`]
+    /// for roots. `None` = unknown; a dotted key is only minted as
+    /// a tracked key when this returns `Some` (see
+    /// `read_path`), so unlike roots the sweep never has to
+    /// treat `None` as changed.
+    fn path_fingerprint(&self, path: &[&str]) -> Option<u64> {
+        let _ = path;
+        None
+    }
+
     /// RFC-096 S3 — typed text projection of one declared field:
     /// `Some(string)` for serde-scalar fields (rendered exactly
     /// as `pp-text` would), `None` for compound fields and
@@ -542,6 +567,17 @@ fn read_field_tracked(
     key: &str,
 ) -> JsValue {
     track(scope_id, key);
+    read_field_untracked(scope_id, state, key)
+}
+
+/// [`read_field_tracked`] minus the subscription — RFC-113's
+/// leaf-granular reads resolve the container through here after
+/// tracking the full dotted path instead of the root.
+fn read_field_untracked(
+    scope_id: ScopeId,
+    state: &Rc<RefCell<dyn ComponentState>>,
+    key: &str,
+) -> JsValue {
     // Derived scopes (`SlotScope`, etc.) compose their return value
     // from a parent proxy on every read — caching would freeze the
     // value at the first call. Skip the cache lookup AND the cache
@@ -602,6 +638,42 @@ impl crate::expr::ScopeAccess for ScopedFieldAccess {
         }
         write_field_tracked(self.scope_id, &self.state, key, value.clone());
         true
+    }
+
+    fn read_path(&self, path: &[&str]) -> Option<JsValue> {
+        let [root, rest @ ..] = path else { return None };
+        if rest.is_empty() || root.starts_with('$') {
+            return None;
+        }
+        // Derived scopes (loop/slot) compose from their parent —
+        // the trigger topology lives there; keep root granularity.
+        if !self.state.borrow().cacheable_fields() {
+            return None;
+        }
+        // Numeric segments are positions, not identity — one
+        // reorder and a leaf key would lie. Keyed row plans own
+        // element identity; these stay root-tracked.
+        if rest
+            .iter()
+            .any(|s| s.chars().next().is_some_and(|c| c.is_ascii_digit()))
+        {
+            return None;
+        }
+        // Leaf granularity is opt-in via `PathAccess`: without
+        // fingerprint reach the dirty sweep couldn't gate this key
+        // and every handler would re-run the subscriber. No reach →
+        // root-tracked fallback (today's behavior).
+        self.state.borrow().path_fingerprint(path)?;
+        track(self.scope_id, &path.join("."));
+        let mut cur = read_field_untracked(self.scope_id, &self.state, root);
+        for seg in rest {
+            cur = js_sys::Reflect::get(&cur, &JsValue::from_str(seg)).unwrap_or(JsValue::UNDEFINED);
+        }
+        Some(cur)
+    }
+
+    fn write_path(&self, path: &[&str], value: &JsValue) -> bool {
+        write_path_tracked(self.scope_id, &self.state, path, value)
     }
 }
 
@@ -812,6 +884,15 @@ pub fn write_field_tracked(
     if let Some(container) = flatten_container {
         trigger(scope_id, container);
     }
+    // RFC-113 — a whole-field write must reach the leaf-granular
+    // subscribers under it (they subscribed to dotted keys ONLY,
+    // to stay isolated from sibling leaves). v1 fans down
+    // unconditionally — same effective granularity today's root
+    // subscribers get.
+    trigger_nested_under(scope_id, key);
+    if let Some(container) = flatten_container {
+        trigger_nested_under(scope_id, container);
+    }
 }
 
 /// [`write_field_tracked`] with the state resolved from the scope
@@ -824,6 +905,80 @@ pub fn write_field(scope_id: ScopeId, key: &str, value: &JsValue) -> bool {
     };
     write_field_tracked(scope_id, &scope.state, key, value.clone());
     true
+}
+
+/// RFC-112/113 — the native nested write: `path` =
+/// `[field, nested…]` routes through `ComponentState::set_path`
+/// (leaf-typed deserialize, no container round-trip), then fires
+/// the trigger lattice. `false` = not natively reachable — the
+/// caller (`path::write_segments_with`) falls back to the
+/// snapshot round-trip.
+pub(crate) fn write_path_tracked(
+    scope_id: ScopeId,
+    state: &Rc<RefCell<dyn ComponentState>>,
+    path: &[&str],
+    value: &JsValue,
+) -> bool {
+    let [root, rest @ ..] = path else {
+        return false;
+    };
+    if rest.is_empty() || root.starts_with('$') {
+        return false;
+    }
+    let origin = crate::model_runtime::current_write_origin();
+    let ok = crate::model_runtime::with_scope_write(scope_id, origin, || {
+        state.borrow_mut().set_path(path, value)
+    });
+    if !ok {
+        return false;
+    }
+    // The container's cached projection is stale — the native
+    // write bypassed serde entirely.
+    let flatten_container = state.borrow().flatten_container_of(root);
+    projection_invalidate(crate::reactive::ensure_field_signal(scope_id, root));
+    if let Some(container) = flatten_container {
+        projection_invalidate(crate::reactive::ensure_field_signal(scope_id, container));
+    }
+    // Trigger lattice: the exact key, subscribed keys UNDER it,
+    // and subscribed ancestors (whole-container readers,
+    // `#[watch(container)]`). Sibling leaves are the whole point —
+    // they are NOT fired.
+    let written = path.join(".");
+    for key in crate::reactive::tracked_keys(scope_id) {
+        let k = key.as_ref();
+        if k != *root && (k == written || is_path_under(k, &written) || is_path_under(&written, k))
+        {
+            trigger(scope_id, k);
+        }
+    }
+    trigger(scope_id, root);
+    if let Some(container) = flatten_container {
+        trigger(scope_id, container);
+    }
+    true
+}
+
+/// True when `key` is strictly below `prefix` in path space
+/// (`"a.b.c"` is under `"a.b"`, not under `"a.bx"`).
+fn is_path_under(key: &str, prefix: &str) -> bool {
+    key.len() > prefix.len() && key.starts_with(prefix) && key.as_bytes()[prefix.len()] == b'.'
+}
+
+/// Fire every subscribed dotted key strictly under `root` — the
+/// down-fan for whole-field writes (RFC-113 v1: unconditional;
+/// fingerprint-filtered descent is the v2 refinement). The
+/// `has_nested_keys` gate keeps flat-only scopes at zero cost
+/// (one HashSet miss, no allocation) — the neutrality guarantee.
+fn trigger_nested_under(scope_id: ScopeId, root: &str) {
+    if !crate::reactive::has_nested_keys(scope_id) {
+        return;
+    }
+    for key in crate::reactive::tracked_keys(scope_id) {
+        let k = key.as_ref();
+        if is_path_under(k, root) {
+            trigger(scope_id, k);
+        }
+    }
 }
 
 thread_local! {
@@ -1045,7 +1200,7 @@ impl DirtySweep {
             .iter()
             .map(|k| {
                 count_fingerprint();
-                state.field_fingerprint(k.as_ref())
+                sweep_fingerprint(&*state, k.as_ref())
             })
             .collect();
         let lens_before = keys
@@ -1084,7 +1239,7 @@ impl DirtySweep {
                 continue;
             }
             count_fingerprint();
-            let after = state_ref.field_fingerprint(k.as_ref());
+            let after = sweep_fingerprint(&*state_ref, k.as_ref());
             let unchanged = matches!((before, &after), (Some(b), Some(a)) if b == a);
             if !unchanged {
                 changed.push(k.clone());
@@ -1105,10 +1260,33 @@ impl DirtySweep {
             } else {
                 projection_invalidate(sid);
             }
+            // RFC-113 — a changed dotted key means its ROOT
+            // container changed too; the container's cached
+            // projection (populated by leaf-granular reads) must
+            // not survive even when the root key itself isn't
+            // tracked and so never reaches the loop above.
+            if let Some(root) = k.as_ref().split_once('.').map(|(r, _)| r) {
+                projection_invalidate(crate::reactive::ensure_field_signal(self.scope_id, root));
+            }
         }
         for k in &changed {
             crate::reactive::trigger(self.scope_id, k.as_ref());
         }
+    }
+}
+
+/// Fingerprint one sweep key: dotted keys (RFC-113 leaf-granular
+/// subscriptions) route through `ComponentState::path_fingerprint`;
+/// roots keep `field_fingerprint`. Without this split a dotted key
+/// would hit the root matcher's `_ => None` arm and — since the
+/// sweep treats unknown as changed — re-run its subscriber on
+/// EVERY handler invoke.
+fn sweep_fingerprint(state: &dyn ComponentState, key: &str) -> Option<u64> {
+    if key.contains('.') {
+        let segs: Vec<&str> = key.split('.').collect();
+        state.path_fingerprint(&segs)
+    } else {
+        state.field_fingerprint(key)
     }
 }
 

--- a/crates/pocopine-core/tests/nested_signals.rs
+++ b/crates/pocopine-core/tests/nested_signals.rs
@@ -1,0 +1,323 @@
+//! RFC-112/113 — nested signals: leaf-granular tracking, native
+//! deep writes, the trigger lattice, and the path-aware dirty
+//! sweep. Fixtures hand-implement `PathAccess` /
+//! `ComponentState::{set_path, path_fingerprint}` (what the
+//! derives emit) so the runtime semantics are tested without the
+//! macro layer. Runs under `wasm-pack test --node`.
+
+#![cfg(target_arch = "wasm32")]
+
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+use pocopine_core::path_access::PathAccess;
+use pocopine_core::{Scope, effect, flush_sync, set_auto_flush};
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::JsValue;
+use wasm_bindgen_test::wasm_bindgen_test;
+
+fn setup() {
+    set_auto_flush(false);
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+struct Settings {
+    theme: String,
+    size: i32,
+}
+
+impl PathAccess for Settings {
+    fn path_set(&mut self, path: &[&str], value: &JsValue) -> bool {
+        match path {
+            [] => pocopine_core::path_access::set_leaf(self, value),
+            ["theme"] => pocopine_core::path_access::set_leaf(&mut self.theme, value),
+            ["size"] => pocopine_core::path_access::set_leaf(&mut self.size, value),
+            _ => false,
+        }
+    }
+    fn path_fingerprint(&self, path: &[&str]) -> Option<u64> {
+        match path {
+            [] => pocopine_core::fingerprint::fingerprint(self),
+            ["theme"] => pocopine_core::fingerprint::fingerprint(&self.theme),
+            ["size"] => pocopine_core::fingerprint::fingerprint(&self.size),
+            _ => None,
+        }
+    }
+}
+
+/// A nested struct WITHOUT PathAccess reach — exercises the
+/// snapshot fallback lane.
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq)]
+struct Blob {
+    x: i32,
+    y: i32,
+}
+
+struct NestedState {
+    settings: Settings,
+    blob: Blob,
+    count: i32,
+}
+
+impl Default for NestedState {
+    fn default() -> Self {
+        Self {
+            settings: Settings {
+                theme: "light".into(),
+                size: 14,
+            },
+            blob: Blob { x: 1, y: 2 },
+            count: 0,
+        }
+    }
+}
+
+impl pocopine_core::ComponentState for NestedState {
+    fn get(&self, key: &str) -> JsValue {
+        match key {
+            "settings" => serde_wasm_bindgen::to_value(&self.settings).unwrap_or(JsValue::NULL),
+            "blob" => serde_wasm_bindgen::to_value(&self.blob).unwrap_or(JsValue::NULL),
+            "count" => JsValue::from_f64(self.count as f64),
+            _ => JsValue::UNDEFINED,
+        }
+    }
+    fn set(&mut self, key: &str, value: JsValue) {
+        match key {
+            "settings" => {
+                if let Ok(v) = serde_wasm_bindgen::from_value(value) {
+                    self.settings = v;
+                }
+            }
+            "blob" => {
+                if let Ok(v) = serde_wasm_bindgen::from_value(value) {
+                    self.blob = v;
+                }
+            }
+            "count" => self.count = value.as_f64().unwrap_or_default() as i32,
+            _ => {}
+        }
+    }
+    fn keys(&self) -> &'static [&'static str] {
+        &["settings", "blob", "count"]
+    }
+    fn field_fingerprint(&self, key: &str) -> Option<u64> {
+        match key {
+            "settings" => pocopine_core::fingerprint::fingerprint(&self.settings),
+            "blob" => pocopine_core::fingerprint::fingerprint(&self.blob),
+            "count" => pocopine_core::fingerprint::fingerprint(&self.count),
+            _ => None,
+        }
+    }
+    fn set_path(&mut self, path: &[&str], value: &JsValue) -> bool {
+        match path {
+            ["settings", rest @ ..] if !rest.is_empty() => self.settings.path_set(rest, value),
+            _ => false,
+        }
+    }
+    fn path_fingerprint(&self, path: &[&str]) -> Option<u64> {
+        match path {
+            ["settings", rest @ ..] if !rest.is_empty() => self.settings.path_fingerprint(rest),
+            _ => None,
+        }
+    }
+    fn invoke(&mut self, key: &str, _args: &js_sys::Array) -> JsValue {
+        match key {
+            "grow" => self.settings.size += 1,
+            "retheme" => self.settings.theme = "dark".into(),
+            "touch_restore" => {
+                self.settings.size += 1;
+                self.settings.size -= 1;
+            }
+            "bump_count" => self.count += 1,
+            _ => {}
+        }
+        JsValue::UNDEFINED
+    }
+}
+
+struct Fixture {
+    state: Rc<RefCell<NestedState>>,
+    scope: Scope,
+    access: pocopine_core::expr::RootAccess,
+}
+
+fn fixture() -> Fixture {
+    let state = Rc::new(RefCell::new(NestedState::default()));
+    let scope = Scope::new(state.clone());
+    let access = pocopine_core::scope::scoped_root_reader(scope.id).expect("live scope");
+    Fixture {
+        state,
+        scope,
+        access,
+    }
+}
+
+/// Effect that reads `path` through the scoped access (the way a
+/// template binding does) and counts its runs.
+fn observe(fx: &Fixture, path: &'static str) -> (Rc<Cell<u32>>, Rc<RefCell<JsValue>>) {
+    let runs = Rc::new(Cell::new(0));
+    let seen = Rc::new(RefCell::new(JsValue::UNDEFINED));
+    let (runs_w, seen_w) = (runs.clone(), seen.clone());
+    let access = fx.access.clone();
+    effect(move || {
+        runs_w.set(runs_w.get() + 1);
+        *seen_w.borrow_mut() =
+            pocopine_core::path::resolve_path_with(&JsValue::UNDEFINED, Some(&access), path);
+    });
+    (runs, seen)
+}
+
+#[wasm_bindgen_test]
+fn native_leaf_write_isolates_sibling_leaf() {
+    setup();
+    let fx = fixture();
+    let (theme_runs, theme_seen) = observe(&fx, "settings.theme");
+    let (size_runs, _) = observe(&fx, "settings.size");
+    assert_eq!((theme_runs.get(), size_runs.get()), (1, 1));
+
+    let ok = pocopine_core::path::write_path_with(
+        &JsValue::UNDEFINED,
+        Some(&fx.access),
+        "settings.theme",
+        &JsValue::from_str("dark"),
+    );
+    assert!(ok);
+    flush_sync();
+
+    assert_eq!(fx.state.borrow().settings.theme, "dark");
+    assert_eq!(fx.state.borrow().settings.size, 14);
+    assert_eq!(theme_runs.get(), 2, "leaf subscriber re-runs");
+    assert_eq!(size_runs.get(), 1, "sibling leaf must stay quiet");
+    assert_eq!(theme_seen.borrow().as_string().as_deref(), Some("dark"));
+}
+
+#[wasm_bindgen_test]
+fn container_write_reaches_leaf_subscribers() {
+    setup();
+    let fx = fixture();
+    let (theme_runs, theme_seen) = observe(&fx, "settings.theme");
+    let (size_runs, _) = observe(&fx, "settings.size");
+
+    let next = serde_wasm_bindgen::to_value(&Settings {
+        theme: "sepia".into(),
+        size: 18,
+    })
+    .unwrap();
+    let ok = pocopine_core::path::write_path_with(
+        &JsValue::UNDEFINED,
+        Some(&fx.access),
+        "settings",
+        &next,
+    );
+    assert!(ok);
+    flush_sync();
+
+    assert_eq!(theme_runs.get(), 2, "down-fan reaches theme leaf");
+    assert_eq!(size_runs.get(), 2, "down-fan reaches size leaf");
+    assert_eq!(theme_seen.borrow().as_string().as_deref(), Some("sepia"));
+}
+
+#[wasm_bindgen_test]
+fn native_leaf_write_fires_container_subscriber_with_fresh_value() {
+    setup();
+    let fx = fixture();
+    // Whole-container reader (a `#[watch(settings)]`-shaped dep).
+    let (root_runs, root_seen) = observe(&fx, "settings");
+
+    pocopine_core::path::write_path_with(
+        &JsValue::UNDEFINED,
+        Some(&fx.access),
+        "settings.size",
+        &JsValue::from_f64(99.0),
+    );
+    flush_sync();
+
+    assert_eq!(root_runs.get(), 2, "ancestor subscriber fires");
+    let size = js_sys::Reflect::get(&root_seen.borrow(), &JsValue::from_str("size"))
+        .unwrap()
+        .as_f64();
+    assert_eq!(size, Some(99.0), "container projection was invalidated");
+}
+
+#[wasm_bindgen_test]
+fn handler_sweep_is_leaf_precise() {
+    setup();
+    let fx = fixture();
+    let (theme_runs, _) = observe(&fx, "settings.theme");
+    let (size_runs, size_seen) = observe(&fx, "settings.size");
+    let (count_runs, _) = observe(&fx, "count");
+
+    fx.scope.invoke("grow", &js_sys::Array::new());
+    flush_sync();
+
+    assert_eq!(size_runs.get(), 2, "mutated leaf re-runs");
+    assert_eq!(theme_runs.get(), 1, "untouched sibling stays quiet");
+    assert_eq!(count_runs.get(), 1, "untouched root stays quiet");
+    assert_eq!(size_seen.borrow().as_f64(), Some(15.0));
+
+    fx.scope.invoke("retheme", &js_sys::Array::new());
+    flush_sync();
+    assert_eq!(theme_runs.get(), 2);
+    assert_eq!(size_runs.get(), 2);
+}
+
+#[wasm_bindgen_test]
+fn handler_no_net_change_leaf_triggers_nothing() {
+    setup();
+    let fx = fixture();
+    let (theme_runs, _) = observe(&fx, "settings.theme");
+    let (size_runs, _) = observe(&fx, "settings.size");
+
+    fx.scope.invoke("touch_restore", &js_sys::Array::new());
+    flush_sync();
+
+    assert_eq!(size_runs.get(), 1, "mutate-and-restore fires nothing");
+    assert_eq!(theme_runs.get(), 1);
+}
+
+#[wasm_bindgen_test]
+fn no_path_access_reach_degrades_to_root_granularity() {
+    setup();
+    let fx = fixture();
+    // `blob` has no set_path/path_fingerprint arms — reads stay
+    // root-tracked, writes take the snapshot round-trip.
+    let (x_runs, x_seen) = observe(&fx, "blob.x");
+    let (y_runs, _) = observe(&fx, "blob.y");
+
+    let ok = pocopine_core::path::write_path_with(
+        &JsValue::UNDEFINED,
+        Some(&fx.access),
+        "blob.x",
+        &JsValue::from_f64(42.0),
+    );
+    assert!(ok, "snapshot fallback still lands the write");
+    flush_sync();
+
+    assert_eq!(fx.state.borrow().blob.x, 42);
+    assert_eq!(fx.state.borrow().blob.y, 2, "sibling survives round-trip");
+    assert_eq!(x_runs.get(), 2);
+    assert_eq!(y_runs.get(), 2, "root granularity: sibling re-runs too");
+    assert_eq!(x_seen.borrow().as_f64(), Some(42.0));
+}
+
+#[wasm_bindgen_test]
+fn flat_fields_unaffected() {
+    setup();
+    let fx = fixture();
+    let (count_runs, count_seen) = observe(&fx, "count");
+
+    fx.scope.invoke("bump_count", &js_sys::Array::new());
+    flush_sync();
+    assert_eq!(count_runs.get(), 2);
+    assert_eq!(count_seen.borrow().as_f64(), Some(1.0));
+
+    // A leaf write elsewhere leaves flat subscribers alone.
+    pocopine_core::path::write_path_with(
+        &JsValue::UNDEFINED,
+        Some(&fx.access),
+        "settings.theme",
+        &JsValue::from_str("dark"),
+    );
+    flush_sync();
+    assert_eq!(count_runs.get(), 2);
+}

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -1010,6 +1010,68 @@ pub(crate) fn kebab_case(ident: &str) -> String {
 /// projection lanes (fingerprint, quick-len, text) that each wrap a
 /// single `::pocopine::__private` call around the field reference, so
 /// the two macros can't drift on the arm shape.
+/// RFC-112/113 — `ComponentState::set_path` / `path_fingerprint`
+/// override bodies: one arm per direct field, descending through
+/// the autoref dispatch so field types without `PathAccess`
+/// terminate the native path (the runtime then falls back to the
+/// snapshot round-trip). Serde-skipped fields are excluded — their
+/// projections never carry them, so nested template paths can't
+/// reach them anyway.
+fn path_dispatch_methods(
+    field_idents: &[syn::Ident],
+    field_names: &[String],
+    field_is_serde_skip: &[bool],
+) -> proc_macro2::TokenStream {
+    let mut set_arms = Vec::new();
+    let mut fp_arms = Vec::new();
+    for ((ident, name), skip) in field_idents
+        .iter()
+        .zip(field_names.iter())
+        .zip(field_is_serde_skip.iter())
+    {
+        if *skip {
+            continue;
+        }
+        set_arms.push(quote! {
+            #name => ::pocopine::__private::PathSetDispatch(&mut self.#ident)
+                .__poc_dispatch_set(rest, value),
+        });
+        fp_arms.push(quote! {
+            #name => ::pocopine::__private::PathFpDispatch(&self.#ident)
+                .__poc_dispatch_fp(rest),
+        });
+    }
+    quote! {
+        fn set_path(
+            &mut self,
+            path: &[&str],
+            value: &::pocopine::__private::JsValue,
+        ) -> bool {
+            #[allow(unused_imports)]
+            use ::pocopine::__private::{PathSetNoAccess as _, PathSetViaAccess as _};
+            match path {
+                [root, rest @ ..] if !rest.is_empty() => match *root {
+                    #(#set_arms)*
+                    _ => false,
+                },
+                _ => false,
+            }
+        }
+
+        fn path_fingerprint(&self, path: &[&str]) -> ::core::option::Option<u64> {
+            #[allow(unused_imports)]
+            use ::pocopine::__private::{PathFpNoAccess as _, PathFpViaAccess as _};
+            match path {
+                [root, rest @ ..] if !rest.is_empty() => match *root {
+                    #(#fp_arms)*
+                    _ => ::core::option::Option::None,
+                },
+                _ => ::core::option::Option::None,
+            }
+        }
+    }
+}
+
 fn field_call_arms<'a>(
     field_idents: &'a [syn::Ident],
     field_names: &'a [String],
@@ -2330,6 +2392,9 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
         &field_names,
         quote! { ::pocopine::__private::quick_len_value },
     );
+    // RFC-112/113 — native nested-path dispatch overrides.
+    let path_dispatch_tokens =
+        path_dispatch_methods(&field_idents, &field_names, &field_is_serde_skip);
 
     // RFC-096 S3 — typed text lane. Same Serialize bound as
     // get(); the projector itself decides scalar-vs-compound.
@@ -3469,6 +3534,8 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
                     _ => ::core::option::Option::None,
                 }
             }
+
+            #path_dispatch_tokens
             fn field_as_text(&self, key: &str) -> ::core::option::Option<::std::string::String> {
                 match key {
                     #(#text_arms)*
@@ -4485,6 +4552,9 @@ pub fn store(attr: TokenStream, item: TokenStream) -> TokenStream {
         &field_names,
         quote! { ::pocopine::__private::quick_len_value },
     );
+    // RFC-112/113 — native nested-path dispatch overrides.
+    let path_dispatch_tokens =
+        path_dispatch_methods(&field_idents, &field_names, &field_is_serde_skip);
     let set_arms = field_idents.iter().zip(field_names.iter()).map(|(id, name)| {
         quote! {
             #name => {
@@ -4590,6 +4660,8 @@ pub fn store(attr: TokenStream, item: TokenStream) -> TokenStream {
                     _ => ::core::option::Option::None,
                 }
             }
+
+            #path_dispatch_tokens
             fn invoke(
                 &mut self,
                 key: &str,
@@ -6671,4 +6743,88 @@ pub fn app(input: TokenStream) -> TokenStream {
 #[proc_macro]
 pub fn asset(input: TokenStream) -> TokenStream {
     assets::expand(input)
+}
+
+/// RFC-112 — `#[derive(PathAccess)]`: recursive typed nested-path
+/// access. Each derive handles its OWN named fields and descends
+/// into children through the autoref dispatch — children that also
+/// derive keep descending; children that don't terminate the
+/// native path and the runtime falls back to the RFC-024 §7
+/// snapshot round-trip. Empty path = the value itself (what a
+/// `Vec` element hit with an exhausted path needs). Field leaves
+/// deserialize/fingerprint via serde, so the derive compiles
+/// wherever the struct's serde derives do.
+#[proc_macro_derive(PathAccess)]
+pub fn derive_path_access(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let struct_ident = &input.ident;
+    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
+
+    let Data::Struct(data) = &input.data else {
+        return syn::Error::new_spanned(
+            &input.ident,
+            "#[derive(PathAccess)] supports structs only",
+        )
+        .to_compile_error()
+        .into();
+    };
+    let syn::Fields::Named(fields) = &data.fields else {
+        return syn::Error::new_spanned(
+            &input.ident,
+            "#[derive(PathAccess)] requires named fields",
+        )
+        .to_compile_error()
+        .into();
+    };
+
+    let mut set_arms = Vec::new();
+    let mut fp_arms = Vec::new();
+    for field in &fields.named {
+        let Some(ident) = &field.ident else { continue };
+        let name = ident.to_string();
+        set_arms.push(quote! {
+            [#name] => ::pocopine::__private::path_set_leaf(&mut self.#ident, value),
+            [#name, rest @ ..] => {
+                ::pocopine::__private::PathSetDispatch(&mut self.#ident)
+                    .__poc_dispatch_set(rest, value)
+            }
+        });
+        fp_arms.push(quote! {
+            [#name] => ::pocopine::__private::fingerprint_value(&self.#ident),
+            [#name, rest @ ..] => {
+                ::pocopine::__private::PathFpDispatch(&self.#ident).__poc_dispatch_fp(rest)
+            }
+        });
+    }
+
+    let out = quote! {
+        impl #impl_generics ::pocopine::__private::PathAccess for #struct_ident #ty_generics
+        #where_clause
+        {
+            fn path_set(
+                &mut self,
+                path: &[&str],
+                value: &::pocopine::__private::JsValue,
+            ) -> bool {
+                #[allow(unused_imports)]
+                use ::pocopine::__private::{PathSetNoAccess as _, PathSetViaAccess as _};
+                match path {
+                    [] => ::pocopine::__private::path_set_leaf(self, value),
+                    #(#set_arms)*
+                    _ => false,
+                }
+            }
+
+            fn path_fingerprint(&self, path: &[&str]) -> ::core::option::Option<u64> {
+                #[allow(unused_imports)]
+                use ::pocopine::__private::{PathFpNoAccess as _, PathFpViaAccess as _};
+                match path {
+                    [] => ::pocopine::__private::fingerprint_value(self),
+                    #(#fp_arms)*
+                    _ => ::core::option::Option::None,
+                }
+            }
+        }
+    };
+    out.into()
 }

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -1017,10 +1017,19 @@ pub(crate) fn kebab_case(ident: &str) -> String {
 /// snapshot round-trip). Serde-skipped fields are excluded — their
 /// projections never carry them, so nested template paths can't
 /// reach them anyway.
+///
+/// RFC-044 flatten routing: a path rooted at an EXPLICIT-LIST
+/// flatten leaf (`tab_config.max`) re-roots into the container
+/// with the FULL path — the container's `PathAccess` matches
+/// `[leaf, rest…]`. The RFC-044 collision rule guarantees leaf
+/// names never shadow real fields, so the arms share one match.
+/// Bare-flatten leaves need no routing: `PropValue` bounds them
+/// to scalars, which can never root a nested path.
 fn path_dispatch_methods(
     field_idents: &[syn::Ident],
     field_names: &[String],
     field_is_serde_skip: &[bool],
+    flatten_fields: &[(syn::Ident, Vec<String>, bool)],
 ) -> proc_macro2::TokenStream {
     let mut set_arms = Vec::new();
     let mut fp_arms = Vec::new();
@@ -1033,13 +1042,33 @@ fn path_dispatch_methods(
             continue;
         }
         set_arms.push(quote! {
-            #name => ::pocopine::__private::PathSetDispatch(&mut self.#ident)
-                .__poc_dispatch_set(rest, value),
+            #name => {
+                return ::pocopine::__private::PathSetDispatch(&mut self.#ident)
+                    .__poc_dispatch_set(rest, value);
+            }
         });
         fp_arms.push(quote! {
-            #name => ::pocopine::__private::PathFpDispatch(&self.#ident)
-                .__poc_dispatch_fp(rest),
+            #name => {
+                return ::pocopine::__private::PathFpDispatch(&self.#ident)
+                    .__poc_dispatch_fp(rest);
+            }
         });
+    }
+    for (container, leaves, _) in flatten_fields {
+        for leaf in leaves {
+            set_arms.push(quote! {
+                #leaf => {
+                    return ::pocopine::__private::PathSetDispatch(&mut self.#container)
+                        .__poc_dispatch_set(path, value);
+                }
+            });
+            fp_arms.push(quote! {
+                #leaf => {
+                    return ::pocopine::__private::PathFpDispatch(&self.#container)
+                        .__poc_dispatch_fp(path);
+                }
+            });
+        }
     }
     quote! {
         fn set_path(
@@ -1049,25 +1078,33 @@ fn path_dispatch_methods(
         ) -> bool {
             #[allow(unused_imports)]
             use ::pocopine::__private::{PathSetNoAccess as _, PathSetViaAccess as _};
-            match path {
-                [root, rest @ ..] if !rest.is_empty() => match *root {
-                    #(#set_arms)*
-                    _ => false,
-                },
-                _ => false,
+            let [root, rest @ ..] = path else {
+                return false;
+            };
+            if rest.is_empty() {
+                return false;
             }
+            match *root {
+                #(#set_arms)*
+                _ => {}
+            }
+            false
         }
 
         fn path_fingerprint(&self, path: &[&str]) -> ::core::option::Option<u64> {
             #[allow(unused_imports)]
             use ::pocopine::__private::{PathFpNoAccess as _, PathFpViaAccess as _};
-            match path {
-                [root, rest @ ..] if !rest.is_empty() => match *root {
-                    #(#fp_arms)*
-                    _ => ::core::option::Option::None,
-                },
-                _ => ::core::option::Option::None,
+            let [root, rest @ ..] = path else {
+                return ::core::option::Option::None;
+            };
+            if rest.is_empty() {
+                return ::core::option::Option::None;
             }
+            match *root {
+                #(#fp_arms)*
+                _ => {}
+            }
+            ::core::option::Option::None
         }
     }
 }
@@ -1749,6 +1786,7 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
             }
         });
         let out = quote! {
+
             #input
 
             impl #struct_ident {
@@ -2393,8 +2431,12 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
         quote! { ::pocopine::__private::quick_len_value },
     );
     // RFC-112/113 — native nested-path dispatch overrides.
-    let path_dispatch_tokens =
-        path_dispatch_methods(&field_idents, &field_names, &field_is_serde_skip);
+    let path_dispatch_tokens = path_dispatch_methods(
+        &field_idents,
+        &field_names,
+        &field_is_serde_skip,
+        &flatten_fields,
+    );
 
     // RFC-096 S3 — typed text lane. Same Serialize bound as
     // get(); the projector itself decides scalar-vs-compound.
@@ -4552,9 +4594,10 @@ pub fn store(attr: TokenStream, item: TokenStream) -> TokenStream {
         &field_names,
         quote! { ::pocopine::__private::quick_len_value },
     );
-    // RFC-112/113 — native nested-path dispatch overrides.
+    // RFC-112/113 — native nested-path dispatch overrides (stores
+    // have no flatten props).
     let path_dispatch_tokens =
-        path_dispatch_methods(&field_idents, &field_names, &field_is_serde_skip);
+        path_dispatch_methods(&field_idents, &field_names, &field_is_serde_skip, &[]);
     let set_arms = field_idents.iter().zip(field_names.iter()).map(|(id, name)| {
         quote! {
             #name => {
@@ -6319,7 +6362,22 @@ pub fn derive_props(input: TokenStream) -> TokenStream {
         }
     });
 
+    // RFC-112 — prop groups are lenses too: a leaves-only
+    // `PathAccess` impl (no whole-self arm, so no new serde bounds
+    // land on the group struct itself) lets flatten-leaf-rooted
+    // template paths and nested prop structs ride the native lane.
+    let pa_pairs: Vec<(syn::Ident, String)> = leaves
+        .iter()
+        .map(|(i, _)| {
+            let name = i.to_string().trim_start_matches("r#").to_string();
+            (i.clone(), name)
+        })
+        .collect();
+    let path_access_impl = path_access_impl_tokens(struct_ident, &input.generics, &pa_pairs, false);
+
     let out = quote! {
+        #path_access_impl
+
         impl #impl_generics ::pocopine::__private::Props for #struct_ident #ty_generics
             #where_clause
         {
@@ -6745,6 +6803,78 @@ pub fn asset(input: TokenStream) -> TokenStream {
     assets::expand(input)
 }
 
+/// RFC-112 — build a `PathAccess` impl over `(ident, name)` field
+/// pairs. `whole_self_arm` adds `[] => replace self via serde`
+/// (requires `Self: Serialize + DeserializeOwned` — true for
+/// `#[derive(PathAccess)]` targets, deliberately NOT required of
+/// `#[derive(Props)]` groups, whose impl covers `#[prop]` leaves
+/// only so no new bounds land on existing prop structs).
+fn path_access_impl_tokens(
+    struct_ident: &syn::Ident,
+    generics: &syn::Generics,
+    fields: &[(syn::Ident, String)],
+    whole_self_arm: bool,
+) -> proc_macro2::TokenStream {
+    let (impl_generics, ty_generics, where_clause) = generics.split_for_impl();
+    let mut set_arms = Vec::new();
+    let mut fp_arms = Vec::new();
+    for (ident, name) in fields {
+        set_arms.push(quote! {
+            [#name] => ::pocopine::__private::path_set_leaf(&mut self.#ident, value),
+            [#name, rest @ ..] => {
+                ::pocopine::__private::PathSetDispatch(&mut self.#ident)
+                    .__poc_dispatch_set(rest, value)
+            }
+        });
+        fp_arms.push(quote! {
+            [#name] => ::pocopine::__private::fingerprint_value(&self.#ident),
+            [#name, rest @ ..] => {
+                ::pocopine::__private::PathFpDispatch(&self.#ident).__poc_dispatch_fp(rest)
+            }
+        });
+    }
+    let (self_set_arm, self_fp_arm) = if whole_self_arm {
+        (
+            quote! { [] => ::pocopine::__private::path_set_leaf(self, value), },
+            quote! { [] => ::pocopine::__private::fingerprint_value(self), },
+        )
+    } else {
+        (
+            quote! { [] => false, },
+            quote! { [] => ::core::option::Option::None, },
+        )
+    };
+    quote! {
+        impl #impl_generics ::pocopine::__private::PathAccess for #struct_ident #ty_generics
+        #where_clause
+        {
+            fn path_set(
+                &mut self,
+                path: &[&str],
+                value: &::pocopine::__private::JsValue,
+            ) -> bool {
+                #[allow(unused_imports)]
+                use ::pocopine::__private::{PathSetNoAccess as _, PathSetViaAccess as _};
+                match path {
+                    #self_set_arm
+                    #(#set_arms)*
+                    _ => false,
+                }
+            }
+
+            fn path_fingerprint(&self, path: &[&str]) -> ::core::option::Option<u64> {
+                #[allow(unused_imports)]
+                use ::pocopine::__private::{PathFpNoAccess as _, PathFpViaAccess as _};
+                match path {
+                    #self_fp_arm
+                    #(#fp_arms)*
+                    _ => ::core::option::Option::None,
+                }
+            }
+        }
+    }
+}
+
 /// RFC-112 — `#[derive(PathAccess)]`: recursive typed nested-path
 /// access. Each derive handles its OWN named fields and descends
 /// into children through the autoref dispatch — children that also
@@ -6754,11 +6884,13 @@ pub fn asset(input: TokenStream) -> TokenStream {
 /// `Vec` element hit with an exhausted path needs). Field leaves
 /// deserialize/fingerprint via serde, so the derive compiles
 /// wherever the struct's serde derives do.
+///
+/// `#[derive(Props)]` groups get a leaves-only impl automatically —
+/// deriving BOTH on one type is a (clear) conflicting-impl error.
 #[proc_macro_derive(PathAccess)]
 pub fn derive_path_access(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let struct_ident = &input.ident;
-    let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
     let Data::Struct(data) = &input.data else {
         return syn::Error::new_spanned(
@@ -6777,54 +6909,15 @@ pub fn derive_path_access(input: TokenStream) -> TokenStream {
         .into();
     };
 
-    let mut set_arms = Vec::new();
-    let mut fp_arms = Vec::new();
-    for field in &fields.named {
-        let Some(ident) = &field.ident else { continue };
-        let name = ident.to_string();
-        set_arms.push(quote! {
-            [#name] => ::pocopine::__private::path_set_leaf(&mut self.#ident, value),
-            [#name, rest @ ..] => {
-                ::pocopine::__private::PathSetDispatch(&mut self.#ident)
-                    .__poc_dispatch_set(rest, value)
-            }
-        });
-        fp_arms.push(quote! {
-            [#name] => ::pocopine::__private::fingerprint_value(&self.#ident),
-            [#name, rest @ ..] => {
-                ::pocopine::__private::PathFpDispatch(&self.#ident).__poc_dispatch_fp(rest)
-            }
-        });
-    }
-
-    let out = quote! {
-        impl #impl_generics ::pocopine::__private::PathAccess for #struct_ident #ty_generics
-        #where_clause
-        {
-            fn path_set(
-                &mut self,
-                path: &[&str],
-                value: &::pocopine::__private::JsValue,
-            ) -> bool {
-                #[allow(unused_imports)]
-                use ::pocopine::__private::{PathSetNoAccess as _, PathSetViaAccess as _};
-                match path {
-                    [] => ::pocopine::__private::path_set_leaf(self, value),
-                    #(#set_arms)*
-                    _ => false,
-                }
-            }
-
-            fn path_fingerprint(&self, path: &[&str]) -> ::core::option::Option<u64> {
-                #[allow(unused_imports)]
-                use ::pocopine::__private::{PathFpNoAccess as _, PathFpViaAccess as _};
-                match path {
-                    [] => ::pocopine::__private::fingerprint_value(self),
-                    #(#fp_arms)*
-                    _ => ::core::option::Option::None,
-                }
-            }
-        }
-    };
-    out.into()
+    let pairs: Vec<(syn::Ident, String)> = fields
+        .named
+        .iter()
+        .filter_map(|f| {
+            f.ident.clone().map(|i| {
+                let name = i.to_string().trim_start_matches("r#").to_string();
+                (i, name)
+            })
+        })
+        .collect();
+    path_access_impl_tokens(struct_ident, &input.generics, &pairs, true).into()
 }

--- a/crates/pocopine/src/lib.rs
+++ b/crates/pocopine/src/lib.rs
@@ -46,6 +46,10 @@ pub use pocopine_core::{
 };
 #[doc(inline)]
 pub use pocopine_core::{create_context, inject_key};
+// RFC-112 — the nested-path access trait (same name as the derive,
+// different namespace — the serde `Serialize`/`derive(Serialize)`
+// convention).
+pub use pocopine_core::path_access::PathAccess;
 #[cfg(not(target_arch = "wasm32"))]
 pub use pocopine_jobs::{
     DeadLetter, JobBackend, JobClient, JobDescriptor, JobFuture, JobHandler, JobId,
@@ -55,8 +59,8 @@ pub use pocopine_jobs::{JobError, JobResult};
 // Note: `store` exists in both the value namespace (the accessor `fn store<T>()`)
 // and the macro namespace (the attribute `#[store]`). They don't collide.
 pub use pocopine_macros::{
-    Emit, Props, RouteComponent, app, asset, client_module, component, handlers, job, protected,
-    server, store,
+    Emit, PathAccess, Props, RouteComponent, app, asset, client_module, component, handlers, job,
+    protected, server, store,
 };
 
 pub mod auth {
@@ -102,8 +106,8 @@ pub mod prelude {
         ComponentState, ComponentUnmounted, Computed, ContextKey, ContextMarker, Emit, FieldHandle,
         ForComponent, Handle, Hook, Inject, IntoRouteTarget, JobError, JobResult, Loader,
         LoaderContext, LoaderError, LocalStorage, NavigationFailure, NavigationResult,
-        NearestParent, PageLink, PageMeta, PageMetaContext, PageMetaTag, Parent, Permission,
-        Plugin, PluginValidationError, Plugins, Prefetch, PrefetchResult, PrefetchSkip,
+        NearestParent, PageLink, PageMeta, PageMetaContext, PageMetaTag, Parent, PathAccess,
+        Permission, Plugin, PluginValidationError, Plugins, Prefetch, PrefetchResult, PrefetchSkip,
         PrefetchTrigger, Principal, Props, ReturnTo, Role, RouteComponent, RouteConfig,
         RouteContext, RouteErrorSurface, RouteGuard, RouteGuardDecision, RouteLoader,
         RouteLocation, RouteMeta, RouteMetaKey, RouteName, RouteNavigationCompleted,
@@ -160,7 +164,14 @@ pub mod __private {
     // RFC-095 W2 — per-field dirty-check fingerprint. The macro
     // emits one `field_fingerprint` arm per declared field.
     pub use pocopine_core::fingerprint::fingerprint as fingerprint_value;
+    // RFC-112 — typed nested-path access: the trait, the autoref
+    // dispatch pair (macro-generated call sites), and the leaf
+    // deserializer.
     pub use pocopine_core::fingerprint::quick_len as quick_len_value;
+    pub use pocopine_core::path_access::{
+        PathAccess, PathFpDispatch, PathFpNoAccess, PathFpViaAccess, PathSetDispatch,
+        PathSetNoAccess, PathSetViaAccess, set_leaf as path_set_leaf,
+    };
     // RFC-096 S3 — typed text lane: one `field_as_text` arm per
     // declared field.
     pub use pocopine_core::fingerprint::text_projection;

--- a/crates/pocopine/tests/path_access_ui.rs
+++ b/crates/pocopine/tests/path_access_ui.rs
@@ -1,0 +1,14 @@
+//! RFC-112 — compile contract for `#[derive(PathAccess)]` + the
+//! `#[component]`/`#[store]` nested-path dispatch. Behavior is
+//! covered by `pocopine-core`'s `nested_signals` wasm suite; this
+//! pins that the full macro stack (derive + autoref dispatch +
+//! RFC-111 validation) compiles together.
+//!
+//! Host-only: trybuild shells out to cargo and isn't a wasm target.
+#![cfg(not(target_arch = "wasm32"))]
+
+#[test]
+fn path_access_compiles() {
+    let cases = trybuild::TestCases::new();
+    cases.pass("tests/ui/pa_derive_pass.rs");
+}

--- a/crates/pocopine/tests/ui/pa_derive_pass.rs
+++ b/crates/pocopine/tests/ui/pa_derive_pass.rs
@@ -25,6 +25,25 @@ struct Plain {
     x: i32,
 }
 
+/// RFC-112 — `#[derive(Props)]` groups get a leaves-only
+/// `PathAccess` impl for free: used as a NORMAL nested field,
+/// `config.tab_name` descends natively.
+#[derive(Serialize, Deserialize, Clone, Default, Props)]
+struct TabProps {
+    #[prop]
+    tab_name: String,
+    #[prop]
+    tab_size: i32,
+}
+
+/// Explicit-list flatten container with a STRUCT leaf — the
+/// leaf-rooted nested path (`panel_limits.max`) re-roots into the
+/// container, whose own PathAccess derive descends natively.
+#[derive(Serialize, Deserialize, Clone, Default, PathAccess)]
+struct Panel {
+    panel_limits: Limits,
+}
+
 #[derive(Default, Serialize, Deserialize)]
 #[component(
     name = "pa-demo",
@@ -32,12 +51,17 @@ struct Plain {
   <input pp-model="settings.theme" />
   <span pp-text="settings.limits.max"></span>
   <span pp-text="plain.x"></span>
+  <span pp-text="config.tab_name"></span>
+  <input pp-model="panel_limits.max" />
   <button pp-on:click="grow">+</button>
 </div>"#
 )]
 struct PaDemo {
     settings: Settings,
     plain: Plain,
+    config: TabProps,
+    #[prop(flatten = ["panel_limits"])]
+    panel: Panel,
     count: i32,
 }
 

--- a/crates/pocopine/tests/ui/pa_derive_pass.rs
+++ b/crates/pocopine/tests/ui/pa_derive_pass.rs
@@ -1,0 +1,51 @@
+//! RFC-112 — compile-pass: `#[derive(PathAccess)]` chains through
+//! nested structs and Vecs; the `#[component]` dispatch arms
+//! resolve via autoref for deriving AND non-deriving field types;
+//! nested template paths coexist with RFC-111 validation.
+use pocopine::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Default, PathAccess)]
+struct Limits {
+    max: i32,
+}
+
+#[derive(Serialize, Deserialize, Clone, Default, PathAccess)]
+struct Settings {
+    theme: String,
+    limits: Limits,
+    items: Vec<Limits>,
+    tags: Vec<String>,
+}
+
+/// No PathAccess — the component's dispatch arm must degrade to
+/// the fallback through autoref, not fail to compile.
+#[derive(Serialize, Deserialize, Clone, Default)]
+struct Plain {
+    x: i32,
+}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "pa-demo",
+    template_inline = r#"<div>
+  <input pp-model="settings.theme" />
+  <span pp-text="settings.limits.max"></span>
+  <span pp-text="plain.x"></span>
+  <button pp-on:click="grow">+</button>
+</div>"#
+)]
+struct PaDemo {
+    settings: Settings,
+    plain: Plain,
+    count: i32,
+}
+
+#[handlers]
+impl PaDemo {
+    pub fn grow(&mut self) {
+        self.settings.limits.max += 1;
+    }
+}
+
+fn main() {}

--- a/rfcs/rfc-112-path-access.md
+++ b/rfcs/rfc-112-path-access.md
@@ -72,6 +72,51 @@ RFC-113 its fingerprint reach.
   projections; leaf projections are RFC-113's v2).
 - Enums, tuple structs, generics beyond what `split_for_impl` gives.
 
+## Prior art & alternatives (deep-researched, 2026-07-03)
+
+Adversarially-verified survey of the 2024–2026 ecosystem; every claim
+below survived 3-vote verification against primary sources.
+
+- **bevy_reflect `GetPath`** — the reference string-path design (one
+  blanket impl over `#[derive(Reflect)]`), but: not dyn-compatible
+  (traversal must flow through `dyn PartialReflect`), derive metadata
+  costs **~1.7 KiB/type of wasm after `wasm-opt -Oz`** (bevy PR
+  #15030's own tables; engine-type registration = +11.46% wasm), and
+  bevy's own path author flags per-segment dyn dispatch as too slow
+  for hot access (discussion #10285), proposing offset-based
+  Swift-style keypaths (Oct 2023) — **never shipped**, in bevy or any
+  standalone crate.
+- **Leptos `reactive_stores`** — eliminates runtime strings via
+  `#[derive(Store)]` typed accessors + numeric `StorePath` into an
+  `Arc<RwLock>` trigger registry with a this/children split (their
+  answer to our trigger lattice). Rejected by construction: mandatory
+  `.write()`/`.set()` proxies + write-observation detection violate
+  the plain-Rust-handlers and diffing invariants. Cautionary data:
+  two correctness bugs in its first two months (#3338 re-entrant
+  RwLock wasm panic on nested keyed Vecs; #3523 missed descendant
+  notifications, fixed by making every leaf write O(path-depth)
+  trigger-map lookups).
+- **facet / facet-reflect** — the only candidate that could subsume
+  serde AND this derive under one `#[derive(Facet)]` (Peek/Poke +
+  FieldPath). Self-described experimental with acknowledged soundness
+  issues; the "const shapes avoid registry-style wasm weight" claim
+  was REFUTED 0-3 in verification. Re-evaluate if it stabilizes.
+- **`field_access` & keypath/lens crates** — single-level or
+  typed-only; none traverse dotted runtime paths across unnameable
+  intermediate types.
+
+Verdict: absent language-level field projections, every design
+converges on derive-generated per-type descent (match arms here,
+const metadata in bevy/facet, accessor codegen in Leptos); the
+differences are cost trades, not elegance wins. This design occupies
+the point the constraints define. The one evidenced refinement (an
+inference, not established art — no framework found doing it): let
+the component macro emit compile-time-resolved typed accessor
+closures for OWN-field paths (bevy's `animated_field!` retreat from
+dyn paths is the precedent), reserving the runtime string match for
+cross-type `$store` paths — worth considering only if a profile ever
+shows the per-hop match on the write path.
+
 ## Tests
 
 `pocopine-core/tests/nested_signals.rs` (hand-implemented trait —

--- a/rfcs/rfc-112-path-access.md
+++ b/rfcs/rfc-112-path-access.md
@@ -63,6 +63,18 @@ RFC-113 its fingerprint reach.
   `set_leaf` mirrors the macro `set`'s empty-string→`null` retry.
 - **Exports.** Trait at `pocopine::PathAccess`, derive under the
   same name (the serde convention); both in the prelude.
+- **`#[derive(Props)]` implies `PathAccess`.** Prop groups get a
+  leaves-only impl for free (no whole-self arm, so no new serde
+  bounds land on the group struct): a Props struct used as a normal
+  nested field descends natively, and EXPLICIT-list flatten leaves
+  (`#[prop(flatten = ["panel_limits"])]` — the only flatten form
+  that can carry struct leaves) get compile-time re-rooting arms in
+  the component's `set_path`/`path_fingerprint`, routing
+  `panel_limits.max` into the container with the full path.
+  Bare-flatten leaves need no routing — `PropValue` bounds them to
+  scalars, which can never root a nested path. Deriving BOTH
+  `Props` and `PathAccess` on one type is a conflicting-impl error
+  (Props already provides it).
 
 ## Non-goals
 

--- a/rfcs/rfc-112-path-access.md
+++ b/rfcs/rfc-112-path-access.md
@@ -1,0 +1,81 @@
+# RFC-112: PathAccess — typed nested-path access
+
+**Status:** IMPLEMENTED (this branch)
+**Crates:** `pocopine-core` (`path_access`), `pocopine-macros` (`#[derive(PathAccess)]`, `#[component]`/`#[store]` dispatch), `pocopine` (re-exports)
+**Relates to:** RFC-024 §7 update (the snapshot round-trip this accelerates and falls back to), RFC-095 W2 (fingerprints), RFC-113 (nested signals — built on this substrate)
+
+## Summary
+
+A recursive, serde-style derive giving the runtime **typed access to
+nested locations** addressed by template path strings:
+
+```rust
+#[derive(Serialize, Deserialize, Default, PathAccess)]
+struct Settings { theme: String, limits: Limits }   // Limits also derives
+```
+
+Two operations, composing one level at a time:
+
+- `path_set(&mut self, path, &JsValue) -> bool` — write a leaf by
+  deserializing **at the leaf arm, where the concrete type is known**.
+  A `get_mut() -> &mut ?` shape cannot cross `dyn ComponentState`
+  (the leaf type varies per runtime path), so the value is pushed
+  down instead of a reference pulled up.
+- `path_fingerprint(&self, path) -> Option<u64>` — the nested
+  analogue of `field_fingerprint`, feeding RFC-113's leaf-granular
+  dirty sweep.
+
+`Vec<T: PathAccess>` traverses numeric segments; `Option<T>`
+traverses through `Some`; empty path means *the value itself* (what
+a `Vec` element hit with an exhausted path needs).
+
+## Why
+
+Since the RFC-024 §7 update, deep template writes work — via a
+snapshot round-trip: serialize the whole container, mutate the JS
+snapshot, deserialize the whole container back. Costs that
+accumulate: a keystroke into a field of a big `Vec` round-trips the
+entire `Vec`; `#[serde(skip)]` siblings get reset to `Default` by the
+whole-container deserialize; map fields aren't reachable at all
+(serde_wasm_bindgen emits ES `Map`s that `Reflect` can't walk).
+A native leaf write is O(leaf), touches nothing else, and gives
+RFC-113 its fingerprint reach.
+
+## Design
+
+- **Dispatch across unknown types — autoref specialization.** The
+  macros emit descent calls without knowing whether a child type
+  implements `PathAccess`:
+  `PathSetDispatch(&mut self.field).__poc_dispatch_set(rest, value)`.
+  Method resolution picks the by-value impl (bound on `PathAccess`)
+  when the bound holds; otherwise autoref finds the by-reference
+  fallback which returns `false`/`None` — terminating the native
+  path so the runtime degrades to the snapshot round-trip. Foreign
+  field types need nothing.
+- **`ComponentState` hooks.** `set_path` / `path_fingerprint`
+  (defaults: `false`/`None`); `#[component]` and `#[store]` emit
+  per-field dispatch arms (serde-skipped fields excluded — their
+  projections never carry them, so template paths can't reach them).
+- **The write lane.** `path::write_segments_with` tries
+  `ScopeAccess::write_path` (→ `scope::write_path_tracked`:
+  `set_path`, container-projection invalidation, the RFC-113
+  trigger lattice) before the snapshot fallback. Behavior parity:
+  `set_leaf` mirrors the macro `set`'s empty-string→`null` retry.
+- **Exports.** Trait at `pocopine::PathAccess`, derive under the
+  same name (the serde convention); both in the prelude.
+
+## Non-goals
+
+- Map keys in paths (needs a read-side story first — ES `Map`
+  projections aren't template-walkable).
+- A `path_get` read lane (v1 reads keep walking container
+  projections; leaf projections are RFC-113's v2).
+- Enums, tuple structs, generics beyond what `split_for_impl` gives.
+
+## Tests
+
+`pocopine-core/tests/nested_signals.rs` (hand-implemented trait —
+runtime semantics without the macro layer) +
+`pocopine/tests/path_access_ui.rs` (trybuild compile-pass: derive +
+autoref dispatch for deriving AND non-deriving fields + nested
+`pp-model` under RFC-111 validation).

--- a/rfcs/rfc-113-nested-signals.md
+++ b/rfcs/rfc-113-nested-signals.md
@@ -1,0 +1,91 @@
+# RFC-113: Nested signals — leaf-granular reactivity
+
+**Status:** IMPLEMENTED, v1 (this branch)
+**Crates:** `pocopine-core` (`reactive`, `scope`, `path`)
+**Relates to:** RFC-112 (the substrate), RFC-095 W2 (the dirty sweep this extends), RFC-096 (signals-first core), RFC-054 (row plans — own Vec element identity)
+
+## Summary
+
+Reactivity granularity widens from top-level fields to **paths**:
+a binding on `settings.theme` subscribes to the signal keyed
+`(scope, "settings.theme")`; a handler mutating `settings.size`
+re-runs only `size` subscribers. The "group store fields by update
+cadence, not by theme" constraint dissolves for types that derive
+`PathAccess` — nesting becomes free.
+
+Not a fingerprint replacement: detection (how change is learned)
+and addressing (how precisely it's named) are independent axes.
+Handlers stay plain Rust, so detection stays **diffing** — the
+sweep just asks finer questions, and each hash is cheaper (scalar
+leaves instead of whole structs).
+
+## Design
+
+The signal graph was already string-keyed (`(ScopeId, Key)`), so
+this is parameter-widening plus one new piece of logic:
+
+1. **Leaf tracking (read side).** `resolve_path_with` offers nested
+   paths to `ScopeAccess::read_path`, which tracks the FULL dotted
+   key and resolves the container **untracked**
+   (`read_field_untracked` — the tracked read's body minus the
+   subscription). Eligibility gates, each falling back to today's
+   root-tracked walk: real component/store scopes only (derived
+   loop/slot scopes compose from parents), no `$`-roots, **no
+   numeric segments** (positions aren't identity — keyed row plans
+   own Vec elements), and `path_fingerprint` must have reach
+   (without it the sweep couldn't gate the key and every handler
+   would re-run the subscriber).
+2. **The trigger lattice (door 1 — explicit writes).** A native
+   leaf write (`write_path_tracked`) fires: the exact key,
+   subscribed keys *under* it, and subscribed *ancestors*
+   (whole-container readers, `#[watch(container)]`) —
+   **sibling leaves stay quiet**, which is the point. A whole-field
+   write down-fans to subscribed dotted keys under it
+   (`trigger_nested_under` — v1 unconditional, matching today's
+   effective granularity; fingerprint-filtered descent is v2).
+   The flat path pays nothing: a `has_nested_keys` scope marker
+   (set at dotted-key interning, cleared at scope teardown) makes
+   the down-fan a single `HashSet` miss for flat-only scopes — the
+   neutrality gate.
+3. **The sweep (door 2 — handler mutations).** Dotted tracked keys
+   route through `ComponentState::path_fingerprint`
+   (`sweep_fingerprint`); roots keep `field_fingerprint`. A changed
+   dotted key also invalidates its **root's projection** — the
+   container snapshot leaf reads walk through must not survive a
+   leaf change even when the root key itself isn't tracked.
+   No-net-change, length probes, `patch_*` marks, read-only-handler
+   skip: all unchanged.
+4. **Invalidations.** Native leaf writes invalidate the container
+   projection (they bypassed serde entirely); flatten containers
+   ride the existing rails.
+
+## What stays deliberately out (v1 → v2 lines)
+
+- **Leaf projections / typed leaf lane** — leaf reads still walk
+  the container projection; the granularity win is in *triggering*.
+  v2: serialize just the leaf, scalar leaves zero-serde.
+- **Fingerprint-filtered down-fan** — container replaces currently
+  over-trigger nested subscribers (exactly today's behavior).
+- **Vec index signals** — never: one reorder and every index key
+  lies. Row plans own element identity.
+- **Persistent fingerprints on signal slots** (skip `begin`
+  snapshots) — widens the door-1/door-2 invariant surface; only
+  with a profile demanding it.
+
+## The invariant to keep fuzzing
+
+Door 1 and door 2 must agree: the same value arriving via
+`path_set` vs via handler mutation leaves identical fingerprint
+state and fires identical keys. The `nested_signals` suite pins the
+directions individually; extending the RFC-096 differential fuzz
+with nested ops is the standing follow-up.
+
+## Tests
+
+`pocopine-core/tests/nested_signals.rs`: sibling-leaf isolation
+(native write + handler sweep), container-write down-fan, ancestor
+firing with fresh container projection, no-net-change leaf,
+no-`PathAccess` degradation to root granularity, flat-field
+neutrality. Full core battery + pine's 126-test wasm suite green
+(no pine type derives `PathAccess` — zero behavior change without
+opt-in).


### PR DESCRIPTION
Nested signals: reactivity granularity widens from top-level fields to **paths**. A binding on `settings.theme` subscribes to `(scope, "settings.theme")`; a handler mutating `settings.size` re-runs only `size` subscribers. The "group store fields by update cadence, not by theme" constraint dissolves for types that opt in — nesting becomes free.

Not a fingerprint replacement: detection (how change is learned) and addressing (how precisely it's named) are independent axes. Handlers stay plain Rust, so detection stays **diffing** — the sweep just asks finer, cheaper (scalar-leaf) questions.

## RFC-112 — `PathAccess`, the substrate

`#[derive(PathAccess)]` — serde-style recursive derive turning runtime string paths into typed field access, one hop per type:

```mermaid
flowchart LR
    P["path: [settings, limits, max]<br/>value: JsValue(42)"] --> A["Editor::set_path<br/>(#[component] arms)"]
    A -->|"[limits, max]"| B["Settings::path_set<br/>(derive arms)"]
    B -->|"[max]"| C["Limits::path_set<br/>leaf: from_value::&lt;i32&gt; HERE"]
    style C fill:#2d5016,color:#fff
```

- Values are pushed **down** (deserialized at the leaf arm, where the type is concrete) — a `get_mut` shape can't cross `dyn ComponentState`.
- Autoref-specialization dispatch: macros descend into field types without knowing whether they implement the trait; non-deriving types terminate the native path and the runtime falls back to the PR #263 snapshot round-trip. Foreign types need nothing; correctness never depends on opt-in.
- `Vec` traverses numeric segments, `Option` through `Some`; `path_fingerprint` gives the dirty sweep leaf reach.
- **`#[derive(Props)]` implies `PathAccess`** (leaves-only — zero new bounds on existing prop groups); explicit-list flatten struct leaves get compile-time re-rooting arms (`panel_limits.max` → container). Bare-flatten leaves are `PropValue`-bounded scalars and can never root a nested path.
- Native leaf writes are O(leaf): no whole-container serde round-trip per keystroke, `#[serde(skip)]` siblings survive.

## RFC-113 — leaf-granular reactivity

The signal graph was already string-keyed; this is parameter-widening plus one new piece of logic:

- **Leaf tracking**: `read_path` tracks the full dotted key, resolves the container untracked. Gates (each → root-tracked fallback): real scopes only, no `$`-roots, **no numeric segments** (positions aren't identity — keyed row plans own Vec elements), and fingerprint reach required.
- **Trigger lattice** (explicit writes): exact + descendants + ancestors — **siblings stay quiet**. Whole-field writes down-fan to dotted keys under them (v1 unconditional). A `has_nested_keys` marker keeps flat-only scopes at one HashSet miss — the neutrality gate.
- **Sweep** (handler mutations): dotted tracked keys route through `path_fingerprint`; a changed dotted key also invalidates its root's projection so container snapshots never serve stale leaves. No-net-change, length probes, patch marks, readonly-skip: unchanged.

Deferred to v2 (documented in RFC-113): leaf projections / typed leaf lane, fingerprint-filtered down-fan, persistent fingerprints.

## Prior art (deep-researched, adversarially verified — RFC-112 §Prior art)

bevy_reflect (~1.7 KiB/type wasm metadata, dyn-per-hop rejected by its own path author, offset keypaths unshipped since 2023), Leptos `reactive_stores` (typed accessors + `Arc<RwLock>` trigger registry — violates plain-Rust-handlers + diffing invariants; shipped two trigger-topology bugs in its first two months), facet (experimental; wasm-weight claim refuted 0-3), field_access (single-level). Verdict: every design converges on derive-generated per-type descent; this one sits on the point the constraints define.

## Verification

- `pocopine-core/tests/nested_signals.rs` (7): sibling-leaf isolation through both write doors, container-write down-fan, ancestor firing with fresh projection, no-net-change leaf, no-derive degradation to root granularity, flat-field neutrality
- `deep_write` regression suite green (snapshot fallback lane intact)
- trybuild compile-pass: derive + autoref (deriving AND non-deriving fields) + Props flatten shapes + nested `pp-model` under RFC-111 validation
- 97 macro unit tests; full core wasm battery; pine's 126-test suite green untouched (zero behavior change without opt-in)
- workspace check, CI clippy-wasm (`--all-targets`), clippy-host, fmt

## Known follow-ups

- Extend the RFC-096 differential fuzz with nested ops (the door-1/door-2 agreement invariant) — the Leptos bug history says trigger topology is where this class of design breaks.
- A max-effort multi-agent review was attempted but aborted on usage limits (verification pass never ran) — worth a fresh review pass on this PR.
