### PR TITLE
sync: delete tombstones + implementor-provided principal scope (wipe-and-re-sync)

### DIFF
--- a/crates/pocopine-sync-indexdb/src/wasm.rs
+++ b/crates/pocopine-sync-indexdb/src/wasm.rs
@@ -253,9 +253,12 @@ async fn save_snapshot(database_name: String, snapshot: LocalSnapshotBatch) -> S
     // Only overwrite when the caller carries a value; passing `None`
     // from a code path that hasn't observed the advertised version yet
     // must not clobber a previously recorded value. Mirrors the
-    // `coalesce(...)` in the SQLite UPSERT.
+    // `coalesce(...)` in the SQLite UPSERT. Same contract for `scope`.
     if let Some(version) = snapshot.application_schema_version {
         state.application_schema_version = Some(version);
+    }
+    if let Some(scope) = snapshot.scope {
+        state.scope = Some(scope);
     }
     put_stream_state(&store, &state).await?;
     await_transaction(done).await?;

--- a/crates/pocopine-sync-query/src/client.rs
+++ b/crates/pocopine-sync-query/src/client.rs
@@ -1027,9 +1027,8 @@ impl QueryClient {
             return;
         };
         for sub in self.collect_subscriptions_on_stream::<Row>(stream) {
-            let (compartment, canonical, cursor, app_version) = {
+            let (compartment, canonical, cursor, app_version, scope) = {
                 let state = sub.state().borrow();
-                let sub_stream = sub.query().stream().clone();
                 let canonical: Vec<SyncRow<Value>> = state
                     .canonical_rows()
                     .filter_map(|row| {
@@ -1043,10 +1042,11 @@ impl QueryClient {
                     })
                     .collect();
                 (
-                    pocopine_sync::local_stream_key(&sub_stream, sub.query().params()),
+                    pocopine_sync::local_stream_key(sub.query().stream(), sub.query().params()),
                     canonical,
                     state.cursor.clone(),
                     state.application_schema_version,
+                    state.sync_scope.clone(),
                 )
             };
             // sync-query has no separate "collection" surface; reuse the
@@ -1061,7 +1061,8 @@ impl QueryClient {
                 canonical,
                 cursor,
             )
-            .with_application_schema_version(app_version);
+            .with_application_schema_version(app_version)
+            .with_scope(scope);
             if let Err(err) = store.save_snapshot(batch).await {
                 tracing::warn!(
                     target: "pocopine.log",
@@ -1471,36 +1472,38 @@ impl QueryClient {
                 if !state.remove_pending(mutation_id).is_empty() {
                     touched = true;
                 }
-                for change in canonical {
-                    match change {
-                        RowChange::Upsert(row) => {
-                            let key = match row_key_of(row) {
-                                Some(k) => k,
-                                None => continue,
-                            };
-                            if typed.matches(row) {
-                                state.upsert_canonical(SyncRow {
-                                    key,
-                                    version: None,
-                                    value: row.clone(),
-                                    pending: false,
-                                    conflict: false,
-                                });
-                                touched = true;
-                            } else if state.canonical_rows().any(|r| r.key == key) {
-                                state.remove_canonical(&key);
-                                touched = true;
+                {
+                    for change in canonical {
+                        match change {
+                            RowChange::Upsert(row) => {
+                                let key = match row_key_of(row) {
+                                    Some(k) => k,
+                                    None => continue,
+                                };
+                                if typed.matches(row) {
+                                    state.upsert_canonical(SyncRow {
+                                        key,
+                                        version: None,
+                                        value: row.clone(),
+                                        pending: false,
+                                        conflict: false,
+                                    });
+                                    touched = true;
+                                } else if state.canonical_rows().any(|r| r.key == key) {
+                                    state.remove_canonical(&key);
+                                    touched = true;
+                                }
                             }
-                        }
-                        RowChange::Delete(key) => {
-                            if state.canonical_rows().any(|r| &r.key == key) {
-                                state.remove_canonical(key);
-                                touched = true;
+                            RowChange::Delete(key) => {
+                                if state.canonical_rows().any(|r| &r.key == key) {
+                                    state.remove_canonical(key);
+                                    touched = true;
+                                }
                             }
                         }
                     }
+                    touched
                 }
-                touched
             };
             if touched {
                 typed.notify_listeners();
@@ -1533,6 +1536,11 @@ impl QueryClient {
     /// matching key remain visible; the merge in `QueryView::rows`
     /// makes the optimistic upsert win over the canonical until
     /// the matching `mutate()` clears it.
+    ///
+    /// Server-confirmed deletes that remove a row a view actually
+    /// held are recorded as `Deleted` evictions on THAT view — every
+    /// affected subscription learns the delete propagated, not just
+    /// the one whose pull carried the tombstone.
     pub(crate) fn route_canonical_pull<Row>(
         inner: &Rc<QueryClientInner>,
         stream: &SyncStreamName,
@@ -1566,8 +1574,16 @@ impl QueryClient {
                             }
                         }
                         RowChange::Delete(key) => {
-                            if state.canonical_contains(key) {
+                            if let Some(row) = state.canonical_get(key).cloned() {
                                 state.remove_canonical(key);
+                                // The server delete actually removed
+                                // a row from THIS view — report it so
+                                // recovery policy on every affected
+                                // view knows never to re-push it.
+                                state.record_evictions(vec![crate::EvictedRow {
+                                    row,
+                                    reason: crate::EvictionReason::Deleted,
+                                }]);
                                 touched = true;
                             }
                         }
@@ -1623,6 +1639,97 @@ impl QueryClient {
     pub(crate) fn take_replay_entries(inner: &Rc<QueryClientInner>) -> Vec<ReplayEntry> {
         let mut q = inner.replay_queue.borrow_mut();
         q.drain(..).collect()
+    }
+
+    /// Driver-only: the scope-drift fan-out fence. A scope drift
+    /// means the SESSION changed principals, so every subscription
+    /// on the stream (of this Row type — exactly the set a settled
+    /// pull fans out to) is holding the previous principal's state,
+    /// not just the subscription whose pull detected the change.
+    /// Reset each one's in-memory state, stamp it with the newly
+    /// observed scope (each then re-syncs cursor-less from its own
+    /// next pull), and return the distinct compartment keys so the
+    /// caller can wipe the durable side too. Without this fence, the
+    /// refetched response would route the new principal's rows into
+    /// sibling views still showing the old principal's data.
+    ///
+    /// Deliberately does NOT notify listeners: the caller notifies
+    /// via [`Self::notify_stream_subscriptions`] AFTER the durable
+    /// wipes finish, so an `on_update` callback reading the store
+    /// can't observe the previous principal's rows post-reset.
+    pub(crate) fn reset_stream_subscriptions_for_scope_drift<Row>(
+        inner: &Rc<QueryClientInner>,
+        stream: &SyncStreamName,
+        new_scope: Option<pocopine_sync::SyncScope>,
+    ) -> Vec<SyncStreamName>
+    where
+        Row: Clone + 'static,
+    {
+        let mut compartments: Vec<SyncStreamName> = Vec::new();
+        for typed in collect_subscriptions_on_stream_inner::<Row>(inner, stream) {
+            {
+                let mut state = typed.state.borrow_mut();
+                // Preserve the advertised schema version across the
+                // scope reset — a pull-path drift has no follow-up
+                // /open to re-learn it before the next persist.
+                let schema_version = state.application_schema_version;
+                state.reset();
+                state.application_schema_version = schema_version;
+                state.sync_scope = new_scope.clone();
+            }
+            compartments.push(pocopine_sync::local_stream_key(
+                stream,
+                typed.query.params(),
+            ));
+        }
+        // The bare-stream compartment too: `persist_pending_mutation`
+        // falls back to it when no subscription matched at mutate
+        // time, and `hydrate_phase` merges its pendings on every
+        // spawn — a previous principal's queued mutation parked
+        // there must not survive the principal change.
+        compartments.push(stream.clone());
+        compartments.sort();
+        compartments.dedup();
+        compartments
+    }
+
+    /// Driver-only: fire `on_update` listeners on every same-stream
+    /// subscription. Pairs with the fence above — called after the
+    /// durable wipes complete.
+    pub(crate) fn notify_stream_subscriptions<Row>(
+        inner: &Rc<QueryClientInner>,
+        stream: &SyncStreamName,
+    ) where
+        Row: Clone + 'static,
+    {
+        for typed in collect_subscriptions_on_stream_inner::<Row>(inner, stream) {
+            typed.notify_listeners_external();
+        }
+    }
+
+    /// Driver-only: drop EVERY queued replay entry, all streams —
+    /// the "clear everything" half of the scope-drift rule. A
+    /// principal change is a SESSION event: queued mutations made
+    /// under the previous principal exist on every stream, and the
+    /// detecting driver's own replay tick drains the client-wide
+    /// queue, so per-stream dropping would let another stream's
+    /// stale mutation push under the new principal before that
+    /// stream observes its own drift. Durable pendings stay in
+    /// their compartments and are dealt with by each stream's own
+    /// drift wipe. Returns the number of entries dropped.
+    pub(crate) fn clear_replay_queue(inner: &Rc<QueryClientInner>) -> usize {
+        let mut q = inner.replay_queue.borrow_mut();
+        let dropped = q.len();
+        q.clear();
+        if dropped > 0 {
+            tracing::info!(
+                target: "pocopine.log",
+                dropped,
+                "sync-query: discarded ALL queued replays on scope drift \
+                 (the session changed principals; clear everything and re-sync)",
+            );
+        }
+        dropped
     }
 
     /// Register a [`crate::Mutator`] impl so the hydrate path can
@@ -2412,6 +2519,30 @@ impl<Row: 'static> QueryView<Row> {
         }
 
         rows
+    }
+
+    /// Drain the eviction report: every previously-canonical row a
+    /// settled `/pull` has removed from this view since the last
+    /// drain, tagged with WHY (see [`crate::EvictionReason`]).
+    ///
+    /// This is the engine-level hook for local-first recovery policy.
+    /// `Deleted` rows were positively tombstoned at the authority —
+    /// the delete has propagated; re-pushing one would resurrect data
+    /// another device deliberately removed. `Unexplained` rows left a
+    /// full snapshot without a tombstone — an app whose rows only
+    /// leave its filter by deletion may choose to re-push them
+    /// ("server-side loss must not become client-side loss"); an app
+    /// with volatile filters should not.
+    ///
+    /// Typical shape: call from an [`Self::on_update`] callback so
+    /// each settle's report is judged exactly once. The buffer is
+    /// bounded (oldest entries drop past 256) so an app that never
+    /// drains doesn't leak.
+    pub fn take_evictions(&self) -> Vec<crate::EvictedRow<Row>>
+    where
+        Row: Clone,
+    {
+        self.handle.shared_state().borrow_mut().take_evictions()
     }
 
     /// Monotonic state-version counter. Bumps on every mutation

--- a/crates/pocopine-sync-query/src/driver.rs
+++ b/crates/pocopine-sync-query/src/driver.rs
@@ -56,7 +56,7 @@ use serde_json::Value;
 
 use crate::client::{QueryClient, QueryClientInner, QuerySubscription};
 use crate::mutator::RowChange;
-use crate::state::PendingOverlay;
+use crate::state::{EvictedRow, EvictionReason, PendingOverlay};
 use crate::wire::{build_open_request, build_pull_request};
 
 /// Default sync endpoint prefix. Re-exported from `pocopine-sync`
@@ -311,10 +311,16 @@ where
         // gate in apply_open will wipe the in-memory state if
         // /open advertises a fresh version; until that lands, the
         // hydrated rows are shown.
-        self.hydrate_phase().await;
+        let hydrated_pendings = self.hydrate_phase().await;
         if !self.epoch.is_current() {
             return;
         }
+        // The principal the pendings were hydrated under — checked
+        // again at enqueue time, because a SIBLING driver's
+        // scope-drift fence can restamp this subscription while our
+        // /open is still in flight, and the captured pendings must
+        // not replay under the fence's new principal.
+        let hydrated_scope = self.with_state_borrow(|s| s.sync_scope.clone()).flatten();
 
         // ── Phase 1: /open ──────────────────────────────────────
         //
@@ -331,6 +337,11 @@ where
                     return;
                 }
                 self.mark_error(err);
+                // Offline-first: without server contact there is no
+                // drift to vet against, so the hydrated pendings
+                // replay as always (the implementor's scope contract
+                // only speaks through responses).
+                self.enqueue_hydrated_pendings(hydrated_pendings, hydrated_scope);
                 // Fall through to the loop so a subsequent retry can
                 // recover when the network comes back.
                 self.run_loop().await;
@@ -340,11 +351,24 @@ where
         if !self.epoch.is_current() {
             return;
         }
-        if let Err(()) = self.apply_open(open_response).await {
-            // Schema-drift path bumped state.version; nothing more
-            // to do here, the next /pull rebuilds the rows. The
-            // durable wipe (clear_stream) was awaited inside
-            // apply_open so it's already on disk.
+        match self.apply_open(open_response).await {
+            OpenOutcome::Clean | OpenOutcome::SchemaDrift => {
+                // The session's principal is confirmed unchanged, so
+                // the hydrated pendings belong to it — queue their
+                // replays now. Enqueueing BEFORE the open would let
+                // another stream's driver drain and push them in the
+                // window before a scope wipe could discard them.
+                // (Schema drift wiped the DURABLE queue per the
+                // schema-bump contract, but these already-hydrated
+                // replays still fire once; the server's
+                // migrate_payload handles stale payload shapes.)
+                self.enqueue_hydrated_pendings(hydrated_pendings, hydrated_scope);
+            }
+            OpenOutcome::ScopeDrift => {
+                // The principal changed: everything the previous one
+                // touched was cleared inside apply_open — the
+                // hydrated pendings go with it.
+            }
         }
 
         // ── Phase 2: initial /pull ──────────────────────────────
@@ -362,9 +386,15 @@ where
         if !self.epoch.is_current() {
             return;
         }
-        self.apply_pull(pull_response);
+        let scope_changed = self.apply_pull(pull_response);
         if !self.epoch.is_current() {
             return;
+        }
+        if scope_changed {
+            self.refetch_after_scope_drift().await;
+            if !self.epoch.is_current() {
+                return;
+            }
         }
         // Persist the freshly-pulled canonical snapshot. Runs after
         // apply_pull so the persisted view matches what's on the
@@ -407,7 +437,10 @@ where
             if !self.epoch.is_current() {
                 return;
             }
-            // 3. Walk pending replay queue (offline-replay).
+            // 3. Walk pending replay queue (offline-replay). A scope
+            //    change inside tick_pull already dropped the previous
+            //    principal's queued entries — whatever remains
+            //    belongs to the current session.
             self.replay_pending().await;
             if !self.epoch.is_current() {
                 return;
@@ -512,7 +545,11 @@ where
     /// Issue a /pull and route results into canonical state.
     /// Errors surface into `state.error`; the next tick retries.
     async fn tick_pull(&self) {
-        let cursor = self.with_state_borrow(|s| s.cursor.clone()).flatten();
+        let Some((cursor, generation)) =
+            self.with_state_borrow(|s| (s.cursor.clone(), s.request_generation()))
+        else {
+            return;
+        };
         let response = match self.send_pull(cursor).await {
             Ok(resp) => resp,
             Err(err) => {
@@ -526,13 +563,125 @@ where
         if !self.epoch.is_current() {
             return;
         }
-        self.apply_pull(response);
+        // Discard the response if ANY reset (a sibling driver's
+        // scope-drift fence, a schema wipe) invalidated the state
+        // this request was issued for — its cursor belongs to state
+        // that no longer exists, and settling it (especially an
+        // Incremental body) would leave a partial view. The next
+        // tick pulls fresh against the reset state.
+        let still_current = self
+            .with_state_borrow(|s| s.request_generation() == generation)
+            .unwrap_or(false);
+        if !still_current {
+            tracing::debug!(
+                target: "pocopine.log",
+                "sync-query: discarding a pull response issued before a state reset",
+            );
+            return;
+        }
+        let scope_changed = self.apply_pull(response);
         if !self.epoch.is_current() {
             return;
+        }
+        if scope_changed {
+            self.refetch_after_scope_drift().await;
+            if !self.epoch.is_current() {
+                return;
+            }
         }
         // Persist after every successful /pull (RFC 088 §A.3) so a
         // reload after the tick observes the latest canonical set.
         self.persist_snapshot().await;
+    }
+
+    /// The re-sync half of a mid-loop scope drift. `apply_pull`
+    /// already discarded the cross-principal response and reset the
+    /// ORIGINATING subscription (the drifted response was requested
+    /// with the OLD principal's cursor, so settling it — especially
+    /// an `Incremental` body — would leave a partial view). Here we
+    /// extend the wipe to EVERY same-stream subscription — the
+    /// session changed for the whole client, and the refetched
+    /// response fans out stream-wide, so sibling views still holding
+    /// the previous principal's state must be cleared BEFORE the
+    /// settle can reach them — make the wipes durable, and
+    /// immediately re-pull WITHOUT a cursor so the new principal's
+    /// view settles from a full snapshot. If the scope is STILL
+    /// flapping on the refetch, we leave the (empty, wiped) state
+    /// for the next tick to retry.
+    async fn refetch_after_scope_drift(&self) {
+        // The originating sub adopted the new scope in apply_pull's
+        // drift branch — read it back to stamp the siblings.
+        let adopted = self.with_state_borrow(|s| s.sync_scope.clone()).flatten();
+        let compartments = match (self.client.upgrade(), self.subscription.upgrade()) {
+            (Some(client_inner), Some(sub)) => {
+                QueryClient::reset_stream_subscriptions_for_scope_drift::<Row>(
+                    &client_inner,
+                    sub.query().stream(),
+                    adopted,
+                )
+            }
+            _ => return,
+        };
+        if let Some(store) = self.local_store.clone() {
+            for compartment in compartments {
+                if let Err(err) = store.clear_stream(&compartment).await {
+                    tracing::warn!(
+                        target: "pocopine.log",
+                        stream = compartment.as_str(),
+                        error = %err,
+                        "sync-query: scope-drift wipe failed; the next persist still \
+                         replaces the compartment's rows",
+                    );
+                }
+                if !self.epoch.is_current() {
+                    return;
+                }
+            }
+        }
+        // Notify AFTER the durable wipes: an `on_update` callback
+        // reading the store must not observe the previous
+        // principal's rows post-reset.
+        if let (Some(client_inner), Some(sub)) =
+            (self.client.upgrade(), self.subscription.upgrade())
+        {
+            QueryClient::notify_stream_subscriptions::<Row>(&client_inner, sub.query().stream());
+        }
+        let response = match self.send_pull(None).await {
+            Ok(resp) => resp,
+            Err(err) => {
+                if self.epoch.is_current() {
+                    self.mark_error(err);
+                }
+                return;
+            }
+        };
+        if !self.epoch.is_current() {
+            return;
+        }
+        if self.apply_pull(response) {
+            // Flapped again mid-refetch — wipe the just-adopted
+            // scope's durable slate too and let the next tick
+            // re-sync.
+            self.clear_durable_compartment().await;
+        }
+    }
+
+    /// Durably wipe this subscription's compartment — the storage
+    /// half of "clear everything and re-sync" on scope drift.
+    async fn clear_durable_compartment(&self) {
+        let Some(store) = self.local_store.clone() else {
+            return;
+        };
+        let compartment = self.compartment_key();
+        if let Err(err) = store.clear_stream(&compartment).await {
+            tracing::warn!(
+                target: "pocopine.log",
+                stream = compartment.as_str(),
+                error = %err,
+                "sync-query: scope-drift wipe failed; the next persist still \
+                 replaces the compartment's rows",
+            );
+        }
     }
 
     /// Walk the pending-replay queue on the client and re-fire
@@ -628,12 +777,14 @@ where
         res.map_err(DriverError::from_server_error)
     }
 
-    /// Apply an `/open` response: validate the stream, detect
-    /// schema drift, install cursor.
+    /// Apply an `/open` response: validate the stream, detect schema
+    /// and scope drift, install cursor.
     ///
-    /// Returns `Err(())` when schema-drift triggered a state
-    /// reset — caller should NOT treat that as a hard error
-    /// (the next `/pull` rebuilds the canonical set).
+    /// Returns which drift (if any) triggered a state reset — never
+    /// a hard error; the next `/pull` rebuilds the canonical set.
+    /// The caller uses the distinction to decide the hydrated
+    /// pendings' fate (kept for schema drift, discarded for scope
+    /// drift).
     ///
     /// Schema-drift wipe atomicity: when drift is detected we
     /// awaited the durable wipe (`clear_stream`) FIRST, then the
@@ -642,9 +793,9 @@ where
     /// transition in one borrow — no observer can land between
     /// `clear_stream` and `reset` and read empty-but-stale-version
     /// state.
-    async fn apply_open(&self, response: SyncOpenResponse) -> Result<(), ()> {
+    async fn apply_open(&self, response: SyncOpenResponse) -> OpenOutcome {
         let Some(sub) = self.subscription.upgrade() else {
-            return Ok(());
+            return OpenOutcome::Clean;
         };
         let stream_name = sub.query().stream().clone();
         let Some(opened) = response
@@ -659,60 +810,150 @@ where
                 "/open response missing stream {}",
                 stream_name.as_str()
             )));
-            return Ok(());
+            return OpenOutcome::Clean;
         };
         let SyncOpenStream {
             cursor,
             schema_version,
+            scope: server_scope,
             ..
         } = opened;
-        // Schema-drift detection MUST run while not holding the
-        // state borrow — the durable wipe is async and we don't
-        // want a `RefMut` held across an .await. Read the cached
-        // version, drop the borrow, run the wipe, then re-borrow
-        // to apply the in-memory transition atomically.
-        let cached = self
-            .with_state_borrow(|s| s.application_schema_version)
-            .flatten();
-        let drift = matches!(cached, Some(c) if c != schema_version);
+        // Drift detection MUST run while not holding the state
+        // borrow — the durable wipe is async and we don't want a
+        // `RefMut` held across an .await. Read the cached values,
+        // drop the borrow, run the wipe, then re-borrow to apply
+        // the in-memory transition atomically.
+        //
+        // Two kinds of drift, one rule — the local cache is stale
+        // or belongs to someone else, so CLEAR EVERYTHING AND
+        // RE-SYNC (the server is the source of truth):
+        //
+        // * schema drift — the advertised application schema
+        //   version differs from the one the cache was written
+        //   under.
+        // * scope drift — the responding principal differs from the
+        //   one the cache settled under (session expired to
+        //   guest/anonymous, user switch, scoping rollback). The
+        //   previous principal's rows AND queued offline mutations
+        //   are discarded; every committed row rebuilds from the
+        //   server on the next pull. A fresh/unstamped cache
+        //   meeting its first scoped response adopts silently — no
+        //   wipe.
+        let (cached_version, cached_scope) = self
+            .with_state_borrow(|s| (s.application_schema_version, s.sync_scope.clone()))
+            .unwrap_or((None, None));
+        let schema_drift = matches!(cached_version, Some(c) if c != schema_version);
+        // The engine only compares two PROVIDED principals: drift
+        // requires both the cached stamp and the advertised scope to
+        // be `Some` and differ. `None` on either side means "no
+        // principal provided" and never triggers anything — users,
+        // sessions, and anonymity are the implementor's model, not
+        // the engine's. Implementors that want expiry/anonymous
+        // transitions detected return a token for those sessions too.
+        let scope_drift = matches!(
+            (&cached_scope, &server_scope),
+            (Some(cached), Some(advertised)) if cached != advertised
+        );
+        let drift = schema_drift || scope_drift;
         if drift {
             tracing::info!(
                 target: "pocopine.log",
                 stream = stream_name.as_str(),
-                from = ?cached,
-                to = schema_version,
-                "sync-query: schema drift detected; resetting state + wiping store",
+                schema_drift,
+                scope_drift,
+                "sync-query: drift detected at /open; clearing local state + re-syncing",
             );
-            if let Some(store) = &self.local_store {
+            if scope_drift {
+                // The previous principal's queued replays must not
+                // push under the new session — drop them alongside
+                // the durable wipe. (Schema-only drift deliberately
+                // leaves the queue alone: sibling queries' pendings
+                // are still this principal's, and stale-schema
+                // payloads are the server's migrate_payload
+                // contract, not the client's problem.)
+                if let Some(client_inner) = self.client.upgrade() {
+                    QueryClient::clear_replay_queue(&client_inner);
+                }
+                // The session changed principals for the WHOLE
+                // client: fence every same-stream subscription (this
+                // one included) — in-memory reset + new stamp — and
+                // wipe every compartment, including the bare-stream
+                // pending fallback, so the initial pull's fan-out
+                // can't mix the new principal's rows into a sibling
+                // still holding the old principal's hydrated state.
+                let compartments = match self.client.upgrade() {
+                    Some(client_inner) => {
+                        QueryClient::reset_stream_subscriptions_for_scope_drift::<Row>(
+                            &client_inner,
+                            &stream_name,
+                            server_scope.clone(),
+                        )
+                    }
+                    None => Vec::new(),
+                };
+                if let Some(store) = &self.local_store {
+                    for compartment in compartments {
+                        if let Err(err) = store.clear_stream(&compartment).await {
+                            tracing::warn!(
+                                target: "pocopine.log",
+                                stream = compartment.as_str(),
+                                error = %err,
+                                "sync-query: drift wipe failed; in-memory reset still proceeds",
+                            );
+                        }
+                        if !self.epoch.is_current() {
+                            return OpenOutcome::Clean;
+                        }
+                    }
+                }
+                // Notify AFTER the durable wipes: an `on_update`
+                // callback reading the store must not observe the
+                // previous principal's rows post-reset (Codex).
+                if let Some(client_inner) = self.client.upgrade() {
+                    QueryClient::notify_stream_subscriptions::<Row>(&client_inner, &stream_name);
+                }
+            } else if let Some(store) = &self.local_store {
                 let compartment = self.compartment_key();
                 if let Err(err) = store.clear_stream(&compartment).await {
                     tracing::warn!(
                         target: "pocopine.log",
                         stream = stream_name.as_str(),
                         error = %err,
-                        "sync-query: schema-drift wipe failed; in-memory reset still proceeds",
+                        "sync-query: drift wipe failed; in-memory reset still proceeds",
                     );
                 }
                 if !self.epoch.is_current() {
-                    return Ok(());
+                    return OpenOutcome::Clean;
                 }
             }
         }
         let mut state = sub.state().borrow_mut();
         if drift {
-            // Reset BEFORE writing the new schema_version so an
-            // observer that reads inside the RefMut would see
+            // Reset BEFORE writing the new schema_version/scope so
+            // an observer that reads inside the RefMut sees
             // `(canonical_empty, version=new)` rather than
             // `(canonical_stale, version=new)`.
             state.reset();
         }
         state.application_schema_version = Some(schema_version);
+        // The stamp is sticky: only a PROVIDED principal updates it,
+        // so a gap of unscoped responses can't erase the last known
+        // owner between two provided-but-different principals.
+        if let Some(scope) = server_scope {
+            state.sync_scope = Some(scope);
+        }
         state.cursor = cursor;
         state.error.clear();
         state.last_reason = SyncReason::Initial;
         drop(state);
         sub.notify_listeners_external();
-        if drift { Err(()) } else { Ok(()) }
+        if scope_drift {
+            OpenOutcome::ScopeDrift
+        } else if schema_drift {
+            OpenOutcome::SchemaDrift
+        } else {
+            OpenOutcome::Clean
+        }
     }
 
     /// Apply a `/pull` response.
@@ -727,39 +968,200 @@ where
     ///
     /// `Incremental` mode just routes the deltas through
     /// `route_canonical_pull`; nothing is wiped first.
-    fn apply_pull(&self, response: SyncPullResponse<Value>) {
+    ///
+    /// Tombstones (either mode) are positive server deletes: they
+    /// route as `RowChange::Delete` to EVERY subscription on the
+    /// stream — the server is the source of truth, so a delete at
+    /// the authority always propagates to the client.
+    ///
+    /// The originating subscription additionally gets an eviction
+    /// report: every previously-canonical row the settle removed,
+    /// tagged `Deleted` (tombstoned) or `Unexplained` (absent from a
+    /// full snapshot with no tombstone). See [`EvictionReason`] for
+    /// what app policy may do with each.
+    ///
+    /// Returns `true` when the response's scope named a DIFFERENT
+    /// principal than the one this subscription settled under
+    /// (session expired mid-loop, user switch). In that case the
+    /// previous principal's local state was cleared — in-memory
+    /// reset, cursor dropped, queued replays discarded, the new
+    /// scope adopted — and the response itself was DISCARDED, not
+    /// settled: it was requested with the old principal's cursor,
+    /// so an `Incremental` body would be a partial delta of the new
+    /// principal's view. The caller must `clear_stream` the durable
+    /// compartment and immediately re-pull WITHOUT a cursor so the
+    /// re-sync settles from a full snapshot (Codex: no cursored
+    /// settles across a principal change).
+    fn apply_pull(&self, response: SyncPullResponse<Value>) -> bool {
         let Some(sub) = self.subscription.upgrade() else {
-            return;
+            return false;
         };
         let Some(client_inner) = self.client.upgrade() else {
-            return;
+            return false;
         };
+
+        // ── Scope drift: clear everything and re-sync ───────────
+        // The response names the principal the session belongs to
+        // NOW. If that differs from the principal this subscription
+        // settled under, the local state (rows, overlays, queued
+        // replays) belongs to someone else — discard it ALL,
+        // including this response, and re-sync fresh. The server is
+        // the source of truth; committed rows rebuild from it. A
+        // fresh/unstamped subscription adopts the first observed
+        // scope silently.
+        let established = {
+            let state = sub.state().borrow();
+            state.sync_scope.clone()
+        };
+        // The engine only compares two PROVIDED principals: drift
+        // requires both the established stamp and the response scope
+        // to be `Some` and differ. `None` on either side means "no
+        // principal provided" and never triggers anything.
+        let scope_drift = matches!(
+            (&established, &response.scope),
+            (Some(mine), Some(theirs)) if mine != theirs
+        );
+        if scope_drift {
+            tracing::info!(
+                target: "pocopine.log",
+                stream = response.stream.as_str(),
+                "sync-query: pull scope changed; clearing local state + re-syncing",
+            );
+            QueryClient::clear_replay_queue(&client_inner);
+            let mut state = sub.state().borrow_mut();
+            // Preserve the advertised schema version across the
+            // scope reset: there is no follow-up /open on this path
+            // to re-learn it, and persisting the refetched rows with
+            // `None` would make the next reload adopt a future
+            // schema bump without the intended wipe.
+            let schema_version = state.application_schema_version;
+            state.reset();
+            state.application_schema_version = schema_version;
+            state.sync_scope = response.scope.clone();
+            return true;
+        }
+        if established.is_none() && response.scope.is_some() {
+            sub.state().borrow_mut().sync_scope = response.scope.clone();
+        }
+
         let stream = response.stream.clone();
         let new_cursor = response.cursor.clone();
+        let is_snapshot = matches!(response.mode, SyncPullMode::Snapshot);
 
         // Build a Vec<RowChange<Row>> from the wire response.
         // Decode failures are warned + skipped per RFC 086.
-        let changes = decode_pull_changes::<Row>(&response);
+        let mut changes = decode_pull_changes::<Row>(&response);
 
-        if matches!(response.mode, SyncPullMode::Snapshot) {
+        // Keys this response positively carries a row FOR, straight
+        // from the wire envelope — snapshot rows plus incremental
+        // upserts. Wire-level (not the decoded set) because a row
+        // that failed to DECODE is still present at the authority
+        // and must not read as evicted or deletable.
+        let mut present_keys: std::collections::HashSet<pocopine_sync::RowKey> =
+            response.rows.iter().map(|r| r.key.clone()).collect();
+        for change in &response.changes {
+            if matches!(change.op, pocopine_sync::SyncOp::Upsert)
+                && let Some(key) = change
+                    .row
+                    .as_ref()
+                    .map(|row| row.key.clone())
+                    .or_else(|| change.key.clone())
+            {
+                present_keys.insert(key);
+            }
+        }
+        let snapshot_keys = &present_keys;
+
+        // Fold tombstones into the routed change set. A tombstone
+        // whose key the same response also carries a row for
+        // (snapshot row, or incremental upsert — a row recreated or
+        // updated inside the tombstone retention window) is
+        // contradictory — trust the row (presence is the stronger
+        // claim) and warn.
+        let mut tombstone_keys: std::collections::HashSet<pocopine_sync::RowKey> =
+            std::collections::HashSet::new();
+        for tombstone in &response.tombstones {
+            if present_keys.contains(&tombstone.key) {
+                tracing::warn!(
+                    target: "pocopine.log",
+                    stream = stream.as_str(),
+                    key = tombstone.key.as_str(),
+                    "sync-query: /pull carried a tombstone for a key the same \
+                     response also carries a row for; ignoring the tombstone",
+                );
+                continue;
+            }
+            if tombstone_keys.insert(tombstone.key.clone()) {
+                changes.push(RowChange::Delete(tombstone.key.clone()));
+            }
+        }
+
+        // Capture the originating subscription's previous canonical
+        // rows BEFORE the snapshot wipe — the eviction report is the
+        // diff between them and what this settle explains.
+        // (Incremental settles don't wipe; their deletes are
+        // recorded by the routing engine per affected view.)
+        let prev_rows: Vec<SyncRow<Row>> = if is_snapshot {
+            let state = sub.state().borrow();
+            state.canonical_rows().cloned().collect()
+        } else {
+            Vec::new()
+        };
+
+        if is_snapshot && !prev_rows.is_empty() {
             // Wipe only THIS subscription's canonical set; the
             // routing engine's predicate evaluation below
             // re-inserts the matching rows. Other subscriptions
             // on the same stream are untouched — their cursors
             // and snapshots are independent.
-            let keys: Vec<pocopine_sync::RowKey> = {
-                let state = sub.state().borrow();
-                state.canonical_rows().map(|r| r.key.clone()).collect()
-            };
-            if !keys.is_empty() {
-                let mut state = sub.state().borrow_mut();
-                for key in keys {
-                    state.remove_canonical(&key);
-                }
+            let mut state = sub.state().borrow_mut();
+            for row in &prev_rows {
+                state.remove_canonical(&row.key);
             }
         }
 
         QueryClient::route_canonical_pull::<Row>(&client_inner, &stream, &changes);
+
+        // Eviction report for the originating subscription. The
+        // routing engine records `Deleted` evictions on every view a
+        // server delete actually removed a row from — which covers
+        // incremental mode entirely, and covers OTHER subscriptions
+        // in snapshot mode. The originating snapshot subscription is
+        // the exception: its rows were wiped BEFORE routing, so the
+        // Delete routing found nothing to remove there — its Deleted
+        // (tombstoned ∩ previously-held) and Unexplained reports are
+        // computed here from the pre-wipe capture.
+        let evictions: Vec<EvictedRow<Row>> = if is_snapshot {
+            // A truncated snapshot (server said has_more, or the row
+            // count hit the query's own limit) can't distinguish
+            // "absent" from "beyond the page" — suppress Unexplained
+            // reports and only keep the positive deletes.
+            let truncated = response.has_more
+                || sub
+                    .query()
+                    .limit()
+                    .is_some_and(|limit| response.rows.len() as u64 >= u64::from(limit));
+            prev_rows
+                .into_iter()
+                .filter_map(|row| {
+                    if tombstone_keys.contains(&row.key) {
+                        Some(EvictedRow {
+                            row,
+                            reason: EvictionReason::Deleted,
+                        })
+                    } else if !snapshot_keys.contains(&row.key) && !truncated {
+                        Some(EvictedRow {
+                            row,
+                            reason: EvictionReason::Unexplained,
+                        })
+                    } else {
+                        None
+                    }
+                })
+                .collect()
+        } else {
+            Vec::new()
+        };
 
         // Update cursor and reason on the originating
         // subscription (not all subscriptions on the stream — a
@@ -767,6 +1169,7 @@ where
         // this one, since each subscription's /pull is
         // independent).
         let mut state = sub.state().borrow_mut();
+        state.record_evictions(evictions);
         state.cursor = new_cursor;
         state.syncing = false;
         state.loading = false;
@@ -774,6 +1177,7 @@ where
         state.error.clear();
         drop(state);
         sub.notify_listeners_external();
+        scope_drift
     }
 
     /// Stable cache compartment for this driver's subscription.
@@ -799,9 +1203,15 @@ where
     /// Failures are warned and skipped — the subsequent `/open`
     /// + `/pull` rebuild from scratch, the user just doesn't get
     ///   the instant-paint UX.
-    async fn hydrate_phase(&self) {
+    ///
+    /// Returns the hydrated pending mutations. The caller queues
+    /// their replays only AFTER `/open` settles the drift question —
+    /// enqueueing earlier would let another stream's driver drain
+    /// and push them in the window before a drift wipe discards
+    /// them.
+    async fn hydrate_phase(&self) -> Vec<pocopine_sync::ClientMutation<Value>> {
         let Some(store) = self.local_store.clone() else {
-            return;
+            return Vec::new();
         };
         let compartment = self.compartment_key();
         let mut snapshot = match store.hydrate_stream(&compartment).await {
@@ -813,11 +1223,11 @@ where
                     error = %err,
                     "sync-query: hydrate failed; continuing with empty state",
                 );
-                return;
+                return Vec::new();
             }
         };
         if !self.epoch.is_current() {
-            return;
+            return Vec::new();
         }
         // Codex P2: also drain the bare-stream compartment's pending
         // queue. `persist_pending_mutation` writes into the
@@ -854,13 +1264,59 @@ where
                 }
             }
             if !self.epoch.is_current() {
-                return;
+                return Vec::new();
             }
         }
         let Some(sub) = self.subscription.upgrade() else {
+            return Vec::new();
+        };
+        self.apply_hydrated_snapshot(&sub, snapshot)
+    }
+
+    /// Queue the replays for pendings returned by
+    /// [`Self::hydrate_phase`]. Split from the hydrate so `run()` can
+    /// order it AFTER a drift-free `/open`.
+    ///
+    /// `hydrated_scope` is the principal the pendings were hydrated
+    /// under. The same both-provided-and-different rule as every
+    /// other scope check applies at this last gate: if a sibling
+    /// driver's scope-drift fence restamped this subscription with a
+    /// DIFFERENT provided principal while our /open was in flight,
+    /// the pendings belong to the wiped slate and are dropped.
+    fn enqueue_hydrated_pendings(
+        &self,
+        pendings: Vec<pocopine_sync::ClientMutation<Value>>,
+        hydrated_scope: Option<pocopine_sync::SyncScope>,
+    ) {
+        if pendings.is_empty() {
+            return;
+        }
+        let (Some(client_inner), Some(sub)) = (self.client.upgrade(), self.subscription.upgrade())
+        else {
             return;
         };
-        self.apply_hydrated_snapshot(&sub, snapshot);
+        let current_scope = sub.state().borrow().sync_scope.clone();
+        // A REPLAY only fires when the principal context it was
+        // captured under is UNCHANGED. That includes None -> Some:
+        // an orphan pending hydrated with no provided principal
+        // (bare-stream fallback, pre-scope cache) must not replay
+        // once /open names one — the naming itself is new context
+        // the pending was never attributed to.
+        if current_scope.is_some() && hydrated_scope != current_scope {
+            tracing::info!(
+                target: "pocopine.log",
+                stream = sub.query().stream().as_str(),
+                dropped = pendings.len(),
+                "sync-query: discarding hydrated replays; the subscription was \
+                 restamped with a different principal while /open was in flight",
+            );
+            return;
+        }
+        QueryClient::enqueue_hydrated_pending(
+            &client_inner,
+            sub.query().stream().clone(),
+            pendings,
+        );
     }
 
     /// The driver's bare stream name (without the params hash).
@@ -884,7 +1340,7 @@ where
         &self,
         sub: &Rc<QuerySubscription<Row>>,
         snapshot: LocalStreamSnapshot,
-    ) {
+    ) -> Vec<pocopine_sync::ClientMutation<Value>> {
         let stream_name = sub.query().stream().clone();
         let mut state = sub.state().borrow_mut();
         // Adopt the cached schema_version BEFORE writing rows so
@@ -892,6 +1348,14 @@ where
         // version + rows together (we never expose a row count
         // with a stale schema_version).
         state.application_schema_version = snapshot.application_schema_version;
+        // Adopt the compartment's scope stamp — the principal these
+        // cached rows were settled under. `apply_open` reconciles it
+        // against the server's freshly-advertised scope. An unstamped
+        // compartment maps to never-observed (the durable stamp can't
+        // distinguish "legacy" from "observed unscoped"; that's safe
+        // across reloads because the initial pull is cursor-less and
+        // snapshot-replaces).
+        state.sync_scope = snapshot.scope.clone();
         state.cursor = snapshot.cursor.clone();
         // Hydrated canonical rows. Per-row decode failures are
         // logged and skipped; the next /pull will resurface them
@@ -977,25 +1441,15 @@ where
         // mark_loading bumps loading=true).
         // If apply_open detects drift it resets state + notifies
         // empty; if not, the rows stay visible.
-        // Hand persisted pending mutations to the client-level
-        // replay path so the first tick after /open runs them
-        // through the registered MutatorRegistry → AnyMutator.
-        // We pass the wire mutation list (with persistence
-        // envelope intact); the registry unwraps before invoking
-        // apply_remote.
-        let Some(client_inner) = self.client.upgrade() else {
-            return;
-        };
-        let stream_for_replay = stream_name;
-        QueryClient::enqueue_hydrated_pending(
-            &client_inner,
-            stream_for_replay,
-            snapshot
-                .pending_mutations
-                .into_iter()
-                .map(|p| p.mutation)
-                .collect(),
-        );
+        // Return the persisted pending mutations for the caller to
+        // hand to the client-level replay path AFTER a drift-free
+        // /open — the registry unwraps the persistence envelope
+        // before invoking apply_remote.
+        snapshot
+            .pending_mutations
+            .into_iter()
+            .map(|p| p.mutation)
+            .collect()
     }
 
     /// Persist the current canonical state into the local store.
@@ -1014,9 +1468,9 @@ where
         // because the local store contract is `SyncRow<Value>`.
         let snapshot_inputs = {
             let state = sub.state().borrow();
-            let stream = sub.query().stream().clone();
             let cursor = state.cursor.clone();
             let app_version = state.application_schema_version;
+            let scope = state.sync_scope.clone();
             let canonical: Vec<SyncRow<Value>> = state
                 .canonical_rows()
                 .filter_map(|row| {
@@ -1049,10 +1503,12 @@ where
                         .with_optimistic_row(optimistic_row)
                 })
                 .collect();
-            (stream, cursor, app_version, canonical, pending)
+            (cursor, app_version, scope, canonical, pending)
         };
-        let (stream, cursor, app_version, canonical, pending) = snapshot_inputs;
-        let compartment = local_stream_key(&stream, sub.query().params());
+        let (cursor, app_version, scope, canonical, pending) = snapshot_inputs;
+        // Redirect-aware: after a scope redirect this is the
+        // scope-qualified sibling, not the primary key.
+        let compartment = self.compartment_key();
         // sync-query streams don't have a separate "collection"
         // surface; reuse the stream name as the collection token
         // so the local store's compartment is stable. The
@@ -1071,7 +1527,8 @@ where
             }
         };
         let batch = LocalSnapshotBatch::new(compartment.clone(), collection, canonical, cursor)
-            .with_application_schema_version(app_version);
+            .with_application_schema_version(app_version)
+            .with_scope(scope);
         if let Err(err) = store.save_snapshot(batch).await {
             tracing::warn!(
                 target: "pocopine.log",
@@ -1357,6 +1814,24 @@ impl std::fmt::Debug for ReplayEntry {
             .field("mutation_id", &self.mutation_id)
             .finish_non_exhaustive()
     }
+}
+
+/// What `apply_open` did with the advertised stream metadata —
+/// drives whether the hydrated pending mutations may be enqueued
+/// for replay.
+#[derive(Debug)]
+enum OpenOutcome {
+    /// No drift: metadata applied, cached state confirmed.
+    Clean,
+    /// The application schema version changed: state + compartment
+    /// were wiped, BUT the session's principal did not change — the
+    /// hydrated pendings still belong to it and replay once (the
+    /// server's `migrate_payload` contract owns stale payload
+    /// shapes).
+    SchemaDrift,
+    /// The provided principal changed: everything the previous
+    /// principal touched was cleared, hydrated pendings included.
+    ScopeDrift,
 }
 
 /// Why the driver woke up. Returned from `wait_for_tick` so the

--- a/crates/pocopine-sync-query/src/lib.rs
+++ b/crates/pocopine-sync-query/src/lib.rs
@@ -81,7 +81,7 @@ pub use predicate::{
 };
 pub use query::{MatchFn, Order, OrderBy, PartitionHashFn, Query, QueryBuilder, QueryKey};
 pub use selector::{AnyArgs, AnyTrackable, SelectorId, SelectorView, TrackToken};
-pub use state::QueryState;
+pub use state::{EvictedRow, EvictionReason, QueryState};
 
 // RFC 090 Phase 1 — Query-native server source. The crate also
 // continues to expose CRUD-shaped registration through

--- a/crates/pocopine-sync-query/src/source.rs
+++ b/crates/pocopine-sync-query/src/source.rs
@@ -33,7 +33,7 @@ use std::sync::Arc;
 
 use pocopine_sync::{
     RowVersion, StreamParams, SyncCollectionName, SyncError, SyncOp, SyncRejectedMutation,
-    SyncResult, SyncRow, SyncStreamName,
+    SyncResult, SyncRow, SyncScope, SyncStreamName, SyncTombstone,
 };
 use serde::Serialize;
 use serde::de::DeserializeOwned;
@@ -245,6 +245,53 @@ pub trait Source: Send + Sync + 'static {
         id: Self::Id,
         expected_version: Option<RowVersion>,
     ) -> SourceFuture<'a, SyncResult<DeleteResult<Self::Row>>>;
+
+    /// Positive deletion records for rows this query would have
+    /// matched (see [`SyncTombstone`]). The adapter attaches the
+    /// returned tombstones to every snapshot pull response, so
+    /// clients can tell "deleted at the authority" apart from "absent
+    /// for an unknown reason" and propagate server deletes with
+    /// confidence instead of guessing from absence.
+    ///
+    /// Default: empty — sources that don't track deletions keep the
+    /// pre-tombstone behavior (all absences unexplained). Sources
+    /// that do (a `deleted_at` column, a deletions side table) should
+    /// scope the result the same way `list_stream` scopes rows
+    /// (tenant filters from `query.params()`) and GC entries after a
+    /// retention window comfortably longer than the longest expected
+    /// client offline period — a too-short window degrades to
+    /// "unexplained absence", never to a wrong delete.
+    fn list_tombstones<'a>(
+        &'a self,
+        ctx: Self::Context,
+        query: &'a Query<Self::Row>,
+    ) -> SourceFuture<'a, SyncResult<Vec<SyncTombstone>>> {
+        let _ = (ctx, query);
+        Box::pin(async { Ok(Vec::new()) })
+    }
+
+    /// Opaque principal scope for one extracted [`Self::Context`].
+    ///
+    /// Mirrors [`pocopine_sync::SyncStreamSource::scope`] at the typed
+    /// layer: the adapter extracts the context once, then projects it
+    /// through this method and stamps the result onto `/open` and
+    /// `/pull` responses.
+    ///
+    /// **The implementor provides the principal — the engine never
+    /// models one.** The client compares two PROVIDED tokens for
+    /// equality; when they differ, it clears its local state and
+    /// re-syncs from the server. `None` (the default) means "no
+    /// principal provided" and never triggers anything. So: if you
+    /// want session expiry, anonymous access, or user switches to
+    /// invalidate the client cache, return a token for those sessions
+    /// too (e.g. `Some("anon")`, or the session id) — a `None` gap
+    /// between two different tokens is fine (the client's stamp is
+    /// sticky), but a transition INTO a `None`-scoped session is
+    /// invisible to the engine by design.
+    fn scope(&self, ctx: &Self::Context) -> SyncResult<Option<SyncScope>> {
+        let _ = ctx;
+        Ok(None)
+    }
 
     /// Provide an idempotency log keyed on this Source's writes.
     /// Default: `None` — `SourceResource` auto-provisions an
@@ -549,6 +596,22 @@ where
         Ok(())
     }
 
+    /// Delegate to [`Source::scope`] after the usual typed-context
+    /// extraction, so a `Source` impl only thinks in terms of its own
+    /// `Context` type. The open/pull handlers stamp the result onto
+    /// their responses.
+    fn scope<'a>(
+        &'a self,
+        ctx: &'a pocopine_core::server::RequestContext,
+    ) -> pocopine_sync::SyncBoxFuture<'a, Option<SyncScope>> {
+        let source = self.source.clone();
+        let ctx = ctx.clone();
+        Box::pin(async move {
+            let source_ctx = source.extract_context(ctx).await?;
+            source.scope(&source_ctx)
+        })
+    }
+
     /// RFC 088 §C: delegate to the closure attached via
     /// [`SourceResource::params_of`]. Phase 4 will auto-wire from the
     /// macro.
@@ -622,7 +685,7 @@ where
             // a `Vec<Row>` and wraps it in `futures::stream::iter`
             // gets the same correctness behaviour with no streaming
             // benefit, which is the right escape hatch.
-            let mut row_stream = source.list_stream(source_ctx, &query);
+            let mut row_stream = source.list_stream(source_ctx.clone(), &query);
             // Codex review P2: the cap is `effective_limit`, NOT
             // `max_snapshot_rows`. A `.limit(10)` pull must not
             // ship more than 10 rows even if the source ignores
@@ -664,6 +727,13 @@ where
                 );
             }
 
+            // Positive deletion records ride the same snapshot so the
+            // client can apply server deletes with confidence and
+            // classify the remaining absences. Collected AFTER the row
+            // stream is fully drained (and dropped) so sources backed
+            // by a single connection don't see interleaved queries.
+            let tombstones = source.list_tombstones(source_ctx, &query).await?;
+
             let mut sync_rows: Vec<SyncRow<Value>> = Vec::with_capacity(rows.len());
             for row in rows {
                 let key = (id_of)(&row).to_row_key()?;
@@ -691,9 +761,22 @@ where
                 });
             }
 
