### PR TITLE
Harden core feature coverage and remove dead runtime paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,22 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
+  core-feature-matrix:
+    name: pocopine-core feature matrix
+    runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.ci == 'true'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-02-21
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: pocopine-core-feature-matrix
+      - run: bash scripts/ci/pocopine_core_feature_matrix.sh
+
   clippy-wasm:
     name: clippy (wasm32)
     runs-on: ubuntu-latest

--- a/crates/pocopine-core/src/devtools/signal_last.rs
+++ b/crates/pocopine-core/src/devtools/signal_last.rs
@@ -36,9 +36,3 @@ pub(super) fn record(id: SignalId) {
 pub(super) fn get(id: SignalId) -> Option<f64> {
     LAST_CHANGED.with(|m| m.borrow().get(&id).copied())
 }
-
-/// Whole-table snapshot for the signal graph panel.
-#[allow(dead_code)] // used by PR D
-pub(super) fn snapshot() -> HashMap<SignalId, f64> {
-    LAST_CHANGED.with(|m| m.borrow().clone())
-}

--- a/crates/pocopine-core/src/handler.rs
+++ b/crates/pocopine-core/src/handler.rs
@@ -95,14 +95,6 @@ pub trait HandlerDispatch {
         false
     }
 
-    /// Symmetric with [`has_on_mount`] for `on_unmount`. Currently
-    /// informational — the mount doesn't sweep on unmount — but kept
-    /// for parity and so future devtools can show per-component
-    /// lifecycle coverage.
-    fn has_on_unmount(&self) -> bool {
-        false
-    }
-
     /// RFC-038 — preset name the component animates with by default
     /// on enter (symmetric if `transition_out_preset` returns the
     /// same). Empty string means "no transition preset declared on

--- a/crates/pocopine-core/src/lib.rs
+++ b/crates/pocopine-core/src/lib.rs
@@ -117,11 +117,11 @@ pub use reactive::{
     effect_with, flush_sync, on_cleanup, release, run_now, set_auto_flush, track, trigger_scope,
 };
 pub use registry::{
-    COMPONENT_ENTRIES, ComponentCtor, ComponentEntry, ComponentMountFn, ComponentVTable,
-    RegisteredComponent, RegistryError, RegistryErrorKind, assert_registry_clean,
-    canonical_component_name, mark_registered, register_component, register_component_as,
-    register_component_prefixed, register_component_with_mount, registered_component_names,
-    registry_errors, render_boot_error, verify_registry,
+    ComponentCtor, ComponentMountFn, ComponentVTable, RegisteredComponent, RegistryError,
+    RegistryErrorKind, assert_registry_clean, canonical_component_name, mark_registered,
+    register_component, register_component_as, register_component_prefixed,
+    register_component_with_mount, registered_component_names, registry_errors, render_boot_error,
+    verify_registry,
 };
 pub use router::{
     MatchedRoute, MatchedRouteChain, NavigationFailure, NavigationResult, PrefetchResult,

--- a/crates/pocopine-core/src/lifecycle.rs
+++ b/crates/pocopine-core/src/lifecycle.rs
@@ -10,7 +10,7 @@
 //! `Option<T>`.
 
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::marker::PhantomData;
 
 use wasm_bindgen::JsCast;
@@ -61,6 +61,9 @@ pub struct LifecycleContext<'a> {
     /// Which lifecycle slot the mount fired this hook from.
     /// Element-dependent extractors guard on this.
     pub phase: LifecyclePhase,
+    /// Per-scope hook epoch, minted with the context so repeated
+    /// extractions stay stable within one hook invocation.
+    mount_epoch: u64,
 }
 
 impl<'a> LifecycleContext<'a> {
@@ -73,6 +76,7 @@ impl<'a> LifecycleContext<'a> {
             el,
             scope_id,
             phase,
+            mount_epoch: next_mount_epoch(scope_id),
         }
     }
 }
