### PR TITLE
Surface nested template plan failures

### DIFF
--- a/crates/pocopine-cli/src/build.rs
+++ b/crates/pocopine-cli/src/build.rs
@@ -1,3 +1,4 @@
+use std::fs::{File, OpenOptions, TryLockError};
 use std::path::Path;
 use std::process::Output;
 
@@ -6,31 +7,94 @@ use anyhow::{Context, Result, bail};
 use crate::config::PocopineConfig;
 use crate::tools;
 
+// `wasm-pack` mutates a shared `pkg/` in several non-atomic steps. In
+// particular it removes `package.json` near the start, then interprets any
+// file that reappears before its final manifest step as a wasm-bindgen NPM
+// dependency map. An overlapping build can write the normal manifest in that
+// window, making wasm-pack deserialize `"files": [...]` as a String. Keep the
+// lock outside `pkg/` because wasm-pack owns that directory, and hold it until
+// our post-build hashing has finished renaming the generated pair too.
+const WASM_BUILD_LOCK_FILE: &str = ".pocopine-wasm-build.lock";
+
+enum WasmBuildLockAttempt {
+    Acquired(File),
+    Contended(File),
+}
+
 pub fn wasm(path: &Path, release: bool) -> Result<()> {
     let path = path
         .canonicalize()
         .with_context(|| format!("could not resolve project path: {}", path.display()))?;
-    println!("▶ wasm-pack build ({})", path.display());
-    let project_tools = tools::ProjectTools::load(&path)?;
-    let mut cmd = project_tools.wasm_pack().command();
-    cmd.arg("build").arg("--target").arg("web");
-    if release {
-        cmd.arg("--release");
-    } else {
-        cmd.arg("--dev");
+    with_wasm_build_lock(&path, || {
+        println!("▶ wasm-pack build ({})", path.display());
+        let project_tools = tools::ProjectTools::load(&path)?;
+        let mut cmd = project_tools.wasm_pack().command();
+        cmd.arg("build").arg("--target").arg("web");
+        if release {
+            cmd.arg("--release");
+        } else {
+            cmd.arg("--dev");
+        }
+        cmd.current_dir(&path);
+        // RFC-100 §6 — export the assets/ fingerprint so `asset!`
+        // re-expands (and re-hashes) when the assets tree changed.
+        crate::assets_sync::apply_fingerprint_env(&mut cmd, &path);
+        let status = cmd
+            .status()
+            .context("failed to invoke wasm-pack (is it on $PATH?)")?;
+        if !status.success() {
+            bail!("wasm-pack build failed with status {status}");
+        }
+        hash_pkg_bundle(&path)?;
+        Ok(())
+    })
+}
+
+fn with_wasm_build_lock<T>(project: &Path, operation: impl FnOnce() -> Result<T>) -> Result<T> {
+    let _lock = acquire_wasm_build_lock(project)?;
+    operation()
+}
+
+fn acquire_wasm_build_lock(project: &Path) -> Result<File> {
+    match try_wasm_build_lock(project)? {
+        WasmBuildLockAttempt::Acquired(file) => Ok(file),
+        WasmBuildLockAttempt::Contended(file) => {
+            println!("⏳ waiting for another wasm build ({})", project.display());
+            file.lock().with_context(|| {
+                format!(
+                    "wait for wasm build lock: {}",
+                    wasm_build_lock_path(project).display()
+                )
+            })?;
+            Ok(file)
+        }
     }
-    cmd.current_dir(&path);
-    // RFC-100 §6 — export the assets/ fingerprint so `asset!`
-    // re-expands (and re-hashes) when the assets tree changed.
-    crate::assets_sync::apply_fingerprint_env(&mut cmd, &path);
-    let status = cmd
-        .status()
-        .context("failed to invoke wasm-pack (is it on $PATH?)")?;
-    if !status.success() {
-        bail!("wasm-pack build failed with status {status}");
+}
+
+fn try_wasm_build_lock(project: &Path) -> Result<WasmBuildLockAttempt> {
+    let lock_path = wasm_build_lock_path(project);
+    if let Some(parent) = lock_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("create wasm build lock directory: {}", parent.display()))?;
     }
-    hash_pkg_bundle(&path)?;
-    Ok(())
+    let file = OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(&lock_path)
+        .with_context(|| format!("open wasm build lock: {}", lock_path.display()))?;
+    match file.try_lock() {
+        Ok(()) => Ok(WasmBuildLockAttempt::Acquired(file)),
+        Err(TryLockError::WouldBlock) => Ok(WasmBuildLockAttempt::Contended(file)),
+        Err(TryLockError::Error(error)) => {
+            Err(error).with_context(|| format!("lock wasm build: {}", lock_path.display()))
+        }
+    }
+}
+
+fn wasm_build_lock_path(project: &Path) -> std::path::PathBuf {
+    project.join("target").join(WASM_BUILD_LOCK_FILE)
 }
 
 /// Content-hash the wasm-pack output pair so the JS glue and the wasm