-            Ok(pocopine_sync::SyncPullResponse::snapshot(
-                stream, collection, sync_rows, None,
-            ))
+            // Codex R1 P2: a page that FILLS the effective limit may
+            // be truncated — the adapter clamps even unlimited
+            // queries to `max_snapshot_rows`, and the client can't
+            // see that implicit cap. Say so via `has_more` so the
+            // client suppresses `Unexplained` eviction reports for
+            // rows beyond the page instead of misreading pagination
+            // as loss. Conservative by design: a view holding
+            // EXACTLY `cap` rows also reports `has_more` (the server
+            // can't cheaply disprove an extra row when the source
+            // honors the pushed-down limit).
+            let has_more = source_overyielded || sync_rows.len() >= cap;
+            let mut response =
+                pocopine_sync::SyncPullResponse::snapshot(stream, collection, sync_rows, None)
+                    .with_tombstones(tombstones);
+            response.has_more = has_more;
+            Ok(response)
         })
     }
 
@@ -1210,11 +1293,11 @@ mod tests {
         let query: Query<Issue> = query_from_pull_request(&request);
 
         let ctx = test_ctx();
-        let source_ctx = source.extract_context(ctx).await.expect("extract_context");
+        source.extract_context(ctx).await.expect("extract_context");
         let rows: Vec<Issue> = {
             use futures::stream::StreamExt;
             source
-                .list_stream(source_ctx, &query)
+                .list_stream((), &query)
                 .collect::<Vec<_>>()
                 .await
                 .into_iter()

--- a/crates/pocopine-sync-query/src/state.rs
+++ b/crates/pocopine-sync-query/src/state.rs
@@ -15,8 +15,43 @@
 
 use std::collections::BTreeMap;
 
-use pocopine_sync::{ClientMutation, MutationId, RowKey, SyncCursor, SyncReason, SyncRow};
+use pocopine_sync::{
+    ClientMutation, MutationId, RowKey, SyncCursor, SyncReason, SyncRow, SyncScope,
+};
 use serde::{Deserialize, Serialize};
+
+/// Why a canonical row left the view on a settled pull.
+///
+/// The server snapshot stays authoritative either way — the row IS
+/// removed from the view. The reason tells app-level recovery policy
+/// what it may safely do about it.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum EvictionReason {
+    /// The authority carried a tombstone for this key: the row was
+    /// positively deleted. Re-pushing it would resurrect data another
+    /// device deliberately removed — don't.
+    Deleted,
+    /// The row was absent from a full snapshot with no tombstone. The
+    /// engine can't tell "no longer matches the query's filter" from
+    /// "lost at the backend" — that's app policy. A local-first app
+    /// whose rows only ever leave the view by deletion may treat this
+    /// as recoverable and re-push; an app with volatile filters should
+    /// not.
+    Unexplained,
+}
+
+/// One canonical row a settled pull removed from the view, plus why.
+/// Drained via `QueryView::take_evictions`.
+#[derive(Clone, Debug)]
+pub struct EvictedRow<Row> {
+    pub row: SyncRow<Row>,
+    pub reason: EvictionReason,
+}
+
+/// Cap on the eviction report buffer. A consumer that never drains
+/// must not turn the buffer into a leak; on overflow the OLDEST
+/// entries drop first (the newest evictions are the actionable ones).
+const MAX_EVICTIONS: usize = 256;
 
 /// Per-query reactive state. Lives inside a `QuerySubscription`; readers
 /// (via `QueryHandle`) get a reactive borrow.
@@ -29,12 +64,30 @@ pub struct QueryState<Row> {
     canonical_rows: BTreeMap<RowKey, SyncRow<Row>>,
     /// In-flight optimistic mutations, in apply order.
     pending: Vec<PendingOverlay<Row>>,
+    /// Rows settled pulls removed from the view, awaiting a
+    /// `take_evictions` drain. In-memory only — hydrating a stale
+    /// eviction report after reload would hand the app rows to
+    /// re-judge that the next pull re-derives anyway.
+    #[serde(skip)]
+    evictions: Vec<EvictedRow<Row>>,
     /// Server cursor for the next incremental pull.
     pub cursor: Option<SyncCursor>,
     /// Schema version this state's canonical rows were fetched under.
     /// `None` means "never observed" (fresh state); compared on every
     /// open to detect schema drift on this query's compartment.
     pub application_schema_version: Option<u32>,
+    /// Last principal PROVIDED BY THE IMPLEMENTOR that this state's
+    /// canonical rows were settled under (via `Source::scope` /
+    /// `SyncStreamSource::scope` on the server). The engine does not
+    /// model users, sessions, or anonymity — it only compares two
+    /// provided tokens for equality: when both this and a response's
+    /// scope are `Some` and differ, the local state belongs to a
+    /// different principal and the engine clears everything and
+    /// re-syncs. `None` (here or on a response) simply means "no
+    /// principal provided" and never triggers anything. Implementors
+    /// that want session-expiry or anonymous transitions detected
+    /// return a token for those sessions too.
+    pub sync_scope: Option<SyncScope>,
     /// True while the first hydrate + pull are in flight.
     pub loading: bool,
     /// True while a background pull / push is in flight after the first.
@@ -97,8 +150,10 @@ impl<Row> Default for QueryState<Row> {
         Self {
             canonical_rows: BTreeMap::new(),
             pending: Vec::new(),
+            evictions: Vec::new(),
             cursor: None,
             application_schema_version: None,
+            sync_scope: None,
             loading: false,
             syncing: false,
             stale: false,
@@ -144,6 +199,23 @@ impl<Row> QueryState<Row> {
     pub fn pending(&self) -> &[PendingOverlay<Row>] {
         &self.pending
     }
+
+    /// Generation token for in-flight work: every `reset()` bumps it,
+    /// so a task that captured the token before an `.await` can
+    /// detect that the state its request was issued for no longer
+    /// exists (scope-drift fence, schema wipe) and discard the
+    /// response instead of settling it.
+    pub fn request_generation(&self) -> u64 {
+        self.request_generation
+    }
+
+    /// Rows settled pulls have removed from the view since the last
+    /// drain, oldest first. Prefer `QueryView::take_evictions` — a
+    /// drain — so each eviction is judged once; this accessor exists
+    /// for read-only inspection.
+    pub fn evictions(&self) -> &[EvictedRow<Row>] {
+        &self.evictions
+    }
 }
 
 // `remove_canonical` / `push_pending` / `remove_pending` are entrypoints
@@ -156,6 +228,7 @@ impl<Row: Clone> QueryState<Row> {
     pub fn reset(&mut self) {
         self.canonical_rows.clear();
         self.pending.clear();
+        self.evictions.clear();
         self.cursor = None;
         self.loading = false;
         self.syncing = false;
@@ -190,6 +263,33 @@ impl<Row: Clone> QueryState<Row> {
     pub(crate) fn push_pending(&mut self, overlay: PendingOverlay<Row>) {
         self.pending.push(overlay);
         self.bump_version();
+    }
+
+    /// Append eviction records from a settled pull, keeping the buffer
+    /// bounded (oldest entries drop first past [`MAX_EVICTIONS`]).
+    pub(crate) fn record_evictions(&mut self, evicted: Vec<EvictedRow<Row>>) {
+        if evicted.is_empty() {
+            return;
+        }
+        self.evictions.extend(evicted);
+        if self.evictions.len() > MAX_EVICTIONS {
+            let excess = self.evictions.len() - MAX_EVICTIONS;
+            self.evictions.drain(..excess);
+        }
+        self.bump_version();
+    }
+
+    /// Drain the eviction report. Each entry is handed out exactly
+    /// once.
+    pub(crate) fn take_evictions(&mut self) -> Vec<EvictedRow<Row>> {
+        if self.evictions.is_empty() {
+            return Vec::new();
+        }
+        // Draining is a state change observers may care about (an
+        // "n unsynced rows" badge clearing) — bump like every other
+        // mutation.
+        self.bump_version();
+        std::mem::take(&mut self.evictions)
     }
 
     /// Internal helper for the routing engine. Removes EVERY pending

--- a/crates/pocopine-sync-query/tests/driver.rs
+++ b/crates/pocopine-sync-query/tests/driver.rs
@@ -154,6 +154,7 @@ fn open_response(schema_version: u32, cursor: Option<SyncCursor>) -> SyncOpenRes
         collection: SyncCollectionName::new(COLLECTION).unwrap(),
         cursor,
         schema_version,
+        scope: None,
         params: pocopine_sync::StreamParams::new(),
     }])
 }
@@ -191,6 +192,165 @@ fn test_config() -> QueryClientConfig {
         disable_live: true,
         ..QueryClientConfig::default()
     }
+}
+
+#[tokio::test]
+async fn tombstones_delete_with_confidence_and_absences_report_unexplained() {
+    // Snapshot 1: rows a, b, c. Snapshot 2: only a, plus a tombstone
+    // for b. The engine must (1) remove BOTH b and c from the view —
+    // the server snapshot is the source of truth either way — and
+    // (2) report b as Deleted (tombstoned: don't resurrect) and c as
+    // Unexplained (absent with no explanation: app policy decides).
+    let local = LocalSet::new();
+    local
+        .run_until(async {
+            reset_middleware();
+            let pull_calls = Rc::new(RefCell::new(0u32));
+            let pull_for_mw = pull_calls.clone();
+            install_middleware(move |req: FetchRequest, _next: FetchNext| {
+                let pull_for_mw = pull_for_mw.clone();
+                async move {
+                    match req.url.as_str() {
+                        SYNC_OPEN_PATH => Ok(json_response(&open_response(1, None))),
+                        SYNC_PULL_PATH => {
+                            let n = {
+                                let mut c = pull_for_mw.borrow_mut();
+                                *c += 1;
+                                *c
+                            };
+                            let issue = |id: &str, title: &str| Issue {
+                                id: id.into(),
+                                workspace_id: "W1".into(),
+                                title: title.into(),
+                            };
+                            let response = if n == 1 {
+                                snapshot_response(vec![
+                                    issue("a", "kept"),
+                                    issue("b", "deleted elsewhere"),
+                                    issue("c", "lost at the server"),
+                                ])
+                            } else {
+                                snapshot_response(vec![issue("a", "kept")]).with_tombstones(vec![
+                                    pocopine_sync::SyncTombstone::new("b").unwrap(),
+                                ])
+                            };
+                            Ok(json_response(&response))
+                        }
+                        other => Err(ServerError::Network(format!("unexpected {other}"))),
+                    }
+                }
+            });
+
+            let client = query_client_plugin().config(test_config()).into_client();
+            let view = client.observe(Issue::query().eq(issues::field::workspace_id, "W1").build());
+            settle_ticks(3).await;
+            assert_eq!(view.rows().len(), 3, "first snapshot populated");
+            // The first snapshot settled onto an empty subscription —
+            // nothing was evicted.
+            assert!(view.take_evictions().is_empty());
+
+            // Wait for the second poll tick to settle.
+            settle_ticks(12).await;
+            let rows = view.rows();
+            assert_eq!(
+                rows.iter().map(|r| r.id.as_str()).collect::<Vec<_>>(),
+                vec!["a"],
+                "server truth wins: both the tombstoned and the absent row leave the view"
+            );
+
+            let evictions = view.take_evictions();
+            let mut summary: Vec<(String, pocopine_sync_query::EvictionReason)> = evictions
+                .iter()
+                .map(|e| (e.row.key.as_str().to_string(), e.reason))
+                .collect();
+            summary.sort_by(|a, b| a.0.cmp(&b.0));
+            assert_eq!(
+                summary,
+                vec![
+                    (
+                        "b".to_string(),
+                        pocopine_sync_query::EvictionReason::Deleted
+                    ),
+                    (
+                        "c".to_string(),
+                        pocopine_sync_query::EvictionReason::Unexplained
+                    ),
+                ]
+            );
+            // Drained exactly once.
+            assert!(view.take_evictions().is_empty());
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn truncated_snapshots_suppress_unexplained_evictions() {
+    // A snapshot that fills the query's own limit can't distinguish
+    // "absent" from "beyond the page": rows past the limit still
+    // leave the canonical set (server truth), but they must NOT be
+    // reported as Unexplained — a recovery policy acting on them
+    // would re-push rows the server still has.
+    let local = LocalSet::new();
+    local
+        .run_until(async {
+            reset_middleware();
+            let pull_calls = Rc::new(RefCell::new(0u32));
+            let pull_for_mw = pull_calls.clone();
+            install_middleware(move |req: FetchRequest, _next: FetchNext| {
+                let pull_for_mw = pull_for_mw.clone();
+                async move {
+                    match req.url.as_str() {
+                        SYNC_OPEN_PATH => Ok(json_response(&open_response(1, None))),
+                        SYNC_PULL_PATH => {
+                            let n = {
+                                let mut c = pull_for_mw.borrow_mut();
+                                *c += 1;
+                                *c
+                            };
+                            let issue = |id: &str| Issue {
+                                id: id.into(),
+                                workspace_id: "W1".into(),
+                                title: id.into(),
+                            };
+                            // First snapshot: two rows (under limit).
+                            // Second: two DIFFERENT rows, exactly at
+                            // the limit — the old rows' absence is
+                            // unexplainable.
+                            let response = if n == 1 {
+                                snapshot_response(vec![issue("a"), issue("b")])
+                            } else {
+                                snapshot_response(vec![issue("x"), issue("y")])
+                            };
+                            Ok(json_response(&response))
+                        }
+                        other => Err(ServerError::Network(format!("unexpected {other}"))),
+                    }
+                }
+            });
+
+            let client = query_client_plugin().config(test_config()).into_client();
+            let view = client.observe(
+                Issue::query()
+                    .eq(issues::field::workspace_id, "W1")
+                    .limit(2)
+                    .build(),
+            );
+            settle_ticks(3).await;
+            assert_eq!(view.rows().len(), 2);
+            settle_ticks(12).await;
+
+            let rows = view.rows();
+            assert_eq!(
+                rows.iter().map(|r| r.id.as_str()).collect::<Vec<_>>(),
+                vec!["x", "y"],
+                "the full second snapshot still replaces the view"
+            );
+            assert!(
+                view.take_evictions().is_empty(),
+                "a limit-filling snapshot reports no Unexplained evictions"
+            );
+        })
+        .await;
 }
 
 #[tokio::test]
@@ -483,4 +643,91 @@ fn live_event_filter_drops_non_matching_params() {
     assert!(pocopine_sync_query::live_event_matches_params(
         &want, &empty
     ));
+}
+
+#[tokio::test]
+async fn incremental_upserts_beat_retained_tombstones_for_the_same_key() {
+    // A row deleted and then RECREATED inside the tombstone retention
+    // window arrives as an incremental upsert alongside its retained
+    // tombstone. Presence is the stronger claim: the upsert must win,
+    // while a non-conflicting tombstone in the same delta still
+    // deletes.
+    let local = LocalSet::new();
+    local
+        .run_until(async {
+            reset_middleware();
+            let pull_calls = Rc::new(RefCell::new(0u32));
+            let pull_for_mw = pull_calls.clone();
+            install_middleware(move |req: FetchRequest, _next: FetchNext| {
+                let pull_for_mw = pull_for_mw.clone();
+                async move {
+                    match req.url.as_str() {
+                        SYNC_OPEN_PATH => Ok(json_response(&open_response(1, None))),
+                        SYNC_PULL_PATH => {
+                            let n = {
+                                let mut c = pull_for_mw.borrow_mut();
+                                *c += 1;
+                                *c
+                            };
+                            let issue = |id: &str| Issue {
+                                id: id.into(),
+                                workspace_id: "W1".into(),
+                                title: id.into(),
+                            };
+                            let response = if n == 1 {
+                                snapshot_response(vec![issue("kept"), issue("doomed")])
+                            } else {
+                                // Incremental delta: "reborn" was
+                                // deleted AND recreated in the window
+                                // (upsert + retained tombstone);
+                                // "doomed" only has its tombstone.
+                                let reborn = issue("reborn");
+                                let change = pocopine_sync::SyncChange {
+                                    stream: SyncStreamName::new(STREAM).unwrap(),
+                                    collection: SyncCollectionName::new(COLLECTION).unwrap(),
+                                    key: Some(pocopine_sync::RowKey::new("reborn").unwrap()),
+                                    op: pocopine_sync::SyncOp::Upsert,
+                                    row: Some(
+                                        SyncRow::new(
+                                            "reborn",
+                                            serde_json::to_value(&reborn).unwrap(),
+                                        )
+                                        .unwrap(),
+                                    ),
+                                    cursor: SyncCursor::new("c_2").unwrap(),
+                                };
+                                SyncPullResponse::incremental(
+                                    SyncStreamName::new(STREAM).unwrap(),
+                                    SyncCollectionName::new(COLLECTION).unwrap(),
+                                    vec![change],
+                                    Some(SyncCursor::new("c_2").unwrap()),
+                                )
+                                .with_tombstones(vec![
+                                    pocopine_sync::SyncTombstone::new("reborn").unwrap(),
+                                    pocopine_sync::SyncTombstone::new("doomed").unwrap(),
+                                ])
+                            };
+                            Ok(json_response(&response))
+                        }
+                        other => Err(ServerError::Network(format!("unexpected {other}"))),
+                    }
+                }
+            });
+
+            let client = query_client_plugin().config(test_config()).into_client();
+            let view = client.observe(Issue::query().eq(issues::field::workspace_id, "W1").build());
+            settle_ticks(3).await;
+            assert_eq!(view.rows().len(), 2, "initial snapshot settled");
+            settle_ticks(12).await;
+
+            let mut ids: Vec<String> = view.rows().into_iter().map(|r| r.id).collect();
+            ids.sort();
+            assert_eq!(
+                ids,
+                vec!["kept", "reborn"],
+                "the recreated row survives its retained tombstone; \
+                 the plain tombstone still deletes"
+            );
+        })
+        .await;
 }

--- a/crates/pocopine-sync-query/tests/persistence.rs
+++ b/crates/pocopine-sync-query/tests/persistence.rs
@@ -157,6 +157,7 @@ fn open_response(schema_version: u32, cursor: Option<SyncCursor>) -> SyncOpenRes
         collection: SyncCollectionName::new(COLLECTION).unwrap(),
         cursor,
         schema_version,
+        scope: None,
         params: StreamParams::new(),
     }])
 }
@@ -823,6 +824,532 @@ async fn external_change_survives_offline_reload() {
                 assert_eq!(rows[0].id, "issue_ws");
                 assert_eq!(rows[0].title, "delivered over WS");
             }
+        })
+        .await;
+}
+
+// ─── Scope guard: cross-principal clobber prevention ────────────────
+
+thread_local! {
+    // (scope, rows) the mock server currently answers with — flipped
+    // mid-test to simulate a session expiring to a different
+    // principal or a user switch between reloads.
+    static SERVER_PRINCIPAL: RefCell<(String, Vec<Issue>)> =
+        const { RefCell::new((String::new(), Vec::new())) };
+}
+
+fn set_server_principal(scope: &str, rows: Vec<Issue>) {
+    SERVER_PRINCIPAL.with(|p| *p.borrow_mut() = (scope.to_string(), rows));
+}
+
+fn install_scoped_middleware() {
+    reset_middleware();
+    install_middleware(|req: FetchRequest, _next: FetchNext| async move {
+        let (scope, rows) = SERVER_PRINCIPAL.with(|p| p.borrow().clone());
+        // Empty principal = the server answers UNSCOPED (an
+        // anonymous session on a stream that only scopes
+        // authenticated principals, or a scoping rollback).
+        let scope = (!scope.is_empty()).then(|| pocopine_sync::SyncScope::new(scope).unwrap());
+        match req.url.as_str() {
+            SYNC_OPEN_PATH => {
+                let mut response = open_response(1, None);
+                response.streams[0].scope = scope;
+                Ok(json_response(&response))
+            }
+            SYNC_PULL_PATH => Ok(json_response(&snapshot_response(rows).with_scope(scope))),
+            other => Err(ServerError::Network(format!("unexpected {other}"))),
+        }
+    });
+}
+
+fn w1_issue(id: &str) -> Issue {
+    Issue {
+        id: id.into(),
+        workspace_id: "W1".into(),
+        title: id.into(),
+    }
+}
+
+fn w1_query() -> pocopine_sync_query::Query<Issue> {
+    Issue::query().eq(issues::field::workspace_id, "W1").build()
+}
+
+fn w1_compartment() -> SyncStreamName {
+    let stream = SyncStreamName::new(STREAM).unwrap();
+    let mut params = StreamParams::new();
+    params.insert("workspace_id".into(), serde_json::json!("W1"));
+    local_stream_key(&stream, &params)
+}
+
+#[tokio::test]
+async fn scope_change_wipes_local_state_and_resyncs() {
+    // THE rule: when the responding principal changes (session
+    // expired to a guest, user switch), the local cache is someone
+    // else's — clear everything and re-sync. The server is the
+    // source of truth; committed rows rebuild from it when the
+    // original session returns.
+    let local = LocalSet::new();
+    local
+        .run_until(async {
+            install_scoped_middleware();
+            set_server_principal("user:alice", vec![w1_issue("a1"), w1_issue("a2")]);
+
+            let store = Rc::new(MemoryLocalStore::new());
+            let store_handle: Rc<dyn SyncLocalStore> = store.clone();
+            let client = query_client_plugin()
+                .config(test_config_with_store(store_handle))
+                .into_client();
+            let view = client.observe(w1_query());
+            settle(4).await;
+            assert_eq!(view.rows().len(), 2, "alice's snapshot settled");
+
+            // Session expires: the server now answers as guest with
+            // an empty view. Alice's local state is cleared and the
+            // guest truth settles.
+            set_server_principal("guest", Vec::new());
+            for _ in 0..6 {
+                tokio::time::sleep(Duration::from_millis(40)).await;
+            }
+            assert_eq!(
+                view.rows().len(),
+                0,
+                "scope change wiped the previous principal's view"
+            );
+            let persisted = store.hydrate_stream(&w1_compartment()).await.unwrap();
+            assert!(
+                persisted.rows.is_empty(),
+                "the durable compartment was cleared and re-persisted as the new truth"
+            );
+            assert_eq!(
+                persisted.scope,
+                Some(pocopine_sync::SyncScope::new("guest").unwrap()),
+                "the compartment is stamped with the current principal"
+            );
+
+            // Alice's session returns: wipe the guest state, re-sync
+            // her rows FROM THE SERVER — nothing depends on the local
+            // cache surviving.
+            set_server_principal(
+                "user:alice",
+                vec![w1_issue("a1"), w1_issue("a2"), w1_issue("a3")],
+            );
+            for _ in 0..6 {
+                tokio::time::sleep(Duration::from_millis(40)).await;
+            }
+            assert_eq!(view.rows().len(), 3, "alice re-synced from server truth");
+            let persisted = store.hydrate_stream(&w1_compartment()).await.unwrap();
+            assert_eq!(persisted.rows.len(), 3);
+            assert_eq!(
+                persisted.scope,
+                Some(pocopine_sync::SyncScope::new("user:alice").unwrap())
+            );
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn queued_mutations_are_discarded_on_principal_change() {
+    // Unpushed offline mutations belong to the session that made
+    // them. When the principal changes, they are DISCARDED along
+    // with the rest of the local state — never pushed under the new
+    // principal, and not resurrected when the original returns
+    // (clear everything and re-sync; the server is the source of
+    // truth for what exists).
+    let local = LocalSet::new();
+    local
+        .run_until(async {
+            install_scoped_middleware();
+            set_server_principal("user:alice", vec![w1_issue("a1")]);
+            FLAKY_MODE.with(|m| *m.borrow_mut() = FlakyMode::Offline);
+            FLAKY_HITS.with(|h| h.borrow_mut().clear());
+
+            let store = Rc::new(MemoryLocalStore::new());
+            let store_handle: Rc<dyn SyncLocalStore> = store.clone();
+            let client = query_client_plugin()
+                .config(test_config_with_store(store_handle))
+                .into_client();
+            client.register_mutator::<FlakyCreate>();
+            let view = client.observe(w1_query());
+            settle(4).await;
+
+            // Alice queues an offline mutation.
+            let ctx = StubContext::new();
+            client
+                .mutate::<FlakyCreate>(
+                    Issue {
+                        id: "a_queued".into(),
+                        workspace_id: "W1".into(),
+                        title: "alice offline".into(),
+                    },
+                    &ctx,
+                )
+                .await
+                .expect_err("offline mutate returns transport error");
+            assert_eq!(view.state().pending().len(), 1);
+            let hits_after_mutate = FLAKY_HITS.with(|h| h.borrow().len());
+
+            // Principal changes to guest AND the network returns —
+            // the queued mutation must be discarded, not pushed.
+            set_server_principal("guest", Vec::new());
+            FLAKY_MODE.with(|m| *m.borrow_mut() = FlakyMode::Online);
+            for _ in 0..8 {
+                tokio::time::sleep(Duration::from_millis(40)).await;
+            }
+            assert_eq!(
+                FLAKY_HITS.with(|h| h.borrow().len()),
+                hits_after_mutate,
+                "alice's queued mutation must never push under the guest session"
+            );
+            assert_eq!(
+                view.state().pending().len(),
+                0,
+                "the pending overlay was cleared with the rest of alice's state"
+            );
+            let pending = store.pending_mutations(&w1_compartment()).await.unwrap();
+            assert!(pending.is_empty(), "the durable pending was wiped");
+
+            // Alice returns: her view re-syncs from the server; the
+            // discarded mutation stays discarded.
+            set_server_principal("user:alice", vec![w1_issue("a1")]);
+            for _ in 0..8 {
+                tokio::time::sleep(Duration::from_millis(40)).await;
+            }
+            assert_eq!(
+                FLAKY_HITS.with(|h| h.borrow().len()),
+                hits_after_mutate,
+                "the discarded mutation is not resurrected"
+            );
+            assert_eq!(view.rows().len(), 1, "server truth re-synced");
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn principal_round_trip_resyncs_from_the_server() {
+    // alice -> bob -> alice on the same device and query: each
+    // change wipes the compartment and re-syncs the new principal's
+    // truth from the server. One compartment, always owned by the
+    // CURRENT principal — no sibling caches, no stale state.
+    let local = LocalSet::new();
+    local
+        .run_until(async {
+            install_scoped_middleware();
+            let store = Rc::new(MemoryLocalStore::new());
+            let store_handle: Rc<dyn SyncLocalStore> = store.clone();
+            let client = query_client_plugin()
+                .config(test_config_with_store(store_handle))
+                .into_client();
+
+            set_server_principal("user:alice", vec![w1_issue("a1")]);
+            let view = client.observe(w1_query());
+            settle(4).await;
+            assert_eq!(view.rows().len(), 1);
+
+            set_server_principal("user:bob", vec![w1_issue("b1"), w1_issue("b2")]);
+            for _ in 0..6 {
+                tokio::time::sleep(Duration::from_millis(40)).await;
+            }
+            let mut ids: Vec<String> = view.rows().into_iter().map(|r| r.id).collect();
+            ids.sort();
+            assert_eq!(ids, vec!["b1", "b2"], "bob's truth replaced alice's");
+            let persisted = store.hydrate_stream(&w1_compartment()).await.unwrap();
+            assert_eq!(persisted.rows.len(), 2);
+            assert_eq!(
+                persisted.scope,
+                Some(pocopine_sync::SyncScope::new("user:bob").unwrap())
+            );
+
+            set_server_principal("user:alice", vec![w1_issue("a1")]);
+            for _ in 0..6 {
+                tokio::time::sleep(Duration::from_millis(40)).await;
+            }
+            let ids: Vec<String> = view.rows().into_iter().map(|r| r.id).collect();
+            assert_eq!(ids, vec!["a1"], "alice re-synced from the server");
+            let persisted = store.hydrate_stream(&w1_compartment()).await.unwrap();
+            assert_eq!(persisted.rows.len(), 1);
+            assert_eq!(
+                persisted.scope,
+                Some(pocopine_sync::SyncScope::new("user:alice").unwrap())
+            );
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn unstamped_compartment_adopts_the_first_advertised_scope() {
+    // Migration path: a compartment persisted by a pre-scope server
+    // (no stamp) meets a server that started scoping. The client
+    // adopts silently — no wipe, no redirect — and the next persist
+    // stamps the compartment.
+    let local = LocalSet::new();
+    local
+        .run_until(async {
+            // Session 1: an UNSCOPED server persists the compartment.
+            reset_middleware();
+            install_middleware(|req: FetchRequest, _next: FetchNext| async move {
+                match req.url.as_str() {
+                    SYNC_OPEN_PATH => Ok(json_response(&open_response(1, None))),
+                    SYNC_PULL_PATH => {
+                        Ok(json_response(&snapshot_response(vec![w1_issue("legacy")])))
+                    }
+                    other => Err(ServerError::Network(format!("unexpected {other}"))),
+                }
+            });
+            let store = Rc::new(MemoryLocalStore::new());
+            let store_handle: Rc<dyn SyncLocalStore> = store.clone();
+            let client1 = query_client_plugin()
+                .config(test_config_with_store(store_handle.clone()))
+                .into_client();
+            let view1 = client1.observe(w1_query());
+            settle(4).await;
+            assert_eq!(view1.rows().len(), 1);
+            let persisted = store.hydrate_stream(&w1_compartment()).await.unwrap();
+            assert!(
+                persisted.scope.is_none(),
+                "pre-scope compartment is unstamped"
+            );
+            drop(view1);
+            drop(client1);
+            settle(2).await;
+
+            // Session 2: the server now scopes its responses.
+            install_scoped_middleware();
+            set_server_principal("user:alice", vec![w1_issue("legacy"), w1_issue("fresh")]);
+            let client2 = query_client_plugin()
+                .config(test_config_with_store(store_handle))
+                .into_client();
+            let view2 = client2.observe(w1_query());
+            for _ in 0..6 {
+                tokio::time::sleep(Duration::from_millis(40)).await;
+            }
+            assert_eq!(view2.rows().len(), 2, "adoption settles normally, no wipe");
+            let persisted = store.hydrate_stream(&w1_compartment()).await.unwrap();
+            assert_eq!(
+                persisted.scope,
+                Some(pocopine_sync::SyncScope::new("user:alice").unwrap()),
+                "the PRIMARY compartment got stamped on the next persist"
+            );
+            assert_eq!(persisted.rows.len(), 2);
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn external_deletes_record_evictions_on_affected_views() {
+    // Codex R5: a server-confirmed delete routed OUTSIDE a view's own
+    // pull (external change, or another subscription's tombstone)
+    // must still surface as a Deleted eviction on the view it removed
+    // a row from — otherwise that view's recovery policy can never
+    // learn the delete propagated.
+    let local = LocalSet::new();
+    local
+        .run_until(async {
+            reset_middleware();
+            install_middleware(|req: FetchRequest, _next: FetchNext| async move {
+                match req.url.as_str() {
+                    SYNC_OPEN_PATH => Ok(json_response(&open_response(1, None))),
+                    SYNC_PULL_PATH => Ok(json_response(&snapshot_response(vec![
+                        w1_issue("keep"),
+                        w1_issue("doomed"),
+                    ]))),
+                    other => Err(ServerError::Network(format!("unexpected {other}"))),
+                }
+            });
+            let store = Rc::new(MemoryLocalStore::new());
+            let store_handle: Rc<dyn SyncLocalStore> = store.clone();
+            let client = query_client_plugin()
+                .config(test_config_with_store(store_handle))
+                .into_client();
+            let view = client.observe(w1_query());
+            settle(4).await;
+            assert_eq!(view.rows().len(), 2);
+            let _ = view.take_evictions();
+
+            client
+                .apply_external_changes::<Issue>(
+                    &SyncStreamName::new(STREAM).unwrap(),
+                    vec![RowChange::Delete(
+                        pocopine_sync::RowKey::new("doomed").unwrap(),
+                    )],
+                )
+                .await;
+
+            assert_eq!(view.rows().len(), 1, "the external delete propagated");
+            let evictions = view.take_evictions();
+            assert_eq!(evictions.len(), 1);
+            assert_eq!(evictions[0].row.key.as_str(), "doomed");
+            assert_eq!(
+                evictions[0].reason,
+                pocopine_sync_query::EvictionReason::Deleted
+            );
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn offline_first_mutations_work_on_a_hydrated_stamped_view() {
+    // Codex R7: a reload that starts OFFLINE hydrates alice's stamped
+    // compartment but never observes a session scope. Her mutation
+    // must still render on her own view and persist into her own
+    // compartment — never-observed is permissive, only a POSITIVELY
+    // different session scope gates mutation routing.
+    let local = LocalSet::new();
+    local
+        .run_until(async {
+            // Session 1 (online): alice settles and stamps the
+            // compartment.
+            install_scoped_middleware();
+            set_server_principal("user:alice", vec![w1_issue("a1")]);
+            let store = Rc::new(MemoryLocalStore::new());
+            let store_handle: Rc<dyn SyncLocalStore> = store.clone();
+            let client1 = query_client_plugin()
+                .config(test_config_with_store(store_handle.clone()))
+                .into_client();
+            let view1 = client1.observe(w1_query());
+            settle(4).await;
+            assert_eq!(view1.rows().len(), 1);
+            drop(view1);
+            drop(client1);
+            settle(2).await;
+
+            // Session 2: fully offline — every request fails.
+            reset_middleware();
+            install_middleware(|_req: FetchRequest, _next: FetchNext| async move {
+                Err(ServerError::Network("offline".into()))
+            });
+            FLAKY_MODE.with(|m| *m.borrow_mut() = FlakyMode::Offline);
+            let client2 = query_client_plugin()
+                .config(test_config_with_store(store_handle))
+                .into_client();
+            client2.register_mutator::<FlakyCreate>();
+            let view2 = client2.observe(w1_query());
+            settle(4).await;
+            assert_eq!(view2.rows().len(), 1, "hydrate painted alice's cache");
+
+            let ctx = StubContext::new();
+            client2
+                .mutate::<FlakyCreate>(
+                    Issue {
+                        id: "a_offline_first".into(),
+                        workspace_id: "W1".into(),
+                        title: "offline edit".into(),
+                    },
+                    &ctx,
+                )
+                .await
+                .expect_err("offline mutate returns transport error");
+
+            assert!(
+                view2.rows().iter().any(|r| r.id == "a_offline_first"),
+                "the offline edit renders on the hydrated stamped view"
+            );
+            let pending = store.pending_mutations(&w1_compartment()).await.unwrap();
+            assert_eq!(
+                pending.len(),
+                1,
+                "the offline edit persists into the view's own compartment, not the bare fallback"
+            );
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn scope_drift_clears_sibling_subscriptions_on_the_same_stream() {
+    // Two live queries on one stream: the drift detected by either
+    // driver must clear BOTH — the refetched response fans out
+    // stream-wide, and a sibling still holding the previous
+    // principal's rows would otherwise mix the two until its own
+    // next tick.
+    let local = LocalSet::new();
+    local
+        .run_until(async {
+            install_scoped_middleware();
+            set_server_principal("user:alice", vec![w1_issue("a1"), w1_issue("a2")]);
+
+            let store = Rc::new(MemoryLocalStore::new());
+            let store_handle: Rc<dyn SyncLocalStore> = store.clone();
+            let client = query_client_plugin()
+                .config(test_config_with_store(store_handle))
+                .into_client();
+            let view_a = client.observe(w1_query());
+            let view_b = client.observe(
+                Issue::query()
+                    .eq(issues::field::workspace_id, "W1")
+                    .limit(10)
+                    .build(),
+            );
+            settle(4).await;
+            assert_eq!(view_a.rows().len(), 2);
+            assert_eq!(view_b.rows().len(), 2);
+
+            // Principal changes; whichever driver ticks first fences
+            // BOTH subscriptions before its refetch settles.
+            set_server_principal("user:bob", vec![w1_issue("b1")]);
+            for _ in 0..8 {
+                tokio::time::sleep(Duration::from_millis(40)).await;
+            }
+            let ids_a: Vec<String> = view_a.rows().into_iter().map(|r| r.id).collect();
+            let ids_b: Vec<String> = view_b.rows().into_iter().map(|r| r.id).collect();
+            assert_eq!(ids_a, vec!["b1"], "no alice leftovers in view A");
+            assert_eq!(ids_b, vec!["b1"], "no alice leftovers in view B");
+        })
+        .await;
+}
+
+#[tokio::test]
+async fn scope_drift_wipes_the_bare_stream_pending_fallback() {
+    // A mutation whose predicate matched NO active subscription
+    // parks its durable pending in the bare-stream compartment;
+    // hydrate merges that queue on every driver spawn. A principal
+    // change must wipe it too — otherwise the old principal's
+    // queued mutation replays under whoever reloads next.
+    let local = LocalSet::new();
+    local
+        .run_until(async {
+            install_scoped_middleware();
+            set_server_principal("user:alice", vec![w1_issue("a1")]);
+            FLAKY_MODE.with(|m| *m.borrow_mut() = FlakyMode::Offline);
+
+            let store = Rc::new(MemoryLocalStore::new());
+            let store_handle: Rc<dyn SyncLocalStore> = store.clone();
+            let client = query_client_plugin()
+                .config(test_config_with_store(store_handle))
+                .into_client();
+            client.register_mutator::<FlakyCreate>();
+            let _view = client.observe(w1_query());
+            settle(4).await;
+
+            // A W2 row matches no active subscription — the pending
+            // falls back to the bare-stream compartment.
+            let ctx = StubContext::new();
+            client
+                .mutate::<FlakyCreate>(
+                    Issue {
+                        id: "w2_orphan".into(),
+                        workspace_id: "W2".into(),
+                        title: "no matching view".into(),
+                    },
+                    &ctx,
+                )
+                .await
+                .expect_err("offline mutate returns transport error");
+            let bare = SyncStreamName::new(STREAM).unwrap();
+            assert_eq!(
+                store.pending_mutations(&bare).await.unwrap().len(),
+                1,
+                "the orphan pending parked in the bare compartment"
+            );
+
+            // Principal changes: the drift wipe covers the bare
+            // fallback too.
+            set_server_principal("user:bob", vec![w1_issue("b1")]);
+            for _ in 0..8 {
+                tokio::time::sleep(Duration::from_millis(40)).await;
+            }
+            assert!(
+                store.pending_mutations(&bare).await.unwrap().is_empty(),
+                "alice's orphan pending must not survive the principal change"
+            );
         })
         .await;
 }

--- a/crates/pocopine-sync-query/tests/source_phase1.rs
+++ b/crates/pocopine-sync-query/tests/source_phase1.rs
@@ -63,6 +63,9 @@ type ObservedCalls = Arc<Mutex<Vec<(BTreeMap<String, Value>, Option<u32>)>>>;
 #[derive(Clone)]
 struct IssuesSource {
     rows: Arc<Mutex<Vec<Issue>>>,
+    /// (row key, workspace_id) pairs the source retains as deletion
+    /// records — the backing table for `list_tombstones`.
+    deleted: Arc<Mutex<Vec<(String, String)>>>,
     observed: ObservedCalls,
 }
 
@@ -87,8 +90,17 @@ impl IssuesSource {
         ];
         Self {
             rows: Arc::new(Mutex::new(rows)),
+            deleted: Arc::new(Mutex::new(Vec::new())),
             observed: Arc::new(Mutex::new(Vec::new())),
         }
+    }
+
+    fn with_deleted(self, key: &str, workspace: &str) -> Self {
+        self.deleted
+            .lock()
+            .unwrap()
+            .push((key.to_string(), workspace.to_string()));
+        self
     }
 }
 
@@ -135,6 +147,33 @@ impl Source for IssuesSource {
             .take(limit)
             .collect();
         Box::pin(futures::stream::iter(filtered.into_iter().map(Ok)))
+    }
+
+    fn list_tombstones<'a>(
+        &'a self,
+        _ctx: (),
+        query: &'a Query<Self::Row>,
+    ) -> SourceFuture<'a, SyncResult<Vec<pocopine_sync::SyncTombstone>>> {
+        // Deletion records honor the same tenant filter as
+        // `list_stream` — a W1 subscription never learns about W2's
+        // deletes.
+        let workspace_filter = query
+            .params()
+            .get("workspace_id")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let deleted = self.deleted.lock().unwrap().clone();
+        Box::pin(async move {
+            deleted
+                .into_iter()
+                .filter(|(_, w)| workspace_filter.as_deref().is_none_or(|f| w == f))
+                .map(|(key, _)| pocopine_sync::SyncTombstone::new(key))
+                .collect()
+        })
+    }
+
+    fn scope(&self, _ctx: &()) -> SyncResult<Option<pocopine_sync::SyncScope>> {
+        Ok(Some(pocopine_sync::SyncScope::new("tenant:test")?))
     }
 
     fn get<'a>(
@@ -230,6 +269,68 @@ async fn pull(
     let outer: pocopine_core::ServerResult<SyncPullResponse<Value>> =
         serde_json::from_slice(&bytes).unwrap();
     outer.unwrap()
+}
+
+#[tokio::test]
+async fn snapshot_pull_carries_tenant_filtered_tombstones_and_scope() {
+    // The adapter attaches `Source::list_tombstones` to every
+    // snapshot response (filtered by the same query the rows were)
+    // and the pull handler stamps `Source::scope` — the two halves
+    // of "a server delete propagates with confidence, and only to
+    // the principal it belongs to".
+    let source = IssuesSource::seeded()
+        .with_deleted("i_w1_gone", "W1")
+        .with_deleted("i_w2_gone", "W2");
+    let app = build_app(source);
+
+    let w1 = pull(&app, Some("W1")).await;
+    let keys: Vec<&str> = w1.tombstones.iter().map(|t| t.key.as_str()).collect();
+    assert_eq!(keys, vec!["i_w1_gone"], "W2's delete must not leak to W1");
+    assert_eq!(
+        w1.scope,
+        Some(pocopine_sync::SyncScope::new("tenant:test").unwrap()),
+        "pull handler stamps the typed Source::scope"
+    );
+
+    let all = pull(&app, None).await;
+    assert_eq!(
+        all.tombstones.len(),
+        2,
+        "unfiltered pull sees every tombstone"
+    );
+}
+
+#[tokio::test]
+async fn cap_filled_snapshots_advertise_has_more() {
+    // Codex R1 P2: the adapter clamps even unlimited queries to
+    // max_snapshot_rows, and the client can't see that implicit cap.
+    // A page that fills the effective limit must say `has_more` so
+    // client-side eviction reporting doesn't misread pagination as
+    // loss.
+    pocopine_server::__reset_for_test();
+    let sync = SyncServer::builder()
+        .public_stream(
+            build_source(STREAM, IssuesSource::seeded())
+                .expect("stream name")
+                .max_snapshot_rows(2)
+                .expect("cap")
+                .id(|r: &Issue| r.id.clone()),
+        )
+        .build();
+    let app = Server::new(pocopine_server::axum::Router::new())
+        .plugin(sync_server_plugin(sync))
+        .try_finalize()
+        .expect("server finalizes");
+
+    // Three seeded rows, cap 2: the unfiltered page fills the cap.
+    let all = pull(&app, None).await;
+    assert_eq!(all.rows.len(), 2);
+    assert!(all.has_more, "a cap-filled page may be truncated");
+
+    // One W2 row, cap 2: genuinely complete.
+    let w2 = pull(&app, Some("W2")).await;
+    assert_eq!(w2.rows.len(), 1);
+    assert!(!w2.has_more, "an under-cap page is a full view");
 }
 
 #[tokio::test]

--- a/crates/pocopine-sync-sqlite/src/native.rs
+++ b/crates/pocopine-sync-sqlite/src/native.rs
@@ -17,9 +17,9 @@ use crate::schema::{
     BOOTSTRAP_SQL, CLEAR_ALL_STREAMS_SQL, CLEAR_ROW_CONFLICT_SQL, CLEAR_STREAM_SQL,
     DELETE_MUTATION_SQL, DELETE_PENDING_FOR_ROW_SQL, DELETE_ROW_SQL, DELETE_STREAM_ROWS_SQL,
     META_DEVICE_ID, META_NEXT_MUTATION_COUNTER, META_SCHEMA_VERSION,
-    MIGRATION_V3_TO_V4_ADD_APP_SCHEMA_VERSION, SCHEMA_VERSION, SELECT_PENDING_MUTATIONS_SQL,
-    SELECT_ROWS_SQL, SELECT_STREAM_SQL, UPDATE_ROW_CONFLICT_SQL, UPSERT_MUTATION_SQL,
-    UPSERT_ROW_SQL, UPSERT_STREAM_SQL,
+    MIGRATION_V3_TO_V4_ADD_APP_SCHEMA_VERSION, MIGRATION_V4_TO_V5_ADD_SCOPE, SCHEMA_VERSION,
+    SELECT_PENDING_MUTATIONS_SQL, SELECT_ROWS_SQL, SELECT_STREAM_SQL, UPDATE_ROW_CONFLICT_SQL,
+    UPSERT_MUTATION_SQL, UPSERT_ROW_SQL, UPSERT_STREAM_SQL,
 };
 
 /// SQLite-backed [`SyncLocalStore`] for host/native targets.
@@ -210,9 +210,9 @@ fn migrate_schema(tx: &Transaction<'_>) -> SyncResult<()> {
     // silently stamped as v4 (which would compile but explode at first
     // `UPSERT_MUTATION_SQL`).
     match version {
-        2 | 3 => {}
+        2..=4 => {}
         v if v == SCHEMA_VERSION => return Ok(()),
-        // Any other version (e.g. v1 or a future v5+) falls through to
+        // Any other version (e.g. v1 or a future v6+) falls through to
         // validate_schema_version which returns
         // `incompatible sync sqlite schema version`.
         _ => return Ok(()),
@@ -232,6 +232,13 @@ fn migrate_schema(tx: &Transaction<'_>) -> SyncResult<()> {
     // as a forced wipe — so this migration is non-destructive.
     if !column_exists(tx, "__pocopine_streams", "app_schema_version")? {
         tx.execute(MIGRATION_V3_TO_V4_ADD_APP_SCHEMA_VERSION, [])
+            .map_err(sqlite_error)?;
+    }
+    // v4 -> v5 (also runs for older stores after the alters above):
+    // scope column on the streams table. Existing rows observe `NULL`
+    // = "never observed a scope; adopt on next save" — non-destructive.
+    if !column_exists(tx, "__pocopine_streams", "scope")? {
+        tx.execute(MIGRATION_V4_TO_V5_ADD_SCOPE, [])
             .map_err(sqlite_error)?;
     }
     // Only stamp the new version when we actually migrated forward.
@@ -328,6 +335,7 @@ fn hydrate_stream(
                 row.get::<_, String>(0)?,
                 row.get::<_, Option<String>>(1)?,
                 row.get::<_, Option<u32>>(2)?,
+                row.get::<_, Option<String>>(3)?,
             ))
         })
         .optional()
@@ -335,7 +343,7 @@ fn hydrate_stream(
 
     let rows = load_rows(conn, &stream)?;
     let pending_mutations = pending_mutation_records(conn, &stream)?;
-    let Some((collection, cursor, application_schema_version)) = stream_meta else {
+    let Some((collection, cursor, application_schema_version, scope)) = stream_meta else {
         if rows.is_empty() && pending_mutations.is_empty() {
             return Ok(LocalStreamSnapshot::empty(stream));
         }
@@ -347,6 +355,7 @@ fn hydrate_stream(
             rows,
             pending_mutations,
             application_schema_version: None,
+            scope: None,
         });
     };
 
@@ -357,6 +366,7 @@ fn hydrate_stream(
         rows,
         pending_mutations,
         application_schema_version,
+        scope: scope.map(pocopine_sync::SyncScope::new).transpose()?,
     })
 }
 
@@ -370,6 +380,7 @@ fn save_snapshot(conn: &mut Connection, snapshot: LocalSnapshotBatch) -> SyncRes
         snapshot.cursor.as_ref(),
         now,
         snapshot.application_schema_version,
+        snapshot.scope.as_ref(),
     )?;
     tx.execute(DELETE_STREAM_ROWS_SQL, params![snapshot.stream.as_str()])
         .map_err(sqlite_error)?;
@@ -383,15 +394,16 @@ fn apply_changes(conn: &mut Connection, changes: LocalChangeBatch) -> SyncResult
     let tx = conn.transaction().map_err(sqlite_error)?;
     let now = epoch_ms();
     let stream = changes.stream;
-    // apply_changes doesn't carry an advertised schema_version (it's a
-    // post-open delta path), so pass None — the coalesce in the UPSERT
-    // preserves whatever value `save_snapshot` already recorded.
+    // apply_changes doesn't carry an advertised schema_version or a
+    // scope (it's a post-open delta path), so pass None — the coalesce
+    // in the UPSERT preserves whatever `save_snapshot` already recorded.
     upsert_stream(
         &tx,
         &stream,
         &changes.collection,
         changes.cursor.as_ref(),
         now,
+        None,
         None,
     )?;
     let changes = changes_after_last_reset(changes.changes);
@@ -464,6 +476,7 @@ fn mark_push_result(conn: &mut Connection, result: LocalPushResult) -> SyncResul
             collection,
             result.cursor.as_ref(),
             now,
+            None,
             None,
         )?;
     } else if let Some(cursor) = result.cursor.as_ref() {
@@ -661,12 +674,13 @@ fn upsert_stream(
     cursor: Option<&SyncCursor>,
     updated_at_ms: i64,
     application_schema_version: Option<u32>,
+    scope: Option<&pocopine_sync::SyncScope>,
 ) -> SyncResult<()> {
     // The UPSERT uses `coalesce(excluded.app_schema_version,
-    // __pocopine_streams.app_schema_version)` so passing `None` here
-    // doesn't clobber a previously recorded value. The storage-level
-    // `schema_version` column at ?4 still records this constant for
-    // historical reasons.
+    // __pocopine_streams.app_schema_version)` (same for `scope`) so
+    // passing `None` here doesn't clobber a previously recorded value.
+    // The storage-level `schema_version` column at ?4 still records
+    // this constant for historical reasons.
     tx.execute(
         UPSERT_STREAM_SQL,
         params![
@@ -676,6 +690,7 @@ fn upsert_stream(
             SCHEMA_VERSION,
             updated_at_ms,
             application_schema_version,
+            scope.map(pocopine_sync::SyncScope::as_str),
         ],
     )
     .map_err(sqlite_error)?;
@@ -1807,6 +1822,91 @@ mod tests {
         .unwrap();
         let s = block(store.hydrate_stream(&stream)).unwrap();
         assert_eq!(s.application_schema_version, Some(5));
+    }
+
+    #[test]
+    fn sqlite_store_migrates_v4_to_v5_scope_column() {
+        // Simulate a v4 store: streams table WITH app_schema_version
+        // but WITHOUT scope, seed schema_version=4, and verify open
+        // succeeds + existing rows observe NULL scope + a scoped save
+        // stamps and a scope-less save preserves (coalesce).
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "create table __pocopine_meta (
+                key text primary key,
+                value text not null
+            );
+            create table __pocopine_streams (
+                stream text primary key,
+                collection text not null,
+                cursor text,
+                schema_version integer not null,
+                app_schema_version integer,
+                updated_at_ms integer not null
+            );
+            create table __pocopine_rows (
+                stream text not null,
+                row_key text not null,
+                version text,
+                payload text not null,
+                pending integer not null default 0,
+                conflict integer not null default 0,
+                updated_at_ms integer not null,
+                primary key (stream, row_key)
+            );
+            create table __pocopine_mutations (
+                enqueue_seq integer primary key autoincrement,
+                stream text not null,
+                mutation_id text not null unique,
+                row_key text,
+                base_version text,
+                op text not null,
+                payload text,
+                optimistic_row text,
+                status text not null,
+                error text,
+                created_at_ms integer not null,
+                updated_at_ms integer not null
+            );
+            insert into __pocopine_meta (key, value) values ('schema_version', '4');
+            insert into __pocopine_streams (stream, collection, cursor, schema_version, updated_at_ms)
+                values ('posts', 'posts', null, 4, 0);",
+        )
+        .unwrap();
+
+        let store = SqliteLocalStore::from_connection(conn).unwrap();
+        let stream = SyncStreamName::new("posts").unwrap();
+        // Existing row pre-migration → scope observes None.
+        let s = block(store.hydrate_stream(&stream)).unwrap();
+        assert_eq!(s.scope, None);
+
+        // A scoped save stamps the compartment.
+        let scope = pocopine_sync::SyncScope::new("user:alice").unwrap();
+        block(
+            store.save_snapshot(
+                LocalSnapshotBatch::new(
+                    stream.clone(),
+                    SyncCollectionName::new("posts").unwrap(),
+                    vec![],
+                    None,
+                )
+                .with_scope(Some(scope.clone())),
+            ),
+        )
+        .unwrap();
+        let s = block(store.hydrate_stream(&stream)).unwrap();
+        assert_eq!(s.scope, Some(scope.clone()));
+
+        // A later scope-less save preserves the stamp (coalesce).
+        block(store.save_snapshot(LocalSnapshotBatch::new(
+            stream.clone(),
+            SyncCollectionName::new("posts").unwrap(),
+            vec![],
+            None,
+        )))
+        .unwrap();
+        let s = block(store.hydrate_stream(&stream)).unwrap();
+        assert_eq!(s.scope, Some(scope));
     }
 
     fn block<T>(future: SyncLocalFuture<'_, T>) -> SyncResult<T> {

--- a/crates/pocopine-sync-sqlite/src/schema.rs
+++ b/crates/pocopine-sync-sqlite/src/schema.rs
@@ -11,7 +11,12 @@
 ///   `ALTER TABLE … ADD COLUMN`; existing rows observe `NULL` and the
 ///   client treats `NULL` as "never observed, adopt server value
 ///   silently on next save" rather than as a forced wipe.
-pub const SCHEMA_VERSION: u32 = 4;
+/// * v5: added `__pocopine_streams.scope` — the opaque principal scope
+///   the compartment's rows were settled under (cross-principal
+///   clobber guard). Same in-place `ALTER TABLE … ADD COLUMN`
+///   migration shape as v4; existing rows observe `NULL` = "never
+///   observed a scope", which the client treats as adopt-on-next-save.
+pub const SCHEMA_VERSION: u32 = 5;
 
 /// Metadata table for device identity and internal settings.
 pub const META_TABLE: &str = "__pocopine_meta";
@@ -41,6 +46,7 @@ pub const BOOTSTRAP_SQL: &[&str] = &[
         cursor text,
         schema_version integer not null,
         app_schema_version integer,
+        scope text,
         updated_at_ms integer not null
     )",
     "create table if not exists __pocopine_rows (
@@ -75,17 +81,20 @@ pub const BOOTSTRAP_SQL: &[&str] = &[
 
 /// SQL upsert used for stream cursor metadata. `app_schema_version`
 /// (?6) is the APPLICATION-level schema version the server most
-/// recently advertised for this stream; `NULL` means "not yet
-/// observed". On conflict we use `coalesce(excluded, existing)` so a
-/// caller passing `NULL` doesn't clobber a previously-recorded value.
+/// recently advertised for this stream; `scope` (?7) is the principal
+/// scope the compartment was settled under; `NULL` means "not yet
+/// observed" for both. On conflict we use `coalesce(excluded,
+/// existing)` so a caller passing `NULL` doesn't clobber a
+/// previously-recorded value.
 pub const UPSERT_STREAM_SQL: &str = "insert into __pocopine_streams
-    (stream, collection, cursor, schema_version, app_schema_version, updated_at_ms)
-    values (?1, ?2, ?3, ?4, ?6, ?5)
+    (stream, collection, cursor, schema_version, app_schema_version, scope, updated_at_ms)
+    values (?1, ?2, ?3, ?4, ?6, ?7, ?5)
     on conflict(stream) do update set
         collection = excluded.collection,
         cursor = excluded.cursor,
         schema_version = excluded.schema_version,
         app_schema_version = coalesce(excluded.app_schema_version, __pocopine_streams.app_schema_version),
+        scope = coalesce(excluded.scope, __pocopine_streams.scope),
         updated_at_ms = excluded.updated_at_ms";
 
 /// SQL statements used to clear one stream before saving a replacement snapshot.
@@ -165,11 +174,11 @@ pub const SELECT_ROWS_SQL: &str = "select row_key, version, payload, pending, co
     order by row_key asc";
 
 /// SQL query used to hydrate stream metadata. Returns `NULL` for
-/// `app_schema_version` on rows that pre-date the v3→v4 migration —
-/// the client treats `NULL` as "never observed; adopt server value
-/// silently on next save" rather than as a forced wipe.
-pub const SELECT_STREAM_SQL: &str =
-    "select collection, cursor, app_schema_version from __pocopine_streams where stream = ?1";
+/// `app_schema_version` / `scope` on rows that pre-date the v3→v4 /
+/// v4→v5 migrations — the client treats `NULL` as "never observed;
+/// adopt server value silently on next save" rather than as a forced
+/// wipe.
+pub const SELECT_STREAM_SQL: &str = "select collection, cursor, app_schema_version, scope from __pocopine_streams where stream = ?1";
 
 /// SQL statements used by `SyncLocalStore::clear_stream`. Drops every
 /// row, mutation queue entry, and the stream metadata row for ONE
@@ -187,6 +196,11 @@ pub const CLEAR_STREAM_SQL: &[&str] = &[
 /// `app_schema_version` column. Existing rows observe `NULL`.
 pub const MIGRATION_V3_TO_V4_ADD_APP_SCHEMA_VERSION: &str =
     "alter table __pocopine_streams add column app_schema_version integer";
+
+/// SQL used by the v4 -> v5 migration to add the `scope` column.
+/// Existing rows observe `NULL` = "never observed a scope".
+pub const MIGRATION_V4_TO_V5_ADD_SCOPE: &str =
+    "alter table __pocopine_streams add column scope text";
 
 #[cfg(test)]
 mod tests {

--- a/crates/pocopine-sync-sqlite/src/wasm.rs
+++ b/crates/pocopine-sync-sqlite/src/wasm.rs
@@ -6,7 +6,7 @@ use pocopine_sync::{
     ClientMutation, LocalChangeBatch, LocalPendingMutation, LocalPushResult, LocalSnapshotBatch,
     LocalStreamSnapshot, MutationId, RowKey, RowVersion, SyncCollectionName, SyncCursor,
     SyncDeviceId, SyncError, SyncLocalFuture, SyncLocalIdentity, SyncLocalStore, SyncOp,
-    SyncResult, SyncRow, SyncStreamName, generate_sync_device_id,
+    SyncResult, SyncRow, SyncScope, SyncStreamName, generate_sync_device_id,
 };
 use serde_json::Value;
 use wasm_bindgen::{JsCast, JsValue};
@@ -15,9 +15,9 @@ use crate::schema::{
     BOOTSTRAP_SQL, CLEAR_ALL_STREAMS_SQL, CLEAR_ROW_CONFLICT_SQL, CLEAR_STREAM_SQL,
     DELETE_MUTATION_SQL, DELETE_PENDING_FOR_ROW_SQL, DELETE_ROW_SQL, DELETE_STREAM_ROWS_SQL,
     META_DEVICE_ID, META_NEXT_MUTATION_COUNTER, META_SCHEMA_VERSION,
-    MIGRATION_V3_TO_V4_ADD_APP_SCHEMA_VERSION, SCHEMA_VERSION, SELECT_PENDING_MUTATIONS_SQL,
-    SELECT_ROWS_SQL, SELECT_STREAM_SQL, UPDATE_ROW_CONFLICT_SQL, UPSERT_MUTATION_SQL,
-    UPSERT_ROW_SQL, UPSERT_STREAM_SQL,
+    MIGRATION_V3_TO_V4_ADD_APP_SCHEMA_VERSION, MIGRATION_V4_TO_V5_ADD_SCOPE, SCHEMA_VERSION,
+    SELECT_PENDING_MUTATIONS_SQL, SELECT_ROWS_SQL, SELECT_STREAM_SQL, UPDATE_ROW_CONFLICT_SQL,
+    UPSERT_MUTATION_SQL, UPSERT_ROW_SQL, UPSERT_STREAM_SQL,
 };
 
 const DEFAULT_DATABASE_NAME: &str = "pocopine_sync.sqlite3";
@@ -261,7 +261,7 @@ async fn migrate_schema() -> SyncResult<()> {
     // see native.rs::migrate_schema for the full rationale. A v1 store
     // must fall through to the reject path in validate_schema_version.
     match version {
-        2 | 3 => {}
+        2..=4 => {}
         v if v == SCHEMA_VERSION => return Ok(()),
         _ => return Ok(()),
     }
@@ -278,7 +278,12 @@ async fn migrate_schema() -> SyncResult<()> {
     if !column_exists("__pocopine_streams", "app_schema_version").await? {
         exec(MIGRATION_V3_TO_V4_ADD_APP_SCHEMA_VERSION, Vec::new()).await?;
     }
-    // Stamp the current version — we only reach here from v2 or v3.
+    // v4 -> v5: scope column on the streams table. Existing rows
+    // observe `NULL` = "never observed a scope" — non-destructive.
+    if !column_exists("__pocopine_streams", "scope").await? {
+        exec(MIGRATION_V4_TO_V5_ADD_SCOPE, Vec::new()).await?;
+    }
+    // Stamp the current version — we only reach here from v2..v4.
     upsert_meta(META_SCHEMA_VERSION, &SCHEMA_VERSION.to_string()).await?;
     Ok(())
 }
@@ -346,6 +351,7 @@ async fn hydrate_stream(stream: SyncStreamName) -> SyncResult<LocalStreamSnapsho
             rows,
             pending_mutations,
             application_schema_version: None,
+            scope: None,
         });
     };
 
@@ -361,6 +367,9 @@ async fn hydrate_stream(stream: SyncStreamName) -> SyncResult<LocalStreamSnapsho
         rows,
         pending_mutations,
         application_schema_version: optional_u32(meta, "app_schema_version")?,
+        scope: optional_string(meta, "scope")?
+            .map(SyncScope::new)
+            .transpose()?,
     })
 }
 
@@ -374,6 +383,7 @@ async fn save_snapshot(snapshot: LocalSnapshotBatch) -> SyncResult<()> {
             snapshot.cursor.as_ref(),
             now,
             snapshot.application_schema_version,
+            snapshot.scope.as_ref(),
         )
         .await?;
         exec(
@@ -395,14 +405,16 @@ async fn apply_changes(changes: LocalChangeBatch) -> SyncResult<()> {
     let result = async {
         let now = epoch_ms();
         let stream = changes.stream;
-        // apply_changes doesn't carry an advertised schema_version (it
-        // is a post-open delta path); pass None — the UPSERT's coalesce
-        // preserves whatever value `save_snapshot` already recorded.
+        // apply_changes doesn't carry an advertised schema_version or a
+        // scope (it is a post-open delta path); pass None — the
+        // UPSERT's coalesce preserves whatever `save_snapshot` already
+        // recorded.
         upsert_stream(
             &stream,
             &changes.collection,
             changes.cursor.as_ref(),
             now,
+            None,
             None,
         )
         .await?;
@@ -481,6 +493,7 @@ async fn mark_push_result(result: LocalPushResult) -> SyncResult<()> {
                 collection,
                 result.cursor.as_ref(),
                 now,
+                None,
                 None,
             )
             .await?;
@@ -684,10 +697,11 @@ async fn upsert_stream(
     cursor: Option<&SyncCursor>,
     updated_at_ms: i64,
     application_schema_version: Option<u32>,
+    scope: Option<&SyncScope>,
 ) -> SyncResult<()> {
     // The UPSERT uses `coalesce(excluded.app_schema_version,
-    // __pocopine_streams.app_schema_version)` so passing `None` here
-    // doesn't clobber a previously recorded value.
+    // __pocopine_streams.app_schema_version)` (same for `scope`) so
+    // passing `None` here doesn't clobber a previously recorded value.
     let app_schema_version_param = match application_schema_version {
         Some(v) => JsValue::from_f64(v as f64),
         None => JsValue::NULL,
@@ -701,6 +715,7 @@ async fn upsert_stream(
             JsValue::from_f64(SCHEMA_VERSION as f64),
             JsValue::from_f64(updated_at_ms as f64),
             app_schema_version_param,
+            optional_param(scope.map(SyncScope::as_str)),
         ],
     )
     .await

--- a/crates/pocopine-sync/src/lib.rs
+++ b/crates/pocopine-sync/src/lib.rs
@@ -29,9 +29,9 @@ pub use protocol::{
     SYNC_PROTOCOL_V1, SYNC_PULL_PATH, SYNC_PUSH_PATH, StreamParams, SyncChange, SyncCollectionName,
     SyncConflict, SyncCursor, SyncDeviceId, SyncOp, SyncOpenRequest, SyncOpenResponse,
     SyncOpenStream, SyncPullMode, SyncPullRequest, SyncPullResponse, SyncPushRequest,
-    SyncPushResponse, SyncRejectedMutation, SyncRow, SyncSessionId, SyncStreamName,
-    SyncStreamSubscription, default_schema_version_one, local_stream_key, stream_params_hash,
-    sync_stream_params_tag, sync_stream_tag,
+    SyncPushResponse, SyncRejectedMutation, SyncRow, SyncScope, SyncSessionId, SyncStreamName,
+    SyncStreamSubscription, SyncTombstone, default_schema_version_one, local_stream_key,
+    stream_params_hash, sync_stream_params_tag, sync_stream_tag,
 };
 pub use state::SyncReason;
 

--- a/crates/pocopine-sync/src/local_memory/store.rs
+++ b/crates/pocopine-sync/src/local_memory/store.rs
@@ -35,6 +35,7 @@ struct MemoryStreamState {
     rows: BTreeMap<RowKey, SyncRow<serde_json::Value>>,
     pending: Vec<LocalPendingMutation>,
     application_schema_version: Option<u32>,
+    scope: Option<crate::SyncScope>,
 }
 
 impl MemoryLocalStore {
@@ -96,6 +97,7 @@ impl SyncLocalStore for MemoryLocalStore {
                 rows: state.rows.values().cloned().collect(),
                 pending_mutations: state.pending.clone(),
                 application_schema_version: state.application_schema_version,
+                scope: state.scope.clone(),
             })
         }))
     }
@@ -116,6 +118,12 @@ impl SyncLocalStore for MemoryLocalStore {
             // recorded value.
             if let Some(version) = snapshot.application_schema_version {
                 state.application_schema_version = Some(version);
+            }
+            // Same coalesce contract as `application_schema_version`:
+            // a save that hasn't observed a scoped response must not
+            // erase a previously recorded stamp.
+            if let Some(scope) = snapshot.scope {
+                state.scope = Some(scope);
             }
             Ok(())
         }))

--- a/crates/pocopine-sync/src/local_store/types.rs
+++ b/crates/pocopine-sync/src/local_store/types.rs
@@ -200,6 +200,15 @@ pub struct LocalStreamSnapshot {
     /// advertised value is adopted silently on the next snapshot save.
     #[serde(default)]
     pub application_schema_version: Option<u32>,
+    /// Principal scope this compartment's rows were settled under,
+    /// captured from the server's scoped `/open`/`/pull` responses.
+    /// `None` means "never observed a scope" — a fresh compartment, a
+    /// snapshot persisted before the field existed, or an unscoped
+    /// server. The client compares this against the freshly-advertised
+    /// scope on every open: a mismatch redirects the subscription to a
+    /// scope-qualified compartment instead of overwriting this one.
+    #[serde(default)]
+    pub scope: Option<crate::SyncScope>,
 }
 
 impl LocalStreamSnapshot {
@@ -212,6 +221,7 @@ impl LocalStreamSnapshot {
             rows: Vec::new(),
             pending_mutations: Vec::new(),
             application_schema_version: None,
+            scope: None,
         }
     }
 }
@@ -230,6 +240,13 @@ pub struct LocalSnapshotBatch {
     /// open with a known advertised version will set it.
     #[serde(default)]
     pub application_schema_version: Option<u32>,
+    /// Principal scope to record alongside this snapshot. `None` means
+    /// the caller hasn't observed a scoped response yet; stores keep an
+    /// existing recorded scope in that case (coalesce, mirroring
+    /// `application_schema_version`) so a mid-rollout unscoped save
+    /// doesn't erase a valid stamp.
+    #[serde(default)]
+    pub scope: Option<crate::SyncScope>,
 }
 
 impl LocalSnapshotBatch {
@@ -245,6 +262,7 @@ impl LocalSnapshotBatch {
             cursor,
             rows,
             application_schema_version: None,
+            scope: None,
         }
     }
 
@@ -253,6 +271,13 @@ impl LocalSnapshotBatch {
     /// that advertised the version.
     pub fn with_application_schema_version(mut self, version: Option<u32>) -> Self {
         self.application_schema_version = version;
+        self
+    }
+
+    /// Fluent setter for the principal scope this snapshot was settled
+    /// under.
+    pub fn with_scope(mut self, scope: Option<crate::SyncScope>) -> Self {
+        self.scope = scope;
         self
     }
 }

--- a/crates/pocopine-sync/src/protocol/names.rs
+++ b/crates/pocopine-sync/src/protocol/names.rs
@@ -163,6 +163,17 @@ opaque_string_type!(
     "session id",
     "Ephemeral sync session identity for one running client instance."
 );
+opaque_string_type!(
+    SyncScope,
+    "scope",
+    "Opaque server-derived principal scope for one authenticated response. \
+     Sources derive it from the request's authenticated context (user id, \
+     tenant id, or a hash of either — the client never interprets it, only \
+     compares for equality). Carried on `/open` and `/pull` responses so \
+     the client can refuse to settle another principal's server truth into \
+     a compartment a different principal populated. `None` (the default) \
+     means the stream doesn't scope its responses and the guard is inert."
+);
 
 #[cfg(test)]
 mod tests {

--- a/crates/pocopine-sync/src/protocol/response.rs
+++ b/crates/pocopine-sync/src/protocol/response.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 
 use super::{
     MutationId, RowKey, SYNC_PROTOCOL_V1, StreamParams, SyncCollectionName, SyncCursor, SyncRow,
-    SyncStreamName, deserialize_params_null_as_default,
+    SyncScope, SyncStreamName, SyncTombstone, deserialize_params_null_as_default,
 };
 
 /// Stream accepted by an open response.
@@ -40,6 +40,19 @@ pub struct SyncOpenStream {
         skip_serializing_if = "BTreeMap::is_empty"
     )]
     pub params: StreamParams,
+    /// Opaque principal scope the server derived from this request's
+    /// authenticated context (see [`SyncStreamSource::scope`]). The
+    /// client compares it against the scope persisted with the stream's
+    /// durable compartment: a mismatch means a *different* principal is
+    /// now answering for the same `(stream, params)` subscription, and
+    /// the client redirects to a scope-qualified compartment instead of
+    /// letting the new principal's truth overwrite the old one's cache.
+    /// `None` (the wire default — old servers, unscoped sources) leaves
+    /// the guard inert.
+    ///
+    /// [`SyncStreamSource::scope`]: crate::SyncStreamSource::scope
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<SyncScope>,
 }
 
 /// Default schema version when the wire field is missing or the source
@@ -100,8 +113,25 @@ pub struct SyncPullResponse<T> {
     pub rows: Vec<SyncRow<T>>,
     #[serde(default)]
     pub changes: Vec<super::SyncChange<T>>,
+    /// Positive deletions the source still retains (see
+    /// [`SyncTombstone`]). In `Snapshot` mode these disambiguate a
+    /// row's absence — tombstoned keys were deleted at the authority;
+    /// other absent keys are unexplained. In `Incremental` mode they
+    /// carry deletions the same way a `SyncChange` with
+    /// `SyncOp::Delete` would. Old servers never set the field and
+    /// old clients ignore it — `#[serde(default)]` keeps both
+    /// directions compatible.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tombstones: Vec<SyncTombstone>,
     pub cursor: Option<SyncCursor>,
     pub has_more: bool,
+    /// Principal scope of the authenticated context that produced this
+    /// response. Same contract as [`SyncOpenStream::scope`]; stamped by
+    /// the pull handler on every response so a session that changes
+    /// principals mid-subscription (expiry to guest, tenant switch) is
+    /// caught at settle time, not just at `/open`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub scope: Option<SyncScope>,
 }
 
 impl<T> SyncPullResponse<T> {
@@ -118,8 +148,10 @@ impl<T> SyncPullResponse<T> {
             mode: super::SyncPullMode::Snapshot,
             rows,
             changes: Vec::new(),
+            tombstones: Vec::new(),
             cursor,
             has_more: false,
+            scope: None,
         }
     }
 
@@ -136,9 +168,23 @@ impl<T> SyncPullResponse<T> {
             mode: super::SyncPullMode::Incremental,
             rows: Vec::new(),
             changes,
+            tombstones: Vec::new(),
             cursor,
             has_more: false,
+            scope: None,
         }
+    }
+
+    /// Attach positive deletion records to this response.
+    pub fn with_tombstones(mut self, tombstones: Vec<SyncTombstone>) -> Self {
+        self.tombstones = tombstones;
+        self
+    }
+
+    /// Attach the responding principal's scope to this response.
+    pub fn with_scope(mut self, scope: Option<SyncScope>) -> Self {
+        self.scope = scope;
+        self
     }
 }
 
@@ -238,5 +284,95 @@ mod tests {
         });
         let stream: SyncOpenStream = serde_json::from_value(json).unwrap();
         assert_eq!(stream.schema_version, 7);
+    }
+
+    #[test]
+    fn open_stream_scope_is_backwards_compatible() {
+        // A pre-scope server response deserializes with scope = None
+        // (the guard stays inert against old servers).
+        let json = serde_json::json!({
+            "stream": "posts",
+            "collection": "posts",
+            "cursor": null,
+        });
+        let stream: SyncOpenStream = serde_json::from_value(json).unwrap();
+        assert!(stream.scope.is_none());
+
+        // A scoped response round-trips, and serialization skips the
+        // field when None so old clients never see an unknown key
+        // for the common unscoped case.
+        let json = serde_json::json!({
+            "stream": "posts",
+            "collection": "posts",
+            "cursor": null,
+            "scope": "user:alice",
+        });
+        let stream: SyncOpenStream = serde_json::from_value(json).unwrap();
+        assert_eq!(
+            stream.scope,
+            Some(super::super::SyncScope::new("user:alice").unwrap())
+        );
+        let unscoped = SyncOpenStream {
+            scope: None,
+            ..stream
+        };
+        let value = serde_json::to_value(&unscoped).unwrap();
+        assert!(value.get("scope").is_none());
+    }
+
+    #[test]
+    fn pull_response_tombstones_and_scope_are_backwards_compatible() {
+        use super::super::{RowVersion, SyncScope, SyncTombstone};
+
+        // A pre-tombstone server response (no `tombstones`, no
+        // `scope`) deserializes to the empty defaults.
+        let json = serde_json::json!({
+            "protocol": SYNC_PROTOCOL_V1,
+            "stream": "posts",
+            "collection": "posts",
+            "mode": "snapshot",
+            "rows": [],
+            "cursor": null,
+            "has_more": false,
+        });
+        let response: SyncPullResponse<String> = serde_json::from_value(json).unwrap();
+        assert!(response.tombstones.is_empty());
+        assert!(response.scope.is_none());
+
+        // Tombstones + scope round-trip through the wire shape.
+        let response = SyncPullResponse::<String>::snapshot(
+            SyncStreamName::new("posts").unwrap(),
+            SyncCollectionName::new("posts").unwrap(),
+            Vec::new(),
+            None,
+        )
+        .with_tombstones(vec![
+            SyncTombstone::new("post_1").unwrap(),
+            SyncTombstone::new("post_2").unwrap().version("v9").unwrap(),
+        ])
+        .with_scope(Some(SyncScope::new("user:alice").unwrap()));
+        let value = serde_json::to_value(&response).unwrap();
+        let decoded: SyncPullResponse<String> = serde_json::from_value(value).unwrap();
+        assert_eq!(decoded.tombstones.len(), 2);
+        assert_eq!(decoded.tombstones[0].key.as_str(), "post_1");
+        assert!(decoded.tombstones[0].version.is_none());
+        assert_eq!(
+            decoded.tombstones[1].version,
+            Some(RowVersion::new("v9").unwrap())
+        );
+        assert_eq!(decoded.scope, Some(SyncScope::new("user:alice").unwrap()));
+
+        // Empty tombstones + no scope serialize to a wire body with
+        // NEITHER key present — an old client deserializing the
+        // common case never sees the new fields at all.
+        let bare = SyncPullResponse::<String>::snapshot(
+            SyncStreamName::new("posts").unwrap(),
+            SyncCollectionName::new("posts").unwrap(),
+            Vec::new(),
+            None,
+        );
+        let value = serde_json::to_value(&bare).unwrap();
+        assert!(value.get("tombstones").is_none());
+        assert!(value.get("scope").is_none());
     }
 }

--- a/crates/pocopine-sync/src/protocol/wire.rs
+++ b/crates/pocopine-sync/src/protocol/wire.rs
@@ -89,6 +89,45 @@ impl<T> SyncRow<T> {
     }
 }
 
