### PR TITLE
AgenKitty findings: agent streaming/threads/redaction + template-compiler fixes (nested slot outlets)

### DIFF
--- a/crates/agenkitty/src/supervisor/runtime.rs
+++ b/crates/agenkitty/src/supervisor/runtime.rs
@@ -528,7 +528,9 @@ impl FrameworkRunner {
         let mut events = vec![started];
         let mut stream = session.prompt(options.prompt);
         while let Some(event) = stream.next().await {
-            let event = map_agent_event(event);
+            let Some(event) = map_agent_event(event) else {
+                continue;
+            };
             self.session_runtime
                 .store()
                 .append_event(
@@ -643,9 +645,15 @@ fn project_id_from_root(root: &Path) -> String {
         .into_owned()
 }
 
-fn map_agent_event(event: AgentEvent) -> FrameworkEvent {
-    match event {
+/// Map a runtime event onto the supervisor's persisted [`FrameworkEvent`]
+/// surface. `None` = deliberately dropped: `AssistantDelta` fragments are a
+/// live-UI concern (ephemeral by contract) — this batch runner persists the
+/// assembled `AssistantText` that follows them, so folding every word-sized
+/// fragment into the session log would only bloat it.
+fn map_agent_event(event: AgentEvent) -> Option<FrameworkEvent> {
+    Some(match event {
         AgentEvent::Started => FrameworkEvent::started("turn started"),
+        AgentEvent::AssistantDelta { .. } => return None,
         AgentEvent::AssistantText { text } => {
             FrameworkEvent::assistant_text(redact_text_to_limit(&text, 4096))
         }
@@ -686,7 +694,7 @@ fn map_agent_event(event: AgentEvent) -> FrameworkEvent {
         }),
         AgentEvent::Failed { error } => FrameworkEvent::failed(redact_text_to_limit(&error, 4096)),
         _ => FrameworkEvent::unknown("unknown agenkit event"),
-    }
+    })
 }
 
 fn tool_call_ref(call_id: &str, tool_id: &str) -> SessionSourceRef {
@@ -705,9 +713,22 @@ mod tests {
     fn map_agent_event_redacts_assistant_text_in_report_events() {
         let event = map_agent_event(AgentEvent::AssistantText {
             text: "api_key=secret".to_string(),
-        });
+        })
+        .expect("assistant text maps to an event");
 
         assert_eq!(event.message.as_deref(), Some("[redacted]"));
+    }
+
+    #[test]
+    fn map_agent_event_drops_assistant_deltas() {
+        // Deltas are ephemeral live-UI fragments; the batch supervisor persists
+        // only the assembled AssistantText that follows them.
+        assert!(
+            map_agent_event(AgentEvent::AssistantDelta {
+                text: "frag".to_string(),
+            })
+            .is_none()
+        );
     }
 
     #[test]
@@ -721,7 +742,8 @@ mod tests {
             id: "call-1".to_string(),
             tool: "process.run".to_string(),
             output: serde_json::json!({ "stdout": "export TOKEN=bearer sk-live-123" }),
-        });
+        })
+        .expect("tool completion maps to an event");
         let payload = event.payload.expect("tool payload");
         assert_eq!(payload["output"]["stdout"], "[redacted]");
     }

--- a/crates/agenkitty/src/tools/session/common.rs
+++ b/crates/agenkitty/src/tools/session/common.rs
@@ -11,7 +11,7 @@ use agenkitty_core::{
     SessionNote, SessionSourceRef, SessionStoreKind, SessionSummary,
 };
 use pocopine_agenkit::server::session::ThreadId;
-use pocopine_agenkit_core::{AgenkitError, AgenkitResult};
+use pocopine_agenkit_core::{AgenkitError, AgenkitResult, Redactor};
 use serde_json::{Map, Value};
 
 pub type SessionMetadataFuture<'a, T> = Pin<Box<dyn Future<Output = AgenkitResult<T>> + Send + 'a>>;
@@ -712,44 +712,23 @@ pub(super) fn redact_text(text: &str) -> String {
     redact_text_to_limit(text, 4096)
 }
 
+/// The session redactor: the shared wire-boundary [`Redactor`] (truncation,
+/// sensitive-key blanking) plugged with [`agenkitty_core::looks_like_secret`]
+/// — the redaction side of the shared classifier (F3), the same predicate
+/// memory/artifacts *reject* on — so every tool's output flowing through here
+/// (fs / patch / process / network results become session events) is covered
+/// by one predicate.
+fn wire_redactor() -> &'static Redactor {
+    static REDACTOR: std::sync::OnceLock<Redactor> = std::sync::OnceLock::new();
+    REDACTOR.get_or_init(|| Redactor::new().secret_classifier(agenkitty_core::looks_like_secret))
+}
+
 pub(crate) fn redact_text_to_limit(text: &str, max_bytes: usize) -> String {
-    if text_needs_full_redaction(text) {
-        return "[redacted]".to_string();
-    }
-    truncate_utf8(text, max_bytes)
+    wire_redactor().text_to_limit(text, max_bytes)
 }
 
 pub(crate) fn redact_json_value(value: &Value, max_string_bytes: usize) -> Value {
-    redact_json_value_at_depth(value, max_string_bytes, 0)
-}
-
-fn redact_json_value_at_depth(value: &Value, max_string_bytes: usize, depth: usize) -> Value {
-    const MAX_JSON_REDACTION_DEPTH: usize = 64;
-    if depth > MAX_JSON_REDACTION_DEPTH {
-        return Value::String("[redacted: too deep]".to_string());
-    }
-    match value {
-        Value::String(text) => Value::String(redact_text_to_limit(text, max_string_bytes)),
-        Value::Array(items) => Value::Array(
-            items
-                .iter()
-                .map(|item| redact_json_value_at_depth(item, max_string_bytes, depth + 1))
-                .collect(),
-        ),
-        Value::Object(object) => {
-            let mut redacted = Map::new();
-            for (key, value) in object {
-                let value = if is_sensitive_key(key) {
-                    Value::String("[redacted]".to_string())
-                } else {
-                    redact_json_value_at_depth(value, max_string_bytes, depth + 1)
-                };
-                redacted.insert(key.clone(), value);
-            }
-            Value::Object(redacted)
-        }
-        _ => value.clone(),
-    }
+    wire_redactor().json_to_limit(value, max_string_bytes)
 }
 
 pub(crate) fn redact_artifact_link(mut link: SessionArtifactLink) -> SessionArtifactLink {
@@ -859,58 +838,6 @@ pub(crate) fn redact_source_refs(source_refs: Vec<SessionSourceRef>) -> Vec<Sess
             },
         })
         .collect()
-}
-
-/// The session redactor replaces text carrying credential material with
-/// `[redacted]` before it persists. This is the *redaction* side of the shared
-/// [`agenkitty_core::looks_like_secret`] classifier (F3) — the same predicate
-/// memory/artifacts *reject* on — so every tool's output flowing through this
-/// redactor (fs / patch / process / network results become session events) is
-/// covered by one predicate.
-fn text_needs_full_redaction(text: &str) -> bool {
-    agenkitty_core::looks_like_secret(text)
-}
-
-fn is_sensitive_key(key: &str) -> bool {
-    let normalized = key
-        .chars()
-        .filter(|ch| ch.is_ascii_alphanumeric())
-        .flat_map(|ch| ch.to_lowercase())
-        .collect::<String>();
-    matches!(
-        normalized.as_str(),
-        "apikey"
-            | "xapikey"
-            | "token"
-            | "accesstoken"
-            | "refreshtoken"
-            | "idtoken"
-            | "authorization"
-            | "auth"
-            | "password"
-            | "passwd"
-            | "pwd"
-            | "secret"
-            | "clientsecret"
-            | "secretkey"
-            | "privatekey"
-            | "credential"
-            | "credentials"
-    ) || normalized.ends_with("apikey")
-        || normalized.ends_with("token")
-        || normalized.ends_with("secret")
-        || normalized.ends_with("password")
-}
-
-pub fn truncate_utf8(text: &str, max_bytes: usize) -> String {
-    if text.len() <= max_bytes {
-        return text.to_string();
-    }
-    let mut end = max_bytes;
-    while !text.is_char_boundary(end) {
-        end -= 1;
-    }
-    format!("{}…", &text[..end])
 }
 
 fn lock_err<T>(_: std::sync::PoisonError<T>) -> AgenkitError {

--- a/crates/pine-icons/src/PineIcon.css
+++ b/crates/pine-icons/src/PineIcon.css
@@ -1,10 +1,18 @@
 /* <pine-icon> renders as role="visual" → <span>. Inline-flex so
    it aligns to baseline with sibling text like any other inline
-   glyph, while letting the injected SVG fill the sized box. */
+   glyph, while letting the injected SVG fill the sized box.
+
+   The 1em default box makes an unsized icon ride the surrounding
+   font-size — exactly what a paired text/icon scale wants. It's a
+   class rule (not an inline style), so app CSS can override
+   width/height without `!important`; an explicit `size` prop wins
+   via the inline style the component then writes. */
 .pine-icon {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  width: 1em;
+  height: 1em;
   line-height: 1;
   vertical-align: middle;
 }

--- a/crates/pine-icons/src/primitive.rs
+++ b/crates/pine-icons/src/primitive.rs
@@ -20,7 +20,7 @@
 use pocopine::prelude::*;
 use serde::{Deserialize, Serialize};
 
-#[derive(Serialize, Deserialize)]
+#[derive(Default, Serialize, Deserialize)]
 #[component(
     template = "PineIcon.poco",
     style = "PineIcon.css",
@@ -37,7 +37,11 @@ pub struct PineIcon {
     /// the common case.
     #[prop]
     pub variant: String,
-    /// Render size in CSS pixels. `0` falls back to `20`.
+    /// Render size in CSS pixels. Unset (`0`) writes no inline
+    /// style at all: the icon's box defaults to `1em` via CSS, so
+    /// it rides the surrounding font-size and app stylesheets can
+    /// resize it without `!important`. An explicit size pins the
+    /// box in px via inline style.
     #[prop]
     pub size: u32,
     /// Computed SVG body, fed to `pp-html` in the template.
@@ -53,19 +57,6 @@ pub struct PineIcon {
     pub svg_hash: u64,
     /// Computed inline-style for the sized box.
     pub size_style: String,
-}
-
-impl Default for PineIcon {
-    fn default() -> Self {
-        Self {
-            name: String::new(),
-            variant: String::new(),
-            size: 20,
-            svg: String::new(),
-            svg_hash: 0,
-            size_style: String::new(),
-        }
-    }
 }
 
 #[handlers]
@@ -137,12 +128,19 @@ impl PineIcon {
         }
     }
 
-    /// Recompute the inline `width/height` style. Same no-op
-    /// guard pattern — resizing a primitive without actually
+    /// Recompute the inline `width/height` style. Unset (`0`)
+    /// emits NO inline style — the `.pine-icon` class defaults the
+    /// box to `1em`, and keeping the style attribute empty is what
+    /// lets app CSS override the size without `!important`. Same
+    /// no-op guard pattern — resizing a primitive without actually
     /// changing `size` shouldn't retrigger downstream effects.
     fn refresh_size_style(&mut self) {
-        let s = if self.size == 0 { 20 } else { self.size };
-        let next = format!("width:{s}px;height:{s}px");
+        let next = if self.size == 0 {
+            String::new()
+        } else {
+            let s = self.size;
+            format!("width:{s}px;height:{s}px")
+        };
         if self.size_style != next {
             self.size_style = next;
         }

--- a/crates/pocopine-agenkit-core/src/lib.rs
+++ b/crates/pocopine-agenkit-core/src/lib.rs
@@ -43,6 +43,7 @@ pub mod events;
 pub mod flow;
 pub mod id;
 pub mod manifest;
+pub mod redact;
 pub mod reduce;
 pub mod retrieval;
 pub mod schema;
@@ -66,13 +67,14 @@ pub use id::{
     AgentThreadId, ModelRef, ParallelGroupId, ProviderRef, RunId, SessionId, StepId, TraceId,
 };
 pub use manifest::{ContextGapDiagnostic, ContextManifest, DeclaredResource};
+pub use redact::{Redactor, is_sensitive_key, truncate_utf8};
 pub use reduce::ReducerDecision;
 pub use retrieval::{
     Citation, RetrievalHit, RetrievalQuery, RetrievalSet, RetrieverDescriptor, SourceRef,
 };
 pub use schema::SchemaRef;
 pub use sse::SseFraming;
-pub use stream::FlowStreamEvent;
+pub use stream::{AgentWireEvent, FlowStreamEvent, WireStopReason};
 pub use thread::{AgentThreadDescriptor, ThreadCheckpoint, ThreadMessage};
 pub use tool::{ToolCall, ToolDescriptor, ToolResult};
 pub use tool_name::{ToolNameMap, sanitize_tool_name};

--- a/crates/pocopine-agenkit-core/src/redact.rs
+++ b/crates/pocopine-agenkit-core/src/redact.rs
@@ -1,0 +1,251 @@
+//! Wire-boundary redaction (§D10) — the shared helpers every UI bridge uses to
+//! map trusted host-side data onto a client-facing surface, instead of each
+//! consumer hand-rolling its own (redaction-by-construction).
+//!
+//! A [`Redactor`] bounds text/JSON payload sizes, blanks values under
+//! credential-shaped keys ([`is_sensitive_key`]), and — when the host plugs in
+//! a secret-content classifier — fully redacts any string the classifier
+//! flags. The classifier is pluggable because content classification is host
+//! policy (e.g. agenkitty's shared `looks_like_secret`), while the structural
+//! rules here are universal.
+
+use std::sync::Arc;
+
+use serde_json::{Map, Value};
+
+/// The replacement marker for redacted content.
+pub const REDACTED: &str = "[redacted]";
+
+/// Nesting depth beyond which a JSON value is replaced instead of walked (a
+/// guard against adversarially deep payloads).
+const MAX_JSON_REDACTION_DEPTH: usize = 64;
+
+/// A pluggable secret-content classifier (see
+/// [`secret_classifier`](Redactor::secret_classifier)).
+type SecretClassifier = Arc<dyn Fn(&str) -> bool + Send + Sync>;
+
+/// A reusable text/JSON redaction policy for one wire boundary.
+///
+/// Defaults: text capped at 4096 bytes, JSON strings at 2048 bytes, values
+/// under credential-shaped keys blanked, no content classifier. Plug one in
+/// with [`secret_classifier`](Redactor::secret_classifier) to also fully
+/// redact any string whose *content* looks like a secret.
+#[derive(Clone, Default)]
+pub struct Redactor {
+    text_limit: Option<usize>,
+    json_string_limit: Option<usize>,
+    is_secret: Option<SecretClassifier>,
+}
+
+impl Redactor {
+    /// The default policy (4096-byte text, 2048-byte JSON strings, no
+    /// content classifier).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Override the byte cap applied by [`text`](Redactor::text).
+    pub fn text_limit(mut self, bytes: usize) -> Self {
+        self.text_limit = Some(bytes);
+        self
+    }
+
+    /// Override the byte cap applied to each JSON string by
+    /// [`json`](Redactor::json).
+    pub fn json_string_limit(mut self, bytes: usize) -> Self {
+        self.json_string_limit = Some(bytes);
+        self
+    }
+
+    /// Plug in a secret-content classifier: any string it flags is replaced
+    /// with `[redacted]` wholesale (not merely truncated).
+    pub fn secret_classifier(
+        mut self,
+        classify: impl Fn(&str) -> bool + Send + Sync + 'static,
+    ) -> Self {
+        self.is_secret = Some(Arc::new(classify));
+        self
+    }
+
+    /// Whether the plugged-in secret classifier flags `text` (`false` when no
+    /// classifier is configured). Exposed for stateful stream adapters that
+    /// must classify *assembled* text across fragments — per-fragment
+    /// classification alone misses a secret split across chunk boundaries.
+    pub fn flags_secret(&self, text: &str) -> bool {
+        self.is_secret.as_ref().is_some_and(|f| f(text))
+    }
+
+    /// Redact free text: fully replaced if the classifier flags it, else
+    /// truncated to the configured text limit.
+    pub fn text(&self, text: &str) -> String {
+        self.text_to_limit(text, self.text_limit.unwrap_or(4096))
+    }
+
+    /// [`text`](Redactor::text) with an explicit byte cap (for callers with
+    /// per-field limits, e.g. a short title vs a long body).
+    pub fn text_to_limit(&self, text: &str, max_bytes: usize) -> String {
+        if self.flags_secret(text) {
+            return REDACTED.to_string();
+        }
+        truncate_utf8(text, max_bytes)
+    }
+
+    /// Redact a JSON payload: values under credential-shaped keys are blanked,
+    /// every string is classifier-checked and capped at the configured JSON
+    /// string limit, and pathologically deep values are cut off.
+    pub fn json(&self, value: &Value) -> Value {
+        self.json_to_limit(value, self.json_string_limit.unwrap_or(2048))
+    }
+
+    /// [`json`](Redactor::json) with an explicit per-string byte cap.
+    pub fn json_to_limit(&self, value: &Value, max_string_bytes: usize) -> Value {
+        self.json_at_depth(value, max_string_bytes, 0)
+    }
+
+    fn json_at_depth(&self, value: &Value, max_string_bytes: usize, depth: usize) -> Value {
+        if depth > MAX_JSON_REDACTION_DEPTH {
+            return Value::String("[redacted: too deep]".to_string());
+        }
+        match value {
+            Value::String(text) => Value::String(self.text_to_limit(text, max_string_bytes)),
+            Value::Array(items) => Value::Array(
+                items
+                    .iter()
+                    .map(|item| self.json_at_depth(item, max_string_bytes, depth + 1))
+                    .collect(),
+            ),
+            Value::Object(object) => {
+                let mut redacted = Map::new();
+                for (key, value) in object {
+                    let value = if is_sensitive_key(key) {
+                        Value::String(REDACTED.to_string())
+                    } else {
+                        self.json_at_depth(value, max_string_bytes, depth + 1)
+                    };
+                    redacted.insert(key.clone(), value);
+                }
+                Value::Object(redacted)
+            }
+            _ => value.clone(),
+        }
+    }
+}
+
+impl std::fmt::Debug for Redactor {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Redactor")
+            .field("text_limit", &self.text_limit)
+            .field("json_string_limit", &self.json_string_limit)
+            .field("has_secret_classifier", &self.is_secret.is_some())
+            .finish()
+    }
+}
+
+/// Whether a JSON object key names credential material (`api_key`, `token`,
+/// `password`, …). Matched on the key's alphanumerics, case-insensitively, so
+/// `X-Api-Key`, `apiKey` and `api_key` all count.
+pub fn is_sensitive_key(key: &str) -> bool {
+    let normalized = key
+        .chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .flat_map(|ch| ch.to_lowercase())
+        .collect::<String>();
+    matches!(
+        normalized.as_str(),
+        "apikey"
+            | "xapikey"
+            | "token"
+            | "accesstoken"
+            | "refreshtoken"
+            | "idtoken"
+            | "authorization"
+            | "auth"
+            | "password"
+            | "passwd"
+            | "pwd"
+            | "secret"
+            | "clientsecret"
+            | "secretkey"
+            | "privatekey"
+            | "credential"
+            | "credentials"
+    ) || normalized.ends_with("apikey")
+        || normalized.ends_with("token")
+        || normalized.ends_with("secret")
+        || normalized.ends_with("password")
+}
+
+/// Truncate `text` to at most `max_bytes` bytes on a char boundary, appending
+/// `…` when anything was cut.
+pub fn truncate_utf8(text: &str, max_bytes: usize) -> String {
+    if text.len() <= max_bytes {
+        return text.to_string();
+    }
+    let mut end = max_bytes;
+    while !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}…", &text[..end])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn text_truncates_on_char_boundaries() {
+        let redactor = Redactor::new().text_limit(4);
+        // "héllo" = h(1) é(2) l(1)… — byte 4 falls inside a char? h=1,é=2..3,l=4
+        assert_eq!(redactor.text("héllo"), "hél…");
+        assert_eq!(redactor.text("hey"), "hey");
+    }
+
+    #[test]
+    fn classifier_fully_redacts_flagged_text() {
+        let redactor = Redactor::new().secret_classifier(|text| text.contains("sk-live"));
+        assert_eq!(redactor.text("token sk-live-123"), REDACTED);
+        assert_eq!(redactor.text("plain"), "plain");
+    }
+
+    #[test]
+    fn json_blanks_sensitive_keys_and_walks_nested_values() {
+        let redactor = Redactor::new().secret_classifier(|text| text.contains("hunter2"));
+        let value = serde_json::json!({
+            "api_key": "abc",
+            "nested": { "Authorization": "Bearer x", "note": "hunter2 is my password" },
+            "list": ["ok", { "refresh_token": 1 }],
+            "count": 3,
+        });
+        let redacted = redactor.json(&value);
+        assert_eq!(redacted["api_key"], REDACTED);
+        assert_eq!(redacted["nested"]["Authorization"], REDACTED);
+        assert_eq!(redacted["nested"]["note"], REDACTED);
+        assert_eq!(redacted["list"][1]["refresh_token"], REDACTED);
+        assert_eq!(redacted["list"][0], "ok");
+        assert_eq!(redacted["count"], 3);
+    }
+
+    #[test]
+    fn json_cuts_off_pathological_depth() {
+        let mut value = serde_json::json!("leaf");
+        for _ in 0..80 {
+            value = serde_json::json!([value]);
+        }
+        let redacted = Redactor::new().json(&value);
+        assert!(
+            serde_json::to_string(&redacted)
+                .unwrap()
+                .contains("[redacted: too deep]")
+        );
+    }
+
+    #[test]
+    fn sensitive_key_matches_are_format_insensitive() {
+        for key in ["X-Api-Key", "apiKey", "ACCESS_TOKEN", "my_client_secret"] {
+            assert!(is_sensitive_key(key), "{key}");
+        }
+        for key in ["name", "tokens_used", "content"] {
+            assert!(!is_sensitive_key(key), "{key}");
+        }
+    }
+}