@@ -216,20 +220,47 @@ impl<'a> From<LifecycleContext<'a>> for Body {
 #[derive(Clone, Copy)]
 pub struct TagName(pub &'static str);
 
+thread_local! {
+    /// Fallback interner for non-component roots (`pp-as`, plain HTML/SVG).
+    /// Registered component tags already live in the registry as static
+    /// strings, so this table is bounded by the distinct fallback tag names
+    /// observed by the page rather than growing once per extraction.
+    static INTERNED_TAG_NAMES: RefCell<HashSet<&'static str>> = RefCell::new(HashSet::new());
+}
+
+fn intern_tag_name(name: String) -> &'static str {
+    // Preserve TagName's original contract (`tag_name().to_lowercase()`),
+    // including SVG names whose `local_name()` may retain mixed case.
+    let name = name.to_lowercase();
+    if let Some(registered) = crate::registry::registered_component_tag(&name) {
+        return registered;
+    }
+
+    INTERNED_TAG_NAMES.with(|names| {
+        let mut names = names.borrow_mut();
+        if let Some(&existing) = names.get(name.as_str()) {
+            return existing;
+        }
+        let interned: &'static str = Box::leak(name.into_boxed_str());
+        names.insert(interned);
+        interned
+    })
+}
+
 impl<'a> From<LifecycleContext<'a>> for TagName {
     #[track_caller]
     fn from(ctx: LifecycleContext<'a>) -> Self {
         check_phase(ctx.phase, ELEMENT_PHASES, "TagName");
         // Resolve at hook-call time: rendered-root's parent is
-        // normally the custom-element tag. Leak the string to get
-        // a `'static str` — one per tag-name string, tiny cost,
-        // matches `type_name()`'s existing lifetime story.
+        // normally the custom-element tag. Registered tags reuse the
+        // registry's static string; fallback roots are interned once
+        // per distinct tag rather than leaked once per extraction.
         let name = ctx
             .el
             .parent_element()
-            .map(|p| p.tag_name().to_lowercase())
-            .unwrap_or_else(|| ctx.el.tag_name().to_lowercase());
-        TagName(Box::leak(name.into_boxed_str()))
+            .map(|p| p.local_name())
+            .unwrap_or_else(|| ctx.el.local_name());
+        TagName(intern_tag_name(name))
     }
 }
 
@@ -384,11 +415,19 @@ impl<'a> From<LifecycleContext<'a>> for TeleportHost {
 }
 
 thread_local! {
-    /// Monotonic counter bumped by the mount for each scope's
-    /// first hook firing. `MountEpoch` exposes it so authors can
-    /// tell a re-walk apart from the original mount.
-    static MOUNT_EPOCH_COUNTER: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+    /// Next lifecycle-hook epoch for each live scope. Entries are removed by
+    /// `Scope::remove` (and the compiled-row bulk teardown).
     static MOUNT_EPOCHS: RefCell<HashMap<ScopeId, u64>> = RefCell::new(HashMap::new());
+}
+
+fn next_mount_epoch(scope: ScopeId) -> u64 {
+    MOUNT_EPOCHS.with(|epochs| {
+        let mut epochs = epochs.borrow_mut();
+        let next = epochs.entry(scope).or_insert(0);
+        let current = *next;
+        *next = current.saturating_add(1);
+        current
+    })
 }
 
 /// Monotonic mount epoch for this scope — increments on each hook
@@ -400,16 +439,7 @@ pub struct MountEpoch(pub u64);
 
 impl<'a> From<LifecycleContext<'a>> for MountEpoch {
     fn from(ctx: LifecycleContext<'a>) -> Self {
-        MountEpoch(MOUNT_EPOCHS.with(|m| {
-            let mut map = m.borrow_mut();
-            *map.entry(ctx.scope_id).or_insert_with(|| {
-                MOUNT_EPOCH_COUNTER.with(|c| {
-                    let v = c.get();
-                    c.set(v + 1);
-                    v
-                })
-            })
-        }))
+        MountEpoch(ctx.mount_epoch)
     }
 }
 
@@ -466,6 +496,66 @@ impl<'a, T: 'static> From<LifecycleContext<'a>> for crate::plugin::Plugin<T> {
 impl<'a, T: 'static> From<LifecycleContext<'a>> for Option<crate::plugin::Plugin<T>> {
     fn from(_: LifecycleContext<'a>) -> Self {
         crate::plugin::active_plugin::<T>()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mount_epoch_starts_at_zero_and_advances_per_scope() {
+        let first = ScopeId(u64::MAX - 10);
+        let second = ScopeId(u64::MAX - 11);
+        __clear_mount_epoch(first);
+        __clear_mount_epoch(second);
+
+        assert_eq!(next_mount_epoch(first), 0);
+        assert_eq!(next_mount_epoch(first), 1);
+        assert_eq!(next_mount_epoch(second), 0);
+
+        __clear_mount_epoch(first);
+        __clear_mount_epoch(second);
+    }
+
+    #[test]
+    fn mount_epoch_advances_once_per_context_not_per_extractor() {
+        let scope = ScopeId(u64::MAX - 13);
+        __clear_mount_epoch(scope);
+        let el: Element = wasm_bindgen::JsValue::NULL.unchecked_into();
+
+        let first = LifecycleContext::__new(&el, scope, LifecyclePhase::Setup);
+        assert_eq!(MountEpoch::from(first).0, 0);
+        assert_eq!(MountEpoch::from(first).0, 0);
+
+        let second = LifecycleContext::__new(&el, scope, LifecyclePhase::Mount);
+        assert_eq!(MountEpoch::from(second).0, 1);
+        assert_eq!(MountEpoch::from(second).0, 1);
+
+        __clear_mount_epoch(scope);
+    }
+
+    #[test]
+    fn clearing_mount_epoch_resets_the_scope_generation() {
+        let scope = ScopeId(u64::MAX - 12);
+        __clear_mount_epoch(scope);
+
+        assert_eq!(next_mount_epoch(scope), 0);
+        assert_eq!(next_mount_epoch(scope), 1);
+        __clear_mount_epoch(scope);
+        assert_eq!(next_mount_epoch(scope), 0);
+
+        __clear_mount_epoch(scope);
+    }
+
+    #[test]
+    fn tag_name_interner_reuses_one_fallback_allocation() {
+        let first = intern_tag_name("Pocopine-Test-Fallback-Tag".to_owned());
+        let second = intern_tag_name("pocopine-test-fallback-tag".to_owned());
+
+        assert_eq!(first, "pocopine-test-fallback-tag");
+        assert_eq!(first, second);
+        assert!(std::ptr::eq(first.as_ptr(), second.as_ptr()));
     }
 }
 

--- a/crates/pocopine-core/src/mount.rs
+++ b/crates/pocopine-core/src/mount.rs
@@ -1729,7 +1729,6 @@ fn release_subtree_inner(node: &Node) {
                 // didn't host a route loader.
                 crate::router::release_loader_slot(scope_id);
                 Scope::remove(scope_id);
-                crate::lifecycle::__clear_mount_epoch(scope_id);
             }
         }
         crate::directives::transition::release(&el);