+/// Positive deletion record for one row, carried on pull responses.
+///
+/// A tombstone is the authority saying "this key existed and was
+/// deleted" — as opposed to a row merely being absent from a snapshot,
+/// which is ambiguous (deleted? no longer matching the query's filter?
+/// beyond the snapshot limit? lost at the backend?). Clients apply
+/// tombstoned deletes with confidence; un-tombstoned absences stay a
+/// policy decision (see `EvictionReason` in `pocopine-sync-query`).
+///
+/// Retention is the source's business: keep tombstones for a window
+/// comfortably longer than the longest expected client offline period,
+/// then GC. A client that was offline past the window sees the row as
+/// an unexplained absence rather than a confirmed delete — degraded,
+/// never wrong.
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct SyncTombstone {
+    pub key: RowKey,
+    /// Version the row had when it was deleted, when the source tracks
+    /// one. Informational — equality on `key` is what drives the
+    /// client-side delete.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub version: Option<RowVersion>,
+}
+
+impl SyncTombstone {
+    pub fn new(key: impl Into<String>) -> SyncResult<Self> {
+        Ok(Self {
+            key: RowKey::new(key)?,
+            version: None,
+        })
+    }
+
+    /// Attach the deleted row's last version.
+    pub fn version(mut self, version: impl Into<String>) -> SyncResult<Self> {
+        self.version = Some(RowVersion::new(version)?);
+        Ok(self)
+    }
+}
+
 /// One ordered change in a sync stream.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(bound(serialize = "T: Serialize", deserialize = "T: Deserialize<'de>"))]