--- a/crates/pocopine-agenkit-core/src/stream.rs
+++ b/crates/pocopine-agenkit-core/src/stream.rs
@@ -213,6 +213,110 @@ pub enum FlowStreamEvent {
     Unknown,
 }
 
+/// The public, client-safe projection of a conversational agent turn — the
+/// session analogue of [`FlowStreamEvent`]. Produced by
+/// `pocopine_agenkit::server::AgentEventRedactor`, the stateful adapter that
+/// maps the trusted host-side `AgentEvent` firehose through a
+/// [`Redactor`](crate::redact::Redactor) — classifying the *assembled* delta
+/// text so a fragment-split secret can't stream out — so every UI bridge
+/// (SSE, websocket, CLI) shares one redaction-by-construction path instead of
+/// hand-rolling its own trusted→wire mapping.
+///
+/// Tool `args`/`output` ride the wire *redacted* (size-capped, sensitive keys
+/// blanked, classifier-checked) — present because a chat harness renders them;
+/// a bridge that wants them off the wire entirely can drop the fields in its
+/// own mapping.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum AgentWireEvent {
+    /// A prompt was accepted; the turn begins.
+    Started,
+    /// An incremental fragment of the assistant's answer (a live view — the
+    /// assembled message follows as [`AssistantText`](AgentWireEvent::AssistantText)).
+    AssistantDelta {
+        /// The next fragment of the assistant's text.
+        text: String,
+    },
+    /// An assistant text response (assembled; may precede tool calls).
+    AssistantText {
+        /// The assistant's text.
+        text: String,
+    },
+    /// A tool call is about to run.
+    ToolStarted {
+        /// The provider's call id.
+        id: String,
+        /// The tool's registry id.
+        tool: String,
+        /// The call arguments (redacted).
+        args: serde_json::Value,
+    },
+    /// A tool call returned.
+    ToolCompleted {
+        /// The provider's call id.
+        id: String,
+        /// The tool's registry id.
+        tool: String,
+        /// The tool's output (redacted).
+        output: serde_json::Value,
+    },
+    /// A tool call failed (the loop continues).
+    ToolFailed {
+        /// The provider's call id.
+        id: String,
+        /// The tool's registry id.
+        tool: String,
+        /// The error text (redacted).
+        error: String,
+    },
+    /// A hook blocked a tool call.
+    ToolBlocked {
+        /// The provider's call id.
+        id: String,
+        /// The tool's registry id.
+        tool: String,
+        /// Why it was blocked (redacted).
+        reason: String,
+    },
+    /// The thread was compacted.
+    Compacted {
+        /// How many messages were folded into the summary.
+        folded: u64,
+    },
+    /// Terminal: the turn finished successfully.
+    Stopped {
+        /// Why the turn ended.
+        reason: WireStopReason,
+    },
+    /// Terminal: the turn failed.
+    Failed {
+        /// The error text (redacted).
+        error: String,
+    },
+    /// Forward-compatibility fallback: an event tag this build does not know.
+    /// Never constructed by the server; produced on the decode side so an
+    /// older client skips a newer server's events instead of failing.
+    #[serde(other)]
+    Unknown,
+}
+
+/// Why a turn ended, on the wire.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum WireStopReason {
+    /// The model answered with no tool calls — waiting for the next prompt.
+    Idle,
+    /// The per-turn step budget was hit.
+    MaxSteps,
+    /// The turn was cancelled.
+    Aborted,
+    /// Forward-compatibility fallback for a reason this build does not know.
+    #[serde(other)]
+    Unknown,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -293,5 +397,31 @@ mod tests {
         let event: FlowStreamEvent =
             serde_json::from_str(r#"{"event":"added_in_a_future_version"}"#).unwrap();
         assert_eq!(event, FlowStreamEvent::Unknown);
+    }
+
+    #[test]
+    fn agent_wire_events_are_tagged_and_degrade_to_unknown() {
+        let delta = AgentWireEvent::AssistantDelta {
+            text: "hel".to_string(),
+        };
+        let json = serde_json::to_string(&delta).unwrap();
+        assert!(json.contains(r#""event":"assistant_delta""#));
+        assert_eq!(
+            serde_json::from_str::<AgentWireEvent>(&json).unwrap(),
+            delta
+        );
+
+        let stopped = AgentWireEvent::Stopped {
+            reason: WireStopReason::MaxSteps,
+        };
+        let json = serde_json::to_string(&stopped).unwrap();
+        assert!(json.contains(r#""reason":"max_steps""#));
+
+        // An old client reading a newer server's stream skips, not fails.
+        let event: AgentWireEvent =
+            serde_json::from_str(r#"{"event":"added_in_a_future_version"}"#).unwrap();
+        assert_eq!(event, AgentWireEvent::Unknown);
+        let reason: WireStopReason = serde_json::from_str(r#""new_reason""#).unwrap();
+        assert_eq!(reason, WireStopReason::Unknown);
     }
 }

--- a/crates/pocopine-agenkit/src/server/agenkit.rs
+++ b/crates/pocopine-agenkit/src/server/agenkit.rs
@@ -121,6 +121,12 @@ impl Agenkit {
         &self.inner.embedders
     }
 
+    /// The configured agent-thread store — e.g. to list a principal's threads
+    /// for a sidebar (`agenkit.thread_store().list(owner)`).
+    pub fn thread_store(&self) -> &Arc<dyn AgentThreadStore> {
+        &self.inner.thread_store
+    }
+
     /// A fresh execution context over the runtime's app state.
     pub fn context(&self) -> AiContext {
         AiContext::new(self.inner.state.clone())

--- a/crates/pocopine-agenkit/src/server/loop_core.rs
+++ b/crates/pocopine-agenkit/src/server/loop_core.rs
@@ -16,15 +16,18 @@
 
 use std::sync::Arc;
 
+use futures::StreamExt;
 use futures::future::BoxFuture;
 use pocopine_agenkit_core::{
-    AgenkitError, AgenkitResult, Message, ModelRef, StepId, StepKind, StepStatus, ToolCall, Usage,
-    events,
+    AgenkitError, AgenkitResult, Content, ContentPart, Message, ModelRef, StepId, StepKind,
+    StepStatus, ToolCall, Usage, events,
 };
 
 use super::agenkit::AgenkitInner;
 use super::context::AiContext;
-use super::provider::{GenerateRequest, GenerateResponse, Provider, ProviderContext};
+use super::provider::{
+    FinishReason, GenerateRequest, GenerateResponse, Provider, ProviderContext, StreamChunk,
+};
 use super::run::RunState;
 
 /// A `before_tool_call` hook's decision for one tool call (L3). Mirrors the
@@ -71,6 +74,11 @@ pub(crate) trait LoopObserver {
     fn model_request(&self, _model: &ModelRef) -> Option<StepId> {
         None
     }
+    /// A user-visible fragment of the assistant's answer arrived on the model's
+    /// response stream (only [`run_model_step_streamed`] reports these). The
+    /// assembled text still arrives whole via the response — deltas are a live
+    /// view, not a substitute.
+    fn assistant_delta(&self, _delta: &str) {}
     /// The model responded (`usage` = token accounting, if the provider gave it).
     fn model_response(&self, _step: Option<StepId>, _model: &ModelRef, _usage: Option<Usage>) {}
     /// A tool is about to run; returns the trace step it opened.
@@ -104,6 +112,78 @@ pub(crate) async fn run_model_step(
         .generate(request, cx)
         .await
         .map_err(super::generate::reclassify_overflow)?;
+    observer.model_response(step, model, response.usage);
+    Ok(response)
+}
+
+/// Call the model for one step, **streaming**: like [`run_model_step`], but
+/// consumes the provider's incremental stream — reporting each user-visible text
+/// fragment through [`LoopObserver::assistant_delta`] as it arrives — and then
+/// assembles the same finished [`GenerateResponse`] (reasoning + text + tool
+/// calls + usage) the one-shot path returns, so the caller's termination logic
+/// is unchanged. A provider without native streaming degrades to a single delta
+/// carrying the whole answer (§D13). The assembly mirrors the flow path's
+/// `run_streamed` (`server/generate.rs`): reasoning rides the response content
+/// server-side only — it is never reported as a delta (§D10).
+pub(crate) async fn run_model_step_streamed(
+    provider: &Arc<dyn Provider>,
+    request: GenerateRequest,
+    cx: &ProviderContext,
+    model: &ModelRef,
+    observer: &(dyn LoopObserver + Sync),
+) -> AgenkitResult<GenerateResponse> {
+    let step = observer.model_request(model);
+
+    // Honor the declared streaming capability: stream natively when supported,
+    // else adapt a one-shot generation to the streaming contract (§D13).
+    let mut stream = if provider.capabilities().streaming {
+        provider.generate_stream(request, cx)
+    } else {
+        super::provider::fallback_stream(provider.as_ref(), request, cx)
+    };
+
+    let mut text = String::new();
+    let mut thinking_parts: Vec<ContentPart> = Vec::new();
+    let mut tool_calls = Vec::new();
+    let mut usage = None;
+    while let Some(chunk) = stream.next().await {
+        match chunk {
+            Ok(StreamChunk::Text(delta)) => {
+                observer.assistant_delta(&delta);
+                text.push_str(&delta);
+            }
+            Ok(StreamChunk::Thinking { text, signature }) => {
+                thinking_parts.push(ContentPart::thinking(text, signature));
+            }
+            Ok(StreamChunk::ToolCall(call)) => tool_calls.push(call),
+            Ok(StreamChunk::Usage(reported)) => usage = Some(reported),
+            // A mid-stream failure fails the step (partial text is discarded —
+            // the caller's turn fails and nothing is persisted, so a consumer
+            // never sees deltas confirmed by a final message).
+            Err(error) => return Err(super::generate::reclassify_overflow(error)),
+        }
+    }
+    drop(stream);
+
+    let finish_reason = if tool_calls.is_empty() {
+        FinishReason::Stop
+    } else {
+        FinishReason::ToolCalls
+    };
+    // Reasoning parts (if any) precede the answer text — parity with the
+    // non-streamed response shape, so replay/persistence see one contract.
+    let content = if thinking_parts.is_empty() {
+        Content::text(text)
+    } else {
+        thinking_parts.push(ContentPart::text(text));
+        Content::from_parts(thinking_parts)
+    };
+    let response = GenerateResponse {
+        content,
+        tool_calls,
+        usage,
+        finish_reason,
+    };
     observer.model_response(step, model, response.usage);
     Ok(response)
 }

--- a/crates/pocopine-agenkit/src/server/mod.rs
+++ b/crates/pocopine-agenkit/src/server/mod.rs
@@ -68,9 +68,12 @@ pub use provider::{
 pub use reduce::ReduceBuilder;
 pub use retrieval::{AiRetriever, DynRetriever, RetrieverRegistry, retriever_as_tool};
 pub use runtime::{
-    AbortHandle, AgentConfig, AgentEvent, AgentSession, AgentSessionBuilder, CapturePolicy,
-    StopReason, ToolDecision,
+    AbortHandle, AgentConfig, AgentEvent, AgentEventRedactor, AgentSession, AgentSessionBuilder,
+    CapturePolicy, StopReason, ToolDecision,
 };
+// Beside [`AgentEventRedactor`]: the policy it applies and the wire type it
+// produces (both live in the wasm-safe core crate so clients can decode).
+pub use pocopine_agenkit_core::{AgentWireEvent, Redactor, WireStopReason};
 // Beside [`ToolDecision`]: the parameter type a `before_tool_call` hook receives.
 pub use pocopine_agenkit_core::ToolCall;
 pub use thread::{

--- a/crates/pocopine-agenkit/src/server/mod.rs
+++ b/crates/pocopine-agenkit/src/server/mod.rs
@@ -74,6 +74,7 @@ pub use runtime::{
 // Beside [`ToolDecision`]: the parameter type a `before_tool_call` hook receives.
 pub use pocopine_agenkit_core::ToolCall;
 pub use thread::{
-    AgentThreadHandle, AgentThreadStore, SessionThreadStore, ThreadBuilder, ThreadOwner,
+    AgentThreadHandle, AgentThreadMeta, AgentThreadStore, SessionThreadStore, ThreadBuilder,
+    ThreadOwner,
 };
 pub use tool::{AiTool, DynTool, ToolRegistry};

--- a/crates/pocopine-agenkit/src/server/runtime.rs
+++ b/crates/pocopine-agenkit/src/server/runtime.rs
@@ -27,9 +27,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 
 use futures::future::BoxFuture;
 use pocopine_agenkit_core::{
-    AgenkitError, AgenkitResult, AgentThreadId, Content, CostEstimate, Message, ModelRef, RunId,
-    StepId, StepKind, StepStatus, ThreadRetention, ToolCall, ToolDescriptor, TraceId, Usage,
-    events,
+    AgenkitError, AgenkitResult, AgentThreadId, AgentWireEvent, Content, CostEstimate, Message,
+    ModelRef, Redactor, RunId, StepId, StepKind, StepStatus, ThreadRetention, ToolCall,
+    ToolDescriptor, TraceId, Usage, WireStopReason, events,
 };
 use pocopine_auth::Principal;
 use tokio::sync::mpsc::{UnboundedSender, unbounded_channel};
@@ -208,6 +208,133 @@ impl AgentConfig {
     pub fn max_steps_per_turn(mut self, steps: u32) -> Self {
         self.max_steps_per_turn = steps.max(1);
         self
+    }
+}
+
+/// The trusted→wire adapter every UI bridge (SSE, websocket, CLI) shares,
+/// instead of hand-rolling its own (§D10, redaction-by-construction): feed it
+/// each [`AgentEvent`] from a turn stream, forward each `Some` it returns.
+///
+/// It is **stateful** so streaming can't leak what whole-message redaction
+/// would catch: a secret split across [`AssistantDelta`] fragments (`api_`
+/// then `key = sk-…`) evades any per-fragment classifier, so the adapter
+/// classifies the **assembled** text so far on every fragment. When the
+/// classifier trips, the fragment is replaced by one `[redacted]` marker and
+/// every later fragment of that message is suppressed (`None`); the final
+/// [`AssistantText`] is redacted whole as usual, so the client's replace-on-
+/// final rendering converges. Non-delta events map statelessly: free text and
+/// error strings through [`Redactor::text`], tool args/outputs through
+/// [`Redactor::json`] (size-capped, credential-shaped keys blanked).
+///
+/// One adapter instance per event stream (its state is one in-flight
+/// message); construct with the same [`Redactor`] the bridge uses elsewhere.
+///
+/// [`AssistantDelta`]: AgentEvent::AssistantDelta
+/// [`AssistantText`]: AgentEvent::AssistantText
+#[derive(Debug)]
+pub struct AgentEventRedactor {
+    redactor: Redactor,
+    /// The in-flight assistant message assembled from its deltas — what the
+    /// classifier runs on, so a fragment-split secret is still caught.
+    assembled: String,
+    /// The classifier tripped on the assembled prefix: the remaining deltas
+    /// of this message are suppressed.
+    tripped: bool,
+}
+
+impl AgentEventRedactor {
+    /// A stream adapter applying `redactor` to every event.
+    pub fn new(redactor: Redactor) -> Self {
+        Self {
+            redactor,
+            assembled: String::new(),
+            tripped: false,
+        }
+    }
+
+    /// Map the next event of the stream. `None` = deliberately dropped (a
+    /// suppressed delta after the classifier tripped) — forward everything
+    /// else to the client.
+    pub fn redact(&mut self, event: &AgentEvent) -> Option<AgentWireEvent> {
+        match event {
+            AgentEvent::AssistantDelta { text } => {
+                if self.tripped {
+                    return None;
+                }
+                self.assembled.push_str(text);
+                if self.redactor.flags_secret(&self.assembled) {
+                    // Trip: one marker crosses (so a live caret shows the
+                    // redaction), the rest of the message is suppressed, and
+                    // the assembled AssistantText below replaces it all.
+                    self.tripped = true;
+                    self.assembled.clear();
+                    return Some(AgentWireEvent::AssistantDelta {
+                        text: pocopine_agenkit_core::redact::REDACTED.to_string(),
+                    });
+                }
+                Some(AgentWireEvent::AssistantDelta {
+                    text: self.redactor.text(text),
+                })
+            }
+            // A message boundary (assembled text / new turn / terminal):
+            // reset the delta state, then map statelessly.
+            AgentEvent::AssistantText { .. }
+            | AgentEvent::Started
+            | AgentEvent::Stopped { .. }
+            | AgentEvent::Failed { .. } => {
+                self.assembled.clear();
+                self.tripped = false;
+                Some(redact_agent_event(event, &self.redactor))
+            }
+            other => Some(redact_agent_event(other, &self.redactor)),
+        }
+    }
+}
+
+/// Stateless single-event mapping (everything but the delta accumulation).
+/// Internal: the public adapter is [`AgentEventRedactor`] — exposing this
+/// would invite exactly the per-fragment-classification leak it guards
+/// against.
+fn redact_agent_event(event: &AgentEvent, redactor: &Redactor) -> AgentWireEvent {
+    match event {
+        AgentEvent::Started => AgentWireEvent::Started,
+        AgentEvent::AssistantDelta { text } => AgentWireEvent::AssistantDelta {
+            text: redactor.text(text),
+        },
+        AgentEvent::AssistantText { text } => AgentWireEvent::AssistantText {
+            text: redactor.text(text),
+        },
+        AgentEvent::ToolStarted { id, tool, args } => AgentWireEvent::ToolStarted {
+            id: id.clone(),
+            tool: tool.clone(),
+            args: redactor.json(args),
+        },
+        AgentEvent::ToolCompleted { id, tool, output } => AgentWireEvent::ToolCompleted {
+            id: id.clone(),
+            tool: tool.clone(),
+            output: redactor.json(output),
+        },
+        AgentEvent::ToolFailed { id, tool, error } => AgentWireEvent::ToolFailed {
+            id: id.clone(),
+            tool: tool.clone(),
+            error: redactor.text(error),
+        },
+        AgentEvent::ToolBlocked { id, tool, reason } => AgentWireEvent::ToolBlocked {
+            id: id.clone(),
+            tool: tool.clone(),
+            reason: redactor.text(reason),
+        },
+        AgentEvent::Compacted { folded } => AgentWireEvent::Compacted { folded: *folded },
+        AgentEvent::Stopped { reason } => AgentWireEvent::Stopped {
+            reason: match reason {
+                StopReason::Idle => WireStopReason::Idle,
+                StopReason::MaxSteps => WireStopReason::MaxSteps,
+                StopReason::Aborted => WireStopReason::Aborted,
+            },
+        },
+        AgentEvent::Failed { error } => AgentWireEvent::Failed {
+            error: redactor.text(error),
+        },
     }
 }
 
@@ -1189,6 +1316,109 @@ mod tests {
         // A second prompt appends another turn (multi-turn conversation).
         let _ = session.prompt("again").collect::<Vec<_>>().await;
         assert_eq!(session.history().await.unwrap().len(), 4);
+    }
+
+    #[test]
+    fn redactor_adapter_maps_events_through_the_shared_policy() {
+        let mut adapter =
+            AgentEventRedactor::new(Redactor::new().secret_classifier(|t| t.contains("sk-live")));
+
+        // Assistant text carrying a secret is fully redacted.
+        let wire = adapter
+            .redact(&AgentEvent::AssistantText {
+                text: "key sk-live-1".to_string(),
+            })
+            .unwrap();
+        assert_eq!(
+            wire,
+            AgentWireEvent::AssistantText {
+                text: "[redacted]".to_string()
+            }
+        );
+
+        // Tool args: credential-shaped keys blanked, the rest passes.
+        let wire = adapter
+            .redact(&AgentEvent::ToolStarted {
+                id: "c1".to_string(),
+                tool: "net.fetch".to_string(),
+                args: serde_json::json!({ "url": "https://x.test", "api_key": "abc" }),
+            })
+            .unwrap();
+        let AgentWireEvent::ToolStarted { args, .. } = wire else {
+            panic!("expected ToolStarted, got {wire:?}");
+        };
+        assert_eq!(args["api_key"], "[redacted]");
+        assert_eq!(args["url"], "https://x.test");
+
+        // Benign deltas and terminal reasons map across.
+        assert_eq!(
+            adapter.redact(&AgentEvent::AssistantDelta {
+                text: "hel".to_string()
+            }),
+            Some(AgentWireEvent::AssistantDelta {
+                text: "hel".to_string()
+            })
+        );
+        assert_eq!(
+            adapter.redact(&AgentEvent::Stopped {
+                reason: StopReason::MaxSteps
+            }),
+            Some(AgentWireEvent::Stopped {
+                reason: WireStopReason::MaxSteps
+            })
+        );
+    }
+
+    #[test]
+    fn redactor_adapter_catches_a_secret_split_across_delta_fragments() {
+        // The P1 leak shape: no single fragment matches the classifier, but
+        // the assembled text does. The adapter classifies the assembled
+        // prefix, so the fragment completing the secret is replaced by one
+        // [redacted] marker and everything after it is suppressed — the
+        // credential value never streams out.
+        let mut adapter = AgentEventRedactor::new(
+            Redactor::new().secret_classifier(|t| t.contains("api_key = sk-live")),
+        );
+        let delta = |t: &str| AgentEvent::AssistantDelta {
+            text: t.to_string(),
+        };
+
+        assert_eq!(
+            adapter.redact(&delta("Use api_")),
+            Some(AgentWireEvent::AssistantDelta {
+                text: "Use api_".to_string()
+            })
+        );
+        // This fragment completes the secret in the ASSEMBLED text (the
+        // fragment alone doesn't match) → one marker, not the fragment.
+        assert_eq!(
+            adapter.redact(&delta("key = sk-live")),
+            Some(AgentWireEvent::AssistantDelta {
+                text: "[redacted]".to_string()
+            })
+        );
+        // The secret's tail — and anything after — is suppressed outright.
+        assert_eq!(adapter.redact(&delta("-12345 rest of answer")), None);
+        assert_eq!(adapter.redact(&delta(" more")), None);
+
+        // The assembled message is redacted whole, and the message boundary
+        // resets the adapter for the next message.
+        assert_eq!(
+            adapter
+                .redact(&AgentEvent::AssistantText {
+                    text: "Use api_key = sk-live-12345 rest of answer more".to_string()
+                })
+                .unwrap(),
+            AgentWireEvent::AssistantText {
+                text: "[redacted]".to_string()
+            }
+        );
+        assert_eq!(
+            adapter.redact(&delta("clean again")),
+            Some(AgentWireEvent::AssistantDelta {
+                text: "clean again".to_string()
+            })
+        );
     }
 
     #[tokio::test]

--- a/crates/pocopine-agenkit/src/server/runtime.rs
+++ b/crates/pocopine-agenkit/src/server/runtime.rs
@@ -39,7 +39,7 @@ use super::agenkit::{Agenkit, AgenkitInner};
 use super::context::AiContext;
 pub use super::loop_core::ToolDecision;
 use super::loop_core::{
-    LoopObserver, ToolErrorMode, TraceObserver, dispatch_tool_calls, run_model_step,
+    LoopObserver, ToolErrorMode, TraceObserver, dispatch_tool_calls, run_model_step_streamed,
 };
 use super::provider::{GenerateRequest, ProviderContext};
 use super::run::RunState;
@@ -68,7 +68,21 @@ pub enum StopReason {
 pub enum AgentEvent {
     /// A prompt was accepted; the loop begins.
     Started,
-    /// A model text response within the turn (may precede tool calls).
+    /// An incremental fragment of an assistant text response, emitted as the
+    /// model streams — many per [`AssistantText`](AgentEvent::AssistantText),
+    /// which follows with the assembled message. Deltas are **ephemeral**: they
+    /// are never persisted to the thread log (only the final message is), so a
+    /// consumer that ignores them (or an older client) sees exactly the
+    /// pre-delta behavior. A provider without native streaming delivers the
+    /// whole answer as one delta.
+    AssistantDelta {
+        /// The next fragment of the assistant's text.
+        text: String,
+    },
+    /// A model text response within the turn (may precede tool calls). The
+    /// assembled message — the same text the preceding
+    /// [`AssistantDelta`](AgentEvent::AssistantDelta)s carried piecewise — and
+    /// what is persisted to the thread log.
     AssistantText {
         /// The assistant's text.
         text: String,
@@ -447,7 +461,11 @@ impl AgentLoop {
                     max_tokens: self.config.max_tokens,
                     thinking: Default::default(),
                 };
-                let response = run_model_step(&provider, request, &cx, &model, &observer).await?;
+                // Streamed: each text fragment reaches the firehose as an
+                // `AssistantDelta` (via the observer) while the step assembles
+                // the full response for the transcript.
+                let response =
+                    run_model_step_streamed(&provider, request, &cx, &model, &observer).await?;
 
                 let text = response.text_output();
                 if !text.is_empty() {
@@ -529,6 +547,12 @@ struct RuntimeObserver<'a> {
 impl LoopObserver for RuntimeObserver<'_> {
     fn model_request(&self, model: &ModelRef) -> Option<StepId> {
         self.trace.model_request(model)
+    }
+
+    fn assistant_delta(&self, delta: &str) {
+        let _ = self.events.send(AgentEvent::AssistantDelta {
+            text: delta.to_string(),
+        });
     }
 
     fn model_response(&self, step: Option<StepId>, model: &ModelRef, usage: Option<Usage>) {
@@ -1157,6 +1181,39 @@ mod tests {
         // A second prompt appends another turn (multi-turn conversation).
         let _ = session.prompt("again").collect::<Vec<_>>().await;
         assert_eq!(session.history().await.unwrap().len(), 4);
+    }
+
+    #[tokio::test]
+    async fn session_prompt_streams_assistant_deltas_that_assemble_the_final_text() {
+        let agenkit = chat("hello streaming world");
+        let session = AgentSession::builder(&agenkit).open(None).await.unwrap();
+
+        let events: Vec<AgentEvent> = session.prompt("hi").collect().await;
+
+        // Multiple deltas arrive (the mock streams word-sized fragments), all
+        // BEFORE the assembled AssistantText, and concatenate to exactly it.
+        let mut assembled = String::new();
+        let mut deltas = 0;
+        let mut final_text = None;
+        for event in &events {
+            match event {
+                AgentEvent::AssistantDelta { text } => {
+                    assert!(final_text.is_none(), "delta after final text: {events:?}");
+                    assembled.push_str(text);
+                    deltas += 1;
+                }
+                AgentEvent::AssistantText { text } => final_text = Some(text.clone()),
+                _ => {}
+            }
+        }
+        assert!(deltas > 1, "expected word-sized deltas, got {deltas}");
+        assert_eq!(final_text.as_deref(), Some("hello streaming world"));
+        assert_eq!(assembled, "hello streaming world");
+
+        // Deltas are ephemeral: the thread log holds only user + final message.
+        let history = session.history().await.unwrap();
+        assert_eq!(history.len(), 2);
+        assert_eq!(history[1].content.as_text(), "hello streaming world");
     }
 
     #[tokio::test]

--- a/crates/pocopine-agenkit/src/server/runtime.rs
+++ b/crates/pocopine-agenkit/src/server/runtime.rs
@@ -662,6 +662,14 @@ impl AgentSession {
         self.thread.history().await
     }
 
+    /// Merge `patch` into this thread's attributes (e.g. a title, so a sidebar
+    /// can label the conversation) — see
+    /// [`AgentThreadStore`](super::thread::AgentThreadStore::update_attributes)
+    /// for the merge semantics and the reserved keys.
+    pub async fn update_attributes(&self, patch: serde_json::Value) -> AgenkitResult<()> {
+        self.thread.update_attributes(patch).await
+    }
+
     /// The durable usage provenance entries for this thread (this thread's own
     /// turns only — a fork reports its own usage, not the inherited prefix's).
     /// Empty if the backing store doesn't record provenance.

--- a/crates/pocopine-agenkit/src/server/session/blob.rs
+++ b/crates/pocopine-agenkit/src/server/session/blob.rs
@@ -213,6 +213,20 @@ impl SessionStore for ExternalizingSessionStore {
         self.inner.meta(id)
     }
 
+    fn threads<'a>(&'a self) -> SessionFuture<'a, Vec<ThreadMeta>> {
+        self.inner.threads()
+    }
+
+    fn set_attributes<'a>(
+        &'a self,
+        id: &'a ThreadId,
+        attributes: serde_json::Value,
+    ) -> SessionFuture<'a, ()> {
+        // Like create_thread: metadata is small and frequently queried — never
+        // externalized.
+        self.inner.set_attributes(id, attributes)
+    }
+
     fn append<'a>(
         &'a self,
         id: &'a ThreadId,

--- a/crates/pocopine-agenkit/src/server/session/jsonl.rs
+++ b/crates/pocopine-agenkit/src/server/session/jsonl.rs
@@ -2,8 +2,9 @@
 //!
 //! Each thread is two files in the store dir: `<id>.jsonl` — the append-only
 //! record log, one JSON [`Record`](super::Record) per line — and `<id>.meta.json`
-//! — the immutable thread metadata (parent link + creation time). `last_seq` is
-//! derived from the log's line count, so the meta file is written once.
+//! — the thread metadata (parent link + creation time + attributes; rewritten
+//! only by `set_attributes`). `last_seq` is derived from the log's line count,
+//! so appends never touch the meta file.
 //!
 //! This is the **dev/reference** durable store: `children` and `last_seq` scan
 //! files (O(n)). A production store would keep a KV/SQL index (the roadmap's
@@ -20,7 +21,8 @@ use super::{
     ThreadMeta, backend, now_ms,
 };
 
-/// The on-disk meta sidecar (immutable; `last_seq` is derived from the log).
+/// The on-disk meta sidecar (`last_seq` is derived from the log; the file is
+/// rewritten only when `set_attributes` replaces the attributes).
 #[derive(Serialize, Deserialize)]
 struct StoredMeta {
     id: ThreadId,
@@ -79,6 +81,32 @@ async fn count_records(path: &Path) -> SessionResult<u64> {
         Err(e) => return Err(backend(e)),
     };
     Ok(body.lines().filter(|l| !l.trim().is_empty()).count() as u64)
+}
+
+/// Scan the store dir for meta sidecars (missing dir → empty). Shared by
+/// `children` (which filters by parent) and `threads` (which returns them all).
+async fn scan_metas(dir: &Path) -> SessionResult<Vec<StoredMeta>> {
+    let mut out = Vec::new();
+    let mut entries = match tokio::fs::read_dir(dir).await {
+        Ok(e) => e,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(out),
+        Err(e) => return Err(backend(e)),
+    };
+    while let Some(entry) = entries.next_entry().await.map_err(backend)? {
+        let path = entry.path();
+        if !path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.ends_with(".meta.json"))
+        {
+            continue;
+        }
+        let body = tokio::fs::read_to_string(&path).await.map_err(backend)?;
+        let stored: StoredMeta =
+            serde_json::from_str(&body).map_err(|e| SessionError::Corrupt(e.to_string()))?;
+        out.push(stored);
+    }
+    Ok(out)
 }
 
 /// Parse a JSONL log file into records (missing file → empty).
@@ -203,34 +231,54 @@ impl SessionStore for JsonlSessionStore {
         })
     }
 
-    fn children<'a>(&'a self, id: &'a ThreadId) -> SessionFuture<'a, Vec<ThreadId>> {
+    fn threads<'a>(&'a self) -> SessionFuture<'a, Vec<ThreadMeta>> {
         Box::pin(async move {
             let mut out = Vec::new();
-            let mut entries = match tokio::fs::read_dir(&self.dir).await {
-                Ok(e) => e,
-                Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(out),
-                Err(e) => return Err(backend(e)),
-            };
-            while let Some(entry) = entries.next_entry().await.map_err(backend)? {
-                let path = entry.path();
-                if path.extension().and_then(|e| e.to_str()) != Some("json") {
-                    continue;
-                }
-                if !path
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .is_some_and(|n| n.ends_with(".meta.json"))
-                {
-                    continue;
-                }
-                let body = tokio::fs::read_to_string(&path).await.map_err(backend)?;
-                let stored: StoredMeta = serde_json::from_str(&body)
-                    .map_err(|e| SessionError::Corrupt(e.to_string()))?;
-                if stored.parent.as_ref().is_some_and(|p| &p.parent == id) {
-                    out.push(stored.id);
-                }
+            for stored in scan_metas(&self.dir).await? {
+                let last_seq = count_records(&self.log_path(&stored.id)?).await?;
+                out.push(ThreadMeta {
+                    id: stored.id,
+                    parent: stored.parent,
+                    created_ms: stored.created_ms,
+                    last_seq,
+                    attributes: stored.attributes,
+                });
             }
             Ok(out)
+        })
+    }
+
+    fn set_attributes<'a>(
+        &'a self,
+        id: &'a ThreadId,
+        attributes: serde_json::Value,
+    ) -> SessionFuture<'a, ()> {
+        Box::pin(async move {
+            let path = self.meta_path(id)?;
+            let body = match tokio::fs::read_to_string(&path).await {
+                Ok(b) => b,
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                    return Err(SessionError::NotFound);
+                }
+                Err(e) => return Err(backend(e)),
+            };
+            let mut stored: StoredMeta =
+                serde_json::from_str(&body).map_err(|e| SessionError::Corrupt(e.to_string()))?;
+            stored.attributes = attributes;
+            let json = serde_json::to_string(&stored).map_err(backend)?;
+            tokio::fs::write(&path, json).await.map_err(backend)?;
+            Ok(())
+        })
+    }
+
+    fn children<'a>(&'a self, id: &'a ThreadId) -> SessionFuture<'a, Vec<ThreadId>> {
+        Box::pin(async move {
+            Ok(scan_metas(&self.dir)
+                .await?
+                .into_iter()
+                .filter(|s| s.parent.as_ref().is_some_and(|p| &p.parent == id))
+                .map(|s| s.id)
+                .collect())
         })
     }
 

--- a/crates/pocopine-agenkit/src/server/session/memory.rs
+++ b/crates/pocopine-agenkit/src/server/session/memory.rs
@@ -74,6 +74,26 @@ impl SessionStore for MemorySessionStore {
         })())
     }
 
+    fn threads<'a>(&'a self) -> SessionFuture<'a, Vec<ThreadMeta>> {
+        ready((|| {
+            let threads = self.lock()?;
+            Ok(threads.values().map(|e| e.meta.clone()).collect())
+        })())
+    }
+
+    fn set_attributes<'a>(
+        &'a self,
+        id: &'a ThreadId,
+        attributes: serde_json::Value,
+    ) -> SessionFuture<'a, ()> {
+        ready((|| {
+            let mut threads = self.lock()?;
+            let entry = threads.get_mut(id).ok_or(SessionError::NotFound)?;
+            entry.meta.attributes = attributes;
+            Ok(())
+        })())
+    }
+
     fn append<'a>(
         &'a self,
         id: &'a ThreadId,