--- a/crates/pocopine-core/src/reactive.rs
+++ b/crates/pocopine-core/src/reactive.rs
@@ -36,7 +36,6 @@ use slab::Slab;
 
 use js_sys::Promise;
 use wasm_bindgen::JsValue;
-use wasm_bindgen::closure::Closure;
 use wasm_bindgen_futures::JsFuture;
 
 /// Dependency-map key: the scope-scoped field name. Stored as
@@ -840,7 +839,3 @@ pub fn signal_graph_snapshot() -> Vec<SignalSnapshot> {
 pub fn is_scheduler_routed(id: EffectId) -> bool {
     with_effect(id, |e| e.scheduler.is_some()).unwrap_or(false)
 }
-
-// Keep unused-import noise away when `wasm-bindgen-futures` features drift.
-#[allow(dead_code)]
-fn _unused(_: Closure<dyn FnMut()>) {}

--- a/crates/pocopine-core/src/registry.rs
+++ b/crates/pocopine-core/src/registry.rs
@@ -35,14 +35,6 @@ pub type ComponentCtor = fn() -> Scope;
 /// static-plan fallback hook.
 pub type ComponentMountFn = fn(&Element, ScopeId, &JsValue);
 
-/// Kept as a public type so users with their own registration path have
-/// something to hand back to the runtime.
-pub struct ComponentEntry {
-    pub name: &'static str,
-    pub ctor: ComponentCtor,
-    pub mount_template: Option<ComponentMountFn>,
-}
-
 /// Snapshot of a registered canonical entry. Aliases resolve to the
 /// canonical entry by name, so introspection happens through here.
 #[derive(Clone, Copy)]
@@ -322,9 +314,6 @@ pub fn register_component_prefixed(
     register_component(combined, owner, ctor);
 }
 
-/// Exposed for symmetry with the `ComponentEntry` type.
-pub static COMPONENT_ENTRIES: &[ComponentEntry] = &[];
-
 /// Instantiate a component by name. Resolves through aliases. `None` if
 /// the name wasn't registered.
 pub fn instantiate(name: &str) -> Option<Scope> {
@@ -369,6 +358,19 @@ pub fn canonical_component_name(name: &str) -> Option<&'static str> {
             return Some(entry.canonical);
         }
         None
+    })
+}
+
+/// Return the exact registered spelling for a canonical tag or alias.
+/// Unlike [`canonical_component_name`], aliases remain aliases. Lifecycle's
+/// `TagName` extractor uses this to reuse registry-owned static strings.
+pub(crate) fn registered_component_tag(name: &str) -> Option<&'static str> {
+    REGISTRY.with(|r| {
+        let reg = r.borrow();
+        reg.canonical
+            .get_key_value(name)
+            .map(|(&tag, _)| tag)
+            .or_else(|| reg.aliases.get_key_value(name).map(|(&tag, _)| tag))
     })
 }
 