--- a/crates/pocopine-sync/src/server/handlers.rs
+++ b/crates/pocopine-sync/src/server/handlers.rs
@@ -52,6 +52,7 @@ async fn open(
             cursor: stream.source.current_cursor(&ctx),
             schema_version: stream.source.schema_version(),
             params: requested.params,
+            scope: stream.source.scope(&ctx).await.map_err(server_error)?,
         });
     }
     Ok(SyncOpenResponse::new(streams))
@@ -79,7 +80,22 @@ pub(crate) async fn pull_handler(
             .source
             .validate_params(&request.params)
             .map_err(server_error)?;
-        stream.source.pull(ctx, request).await.map_err(server_error)
+        // Resolve the responding principal's scope BEFORE the pull so
+        // a scope-resolution failure rejects the request instead of
+        // shipping rows stamped with the wrong (or no) principal.
+        let scope = stream.source.scope(&ctx).await.map_err(server_error)?;
+        let mut response = stream
+            .source
+            .pull(ctx, request)
+            .await
+            .map_err(server_error)?;
+        // Stamp only when the source's `pull` didn't set it itself —
+        // a custom `SyncStreamSource` that stamps per-response keeps
+        // its more specific value.
+        if response.scope.is_none() {
+            response.scope = scope;
+        }
+        Ok(response)
     }
     .await;
     Json(result)

