### PR TITLE
fix(core): release removed pp-for row subtrees — reap orphaned portal clones

### DIFF
--- a/crates/pocopine-core/src/directives/for_.rs
+++ b/crates/pocopine-core/src/directives/for_.rs
@@ -147,10 +147,16 @@ fn fire_staggered_enter(clones: &[Element], stagger_ms: u32) {
 }
 
 fn remove_or_leave(root: &Element) {
+    // RFC-058 Phase 6.5 — no MutationObserver releases removed subtrees
+    // anymore, so removal must release synchronously (mirrors pp-if's
+    // leave completion): otherwise every nested component scope, effect,
+    // and listener in the row leaks — and any portal clone stashed on a
+    // descendant (`pp-teleport`) is orphaned at its target forever.
     if !crate::directives::transition::has_transition_in_subtree(root) {
         if let Some(parent) = root.parent_node() {
             let _ = parent.remove_child(root);
         }
+        crate::mount::release_subtree(root.as_ref());
         return;
     }
     let root_cap = root.clone();
@@ -158,6 +164,7 @@ fn remove_or_leave(root: &Element) {
         if let Some(parent) = root_cap.parent_node() {
             let _ = parent.remove_child(&root_cap);
         }
+        crate::mount::release_subtree(root_cap.as_ref());
     });
 }
 
@@ -1190,6 +1197,11 @@ fn try_single_remove_fast_path(
         if let Some(parent) = entry.element.parent_node() {
             let _ = parent.remove_child(&entry.element);
         }
+        // Same post-removal release contract as the drain path (RFC-058
+        // Phase 6.5 — no observer releases removed subtrees): drop the
+        // row's loop scope, nested state, and any teleport stash, or the
+        // fast path leaks what the slow path now frees.
+        crate::mount::release_subtree(entry.element.as_ref());
         crate::directives::for_plan::unmount_row_compiled(entry.scope_id);
     }
     crate::profiler::reconcile::record_leaver_drain(leaver_drain_start);
@@ -1834,6 +1846,13 @@ fn run_keyed(
                     if let Some(parent) = el.parent_node() {
                         let _ = parent.remove_child(&el);
                     }
+                    // RFC-058 Phase 6.5 — the MutationObserver that used to
+                    // release removed rows asynchronously is gone: release
+                    // here, synchronously, or everything nested in the row
+                    // (component scopes, effects, listeners — and any
+                    // pp-teleport clone stashed on a descendant, which would
+                    // otherwise stay orphaned at its target) leaks.
+                    crate::mount::release_subtree(el.as_ref());
                     crate::directives::for_plan::unmount_row_compiled(scope_id_for_unmount);
                     retract_from_prior(&prior_for_retract, &key_for_retract);
                     // No transition → the entry is fully retired
@@ -1841,20 +1860,35 @@ fn run_keyed(
                     // below keeps the dead entry out of
                     // `fresh.extend(leavers)`, which would
                     // otherwise re-stash it into `prior` and let
-                    // the *next* reconcile reuse the clone after
-                    // its scope was already removed by the async
-                    // observer — `mount_row_compiled` would then
-                    // run with `loop_state = None` and every
-                    // binding would evaluate to UNDEFINED.
+                    // the *next* reconcile reuse the released clone —
+                    // `mount_row_compiled` would then run with
+                    // `loop_state = None` and every binding would
+                    // evaluate to UNDEFINED.
                     continue;
                 }
+                let done_synchronously = Rc::new(std::cell::Cell::new(false));
+                let done_flag = done_synchronously.clone();
                 crate::directives::transition::leave_subtree(&el, move || {
                     if let Some(parent) = el_for_cb.parent_node() {
                         let _ = parent.remove_child(&el_for_cb);
                     }
+                    // Completion-only release: a leaver resumed mid-leave
+                    // (its key re-added) cancels the leave, so this callback
+                    // never fires for it and the clone stays live — same
+                    // contract as pp-if's leave teardown.
+                    crate::mount::release_subtree(el_for_cb.as_ref());
                     crate::directives::for_plan::unmount_row_compiled(scope_id_for_unmount);
                     retract_from_prior(&prior_for_retract, &key_for_retract);
+                    done_flag.set(true);
                 });
+                // Reduced motion / disabled animations complete the leave
+                // SYNCHRONOUSLY: the clone above is already released, so it
+                // must not enter the reuse pool — same reasoning as the
+                // no-transition branch (a re-added key would otherwise
+                // resurrect a scope-less, listener-less clone).
+                if done_synchronously.get() {
+                    continue;
+                }
             }
             leavers.push(entry);
         }