--- a/crates/pocopine-core/src/scope.rs
+++ b/crates/pocopine-core/src/scope.rs
@@ -242,12 +242,6 @@ pub trait ComponentState: 'static {
         false
     }
 
-    /// Symmetric with `has_on_mount`. Kept for parity; reserved
-    /// for future devtools coverage displays.
-    fn has_on_unmount(&self) -> bool {
-        false
-    }
-
     /// RFC-038 — enter preset name the component declared at
     /// `#[component(transition = "…")]` (or `transition_in`). The
     /// mount calls this once post-template-clone to stamp the
@@ -448,6 +442,7 @@ impl Scope {
         crate::reactive::clear_scope(id);
         crate::component_computed::clear_scope(id);
         crate::model_runtime::clear_scope(id);
+        crate::lifecycle::__clear_mount_epoch(id);
         crate::task::clear_scope(id);
         // Drop the proxy-trap closures that were pinned in
         // `into_proxy`. The `Box<dyn Any>` drop chain runs the
@@ -1386,6 +1381,3 @@ pub fn invoke_handler(scope_id: ScopeId, key: &str, args: &Array) -> JsValue {
         None => JsValue::UNDEFINED,
     }
 }
-
-#[allow(dead_code)]
-fn _type_check(_: &Function) {}

