### PR TITLE
Fix core lifecycle and reactive teardown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -447,6 +447,15 @@ jobs:
           # RFC-058 Phase 6.5 — runtime walker is gone; the
           # browser job runs the template-plan suite (compiled
           # mount + lifecycle) and the Pine compound suite.
+          - name: pocopine-app-root
+            crate: crates/pocopine
+            args: --test pp_app_root
+          - name: pocopine-light-dom-slots
+            crate: crates/pocopine
+            args: --test light_dom_slots
+          - name: pocopine-typed-refs
+            crate: crates/pocopine
+            args: --test refs_typed
           - name: pocopine-template-plan
             crate: crates/pocopine
             args: --test template_plan

--- a/crates/pocopine-core/src/app.rs
+++ b/crates/pocopine-core/src/app.rs
@@ -2736,6 +2736,7 @@ impl SubtreeHandle {
         }
         mount::release_compiled_subtree(&self.host);
         self.host.set_inner_html("");
+        mount::clear_component_host_stamps(&self.host);
         self.active = false;
     }
 
@@ -2778,6 +2779,12 @@ fn mount_pp_app_subtree(host: &Element) {
                 let Ok(el) = node.dyn_into::<Element>() else {
                     continue;
                 };
+                // Mounting an outer candidate may replace or capture its
+                // original descendants. QuerySelectorAll is a snapshot, so
+                // re-check containment before touching each later candidate.
+                if !host.contains(Some(el.as_ref())) {
+                    continue;
+                }
                 let tag = el.local_name();
                 mount::mount_child_component(&el, &tag);
                 mount::finalize_compiled_subtree(&el);

--- a/crates/pocopine-core/src/context.rs
+++ b/crates/pocopine-core/src/context.rs
@@ -235,6 +235,27 @@ pub fn clear_scope(scope: ScopeId) {
     });
 }
 
+/// Bulk counterpart to [`clear_scope`] for compiled `pp-for` row scopes.
+/// Row scopes normally own only a parent edge, but clearing both tables keeps
+/// this correct if a future row feature adds a provided value.
+pub(crate) fn clear_scopes(scopes: &[ScopeId]) {
+    if scopes.is_empty() {
+        return;
+    }
+    PARENTS.with(|parents| {
+        let mut parents = parents.borrow_mut();
+        for scope in scopes {
+            parents.remove(scope);
+        }
+    });
+    PROVIDES.with(|provides| {
+        let mut provides = provides.borrow_mut();
+        for scope in scopes {
+            provides.remove(scope);
+        }
+    });
+}
+
 /// Marker trait paired with each [`ContextKey<T>`] declared via
 /// [`create_context!`]. Lets `Inject<KEY, T>` (RFC 056 §6.5) name a
 /// key at type level on stable Rust without const generics.

--- a/crates/pocopine-core/src/directives/roving.rs
+++ b/crates/pocopine-core/src/directives/roving.rs
@@ -17,15 +17,12 @@
 //!   the host's `aria-activedescendant` and each item's
 //!   `data-highlighted` attribute.
 
-use js_sys::Reflect;
 use wasm_bindgen::JsCast;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::prelude::*;
-use web_sys::{Element, HtmlElement, KeyboardEvent, NodeList, console};
+use web_sys::{Element, Event, HtmlElement, KeyboardEvent, NodeList, console};
 
 use crate::reactive::ScopeId;
-
-const STATE_KEY: &str = "__pp_roving_state";
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 enum Orientation {
@@ -70,23 +67,6 @@ pub fn install_opaque(
     }
 }
 