@@ -357,6 +421,56 @@ mod tests {
 
     // sha256("wasm-bytes") starts with 7db53183.
     const HASH: &str = "7db53183";
+
+    #[test]
+    fn wasm_build_lock_serializes_and_releases_after_success() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = dir.path();
+
+        let value = with_wasm_build_lock(project, || {
+            assert!(matches!(
+                try_wasm_build_lock(project).unwrap(),
+                WasmBuildLockAttempt::Contended(_)
+            ));
+            Ok(42)
+        })
+        .unwrap();
+
+        assert_eq!(value, 42);
+        assert!(matches!(
+            try_wasm_build_lock(project).unwrap(),
+            WasmBuildLockAttempt::Acquired(_)
+        ));
+    }
+
+    #[test]
+    fn wasm_build_lock_releases_after_failure() {
+        let dir = tempfile::tempdir().unwrap();
+        let project = dir.path();
+
+        let result: Result<()> = with_wasm_build_lock(project, || bail!("sentinel failure"));
+
+        assert_eq!(result.unwrap_err().to_string(), "sentinel failure");
+        assert!(matches!(
+            try_wasm_build_lock(project).unwrap(),
+            WasmBuildLockAttempt::Acquired(_)
+        ));
+    }
+
+    #[test]
+    fn wasm_build_lock_is_scoped_to_one_project() {
+        let first = tempfile::tempdir().unwrap();
+        let second = tempfile::tempdir().unwrap();
+
+        with_wasm_build_lock(first.path(), || {
+            assert!(matches!(
+                try_wasm_build_lock(second.path()).unwrap(),
+                WasmBuildLockAttempt::Acquired(_)
+            ));
+            Ok(())
+        })
+        .unwrap();
+    }
 
     #[test]
     fn rewrite_bundle_refs_handles_fresh_and_rehashed_references() {

--- a/crates/pocopine-macros/src/diagnostics.rs
+++ b/crates/pocopine-macros/src/diagnostics.rs
@@ -53,6 +53,80 @@ pub(crate) fn render_template_error(
     format!("{}", Renderer::styled().render(message))
 }
 
+/// Plain-text variant for diagnostics embedded inside generated
+/// `compile_error!` tokens. Rustc applies its own styling around the outer
+/// error; embedding ANSI sequences would make snapshot output and non-TTY
+/// logs display escape bytes instead of readable source context.
+pub(crate) fn render_template_error_plain(
+    poco_src: &str,
+    file_path: &str,
+    byte_range: Range<usize>,
+    title: &str,
+    label: &str,
+) -> String {
+    let message = Level::Error.title(title).snippet(
+        Snippet::source(poco_src)
+            .origin(file_path)
+            .fold(true)
+            .annotation(Level::Error.span(byte_range).label(label)),
+    );
+    let rendered = strip_ansi(&format!("{}", Renderer::styled().render(message)));
+    rendered
+        .strip_prefix("error: ")
+        .unwrap_or(&rendered)
+        .to_string()
+}
+
+/// Render a diagnostic whose primary failure lives inside a structural
+/// template body. The owning `<template ...>` is marked as context and the
+/// offending descendant as the error. `fold(true)` keeps both ends visible
+/// while collapsing the middle of a large or visually dense body.
+pub(crate) fn render_template_error_plain_with_context(
+    poco_src: &str,
+    file_path: &str,
+    byte_range: Range<usize>,
+    title: &str,
+    label: &str,
+    context_range: Range<usize>,
+    context_label: &str,
+) -> String {
+    // Keep the primary error annotation first: annotate-snippets uses
+    // insertion order for the `--> file:line:column` header, while still
+    // rendering source lines in their natural order. The header therefore
+    // remains anchored to the offending child rather than the owner template.
+    let message = Level::Error.title(title).snippet(
+        Snippet::source(poco_src)
+            .origin(file_path)
+            .fold(true)
+            .annotation(Level::Error.span(byte_range).label(label))
+            .annotation(Level::Info.span(context_range).label(context_label)),
+    );
+
+    let rendered = strip_ansi(&format!("{}", Renderer::styled().render(message)));
+    rendered
+        .strip_prefix("error: ")
+        .unwrap_or(&rendered)
+        .to_string()
+}
+
+fn strip_ansi(input: &str) -> String {
+    let mut output = String::with_capacity(input.len());
+    let mut chars = input.chars().peekable();
+    while let Some(ch) = chars.next() {
+        if ch == '\u{1b}' && chars.peek() == Some(&'[') {
+            chars.next();
+            for code in chars.by_ref() {
+                if ('@'..='~').contains(&code) {
+                    break;
+                }
+            }
+            continue;
+        }
+        output.push(ch);
+    }
+    output
+}
+
 /// Render an error whose byte range is unknown or zero — falls
 /// back to a file-level message without a source snippet.
 /// Used when a `ParseError` surfaces without a range (e.g.
@@ -128,5 +202,102 @@ mod tests {
         let rendered = render_fileless_error("test.poco", "malformed template", "unclosed tag");
         assert!(rendered.contains("test.poco"));
         assert!(rendered.contains("unclosed tag"));
+    }
+
+    #[test]
+    fn compile_error_render_keeps_source_coordinates_without_ansi() {
+        let rendered = render_template_error_plain(
+            "<div>one</div>\n<div>two</div>",
+            "nested.poco",
+            15..18,
+            "invalid nested branch",
+            "second root",
+        );
+        assert!(rendered.contains("nested.poco:2:1"), "{rendered}");
+        assert!(rendered.contains("second root"), "{rendered}");
+        assert!(!rendered.contains('\u{1b}'), "{rendered:?}");
+    }
+
+    #[test]
+    fn compile_error_render_reports_character_column_after_utf8() {
+        let rendered = render_template_error_plain(
+            "é <b>x</b>",
+            "utf8.poco",
+            3..6,
+            "invalid nested branch",
+            "second root",
+        );
+        assert!(rendered.contains("utf8.poco:1:3"), "{rendered}");
+    }
+
+    #[test]
+    fn structural_error_shows_owner_then_offending_child() {
+        let source = r#"<div>
+  <template pp-if="open">
+    <section>
+      <template pp-match="state">
+        <template pp-case="Ready">
+          <b>first</b>
+          <b>second</b>
+        </template>
+      </template>
+    </section>
+  </template>
+</div>
+"#;
+        let context_start = source.find("<template pp-case").unwrap();
+        let context_end = context_start + "<template pp-case=\"Ready\">".len();
+        let primary_start = source.find("<b>second").unwrap();
+        let rendered = render_template_error_plain_with_context(
+            source,
+            "nested.poco",
+            primary_start..primary_start + 3,
+            "invalid nested branch",
+            "second root",
+            context_start..context_end,
+            "`pp-case` template body starts here",
+        );
+
+        assert!(rendered.contains("nested.poco:7:11"), "{rendered}");
+        assert!(
+            rendered.contains("5 |         <template pp-case"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("template body starts here"), "{rendered}");
+        assert!(rendered.contains("<b>second</b>"), "{rendered}");
+    }
+
+    #[test]
+    fn structural_error_folds_a_large_first_child() {
+        let source = r#"<template pp-case="Ready">
+  <section>
+    <div>one</div>
+    <div>two</div>
+    <div>three</div>
+    <div>four</div>
+    <div>five</div>
+    <div>six</div>
+  </section>
+  <b>second</b>
+</template>
+"#;
+        let context_start = source.find("<template pp-case").unwrap();
+        let context_end = context_start + "<template pp-case=\"Ready\">".len();
+        let primary_start = source.find("<b>second").unwrap();
+        let rendered = render_template_error_plain_with_context(
+            source,
+            "nested.poco",
+            primary_start..primary_start + 3,
+            "invalid nested branch",
+            "second root",
+            context_start..context_end,
+            "`pp-case` template body starts here",
+        );
+
+        assert!(rendered.contains("nested.poco:10:3"), "{rendered}");
+        assert!(rendered.contains("<template pp-case"), "{rendered}");
+        assert!(rendered.contains("<b>second</b>"), "{rendered}");
+        assert!(rendered.contains("..."), "{rendered}");
+        assert!(!rendered.contains("<div>three</div>"), "{rendered}");
     }
 }

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -219,16 +219,23 @@ fn validate_file_template(
     // `local_file()` returns `None`; the filesystem walk lets
     // validation still run against the authored file.
     //
-    // Tier 3: give up silently (not an error). If neither
-    // lookup found a file, we return Ok((None, None)) and the
-    // caller emits the normal component registration with no
-    // validation. The real cargo build retries with a
-    // file-backed span so any real template bug still gets
-    // caught at build time.
+    // Tier 3: keep the component buildable, but warn. The generated
+    // `include_str!` may still resolve the file even when proc-macro span
+    // provenance was unavailable; in that case raw HTML would otherwise be
+    // registered with an empty mount function and every directive would be
+    // inert without explanation.
     let resolved_path = resolve_template_path(template_path);
     let resolved_path = match resolved_path {
         Some(p) => p,
-        None => return Ok((None, None)),
+        None => {
+            return Ok((
+                Some(unresolved_template_warning_tokens(
+                    &template_path.value(),
+                    component_name,
+                )),
+                None,
+            ));
+        }
     };
     let file_path_str = resolved_path.to_string_lossy().to_string();
 
@@ -360,6 +367,34 @@ fn build_warning_tokens(rendered: &str) -> proc_macro2::TokenStream {
     }
 }
 
+fn unresolved_template_warning_tokens(
+    template_path: &str,
+    component_name: &str,
+) -> proc_macro2::TokenStream {
+    build_warning_tokens(&format!(
+        "pocopine: template plan compilation was skipped for component \
+         `{component_name}` because `{template_path}` could not be resolved uniquely during \
+         macro expansion; directives will be inert. Use a template path relative to the \
+         component module and ensure it resolves uniquely so \
+         the planner can validate and compile it."
+    ))
+}
+
+fn vtable_template_html_tokens(
+    compiled_html: &proc_macro2::Literal,
+    planner_saw_template: bool,
+) -> proc_macro2::TokenStream {
+    if planner_saw_template {
+        quote! { Some(#compiled_html) }
+    } else {
+        // `register()` still stores the include_str!-backed template in the
+        // thread-local registry. Leaving the PHF payload absent lets runtime
+        // lookup fall through to that real source instead of shadowing it
+        // with the empty string produced when macro-time resolution failed.
+        quote! { None }
+    }
+}
+
 /// RFC 045 §9 — the `POCOPINE_TEMPLATES_LENIENT` env-var
 /// escape hatch. Truthy values: `1`, `true`, `yes` (case-
 /// insensitive). Anything else is strict mode.
@@ -397,8 +432,8 @@ fn manifest_relative(path: &std::path::Path) -> String {
 ///   the template filename. An unambiguous match is used as
 ///   the resolved path; zero or >1 matches → give up.
 ///
-/// Returns `None` when neither tier finds an existing file
-/// — the caller treats that as "silent skip," not an error.
+/// Returns `None` when neither tier finds an existing file. The caller keeps
+/// the component buildable, but emits a warning that its directives are inert.
 fn resolve_template_path(template_path: &LitStr) -> Option<std::path::PathBuf> {
     // Tier 1 — span-based (cargo + rust-analyzer file-backed).
     if let Some(caller_rs) = template_path.span().unwrap().local_file() {
@@ -445,9 +480,8 @@ fn resolve_template_path(template_path: &LitStr) -> Option<std::path::PathBuf> {
     if matches.len() == 1 {
         Some(matches.into_iter().next().unwrap())
     } else {
-        // Zero matches → file doesn't exist; nothing to
-        // validate. More than one match → ambiguous; refuse
-        // to guess. Either way, silent skip.
+        // Zero matches → file doesn't exist. More than one match →
+        // ambiguous; refuse to guess. The caller warns in either case.
         None
     }
 }
@@ -1262,6 +1296,40 @@ mod client_module_tests {
 
         let file = LitStr::new("my_thing.client.ts", Span::call_site());
         assert_eq!(client_module_name_from_file(&file).unwrap(), "my-thing");
+    }
+}
+
+#[cfg(test)]
+mod template_validation_tests {
+    use super::*;
+
+    #[test]
+    fn unresolved_template_warns_that_plan_compilation_was_skipped() {
+        let rendered = unresolved_template_warning_tokens(
+            "__pocopine_test_missing_template_7f30b0.poco",
+            "missing-template-fixture",
+        )
+        .to_string();
+        assert!(rendered.contains("missing-template-fixture"), "{rendered}");
+        assert!(
+            rendered.contains("plan compilation was skipped"),
+            "{rendered}"
+        );
+        assert!(rendered.contains("directives will be inert"), "{rendered}");
+    }
+
+    #[test]
+    fn unavailable_planner_source_does_not_shadow_runtime_template_with_empty_phf_html() {
+        let empty = proc_macro2::Literal::string("");
+        assert_eq!(
+            vtable_template_html_tokens(&empty, false).to_string(),
+            "None"
+        );
+
+        let compiled = proc_macro2::Literal::string("<div>ready</div>");
+        let tokens = vtable_template_html_tokens(&compiled, true).to_string();
+        assert!(tokens.contains("Some"), "{tokens}");
+        assert!(tokens.contains("ready"), "{tokens}");
     }
 }
 
@@ -2914,6 +2982,7 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
                 ast,
                 &row_plans.assignments,
                 role_for_template_plan.clone(),
+                &name_str,
             )
         })
         .unwrap_or_else(|| template_plan::EmittedTemplatePlan {
@@ -2922,6 +2991,7 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
             slot_fragment_fns: proc_macro2::TokenStream::new(),
             if_body_fns: proc_macro2::TokenStream::new(),
             specialized_mount_body: None,
+            diagnostics: proc_macro2::TokenStream::new(),
             ref_names: Vec::new(),
         });
 
@@ -2969,6 +3039,8 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
             .map(|(tag, role_name)| (*tag, role_name.as_str())),
     );
     let compiled_template_html_lit = proc_macro2::Literal::string(&compiled_template_html);
+    let vtable_template_html_tokens =
+        vtable_template_html_tokens(&compiled_template_html_lit, template_ast.is_some());
 
     let template_literal_tokens = if let Some(cleaned) = template_plan.cleaned_html.as_deref() {
         let lit = proc_macro2::Literal::string(cleaned);
@@ -3024,6 +3096,7 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
     let template_plan_module_ident = format_ident!("__poc_plan_{}", struct_ident);
     let template_plan_tokens_for_vtable = template_plan.plan_tokens.clone();
     let specialized_mount_body = template_plan.specialized_mount_body.clone();
+    let template_plan_diagnostics_tokens = template_plan.diagnostics.clone();
     let template_plan_item_tokens = match template_plan.plan_tokens.clone() {
         Some(plan_tokens) => {
             let slot_fns = template_plan.slot_fragment_fns;
@@ -3445,6 +3518,11 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
         // `uses` is declared.
         #unknown_tag_diagnostics_tokens
 
+        // Template-plan diagnostics are emitted independently from the plan
+        // module: an invalid template may collect only diagnostics and emit no
+        // runtime plan at all.
+        #template_plan_diagnostics_tokens
+
         // RFC 063 — hard `compile_error!` for every directive
         // RFC 063 §4.1 deletes (`pp-cloak` today; more in
         // follow-up commits).
@@ -3699,7 +3777,7 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
                 &::pocopine::__private::ComponentVTable {
                     name: #name_str,
                     register: <#struct_ident>::register,
-                    template_html: Some(#compiled_template_html_lit),
+                    template_html: #vtable_template_html_tokens,
                     plan: #vtable_plan_tokens,
                     mount_template: ::core::option::Option::Some(
                         <#struct_ident as ::pocopine::__private::Component>::mount_template,

--- a/crates/pocopine-macros/src/template_plan.rs
+++ b/crates/pocopine-macros/src/template_plan.rs
@@ -13,7 +13,9 @@
 //! 2. A "cleaned HTML" string — the template re-serialised
 //!    with the classified attributes stripped.
 //!
-//! v1 envelope per RFC-057 §6 (deferred to RFC-058 §6.2):
+//! The original v1 envelope from RFC-057/058 has since expanded to cover
+//! structural bodies, child components, slots, models, and selected opaque
+//! directives. One post-walker rule is now fundamental:
 //!
 //! * Eligible: native HTML elements only — every directive
 //!   on or under a non-HTML5 tag is whole-subtree
@@ -30,9 +32,9 @@
 //!   `window`, `document`, `outside`, `capture`, key
 //!   modifiers, `debounce` + numeric-ms pair.
 //!
-//! Every other attribute survives unchanged on the rewritten
-//! HTML — it's the runtime mount's job to handle them as
-//! today (attribute-preserved fallback, RFC-057 §8.1).
+//! Preserving an uncompiled framework directive in HTML is **not** a runtime
+//! fallback: the generic walker is gone. Such syntax is inert, so analysis
+//! failures must surface as diagnostics instead of silently degrading.
 
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
@@ -43,16 +45,15 @@ use crate::template_parser::{Element, Node, TemplateAst};
 pub(crate) struct EmittedTemplatePlan {
     /// `Some(quoted &'static StaticTemplatePlan)` when at least
     /// one plan entry was emitted; `None` when the template has
-    /// nothing eligible (every directive is mount-owned or the
-    /// template has no directives at all). The macro emits
+    /// nothing eligible (normally a fully static template). The macro emits
     /// `register_template_plan` only when this is `Some`.
     pub plan_tokens: Option<TokenStream>,
     /// HTML the macro should pass to `register_template` instead
     /// of the raw `.poco` source. Classified attributes are
     /// stripped; `data-pp-text-managed` is stamped where
     /// `pp-text` was removed. `None` when the analysis emitted
-    /// no entries — the caller falls back to the original
-    /// source bytes.
+    /// no entries — the caller uses the original source bytes. A planner path
+    /// resolution failure also takes that lane, but emits a build warning.
     pub cleaned_html: Option<String>,
     /// RFC-058 Phase 3.5b — `fn` items the macro should emit
     /// inside the parent's `register()` body so the
@@ -71,6 +72,10 @@ pub(crate) struct EmittedTemplatePlan {
     /// mounts use this generated body directly; the generic
     /// plan applier remains for lifted fragment internals only.
     pub specialized_mount_body: Option<TokenStream>,
+    /// Compile-time diagnostics collected at any analysis depth. Kept
+    /// separate from fragment functions so diagnostics-only templates still
+    /// emit errors even when no `StaticTemplatePlan` is generated.
+    pub diagnostics: TokenStream,
     /// RFC 081 — every `pp-ref="name"` collected from the
     /// template, dedup'd in template-order. The consuming
     /// macro emits a `<ComponentName>Refs` struct with one
@@ -78,6 +83,69 @@ pub(crate) struct EmittedTemplatePlan {
     /// can write `refs.body()` instead of
     /// `refs::get_component::<T>("body")`.
     pub ref_names: Vec<String>,
+}
+
+#[derive(Clone)]
+struct PlanDiagnostic {
+    message: String,
+    byte_range: Option<std::ops::Range<usize>>,
+    context: Option<PlanDiagnosticContext>,
+}
+
+#[derive(Clone)]
+struct PlanDiagnosticContext {
+    label: String,
+    byte_range: std::ops::Range<usize>,
+}
+
+#[derive(Default)]
+struct PlanDiagnostics(Vec<PlanDiagnostic>);
+
+impl PlanDiagnostics {
+    fn push(&mut self, message: impl Into<String>) {
+        self.0.push(PlanDiagnostic {
+            message: message.into(),
+            byte_range: None,
+            context: None,
+        });
+    }
+
+    fn push_at(&mut self, message: impl Into<String>, byte_range: std::ops::Range<usize>) {
+        self.0.push(PlanDiagnostic {
+            message: message.into(),
+            byte_range: Some(byte_range),
+            context: None,
+        });
+    }
+
+    fn push_at_with_context(
+        &mut self,
+        message: impl Into<String>,
+        byte_range: std::ops::Range<usize>,
+        context_label: impl Into<String>,
+        context_range: std::ops::Range<usize>,
+    ) {
+        self.0.push(PlanDiagnostic {
+            message: message.into(),
+            byte_range: Some(byte_range),
+            context: Some(PlanDiagnosticContext {
+                label: context_label.into(),
+                byte_range: context_range,
+            }),
+        });
+    }
+
+    fn extend(&mut self, diagnostics: impl IntoIterator<Item = PlanDiagnostic>) {
+        self.0.extend(diagnostics);
+    }
+
+    fn iter(&self) -> impl Iterator<Item = &PlanDiagnostic> {
+        self.0.iter()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
 }
 
 /// Walk the template AST, classify every directive, return the
@@ -99,6 +167,7 @@ pub(crate) fn analyze_template_plan(
     ast: &TemplateAst,
     row_plan_assignments: &[(Vec<u16>, u32)],
     role: Option<(String, String)>,
+    component_name: &str,
 ) -> EmittedTemplatePlan {
     let mut ctx = AnalysisCtx {
         row_plan_assignments: row_plan_assignments.to_vec(),
@@ -114,6 +183,43 @@ pub(crate) fn analyze_template_plan(
             walk(el, &mut ctx, &mut emissions, &mut path);
         }
     }
+    let diagnostics = ctx
+        .diagnostics
+        .iter()
+        .fold(TokenStream::new(), |mut out, diagnostic| {
+            let title = format!("pocopine: template plan error in component `{component_name}`");
+            let rendered = match diagnostic.byte_range.clone() {
+                Some(range) if range.start < range.end && range.end <= ast.source.len() => {
+                    match diagnostic.context.as_ref() {
+                        Some(context)
+                            if context.byte_range.start < context.byte_range.end
+                                && context.byte_range.end <= ast.source.len() =>
+                        {
+                            crate::diagnostics::render_template_error_plain_with_context(
+                                &ast.source,
+                                &ast.file_path,
+                                range,
+                                &title,
+                                &diagnostic.message,
+                                context.byte_range.clone(),
+                                &context.label,
+                            )
+                        }
+                        _ => crate::diagnostics::render_template_error_plain(
+                            &ast.source,
+                            &ast.file_path,
+                            range,
+                            &title,
+                            &diagnostic.message,
+                        ),
+                    }
+                }
+                _ => format!("{title} (`{}`): {}", ast.file_path, diagnostic.message),
+            };
+            let lit = proc_macro2::Literal::string(&rendered);
+            out.extend(quote! { ::core::compile_error!(#lit); });
+            out
+        });
     if !ctx.has_any_entry() && row_plan_assignments.is_empty() {
         return EmittedTemplatePlan {
             plan_tokens: None,
@@ -121,18 +227,13 @@ pub(crate) fn analyze_template_plan(
             slot_fragment_fns: TokenStream::new(),
             if_body_fns: TokenStream::new(),
             specialized_mount_body: None,
+            diagnostics,
             ref_names: ctx.ref_names_dedup(),
         };
     }
     let cleaned_html = serialize_cleaned(&ast.roots, &ctx);
     let slot_fragment_fns = emit_slot_fragment_fns(&emissions);
-    let mut if_body_fns = emit_if_body_fns(&emissions);
-    // RFC-094 — chain build errors surface as compile_error!
-    // items alongside the emitted fragments.
-    for msg in &ctx.diagnostics {
-        let lit = proc_macro2::Literal::string(msg);
-        if_body_fns.extend(quote! { ::core::compile_error!(#lit); });
-    }
+    let if_body_fns = emit_if_body_fns(&emissions);
     // When the only "entry" is a row-plan stamp (template has no
     // plan-eligible directive on its own), still emit cleaned HTML
     // so the row-plan attribute is baked in — but skip the
@@ -150,6 +251,7 @@ pub(crate) fn analyze_template_plan(
         slot_fragment_fns,
         if_body_fns,
         specialized_mount_body,
+        diagnostics,
         ref_names,
     }
 }
@@ -230,7 +332,7 @@ struct AnalysisCtx {
     native_models: Vec<NativeModelLite>,
     /// RFC-094 — chain build errors surfaced as compile_error!
     /// items (orphan/double/misplaced else, bad member shape).
-    diagnostics: Vec<String>,
+    diagnostics: PlanDiagnostics,
     /// RFC-094 — node paths of consumed pp-else-if/pp-else
     /// member templates (kept in cleaned HTML until the
     /// controller detaches them; the serializer stamps them
@@ -421,10 +523,9 @@ struct IfPlanLite {
     /// RFC-058 Phase 4.1d — `Some` when the body subtree was
     /// lift-eligible and the macro emitted a body fragment fn
     /// the `StaticIfPlan` literal should reference. `None`
-    /// when the body falls outside the v1 envelope (`<slot>`,
-    /// `pp-route`, native `pp-model`, etc.) — the
-    /// runtime installer falls back to the legacy
-    /// `clone_template_body` + `mount::walk` path.
+    /// when the body falls outside the compiled envelope. The runtime may
+    /// clone that body as static HTML, but no generic walker installs native
+    /// directives; it records a plan failure instead.
     body_fn_ident: Option<syn::Ident>,
 }
 
@@ -588,19 +689,18 @@ impl AnalysisCtx {
         out
     }
 
-    /// Drain a nested context's ref names (its own `refs` plus
-    /// anything it already aggregated from deeper lifts) into
-    /// this context's `refs_from_lifted`. Called after each
-    /// `analyze_lift_body` / `analyze_slot_subtree` return so
-    /// refs inside lifted subtrees still reach the outer
-    /// `<ComponentName>Refs` codegen.
-    fn absorb_lifted_refs(&mut self, nested: &AnalysisCtx) {
+    /// Absorb metadata that must escape a lifted subtree's otherwise-isolated
+    /// plan context. Ref names feed the outer typed refs API; diagnostics must
+    /// reach the top-level `compile_error!` emission instead of disappearing
+    /// when a nested body is moved into its own fragment plan.
+    fn absorb_lifted_metadata(&mut self, nested: &AnalysisCtx) {
         for r in &nested.refs {
             self.refs_from_lifted.push(r.name.clone());
         }
         for name in &nested.refs_from_lifted {
             self.refs_from_lifted.push(name.clone());
         }
+        self.diagnostics.extend(nested.diagnostics.iter().cloned());
     }
 
     fn emit_specialized_mount_body(&self) -> Option<TokenStream> {
@@ -1673,6 +1773,7 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
             && !el.attrs.iter().any(|(n, _)| n == "pp-teleport")
             && let Some((item_name, items_expr)) = parse_pp_for(&for_attr)
         {
+            check_branch_body_roots("pp-for", el, ctx);
             let key_expr = el
                 .attrs
                 .iter()
@@ -1704,7 +1805,7 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
                 None
             } else {
                 analyze_lift_body(el, emissions).map(|(html, body_ctx)| {
-                    ctx.absorb_lifted_refs(&body_ctx);
+                    ctx.absorb_lifted_metadata(&body_ctx);
                     bodies_need_proxy |= plan_needs_proxy(&body_ctx);
                     let ident = emissions.alloc_if_body_ident("for_body");
                     emissions.if_bodies.push(IfBodyEmission {
@@ -1768,8 +1869,9 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
             // RFC-058 Phase 4.3c — try to lift the teleport
             // body into a fragment fn (same v1 envelope as
             // pp-if / pp-for body lifting).
+            check_branch_body_roots("pp-teleport", el, ctx);
             let body_fn_ident = analyze_lift_body(el, emissions).map(|(html, body_ctx)| {
-                ctx.absorb_lifted_refs(&body_ctx);
+                ctx.absorb_lifted_metadata(&body_ctx);
                 let ident = emissions.alloc_if_body_ident("teleport_body");
                 emissions.if_bodies.push(IfBodyEmission {
                     ident: ident.clone(),
@@ -1923,7 +2025,7 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
                     check_branch_body_roots("pp-case", case_el, ctx);
                     let body_ident =
                         analyze_lift_body(case_el, emissions).map(|(html, body_ctx)| {
-                            ctx.absorb_lifted_refs(&body_ctx);
+                            ctx.absorb_lifted_metadata(&body_ctx);
                             bodies_need_proxy |= plan_needs_proxy(&body_ctx);
                             let ident = emissions.alloc_if_body_ident("case_body");
                             emissions.if_bodies.push(IfBodyEmission {
@@ -1978,13 +2080,10 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
     // graduates into a `StaticIfPlan` entry. The applier
     // resolves the template + parses the expression at compile
     // time; the macro strips the `pp-if` attribute from the
-    // cleaned HTML so the runtime mount's directive-dispatch
-    // path doesn't double-install the effect. The template
+    // cleaned HTML so no second installer can see it. The template
     // body lives in `<template>.content` (a separate
     // `DocumentFragment` that doesn't appear in `el.children`),
-    // so body content stays on the mount — exactly like
-    // today's clone+walk path. Phase 4.1c+ will lift the body
-    // into a fragment function.
+    // body therefore needs its own compiled fragment function.
     if let Some(if_expr) = pp_if_value(el) {
         let teleport_selector = el
             .attrs
@@ -2000,15 +2099,13 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
             // at install).
             check_branch_body_roots("pp-if", el, ctx);
             // RFC-058 Phase 4.1d — try to lift the body
-            // subtree into a fragment fn the runtime installer
-            // invokes instead of `clone_template_body` +
-            // `mount::walk`. v1 envelope is narrow (HTML5
-            // natives + plan-eligible directives only); when
-            // the body falls outside, `body_fn_ident` stays
-            // `None` and the legacy clone+walk path runs.
+            // subtree into a fragment fn the runtime installer invokes.
+            // `body_fn_ident = None` is a fail-fast path, not a directive
+            // fallback: a static clone may render, but native directives in it
+            // remain inert and the runtime records a plan failure.
             let mut bodies_need_proxy = false;
             let body_fn_ident = analyze_lift_body(el, emissions).map(|(html, body_ctx)| {
-                ctx.absorb_lifted_refs(&body_ctx);
+                ctx.absorb_lifted_metadata(&body_ctx);
                 bodies_need_proxy |= plan_needs_proxy(&body_ctx);
                 let ident = emissions.alloc_if_body_ident("if_body");
                 emissions.if_bodies.push(IfBodyEmission {
@@ -2183,7 +2280,7 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
                         // the dynamic slot's plan so the outer
                         // `<ComponentName>Refs` exposes them.
                         if let SlotFragmentEmission::Dynamic { plan, .. } = &emission {
-                            ctx.absorb_lifted_refs(plan);
+                            ctx.absorb_lifted_metadata(plan);
                         }
                         // Duplicate `pp-slot=NAME` at compile time:
                         // both lift fragments get pushed; the
@@ -2219,7 +2316,7 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
                         // RFC 081 P2 — absorb pp-ref names from
                         // the default slot's plan.
                         if let SlotFragmentEmission::Dynamic { plan, .. } = &emission {
-                            ctx.absorb_lifted_refs(plan);
+                            ctx.absorb_lifted_metadata(plan);
                         }
                         slot_fragments.push((
                             "default".to_string(),
@@ -2418,7 +2515,7 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
                             let mut member_needs = false;
                             let body_ident =
                                 analyze_lift_body(member, emissions).map(|(html, body_ctx)| {
-                                    ctx.absorb_lifted_refs(&body_ctx);
+                                    ctx.absorb_lifted_metadata(&body_ctx);
                                     member_needs = plan_needs_proxy(&body_ctx);
                                     let ident = emissions.alloc_if_body_ident(if is_else {
                                         "else_body"
@@ -3159,9 +3256,9 @@ fn is_debounce_ms(m: &str) -> bool {
 
 /// RFC-058 Phase 4.1d v1 envelope — `true` when every node in
 /// the lifted body subtree is safe to install via the Phase 1
-/// helpers and the generated specialized install closure. Anything outside this
-/// envelope falls back to the legacy `clone_template_body` +
-/// `mount::walk` path the controller already drives.
+/// helpers and the generated specialized install closure. Anything outside
+/// this envelope can only produce an uninstalled static clone plus a runtime
+/// plan-failure signal; there is no generic walker fallback.
 ///
 /// RFC-058 Phase 6.5 expansion: `<slot>` elements are now
 /// allowed. The macro records them in the body fragment's
@@ -3189,9 +3286,8 @@ fn if_body_subtree_is_eligible(el: &Element) -> bool {
     }
     // Phase 3.5d expansion: non-HTML5 tags are allowed here.
     // `walk()` emits child_mount entries for them into the
-    // body fragment's own static plan, and the runtime fallback
-    // walk over the cleaned fragment binds any preserved
-    // directives inside the mounted child template.
+    // body fragment's own static plan. The child component then runs its own
+    // specialized mount function; no parent-side fallback walk is involved.
     let _ = is_plan_native(&el.tag); // kept for symmetry with slot eligibility
     for (name, _) in &el.attrs {
         if name == "pp-route" {
@@ -3224,20 +3320,6 @@ fn if_body_subtree_is_eligible(el: &Element) -> bool {
 /// per-subtree state stays isolated; nested fragment fns get
 /// pushed into the shared `Emissions` queue so every emission
 /// lands at the top of the parent's `register()` body.
-/// The number of element roots in a structural `<template>` body. `pp-if` /
-/// `pp-else-if` / `pp-else` / `pp-case` bodies must have exactly one: the
-/// runtime clone path (`clone_template_body`) stamps ONLY the first element
-/// root, so extra roots silently vanish from the branch, and a zero-root body
-/// errors at install — both are surfaced as compile-time diagnostics by the
-/// classifier instead.
-fn template_body_element_count(template_el: &Element) -> usize {
-    template_el
-        .children
-        .iter()
-        .filter(|c| matches!(c, Node::Element(_)))
-        .count()
-}
-
 /// Push the compile-time diagnostic for a structural `<template>` body whose
 /// element-root count breaks the exactly-one rule (the branch analogue of the
 /// component single-root rule). Non-whitespace top-level TEXT is rejected on
@@ -3245,23 +3327,48 @@ fn template_body_element_count(template_el: &Element) -> usize {
 /// so `<template pp-if>Prefix <span>…</span></template>` would silently drop
 /// `Prefix` from the branch.
 fn check_branch_body_roots(directive: &str, template_el: &Element, ctx: &mut AnalysisCtx) {
-    let roots = template_body_element_count(template_el);
-    if roots != 1 {
-        ctx.diagnostics.push(format!(
-            "`{directive}` template must have exactly one root element (found {roots}) — \
+    let element_roots: Vec<&Element> = template_el
+        .children
+        .iter()
+        .filter_map(|child| match child {
+            Node::Element(element) => Some(element),
+            _ => None,
+        })
+        .collect();
+    if element_roots.len() != 1 {
+        let message = format!(
+            "`{directive}` template must have exactly one root element (found {}) — \
              wrap the branch body in a single container",
-        ));
+            element_roots.len(),
+        );
+        if let Some(extra_root) = element_roots.get(1) {
+            ctx.diagnostics.push_at_with_context(
+                message,
+                extra_root.opening_tag_range.clone(),
+                format!("`{directive}` template body starts here"),
+                template_el.opening_tag_range.clone(),
+            );
+        } else {
+            ctx.diagnostics
+                .push_at(message, template_el.opening_tag_range.clone());
+        }
         return;
     }
     let has_loose_text = template_el
         .children
         .iter()
-        .any(|c| matches!(c, Node::Text(text, _) if !text.trim().is_empty()));
+        .any(|child| matches!(child, Node::Text(text, _) if !text.trim().is_empty()));
     if has_loose_text {
-        ctx.diagnostics.push(format!(
-            "`{directive}` template has text beside its root element — the text would \
-             silently drop out of the branch; move it inside the root container",
-        ));
+        // Text-node byte ranges are not mapped by the shared parser yet.
+        // Anchor on the owning template rather than fabricating a plausible
+        // but wrong source coordinate from its 0..0 placeholder range.
+        ctx.diagnostics.push_at(
+            format!(
+                "`{directive}` template has text beside its root element — the text would \
+                 silently drop out of the branch; move it inside the root container",
+            ),
+            template_el.opening_tag_range.clone(),
+        );
     }
 }
 
@@ -3380,7 +3487,10 @@ fn analyze_slot_subtree(nodes: &[Node], emissions: &mut Emissions) -> Option<Slo
     // interpolation (or a native pp-model). `has_any_entry` is the
     // exhaustive "collected anything" predicate, so a new entry kind
     // can't be forgotten here again.
-    let is_dynamic = ctx.has_any_entry();
+    // A diagnostics-only context must stay attached to the parent long enough
+    // for `absorb_lifted_metadata` to propagate its errors. Treat it as
+    // dynamic even though compilation will stop before the fragment runs.
+    let is_dynamic = ctx.has_any_entry() || !ctx.diagnostics.is_empty();
     let ident = emissions.alloc_slot_frag_ident("slot_frag");
     if is_dynamic {
         Some(SlotFragmentEmission::Dynamic {
@@ -3650,21 +3760,25 @@ mod tests {
     fn analyze(source: &str) -> super::EmittedTemplatePlan {
         let (ast, errors) = crate::template_parser::parse(source, "test.poco");
         assert!(errors.is_empty(), "template must parse: {errors:?}");
-        super::analyze_template_plan(&ast, &[], None)
+        super::analyze_template_plan(&ast, &[], None, "test-component")
+    }
+
+    fn diagnostics(plan: &super::EmittedTemplatePlan) -> String {
+        plan.diagnostics.to_string()
     }
 
     #[test]
     fn pp_component_requires_reactive_is_and_emits_a_child_mount() {
         let missing = analyze("<div><pp-component></pp-component></div>");
-        let diagnostics = missing.if_body_fns.to_string();
-        assert!(diagnostics.contains("compile_error"), "{diagnostics}");
-        assert!(diagnostics.contains("reactive"), "{diagnostics}");
+        let errors = diagnostics(&missing);
+        assert!(errors.contains("compile_error"), "{errors}");
+        assert!(errors.contains("reactive"), "{errors}");
 
         let valid = analyze(r#"<div><pp-component :is="active"></pp-component></div>"#);
         assert!(
-            !valid.if_body_fns.to_string().contains("compile_error"),
+            !diagnostics(&valid).contains("compile_error"),
             "{:?}",
-            valid.if_body_fns.to_string(),
+            diagnostics(&valid),
         );
         let plan = valid.plan_tokens.unwrap().to_string();
         assert!(plan.contains("pp-component"), "{plan}");
@@ -3691,7 +3805,7 @@ mod tests {
             r#"<div><template pp-if="open"><x-button @click="remove">Delete</x-button></template></div>"#,
         );
         let body_fns = emitted.if_body_fns.to_string();
-        assert!(!body_fns.contains("compile_error"), "{body_fns}");
+        assert!(!diagnostics(&emitted).contains("compile_error"));
         assert!(body_fns.contains("stamp_if_body_with"), "{body_fns}");
         assert!(body_fns.contains("StaticChildMount"), "{body_fns}");
         assert!(
@@ -3709,26 +3823,26 @@ mod tests {
         // to silently drop out of the conditional. Now a diagnostic.
         let plan =
             analyze("<div><template pp-if=\"open\"><span>a</span><span>b</span></template></div>");
-        let out = plan.if_body_fns.to_string();
+        let out = diagnostics(&plan);
         assert!(out.contains("compile_error"), "{out}");
         assert!(out.contains("exactly one root element"), "{out}");
 
         // Zero element roots errors too (the runtime install would fail).
         let plan = analyze("<div><template pp-if=\"open\">text only</template></div>");
-        let out = plan.if_body_fns.to_string();
+        let out = diagnostics(&plan);
         assert!(out.contains("exactly one root element"), "{out}");
 
         // Non-whitespace text beside the single root errors too — the
         // runtime stamps only the element root, silently dropping the text.
         let plan = analyze("<div><template pp-if=\"open\">Prefix <span>a</span></template></div>");
-        let out = plan.if_body_fns.to_string();
+        let out = diagnostics(&plan);
         assert!(out.contains("text beside its root element"), "{out}");
 
         // A single root (whitespace/comments around it are fine) stays clean.
         let plan = analyze(
             "<div><template pp-if=\"open\">\n  <!-- note -->\n  <span>a</span>\n</template></div>",
         );
-        let out = plan.if_body_fns.to_string();
+        let out = diagnostics(&plan);
         assert!(!out.contains("compile_error"), "{out}");
     }
 
@@ -3739,7 +3853,7 @@ mod tests {
             "<div><template pp-if=\"open\"><span>a</span></template>\
              <template pp-else><span>b</span><span>c</span></template></div>",
         );
-        let out = plan.if_body_fns.to_string();
+        let out = diagnostics(&plan);
         assert!(
             out.contains("`pp-else` template must have exactly one root element"),
             "{out}"
@@ -3751,11 +3865,72 @@ mod tests {
              <template pp-case=\"Ready\"><b>y</b><b>z</b></template>\
              </template></div>",
         );
-        let out = plan.if_body_fns.to_string();
+        let out = diagnostics(&plan);
         assert!(
             out.contains("`pp-case` template must have exactly one root element"),
             "{out}"
         );
+    }
+
+    #[test]
+    fn multi_root_for_and_teleport_bodies_are_compile_errors() {
+        let plan = analyze(
+            "<div><template pp-for=\"item in items\">\
+             <span>a</span><span>b</span></template></div>",
+        );
+        let out = diagnostics(&plan);
+        assert!(
+            out.contains("`pp-for` template must have exactly one root element"),
+            "{out}"
+        );
+
+        let plan = analyze(
+            "<div><template pp-teleport=\"#target\">\
+             <span>a</span><span>b</span></template></div>",
+        );
+        let out = diagnostics(&plan);
+        assert!(
+            out.contains("`pp-teleport` template must have exactly one root element"),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn nested_branch_body_diagnostics_reach_the_component_expansion() {
+        // Each lifted structural body gets its own AnalysisCtx. A diagnostic
+        // raised by the pp-case below must cross the enclosing pp-if body's
+        // context boundary and reach the top-level compile_error! emission.
+        let plan = analyze(
+            "<div><template pp-if=\"open\"><section>\
+             <template pp-match=\"state\">\
+             <template pp-case=\"Ready\"><b>y</b><b>z</b></template>\
+             </template></section></template></div>",
+        );
+        let out = diagnostics(&plan);
+        assert!(out.contains("compile_error"), "{out}");
+        assert!(
+            out.contains("`pp-case` template must have exactly one root element"),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn diagnostics_only_top_level_context_still_emits_a_compile_error() {
+        let plan = analyze("<div><template pp-case=\"Ready\"><span>orphan</span></template></div>");
+        let out = diagnostics(&plan);
+        assert!(out.contains("compile_error"), "{out}");
+        assert!(out.contains("only valid as a direct child"), "{out}");
+    }
+
+    #[test]
+    fn diagnostics_only_slot_context_reaches_the_component_expansion() {
+        let plan = analyze(
+            "<div><x-child><template pp-case=\"Ready\">\
+             <span>orphan</span></template></x-child></div>",
+        );
+        let out = diagnostics(&plan);
+        assert!(out.contains("compile_error"), "{out}");
+        assert!(out.contains("only valid as a direct child"), "{out}");
     }
 
     #[test]

--- a/crates/pocopine/tests/template_plan_diagnostics_ui.rs
+++ b/crates/pocopine/tests/template_plan_diagnostics_ui.rs
@@ -1,0 +1,9 @@
+//! Compile-time diagnostics for structural bodies in nested template plans.
+
+#![cfg(not(target_arch = "wasm32"))]
+
+#[test]
+fn nested_template_plan_diagnostics() {
+    let cases = trybuild::TestCases::new();
+    cases.compile_fail("tests/ui/plan_nested_branch_roots.rs");
+}

--- a/crates/pocopine/tests/ui/plan_nested_branch_roots.poco
+++ b/crates/pocopine/tests/ui/plan_nested_branch_roots.poco
@@ -1,0 +1,12 @@
+<div>
+  <template pp-if="open">
+    <section>
+      <template pp-match="state">
+        <template pp-case="Ready">
+          <b>first</b>
+          <b>second</b>
+        </template>
+      </template>
+    </section>
+  </template>
+</div>

--- a/crates/pocopine/tests/ui/plan_nested_branch_roots.rs
+++ b/crates/pocopine/tests/ui/plan_nested_branch_roots.rs
@@ -1,0 +1,17 @@
+use pocopine::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "plan-nested-branch-roots",
+    template = "plan_nested_branch_roots.poco"
+)]
+struct PlanNestedBranchRoots {
+    open: bool,
+    state: String,
+}
+
+#[handlers]
+impl PlanNestedBranchRoots {}
+
+fn main() {}

--- a/crates/pocopine/tests/ui/plan_nested_branch_roots.stderr
+++ b/crates/pocopine/tests/ui/plan_nested_branch_roots.stderr
@@ -1,0 +1,18 @@
+error: pocopine: template plan error in component `plan-nested-branch-roots`
+        --> tests/ui/plan_nested_branch_roots.poco
+         |
+         |         <template pp-case="Ready">
+         |         -------------------------- info: `pp-case` template body starts here
+         |           <b>first</b>
+         |           <b>second</b>
+         |           ^^^ `pp-case` template must have exactly one root element (found 2) — wrap the branch body in a single container
+         |
+ --> tests/ui/plan_nested_branch_roots.rs:5:1
+  |
+5 | / #[component(
+6 | |     name = "plan-nested-branch-roots",
+7 | |     template = "plan_nested_branch_roots.poco"
+8 | | )]
+  | |__^
+  |
+  = note: this error originates in the attribute macro `component` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/examples/file-browser/src/components/file_detail/FileBrowserFileDetail.poco
+++ b/examples/file-browser/src/components/file_detail/FileBrowserFileDetail.poco
@@ -174,8 +174,10 @@
               <div class="pb-3">
                 <dl class="cfe-detail-attrs" pp-show="$store.storage.detail.metadata.length">
                   <template pp-for="meta in $store.storage.detail.metadata" pp-key="meta.key">
-                    <dt class="break-all" pp-text="meta.key"></dt>
-                    <dd class="break-all" pp-text="meta.value"></dd>
+                    <div class="contents">
+                      <dt class="break-all" pp-text="meta.key"></dt>
+                      <dd class="break-all" pp-text="meta.value"></dd>
+                    </div>
                   </template>
                 </dl>
                 <p class="text-[12px] text-ink-50" pp-show="!$store.storage.detail.metadata.length">No metadata found</p>


### PR DESCRIPTION
## Summary

- propagate template-plan diagnostics from nested lifted bodies and slot fragments to the owning component expansion
- render structural-body failures against the authored `.poco`, showing the owning `<template>` and the exact extra root
- emit diagnostics even when an invalid template generates no runtime plan
- warn when macro-time template resolution is unavailable and avoid shadowing the real runtime template with empty PHF HTML
- serialize per-project wasm builds so overlapping `wasm-pack` processes cannot corrupt the shared `pkg/package.json` lifecycle

## Why

Nested structural-body validation already detected invalid shapes, but diagnostics were trapped in each lifted sub-context. The component then compiled with an empty body and rendered dead UI without explaining the source error.

The separate bare serde failure seen during wasm optimization came from overlapping builds mutating the same `pkg/` directory. A project-scoped file lock makes that build path deterministic.

## Validation

- `cargo fmt --all -- --check`
- CI-compatible wasm clippy matrix with `-D warnings`
- CI-compatible wasm build matrix
- `cargo clippy -p pocopine-macros -p pocopine-cli --all-targets -- -D warnings`
- `cargo test -p pocopine-macros --lib` (114 tests)
- `cargo test -p pocopine --test template_plan_diagnostics_ui`
- `cargo test -p pocopine-cli --bin pocopine build::tests` (8 tests)

The broad host workspace build was also attempted locally, but the temporary 31 GiB filesystem filled while linking unrelated provider/example crates; no test assertion failed before exhaustion. CI remains the authoritative broad workspace run.