--- a/crates/pocopine-core/src/scope.rs
+++ b/crates/pocopine-core/src/scope.rs
@@ -425,6 +425,15 @@ impl Scope {
         })
     }
 
+    /// Live scope count — a cheap health counter for tests/devtools (the
+    /// registry-side sibling of `reactive::stats`). Compiled rows have no
+    /// per-row effects, so a leaked LoopScope is invisible to the effect
+    /// counter; this is the metric that catches it.
+    #[cfg(any(debug_assertions, feature = "devtools"))]
+    pub fn count() -> usize {
+        SCOPES.with(|s| s.borrow().len())
+    }
+
     /// Remove a scope from the registry. Called when its element is
     /// unmounted. Also drops any refs + captured slot content
     /// registered against this scope so we don't leak element

--- a/crates/pocopine/tests/PlanRowPortalHost.html
+++ b/crates/pocopine/tests/PlanRowPortalHost.html
@@ -1,0 +1,9 @@
+<div class="prph-root">
+  <button class="prph-remove" pp-on:click="remove_first">remove</button>
+  <template pp-for="item in items" pp-key="item">
+    <div class="prph-row">
+      <span class="prph-label" pp-text="item"></span>
+      <plan-teleport-slot-child><span class="prph-content">menu</span></plan-teleport-slot-child>
+    </div>
+  </template>
+</div>

--- a/crates/pocopine/tests/PlanTeleportSlotChild.html
+++ b/crates/pocopine/tests/PlanTeleportSlotChild.html
@@ -1,6 +1,10 @@
 <div class="ptsc-shell">
   <button class="ptsc-open" pp-on:click="open_it">open</button>
+  <button class="ptsc-close" pp-on:click="close_it">close</button>
   <template pp-if="open" pp-teleport="body">
-    <div class="ptsc-body"><slot></slot></div>
+    <div class="ptsc-body"
+         pp-transition:leave="ptsc-leaving"
+         pp-transition:leave-start="ptsc-leave-from"
+         pp-transition:leave-end="ptsc-leave-to"><slot></slot></div>
   </template>
 </div>

--- a/crates/pocopine/tests/template_plan.rs
+++ b/crates/pocopine/tests/template_plan.rs
@@ -317,6 +317,9 @@ impl PlanTeleportSlotChild {
     pub fn open_it(&mut self) {
         self.open = true;
     }
+    pub fn close_it(&mut self) {
+        self.open = false;
+    }
 }
 
 /// Compound host over the teleporting child.
@@ -326,6 +329,29 @@ struct PlanCompoundTeleportHost {}
 
 #[handlers]
 impl PlanCompoundTeleportHost {}
+
+/// A keyed pp-for whose rows each host a teleporting child (the AkTreeRow
+/// shape): opening the row's portal puts a clone at `<body>`; deleting the
+/// row must reap that clone. Row teardown is table-driven (it never walks
+/// the row's DOM), so the per-element teleport stash used to be skipped
+/// entirely — orphaning the panel at the viewport corner.
+#[derive(Default, Serialize, Deserialize)]
+#[component(template = "PlanRowPortalHost.html")]
+struct PlanRowPortalHost {
+    items: Vec<String>,
+}
+
+#[handlers]
+impl PlanRowPortalHost {
+    pub fn on_setup(&mut self) {
+        self.items = vec!["a".to_string(), "b".to_string()];
+    }
+    pub fn remove_first(&mut self) {
+        if !self.items.is_empty() {
+            self.items.remove(0);
+        }
+    }
+}
 
 /// Child used by the compiled-finalize regression test. Its
 /// `on_mount` write proves a lifted fragment containing a child