--- a/crates/pocopine-sync/src/server/source.rs
+++ b/crates/pocopine-sync/src/server/source.rs
@@ -33,6 +33,28 @@ pub trait SyncStreamSource: Send + Sync + 'static {
         None
     }
 
+    /// Opaque principal scope for one authenticated request.
+    ///
+    /// The framework calls this on every `/open` and `/pull` and stamps
+    /// the result onto the response, so the client can tell WHICH
+    /// principal's truth it is settling. Derive it from the
+    /// authenticated context — a user id, tenant id, or a stable hash
+    /// of either. The client never interprets the value; it only
+    /// compares for equality against the scope persisted with its
+    /// durable cache compartment, refusing to let one principal's
+    /// responses overwrite another principal's cached rows (the
+    /// session-expired-to-guest clobber).
+    ///
+    /// Default `None` = this stream doesn't scope responses; the
+    /// client-side guard stays inert and behavior is unchanged. An
+    /// `Err` fails the request — a source that scopes MUST be able to
+    /// name the principal, and answering unscoped when the session
+    /// can't be resolved is exactly the bug this hook exists to stop.
+    fn scope<'a>(&'a self, ctx: &'a RequestContext) -> SyncBoxFuture<'a, Option<crate::SyncScope>> {
+        let _ = ctx;
+        Box::pin(async { Ok(None) })
+    }
+
     /// Application-level schema version for this stream's row/draft shape.
     ///
     /// Bump this whenever the row, draft, or payload shape changes in a way