--- a/crates/pocopine-agenkit/src/server/session/mod.rs
+++ b/crates/pocopine-agenkit/src/server/session/mod.rs
@@ -206,6 +206,22 @@ pub trait SessionStore: Send + Sync {
     /// Load a thread's metadata, or `None` if it doesn't exist.
     fn meta<'a>(&'a self, id: &'a ThreadId) -> SessionFuture<'a, Option<ThreadMeta>>;
 
+    /// Every thread's metadata, in no guaranteed order (callers filter/sort).
+    /// This powers owner-scoped enumeration a layer up (e.g. a chat sidebar via
+    /// `AgentThreadStore::list`); the session layer itself stays attribute-blind.
+    fn threads<'a>(&'a self) -> SessionFuture<'a, Vec<ThreadMeta>>;
+
+    /// Replace a thread's creator-attached `attributes` verbatim.
+    /// [`SessionError::NotFound`] for a missing thread. The session layer still
+    /// never interprets attributes — merge/validation policy belongs to the
+    /// caller (read-modify-write is safe: a thread is single-writer by design,
+    /// so there is no lost-update race to guard here).
+    fn set_attributes<'a>(
+        &'a self,
+        id: &'a ThreadId,
+        attributes: serde_json::Value,
+    ) -> SessionFuture<'a, ()>;
+
     /// Append a record to a thread; returns the stored record (with its `seq`).
     fn append<'a>(
         &'a self,