--- a/crates/pocopine-core/src/text/prepare.rs
+++ b/crates/pocopine-core/src/text/prepare.rs
@@ -39,8 +39,6 @@ pub(crate) struct PreparedSegment {
 
 pub struct PreparedText {
     pub(crate) font: Font,
-    #[allow(dead_code)]
-    pub(crate) options: PrepareOptions,
     pub(crate) segments: Vec<PreparedSegment>,
     pub(crate) soft_hyphen_width: f64,
     pub(crate) normalized: String,
@@ -103,7 +101,6 @@ pub fn prepare<M: Measurer>(
 
     PreparedText {
         font: font.clone(),
-        options,
         segments,
         soft_hyphen_width,
         normalized,

--- a/crates/pocopine-core/tests/reactive.rs
+++ b/crates/pocopine-core/tests/reactive.rs
@@ -7,10 +7,12 @@ use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use js_sys::Reflect;
+#[cfg(any(debug_assertions, feature = "devtools"))]
+use pocopine_core::{FieldHandle, Handle};
 use pocopine_core::{
-    FieldHandle, Handle, Scope, batch, computed, effect, flush_sync, on_cleanup,
-    on_scope_unmount_for, release, run_now, rw_signal, set_auto_flush, signal, spawn_for_scope,
-    spawn_latest, spawn_latest_for_scope, spawn_scoped, watch, watch_scope_field_now,
+    Scope, batch, computed, effect, flush_sync, on_cleanup, on_scope_unmount_for, release, run_now,
+    rw_signal, set_auto_flush, signal, spawn_for_scope, spawn_latest, spawn_latest_for_scope,
+    spawn_scoped, watch, watch_scope_field_now,
 };
 use serde::{Deserialize, Serialize};
 use wasm_bindgen::JsValue;
@@ -309,6 +311,7 @@ fn watch_scope_field_now_reads_existing_value_on_install() {
 }
 
 // RFC-097 — FieldHandle::set writes one field with NO dirty sweep.
+#[cfg(any(debug_assertions, feature = "devtools"))]
 #[wasm_bindgen_test]
 fn field_handle_set_writes_one_field_without_a_sweep() {
     setup();
@@ -351,6 +354,7 @@ fn field_handle_set_writes_one_field_without_a_sweep() {
 }
 
 // RFC-097 — FieldHandle::update is a read-modify-write of one field.
+#[cfg(any(debug_assertions, feature = "devtools"))]
 #[wasm_bindgen_test]
 fn field_handle_update_read_modify_writes_one_field() {
     setup();

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -3283,7 +3283,6 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
             }
         }
     });
-    let has_observes = !observes.is_empty();
     let observe_impl = quote! {
         impl #struct_ident {
             #[doc(hidden)]
@@ -3295,8 +3294,6 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
                 let _ = &__handle;
                 #(#observe_install_stmts)*
             }
-            #[doc(hidden)]
-            pub const __POCOPINE_HAS_OBSERVES: bool = #has_observes;
         }
     };
 
@@ -3634,9 +3631,6 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
             }
             fn has_on_ready(&self) -> bool {
                 <Self as ::pocopine::__private::HandlerDispatch>::has_on_ready(self)
-            }
-            fn has_on_unmount(&self) -> bool {
-                <Self as ::pocopine::__private::HandlerDispatch>::has_on_unmount(self)
             }
             fn transition_in_preset(&self) -> &'static str {
                 #transition_in_literal
@@ -4387,7 +4381,6 @@ pub fn handlers(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 let _ = &__ctx;
                 Self::on_unmount(self #(, #unmount_extractor_args)*);
             }
-            fn has_on_unmount(&self) -> bool { true }
         }
     });
 
@@ -4634,8 +4627,6 @@ pub fn store(attr: TokenStream, item: TokenStream) -> TokenStream {
             ) {
                 let _ = __handle;
             }
-            #[doc(hidden)]
-            pub const __POCOPINE_HAS_OBSERVES: bool = false;
         }
 
         impl ::pocopine::__private::ComponentState for #struct_ident {

--- a/crates/pocopine-macros/src/slot.rs
+++ b/crates/pocopine-macros/src/slot.rs
@@ -49,11 +49,6 @@ pub(crate) struct SlotDecl {
     /// `pp-let` binding is typed as `T`. `T` must
     /// `#[derive(Props)]`.
     pub props: Option<Path>,
-    /// Span of the `#[slot(...)]` attribute for diagnostics.
-    /// Currently unused at emit time; kept so future diagnostic
-    /// paths can anchor errors at the declaration.
-    #[allow(dead_code)]
-    pub span: proc_macro2::Span,
 }
 
 #[derive(Debug, Clone)]
@@ -210,7 +205,6 @@ fn parse_slot_attr(attr: &Attribute) -> syn::Result<SlotDecl> {
         mode: mode.unwrap_or(SlotMode::Accepts),
         accepts,
         props,
-        span,
     })
 }
 
@@ -1023,7 +1017,6 @@ mod tests {
                 syn::parse_str::<Path>("PineSeparator").unwrap(),
             ],
             props: None,