-/// Called by `mount::release_subtree` on every released element.
-pub fn release(el: &Element) {
-    let Ok(v) = Reflect::get(el.as_ref(), &STATE_KEY.into()) else {
-        return;
-    };
-    if v.is_undefined() || v.is_null() {
-        return;
-    }
-    if let Ok(target) = v.clone().dyn_into::<web_sys::EventTarget>() {
-        // Impossible to re-use the closure reference after it was
-        // forgotten, so we rely on the `__pp_roving_state` slot
-        // holding a handle the GC will drop alongside the element.
-        let _ = target;
-    }
-    let _ = Reflect::set(el.as_ref(), &STATE_KEY.into(), &JsValue::UNDEFINED);
-}
-
 /// Primary roving install — container owns the arrow-key listener,
 /// items get tabindex management.
 fn install_roving(
@@ -118,8 +98,11 @@ fn install_roving(
     // Keydown listener.
     let container_clone = container.clone();
     let selector_clone = items_selector.clone();
-    let closure: Closure<dyn FnMut(KeyboardEvent)> = Closure::wrap(Box::new({
-        move |ev: KeyboardEvent| {
+    let closure: Closure<dyn FnMut(Event)> = Closure::wrap(Box::new({
+        move |ev: Event| {
+            let Ok(ev) = ev.dyn_into::<KeyboardEvent>() else {
+                return;
+            };
             let key = ev.key();
             let action = classify_key(&key, orientation);
             let Some(action) = action else { return };
@@ -175,13 +158,10 @@ fn install_roving(
                 crate::focus::focus_no_scroll(&html);
             }
         }
-    })
-        as Box<dyn FnMut(KeyboardEvent)>);
+    }) as Box<dyn FnMut(Event)>);
 
     let target: &web_sys::EventTarget = container.as_ref();
-    let _ = target.add_event_listener_with_callback("keydown", closure.as_ref().unchecked_ref());
-    closure.forget();
-    let _ = Reflect::set(container.as_ref(), &STATE_KEY.into(), &JsValue::TRUE);
+    crate::mount::track_listener_on(container, target.clone(), "keydown", false, closure);
 }
 
 /// Entry-transfer form: `pp-roving:<listbox-id>` on an `<input>`.
@@ -201,8 +181,11 @@ fn install_palette_entry(input: &Element, orientation: Orientation) {
     let listbox_arg = read_roving_arg(input);
     let _ = listbox_id;
 
-    let closure: Closure<dyn FnMut(KeyboardEvent)> = Closure::wrap(Box::new({
-        move |ev: KeyboardEvent| {
+    let closure: Closure<dyn FnMut(Event)> = Closure::wrap(Box::new({
+        move |ev: Event| {
+            let Ok(ev) = ev.dyn_into::<KeyboardEvent>() else {
+                return;
+            };
             let direction = match classify_key(&ev.key(), orientation) {
                 Some(KeyAction::Next) => FocusEdge::First,
                 Some(KeyAction::Prev) => FocusEdge::Last,
@@ -246,12 +229,9 @@ fn install_palette_entry(input: &Element, orientation: Orientation) {
                 }
             }
         }
-    })
-        as Box<dyn FnMut(KeyboardEvent)>);
+    }) as Box<dyn FnMut(Event)>);
     let target: &web_sys::EventTarget = input_clone.as_ref();
-    let _ = target.add_event_listener_with_callback("keydown", closure.as_ref().unchecked_ref());
-    closure.forget();
-    let _ = Reflect::set(input.as_ref(), &STATE_KEY.into(), &JsValue::TRUE);
+    crate::mount::track_listener_on(input, target.clone(), "keydown", false, closure);
 }
 
 enum FocusEdge {
@@ -376,8 +356,11 @@ fn install_virtual(
     }
 
     let host_clone = host.clone();
-    let closure: Closure<dyn FnMut(KeyboardEvent)> = Closure::wrap(Box::new({
-        move |ev: KeyboardEvent| {
+    let closure: Closure<dyn FnMut(Event)> = Closure::wrap(Box::new({
+        move |ev: Event| {
+            let Ok(ev) = ev.dyn_into::<KeyboardEvent>() else {
+                return;
+            };
             let action = match classify_key(&ev.key(), orientation) {
                 Some(a) => a,
                 None => return,
@@ -433,13 +416,10 @@ fn install_virtual(
             let _ = host_clone.set_attribute("aria-activedescendant", &id);
             set_highlighted(&items, Some(target));
         }
-    })
-        as Box<dyn FnMut(KeyboardEvent)>);
+    }) as Box<dyn FnMut(Event)>);
 
     let target: &web_sys::EventTarget = host.as_ref();
-    let _ = target.add_event_listener_with_callback("keydown", closure.as_ref().unchecked_ref());
-    closure.forget();
-    let _ = Reflect::set(host.as_ref(), &STATE_KEY.into(), &JsValue::TRUE);
+    crate::mount::track_listener_on(host, target.clone(), "keydown", false, closure);
 }
 
 fn query_virtual_items(listbox_id: &str, selector: &str) -> Vec<Element> {

--- a/crates/pocopine-core/src/mount.rs
+++ b/crates/pocopine-core/src/mount.rs
@@ -89,6 +89,7 @@ const RELEASE_SKIP_KEY: &str = "__pp_release_skip";
 /// scope points.
 pub(crate) const CTX_PARENT_KEY: &str = "__pp_ctx_parent";
 const MOUNT_HOOK_FIRED_KEY: &str = "__pp_mount_hook_fired";
+const SLOT_SCOPE_OWNER_KEY: &str = "__pp_slot_scope_owner";
 
 #[derive(Clone)]
 struct CapturedSlot {
@@ -108,6 +109,59 @@ thread_local! {
     /// + `as_string` round-trip.
     static COMPONENT_NAMES: RefCell<HashMap<ScopeId, &'static str>> =
         RefCell::new(HashMap::new());
+    /// Number of live top-level nodes in each scoped-slot materialization.
+    /// The nodes borrow the SlotScope for evaluation, while this count gives
+    /// that otherwise-ownerless scope a deterministic teardown point.
+    static SLOT_SCOPE_ROOTS: RefCell<HashMap<ScopeId, usize>> =
+        RefCell::new(HashMap::new());
+}
+
+fn bind_slot_scope_owners(scope_id: ScopeId, roots: &[Node]) {
+    if roots.is_empty() {
+        Scope::remove(scope_id);
+        return;
+    }
+    SLOT_SCOPE_ROOTS.with(|owners| {
+        owners.borrow_mut().insert(scope_id, roots.len());
+    });
+    for root in roots {
+        let _ = Reflect::set(
+            root.as_ref(),
+            &SLOT_SCOPE_OWNER_KEY.into(),
+            &JsValue::from_f64(scope_id.0 as f64),
+        );
+    }
+}
+
+fn release_slot_scope_owner(root: &Node) {
+    let Some(scope_id) = Reflect::get(root.as_ref(), &SLOT_SCOPE_OWNER_KEY.into())
+        .ok()
+        .and_then(|value| value.as_f64())
+        .map(|value| ScopeId(value as u64))
+    else {
+        return;
+    };
+    let _ = Reflect::set(
+        root.as_ref(),
+        &SLOT_SCOPE_OWNER_KEY.into(),
+        &JsValue::UNDEFINED,
+    );
+    let remove_scope = SLOT_SCOPE_ROOTS.with(|owners| {
+        let mut owners = owners.borrow_mut();
+        let Some(remaining) = owners.get_mut(&scope_id) else {
+            return false;
+        };
+        *remaining = remaining.saturating_sub(1);
+        if *remaining == 0 {
+            owners.remove(&scope_id);
+            true
+        } else {
+            false
+        }
+    });
+    if remove_scope {
+        Scope::remove(scope_id);
+    }
 }
 
 /// Pin a pre-built scope onto an element so [`enclosing_scope`] resolves
@@ -1077,14 +1131,25 @@ fn materialize_slot(slot_el: &Element) {
             snapshot.push(n);
         }
     }
+    let mut inserted_nodes = Vec::with_capacity(snapshot.len());
+    let mut inserted_elements = Vec::new();
     for n in snapshot {
-        let _ = parent.insert_before(&n, Some(slot_el));
+        if parent.insert_before(&n, Some(slot_el)).is_err() {
+            continue;
+        }
+        inserted_nodes.push(n.clone());
         if let Ok(e) = n.dyn_into::<Element>() {
             if let Some(slot_scope_id) = slot_scope_for_pin {
                 bind_borrowed_scope_to(&e, slot_scope_id, &fragment_parent_proxy);
             }
-            finalize_compiled_subtree(&e);
+            inserted_elements.push(e);
         }
+    }
+    if let Some(slot_scope_id) = slot_scope_for_pin {
+        bind_slot_scope_owners(slot_scope_id, &inserted_nodes);
+    }
+    for element in inserted_elements {
+        finalize_compiled_subtree(&element);
     }
     let _ = parent.remove_child(slot_el);
 }
@@ -1169,9 +1234,13 @@ fn materialize_captured_light_dom_slot(
             snapshot.push(n);
         }
     }
+    let mut inserted_nodes: Vec<Node> = Vec::new();
     let mut inserted: Vec<Element> = Vec::new();
     for n in snapshot {
-        let _ = parent.insert_before(&n, Some(slot_el));
+        if parent.insert_before(&n, Some(slot_el)).is_err() {
+            continue;
+        }
+        inserted_nodes.push(n.clone());
         if let Ok(e) = n.dyn_into::<Element>() {
             inserted.push(e);
         }
@@ -1191,6 +1260,7 @@ fn materialize_captured_light_dom_slot(
         for el in &inserted {
             bind_borrowed_scope_to(el, slot_scope.id, &proxy);
         }
+        bind_slot_scope_owners(slot_scope.id, &inserted_nodes);
     } else {
         for el in &inserted {
             bind_borrowed_scope_to(el, captured.owner_scope_id, &captured.owner_proxy);
@@ -1239,6 +1309,9 @@ fn mount_captured_light_dom_components(root: &Element) {
         }
     }
     for el in roots {
+        if !root.contains(Some(el.as_ref())) {
+            continue;
+        }
         let tag = el.local_name();
         mount_child_component(&el, &tag);
     }
@@ -1682,9 +1755,13 @@ fn release_subtree_inner(node: &Node) {
         // sweep below would pay 5+ `Reflect::get` calls per
         // descendant element for nothing.
         if get_private(&el, RELEASE_SKIP_KEY).is_some() {
+            release_slot_scope_owner(node);
             return;
         }
-        let children = el.children();
+        // Scoped-slot ownership can be stamped on a top-level text node
+        // (for example a bare `{{ ctx.label }}` fragment). Visit all child
+        // nodes, not only elements, so those ownership counts reach zero.
+        let children = el.child_nodes();
         for i in 0..children.length() {
             if let Some(c) = children.item(i) {
                 release_subtree_inner(&c);
@@ -1736,8 +1813,8 @@ fn release_subtree_inner(node: &Node) {
         crate::directives::resize::release(&el);
         crate::directives::intersect::release(&el);
         crate::directives::anchor::release(&el);
-        crate::directives::roving::release(&el);
         crate::directives::flip::release(&el);
+        crate::refs::unregister_element(&el);
         release_listeners(&el);
         match el.local_name().as_str() {
             "pp-component" => crate::dynamic_component::release_host(&el),
@@ -1747,6 +1824,26 @@ fn release_subtree_inner(node: &Node) {
             }
             _ => {}
         }
+    }
+    release_slot_scope_owner(node);
+}
+
+/// Clear the private sentinels that live on a component's custom-element
+/// host. The rendered root owns the scope and is removed separately; these
+/// host-only stamps must not block a later typed remount on the same element.
+pub(crate) fn clear_component_host_stamps(host: &Element) {
+    for key in [
+        "__pp_mounted",
+        HOST_CHILD_SCOPE_ID_KEY,
+        WALKED_KEY,
+        EFFECTS_KEY,
+        LISTENERS_KEY,
+        MOUNT_HOOK_FIRED_KEY,
+        COMPONENT_MOUNT_EVENT_FIRED_KEY,
+        MOUNT_START_MS_KEY,
+        PENDING_EFFECTS_KEY,
+    ] {
+        set_private(host, key, &JsValue::UNDEFINED);
     }
 }
 

--- a/crates/pocopine-core/src/reactive.rs
+++ b/crates/pocopine-core/src/reactive.rs
@@ -608,10 +608,19 @@ fn dispatch_signal(sid: SignalId) {
 /// dispatch quietly (no devtools signal hook): they aren't user
 /// `Signal`s, and the devtools timeline has its own field events.
 pub fn trigger(scope_id: ScopeId, key: &str) {
-    let Some(sid) = field_signal(scope_id, key, false) else {
-        return;
-    };
-    dispatch_signal(sid);
+    if let Some(sid) = field_signal(scope_id, key, false) {
+        dispatch_signal(sid);
+    }
+    // `Handle::observe` intentionally selects from typed Rust state instead
+    // of reading through the proxy, so it subscribes to this reserved
+    // any-field signal. Targeted writes must notify it as well as the named
+    // field; dirty-sweep writes already reach it through `trigger_scope`.
+    const HANDLE_OBSERVE_KEY: &str = "__pp_handle_observe";
+    if key != HANDLE_OBSERVE_KEY
+        && let Some(sid) = field_signal(scope_id, HANDLE_OBSERVE_KEY, false)
+    {
+        dispatch_signal(sid);
+    }
 }
 
 /// Signal-targeted trigger. Skips the `(scope_id, key)` lookup path

--- a/crates/pocopine-core/src/refs.rs
+++ b/crates/pocopine-core/src/refs.rs
@@ -44,7 +44,8 @@
 use std::cell::RefCell;
 use std::collections::HashMap;
 
-use wasm_bindgen::JsCast;
+use js_sys::Reflect;
+use wasm_bindgen::{JsCast, JsValue};
 use web_sys::Element;
 
 use crate::handle::Handle;
@@ -56,15 +57,69 @@ thread_local! {
         RefCell::new(HashMap::new());
 }
 
+const REF_SCOPE_KEY: &str = "__pp_ref_scope";
+const REF_NAME_KEY: &str = "__pp_ref_name";
+
 /// Register `el` as the ref named `name` on `scope_id`. Called by the
 /// `pp-ref` directive during walk.
 pub fn register(scope_id: ScopeId, name: &str, el: &Element) {
+    unregister_element(el);
     REFS.with(|r| {
         r.borrow_mut()
             .entry(scope_id)
             .or_default()
             .insert(name.to_string(), el.clone());
     });
+    let _ = Reflect::set(
+        el.as_ref(),
+        &JsValue::from_str(REF_SCOPE_KEY),
+        &JsValue::from_f64(scope_id.0 as f64),
+    );
+    let _ = Reflect::set(
+        el.as_ref(),
+        &JsValue::from_str(REF_NAME_KEY),
+        &JsValue::from_str(name),
+    );
+}
+
+/// Remove the registration owned by one element. The identity check keeps an
+/// older conditional branch from deleting a newer element that reused the
+/// same ref name before the old branch finished teardown.
+pub(crate) fn unregister_element(el: &Element) {
+    let scope_id = Reflect::get(el.as_ref(), &JsValue::from_str(REF_SCOPE_KEY))
+        .ok()
+        .and_then(|value| value.as_f64())
+        .map(|value| ScopeId(value as u64));
+    let name = Reflect::get(el.as_ref(), &JsValue::from_str(REF_NAME_KEY))
+        .ok()
+        .and_then(|value| value.as_string());
+    if let (Some(scope_id), Some(name)) = (scope_id, name) {
+        REFS.with(|refs| {
+            let mut refs = refs.borrow_mut();
+            let remove_scope = if let Some(scope_refs) = refs.get_mut(&scope_id) {
+                let is_current = scope_refs.get(&name).is_some_and(|current| current == el);
+                if is_current {
+                    scope_refs.remove(&name);
+                }
+                scope_refs.is_empty()
+            } else {
+                false
+            };
+            if remove_scope {
+                refs.remove(&scope_id);
+            }
+        });
+    }
+    let _ = Reflect::set(
+        el.as_ref(),
+        &JsValue::from_str(REF_SCOPE_KEY),
+        &JsValue::UNDEFINED,
+    );
+    let _ = Reflect::set(
+        el.as_ref(),
+        &JsValue::from_str(REF_NAME_KEY),
+        &JsValue::UNDEFINED,
+    );
 }
 
 /// Look up a ref on the current handler's scope. Returns `None`

--- a/crates/pocopine-core/src/scope.rs
+++ b/crates/pocopine-core/src/scope.rs
@@ -481,6 +481,7 @@ impl Scope {
                 map.remove(id);
             }
         });
+        crate::context::clear_scopes(ids);
         crate::reactive::clear_scopes(ids);
         // Compiled rows that never minted a proxy have no entry in
         // PROXY_CLOSURES / PATCHED — the
@@ -1159,13 +1160,13 @@ pub fn patch_list_at_inline<T: serde::Serialize>(field: &str, idx: usize, row: &
     };
     let cached = projection_read(sid, field);
     if let Some(arr) = cached {
-        if arr.is_object()
-            && let Ok(new_js) = serde_wasm_bindgen::to_value(row)
-        {
-            let _ = Reflect::set(&arr, &(idx as u32).into(), &new_js);
-        }
-        // Keep the projection alive across the post-handler sweep.
-        keep_field_fresh(sid, field);
+        let patched = arr.is_object()
+            && serde_wasm_bindgen::to_value(row)
+                .ok()
+                .is_some_and(|new_js| {
+                    Reflect::set(&arr, &(idx as u32).into(), &new_js).unwrap_or(false)
+                });
+        finish_inline_patch(sid, field, patched);
     }
     crate::reactive::trigger(sid, field);
 }
@@ -1180,14 +1181,18 @@ pub fn patch_list_indices_inline<T: serde::Serialize>(field: &str, patches: &[(u
     };
     let cached = projection_read(sid, field);
     if let Some(arr) = cached {
-        if arr.is_object() {
+        let mut patched = arr.is_object();
+        if patched {
             for (idx, row) in patches {
-                if let Ok(new_js) = serde_wasm_bindgen::to_value(row) {
-                    let _ = Reflect::set(&arr, &(*idx as u32).into(), &new_js);
-                }
+                let ok = serde_wasm_bindgen::to_value(row)
+                    .ok()
+                    .is_some_and(|new_js| {
+                        Reflect::set(&arr, &(*idx as u32).into(), &new_js).unwrap_or(false)
+                    });
+                patched &= ok;
             }
         }
-        keep_field_fresh(sid, field);
+        finish_inline_patch(sid, field, patched);
     }
     crate::reactive::trigger(sid, field);
 }
@@ -1202,6 +1207,16 @@ fn keep_field_fresh(scope_id: ScopeId, field: &str) {
     });
 }
 
+fn finish_inline_patch(scope_id: ScopeId, field: &str, patched: bool) {
+    if patched {
+        keep_field_fresh(scope_id, field);
+    } else {
+        // A partial or rejected JS mutation is not authoritative. Drop the
+        // projection so the next read serializes the Rust field again.
+        invalidate_field(scope_id, field);
+    }
+}
+
 /// Swap two indices inside a cached JS Array for a Vec-like field.
 /// Call from inside a handler after swapping the Rust Vec. This keeps
 /// existing row object identities intact, so keyed `pp-for` can avoid
@@ -1212,15 +1227,20 @@ pub fn swap_list_indices_inline(field: &str, a: usize, b: usize) {
     };
     let cached = projection_read(sid, field);
     if let Some(arr) = cached {
-        if arr.is_object() {
+        let patched = if arr.is_object() {
             let a_key = JsValue::from_f64(a as f64);
             let b_key = JsValue::from_f64(b as f64);
-            let a_val = Reflect::get(&arr, &a_key).unwrap_or(JsValue::UNDEFINED);
-            let b_val = Reflect::get(&arr, &b_key).unwrap_or(JsValue::UNDEFINED);
-            let _ = Reflect::set(&arr, &a_key, &b_val);
-            let _ = Reflect::set(&arr, &b_key, &a_val);
-        }
-        keep_field_fresh(sid, field);
+            match (Reflect::get(&arr, &a_key), Reflect::get(&arr, &b_key)) {
+                (Ok(a_val), Ok(b_val)) => {
+                    Reflect::set(&arr, &a_key, &b_val).unwrap_or(false)
+                        && Reflect::set(&arr, &b_key, &a_val).unwrap_or(false)
+                }
+                _ => false,
+            }
+        } else {
+            false
+        };
+        finish_inline_patch(sid, field, patched);
     }
     crate::reactive::trigger(sid, field);
 }
@@ -1234,7 +1254,7 @@ pub fn remove_list_at_inline(field: &str, idx: usize) {
     };
     let cached = projection_read(sid, field);
     if let Some(arr) = cached {
-        if arr.is_object() {
+        let patched = if arr.is_object() {
             let array = js_sys::Array::from(&arr);
             let len = array.length();
             let idx = idx as u32;
@@ -1244,14 +1264,20 @@ pub fn remove_list_at_inline(field: &str, idx: usize) {
                         .map_err(|_| JsValue::from_str("Array.splice is not callable"))
                 })
             {
-                let _ = splice.call2(
-                    &arr,
-                    &JsValue::from_f64(idx as f64),
-                    &JsValue::from_f64(1.0),
-                );
+                splice
+                    .call2(
+                        &arr,
+                        &JsValue::from_f64(idx as f64),
+                        &JsValue::from_f64(1.0),
+                    )
+                    .is_ok()
+            } else {
+                false
             }
-        }
-        keep_field_fresh(sid, field);
+        } else {
+            false
+        };
+        finish_inline_patch(sid, field, patched);
     }
     crate::reactive::trigger(sid, field);
 }
@@ -1266,14 +1292,19 @@ pub fn append_list_inline<T: serde::Serialize>(field: &str, start_idx: usize, ro
     };
     let cached = projection_read(sid, field);
     if let Some(arr) = cached {
-        if arr.is_object() {
+        let mut patched = arr.is_object();
+        if patched {
             for (offset, row) in rows.iter().enumerate() {
-                if let Ok(new_js) = serde_wasm_bindgen::to_value(row) {
-                    let _ = Reflect::set(&arr, &((start_idx + offset) as u32).into(), &new_js);
-                }
+                let ok = serde_wasm_bindgen::to_value(row)
+                    .ok()
+                    .is_some_and(|new_js| {
+                        Reflect::set(&arr, &((start_idx + offset) as u32).into(), &new_js)
+                            .unwrap_or(false)
+                    });
+                patched &= ok;
             }
         }
-        keep_field_fresh(sid, field);
+        finish_inline_patch(sid, field, patched);
     }
     crate::reactive::trigger(sid, field);
 }
@@ -1288,21 +1319,27 @@ pub fn prepend_list_inline<T: serde::Serialize>(field: &str, rows: &[T]) {
     };
     let cached = projection_read(sid, field);
     if let Some(arr) = cached {
-        if arr.is_object() {
+        let mut patched = arr.is_object();
+        if patched {
             let array = js_sys::Array::from(&arr);
             let added = rows.len() as u32;
             let old_len = array.length();
             for idx in (0..old_len).rev() {
-                let value = Reflect::get(&arr, &idx.into()).unwrap_or(JsValue::UNDEFINED);
-                let _ = Reflect::set(&arr, &(idx + added).into(), &value);
+                let ok = Reflect::get(&arr, &idx.into()).ok().is_some_and(|value| {
+                    Reflect::set(&arr, &(idx + added).into(), &value).unwrap_or(false)
+                });
+                patched &= ok;
             }
             for (idx, row) in rows.iter().enumerate() {
-                if let Ok(new_js) = serde_wasm_bindgen::to_value(row) {
-                    let _ = Reflect::set(&arr, &(idx as u32).into(), &new_js);
-                }
+                let ok = serde_wasm_bindgen::to_value(row)
+                    .ok()
+                    .is_some_and(|new_js| {
+                        Reflect::set(&arr, &(idx as u32).into(), &new_js).unwrap_or(false)
+                    });
+                patched &= ok;
             }
         }
-        keep_field_fresh(sid, field);
+        finish_inline_patch(sid, field, patched);
     }
     crate::reactive::trigger(sid, field);
 }

--- a/crates/pocopine-core/src/task.rs
+++ b/crates/pocopine-core/src/task.rs
@@ -1,15 +1,17 @@
 //! Scoped async task helpers.
 //!
 //! `spawn_scoped` and `spawn_latest` tie task lifetime to the current
-//! component scope. Cancellation in v1 is cooperative: cancelling a task
-//! flips a flag and drops it from the scope registry, but a future that
-//! never checks that flag may still run to completion.
+//! component scope. Cancellation drops the wrapped future at its next poll;
+//! the task state stores its current waker so cancellation also wakes a
+//! pending future instead of waiting for the future's own I/O to complete.
 
 use std::borrow::Cow;
 use std::cell::{Cell, RefCell};
 use std::collections::HashMap;
 use std::future::Future;
+use std::pin::Pin;
 use std::rc::Rc;
+use std::task::{Context, Poll, Waker};
 
 use wasm_bindgen_futures::spawn_local;
 
@@ -24,6 +26,52 @@ struct ScopeTasks {
 
 struct TaskState {
     cancelled: Cell<bool>,
+    waker: RefCell<Option<Waker>>,
+}
+
+impl TaskState {
+    fn cancel(&self) {
+        self.cancelled.set(true);
+        // End the RefCell borrow before `wake`: a custom executor may poll
+        // synchronously, and the poll path updates this same waker slot.
+        let waker = self.waker.borrow_mut().take();
+        if let Some(waker) = waker {
+            waker.wake();
+        }
+    }
+}
+
+struct Cancellable<F> {
+    future: Pin<Box<F>>,
+    state: Rc<TaskState>,
+}
+
+impl<F: Future<Output = ()>> Cancellable<F> {
+    fn new(future: F, state: Rc<TaskState>) -> Self {
+        Self {
+            future: Box::pin(future),
+            state,
+        }
+    }
+}
+
+impl<F: Future<Output = ()>> Future for Cancellable<F> {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+        if self.state.cancelled.get() {
+            return Poll::Ready(());
+        }
+        *self.state.waker.borrow_mut() = Some(cx.waker().clone());
+        match self.future.as_mut().poll(cx) {
+            Poll::Ready(()) => {
+                self.state.waker.borrow_mut().take();
+                Poll::Ready(())
+            }
+            Poll::Pending if self.state.cancelled.get() => Poll::Ready(()),
+            Poll::Pending => Poll::Pending,
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -40,6 +88,7 @@ impl TaskHandle {
         Self {
             inner: Rc::new(TaskState {
                 cancelled: Cell::new(false),
+                waker: RefCell::new(None),
             }),
         }
     }
@@ -51,7 +100,7 @@ impl TaskHandle {
     }
 
     pub fn cancel(&self) {
-        self.inner.cancelled.set(true);
+        self.inner.cancel();
     }
 
     pub fn is_cancelled(&self) -> bool {
@@ -88,8 +137,8 @@ pub fn spawn_for_scope(scope_id: ScopeId, fut: impl Future<Output = ()> + 'stati
     });
     let inner = handle.inner.clone();
     spawn_local(async move {
-        fut.await;
-        let _ = inner;
+        Cancellable::new(fut, inner.clone()).await;
+        finish_task(scope_id, &inner, None);
     });
     handle
 }
@@ -119,45 +168,63 @@ pub fn spawn_latest_for_scope(
 
     let task_name = task_name.into().into_owned();
     let handle = TaskHandle::new();
-    TASKS.with(|tasks| {
+    let previous = TASKS.with(|tasks| {
         let mut tasks = tasks.borrow_mut();
         let scope_tasks = tasks.entry(scope_id).or_default();
-        if let Some(prev) = scope_tasks
+        let previous = scope_tasks
             .latest
-            .insert(task_name.clone(), handle.inner.clone())
-        {
-            prev.cancelled.set(true);
-        }
+            .insert(task_name.clone(), handle.inner.clone());
         scope_tasks.tasks.push(handle.inner.clone());
+        previous
     });
+    // Wake the superseded task only after the TASKS RefMut is gone. An
+    // executor may poll synchronously from `wake`, and completion re-enters
+    // the same registry through `finish_task`.
+    if let Some(previous) = previous {
+        previous.cancel();
+    }
     let inner = handle.inner.clone();
     spawn_local(async move {
-        fut.await;
-        TASKS.with(|tasks| {
-            let mut tasks = tasks.borrow_mut();
-            let Some(scope_tasks) = tasks.get_mut(&scope_id) else {
-                return;
-            };
-            if scope_tasks
-                .latest
-                .get(&task_name)
-                .is_some_and(|current| Rc::ptr_eq(current, &inner))
-            {
-                scope_tasks.latest.remove(&task_name);
-            }
-        });
+        Cancellable::new(fut, inner.clone()).await;
+        finish_task(scope_id, &inner, Some(&task_name));
     });
     handle
 }
 
-pub fn clear_scope(scope_id: ScopeId) {
+fn finish_task(scope_id: ScopeId, state: &Rc<TaskState>, latest_name: Option<&str>) {
     TASKS.with(|tasks| {
-        if let Some(scope_tasks) = tasks.borrow_mut().remove(&scope_id) {
-            for task in scope_tasks.tasks {
-                task.cancelled.set(true);
+        let mut tasks = tasks.borrow_mut();
+        let remove_scope = {
+            let Some(scope_tasks) = tasks.get_mut(&scope_id) else {
+                return;
+            };
+            scope_tasks.tasks.retain(|task| !Rc::ptr_eq(task, state));
+            if let Some(name) = latest_name
+                && scope_tasks
+                    .latest
+                    .get(name)
+                    .is_some_and(|current| Rc::ptr_eq(current, state))
+            {
+                scope_tasks.latest.remove(name);
             }
+            scope_tasks.tasks.is_empty() && scope_tasks.latest.is_empty()
+        };
+        if remove_scope {
+            tasks.remove(&scope_id);
         }
     });
+}
+
+pub fn clear_scope(scope_id: ScopeId) {
+    // Remove the registry entry under the RefCell borrow, then wake tasks
+    // only after that borrow has ended. A custom executor is allowed to poll
+    // synchronously from `wake`, and completion re-enters `TASKS`.
+    let scope_tasks = TASKS.with(|tasks| tasks.borrow_mut().remove(&scope_id));
+    if let Some(scope_tasks) = scope_tasks {
+        for task in scope_tasks.tasks {
+            task.cancel();
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/pocopine-core/src/watch.rs
+++ b/crates/pocopine-core/src/watch.rs
@@ -104,10 +104,12 @@ fn read_scope_field<V>(scope_id: ScopeId, field: &'static str) -> V
 where
     V: Clone + PartialEq + Default + DeserializeOwned + 'static,
 {
-    track(scope_id, field);
     let Some(scope) = Scope::find(scope_id) else {
         return V::default();
     };
+    // A delayed install may race the target scope's teardown. Do not
+    // recreate an interned field signal after `Scope::remove` has purged it.
+    track(scope_id, field);
     let v = scope.state.borrow().get(field);
     serde_wasm_bindgen::from_value::<V>(v).unwrap_or_default()
 }
@@ -152,18 +154,16 @@ where
     S: Fn() -> T + 'static,
     C: Fn(&T, Option<&T>) + 'static,
 {
-    use std::cell::Cell;
-    use std::rc::Rc;
-    let pending: Rc<Cell<Option<EffectId>>> = Rc::new(Cell::new(None));
-    let pending_for_install = pending.clone();
+    let owner =
+        current_scope_id().expect("watch_scoped called outside a handler / lifecycle context");
     crate::tick::next(move || {
-        let id = watch(source, cb);
-        pending_for_install.set(Some(id));
-    });
-    crate::events::on_scope_unmount(move || {
-        if let Some(id) = pending.take() {
-            crate::reactive::release(id);
+        if Scope::find(owner).is_none() {
+            return;
         }
+        let id = watch(source, cb);
+        // Register after installation. If the initial callback unmounted the
+        // owner, `on_scope_unmount_for` releases the effect immediately.
+        crate::events::on_scope_unmount_for(owner, move || crate::reactive::release(id));
     });
 }
 
@@ -187,20 +187,13 @@ where
     V: Clone + PartialEq + Default + DeserializeOwned + 'static,
     C: Fn(&V, Option<&V>) + 'static,
 {
-    use std::cell::Cell;
-    use std::rc::Rc;
-    // The install is deferred a tick (same as `watch_scope_field`),
-    // so we have to capture the eventually-minted EffectId in a
-    // shared cell that the unmount closure can read.
-    let pending: Rc<Cell<Option<EffectId>>> = Rc::new(Cell::new(None));
-    let pending_for_install = pending.clone();
+    let owner = current_scope_id()
+        .expect("watch_scope_field_scoped called outside a handler / lifecycle context");
     crate::tick::next(move || {
-        let id = watch_scope_field_now(scope_id, field, cb);
-        pending_for_install.set(Some(id));
-    });
-    crate::events::on_scope_unmount(move || {
-        if let Some(id) = pending.take() {
-            crate::reactive::release(id);
+        if Scope::find(owner).is_none() || Scope::find(scope_id).is_none() {
+            return;
         }
+        let id = watch_scope_field_now(scope_id, field, cb);
+        crate::events::on_scope_unmount_for(owner, move || crate::reactive::release(id));
     });
 }

--- a/crates/pocopine-core/tests/reactive.rs
+++ b/crates/pocopine-core/tests/reactive.rs
@@ -7,7 +7,6 @@ use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use js_sys::Reflect;
-#[cfg(any(debug_assertions, feature = "devtools"))]
 use pocopine_core::{FieldHandle, Handle};
 use pocopine_core::{
     Scope, batch, computed, effect, flush_sync, on_cleanup, on_scope_unmount_for, release, run_now,
@@ -15,13 +14,28 @@ use pocopine_core::{
     spawn_scoped, watch, watch_scope_field_now,
 };
 use serde::{Deserialize, Serialize};
-use wasm_bindgen::JsValue;
+use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_test::wasm_bindgen_test;
 
 fn setup() {
     // spawn_local's microtask host isn't reliable under
     // `wasm-pack test --node`; drive flushes manually.
     set_auto_flush(false);
+}
+
+async fn next_microtasks(count: usize) {
+    for _ in 0..count {
+        let promise = js_sys::Promise::resolve(&JsValue::NULL);
+        let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
+    }
+}
+
+struct DropFlag(Rc<Cell<bool>>);
+
+impl Drop for DropFlag {
+    fn drop(&mut self) {
+        self.0.set(true);
+    }
 }
 
 #[wasm_bindgen_test]
@@ -461,6 +475,253 @@ fn on_scope_unmount_for_runs_when_scope_is_removed() {
     Scope::remove(scope.id);
 
     assert!(ran.get());
+}
+
+#[wasm_bindgen_test(async)]
+async fn scoped_task_future_is_dropped_before_it_can_commit_after_unmount() {
+    setup();
+
+    let scope = Scope::new(Rc::new(RefCell::new(TestScopeState::default())));
+    let committed = Rc::new(Cell::new(false));
+    let committed_for_task = committed.clone();
+    let started = Rc::new(Cell::new(false));
+    let started_for_task = started.clone();
+    let dropped = Rc::new(Cell::new(false));
+    let dropped_for_task = dropped.clone();
+    let handle = spawn_for_scope(scope.id, async move {
+        started_for_task.set(true);
+        let _drop_flag = DropFlag(dropped_for_task);
+        std::future::pending::<()>().await;
+        committed_for_task.set(true);
+    });
+
+    next_microtasks(1).await;
+    assert!(started.get(), "fixture future must reach Poll::Pending");
+    Scope::remove(scope.id);
+    next_microtasks(2).await;
+
+    assert!(handle.is_cancelled());
+    assert!(dropped.get(), "cancellation must drop the pending future");
+    assert!(
+        !committed.get(),
+        "unmount must drop the scoped future before its post-await commit"
+    );
+}
+
+#[wasm_bindgen_test(async)]
+async fn latest_task_drops_the_superseded_future_before_it_can_commit() {
+    setup();
+
+    let scope = Scope::new(Rc::new(RefCell::new(TestScopeState::default())));
+    let first_committed = Rc::new(Cell::new(false));
+    let first_for_task = first_committed.clone();
+    let first_started = Rc::new(Cell::new(false));
+    let started_for_task = first_started.clone();
+    let first_dropped = Rc::new(Cell::new(false));
+    let dropped_for_task = first_dropped.clone();
+    let first = spawn_latest_for_scope(scope.id, "search", async move {
+        started_for_task.set(true);
+        let _drop_flag = DropFlag(dropped_for_task);
+        std::future::pending::<()>().await;
+        first_for_task.set(true);
+    });
+    next_microtasks(1).await;
+    assert!(
+        first_started.get(),
+        "fixture future must be polled before it is superseded"
+    );
+    let second = spawn_latest_for_scope(scope.id, "search", async move {
+        next_microtasks(3).await;
+    });
+
+    next_microtasks(5).await;
+
+    assert!(first.is_cancelled());
+    assert!(
+        first_dropped.get(),
+        "superseding a pending task must drop its future"
+    );
+    assert!(
+        !first_committed.get(),
+        "a superseded latest-wins future must be dropped before it commits"
+    );
+    Scope::remove(scope.id);
+    assert!(
+        !second.is_cancelled(),
+        "a naturally completed task must no longer be retained by its scope"
+    );
+}
+
+#[wasm_bindgen_test(async)]
+async fn completed_scoped_task_is_removed_from_the_scope_registry() {
+    setup();
+
+    let scope = Scope::new(Rc::new(RefCell::new(TestScopeState::default())));
+    let handle = spawn_for_scope(scope.id, async move {});
+    next_microtasks(2).await;
+
+    Scope::remove(scope.id);
+
+    assert!(
+        !handle.is_cancelled(),
+        "scope teardown must not cancel a task that already completed"
+    );
+}
+
+#[cfg(any(debug_assertions, feature = "devtools"))]
+#[wasm_bindgen_test]
+fn watcher_read_does_not_reintern_a_field_for_a_dead_scope() {
+    setup();
+
+    let scope = Scope::new(Rc::new(RefCell::new(TestScopeState::default())));
+    let scope_id = scope.id;
+    Scope::remove(scope_id);
+    let (_, deps_before) = pocopine_core::reactive::stats();
+
+    let watcher = watch_scope_field_now::<String, _>(scope_id, "value", |_, _| {});
+    release(watcher);
+    let (_, deps_after) = pocopine_core::reactive::stats();
+
+    assert_eq!(
+        deps_after, deps_before,
+        "reading a dead scope must not recreate its field-signal entry"
+    );
+}
+
+#[cfg(any(debug_assertions, feature = "devtools"))]
+#[wasm_bindgen_test(async)]
+async fn deferred_scoped_watcher_skips_install_when_target_dies_first() {
+    setup();
+
+    let owner = Scope::new(Rc::new(RefCell::new(TestScopeState::default())));
+    let target = Scope::new(Rc::new(RefCell::new(TestScopeState::default())));
+    let (effects_before, deps_before) = pocopine_core::reactive::stats();
+    pocopine_core::scope::with_current_scope_id(owner.id, || {
+        pocopine_core::watch_scope_field_scoped::<String, _>(target.id, "value", |_, _| {});
+    });
+
+    Scope::remove(target.id);
+    next_microtasks(2).await;
+
+    assert_eq!(
+        pocopine_core::reactive::stats(),
+        (effects_before, deps_before),
+        "a deferred watcher must not install after its target scope unmounts"
+    );
+    Scope::remove(owner.id);
+}
+
+#[wasm_bindgen_test]
+fn handle_observe_sentinel_reacts_to_a_targeted_field_write() {
+    setup();
+
+    let state = Rc::new(RefCell::new(TestScopeState::default()));
+    let scope = Scope::new(state);
+    let runs = Rc::new(Cell::new(0));
+    let runs_for_effect = runs.clone();
+    let scope_id = scope.id;
+    effect(move || {
+        pocopine_core::reactive::track(scope_id, "__pp_handle_observe");
+        runs_for_effect.set(runs_for_effect.get() + 1);
+    });
+    let value: FieldHandle<String> = FieldHandle::__new(scope.id, "value");
+
+    value.set("changed".to_string());
+    flush_sync();
+
+    assert_eq!(
+        runs.get(),
+        2,
+        "the any-field sentinel used by Handle::observe must see targeted writes"
+    );
+    Scope::remove(scope.id);
+}
+
+#[wasm_bindgen_test]
+fn compiled_row_bulk_teardown_clears_context_parent_entries() {
+    setup();
+
+    let parent = Scope::new(Rc::new(RefCell::new(TestScopeState::default())));
+    let row = Scope::new(Rc::new(RefCell::new(TestScopeState::default())));
+    pocopine_core::context::set_parent(row.id, parent.id);
+    assert_eq!(pocopine_core::context::parent_of(row.id), Some(parent.id));
+
+    Scope::remove_compiled_rows(&[row.id]);
+
+    assert_eq!(
+        pocopine_core::context::parent_of(row.id),
+        None,
+        "compiled-row bulk teardown must remove the child-to-parent context edge"
+    );
+    Scope::remove(parent.id);
+}
+
+struct AlwaysFailsToSerialize;
+
+impl Serialize for AlwaysFailsToSerialize {
+    fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        Err(serde::ser::Error::custom("intentional test failure"))
+    }
+}
+
+#[wasm_bindgen_test]
+fn failed_inline_patch_invalidates_instead_of_certifying_stale_projection() {
+    setup();
+
+    let state = Rc::new(RefCell::new(FuzzState {
+        items: vec![1],
+        ..FuzzState::default()
+    }));
+    let scope = Scope::new(state.clone());
+    let proxy = scope.into_proxy();
+    let initial = Reflect::get(&proxy, &JsValue::from_str("items")).unwrap();
+    assert_eq!(js_sys::Array::from(&initial).get(0).as_f64(), Some(1.0));
+    let handle = Handle::new(state, scope.id);
+
+    handle.update(|state| {
+        state.items[0] = 7;
+        pocopine_core::scope::patch_list_at_inline("items", 0, &AlwaysFailsToSerialize);
+    });
+
+    let refreshed = Reflect::get(&proxy, &JsValue::from_str("items")).unwrap();
+    assert_eq!(
+        js_sys::Array::from(&refreshed).get(0).as_f64(),
+        Some(7.0),
+        "a serialization failure must make the next read rebuild from Rust state"
+    );
+    Scope::remove(scope.id);
+}
+
+#[wasm_bindgen_test]
+fn rejected_reflect_set_invalidates_inline_patch_projection() {
+    setup();
+
+    let state = Rc::new(RefCell::new(FuzzState {
+        items: vec![1],
+        ..FuzzState::default()
+    }));
+    let scope = Scope::new(state.clone());
+    let proxy = scope.into_proxy();
+    let cached = Reflect::get(&proxy, &JsValue::from_str("items")).unwrap();
+    let cached_object: &js_sys::Object = cached.unchecked_ref();
+    let _ = js_sys::Object::freeze(cached_object);
+    let handle = Handle::new(state, scope.id);
+
+    handle.update(|state| {
+        state.items[0] = 9;
+        pocopine_core::scope::patch_list_at_inline("items", 0, &state.items[0]);
+    });
+
+    let refreshed = Reflect::get(&proxy, &JsValue::from_str("items")).unwrap();
+    assert_eq!(
+        js_sys::Array::from(&refreshed).get(0).as_f64(),
+        Some(9.0),
+        "Reflect::set=false must make the next read rebuild from Rust state"
+    );
+    Scope::remove(scope.id);
 }
 
 #[wasm_bindgen_test]

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -3269,7 +3269,7 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
             {
                 let __scope = __root.scope_id();
                 let __h = ::core::clone::Clone::clone(&__handle);
-                ::pocopine::watch_scope_field::<#field_ty, _>(
+                ::pocopine::watch_scope_field_scoped::<#field_ty, _>(
                     __scope,
                     #field_name_on_root,
                     move |__v, _| {
@@ -4083,7 +4083,7 @@ pub fn handlers(_attr: TokenStream, item: TokenStream) -> TokenStream {
                     ::std::rc::Rc::new(::std::cell::Cell::new(true));
                 let __watch_initial_ticket =
                     ::std::rc::Rc::new(::std::cell::Cell::new(0_u64));
-                ::pocopine::watch_scope_field_now::<#v_ty, _>(__scope, #field_name, move |new, prev| {
+                let __watch_effect = ::pocopine::watch_scope_field_now::<#v_ty, _>(__scope, #field_name, move |new, prev| {
                     let new_v: #v_ty = new.clone();
                     let prev_v: ::core::option::Option<#v_ty> = prev.cloned();
                     if __watch_initial_pending.get() {
@@ -4115,6 +4115,9 @@ pub fn handlers(_attr: TokenStream, item: TokenStream) -> TokenStream {
                                 });
                         }
                     }
+                });
+                ::pocopine::on_scope_unmount_for(__scope, move || {
+                    ::pocopine::release(__watch_effect);
                 });
             }
         }

--- a/crates/pocopine/tests/light_dom_slots.rs
+++ b/crates/pocopine/tests/light_dom_slots.rs
@@ -12,6 +12,11 @@ use serde::{Deserialize, Serialize};
 use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 use web_sys::{Element, HtmlElement, window};
 
+thread_local! {
+    static GHOST_LIGHT_DOM_SETUP_COUNT: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+    static GHOST_LIGHT_DOM_OUTER_SETUP_COUNT: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+}
+
 wasm_bindgen_test_configure!(run_in_browser);
 
 #[derive(Default, Serialize, Deserialize)]
@@ -23,6 +28,45 @@ struct LdsChild {}
 
 #[handlers]
 impl LdsChild {}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "lds-ghost-inner",
+    template_inline = r#"<span class="lds-ghost-inner">inner</span>"#
+)]
+struct LdsGhostInner {}
+
+#[handlers]
+impl LdsGhostInner {
+    pub fn on_setup(&mut self) {
+        GHOST_LIGHT_DOM_SETUP_COUNT.with(|count| count.set(count.get() + 1));
+    }
+}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "lds-ghost-outer",
+    template_inline = r#"<span class="lds-ghost-outer">outer</span>"#
+)]
+struct LdsGhostOuter {}
+
+#[handlers]
+impl LdsGhostOuter {
+    pub fn on_setup(&mut self) {
+        GHOST_LIGHT_DOM_OUTER_SETUP_COUNT.with(|count| count.set(count.get() + 1));
+    }
+}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "lds-ghost-host",
+    template_inline = r#"<section class="lds-ghost-host"><slot></slot></section>"#,
+    uses = [LdsGhostInner, LdsGhostOuter],
+)]
+struct LdsGhostHost {}
+
+#[handlers]
+impl LdsGhostHost {}
 
 #[derive(Default, Serialize, Deserialize)]
 #[component(
@@ -98,6 +142,26 @@ impl LdsIfSlotHost {
     }
 }
 
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "lds-captured-scoped-host",
+    template_inline = r#"
+<section class="lds-captured-scoped-host">
+  <slot name="row" :label="label"></slot>
+</section>
+"#
+)]
+struct LdsCapturedScopedHost {
+    label: String,
+}
+
+#[handlers]
+impl LdsCapturedScopedHost {
+    pub fn on_setup(&mut self) {
+        self.label = "published".to_string();
+    }
+}
+
 fn doc() -> web_sys::Document {
     window().unwrap().document().unwrap()
 }
@@ -132,6 +196,33 @@ async fn default_light_dom_slot_mounts_custom_child() {
         .expect("custom child in captured default slot mounted");
     assert_eq!(child.text_content().as_deref(), Some("child mounted"));
 
+    handle.unmount();
+    host.remove();
+}
+
+#[wasm_bindgen_test]
+async fn captured_light_dom_discovery_skips_detached_nested_candidates() {
+    GHOST_LIGHT_DOM_SETUP_COUNT.with(|count| count.set(0));
+    GHOST_LIGHT_DOM_OUTER_SETUP_COUNT.with(|count| count.set(0));
+    let (host, _root, handle) = mount_with_light_dom::<LdsGhostHost>(
+        "<div><lds-ghost-outer><lds-ghost-inner></lds-ghost-inner></lds-ghost-outer></div>",
+    );
+    tick().await;
+
+    assert_eq!(
+        GHOST_LIGHT_DOM_OUTER_SETUP_COUNT.with(std::cell::Cell::get),
+        1,
+        "captured outer candidate must mount before its stale child is skipped"
+    );
+    assert!(
+        host.query_selector(".lds-ghost-outer").unwrap().is_some(),
+        "captured outer replacement DOM must be present"
+    );
+    assert_eq!(
+        GHOST_LIGHT_DOM_SETUP_COUNT.with(std::cell::Cell::get),
+        0,
+        "mounting the outer captured candidate detached its child, so child setup must not run"
+    );
     handle.unmount();
     host.remove();
 }
@@ -238,5 +329,44 @@ async fn captured_light_dom_slot_inside_pp_if_replays_initially_and_after_reopen
     );
 
     handle.unmount();
+    host.remove();
+}
+
+#[cfg(any(debug_assertions, feature = "devtools"))]
+#[wasm_bindgen_test]
+async fn captured_scoped_slot_releases_its_slot_scope_across_multiple_roots() {
+    let scopes_before = pocopine_core::scope::Scope::count();
+    let (host, _root, handle) = mount_with_light_dom::<LdsCapturedScopedHost>(
+        r#"<template pp-slot="row" pp-let="ctx">
+            leading text
+            <span class="lds-captured-scoped-first">first</span>
+            <b class="lds-captured-scoped-second">second</b>
+            trailing text
+        </template>"#,
+    );
+    tick().await;
+
+    assert!(
+        host.query_selector(".lds-captured-scoped-first")
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        host.query_selector(".lds-captured-scoped-second")
+            .unwrap()
+            .is_some()
+    );
+    assert!(
+        pocopine_core::scope::Scope::count() > scopes_before,
+        "component and captured SlotScope must both be live before teardown"
+    );
+
+    handle.unmount();
+
+    assert_eq!(
+        pocopine_core::scope::Scope::count(),
+        scopes_before,
+        "captured scoped-slot teardown must release text and element roots plus SlotScope"
+    );
     host.remove();
 }

--- a/crates/pocopine/tests/pp_app_root.rs
+++ b/crates/pocopine/tests/pp_app_root.rs
@@ -26,6 +26,13 @@ use wasm_bindgen::JsValue;
 use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
 use web_sys::window;
 
+thread_local! {
+    static GHOST_SETUP_COUNT: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+    static GHOST_OUTER_SETUP_COUNT: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+    static REMOUNT_MOUNT_COUNT: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+    static REMOUNT_READY_COUNT: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+}
+
 wasm_bindgen_test_configure!(run_in_browser);
 
 // ─── fixtures ───────────────────────────────────────────────────
@@ -50,6 +57,100 @@ struct PapSubtree {}
 #[handlers]
 impl PapSubtree {}
 
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "pap-remount",
+    template_inline = r#"<span class="pap-remount">remount</span>"#
+)]
+struct PapRemount {}
+
+#[handlers]
+impl PapRemount {
+    pub fn on_mount(&mut self) {
+        REMOUNT_MOUNT_COUNT.with(|count| count.set(count.get() + 1));
+    }
+
+    pub fn on_ready(&self) {
+        REMOUNT_READY_COUNT.with(|count| count.set(count.get() + 1));
+    }
+}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "pap-watched",
+    template_inline = r#"<span class="pap-watched" pp-text="value"></span>"#
+)]
+struct PapWatched {
+    value: u32,
+}
+
+#[handlers]
+impl PapWatched {
+    #[watch(value)]
+    fn value_changed(&mut self, _value: u32, _previous: Option<u32>) {}
+}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "pap-observe-child",
+    template_inline = r#"<span class="pap-observe-child" pp-text="value"></span>"#
+)]
+struct PapObserveChild {
+    #[observe(PAP_OBSERVE_ROOT)]
+    value: String,
+}
+
+#[handlers]
+impl PapObserveChild {}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "pap-observe-root",
+    template_inline = r#"<div><pap-observe-child></pap-observe-child></div>"#,
+    uses = [PapObserveChild],
+)]
+struct PapObserveRoot {
+    value: String,
+}
+
+pocopine::create_context!(PAP_OBSERVE_ROOT: Handle<PapObserveRoot>);
+
+#[handlers]
+impl PapObserveRoot {
+    pub fn on_setup(&mut self) {
+        self.value = "seed".to_string();
+        PAP_OBSERVE_ROOT.provide(this::<Self>());
+    }
+}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "pap-ghost-inner",
+    template_inline = r#"<span class="pap-ghost-inner">inner</span>"#
+)]
+struct PapGhostInner {}
+
+#[handlers]
+impl PapGhostInner {
+    pub fn on_setup(&mut self) {
+        GHOST_SETUP_COUNT.with(|count| count.set(count.get() + 1));
+    }
+}
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "pap-ghost-outer",
+    template_inline = r#"<section class="pap-ghost-outer">outer</section>"#
+)]
+struct PapGhostOuter {}
+
+#[handlers]
+impl PapGhostOuter {
+    pub fn on_setup(&mut self) {
+        GHOST_OUTER_SETUP_COUNT.with(|count| count.set(count.get() + 1));
+    }
+}
+
 struct ManualNoopComponent;
 
 impl Component for ManualNoopComponent {
@@ -62,6 +163,13 @@ impl Component for ManualNoopComponent {
 
 fn doc() -> web_sys::Document {
     window().unwrap().document().unwrap()
+}
+
+async fn tick() {
+    for _ in 0..3 {
+        let promise = js_sys::Promise::resolve(&JsValue::NULL);
+        let _ = wasm_bindgen_futures::JsFuture::from(promise).await;
+    }
 }
 
 // ─── tests ──────────────────────────────────────────────────────
@@ -193,6 +301,195 @@ fn mount_subtree_handle_drop_releases_scope() {
     );
     assert_eq!(host.inner_html(), "");
 
+    host.remove();
+}
+
+#[wasm_bindgen_test(async)]
+async fn subtree_host_can_be_mounted_again_after_unmount() {
+    let host = doc().create_element("div").unwrap();
+    doc().body().unwrap().append_child(&host).unwrap();
+    REMOUNT_MOUNT_COUNT.with(|count| count.set(0));
+    REMOUNT_READY_COUNT.with(|count| count.set(0));
+
+    App::mount_subtree::<PapRemount>(&host).unmount();
+    tick().await;
+    assert_eq!(REMOUNT_MOUNT_COUNT.with(std::cell::Cell::get), 1);
+    // The first scope is already gone before its deferred ready callback.
+    assert_eq!(REMOUNT_READY_COUNT.with(std::cell::Cell::get), 0);
+
+    let second = App::mount_subtree::<PapRemount>(&host);
+    tick().await;
+
+    assert!(
+        host.query_selector(".pap-remount").unwrap().is_some(),
+        "subtree teardown must clear host mount stamps so the host can be reused"
+    );
+    assert_eq!(
+        REMOUNT_MOUNT_COUNT.with(std::cell::Cell::get),
+        2,
+        "the second mount must run on_mount instead of stopping at the stale walk guard"
+    );
+    assert_eq!(
+        REMOUNT_READY_COUNT.with(std::cell::Cell::get),
+        1,
+        "the second mount must schedule and run on_ready"
+    );
+    second.unmount();
+    host.remove();
+}
+
+#[cfg(any(debug_assertions, feature = "devtools"))]
+#[wasm_bindgen_test(async)]
+async fn generated_watch_effect_releases_with_its_component_scope() {
+    let host = doc().create_element("div").unwrap();
+    doc().body().unwrap().append_child(&host).unwrap();
+    let baseline = pocopine_core::reactive::stats();
+
+    let handle = App::mount_subtree::<PapWatched>(&host);
+    tick().await;
+    assert!(
+        pocopine_core::reactive::stats().0 > baseline.0,
+        "fixture must install its generated watch effect"
+    );
+    handle.unmount();
+    tick().await;
+
+    assert_eq!(
+        pocopine_core::reactive::stats(),
+        baseline,
+        "#[watch] effects must release when their component unmounts"
+    );
+    host.remove();
+}
+
+#[cfg(any(debug_assertions, feature = "devtools"))]
+#[wasm_bindgen_test(async)]
+async fn generated_observe_effect_releases_with_the_consumer_scope() {
+    let host = doc().create_element("div").unwrap();
+    doc().body().unwrap().append_child(&host).unwrap();
+    let baseline = pocopine_core::reactive::stats();
+
+    let handle = App::mount_subtree::<PapObserveRoot>(&host);
+    tick().await;
+    assert!(
+        pocopine_core::reactive::stats().0 > baseline.0,
+        "fixture must install its generated observe effect"
+    );
+    handle.unmount();
+    tick().await;
+
+    assert_eq!(
+        pocopine_core::reactive::stats(),
+        baseline,
+        "#[observe] effects must be owned by and release with the consumer"
+    );
+    host.remove();
+}
+
+#[cfg(any(debug_assertions, feature = "devtools"))]
+#[wasm_bindgen_test(async)]
+async fn deferred_observe_install_does_not_race_consumer_unmount() {
+    let host = doc().create_element("div").unwrap();
+    doc().body().unwrap().append_child(&host).unwrap();
+    let baseline = pocopine_core::reactive::stats();
+
+    App::mount_subtree::<PapObserveRoot>(&host).unmount();
+    tick().await;
+
+    assert_eq!(
+        pocopine_core::reactive::stats(),
+        baseline,
+        "a deferred observe install must not create an effect after unmount"
+    );
+    host.remove();
+}
+
+#[cfg(any(debug_assertions, feature = "devtools"))]
+#[wasm_bindgen_test(async)]
+async fn deferred_scoped_watcher_does_not_install_after_target_unmount() {
+    let owner = Scope::new(std::rc::Rc::new(std::cell::RefCell::new(
+        PapSubtree::default(),
+    )));
+    let target = Scope::new(std::rc::Rc::new(std::cell::RefCell::new(
+        PapSubtree::default(),
+    )));
+    let baseline = pocopine_core::reactive::stats();
+    pocopine_core::scope::with_current_scope_id(owner.id, || {
+        pocopine_core::watch_scope_field_scoped::<String, _>(target.id, "missing", |_, _| {});
+    });
+
+    Scope::remove(target.id);
+    tick().await;
+
+    assert_eq!(
+        pocopine_core::reactive::stats(),
+        baseline,
+        "a deferred scoped watcher must skip install when its target is already gone"
+    );
+    Scope::remove(owner.id);
+}
+
+#[wasm_bindgen_test(async)]
+async fn handle_observe_reacts_to_typed_targeted_field_writes() {
+    let state = std::rc::Rc::new(std::cell::RefCell::new(PapWatched::default()));
+    let scope = Scope::new(state.clone());
+    let handle = Handle::new(state, scope.id);
+    let seen = std::rc::Rc::new(std::cell::Cell::new(u32::MAX));
+    let hits = std::rc::Rc::new(std::cell::Cell::new(0_u32));
+    let seen_for_cb = seen.clone();
+    let hits_for_cb = hits.clone();
+    pocopine_core::scope::with_current_scope_id(scope.id, || {
+        handle.observe(
+            |state| state.value,
+            move |value, _| {
+                seen_for_cb.set(*value);
+                hits_for_cb.set(hits_for_cb.get() + 1);
+            },
+        );
+    });
+    tick().await;
+    assert_eq!((seen.get(), hits.get()), (0, 1));
+
+    let value = FieldHandle::<u32>::__new(scope.id, "value");
+    value.set(7);
+    pocopine_core::flush_sync();
+    tick().await;
+
+    assert_eq!(
+        (seen.get(), hits.get()),
+        (7, 2),
+        "Handle::observe must rerun after a FieldHandle targeted write"
+    );
+    Scope::remove(scope.id);
+}
+
+#[wasm_bindgen_test]
+fn app_root_discovery_does_not_mount_detached_nested_candidates() {
+    PapGhostOuter::register();
+    PapGhostInner::register();
+    GHOST_SETUP_COUNT.with(|count| count.set(0));
+    GHOST_OUTER_SETUP_COUNT.with(|count| count.set(0));
+    let host = doc().create_element("div").unwrap();
+    host.set_attribute("pp-app", "").unwrap();
+    host.set_inner_html("<pap-ghost-outer><pap-ghost-inner></pap-ghost-inner></pap-ghost-outer>");
+    doc().body().unwrap().append_child(&host).unwrap();
+
+    App::new().run();
+
+    assert_eq!(
+        GHOST_OUTER_SETUP_COUNT.with(std::cell::Cell::get),
+        1,
+        "the outer candidate must mount before its stale child is skipped"
+    );
+    assert!(
+        host.query_selector(".pap-ghost-outer").unwrap().is_some(),
+        "outer replacement DOM must be present"
+    );
+    assert_eq!(
+        GHOST_SETUP_COUNT.with(std::cell::Cell::get),
+        0,
+        "the inner candidate was detached when its parent mounted and must not run setup"
+    );
     host.remove();
 }
 

--- a/crates/pocopine/tests/refs_typed.rs
+++ b/crates/pocopine/tests/refs_typed.rs
@@ -19,12 +19,13 @@
 #![cfg(target_arch = "wasm32")]
 
 use std::cell::RefCell;
+use std::rc::Rc;
 
 use pocopine::prelude::*;
 use serde::{Deserialize, Serialize};
-use wasm_bindgen::JsValue;
+use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
-use web_sys::{Element, window};
+use web_sys::{Element, HtmlElement, window};
 
 wasm_bindgen_test_configure!(run_in_browser);
 
@@ -213,6 +214,60 @@ impl TypedRefsLiftedParent {
     }
 }
 
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "typed-refs-conditional",
+    template_inline = r#"<div class="tr-conditional">
+        <button class="tr-toggle" @click="toggle">toggle</button>
+        <template pp-if="open">
+            <span pp-ref="conditional">conditional</span>
+        </template>
+    </div>"#
+)]
+struct TypedRefsConditional {
+    open: bool,
+}
+
+#[handlers]
+impl TypedRefsConditional {
+    pub fn on_setup(&mut self) {
+        self.open = true;
+    }
+
+    pub fn toggle(&mut self) {
+        self.open = !self.open;
+    }
+}
+
+#[wasm_bindgen_test]
+async fn conditional_ref_unregisters_when_its_branch_unmounts() {
+    let host = doc().create_element("div").unwrap();
+    doc().body().unwrap().append_child(&host).unwrap();
+    let handle = pocopine::App::mount_subtree::<TypedRefsConditional>(&host);
+    tick().await;
+    let root = host.first_element_child().expect("rendered root");
+    let scope_id = pocopine_core::mount::scope_id_of_element(&root).expect("scope id");
+    assert!(
+        pocopine_core::refs::get_on(scope_id, "conditional").is_some(),
+        "truthy branch registers its ref"
+    );
+
+    host.query_selector(".tr-toggle")
+        .unwrap()
+        .unwrap()
+        .dyn_ref::<HtmlElement>()
+        .unwrap()
+        .click();
+    tick().await;
+
+    assert!(
+        pocopine_core::refs::get_on(scope_id, "conditional").is_none(),
+        "branch teardown must unregister the detached ref immediately"
+    );
+    handle.unmount();
+    host.remove();
+}
+
 #[wasm_bindgen_test]
 async fn generated_refs_struct_includes_pp_refs_from_lifted_bodies() {
     OBSERVED_LIFTED_REF_PRESENT.with(|c| *c.borrow_mut() = None);
@@ -317,4 +372,23 @@ async fn generated_refs_struct_method_name_is_compile_time_typo_safe() {
         "free-fn lookup via the same name the macro baked in resolves"
     );
     host.remove();
+}
+
+#[wasm_bindgen_test]
+fn unregistering_an_old_ref_element_does_not_remove_its_replacement() {
+    let parent_scope = Scope::new(Rc::new(RefCell::new(TypedRefsParent::default())));
+    let old = doc().create_element("span").unwrap();
+    let replacement = doc().create_element("span").unwrap();
+    pocopine_core::refs::register(parent_scope.id, "body", &old);
+    pocopine_core::refs::register(parent_scope.id, "body", &replacement);
+
+    pocopine_core::mount::release_compiled_subtree(&old);
+
+    let current = pocopine_core::refs::get_on(parent_scope.id, "body")
+        .expect("replacement ref survives old branch teardown");
+    assert_eq!(
+        current, replacement,
+        "tearing down an old branch must not delete a newer same-name ref"
+    );
+    Scope::remove(parent_scope.id);
 }