--- a/crates/pocopine-sync/src/server/tests.rs
+++ b/crates/pocopine-sync/src/server/tests.rs
@@ -437,6 +437,97 @@ where
         .unwrap()
 }
 
+#[tokio::test]
+async fn open_and_pull_responses_carry_the_source_scope() {
+    let scoped = ScopedStream::new();
+    let sync = SyncServer::builder().public_stream(scoped).build();
+    let router = finalize(sync);
+    let principal = Principal::from_user(AuthUser::new("alice"));
+
+    // /open stamps the per-stream scope the source derived from the
+    // authenticated context.
+    let open = SyncOpenRequest::new([SyncStreamName::new("scoped_stream").unwrap()]);
+    let opened: ServerResult<SyncOpenResponse> = post_json(
+        router.clone(),
+        SYNC_OPEN_PATH,
+        &open,
+        Some(principal.clone()),
+    )
+    .await;
+    let opened = opened.unwrap();
+    assert_eq!(
+        opened.streams[0].scope,
+        Some(crate::SyncScope::new("user:alice").unwrap())
+    );
+
+    // /pull stamps the same scope onto the response (the source's
+    // `pull` didn't set one itself).
+    let pull = SyncPullRequest::new(SyncStreamName::new("scoped_stream").unwrap());
+    let pulled: ServerResult<SyncPullResponse<Value>> =
+        post_json(router.clone(), SYNC_PULL_PATH, &pull, Some(principal)).await;
+    assert_eq!(
+        pulled.unwrap().scope,
+        Some(crate::SyncScope::new("user:alice").unwrap())
+    );
+
+    // An anonymous request resolves to no scope — the wire field is
+    // simply absent and the client guard stays inert.
+    let pulled: ServerResult<SyncPullResponse<Value>> =
+        post_json(router, SYNC_PULL_PATH, &pull, None).await;
+    assert!(pulled.unwrap().scope.is_none());
+}
+
+/// Stream whose `scope` derives from the authenticated principal —
+/// the canonical shape for the cross-principal cache-clobber guard.
+struct ScopedStream {
+    stream: SyncStreamName,
+    collection: SyncCollectionName,
+}
+
+impl ScopedStream {
+    fn new() -> Self {
+        Self {
+            stream: SyncStreamName::new("scoped_stream").unwrap(),
+            collection: SyncCollectionName::new("scoped").unwrap(),
+        }
+    }
+}
+
+impl SyncStreamSource for ScopedStream {
+    fn stream(&self) -> &SyncStreamName {
+        &self.stream
+    }
+
+    fn collection(&self) -> &SyncCollectionName {
+        &self.collection
+    }
+
+    fn scope<'a>(&'a self, ctx: &'a RequestContext) -> SyncBoxFuture<'a, Option<crate::SyncScope>> {
+        let user = ctx.principal().user().map(|user| user.id.clone());
+        Box::pin(async move {
+            user.map(|id| crate::SyncScope::new(format!("user:{id}")))
+                .transpose()
+        })
+    }
+
+    fn pull<'a>(
+        &'a self,
+        _ctx: RequestContext,
+        _request: SyncPullRequest,
+    ) -> SyncBoxFuture<'a, SyncPullResponse<Value>> {
+        let stream = self.stream.clone();
+        let collection = self.collection.clone();
+        Box::pin(async move {
+            Ok(SyncPullResponse::snapshot(
+                stream,
+                collection,
+                Vec::new(),
+                None,
+            ))
+        })
+    }
+}
+
 struct ContextCaptureStream {
     stream: SyncStreamName,
     collection: SyncCollectionName,


### PR DESCRIPTION
Upstream asks from the AgenKitty sync findings (2026-07-05, "server pull can't distinguish deleted from unknown"): the pull protocol had no tombstones — a row absent from a snapshot could mean "deleted elsewhere" or "lost at the authority", and the engine silently replaced the per-stream durable cache with whatever the server returned, so server-side loss (or another principal's empty view after session expiry) became client-side loss. The app works around both in `src/sync.rs` (pre-observe cache snapshot + delayed diff + re-push) with a documented flaw: rows deleted on another device get resurrected. This PR closes both gaps in the framework; the guiding rule is **the server is the source of truth — a delete at the authority always propagates to the client**.

## 1. Delete tombstones in the pull protocol

- `SyncTombstone { key, version? }` + `SyncPullResponse.tombstones`: a positive "this key was deleted at the authority" record. Retention/GC is source policy (keep a window longer than the longest expected client offline period; a too-short window degrades to "unexplained absence", never to a wrong delete).
- `Source::list_tombstones(ctx, &Query)` (defaulted empty) — scoped the same way `list_stream` scopes rows; `SourceResource` attaches the result to every snapshot pull. Tenant isolation tested: a W1 pull never carries W2's deletes.
- Client settle routes tombstones as `RowChange::Delete` **stream-wide**, in both snapshot and incremental mode — the delete propagates to every subscription, and the app's healing can never resurrect it. A tombstone contradicting the same response's own row set is ignored with a warning.

## 2. Eviction report — absence becomes classifiable

The originating subscription records every previously-canonical row a settle removed, tagged:

- `EvictionReason::Deleted` — tombstoned; the delete propagated; never re-push.
- `EvictionReason::Unexplained` — absent from a **full** snapshot with no tombstone: filtered out or lost at the backend; app recovery policy decides. Truncated snapshots (`has_more`, or row count at the query's own limit) suppress `Unexplained` so pagination never reads as loss.

`QueryView::take_evictions()` drains the report (bounded buffer, 256, oldest-first overflow). The view itself still follows server truth — evicted rows leave the view either way; the report only informs policy.

## 3. Principal scope — a change means "clear everything and re-sync"

The compartment key `local_stream_key(stream, params)` captures the *claimed* query, not the *authenticated principal* that produced a response. On session expiry the client keeps pulling with `owner=alice` params while the server answers as guest — and guest's empty truth used to settle and persist into alice's compartment while the client still *believed* it was alice's data.

- `SyncScope` (opaque token) + `scope` on `SyncOpenStream` and `SyncPullResponse`, derived via the defaulted `SyncStreamSource::scope(ctx)` hook (typed mirror: `Source::scope(&Context)`) and stamped by the open/pull handlers. **The implementor provides the principal; the engine never models one** — no users, sessions, or anonymity. The client compares two provided tokens for equality, nothing more. The durable compartment stamps the token it settled under, so a change is detectable across reloads.
- **One rule**: when a response arrives with a provided principal that differs from the one the local state settled under — at `/open` or at any `/pull` — the local state belongs to someone else. The engine **clears everything and re-syncs**: every same-stream subscription reset (siblings fenced before the fan-out can reach them), queued replays dropped, every durable compartment wiped (the bare-stream pending fallback included), the drifted cursored response discarded, and a cursor-less refetch settles the new principal's full snapshot. Scope drift rides the exact same wipe path as schema drift; listeners are notified only after the durable wipes finish. In-flight pulls carry a generation token and are discarded if any reset landed while they were on the wire.
- **`None` never triggers anything.** It means "no principal provided", not "anonymous". Implementors that want session expiry / anonymous transitions detected return a token for those sessions too (documented on `Source::scope`); the client's stamp is sticky, so an unscoped gap between two different provided tokens still drifts.
- **Accepted trade-off** (explicit, tested): unpushed offline mutations made under the previous principal are discarded on a principal change — never pushed under the new session, never resurrected. Every *committed* row rebuilds from the server, which is the source of truth.
- **Migration**: unstamped compartments (pre-scope persists) adopt the first provided token silently — no wipe. Never-scoped servers/sources keep byte-identical wire bodies and the mechanism stays inert. Offline-first editing on a hydrated cache works unchanged.

## Durable stores

`LocalStreamSnapshot`/`LocalSnapshotBatch` gain a coalescing `scope` stamp (same contract as `application_schema_version`): MemoryLocalStore, SQLite (v4 → v5 in-place `ALTER TABLE` column migration, native + wasm), IndexedDB (whole-snapshot serde).

## Verification

- Serde back-compat both directions: old responses deserialize to empty/None; empty tombstones + no scope serialize with neither key present.
- Server: handler stamps `Source::scope` on open + pull; anonymous → no scope; tombstones tenant-filtered e2e through the axum router.
- Driver (mock-middleware, LocalSet): tombstoned row deleted + reported `Deleted`, absent row deleted + reported `Unexplained`, drain-once semantics; limit-filling snapshots suppress `Unexplained`.
- Persistence (shared MemoryLocalStore): the AgenKitty expiry scenario under the final semantics — a principal change wipes the view and compartment and re-syncs the new truth from the server; queued offline mutations of the previous principal are discarded (and stay discarded when it returns); alice→bob→alice round-trips through one compartment; unstamped compartments adopt their first provided token without a wipe; offline-first edits on a hydrated cache render and persist normally; live queries on the same stream are fenced together; the bare-stream pending fallback is wiped on drift.
- SQLite v4→v5 migration + scope round-trip + coalesce; 253 tests green across the four sync crates.
- `cargo fmt --check`, host clippy `-D warnings`, CI's exact wasm32 clippy gate, plus explicit `--target wasm32` clippy on both store crates (they're excluded from the workspace wasm gate): green.
- Codex review: ~20 rounds, every finding fixed or made moot by design.
  - The tombstone/eviction half stabilized early: the implicit `max_snapshot_rows` cap now advertises `has_more` so pagination never reads as loss; `Deleted` evictions are recorded on every affected view; incremental upserts beat retained tombstones for the same key; a wasm-store compile fix (both store crates now gate-checked on `--target wasm32`).
  - An earlier scope design that tried to *preserve* each principal's local state across switches (sibling compartments, routing/replay gates, a per-stream scope registry) accumulated eight rounds of cross-principal edge findings and was dropped wholesale for the wipe-and-re-sync rule — deleting the machinery and its entire failure class.
  - The remaining rounds hardened the **transition instant** itself, each a small application of the same rule: drifted cursored responses are discarded and refetched cursor-less; same-stream siblings are fenced (reset + restamped + compartments wiped, bare fallback included) before any settle fan-out; in-flight pulls carry a generation token and die on any reset; listeners fire only after the durable wipes; hydrated pending replays enqueue only after a drift-free `/open`, survive schema-only drift (the server's `migrate_payload` owns stale shapes), and require unchanged principal context; scope drift clears the client-wide replay queue (a principal change is a session event); the schema version survives scope resets.
  - Known, deliberate residual: a dormant compartment's rows may hydrate-paint briefly on its next observe before its own `/open` wipes them — read-only, no cross-principal write can follow; full-privacy user switches remain the app's `clear_all_streams` call.

## Downstream (AgenKitty)

After `cargo update`: give `SqliteThreadSource` a tombstones table (record on `delete`, GC after a window) + `Source::list_tombstones` + `Source::scope` (owner from the session); replace `open_and_heal`'s pre-snapshot + `delay_ms(3000)` diff with an `on_update` → `take_evictions()` loop that re-pushes only `Unexplained` rows. The app's wipe-on-identity-change stays as privacy policy, but correctness no longer depends on it — the engine wipes and re-syncs on any scope change by itself.

## Non-goals (documented)

- Incremental change-log/cursor support in `SourceResource` (pulls stay snapshot-mode; tombstones ride snapshots).
- Scope-guarding `/push` (server auth owns write authorization).
- Scope stamps on bare-compartment fallback pendings (principal-blind by construction; noted in the redirect path).