@@ -1050,6 +1076,7 @@ fn register_all() {
     PlanCompoundDeferredHost::register();
     PlanTeleportSlotChild::register();
     PlanCompoundTeleportHost::register();
+    PlanRowPortalHost::register();
     PlanLifecycleLeaf::register();
     PlanIfChildHost::register();
     PlanHostDirectiveChild::register();
@@ -1836,6 +1863,224 @@ async fn slot_outlet_in_teleported_child_body_projects_on_open() {
     );
 
     // Cleanup: drop the teleported node too, so later tests see a clean body.
+    if let Some(node) = body.query_selector(".ptsc-body").unwrap() {
+        node.remove();
+    }
+    host.remove();
+}
+
+async fn sleep_ms(ms: i32) {
+    let promise = js_sys::Promise::new(&mut |resolve, _| {
+        if let Some(w) = window() {
+            let _ = w
+                .set_timeout_with_callback_and_timeout_and_arguments_0(resolve.unchecked_ref(), ms);
+        }
+    });
+    let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
+}
+
+/// The exact AgenKitty-11 timeline: the panel's close (leave) animation is
+/// STILL RUNNING when the row unmounts. The row teardown must reap the
+/// mid-leave clone immediately — not wait for a completion that may never
+/// come — and the leave's late backstop callback must then no-op instead of
+/// double-freeing.
+#[wasm_bindgen_test]
+async fn deleting_a_row_mid_close_animation_reaps_the_portal_clone() {
+    register_all();
+    reset_plan_failure_count();
+
+    // Give the clone a real CSS transition (the leave path discovers
+    // animated elements via the fixture's `pp-transition:leave*` attrs;
+    // the stylesheet makes the leave classes actually animate).
+    let style = doc().create_element("style").unwrap();
+    style.set_text_content(Some(
+        ".ptsc-body { opacity: 1; transition: opacity 0.25s linear; } \
+         .ptsc-leave-to { opacity: 0; }",
+    ));
+    doc().head().unwrap().append_child(&style).unwrap();
+
+    let host = mount("<plan-row-portal-host></plan-row-portal-host>");
+    tick().await;
+    let body = doc().body().unwrap();
+
+    // Open, then start CLOSING (leave animation begins; clone still in DOM).
+    host.query_selector(".prph-row .ptsc-open")
+        .unwrap()
+        .unwrap()
+        .dyn_ref::<HtmlElement>()
+        .unwrap()
+        .click();
+    tick().await;
+    host.query_selector(".prph-row .ptsc-close")
+        .unwrap()
+        .unwrap()
+        .dyn_ref::<HtmlElement>()
+        .unwrap()
+        .click();
+    tick().await;
+
+    // Self-check that the test exercises what it claims: the leave window
+    // must actually be OPEN here — the clone still in the DOM, mid-leave.
+    // Without this the test would pass vacuously (a synchronous close
+    // removes the clone before the row delete ever runs).
+    assert!(
+        body.query_selector(".ptsc-body").unwrap().is_some(),
+        "close must start an ANIMATED leave — clone gone means the leave \
+         window never opened and this test is not testing mid-leave"
+    );
+
+    // Delete the row inside the leave window.
+    host.query_selector(".prph-remove")
+        .unwrap()
+        .unwrap()
+        .dyn_ref::<HtmlElement>()
+        .unwrap()
+        .click();
+    tick().await;
+
+    assert!(
+        body.query_selector(".ptsc-body").unwrap().is_none(),
+        "row teardown must reap the mid-leave clone immediately"
+    );
+
+    // Ride out the transition + the 1s leave backstop: the late completion
+    // must be a no-op (no resurrection, no double-free panic).
+    sleep_ms(1200).await;
+    assert!(
+        body.query_selector(".ptsc-body").unwrap().is_none(),
+        "late leave completion must not resurrect the clone"
+    );
+
+    style.remove();
+    host.remove();
+}
+
+/// The compiled single-remove FAST path must release the removed row's loop
+/// scope + reactive bookkeeping too — it early-returns before the drain path,
+/// so it needs its own post-removal release (review finding on the
+/// drain-path fix).
+#[wasm_bindgen_test]
+async fn compiled_single_remove_fast_path_releases_the_row_scope() {
+    register_all();
+    reset_plan_failure_count();
+
+    let host = mount("<rfc064-keyed-fast-host></rfc064-keyed-fast-host>");
+    tick().await;
+    assert_eq!(host.query_selector_all(".r64k-row").unwrap().length(), 3);
+
+    // Compiled rows have no per-row effects (one list-level watcher drives
+    // them), so the leak is only visible in the SCOPE registry: removing a
+    // row must evict exactly its LoopScope.
+    let before = pocopine_core::scope::Scope::count();
+    host.query_selector(".r64k-remove")
+        .unwrap()
+        .unwrap()
+        .dyn_ref::<HtmlElement>()
+        .unwrap()
+        .click();
+    tick().await;
+    assert_eq!(host.query_selector_all(".r64k-row").unwrap().length(), 2);
+    let after = pocopine_core::scope::Scope::count();
+
+    assert_eq!(
+        after,
+        before - 1,
+        "fast-path removal must evict the removed row's loop scope \
+         (scopes {before} -> {after})",
+    );
+
+    host.remove();
+}
+
+/// Row removal must be effect-neutral: everything nested in the row —
+/// component scopes, reactive effects, listeners — releases with it. Before
+/// the fix the drain paths only detached the DOM (relying on a
+/// MutationObserver removed in RFC-058 Phase 6.5), leaking all of it.
+#[wasm_bindgen_test]
+async fn removing_a_keyed_row_releases_its_nested_effects() {
+    register_all();
+    reset_plan_failure_count();
+
+    let host = mount("<plan-row-portal-host></plan-row-portal-host>");
+    tick().await;
+
+    async fn remove_once(host: &Element) {
+        host.query_selector(".prph-remove")
+            .unwrap()
+            .unwrap()
+            .dyn_ref::<HtmlElement>()
+            .unwrap()
+            .click();
+        tick().await;
+    }
+
+    // Warm-up removal absorbs one-time lazy state, then a steady-state
+    // removal must strictly DROP live effects (the removed row's).
+    remove_once(&host).await; // 2 rows → 1
+    let (before, _) = pocopine_core::reactive::stats();
+    remove_once(&host).await; // 1 row → 0
+    let (after, _) = pocopine_core::reactive::stats();
+    assert!(
+        after < before,
+        "removing a row must release its nested effects (before={before}, after={after})"
+    );
+
+    host.remove();
+}
+
+/// Deleting a keyed pp-for row must reap any portal clone its subtree
+/// teleported to `<body>` (AgenKitty finding 11: deleting a tree row while
+/// its context menu was open/closing orphaned the panel at the viewport
+/// corner indefinitely). Row teardown is table-driven — it never walks the
+/// row's DOM — so the clone stashed on the portal's origin element inside
+/// the row was never released.
+#[wasm_bindgen_test]
+async fn deleting_a_row_reaps_its_teleported_portal_clone() {
+    register_all();
+    reset_plan_failure_count();
+
+    let host = mount("<plan-row-portal-host></plan-row-portal-host>");
+    tick().await;
+    let body = doc().body().unwrap();
+
+    // Open the FIRST row's portal → clone lands at <body>.
+    host.query_selector(".prph-row .ptsc-open")
+        .unwrap()
+        .expect("row's portal trigger mounts")
+        .dyn_ref::<HtmlElement>()
+        .unwrap()
+        .click();
+    tick().await;
+    assert!(
+        body.query_selector(".ptsc-body .prph-content")
+            .unwrap()
+            .is_some(),
+        "portal clone must be at <body> while the row lives"
+    );
+
+    // Delete the first row while its portal is OPEN.
+    host.query_selector(".prph-remove")
+        .unwrap()
+        .unwrap()
+        .dyn_ref::<HtmlElement>()
+        .unwrap()
+        .click();
+    tick().await;
+
+    assert!(
+        host.query_selector_all(".prph-row").unwrap().length() == 1,
+        "one row must remain"
+    );
+    // The orphan: the clone must be gone with its row.
+    assert!(
+        body.query_selector(".ptsc-body").unwrap().is_none(),
+        "deleting the row must reap its teleported clone: {:?}",
+        body.query_selector(".ptsc-body")
+            .unwrap()
+            .map(|n| n.outer_html())
+    );
+
+    // Cleanup for later tests.
     if let Some(node) = body.query_selector(".ptsc-body").unwrap() {
         node.remove();
     }


### PR DESCRIPTION
Fixes AgenKitty finding 11: deleting a tree row while its context menu was open (or mid close-animation) left the teleported panel orphaned at `<body>` — its anchor gone, it repositioned to the viewport corner and stayed visible **indefinitely**. The app currently works around it by deferring the store removal 250 ms.

## Root cause — wider than teleport

RFC-058 Phase 6.5 removed the MutationObserver that used to release removed subtrees asynchronously, and patched the **bulk-clear** path ("synchronous bulk teardown does the work directly below") — but the four **per-row** removal lanes still only detached the DOM:

| Lane | Where |
|---|---|
| keyed sync drain (no transition) | `run_keyed` pool drain |
| keyed animated drain | `leave_subtree` completion |
| compiled single-row fast path | `try_single_remove_fast_path` (early-returns before the drain — found in review) |
| unkeyed rebuild | `remove_or_leave` (`run_naive`) |

Nothing released the removed row's subtree: every nested component **scope, effect, and listener leaked**, and a `pp-teleport` clone stashed on a descendant element was invisible to the table-driven row cleanup (`ROW_INSTANCES`/`LIST_WATCHERS` know nothing about DOM expandos) — hence the orphan. This also explains why the 1 s leave backstop "didn't cover it": the backstop only exists if a leave teardown *ran*; the row — and the `pp-if` controller that owns the clone — died before one ever could.

```mermaid
sequenceDiagram
    participant U as user
    participant R as tree row (pp-for)
    participant C as cond controller (pp-if+pp-teleport)
    participant B as clone at <body>
    U->>C: select item → close starts (leave animating)
    U->>R: server confirms → row removed from Vec
    Note over R: OLD: remove_child only —<br/>no release_subtree
    Note over C: controller dies silently,<br/>owns B, tears down nothing
    Note over B: orphaned forever,<br/>repositions to viewport corner
```

## Fix

Each per-row lane now calls `mount::release_subtree` on the row element after detaching it — the same post-removal contract `pp-if`'s leave completion already follows. That walk runs `teleport::release` on the stash element, reaping the clone **whether the portal was open, closing, or mid-leave**: teardown is owned by the row's eviction, animated or not.

Two subtleties handled:
- the animated lane releases in the **completion only**, preserving the leaver-resume contract (a re-added key cancels the leave and keeps its clone);
- when the leave completes **synchronously** (reduced motion / disabled animations), the already-released entry is kept out of the reuse pool so a re-added key can't resurrect a scope-less clone (review finding).

Deliberately **not** changed: the two bulk clear-all lanes stay table-driven — they are the RFC-054 perf lever for 10K-row clears, and compiled-row scopes are envelope-guaranteed not to hold this state. Generic rows with teleporting descendants cleared through the bulk lane remain a known gap (follow-up).

New debug API: `Scope::count()` (debug/devtools-gated) — compiled rows have no per-row effects, so a leaked `LoopScope` is invisible to the effect counter; this is the metric that catches it.

## Tests (each verified to FAIL against the unfixed code)

| Test | Pins |
|---|---|
| `deleting_a_row_reaps_its_teleported_portal_clone` | open menu → delete row → clone must leave `<body>` |
| `deleting_a_row_mid_close_animation_reaps_the_portal_clone` | the exact reported timeline with real `pp-transition:leave*` attrs + CSS; a self-check asserts the leave window actually opened (test can't pass vacuously); rides out the full 1 s backstop to prove the late completion no-ops |
| `removing_a_keyed_row_releases_its_nested_effects` | steady-state row removal strictly drops live effect count (the wider leak) |
| `compiled_single_remove_fast_path_releases_the_row_scope` | the fast path evicts exactly the removed row's `LoopScope` (n → n−1) |

Suites: template_plan (52) · pine (121 — dropdowns/menus/popovers on these exact code paths) · core host (165) · fmt · clippy-wasm — all green. Codex review: 2 rounds, P2s found and fixed (fourth lane, sync-leave reuse, vacuous test).

Downstream: AgenKitty can drop the 250 ms deferral in `agent_client::delete_thread`.