--- a/crates/pocopine-agenkit/src/server/session/sqlite.rs
+++ b/crates/pocopine-agenkit/src/server/session/sqlite.rs
@@ -211,6 +211,73 @@ impl SessionStore for SqliteSessionStore {
         }))
     }
 
+    fn threads<'a>(&'a self) -> SessionFuture<'a, Vec<ThreadMeta>> {
+        Self::ready(self.with_conn(|conn| {
+            // last_seq per thread via the same MAX(seq)+1 seek `meta` uses — a
+            // correlated subquery on the (thread_id, seq) PK, not a COUNT scan.
+            let mut stmt = conn
+                .prepare(
+                    "SELECT t.id, t.parent, t.fork_at_seq, t.created_ms, t.attributes, \
+                            (SELECT COALESCE(MAX(seq), -1) + 1 FROM records r \
+                             WHERE r.thread_id = t.id) \
+                     FROM threads t",
+                )
+                .map_err(db_err)?;
+            let rows = stmt
+                .query_map([], |r| {
+                    Ok((
+                        r.get::<_, String>(0)?,
+                        r.get::<_, Option<String>>(1)?,
+                        r.get::<_, Option<i64>>(2)?,
+                        r.get::<_, i64>(3)?,
+                        r.get::<_, String>(4)?,
+                        r.get::<_, i64>(5)?,
+                    ))
+                })
+                .map_err(db_err)?;
+            let mut out = Vec::new();
+            for row in rows {
+                let (id, parent_id, fork_at, created_ms, attrs_json, last_seq) =
+                    row.map_err(db_err)?;
+                let parent = match (parent_id, fork_at) {
+                    (Some(p), Some(f)) => Some(ParentLink {
+                        parent: ThreadId::new(p),
+                        fork_at_seq: f as u64,
+                    }),
+                    _ => None,
+                };
+                out.push(ThreadMeta {
+                    id: ThreadId::new(id),
+                    parent,
+                    created_ms: created_ms as u64,
+                    last_seq: last_seq as u64,
+                    attributes: serde_json::from_str(&attrs_json).map_err(json_err)?,
+                });
+            }
+            Ok(out)
+        }))
+    }
+
+    fn set_attributes<'a>(
+        &'a self,
+        id: &'a ThreadId,
+        attributes: serde_json::Value,
+    ) -> SessionFuture<'a, ()> {
+        Self::ready(self.with_conn(move |conn| {
+            let attrs_json = serde_json::to_string(&attributes).map_err(json_err)?;
+            let updated = conn
+                .execute(
+                    "UPDATE threads SET attributes = ?2 WHERE id = ?1",
+                    params![id.as_str(), attrs_json],
+                )
+                .map_err(db_err)?;
+            if updated == 0 {
+                return Err(SessionError::NotFound);
+            }
+            Ok(())
+        }))
+    }
+
     fn append<'a>(
         &'a self,
         id: &'a ThreadId,

--- a/crates/pocopine-agenkit/src/server/thread.rs
+++ b/crates/pocopine-agenkit/src/server/thread.rs
@@ -65,6 +65,25 @@ impl<'a> ThreadOwner<'a> {
     }
 }
 
+/// A thread's listing metadata — what an owner-scoped enumeration (e.g. a chat
+/// sidebar) needs: identity, parentage (to rebuild the fork tree), creation
+/// time, and the creator-attached attributes (the agent id, plus anything set
+/// via [`update_attributes`](AgentThreadStore::update_attributes), e.g. a
+/// title).
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct AgentThreadMeta {
+    /// The opaque thread id.
+    pub id: AgentThreadId,
+    /// The thread this one forked from, `None` for a root thread.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub parent: Option<AgentThreadId>,
+    /// When the thread was created (Unix ms).
+    pub created_ms: u64,
+    /// The thread's attributes, verbatim.
+    #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
+    pub attributes: serde_json::Value,
+}
+
 /// Durable-or-not storage for agent threads.
 ///
 /// Every method carries the caller's [`ThreadOwner`] so the store can scope