-            span: proc_macro2::Span::call_site(),
         }];
         let out = emit_slot_traits(
             &syn::Ident::new("PineContextMenuContent", proc_macro2::Span::call_site()),
@@ -1052,7 +1045,6 @@ mod tests {
                 syn::parse_str::<Path>("PineDialogDescription").unwrap(),
             ],
             props: None,
-            span: proc_macro2::Span::call_site(),
         }];
         let out = emit_slot_traits(
             &syn::Ident::new("PineDialogContent", proc_macro2::Span::call_site()),
@@ -1077,7 +1069,6 @@ mod tests {
             mode: SlotMode::Only,
             accepts: vec![syn::parse_str::<Path>("PineTitle").unwrap()],
             props: None,
-            span: proc_macro2::Span::call_site(),
         }];
         let out = emit_slot_traits(
             &syn::Ident::new("Foo", proc_macro2::Span::call_site()),
@@ -1180,7 +1171,6 @@ mod tests {
             mode: SlotMode::Accepts,
             accepts: Vec::new(),
             props: Some(props_path(props)),
-            span: proc_macro2::Span::call_site(),
         }
     }
 

--- a/crates/pocopine-macros/src/uses.rs
+++ b/crates/pocopine-macros/src/uses.rs
@@ -56,12 +56,6 @@ impl UsesTable {
             .iter()
             .find_map(|(t, p)| (t == tag).then_some(p))
     }
-
-    /// Number of entries (for tests / diagnostics).
-    #[allow(dead_code)]
-    pub fn len(&self) -> usize {
-        self.entries.len()
-    }
 }
 
 /// RFC 060 Tier 3 — parse the `extends = [...]` value of a
@@ -218,7 +212,7 @@ mod tests {
         let expr = parse_expr(quote! { [PineContextMenuItem, PineFoo] });
         let entries = parse_uses_array(expr).unwrap();
         let table = resolve_uses(entries).unwrap();
-        assert_eq!(table.len(), 2);
+        assert_eq!(table.entries.len(), 2);
         assert!(table.lookup("pine-context-menu-item").is_some());
         assert!(table.lookup("pine-foo").is_some());
     }
@@ -241,7 +235,7 @@ mod tests {
         });
         let entries = parse_uses_array(expr).unwrap();
         let table = resolve_uses(entries).unwrap();
-        assert_eq!(table.len(), 3);
+        assert_eq!(table.entries.len(), 3);
         assert!(table.lookup("pine-foo").is_some());
         assert!(table.lookup("my-custom-tag").is_some());
         assert!(table.lookup("pine-bar").is_some());

--- a/scripts/ci/pocopine_core_feature_matrix.sh
+++ b/scripts/ci/pocopine_core_feature_matrix.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Keep release-only cfgs honest on both host and wasm. `--all-targets`
+# intentionally compiles integration tests too: instrumentation-backed tests
+# must carry the same cfg as the instrumentation they exercise.
+cargo check -p pocopine-core --release --all-targets --no-default-features
+cargo check -p pocopine-core --release --all-targets --all-features
+cargo check -p pocopine-core --release --target wasm32-unknown-unknown --all-targets --no-default-features
+cargo check -p pocopine-core --release --target wasm32-unknown-unknown --all-targets --all-features


### PR DESCRIPTION
## What changed

- add a release host/wasm feature matrix covering no-default and all-feature builds
- align fingerprint-instrumentation tests with the cfg that provides the counters
- fix `MountEpoch` so it advances once per lifecycle hook context and resets on scope teardown
- intern normalized `TagName` values instead of leaking on every extraction
- remove verified unused runtime and macro plumbing

## Why

A release wasm `--all-targets --no-default-features` build was not compiled in CI and failed because integration tests referenced debug-only instrumentation. The audit also found lifecycle APIs whose implementation did not match their documented behavior and internal code paths with no consumers.

## Impact

The release feature matrix now catches cfg-only regressions. Lifecycle epochs are deterministic per scope, and tag-name extraction has bounded allocation growth.

This intentionally removes the public but non-functional `ComponentEntry` and permanently empty `COMPONENT_ENTRIES` exports. Repository-wide search found no consumers.

## TDD / validation

- reproduced the release wasm no-default compilation failure before the fix
- `bash scripts/ci/pocopine_core_feature_matrix.sh`
- `cargo fmt --all -- --check`
- `cargo test -p pocopine-core --lib` (175 passed)
- `cargo test -p pocopine-macros --lib` (104 passed)
- targeted host/wasm clippy and build checks for core, macros, and umbrella