--- a/crates/pocopine/tests/template_plan.rs
+++ b/crates/pocopine/tests/template_plan.rs
@@ -2944,6 +2944,8 @@ async fn macro_emits_named_slot_fragment() {
 async fn macro_lifts_scoped_slot_fragment_with_pp_let() {
     register_all();
     reset_plan_failure_count();
+    #[cfg(any(debug_assertions, feature = "devtools"))]
+    let scopes_before = pocopine_core::scope::Scope::count();
 
     let plan = template_plan_for("plan-scoped-slot-host")
         .expect("plan-scoped-slot-host has one nested non-HTML5 tag");
@@ -3009,6 +3011,15 @@ async fn macro_lifts_scoped_slot_fragment_with_pp_let() {
 
     assert_eq!(plan_failure_count(), 0);
 
+    #[cfg(any(debug_assertions, feature = "devtools"))]
+    {
+        pocopine_core::mount::release_compiled_subtree(&host);
+        assert_eq!(
+            pocopine_core::scope::Scope::count(),
+            scopes_before,
+            "scoped-slot materialization must release its borrowed SlotScope"
+        );
+    }
     host.remove();
 }
 
@@ -3022,6 +3033,8 @@ async fn macro_lifts_scoped_slot_fragment_with_pp_let() {
 async fn macro_lifts_opaque_runtime_directive() {
     register_all();
     reset_plan_failure_count();
+    #[cfg(any(debug_assertions, feature = "devtools"))]
+    let listeners_before = pocopine_core::mount::listener_count();
 
     let plan = template_plan_for("plan-opaque-directive-host")
         .expect("plan-opaque-directive-host registers a template plan");
@@ -3068,6 +3081,19 @@ async fn macro_lifts_opaque_runtime_directive() {
 
     assert_eq!(plan_failure_count(), 0);
 
+    #[cfg(any(debug_assertions, feature = "devtools"))]
+    {
+        assert!(
+            pocopine_core::mount::listener_count() > listeners_before,
+            "pp-roving must retain its keydown closure in the releasable listener table"
+        );
+        pocopine_core::mount::release_compiled_subtree(&host);
+        assert_eq!(
+            pocopine_core::mount::listener_count(),
+            listeners_before,
+            "pp-roving listener must be removed and its closure dropped on teardown"
+        );
+    }
     host.remove();
 }
 


### PR DESCRIPTION
## What

- make spawned reactive tasks genuinely cancellable and release completed task registrations
- give generated watchers, observers, refs, slots, list projections, and directive listeners explicit lifecycle ownership
- clear host runtime stamps and side tables during subtree teardown so remounts initialize cleanly
- harden nested component containment and inline-list invalidation
- add the affected browser suites to CI

## Root causes

The cancellation flag was recorded but not observed while polling futures, generated effects could outlive their consumer, and several DOM-scoped runtime registries were not reclaimed consistently. Remounts could therefore inherit stale stamps, listeners, refs, or scope state.

## TDD coverage

Regression tests cover cancellation and wake reentrancy, watcher/observer teardown, targeted handle observation, compiled list cleanup and invalidation, multi-root/text slot ownership, roving listeners, ref identity, nested component containment, and subtree remount behavior.

Validated after rebasing onto `main`:

- `cargo fmt --all -- --check`
- `cargo test -p pocopine-core --all-features` (190 passed)
- `cargo test -p pocopine-macros` (104 passed)
- host and wasm Clippy for the affected crates with warnings denied
- browser suites: reactive (41), template plan (53), typed refs (7), light-DOM slots (6), and pp-app-root focused lifecycle coverage
