### PR TITLE
fix(core): serialize synchronous same-scope handler reentry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -465,6 +465,9 @@ jobs:
           - name: pocopine-nested-routes
             crate: crates/pocopine
             args: --test nested_routes
+          - name: pocopine-core-scope-reentrancy
+            crate: crates/pocopine-core
+            args: --test scope_reentrancy
           - name: pine
             crate: crates/pine
             args: ""

--- a/crates/pocopine-core/src/directives/on.rs
+++ b/crates/pocopine-core/src/directives/on.rs
@@ -219,13 +219,38 @@ pub fn install(
                     let r: &JsValue = ev.as_ref();
                     r.clone()
                 };
-                with_current_el(&el_for_closure, || {
-                    crate::scope::with_current_scope_id(scope_id, || {
-                        with_current_event(&ev_js, || {
-                            expr::evaluate_with(&ast, &proxy, access.as_ref());
+                // `focus()` and a few other DOM APIs fire their event
+                // synchronously. If this callback re-entered the component
+                // while its initiating handler still owned `&mut state`, even
+                // a plain handler call would panic on `RefCell::borrow_mut`;
+                // reads/assignments elsewhere in the expression could do the
+                // same. Queue the complete expression at the scope's handler
+                // boundary and drain it before the outer JS callback returns.
+                let queued = crate::scope::queue_event_expression_if_active(scope_id, || {
+                    let el = el_for_closure.clone();
+                    let ast = ast.clone();
+                    let proxy = proxy.clone();
+                    let access = access.clone();
+                    let ev_js = ev_js.clone();
+                    Box::new(move || {
+                        with_current_el(&el, || {
+                            crate::scope::with_current_scope_id(scope_id, || {
+                                with_current_event(&ev_js, || {
+                                    expr::evaluate_with(&ast, &proxy, access.as_ref());
+                                });
+                            });
+                        });
+                    })
+                });
+                if !queued {
+                    with_current_el(&el_for_closure, || {
+                        crate::scope::with_current_scope_id(scope_id, || {
+                            with_current_event(&ev_js, || {
+                                expr::evaluate_with(&ast, &proxy, access.as_ref());
+                            });
                         });
                     });
-                });
+                }
             }
         }
     }) as Box<dyn FnMut(Event)>);