@@ -147,6 +166,37 @@ pub trait AgentThreadStore: Send + Sync + 'static {
     ) -> BoxFuture<'_, AgenkitResult<Option<AgentThreadId>>> {
         let _ = (id, owner);
         Box::pin(async move { Ok(None) })
+    }
+
+    /// The threads owned by `owner`, newest-first (by creation time), with
+    /// parent links so a caller can rebuild the fork tree (a chat sidebar's
+    /// query). The default is empty — a store that doesn't support enumeration
+    /// simply lists nothing (the `fork` → `Ok(None)` convention).
+    fn list(&self, owner: ThreadOwner<'_>) -> BoxFuture<'_, AgenkitResult<Vec<AgentThreadMeta>>> {
+        let _ = owner;
+        Box::pin(async move { Ok(Vec::new()) })
+    }
+
+    /// Merge `patch` (a JSON object) into the attributes of a thread owned by
+    /// `owner` — how a caller stores mutable thread state like a title or a
+    /// `kind`. Shallow merge: each patch key replaces that attribute; a `null`
+    /// value **removes** it. The runtime-owned keys (`owner`, `agent_id`) are
+    /// reserved — a patch naming them is rejected, so the owner scope can never
+    /// be rewritten through this path. A missing/foreign thread is
+    /// `not_found` (no existence oracle). The default errors — a store that
+    /// doesn't support mutation must not silently drop the update.
+    fn update_attributes(
+        &self,
+        id: &AgentThreadId,
+        owner: ThreadOwner<'_>,
+        patch: serde_json::Value,
+    ) -> BoxFuture<'_, AgenkitResult<()>> {
+        let _ = (id, owner, patch);
+        Box::pin(async move {
+            Err(AgenkitError::config(
+                "thread store does not support attribute updates",
+            ))
+        })
     }
 
     /// Record a `state-change` provenance entry (model / usage / cost) alongside
@@ -445,6 +495,93 @@ impl AgentThreadStore for SessionThreadStore {
         })
     }
 
+    fn list(&self, owner: ThreadOwner<'_>) -> BoxFuture<'_, AgenkitResult<Vec<AgentThreadMeta>>> {
+        let sessions = self.sessions.clone();
+        let want = owner.key().map(str::to_string);
+        Box::pin(async move {
+            let mut metas: Vec<session::ThreadMeta> = sessions
+                .threads()
+                .await
+                .map_err(session_err)?
+                .into_iter()
+                .filter(|m| Self::stored_owner(&m.attributes) == want.as_deref())
+                .collect();
+            // Newest-first; the id tiebreak keeps the order deterministic when
+            // several threads share a creation millisecond.
+            metas.sort_by(|a, b| {
+                b.created_ms
+                    .cmp(&a.created_ms)
+                    .then_with(|| b.id.cmp(&a.id))
+            });
+            Ok(metas
+                .into_iter()
+                .map(|m| AgentThreadMeta {
+                    id: AgentThreadId::new(m.id.as_str()),
+                    parent: m.parent.map(|p| AgentThreadId::new(p.parent.as_str())),
+                    created_ms: m.created_ms,
+                    attributes: m.attributes,
+                })
+                .collect())
+        })
+    }
+
+    fn update_attributes(
+        &self,
+        id: &AgentThreadId,
+        owner: ThreadOwner<'_>,
+        patch: serde_json::Value,
+    ) -> BoxFuture<'_, AgenkitResult<()>> {
+        let sessions = self.sessions.clone();
+        let tid = session::ThreadId::new(id.as_str());
+        let want = owner.key().map(str::to_string);
+        Box::pin(async move {
+            let Some(object) = patch.as_object() else {
+                return Err(AgenkitError::validation(
+                    "thread attribute patch must be a JSON object",
+                ));
+            };
+            // The scope/identity keys are runtime-owned: rejecting them here
+            // (not silently skipping) keeps a patch's effect exactly what it
+            // says, and the owner scope unrewritable through this path.
+            for reserved in ["owner", "agent_id"] {
+                if object.contains_key(reserved) {
+                    return Err(AgenkitError::validation(format!(
+                        "thread attribute `{reserved}` is reserved"
+                    )));
+                }
+            }
+            // Owner-scoped, like every other mutation (no existence oracle).
+            let Some(meta) = owner_checked_meta(sessions.as_ref(), &tid, want.as_deref()).await?
+            else {
+                return Err(AgenkitError::not_found("thread not found"));
+            };
+            let mut merged = match meta.attributes {
+                serde_json::Value::Object(map) => map,
+                _ => serde_json::Map::new(),
+            };
+            for (key, value) in object {
+                if value.is_null() {
+                    merged.remove(key);
+                } else {
+                    merged.insert(key.clone(), value.clone());
+                }
+            }
+            sessions
+                .set_attributes(&tid, serde_json::Value::Object(merged))
+                .await
+                .map_err(session_err)?;
+            // Audit trail: the patch rides the provenance channel (it never
+            // reaches the model), so who-renamed-what is reconstructable from
+            // the durable log.
+            let audit = serde_json::json!({ "kind": "attributes", "patch": patch });
+            sessions
+                .append(&tid, RecordKind::StateChange, audit)
+                .await
+                .map_err(session_err)?;
+            Ok(())
+        })
+    }
+
     fn append_state_change(
         &self,
         id: &AgentThreadId,
@@ -562,6 +699,15 @@ impl AgentThreadHandle {
                 store: self.store.clone(),
                 owner,
             }))
+    }
+
+    /// Merge `patch` into the thread's attributes (e.g. a title) — see
+    /// [`AgentThreadStore::update_attributes`] for the merge semantics and the
+    /// reserved keys.
+    pub async fn update_attributes(&self, patch: serde_json::Value) -> AgenkitResult<()> {
+        self.store
+            .update_attributes(&self.id, self.owner(), patch)
+            .await
     }
 
     /// Record a provenance entry (model / usage / cost) outside the conversation
@@ -896,6 +1042,145 @@ mod tests {
         assert_eq!(full[0].content.as_text(), "q1");
         assert_eq!(full[1].content.as_text(), "a1");
         assert_eq!(full[2].content.as_text(), "q2");
+    }
+
+    #[tokio::test]
+    async fn list_returns_only_the_owners_threads_newest_first_with_parents() {
+        let store = SessionThreadStore::in_memory();
+        let (alice_p, bob_p) = (alice(), bob());
+        let alice = ThreadOwner::from_principal(&alice_p);
+        let bob = ThreadOwner::from_principal(&bob_p);
+
+        let first = store
+            .create("chat", alice, ThreadRetention::Durable)
+            .await
+            .unwrap();
+        // Distinct creation timestamps so newest-first is observable.
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        let second = store
+            .create("chat", alice, ThreadRetention::Durable)
+            .await
+            .unwrap();
+        let foreign = store
+            .create("chat", bob, ThreadRetention::Durable)
+            .await
+            .unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+        let branch = store.fork(&first, alice).await.unwrap().unwrap();
+
+        let listed = store.list(alice).await.unwrap();
+        let ids: Vec<&str> = listed.iter().map(|m| m.id.as_str()).collect();
+        // Alice's three threads, newest-first; Bob's never appears.
+        assert_eq!(ids, vec![branch.as_str(), second.as_str(), first.as_str()]);
+        assert!(!ids.contains(&foreign.as_str()));
+        // Parent links let a caller rebuild the fork tree.
+        assert_eq!(listed[0].parent.as_ref().unwrap(), &first);
+        assert!(listed[1].parent.is_none());
+        // Attributes ride along (the agent id the runtime stored at create).
+        assert_eq!(listed[2].attributes["agent_id"], "chat");
+
+        // Bob's view is scoped to his own thread.
+        let bobs = store.list(bob).await.unwrap();
+        assert_eq!(bobs.len(), 1);
+        assert_eq!(bobs[0].id, foreign);
+        // Anonymous is its own bucket — none of the above.
+        assert!(
+            store
+                .list(ThreadOwner::anonymous())
+                .await
+                .unwrap()
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn update_attributes_merges_removes_and_guards_reserved_keys() {
+        let store = SessionThreadStore::in_memory();
+        let (alice_p, bob_p) = (alice(), bob());
+        let alice = ThreadOwner::from_principal(&alice_p);
+        let bob = ThreadOwner::from_principal(&bob_p);
+        let id = store
+            .create("chat", alice, ThreadRetention::Durable)
+            .await
+            .unwrap();
+
+        // Merge in a title + kind; the runtime-owned keys survive untouched.
+        store
+            .update_attributes(
+                &id,
+                alice,
+                serde_json::json!({ "title": "First chat", "kind": "chat" }),
+            )
+            .await
+            .unwrap();
+        let meta = &store.list(alice).await.unwrap()[0];
+        assert_eq!(meta.attributes["title"], "First chat");
+        assert_eq!(meta.attributes["kind"], "chat");
+        assert_eq!(meta.attributes["agent_id"], "chat");
+
+        // A later patch replaces one key and null-removes another.
+        store
+            .update_attributes(
+                &id,
+                alice,
+                serde_json::json!({ "kind": "notebook", "title": null }),
+            )
+            .await
+            .unwrap();
+        let meta = &store.list(alice).await.unwrap()[0];
+        assert_eq!(meta.attributes["kind"], "notebook");
+        assert!(meta.attributes.get("title").is_none());
+
+        // Reserved keys are rejected — the owner scope can't be rewritten.
+        for patch in [
+            serde_json::json!({ "owner": "bob" }),
+            serde_json::json!({ "agent_id": "other" }),
+            serde_json::json!("not an object"),
+        ] {
+            assert!(store.update_attributes(&id, alice, patch).await.is_err());
+        }
+        // A foreign principal can't mutate (reads as not-found)...
+        assert!(
+            store
+                .update_attributes(&id, bob, serde_json::json!({ "title": "hijack" }))
+                .await
+                .is_err()
+        );
+        // ...and nothing above leaked through.
+        let meta = &store.list(alice).await.unwrap()[0];
+        assert_eq!(
+            SessionThreadStore::stored_owner(&meta.attributes),
+            Some("alice")
+        );
+        assert_eq!(meta.attributes["kind"], "notebook");
+
+        // Each successful update left an audit entry on the provenance channel.
+        let audits = store.state_changes(&id, alice).await.unwrap();
+        assert_eq!(audits.len(), 2);
+        assert_eq!(audits[0]["kind"], "attributes");
+        assert_eq!(audits[0]["patch"]["title"], "First chat");
+    }
+
+    #[tokio::test]
+    async fn list_and_update_attributes_work_on_the_sqlite_backend() {
+        // The same owner-scoped listing + mutation through the indexed store.
+        let store = SessionThreadStore::new(Arc::new(
+            session::SqliteSessionStore::open_in_memory().unwrap(),
+        ));
+        let alice_p = alice();
+        let alice = ThreadOwner::from_principal(&alice_p);
+        let id = store
+            .create("chat", alice, ThreadRetention::Durable)
+            .await
+            .unwrap();
+        store
+            .update_attributes(&id, alice, serde_json::json!({ "title": "sq" }))
+            .await
+            .unwrap();
+        let listed = store.list(alice).await.unwrap();
+        assert_eq!(listed.len(), 1);
+        assert_eq!(listed[0].id, id);
+        assert_eq!(listed[0].attributes["title"], "sq");
     }
 
     #[tokio::test]

--- a/crates/pocopine-core/src/mount.rs
+++ b/crates/pocopine-core/src/mount.rs
@@ -978,6 +978,16 @@ fn materialize_slot(slot_el: &Element) {
     let (owner_scope_id, owner_proxy) = match enclosing_scope(slot_el) {
         Some(s) => s,
         None => {
+            // No owner anywhere up the tree: the outlet can't be projected
+            // into, so it is dropped — observably, not silently. A
+            // mis-threaded fragment (e.g. a nested outlet materialised
+            // after losing its author-scope stamp) shows up here instead
+            // of as vanishing content.
+            web_sys::console::error_1(&wasm_bindgen::JsValue::from_str(
+                "pocopine: <slot> outlet has no enclosing scope — dropping it \
+                 (its projected content will not render)",
+            ));
+            crate::templates_plan::record_plan_failure();
             let _ = parent.remove_child(slot_el);
             return;
         }

--- a/crates/pocopine-core/src/mount.rs
+++ b/crates/pocopine-core/src/mount.rs
@@ -1040,6 +1040,12 @@ fn materialize_slot(slot_el: &Element) {
         parent_proxy: &fragment_parent_proxy,
         child_scope_id: owner_scope_id,
     });
+    // Re-home any effects the fragment installed against its detached
+    // wrapper (bare `{{ }}` slot text) onto the live element receiving the
+    // content, so they release with the subtree instead of leaking.
+    if let Some(parent_el) = parent.dyn_ref::<Element>() {
+        adopt_pending_effects(&buffer, parent_el);
+    }
     let kids = buffer.child_nodes();
     let mut snapshot: Vec<Node> = Vec::with_capacity(kids.length() as usize);
     for i in 0..kids.length() {
@@ -1442,6 +1448,48 @@ pub fn track_effect_on(el: &Element, id: EffectId) {
     .unwrap_or_else(Array::new);
     list.push(&JsValue::from_f64(id.0 as f64));
     set_private(el, EFFECTS_KEY, &list);
+}
+
+/// Where a detached-install wrapper's effect ids wait for a live owner (see
+/// [`stash_wrapper_effects`] / [`adopt_pending_effects`]).
+const PENDING_EFFECTS_KEY: &str = "__pp_pending_effects";
+
+/// Move the effect ids tracked on `wrapper` — a temporary install host that
+/// never enters the DOM (e.g. `stamp_dynamic_slot_with`'s `<div>`) — onto the
+/// buffer `host`, so the splice site can re-home them on a live element via
+/// [`adopt_pending_effects`]. Without this, an effect resolved against the
+/// wrapper itself (a bare top-level `{{ }}` slot interpolation) is never
+/// released: `release_subtree` walks live elements only.
+pub(crate) fn stash_wrapper_effects(wrapper: &Element, host: &web_sys::DocumentFragment) {
+    if let Some(v) = get_private(wrapper, EFFECTS_KEY)
+        && v.is_object()
+    {
+        let _ = Reflect::set(host.as_ref(), &PENDING_EFFECTS_KEY.into(), &v);
+        set_private(wrapper, EFFECTS_KEY, &JsValue::UNDEFINED);
+    }
+}
+
+/// Re-home effect ids stashed on a fragment buffer by
+/// [`stash_wrapper_effects`] onto `owner` — the live element that contains
+/// the spliced content, so the effects release exactly when that subtree
+/// does.
+pub(crate) fn adopt_pending_effects(host: &web_sys::DocumentFragment, owner: &Element) {
+    let Ok(v) = Reflect::get(host.as_ref(), &PENDING_EFFECTS_KEY.into()) else {
+        return;
+    };
+    let Ok(arr) = v.dyn_into::<Array>() else {
+        return;
+    };
+    for i in 0..arr.length() {
+        if let Some(n) = arr.get(i).as_f64() {
+            track_effect_on(owner, EffectId(n as u64));
+        }
+    }
+    let _ = Reflect::set(
+        host.as_ref(),
+        &PENDING_EFFECTS_KEY.into(),
+        &JsValue::UNDEFINED,
+    );
 }
 
 // ── Element-scoped listener side-table ────────────────────────────

--- a/crates/pocopine-core/src/slot_fragment.rs
+++ b/crates/pocopine-core/src/slot_fragment.rs
@@ -318,6 +318,13 @@ pub fn stamp_dynamic_slot_with(
         }
     }
     install_plan(&temp, parent_scope_id, parent_proxy);
+    // Effects the install pass tracked on the wrapper itself — a bare
+    // top-level `{{ }}` interpolation resolves against the wrapper (empty
+    // node_path) — must not die with it: the wrapper never enters the DOM,
+    // and `release_subtree` walks live elements only. Park them on the host
+    // buffer; the splice site (`materialize_slot`) re-homes them onto the
+    // live element that receives the content.
+    crate::mount::stash_wrapper_effects(&temp, host);
 
     let kids = temp.child_nodes();
     let mut snapshot: Vec<web_sys::Node> = Vec::with_capacity(kids.length() as usize);

--- a/crates/pocopine-macros/src/template_plan.rs
+++ b/crates/pocopine-macros/src/template_plan.rs
@@ -1908,6 +1908,7 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
                         .find(|(n, _)| n == "pp-let")
                         .map(|(_, v)| v.trim().to_string())
                         .filter(|v| !v.is_empty());
+                    check_branch_body_roots("pp-case", case_el, ctx);
                     let body_ident =
                         analyze_lift_body(case_el, emissions).map(|(html, body_ctx)| {
                             ctx.absorb_lifted_refs(&body_ctx);
@@ -1980,6 +1981,12 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
             .map(|(_, v)| v.clone())
             .filter(|s| !s.trim().is_empty());
         if el.tag == "template" && pocopine_expr::parse(&if_expr).is_ok() {
+            // Exactly one element root, enforced at compile time —
+            // the runtime clone stamps only the FIRST root, so a
+            // multi-root body used to silently drop its extra roots
+            // out of the conditional (and a zero-root body errors
+            // at install).
+            check_branch_body_roots("pp-if", el, ctx);
             // RFC-058 Phase 4.1d — try to lift the body
             // subtree into a fragment fn the runtime installer
             // invokes instead of `clone_template_body` +
@@ -2368,6 +2375,7 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
                                      (RFC-094)",
                                 ));
                             }
+                            check_branch_body_roots(kind, member, ctx);
                             let mut member_needs = false;
                             let body_ident =
                                 analyze_lift_body(member, emissions).map(|(html, body_ctx)| {
@@ -3167,6 +3175,47 @@ fn if_body_subtree_is_eligible(el: &Element) -> bool {
 /// per-subtree state stays isolated; nested fragment fns get
 /// pushed into the shared `Emissions` queue so every emission
 /// lands at the top of the parent's `register()` body.
+/// The number of element roots in a structural `<template>` body. `pp-if` /
+/// `pp-else-if` / `pp-else` / `pp-case` bodies must have exactly one: the
+/// runtime clone path (`clone_template_body`) stamps ONLY the first element
+/// root, so extra roots silently vanish from the branch, and a zero-root body
+/// errors at install — both are surfaced as compile-time diagnostics by the
+/// classifier instead.
+fn template_body_element_count(template_el: &Element) -> usize {
+    template_el
+        .children
+        .iter()
+        .filter(|c| matches!(c, Node::Element(_)))
+        .count()
+}
+
+/// Push the compile-time diagnostic for a structural `<template>` body whose
+/// element-root count breaks the exactly-one rule (the branch analogue of the
+/// component single-root rule). Non-whitespace top-level TEXT is rejected on
+/// the same grounds: the runtime clone stamps only the single element root,
+/// so `<template pp-if>Prefix <span>…</span></template>` would silently drop
+/// `Prefix` from the branch.
+fn check_branch_body_roots(directive: &str, template_el: &Element, ctx: &mut AnalysisCtx) {
+    let roots = template_body_element_count(template_el);
+    if roots != 1 {
+        ctx.diagnostics.push(format!(
+            "`{directive}` template must have exactly one root element (found {roots}) — \
+             wrap the branch body in a single container",
+        ));
+        return;
+    }
+    let has_loose_text = template_el
+        .children
+        .iter()
+        .any(|c| matches!(c, Node::Text(text, _) if !text.trim().is_empty()));
+    if has_loose_text {
+        ctx.diagnostics.push(format!(
+            "`{directive}` template has text beside its root element — the text would \
+             silently drop out of the branch; move it inside the root container",
+        ));
+    }
+}
+
 fn analyze_lift_body(
     template_el: &Element,
     emissions: &mut Emissions,
@@ -3233,6 +3282,31 @@ fn analyze_slot_subtree(nodes: &[Node], emissions: &mut Emissions) -> Option<Slo
     }
     let mut ctx = AnalysisCtx::default();
     let mut path: Vec<u16> = Vec::new();
+    // RFC-058 Phase 6.2 parity for slot content: scan TOP-LEVEL text
+    // nodes for `{{expr}}` interpolation. `walk` only scans the text
+    // children of elements it visits, so bare text passed directly as
+    // slot content (`<x-chip>{{ label }}</x-chip>`) was never collected
+    // and rendered as raw braces. The entry anchors at the fragment
+    // root (empty `node_path`): `stamp_dynamic_slot_with` resolves
+    // paths against its temporary root element, whose text children
+    // are exactly these nodes.
+    let mut text_index: u16 = 0;
+    for node in nodes {
+        let Node::Text(text, _) = node else { continue };
+        if text.contains("{{")
+            && let Ok(segments) = parse_interp_segments(text)
+            && segments
+                .iter()
+                .any(|s| matches!(s, InterpSegment::Dynamic(_)))
+        {
+            ctx.interps.push(InterpLite {
+                node_path: Vec::new(),
+                text_index,
+                segments,
+            });
+        }
+        text_index += 1;
+    }
     for (i, node) in nodes.iter().enumerate() {
         if let Node::Element(el) = node {
             let idx = nodes
@@ -3251,13 +3325,13 @@ fn analyze_slot_subtree(nodes: &[Node], emissions: &mut Emissions) -> Option<Slo
     } else {
         html
     };
-    let is_dynamic = !ctx.bindings.is_empty()
-        || !ctx.listeners.is_empty()
-        || !ctx.refs.is_empty()
-        || !ctx.child_mounts.is_empty()
-        || !ctx.if_plans.is_empty()
-        || !ctx.for_plans.is_empty()
-        || !ctx.teleport_plans.is_empty();
+    // Anything the analyzer collected must survive into an installed
+    // plan — a `Static` emission drops the plan wholesale, which used
+    // to silently discard a slot whose only dynamic content was
+    // interpolation (or a native pp-model). `has_any_entry` is the
+    // exhaustive "collected anything" predicate, so a new entry kind
+    // can't be forgotten here again.
+    let is_dynamic = ctx.has_any_entry();
     let ident = emissions.alloc_slot_frag_ident("slot_frag");
     if is_dynamic {
         Some(SlotFragmentEmission::Dynamic {
@@ -3512,6 +3586,90 @@ mod tests {
         emit_compiled_expr_option, is_lift_eligible_opaque, is_supported_modifier,
         parse_pp_directive_name,
     };
+
+    fn analyze(source: &str) -> super::EmittedTemplatePlan {
+        let (ast, errors) = crate::template_parser::parse(source, "test.poco");
+        assert!(errors.is_empty(), "template must parse: {errors:?}");
+        super::analyze_template_plan(&ast, &[], None)
+    }
+
+    #[test]
+    fn multi_root_pp_if_body_is_a_compile_error() {
+        // The runtime clone stamps only the FIRST root — extra roots used
+        // to silently drop out of the conditional. Now a diagnostic.
+        let plan =
+            analyze("<div><template pp-if=\"open\"><span>a</span><span>b</span></template></div>");
+        let out = plan.if_body_fns.to_string();
+        assert!(out.contains("compile_error"), "{out}");
+        assert!(out.contains("exactly one root element"), "{out}");
+
+        // Zero element roots errors too (the runtime install would fail).
+        let plan = analyze("<div><template pp-if=\"open\">text only</template></div>");
+        let out = plan.if_body_fns.to_string();
+        assert!(out.contains("exactly one root element"), "{out}");
+
+        // Non-whitespace text beside the single root errors too — the
+        // runtime stamps only the element root, silently dropping the text.
+        let plan = analyze("<div><template pp-if=\"open\">Prefix <span>a</span></template></div>");
+        let out = plan.if_body_fns.to_string();
+        assert!(out.contains("text beside its root element"), "{out}");
+
+        // A single root (whitespace/comments around it are fine) stays clean.
+        let plan = analyze(
+            "<div><template pp-if=\"open\">\n  <!-- note -->\n  <span>a</span>\n</template></div>",
+        );
+        let out = plan.if_body_fns.to_string();
+        assert!(!out.contains("compile_error"), "{out}");
+    }
+
+    #[test]
+    fn multi_root_chain_member_and_case_bodies_are_compile_errors() {
+        // pp-else members share the single-root rule with the chain head.
+        let plan = analyze(
+            "<div><template pp-if=\"open\"><span>a</span></template>\
+             <template pp-else><span>b</span><span>c</span></template></div>",
+        );
+        let out = plan.if_body_fns.to_string();
+        assert!(
+            out.contains("`pp-else` template must have exactly one root element"),
+            "{out}"
+        );
+
+        // pp-case arms too.
+        let plan = analyze(
+            "<div><template pp-match=\"state\">\
+             <template pp-case=\"Ready\"><b>y</b><b>z</b></template>\
+             </template></div>",
+        );
+        let out = plan.if_body_fns.to_string();
+        assert!(
+            out.contains("`pp-case` template must have exactly one root element"),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn bare_interpolation_in_slot_content_lifts_into_a_dynamic_fragment() {
+        // `<x-chip>{{ label }}</x-chip>` — bare text passed as slot content
+        // used to render as raw braces: `walk` never visited the text (it
+        // only scans element children), and an interp-only ctx was emitted
+        // as a Static fragment that dropped the plan.
+        let plan = analyze("<div><x-chip>{{ label }}</x-chip></div>");
+        let out = plan.slot_fragment_fns.to_string();
+        assert!(
+            out.contains("install_static_interp_target"),
+            "interp-only slot content must emit a dynamic fragment: {out}"
+        );
+
+        // Element-wrapped interp inside slot content: collected by `walk`
+        // but previously discarded by the Static emission path.
+        let plan = analyze("<div><x-chip><span>Hi {{ name }}</span></x-chip></div>");
+        let out = plan.slot_fragment_fns.to_string();
+        assert!(
+            out.contains("install_static_interp_target"),
+            "element-wrapped slot interp must survive into the plan: {out}"
+        );
+    }
 
     #[test]
     fn parse_failure_emits_compile_error_with_directive_hint() {

--- a/crates/pocopine-macros/src/template_plan.rs
+++ b/crates/pocopine-macros/src/template_plan.rs
@@ -2158,9 +2158,10 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
                         emissions.slot_fragments.push(emission);
                     }
                     None => {
-                        // Slot body falls outside the lift
-                        // envelope — surfaced via
-                        // `record_plan_failure` at install time.
+                        // Slot body falls outside the lift envelope
+                        // (e.g. pp-route content): no fragment is
+                        // emitted; the runtime falls back to the
+                        // light-DOM capture path for this slot.
                     }
                 }
             }
@@ -2191,9 +2192,9 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
                         emissions.slot_fragments.push(emission);
                     }
                     None => {
-                        // Unliftable default slot content —
-                        // surfaced via `record_plan_failure`
-                        // at install time.
+                        // Unliftable default slot content — no
+                        // fragment is emitted; the runtime falls
+                        // back to the light-DOM capture path.
                     }
                 }
             }
@@ -3367,7 +3368,18 @@ fn slot_node_is_lift_eligible(node: &Node) -> bool {
                 return slot_subtree_is_lift_eligible(&el.children);
             }
             if el.tag == "slot" {
-                return false;
+                // Phase 3.5e — a `<slot>` outlet inside slot content (the
+                // compound-component shape: the author's outlet forwarded
+                // through a child, `<x-menu><slot></slot></x-menu>`) lifts
+                // like any template-level outlet: `walk` emits a
+                // `SlotOutletLite`, and the fragment's install pass
+                // materialises it against the author scope (the stamped
+                // fragment's top-level children carry the author's borrowed
+                // scope binding, so `enclosing_scope` resolves ownership
+                // correctly). Rejecting it here used to poison the WHOLE
+                // nested fragment tree — the consumer's projected content
+                // silently vanished and an inert `<slot>` landed in the DOM.
+                return true;
             }
             // Phase 3.5d expansion: non-HTML5 tags = nested
             // child mounts are now allowed. The mount

--- a/crates/pocopine-server/src/server.rs
+++ b/crates/pocopine-server/src/server.rs
@@ -35,7 +35,8 @@ use crate::plugin::{
     ServerListening,
 };
 use crate::{
-    ServerFunctionRouteConflict, SharedAuthProvider, auth_middleware, install_server_functions,
+    ServerFunctionRoute, ServerFunctionRouteConflict, SharedAuthProvider, auth_middleware,
+    install_server_functions,
 };
 
 /// App-level extension point on the host side.
@@ -97,12 +98,39 @@ impl Server {
     /// All linked `#[server]` functions are installed before plugin
     /// work starts, so later [`Self::layer`] calls wrap those routes.
     ///
+    /// **Linking requirement:** `#[server]` routes are collected via
+    /// `inventory`, which only sees crates the binary actually
+    /// **links**. A `[[bin]]` that never references the lib crate
+    /// defining its server functions links none of them — every
+    /// server-fn POST then falls through to the static fallback as a
+    /// 405. Make the binary reference the defining crate (e.g.
+    /// `use my_app::…;` or call its setup fn); a prominent startup
+    /// warning is logged when zero routes register.
+    ///
     /// When `POCOPINE_ASSETS_BUCKET` is set, the RFC-100 Mode B asset
     /// proxy (`GET /assets/<hash>/<path>`, serving the private bucket)
     /// is installed automatically — zero code in the app's `main`; see
     /// the env contract on [`crate::ASSETS_BUCKET_ENV`].
     pub fn new(router: Router) -> Self {
         let (router, server_function_conflicts) = install_server_functions(router);
+        // 0 routes is almost always a linking mistake, not an app without
+        // server functions: `inventory` only collects from crates the binary
+        // links, so a `[[bin]]` that never references its lib crate links
+        // zero `#[server]` fns — and every POST 405s with no hint why.
+        if inventory::iter::<ServerFunctionRoute>
+            .into_iter()
+            .next()
+            .is_none()
+        {
+            tracing::warn!(
+                target: "pocopine.log",
+                "0 server functions registered — if this app defines #[server] \
+                 functions, the binary probably does not reference the crate that \
+                 defines them (routes are collected from linked crates only); \
+                 every server-fn POST will fall through to the static fallback \
+                 as a 405",
+            );
+        }
         let router = crate::assets::install_assets_proxy(router);
         Self {
             router,

--- a/crates/pocopine-stylekit/src/catalog.rs
+++ b/crates/pocopine-stylekit/src/catalog.rs
@@ -261,7 +261,8 @@ pub fn catalog() -> Catalog {
                         None,
                         false,
                         "border-b",
-                        "border, border-0/2/4, sides t/r/b/l, styles solid/dashed/…",
+                        "border, widths border-0/2/4 (all sides or per side: border-l-2), \
+                         sides t/r/b/l, styles solid/dashed/…",
                     ),
                     fam(
                         "rounded",

--- a/crates/pocopine-stylekit/src/registry.rs
+++ b/crates/pocopine-stylekit/src/registry.rs
@@ -39,6 +39,11 @@ impl CssType {
                     || value.ends_with('%')
                     || value.ends_with("vh")
                     || value.ends_with("vw")
+                    || value.ends_with("vmin")
+                    || value.ends_with("vmax")
+                    // `ch` covers the prose-measure idiom (`max-w-[56ch]`);
+                    // note `.ends_with("ch")` isn't shadowed by another unit.
+                    || value.ends_with("ch")
                     || value.ends_with("fr")
                     || value.starts_with("calc(")
                     || value.starts_with("min(")
@@ -612,6 +617,9 @@ fn static_utility(base: &str) -> Option<Decls> {
         "whitespace-nowrap" => d("white-space", "nowrap"),
         "whitespace-normal" => d("white-space", "normal"),
         "whitespace-pre" => d("white-space", "pre"),
+        "whitespace-pre-line" => d("white-space", "pre-line"),
+        "whitespace-pre-wrap" => d("white-space", "pre-wrap"),
+        "whitespace-break-spaces" => d("white-space", "break-spaces"),
         // resize
         "resize" => d("resize", "both"),
         "resize-x" => d("resize", "horizontal"),
@@ -1344,15 +1352,27 @@ fn try_border(base: &str, tokens: &ThemeTokens) -> Resolved {
     if let Ok(n) = name.parse::<u32>() {
         return Some(Ok(decl("border-width", &format!("{n}px"))));
     }
-    // Per-side colour: `border-t-<color>` → border-top-color, etc.
-    for (pfx, prop) in [
-        ("t-", "border-top-color"),
-        ("r-", "border-right-color"),
-        ("b-", "border-bottom-color"),
-        ("l-", "border-left-color"),
+    // Per-side width or colour: `border-l-2` → border-left-width,
+    // `border-l-accent` → border-left-color. The numeric check runs
+    // first so the width scale mirrors the all-sides `border-2` (and
+    // the arbitrary `border-l-[2px]` path) instead of misrouting the
+    // digit into a colour lookup.
+    for (pfx, side) in [
+        ("t-", "top"),
+        ("r-", "right"),
+        ("b-", "bottom"),
+        ("l-", "left"),
     ] {
-        if let Some(color) = name.strip_prefix(pfx) {
-            return Some(resolve_color_value(prop, color, tokens, base));
+        if let Some(rest) = name.strip_prefix(pfx) {
+            if let Ok(n) = rest.parse::<u32>() {
+                return Some(Ok(decl(&format!("border-{side}-width"), &format!("{n}px"))));
+            }
+            return Some(resolve_color_value(
+                &format!("border-{side}-color"),
+                rest,
+                tokens,
+                base,
+            ));
         }
     }
     Some(resolve_color_value("border-color", name, tokens, base))
@@ -3606,10 +3626,21 @@ mod tests {
         // negative fractional translate composes via the transform chain
         assert!(css("-translate-y-1/2").contains("--pp-ty: -50%;"));
         assert!(css("-translate-y-1/2").contains("transform: translate(var(--pp-tx"));
+        // whitespace — full white-space set (pre-wrap was the AgenKitty gap)
+        assert!(css("whitespace-pre-wrap").contains("white-space: pre-wrap;"));
+        assert!(css("whitespace-pre-line").contains("white-space: pre-line;"));
+        assert!(css("whitespace-break-spaces").contains("white-space: break-spaces;"));
         // per-side border colour
         assert!(css("border-t-accent").contains("border-top-color:"));
+        // per-side border WIDTH — the numeric scale mirrors border-2
+        assert!(css("border-l-2").contains("border-left-width: 2px;"));
+        assert!(css("border-t-4").contains("border-top-width: 4px;"));
+        assert!(css("border-r-0").contains("border-right-width: 0px;"));
         // arbitrary min()/clamp() lengths now accepted
         assert!(css("w-[min(90%,32rem)]").contains("width: min(90%,32rem);"));
+        // ch/vmin/vmax units accepted in Length-typed arbitrary values
+        assert!(css("max-w-[56ch]").contains("max-width: 56ch;"));
+        assert!(css("h-[10vmin]").contains("height: 10vmin;"));
         // group-hover → ancestor-prefixed selector; last-of-type pseudo
         assert!(css("group-hover:opacity-50").contains(".group:hover "));
         assert!(css("last-of-type:border-b-0").contains(":last-of-type"));

--- a/crates/pocopine/tests/PlanCompoundDeferredHost.html
+++ b/crates/pocopine/tests/PlanCompoundDeferredHost.html
@@ -1,0 +1,3 @@
+<div class="pcdh-root">
+  <plan-deferred-slot-child><slot></slot></plan-deferred-slot-child>
+</div>

--- a/crates/pocopine/tests/PlanCompoundHost.html
+++ b/crates/pocopine/tests/PlanCompoundHost.html
@@ -1,0 +1,6 @@
+<div class="pch-root">
+  <plan-slot-child>
+    <plan-host-directive-child :label="badge"></plan-host-directive-child>
+    <slot></slot>
+  </plan-slot-child>
+</div>

--- a/crates/pocopine/tests/PlanCompoundTeleportHost.html
+++ b/crates/pocopine/tests/PlanCompoundTeleportHost.html
@@ -1,0 +1,3 @@
+<div class="pcth-root">
+  <plan-teleport-slot-child><slot></slot></plan-teleport-slot-child>
+</div>

--- a/crates/pocopine/tests/PlanDeferredSlotChild.html
+++ b/crates/pocopine/tests/PlanDeferredSlotChild.html
@@ -1,0 +1,6 @@
+<div class="pdsc-shell">
+  <button class="pdsc-open" pp-on:click="open_it">open</button>
+  <template pp-if="open">
+    <div class="pdsc-body"><slot></slot></div>
+  </template>
+</div>

--- a/crates/pocopine/tests/PlanSlotInterpHost.html
+++ b/crates/pocopine/tests/PlanSlotInterpHost.html
@@ -1,0 +1,4 @@
+<div class="psih-root">
+  <plan-slot-child>{{ label }} ready</plan-slot-child>
+  <button class="psih-bump" pp-on:click="bump">bump</button>
+</div>

--- a/crates/pocopine/tests/PlanTeleportSlotChild.html
+++ b/crates/pocopine/tests/PlanTeleportSlotChild.html
@@ -1,0 +1,6 @@
+<div class="ptsc-shell">
+  <button class="ptsc-open" pp-on:click="open_it">open</button>
+  <template pp-if="open" pp-teleport="body">
+    <div class="ptsc-body"><slot></slot></div>
+  </template>
+</div>

--- a/crates/pocopine/tests/template_plan.rs
+++ b/crates/pocopine/tests/template_plan.rs
@@ -235,6 +235,28 @@ impl PlanSlotDynamicHost {
     }
 }
 
+/// Slot content that is *bare* `{{ }}` interpolation (no wrapping
+/// element, no pp-text). The classifier scans top-level slot text
+/// nodes and emits a dynamic fragment whose interp installs against
+/// the author (parent) scope — previously this rendered as raw
+/// braces (the AgenKitty `<pine-avatar-fallback>{{ initials }}</…>`
+/// finding).
+#[derive(Default, Serialize, Deserialize)]
+#[component(template = "PlanSlotInterpHost.html")]
+struct PlanSlotInterpHost {
+    label: String,
+}
+
+#[handlers]
+impl PlanSlotInterpHost {
+    pub fn on_setup(&mut self) {
+        self.label = "first".into();
+    }
+    pub fn bump(&mut self) {
+        self.label = "second".into();
+    }
+}
+
 /// Child used by the compiled-finalize regression test. Its
 /// `on_mount` write proves a lifted fragment containing a child
 /// component can finish lifecycle without falling back to the
@@ -952,6 +974,7 @@ fn register_all() {
     Rfc064KeyedFastHost::register();
     Rfc064GenericPrependHost::register();
     PlanSlotDynamicHost::register();
+    PlanSlotInterpHost::register();
     PlanLifecycleLeaf::register();
     PlanIfChildHost::register();
     PlanHostDirectiveChild::register();
@@ -1569,6 +1592,81 @@ async fn macro_emitted_dynamic_slot_fragment_installs_against_parent() {
     assert_eq!(plan_failure_count(), 0);
 
     host.remove();
+}
+
+/// Bare `{{ }}` interpolation as slot content compiles in the
+/// author's scope — parity with `pp-text` in the same position.
+/// The top-level text node lifts into a dynamic slot fragment
+/// (root-anchored interp entry) that renders and reactively
+/// updates; no raw braces ever reach the DOM.
+#[wasm_bindgen_test]
+async fn slot_content_interpolation_renders_in_author_scope() {
+    register_all();
+    reset_plan_failure_count();
+
+    let host = mount("<plan-slot-interp-host></plan-slot-interp-host>");
+    tick().await;
+
+    let shell = host
+        .query_selector(".psc-shell")
+        .unwrap()
+        .expect("slot child shell must mount");
+    let text = shell.text_content().unwrap_or_default();
+    assert!(
+        text.contains("first ready"),
+        "slot interp must render the author scope's field: {text:?}"
+    );
+    assert!(
+        !text.contains("{{"),
+        "no raw braces may reach the DOM: {text:?}"
+    );
+
+    host.query_selector(".psih-bump")
+        .unwrap()
+        .unwrap()
+        .dyn_ref::<HtmlElement>()
+        .unwrap()
+        .click();
+    tick().await;
+    let text = shell.text_content().unwrap_or_default();
+    assert!(
+        text.contains("second ready"),
+        "slot interp must update reactively: {text:?}"
+    );
+
+    assert_eq!(plan_failure_count(), 0);
+    host.remove();
+}
+
+/// The bare-slot-interp effect must RELEASE on unmount. Its install
+/// resolves against `stamp_dynamic_slot_with`'s detached wrapper, which
+/// never enters the DOM — the runtime re-homes the effect onto the live
+/// element receiving the spliced content, so subtree release disposes it
+/// (previously it leaked, keeping the parent scope + text node alive
+/// across remounts).
+#[wasm_bindgen_test]
+async fn slot_interp_effect_releases_on_unmount() {
+    register_all();
+    reset_plan_failure_count();
+
+    async fn cycle() {
+        let host = mount("<plan-slot-interp-host></plan-slot-interp-host>");
+        tick().await;
+        pocopine_core::mount::release_compiled_subtree(&host);
+        host.remove();
+        tick().await;
+    }
+
+    // The warm-up absorbs any one-time global effects; after it, a
+    // steady-state mount/release cycle must be effect-neutral.
+    cycle().await;
+    let (baseline, _) = pocopine_core::reactive::stats();
+    cycle().await;
+    let (after, _) = pocopine_core::reactive::stats();
+    assert_eq!(
+        after, baseline,
+        "a slot-interp mount/release cycle must not leak effects"
+    );
 }
 
 /// RFC-058 Phase 4.1d — body fragment lifting. The macro emits

--- a/crates/pocopine/tests/template_plan.rs
+++ b/crates/pocopine/tests/template_plan.rs
@@ -257,6 +257,76 @@ impl PlanSlotInterpHost {
     }
 }
 
+/// A compound component: its own `<slot>` outlet sits INSIDE a child
+/// component's slot content (`<plan-slot-child><slot></slot></plan-slot-child>`)
+/// — the AkContextMenu shape. The consumer's projected content must traverse
+/// the child boundary and land inside the child's shell, and the sibling
+/// `:label`-bound child (the `pine-icon :name` shape) must bind against the
+/// author's scope — one rejected `<slot>` used to poison the whole fragment
+/// tree, leaving the binding a raw attribute.
+#[derive(Default, Serialize, Deserialize)]
+#[component(template = "PlanCompoundHost.html")]
+struct PlanCompoundHost {
+    badge: String,
+}
+
+#[handlers]
+impl PlanCompoundHost {
+    pub fn on_setup(&mut self) {
+        self.badge = "badge-ok".into();
+    }
+}
+
+/// A child whose own `<slot>` outlet is DEFERRED inside a `pp-if` body (the
+/// dropdown-portal shape): the outlet only exists once `open` flips, so the
+/// slot content handed to it by a compound host must materialize LATE —
+/// long after everyone mounted.
+#[derive(Default, Serialize, Deserialize)]
+#[component(template = "PlanDeferredSlotChild.html")]
+struct PlanDeferredSlotChild {
+    open: bool,
+}
+
+#[handlers]
+impl PlanDeferredSlotChild {
+    pub fn open_it(&mut self) {
+        self.open = true;
+    }
+}
+
+/// Compound host over the deferred child: its outlet rides the child's slot
+/// content into a pp-if body two boundaries deep.
+#[derive(Default, Serialize, Deserialize)]
+#[component(template = "PlanCompoundDeferredHost.html")]
+struct PlanCompoundDeferredHost {}
+
+#[handlers]
+impl PlanCompoundDeferredHost {}
+
+/// The full dropdown-portal shape: the child's `<slot>` lives in a
+/// `pp-if` + `pp-teleport="body"` template, so the projected content must
+/// materialize late AND land teleported outside the host tree.
+#[derive(Default, Serialize, Deserialize)]
+#[component(template = "PlanTeleportSlotChild.html")]
+struct PlanTeleportSlotChild {
+    open: bool,
+}
+
+#[handlers]
+impl PlanTeleportSlotChild {
+    pub fn open_it(&mut self) {
+        self.open = true;
+    }
+}
+
+/// Compound host over the teleporting child.
+#[derive(Default, Serialize, Deserialize)]
+#[component(template = "PlanCompoundTeleportHost.html")]
+struct PlanCompoundTeleportHost {}
+
+#[handlers]
+impl PlanCompoundTeleportHost {}
+
 /// Child used by the compiled-finalize regression test. Its
 /// `on_mount` write proves a lifted fragment containing a child
 /// component can finish lifecycle without falling back to the
@@ -975,6 +1045,11 @@ fn register_all() {
     Rfc064GenericPrependHost::register();
     PlanSlotDynamicHost::register();
     PlanSlotInterpHost::register();
+    PlanCompoundHost::register();
+    PlanDeferredSlotChild::register();
+    PlanCompoundDeferredHost::register();
+    PlanTeleportSlotChild::register();
+    PlanCompoundTeleportHost::register();
     PlanLifecycleLeaf::register();
     PlanIfChildHost::register();
     PlanHostDirectiveChild::register();
@@ -1635,6 +1710,135 @@ async fn slot_content_interpolation_renders_in_author_scope() {
     );
 
     assert_eq!(plan_failure_count(), 0);
+    host.remove();
+}
+
+/// Compound-component slot projection (the AkContextMenu shape): a `<slot>`
+/// outlet inside a CHILD component's slot content must still receive the
+/// consumer's projected content — traversing the child boundary — and no
+/// literal unresolved `<slot>` element may survive in the DOM.
+#[wasm_bindgen_test]
+async fn slot_outlet_inside_child_slot_content_projects_consumer_content() {
+    register_all();
+    reset_plan_failure_count();
+
+    let host =
+        mount("<plan-compound-host><span class=\"pch-item\">projected</span></plan-compound-host>");
+    tick().await;
+
+    // The consumer's content traversed plan-compound-host's template INTO
+    // plan-slot-child's shell.
+    let item = host
+        .query_selector(".psc-shell .pch-item")
+        .unwrap()
+        .expect("consumer content must project through the child boundary");
+    assert_eq!(item.text_content().as_deref(), Some("projected"));
+
+    // The sibling bound child compiled in the author's scope (symptom 3:
+    // one rejected <slot> used to leave `:label` a raw attribute).
+    let badge = host
+        .query_selector(".psc-shell .phdc-label")
+        .unwrap()
+        .expect("bound child inside the slot content must mount");
+    assert_eq!(badge.text_content().as_deref(), Some("badge-ok"));
+
+    // No inert outlet left behind.
+    assert!(
+        host.query_selector("slot").unwrap().is_none(),
+        "no literal <slot> may survive materialisation: {:?}",
+        host.inner_html()
+    );
+
+    host.remove();
+}
+
+/// The deferred variant (the dropdown-portal shape): the compound host's
+/// outlet rides the child's slot content into a `pp-if` body, so the
+/// consumer's content must materialize LATE — when the branch opens — not
+/// at mount. Before the fix the whole chain silently dropped the content
+/// and cloned an inert literal `<slot>` on open.
+#[wasm_bindgen_test]
+async fn slot_outlet_in_deferred_child_body_projects_on_open() {
+    register_all();
+    reset_plan_failure_count();
+
+    let host = mount(
+        "<plan-compound-deferred-host><span class=\"pcdh-item\">late</span>\
+         </plan-compound-deferred-host>",
+    );
+    tick().await;
+
+    // Closed: the deferred body (and the projected content) is absent.
+    assert!(
+        host.query_selector(".pdsc-body").unwrap().is_none(),
+        "deferred body must not exist before open"
+    );
+
+    host.query_selector(".pdsc-open")
+        .unwrap()
+        .expect("child shell mounts")
+        .dyn_ref::<HtmlElement>()
+        .unwrap()
+        .click();
+    tick().await;
+
+    let item = host
+        .query_selector(".pdsc-body .pcdh-item")
+        .unwrap()
+        .expect("consumer content must project into the opened deferred body");
+    assert_eq!(item.text_content().as_deref(), Some("late"));
+    assert!(
+        host.query_selector("slot").unwrap().is_none(),
+        "no literal <slot> may survive the deferred materialisation: {:?}",
+        host.inner_html()
+    );
+
+    host.remove();
+}
+
+/// The full dropdown-portal shape (`pp-if` + `pp-teleport="body"`): the
+/// projected consumer content must materialize on open AND land in the
+/// teleport target (document body), outside the host tree.
+#[wasm_bindgen_test]
+async fn slot_outlet_in_teleported_child_body_projects_on_open() {
+    register_all();
+    reset_plan_failure_count();
+
+    let host = mount(
+        "<plan-compound-teleport-host><span class=\"pcth-item\">ported</span>\
+         </plan-compound-teleport-host>",
+    );
+    tick().await;
+
+    let body = doc().body().unwrap();
+    assert!(
+        body.query_selector(".ptsc-body").unwrap().is_none(),
+        "teleported body must not exist before open"
+    );
+
+    host.query_selector(".ptsc-open")
+        .unwrap()
+        .expect("child shell mounts")
+        .dyn_ref::<HtmlElement>()
+        .unwrap()
+        .click();
+    tick().await;
+
+    // The content teleported to <body> WITH the projected consumer item.
+    let ported = body
+        .query_selector(".ptsc-body .pcth-item")
+        .unwrap()
+        .expect("consumer content must project into the teleported body");
+    assert_eq!(ported.text_content().as_deref(), Some("ported"));
+    assert!(
+        body.query_selector(".ptsc-body slot").unwrap().is_none(),
+        "no literal <slot> may survive in the teleported body"
+    );
+
+    // Cleanup: drop the teleported node too, so later tests see a clean body.
+    if let Some(node) = body.query_selector(".ptsc-body").unwrap() {
+        node.remove();
+    }
     host.remove();
 }
 

--- a/examples/file-browser/src/components/file_detail/FileBrowserFileDetail.poco
+++ b/examples/file-browser/src/components/file_detail/FileBrowserFileDetail.poco
@@ -121,8 +121,12 @@
           <dd class="font-mono text-[12px]" pp-text="$store.storage.detail.content_type || '—'"></dd>
 
           <template pp-if="$store.storage.detail.created_label">
-            <dt>Created</dt>
-            <dd pp-text="$store.storage.detail.created_label"></dd>
+            <!-- pp-if bodies need a single root; display:contents keeps the
+                 dt/dd participating in the dl's grid as direct items. -->
+            <div class="contents">
+              <dt>Created</dt>
+              <dd pp-text="$store.storage.detail.created_label"></dd>
+            </div>
           </template>
 
           <dt>Updated</dt>


### PR DESCRIPTION
Upstream fixes for every finding from the AgenKitty chat harness (the first UI consumer of the agent crates), plus the follow-up bugs found in review. Eleven commits, Codex-reviewed over four rounds (P1 + 2×P2 found and fixed; rounds 3 and 4 clean).

## Summary

| Area | Change |
|---|---|
| agenkit | `AgentEvent::AssistantDelta` token streaming from `AgentSession` turns (provider stream consumed via new `run_model_step_streamed`; deltas ephemeral, final `AssistantText` unchanged) |
| agenkit | `AgentThreadStore::list(owner)` + `SessionStore::threads()` — owner-scoped thread listing, newest-first with parent links (chat sidebar) |
| agenkit | `update_attributes(id, owner, patch)` — owner-checked shallow merge (`null` removes; `owner`/`agent_id` reserved; audit entry on the provenance channel) |
| agenkit | Shared wire-boundary redaction: `Redactor` + `AgentWireEvent` in core, and the **stateful `AgentEventRedactor`** stream adapter (closes a split-secret streaming leak — see review notes below) |
| macros | `pp-if`/`pp-else`/`pp-case` bodies: multi-root and loose top-level text are now **compile errors** (the runtime stamps only the first element root; extras silently vanished). Caught one real shipped instance in the file-browser example |
| macros | Slotted `{{ }}` interpolation compiles (top-level slot text scanned; interp-only fragments no longer emit a plan-less `Static`) |
| macros+core | **Nested slot outlets project through child-component boundaries** — detailed below |
| core | Detached-install effects re-homed onto live elements (`stash_wrapper_effects`/`adopt_pending_effects`) so slot-fragment effects release on unmount |
| server | `Server::new` warns loudly when zero `#[server]` functions registered (inventory/linking pitfall → every POST 405s with no hint) |
| stylekit | `whitespace-pre-wrap`/`pre-line`/`break-spaces`; per-side numeric border widths (`border-l-2`); `ch`/`vmin`/`vmax` in Length arbitrary values |
| pine-icons | Unset `size` writes **no inline style**; the box defaults to `1em` via CSS — icons ride the surrounding font-size and app CSS can resize without `!important`. Explicit `size` still pins px |

---

## Deep dive: nested slot outlets (the compound-component fix)

### The symptom

A component whose own `<slot>` outlet sits **inside another component's slot content** — the standard compound-component shape — silently lost everything the consumer passed:

```html
<!-- AkContextMenu.poco (the app component) -->
<pine-dropdown-menu-root>
  <pine-dropdown-menu-trigger>…<pine-icon :name="icon"/>…</pine-dropdown-menu-trigger>
  <pine-dropdown-menu-portal>
    <pine-dropdown-menu-content class="ak-menu">
      <slot></slot>                     <!-- ← consumer items should land here -->
    </pine-dropdown-menu-content>
  </pine-dropdown-menu-portal>
</pine-dropdown-menu-root>
```

```html
<!-- consumer -->
<ak-context-menu icon="dots">
  <ak-menu-item>Rename</ak-menu-item>
  <ak-menu-item>Delete</ak-menu-item>
</ak-context-menu>
```

Observed at runtime:
1. the `<ak-menu-item>`s appeared **nowhere** in the document (count 0);
2. the portal's deferred template still contained a **literal, unresolved `<slot></slot>`** — opening the menu cloned an inert element, so it popped up empty;
3. collateral: `:name="icon"` on the trigger's `pine-icon` stayed a **raw attribute** (blank glyph), while `pp-text` elsewhere compiled fine.

### Root cause: one compile-time gate with recursive blast radius

The compiled-views slot analyzer decides per fragment whether slot content is *liftable* into a compiled fragment function. That eligibility check rejected `<slot>` outright:

```rust
// pocopine-macros/src/template_plan.rs — slot_node_is_lift_eligible (before)
if el.tag == "slot" {
    return false;      // "nested designation — Phase 3.5e" (deferred)
}
```

The check is **recursive** — a subtree is eligible only if every node in it is. So one nested `<slot>` disqualified the *entire chain* of enclosing fragments:

```mermaid
graph TD
    A["ak-context-menu template"] --> B["root's slot fragment"]
    B --> C["trigger's fragment<br/>(pine-icon :name)"]
    B --> D["portal's fragment"]
    D --> E["content's fragment"]
    E --> F["&lt;slot&gt; ← rejected by the gate"]
    F -. "recursive ineligibility<br/>poisons EVERY ancestor fragment" .-> B
    style F fill:#8b2635,color:#fff
    style B fill:#7a4a21,color:#fff
    style C fill:#7a4a21,color:#fff
    style D fill:#7a4a21,color:#fff
    style E fill:#7a4a21,color:#fff
```

With no fragments lifted, the failure cascades at runtime:

- `ak-context-menu` mounts its children **without a `SlotSet`** (no compiled fragments to hand down);
- each `pine-*` child falls back to **light-DOM capture** of whatever raw HTML was left in the cleaned template — which deep-clones the authored `<slot>` **inert** (nothing ever materializes an outlet on the capture path);
- the consumer's real content sits parked in `LIGHT_DOM_SLOTS[ak_context_menu_scope]` forever — captured at mount, never projected, because the one `<slot>` that would have pulled it never materializes;
- and since the *whole* fragment tree was ineligible, none of its bindings compiled either — which is symptom 3. `pp-text` worked elsewhere only because those templates had no nested `<slot>` poisoning them.

Silent on every level: no compile diagnostic, no runtime signal, content just vanishes.

### The fix: one line of policy — the machinery already existed

```rust
// slot_node_is_lift_eligible (after)
if el.tag == "slot" {
    return true;   // lifts like any template-level outlet
}
```

This works because every downstream piece was already built and battle-tested by a *different* path — `pp-if`/`pp-teleport` **body** fragments have always permitted `<slot>` (that is how `pine-dropdown-menu-portal`'s own deferred outlet works today):

- `walk()` already lifts any `<slot>` it visits into a `SlotOutletLite` plan entry;
- the fragment install pass already contains the `materialize_slots` step;
- the light-DOM capture registry already supports **late, repeated** materialization (entries are deep-cloned on use, never consumed, and live until the owning scope is removed) — which is what deferred portals and re-opens need.

### Why ownership resolves correctly (the subtle part)

The question that made this look hard: when AkContextMenu's `<slot>` physically lands inside `pine-dropdown-menu-content`'s DOM, how does the runtime know the outlet belongs to *AkContextMenu* (whose consumer content should project) and not to *content* (the component it landed in)?

Answer: **outlets materialize while the fragment is still detached**, and detached fragments carry the *authoring* component's scope stamp.

```mermaid
sequenceDiagram
    participant M as materialize_slot (content's own outlet)
    participant S as stamp_dynamic_slot_with
    participant T as temp &lt;div&gt; (detached)
    participant R as light-DOM registry
    M->>S: run AkContextMenu-authored fragment ("&lt;slot&gt;&lt;/slot&gt;")
    S->>T: innerHTML = fragment html
    S->>T: stamp AUTHOR scope (AkContextMenu) on wrapper + top-level children
    S->>T: run fragment install pass (still detached!)
    Note over T: materialize_slots step reaches the &lt;slot&gt;
    T->>T: enclosing_scope() walks up → hits the AUTHOR stamp
    T->>R: lookup(AkContextMenu scope, "default") → consumer's captured items
    R->>T: deep-clone items, splice before &lt;slot&gt;, remove &lt;slot&gt;
    S->>M: splice finished children into content's DOM
```

Two structural invariants make this sound:

1. **The macro's recursion separates levels.** A `<slot>` inside `<pine-content>` is lifted into *content's* fragment (authored by AkContextMenu), never left inside an outer fragment next to a mounted child. So inside any one temp wrapper, no *other* component's scope marker can sit between the `<slot>` and the author stamp — the walk-up always lands on the right owner.
2. **Materialization happens before splicing.** By the time the content enters the child's live DOM (where the child's scope markers would shadow the walk-up), the outlet is already resolved and gone.

The deferred/teleported cases compose from the same parts: when the portal's `pp-if` body stamps at open time, its install pass materializes the portal's outlet → pulls the portal's slot fragment (registered at mount, still alive) → stamps content → content's install materializes *its* outlet → pulls AkContextMenu's fragment → which finally pulls the consumer's captured light-DOM. Each hop is the same mechanism, and every registry entry survives until its scope dies, so "late" costs nothing.

### Hardening

The runtime audit found one silent bail on this path: if `enclosing_scope` ever returns `None` for an outlet, `materialize_slot` used to **silently delete it**. It now logs a console error and increments the plan-failure counter (the same fail-fast tripwire tests assert stays at zero) — a mis-threaded fragment becomes observable instead of vanishing content.

### Verification

New wasm tests (headless Firefox) pin all three symptoms end to end:

| Test | Shape | Asserts |
|---|---|---|
| `slot_outlet_inside_child_slot_content_projects_consumer_content` | `<x><slot/></x>` direct | consumer content lands in the child's shell; sibling `:prop`-bound child binds in the author scope; no literal `<slot>` survives. **Verified to FAIL before the fix** |
| `slot_outlet_in_deferred_child_body_projects_on_open` | outlet inside the child's `pp-if` body | nothing renders while closed; content projects when the branch opens |
| `slot_outlet_in_teleported_child_body_projects_on_open` | `pp-if` + `pp-teleport="body"` (the portal shape) | content projects into the teleported body in `document.body` |

Blast radius: the full pine suite (121 tests — dialogs/menus/popovers now take the lifted path instead of the capture fallback), all pocopine slot suites, 100 macro unit tests, workspace check, `cargo fmt --check`, and the CI clippy-wasm gate — all green.

---

## Review & verification notes

- **Codex round 1 (P1):** the first redaction adapter classified each `AssistantDelta` fragment independently — a secret split across provider chunks (`api_` then `key = sk-live…`) streamed out live before the assembled `AssistantText` could redact it. Fixed by making the public adapter the stateful `AgentEventRedactor`: it classifies the *assembled* text per fragment, replaces the tripping fragment with one `[redacted]` marker, and suppresses the rest of the message. The stateless mapper is now private.
- **Codex round 2 (2×P2):** (a) bare-slot-interp effects were tracked on the detached install wrapper and leaked on unmount — fixed via the stash/adopt re-homing, with a regression test proven to fail without the fix; (b) the branch-root diagnostic missed non-whitespace text beside a single root — now rejected.
- **Codex rounds 3 & 4:** clean.
- Test totals on the branch: 121 agenkit lib + integration, 565 agenkitty, 100 macros, 48 pocopine wasm (`template_plan`), 121 pine wasm, plus stylekit/server/pine-icons suites.

Breaking-ish behavior notes:
- `pine-icons`: icons relying on the implicit 20px default now render at `1em` of their context; pass `size="20"` to pin the old metric.
- New compile errors (`pp-if` multi-root / loose text) may surface pre-existing latent bugs in downstream templates — one was found and fixed in `examples/file-browser` in this PR.