--- a/crates/pocopine-core/src/emit.rs
+++ b/crates/pocopine-core/src/emit.rs
@@ -204,11 +204,13 @@ pub fn emit_from<T: Serialize>(el: &Element, name: &str, detail: T) {
 /// read back whether a listener called `preventDefault`.
 /// Returns `true` when the event was prevented.
 ///
-/// Trade-off vs [`emit`]: because this fires synchronously, any
-/// listener calling back into the caller's scope re-enters its
-/// active borrow. Safe for fire-and-observe patterns (menu item
-/// asks "can I close?") but not for pp-model-style mirror
-/// flows — use the deferred [`emit`] / [`emit_from`] there.
+/// Trade-off vs [`emit`]: a listener on the caller's own scope cannot run a
+/// second component handler while the first still owns `&mut state`. Pocopine
+/// safely queues that handler expression until the active handler boundary,
+/// so a `preventDefault()` performed *inside* the queued handler is too late to
+/// affect this function's return value. The `.prevent` event modifier still
+/// runs synchronously before handler dispatch. Use deferred [`emit`] /
+/// [`emit_from`] for pp-model-style mirror flows.
 pub fn emit_cancelable<T: Serialize>(name: &str, detail: T) -> bool {
     let Some(el) = current_el() else { return false };
     emit_cancelable_from(&el, name, detail)

--- a/crates/pocopine-core/src/scope.rs
+++ b/crates/pocopine-core/src/scope.rs
@@ -6,7 +6,7 @@
 
 use std::any::Any;
 use std::cell::RefCell;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::rc::Rc;
 
 use js_sys::{Array, Function, Object, Proxy, Reflect};
@@ -306,6 +306,12 @@ struct ProjectionSlot {
     cached: Option<(u32, JsValue)>,
 }
 
+/// One same-scope callback that arrived while a component handler still
+/// owned the state's mutable borrow. Browser APIs such as `focus()` dispatch
+/// their events synchronously, so the event callback must unwind before the
+/// matching handler can safely borrow the component again.
+type PendingInvocation = Box<dyn FnOnce()>;
+
 thread_local! {
     /// Registry of live scopes keyed by id. Directives look up the scope
     /// here to invoke handlers when an event fires.
@@ -379,6 +385,179 @@ thread_local! {
     /// handler returns.
     static CURRENT_SCOPE_ID: std::cell::Cell<Option<ScopeId>> =
         const { std::cell::Cell::new(None) };
+
+    /// Scopes whose handler-dispatch boundary currently owns `&mut state`.
+    /// Same-scope re-entry joins [`PENDING_INVOCATIONS`] instead of attempting
+    /// a second `RefCell::borrow_mut` while the first handler is on the stack.
+    static ACTIVE_INVOCATIONS: RefCell<HashSet<ScopeId>> = RefCell::new(HashSet::new());
+
+    /// FIFO work queued by synchronous same-scope re-entry. The outer handler
+    /// drains it after releasing its state borrow, still in the same JS turn.
+    static PENDING_INVOCATIONS: RefCell<HashMap<ScopeId, VecDeque<PendingInvocation>>> =
+        RefCell::new(HashMap::new());
+
+    /// A queued event expression may invoke a handler of its own. That nested
+    /// handler must not recursively drain the remaining callbacks before the
+    /// current expression has finished evaluating, so one outer drain owns the
+    /// queue until it is empty.
+    static DRAINING_INVOCATIONS: RefCell<HashSet<ScopeId>> = RefCell::new(HashSet::new());
+}
+
+/// Clear the active marker if a handler unwinds before its normal dispatch
+/// boundary. Work queued by the failed handler is discarded: replaying it on
+/// an unrelated later invocation would be both surprising and unsafe.
+struct ActiveInvocationGuard {
+    scope_id: ScopeId,
+    finished: bool,
+}
+
+impl ActiveInvocationGuard {
+    fn begin(scope_id: ScopeId) -> Self {
+        let inserted = ACTIVE_INVOCATIONS.with(|active| active.borrow_mut().insert(scope_id));
+        debug_assert!(inserted, "active invocation must be queued before begin");
+        Self {
+            scope_id,
+            finished: false,
+        }
+    }
+
+    fn finish(mut self) {
+        ACTIVE_INVOCATIONS.with(|active| {
+            active.borrow_mut().remove(&self.scope_id);
+        });
+        self.finished = true;
+    }
+}
+
+impl Drop for ActiveInvocationGuard {
+    fn drop(&mut self) {
+        if self.finished {
+            return;
+        }
+        ACTIVE_INVOCATIONS.with(|active| {
+            active.borrow_mut().remove(&self.scope_id);
+        });
+        PENDING_INVOCATIONS.with(|pending| {
+            pending.borrow_mut().remove(&self.scope_id);
+        });
+    }
+}
+
+/// Own one per-scope queue drain. A handler invoked by a queued event
+/// expression may finish before the rest of that expression; keeping this
+/// marker set prevents it from recursively draining later callbacks out of
+/// order.
+struct InvocationDrainGuard {
+    scope_id: ScopeId,
+    finished: bool,
+}
+
+impl InvocationDrainGuard {
+    fn begin(scope_id: ScopeId) -> Option<Self> {
+        let inserted = DRAINING_INVOCATIONS.with(|draining| draining.borrow_mut().insert(scope_id));
+        inserted.then_some(Self {
+            scope_id,
+            finished: false,
+        })
+    }
+
+    fn finish(mut self) {
+        DRAINING_INVOCATIONS.with(|draining| {
+            draining.borrow_mut().remove(&self.scope_id);
+        });
+        self.finished = true;
+    }
+}
+
+impl Drop for InvocationDrainGuard {
+    fn drop(&mut self) {
+        if self.finished {
+            return;
+        }
+        DRAINING_INVOCATIONS.with(|draining| {
+            draining.borrow_mut().remove(&self.scope_id);
+        });
+        PENDING_INVOCATIONS.with(|pending| {
+            pending.borrow_mut().remove(&self.scope_id);
+        });
+    }
+}
+
+fn invocation_is_active(scope_id: ScopeId) -> bool {
+    ACTIVE_INVOCATIONS.with(|active| active.borrow().contains(&scope_id))
+}
+
+fn enqueue_invocation(scope_id: ScopeId, task: PendingInvocation) {
+    PENDING_INVOCATIONS.with(|pending| {
+        pending
+            .borrow_mut()
+            .entry(scope_id)
+            .or_default()
+            .push_back(task);
+    });
+}
+
+fn drain_invocations(scope_id: ScopeId) {
+    let has_pending = PENDING_INVOCATIONS.with(|pending| {
+        pending
+            .borrow()
+            .get(&scope_id)
+            .is_some_and(|queue| !queue.is_empty())
+    });
+    if !has_pending {
+        return;
+    }
+    let Some(guard) = InvocationDrainGuard::begin(scope_id) else {
+        return;
+    };
+
+    loop {
+        // Teardown wins over an event that re-entered while unmounting. The
+        // queued callback still owns any JS values it captured, so dropping
+        // the queue here releases them without touching dead component state.
+        if Scope::find(scope_id).is_none() {
+            PENDING_INVOCATIONS.with(|pending| {
+                pending.borrow_mut().remove(&scope_id);
+            });
+            break;
+        }
+        let next = PENDING_INVOCATIONS.with(|pending| {
+            pending
+                .borrow_mut()
+                .get_mut(&scope_id)
+                .and_then(VecDeque::pop_front)
+        });
+        let Some(next) = next else {
+            PENDING_INVOCATIONS.with(|pending| {
+                pending.borrow_mut().remove(&scope_id);
+            });
+            break;
+        };
+        next();
+    }
+
+    guard.finish();
+}
+
+/// Queue a browser event expression when a handler for the same scope is still
+/// holding the component's mutable borrow. Returns whether it queued the task.
+/// The factory runs only on the re-entrant path so ordinary events do not clone
+/// their element, AST, proxy, and event solely to build an unused closure.
+///
+/// Queueing the complete expression (rather than only its first handler call)
+/// also keeps reads, assignments, and multi-statement expressions away from
+/// the active `RefCell` borrow. The outer handler drains it synchronously at
+/// its dispatch boundary.
+pub(crate) fn queue_event_expression_if_active(
+    scope_id: ScopeId,
+    task: impl FnOnce() -> PendingInvocation,
+) -> bool {
+    if invocation_is_active(scope_id) {
+        enqueue_invocation(scope_id, task());
+        true
+    } else {
+        false
+    }
 }
 
 impl Scope {
@@ -934,10 +1113,43 @@ impl Scope {
     /// Invoke a handler by name. Mutates Rust state directly, then
     /// runs the RFC-095 per-field dirty sweep: only fields whose
     /// fingerprints moved get their cache slot dropped and their
-    /// subscribers triggered. Falls back to the blanket
-    /// invalidate + scope-wide trigger when the sweep can't
-    /// snapshot (re-entrant invoke holding the state borrow).
+    /// subscribers triggered.
+    ///
+    /// Browser APIs can synchronously dispatch an event back into the same
+    /// component while its first handler still owns `&mut state` (`focus()` is
+    /// the common case). Such same-scope re-entry joins a synchronous FIFO
+    /// trampoline instead of attempting an aliased `RefCell::borrow_mut`.
+    /// The outer dispatch releases its borrow, completes its dirty sweep, and
+    /// drains the queued work before returning to JavaScript. A queued nested
+    /// invocation returns `undefined` to its immediate caller because its real
+    /// result cannot exist until that caller unwinds.
     pub fn invoke(&self, key: &str, args: &Array) -> JsValue {
+        if invocation_is_active(self.id) {
+            let scope = self.clone();
+            let key = key.to_string();
+            // The nested call returns before it executes, so retain the values
+            // as they existed at the call site instead of only cloning the JS
+            // Array handle (which the caller could mutate while unwinding).
+            let args = args.slice(0, args.length());
+            enqueue_invocation(
+                self.id,
+                Box::new(move || {
+                    let _ = scope.invoke(&key, &args);
+                }),
+            );
+            return JsValue::UNDEFINED;
+        }
+
+        let active = ActiveInvocationGuard::begin(self.id);
+        let out = self.invoke_now(key, args);
+        active.finish();
+        drain_invocations(self.id);
+        out
+    }
+
+    /// One non-reentrant handler invocation. [`Scope::invoke`] owns the
+    /// same-scope trampoline around this method.
+    fn invoke_now(&self, key: &str, args: &Array) -> JsValue {
         let prev = CURRENT_SCOPE_ID.with(|c| c.replace(Some(self.id)));
         #[cfg(feature = "devtools")]
         let start = crate::devtools::ring::now_ms_for_scope();

--- a/crates/pocopine-core/tests/reactive.rs
+++ b/crates/pocopine-core/tests/reactive.rs
@@ -949,6 +949,43 @@ struct OpaqueState {
     b: u32,
 }
 
+struct ReentrantInvokeState {
+    order: Rc<RefCell<Vec<&'static str>>>,
+    nested_arg: Rc<RefCell<Option<String>>>,
+}
+
+impl pocopine_core::ComponentState for ReentrantInvokeState {
+    fn get(&self, _key: &str) -> JsValue {
+        JsValue::UNDEFINED
+    }
+
+    fn set(&mut self, _key: &str, _value: JsValue) {}
+
+    fn keys(&self) -> &'static [&'static str] {
+        &[]
+    }
+
+    fn invoke(&mut self, key: &str, args: &js_sys::Array) -> JsValue {
+        match key {
+            "outer" => {
+                self.order.borrow_mut().push("outer:start");
+                let scope_id = pocopine_core::scope::current_scope_id()
+                    .expect("Scope::invoke binds the current scope");
+                let nested_args = js_sys::Array::of1(&JsValue::from_str("at-call-time"));
+                pocopine_core::scope::invoke_handler(scope_id, "nested", &nested_args);
+                nested_args.set(0, JsValue::from_str("mutated-after-call"));
+                self.order.borrow_mut().push("outer:end");
+            }
+            "nested" => {
+                self.order.borrow_mut().push("nested");
+                *self.nested_arg.borrow_mut() = args.get(0).as_string();
+            }
+            _ => {}
+        }
+        JsValue::UNDEFINED
+    }
+}
+
 impl pocopine_core::ComponentState for OpaqueState {
     fn get(&self, key: &str) -> JsValue {
         match key {
@@ -1034,6 +1071,30 @@ fn dirty_sweep_unknown_fingerprints_fall_back_to_full_trigger() {
         (hits_a.get(), hits_b.get()),
         (2, 2),
         "unknown fingerprints must conservatively re-run every tracked effect",
+    );
+}
+
+#[wasm_bindgen_test]
+fn same_scope_handler_reentry_drains_after_the_active_borrow() {
+    setup();
+    let order = Rc::new(RefCell::new(Vec::new()));
+    let nested_arg = Rc::new(RefCell::new(None));
+    let scope = Scope::new(Rc::new(RefCell::new(ReentrantInvokeState {
+        order: order.clone(),
+        nested_arg: nested_arg.clone(),
+    })));
+
+    scope.invoke("outer", &js_sys::Array::new());
+
+    assert_eq!(
+        order.borrow().as_slice(),
+        ["outer:start", "outer:end", "nested"],
+        "same-scope re-entry drains synchronously after the first handler releases state",
+    );
+    assert_eq!(
+        nested_arg.borrow().as_deref(),
+        Some("at-call-time"),
+        "queued invocation snapshots its argument list",
     );
 }
 

--- a/crates/pocopine-core/tests/scope_reentrancy.rs
+++ b/crates/pocopine-core/tests/scope_reentrancy.rs
@@ -1,0 +1,107 @@
+//! Regression coverage for synchronous browser events re-entering the
+//! component handler that caused them.
+
+#![cfg(target_arch = "wasm32")]
+
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use js_sys::Array;
+use pocopine_core::{ComponentState, Scope};
+use wasm_bindgen::{JsCast, JsValue};
+use wasm_bindgen_test::{wasm_bindgen_test, wasm_bindgen_test_configure};
+use web_sys::HtmlElement;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+struct FocusState {
+    input: HtmlElement,
+    order: Rc<RefCell<Vec<&'static str>>>,
+    focused: bool,
+    assigned: bool,
+}
+
+impl ComponentState for FocusState {
+    fn get(&self, key: &str) -> JsValue {
+        match key {
+            "focused" => self.focused.into(),
+            "assigned" => self.assigned.into(),
+            _ => JsValue::UNDEFINED,
+        }
+    }
+
+    fn set(&mut self, key: &str, value: JsValue) {
+        if key == "assigned" {
+            self.assigned = value.as_bool().unwrap_or(false);
+        }
+    }
+
+    fn keys(&self) -> &'static [&'static str] {
+        &["focused", "assigned"]
+    }
+
+    fn invoke(&mut self, key: &str, _args: &Array) -> JsValue {
+        match key {
+            "open" => {
+                self.order.borrow_mut().push("outer:start");
+                self.input.focus().expect("input focuses");
+                self.order.borrow_mut().push("outer:end");
+            }
+            "on_focus" => {
+                self.order.borrow_mut().push("focus");
+                self.focused = true;
+            }
+            _ => {}
+        }
+        JsValue::UNDEFINED
+    }
+}
+
+#[wasm_bindgen_test]
+fn focus_event_waits_for_the_active_handler_borrow_to_end() {
+    let document = web_sys::window()
+        .and_then(|window| window.document())
+        .expect("browser document");
+    let element = document.create_element("input").expect("create input");
+    let input = element.clone().unchecked_into::<HtmlElement>();
+    document
+        .body()
+        .expect("document body")
+        .append_child(&element)
+        .expect("attach input");
+
+    let order = Rc::new(RefCell::new(Vec::new()));
+    let state = Rc::new(RefCell::new(FocusState {
+        input,
+        order: order.clone(),
+        focused: false,
+        assigned: false,
+    }));
+    let scope = Scope::new(state.clone());
+    let proxy = scope.into_proxy();
+    let ast = Rc::new(
+        pocopine_core::expr::parse_cached("on_focus($event); assigned = true")
+            .expect("event expression parses"),
+    );
+    pocopine_core::directives::on::install(&element, scope.id, &proxy, "focus", &[], ast);
+
+    // `HtmlElement::focus()` dispatches `focus` before it returns. The event
+    // expression includes both a handler call and a state assignment so the
+    // complete expression—not just the call—must wait for `open` to release
+    // the component's mutable borrow.
+    scope.invoke("open", &Array::new());
+
+    assert_eq!(
+        order.borrow().as_slice(),
+        ["outer:start", "outer:end", "focus"],
+        "focus work drains in the same turn, after the initiating handler",
+    );
+    assert!(state.borrow().focused, "focus handler ran");
+    assert!(
+        state.borrow().assigned,
+        "the rest of the event expression ran without re-borrowing state",
+    );
+
+    Scope::remove(scope.id);
+    element.remove();
+}

--- a/crates/pocopine/tests/ui/dc_missing_is.stderr
+++ b/crates/pocopine/tests/ui/dc_missing_is.stderr
@@ -1,4 +1,4 @@
-error: `<pp-component>` requires a reactive `:is="..."` binding (RFC-112)
+error: pocopine: template plan error in component `dc-missing-is` (`<inline template for dc-missing-is>`): `<pp-component>` requires a reactive `:is="..."` binding (RFC-112)
  --> tests/ui/dc_missing_is.rs:5:1
   |
 5 | #[component(template_inline = "<pp-component></pp-component>")]


### PR DESCRIPTION
## What

- add a per-scope synchronous FIFO trampoline for handler work that re-enters while the component state is mutably borrowed
- queue the complete browser event expression, not only its handler call, so reads, assignments, and statement sequences cannot re-borrow active state
- preserve call-time direct-invocation arguments with a shallow JS array snapshot and discard queued work on panic or scope teardown
- add a real browser regression for `focus()` synchronously firing `focus`, plus a dedicated Firefox CI matrix entry

## Why

`Scope::invoke` held `RefMut<dyn ComponentState>` across the user handler. A handler calling `focus()` synchronously fired the component's focus listener, which invoked the same scope and panicked at the second `borrow_mut()` (`RefCell already mutably borrowed`).

The trampoline keeps the work in the same JavaScript turn: the initiating handler releases its borrow and completes its dirty sweep, then queued expressions drain FIFO before the outer dispatch returns. Ordinary non-reentrant event dispatch keeps the prior no-clone fast path.

## Impact

Synchronous DOM re-entry no longer crashes the app. Direct nested invocations return `undefined` to their immediate caller because their actual result is produced after that caller unwinds. The `emit_cancelable` docs now spell out the corresponding same-scope `preventDefault` timing caveat.

## Checks

- `cargo fmt --all -- --check`
- `cargo test -p pocopine-core` (175 host tests passed)
- `cargo clippy -p pocopine-core --all-targets -- -D warnings`
- `cargo clippy -p pocopine-core --target wasm32-unknown-unknown --all-targets -- -D warnings`
- `cargo check -p pocopine-core --all-targets`
- `cargo check -p pocopine-core --target wasm32-unknown-unknown --all-targets`
- `cargo build -p pocopine-core --target wasm32-unknown-unknown --all-targets`
- `wasm-pack test --node crates/pocopine-core --test reactive` (42/42 passed)
- exact Firefox focus regression compiles locally and is wired into CI; local execution was blocked by this machine's broken Firefox snap GPU provider slot