### PR TITLE
fix(macros): turn silent drops into compile errors across the macro surface

### DIFF
--- a/crates/pine/src/upload/PineUploadItem.poco
+++ b/crates/pine/src/upload/PineUploadItem.poco
@@ -3,6 +3,6 @@
       :data-status="status"
       :data-extension="extension"
       :data-has-error="error ? true : false"
-      :aria-busy="status === 'uploading'">
+      :aria-busy="status == 'uploading'">
   <slot></slot>
 </root>

--- a/crates/pocopine-core/src/directives/on.rs
+++ b/crates/pocopine-core/src/directives/on.rs
@@ -253,7 +253,7 @@ pub fn install(
                     with_current_el(&el_for_closure, || {
                         crate::scope::with_current_scope_id(scope_id, || {
                             with_current_event(&ev_js, || {
-                                expr::evaluate_with(&ast, &proxy, access.as_ref());
+                                expr::evaluate_with(ast, &proxy, access.as_ref());
                             });
                         });
                     });

--- a/crates/pocopine-core/src/directives/on.rs
+++ b/crates/pocopine-core/src/directives/on.rs
@@ -47,7 +47,9 @@ pub fn install(
     proxy: &JsValue,
     event: &str,
     modifiers: &'static [&'static str],
-    ast: Rc<Spanned<Expr>>,
+    // `None` = effect-only listener (`@pointerdown.stop` with no
+    // handler): the modifiers are applied, nothing is evaluated.
+    ast: Option<Rc<Spanned<Expr>>>,
 ) {
     let event = event.to_string();
     let el = el.clone();
@@ -80,38 +82,38 @@ pub fn install(
     // drops via the element-scoped listener table.
     type DebouncedInvoke = (Option<Function>, Option<Closure<dyn FnMut()>>);
     let last_event: Rc<RefCell<Option<Event>>> = Rc::new(RefCell::new(None));
-    let (invoke_fn, debounce_closure): DebouncedInvoke = if debounce_ms.is_some() {
-        let ast = ast.clone();
-        let last_event = last_event.clone();
-        let el_for_debounce = el.clone();
-        let proxy_for_debounce = proxy.clone();
-        let access_for_debounce = access.clone();
-        let c = Closure::wrap(Box::new(move || {
-            let ev = last_event.borrow().clone();
-            let ev_js: JsValue = match &ev {
-                Some(e) => {
-                    let r: &JsValue = e.as_ref();
-                    r.clone()
-                }
-                None => JsValue::UNDEFINED,
-            };
-            with_current_el(&el_for_debounce, || {
-                crate::scope::with_current_scope_id(scope_id, || {
-                    with_current_event(&ev_js, || {
-                        expr::evaluate_with(
-                            &ast,
-                            &proxy_for_debounce,
-                            access_for_debounce.as_ref(),
-                        );
+    let (invoke_fn, debounce_closure): DebouncedInvoke =
+        if let (true, Some(ast)) = (debounce_ms.is_some(), ast.clone()) {
+            let last_event = last_event.clone();
+            let el_for_debounce = el.clone();
+            let proxy_for_debounce = proxy.clone();
+            let access_for_debounce = access.clone();
+            let c = Closure::wrap(Box::new(move || {
+                let ev = last_event.borrow().clone();
+                let ev_js: JsValue = match &ev {
+                    Some(e) => {
+                        let r: &JsValue = e.as_ref();
+                        r.clone()
+                    }
+                    None => JsValue::UNDEFINED,
+                };
+                with_current_el(&el_for_debounce, || {
+                    crate::scope::with_current_scope_id(scope_id, || {
+                        with_current_event(&ev_js, || {
+                            expr::evaluate_with(
+                                &ast,
+                                &proxy_for_debounce,
+                                access_for_debounce.as_ref(),
+                            );
+                        });
                     });
                 });
-            });
-        }) as Box<dyn FnMut()>);
-        let f: Function = c.as_ref().unchecked_ref::<Function>().clone();
-        (Some(f), Some(c))
-    } else {
-        (None, None)
-    };
+            }) as Box<dyn FnMut()>);
+            let f: Function = c.as_ref().unchecked_ref::<Function>().clone();
+            (Some(f), Some(c))
+        } else {
+            (None, None)
+        };
 
     let window = web_sys::window().expect("window");
     let timer: Rc<Cell<Option<i32>>> = Rc::new(Cell::new(None));
@@ -203,6 +205,11 @@ pub fn install(
                     return;
                 }
             }
+            // Effect-only listener: the modifiers above are the whole
+            // behavior; there is no expression to evaluate.
+            let Some(ast) = ast.as_ref() else {
+                return;
+            };
             if let (Some(ms), Some(invoke_fn)) = (debounce_ms, invoke_fn.as_ref()) {
                 // Remember the most recent event so the delayed
                 // callback can still pass it to the handler.

--- a/crates/pocopine-core/src/templates_plan.rs
+++ b/crates/pocopine-core/src/templates_plan.rs
@@ -359,6 +359,7 @@ pub fn install_static_listener(
 ) {
     let Ok(ast) = listener_ast_for_install(
         entry.expr_src,
+        entry.modifiers,
         "listener-parse",
         template_name,
         entry.node_path,
@@ -369,17 +370,24 @@ pub fn install_static_listener(
 }
 
 /// Parse a listener expression for install. An empty `expr_src` is
-/// an effect-only listener (the macro admits it only alongside
-/// `.prevent`/`.stop`): install with no evaluation step. A non-empty
-/// source that fails to parse records a plan failure.
+/// an effect-only listener, valid only alongside `.prevent`/`.stop`
+/// (the same contract the macro enforces at compile time — a plan
+/// entry violating it is a framework bug and records a plan
+/// failure): install with no evaluation step. A non-empty source
+/// that fails to parse records a plan failure.
 fn listener_ast_for_install(
     expr_src: &'static str,
+    modifiers: &'static [&'static str],
     kind: &str,
     template_name: &str,
     node_path: &'static [u16],
 ) -> Result<Option<Rc<crate::expr::Spanned<crate::expr::Expr>>>, ()> {
     if expr_src.trim().is_empty() {
-        return Ok(None);
+        if modifiers.contains(&"prevent") || modifiers.contains(&"stop") {
+            return Ok(None);
+        }
+        fail(kind, template_name, node_path, Some("<empty listener>"));
+        return Err(());
     }
     match expr::parse_cached(expr_src) {
         Ok(a) => Ok(Some(Rc::new(directives::on::backfill_legacy_call(a)))),
@@ -767,6 +775,7 @@ pub fn apply_static_pp_as_plan(
     for l in plan.listeners.iter().filter(|l| l.node_path.is_empty()) {
         let Ok(ast) = listener_ast_for_install(
             l.expr_src,
+            l.modifiers,
             "pp-as-listener-parse",
             template_name,
             l.node_path,
@@ -847,6 +856,7 @@ fn install_child_host_directives(
     for l in child.listeners {
         let Ok(ast) = listener_ast_for_install(
             l.expr_src,
+            l.modifiers,
             "child-host-listener-parse",
             template_name,
             child.node_path,

--- a/crates/pocopine-core/src/templates_plan.rs
+++ b/crates/pocopine-core/src/templates_plan.rs
@@ -357,26 +357,37 @@ pub fn install_static_listener(
     entry: &'static StaticListener,
     template_name: &str,
 ) {
-    let ast = match expr::parse_cached(entry.expr_src) {
-        Ok(a) => a,
-        Err(_) => {
-            fail(
-                "listener-parse",
-                template_name,
-                entry.node_path,
-                Some(entry.expr_src),
-            );
-            return;
-        }
+    let Ok(ast) = listener_ast_for_install(
+        entry.expr_src,
+        "listener-parse",
+        template_name,
+        entry.node_path,
+    ) else {
+        return;
     };
-    directives::on::install(
-        el,
-        scope_id,
-        proxy,
-        entry.event,
-        entry.modifiers,
-        Rc::new(directives::on::backfill_legacy_call(ast)),
-    );
+    directives::on::install(el, scope_id, proxy, entry.event, entry.modifiers, ast);
+}
+
+/// Parse a listener expression for install. An empty `expr_src` is
+/// an effect-only listener (the macro admits it only alongside
+/// `.prevent`/`.stop`): install with no evaluation step. A non-empty
+/// source that fails to parse records a plan failure.
+fn listener_ast_for_install(
+    expr_src: &'static str,
+    kind: &str,
+    template_name: &str,
+    node_path: &'static [u16],
+) -> Result<Option<Rc<crate::expr::Spanned<crate::expr::Expr>>>, ()> {
+    if expr_src.trim().is_empty() {
+        return Ok(None);
+    }
+    match expr::parse_cached(expr_src) {
+        Ok(a) => Ok(Some(Rc::new(directives::on::backfill_legacy_call(a)))),
+        Err(_) => {
+            fail(kind, template_name, node_path, Some(expr_src));
+            Err(())
+        }
+    }
 }
 
 /// RFC 062 Phase 2 helper used by macro-specialized mount
@@ -754,26 +765,15 @@ pub fn apply_static_pp_as_plan(
         }
     }
     for l in plan.listeners.iter().filter(|l| l.node_path.is_empty()) {
-        let ast = match expr::parse_cached(l.expr_src) {
-            Ok(a) => a,
-            Err(_) => {
-                fail(
-                    "pp-as-listener-parse",
-                    template_name,
-                    l.node_path,
-                    Some(l.expr_src),
-                );
-                continue;
-            }
+        let Ok(ast) = listener_ast_for_install(
+            l.expr_src,
+            "pp-as-listener-parse",
+            template_name,
+            l.node_path,
+        ) else {
+            continue;
         };
-        directives::on::install(
-            root,
-            scope_id,
-            proxy,
-            l.event,
-            l.modifiers,
-            Rc::new(directives::on::backfill_legacy_call(ast)),
-        );
+        directives::on::install(root, scope_id, proxy, l.event, l.modifiers, ast);
     }
     for d in plan
         .opaque_directives
@@ -845,26 +845,15 @@ fn install_child_host_directives(
         }
     }
     for l in child.listeners {
-        let ast = match expr::parse_cached(l.expr_src) {
-            Ok(a) => a,
-            Err(_) => {
-                fail(
-                    "child-host-listener-parse",
-                    template_name,
-                    child.node_path,
-                    Some(l.expr_src),
-                );
-                continue;
-            }
+        let Ok(ast) = listener_ast_for_install(
+            l.expr_src,
+            "child-host-listener-parse",
+            template_name,
+            child.node_path,
+        ) else {
+            continue;
         };
-        directives::on::install(
-            el,
-            scope_id,
-            proxy,
-            l.event,
-            l.modifiers,
-            Rc::new(directives::on::backfill_legacy_call(ast)),
-        );
+        directives::on::install(el, scope_id, proxy, l.event, l.modifiers, ast);
     }
     for m in child.models {
         directives::model::install_compiled(el, scope_id, proxy, m.arg, m.modifiers, m.expr_src);

--- a/crates/pocopine-core/tests/scope_reentrancy.rs
+++ b/crates/pocopine-core/tests/scope_reentrancy.rs
@@ -83,7 +83,7 @@ fn focus_event_waits_for_the_active_handler_borrow_to_end() {
         pocopine_core::expr::parse_cached("on_focus($event); assigned = true")
             .expect("event expression parses"),
     );
-    pocopine_core::directives::on::install(&element, scope.id, &proxy, "focus", &[], ast);
+    pocopine_core::directives::on::install(&element, scope.id, &proxy, "focus", &[], Some(ast));
 
     // `HtmlElement::focus()` dispatches `focus` before it returns. The event
     // expression includes both a handler call and a state assignment so the

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -764,17 +764,47 @@ impl Parse for ComponentArgs {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         let pairs: Punctuated<MetaNameValue, Token![,]> = Punctuated::parse_terminated(input)?;
         let mut args = ComponentArgs::default();
+        // A repeated key used to last-one-win silently — the earlier
+        // value vanished with no diagnostic (matches the guard
+        // `ClientModuleArgs::parse` always had).
+        fn set_once(
+            slot: &mut Option<LitStr>,
+            lit: LitStr,
+            path: &syn::Path,
+            key: &str,
+        ) -> syn::Result<()> {
+            if slot.replace(lit).is_some() {
+                return Err(syn::Error::new_spanned(
+                    path,
+                    format!("duplicate `{key}` argument"),
+                ));
+            }
+            Ok(())
+        }
+        let mut unchecked_paths_seen = false;
         for kv in pairs {
             // `uses = [...]` is the one non-string-valued key;
             // handle it first so the string-lit extraction below
             // doesn't reject it.
             if kv.path.is_ident("uses") {
+                if args.uses.is_some() {
+                    return Err(syn::Error::new_spanned(
+                        kv.path,
+                        "duplicate `uses` argument",
+                    ));
+                }
                 let entries = uses::parse_uses_array(kv.value)?;
                 let table = uses::resolve_uses(entries)?;
                 args.uses = Some(table);
                 continue;
             }
             if kv.path.is_ident("extends") {
+                if args.extends.is_some() {
+                    return Err(syn::Error::new_spanned(
+                        kv.path,
+                        "duplicate `extends` argument",
+                    ));
+                }
                 args.extends = Some(uses::parse_extends_array(kv.value)?);
                 continue;
             }
@@ -788,27 +818,47 @@ impl Parse for ComponentArgs {
                 }
             };
             if kv.path.is_ident("name") {
-                args.name = Some(lit);
+                set_once(&mut args.name, lit, &kv.path, "name")?;
             } else if kv.path.is_ident("template") {
-                args.template = Some(lit);
+                set_once(&mut args.template, lit, &kv.path, "template")?;
             } else if kv.path.is_ident("template_inline") {
-                args.template_inline = Some(lit);
+                set_once(&mut args.template_inline, lit, &kv.path, "template_inline")?;
             } else if kv.path.is_ident("style") {
-                args.style = Some(lit);
+                set_once(&mut args.style, lit, &kv.path, "style")?;
             } else if kv.path.is_ident("role") {
-                args.role = Some(lit);
+                set_once(&mut args.role, lit, &kv.path, "role")?;
             } else if kv.path.is_ident("display") {
-                args.display = Some(lit);
+                set_once(&mut args.display, lit, &kv.path, "display")?;
             } else if kv.path.is_ident("transition") {
-                args.transition = Some(lit);
+                set_once(&mut args.transition, lit, &kv.path, "transition")?;
             } else if kv.path.is_ident("transition_in") {
-                args.transition_in = Some(lit);
+                set_once(&mut args.transition_in, lit, &kv.path, "transition_in")?;
             } else if kv.path.is_ident("transition_out") {
-                args.transition_out = Some(lit);
+                set_once(&mut args.transition_out, lit, &kv.path, "transition_out")?;
             } else if kv.path.is_ident("animate") {
-                args.animate = Some(lit);
+                set_once(&mut args.animate, lit, &kv.path, "animate")?;
             } else if kv.path.is_ident("unchecked_paths") {
-                args.unchecked_paths = lit.value() == "true";
+                if unchecked_paths_seen {
+                    return Err(syn::Error::new_spanned(
+                        kv.path,
+                        "duplicate `unchecked_paths` argument",
+                    ));
+                }
+                unchecked_paths_seen = true;
+                // Only the exact booleans — `"yes"`/`"1"` used to
+                // silently leave the opt-out disabled.
+                args.unchecked_paths = match lit.value().as_str() {
+                    "true" => true,
+                    "false" => false,
+                    other => {
+                        return Err(syn::Error::new_spanned(
+                            lit,
+                            format!(
+                                "`unchecked_paths` expects \"true\" or \"false\", got \"{other}\""
+                            ),
+                        ));
+                    }
+                };
             } else {
                 return Err(syn::Error::new_spanned(
                     kv.path,
@@ -5152,6 +5202,18 @@ pub fn server(attr: TokenStream, item: TokenStream) -> TokenStream {
     let sig = &input.sig;
     let body = &input.block;
     let streaming = returns_stream(sig);
+    // The streaming client path wins unconditionally, so `idempotent`
+    // on a streaming fn was parsed, stored, and never consulted —
+    // dead config that read as replay protection.
+    if streaming && policy.idempotent {
+        return syn::Error::new_spanned(
+            &sig.output,
+            "#[server(idempotent)] has no effect on a streaming function — the \
+             stream transport has no replay envelope; remove `idempotent`",
+        )
+        .to_compile_error()
+        .into();
+    }
 
     let fn_ident = sig.ident.clone();
     let fn_name_str = fn_ident.to_string();
@@ -5783,10 +5845,18 @@ impl Default for JobConfig {
 fn parse_job_config(attr: TokenStream) -> syn::Result<JobConfig> {
     let metas = Punctuated::<Meta, Token![,]>::parse_terminated.parse(attr)?;
     let mut config = JobConfig::default();
+    // Repeated keys used to last-one-win silently (contrast
+    // `parse_server_policy`, which guards every duplicate).
+    let mut queue_seen = false;
+    let mut retries_seen = false;
 
     for meta in metas {
         match meta {
             Meta::NameValue(MetaNameValue { path, value, .. }) if path.is_ident("queue") => {
+                if queue_seen {
+                    return Err(syn::Error::new_spanned(path, "duplicate `queue` argument"));
+                }
+                queue_seen = true;
                 let Expr::Lit(ExprLit {
                     lit: Lit::Str(lit), ..
                 }) = value
@@ -5801,6 +5871,16 @@ fn parse_job_config(attr: TokenStream) -> syn::Result<JobConfig> {
             Meta::NameValue(MetaNameValue { path, value, .. })
                 if path.is_ident("retries") || path.is_ident("max_retries") =>
             {
+                if retries_seen {
+                    // Covers both a repeated key and the
+                    // `retries` + `max_retries` alias conflict.
+                    return Err(syn::Error::new_spanned(
+                        path,
+                        "duplicate retry count — `retries` and `max_retries` are aliases; \
+                         pass one of them once",
+                    ));
+                }
+                retries_seen = true;
                 let Expr::Lit(ExprLit {
                     lit: Lit::Int(lit), ..
                 }) = value
@@ -6465,8 +6545,22 @@ pub fn derive_props(input: TokenStream) -> TokenStream {
     // `#[component]` (RFC-031): `#[prop]` = exposed, default = state.
     let mut leaves: Vec<(syn::Ident, syn::Type)> = Vec::new();
     for field in fields.named.iter() {
-        if !field.attrs.iter().any(|a| a.path().is_ident("prop")) {
+        let Some(prop_attr) = field.attrs.iter().find(|a| a.path().is_ident("prop")) else {
             continue;
+        };
+        // Bare `#[prop]` only. Arguments used to be recognized,
+        // never parsed, and silently discarded — `#[prop(name =
+        // "…")]` / `#[prop(skip)]` compiled green and did nothing.
+        // (`#[prop(flatten)]` is a `#[component]`-field feature,
+        // not a `#[derive(Props)]` one.)
+        if !matches!(prop_attr.meta, syn::Meta::Path(_)) {
+            return syn::Error::new_spanned(
+                prop_attr,
+                "#[derive(Props)] fields take bare `#[prop]` — arguments are not \
+                 supported here (the wire leaf name is always the field name)",
+            )
+            .to_compile_error()
+            .into();
         }
         let Some(ident) = field.ident.clone() else {
             continue;

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -2993,6 +2993,7 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
             specialized_mount_body: None,
             diagnostics: proc_macro2::TokenStream::new(),
             ref_names: Vec::new(),
+            warnings: Vec::new(),
         });
 
     // Build the literal to feed into `compile_template`:
@@ -3097,6 +3098,14 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
     let template_plan_tokens_for_vtable = template_plan.plan_tokens.clone();
     let specialized_mount_body = template_plan.specialized_mount_body.clone();
     let template_plan_diagnostics_tokens = template_plan.diagnostics.clone();
+    // Non-fatal authoring notes (e.g. the JS-equality desugar)
+    // surface via the same `#[deprecated]`-const trick as the
+    // unresolved-template warning (RFC 045 §9.4).
+    let template_plan_warning_tokens = template_plan
+        .warnings
+        .iter()
+        .map(|w| build_warning_tokens(w))
+        .collect::<proc_macro2::TokenStream>();
     let template_plan_item_tokens = match template_plan.plan_tokens.clone() {
         Some(plan_tokens) => {
             let slot_fns = template_plan.slot_fragment_fns;
@@ -3523,6 +3532,9 @@ pub fn component(attr: TokenStream, item: TokenStream) -> TokenStream {
         // runtime plan at all.
         #template_plan_diagnostics_tokens
 
+        // Non-fatal template-plan warnings (deprecated-const trick).
+        #template_plan_warning_tokens
+
         // RFC 063 — hard `compile_error!` for every directive
         // RFC 063 §4.1 deletes (`pp-cloak` today; more in
         // follow-up commits).
@@ -3897,8 +3909,10 @@ pub fn handlers(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 false // strip
             } else if attr.path().is_ident("computed") {
                 if !matches!(attr.meta, syn::Meta::Path(_)) && marker_error.is_none() {
-                    marker_error =
-                        Some(syn::Error::new_spanned(attr, "#[computed] takes no arguments"));
+                    marker_error = Some(syn::Error::new_spanned(
+                        attr,
+                        "#[computed] takes no arguments",
+                    ));
                 }
                 is_computed = true;
                 false
@@ -3924,10 +3938,7 @@ pub fn handlers(_attr: TokenStream, item: TokenStream) -> TokenStream {
             // installed. Anything else is rejected here — before this
             // check, a no-arg handler compiled green and the watch
             // silently never fired.
-            let takes_ref_self = method
-                .sig
-                .receiver()
-                .is_some_and(|r| r.reference.is_some());
+            let takes_ref_self = method.sig.receiver().is_some_and(|r| r.reference.is_some());
             let typed_args: Vec<syn::Type> = method
                 .sig
                 .inputs

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -3869,26 +3869,91 @@ pub fn handlers(_attr: TokenStream, item: TokenStream) -> TokenStream {
         };
         let mut watch_field: Option<syn::Ident> = None;
         let mut is_computed = false;
+        // A marker attr the macro recognizes but cannot install must be
+        // a compile error, never a silent strip — a dropped watch reads
+        // as a dead handler at the call site.
+        let mut marker_error: Option<syn::Error> = None;
         method.attrs.retain(|attr| {
             if attr.path().is_ident("watch") {
-                if let Ok(ident) = attr.parse_args::<syn::Ident>() {
-                    watch_field = Some(ident);
+                match attr.parse_args::<syn::Ident>() {
+                    Ok(ident) => {
+                        if watch_field.replace(ident).is_some() && marker_error.is_none() {
+                            marker_error = Some(syn::Error::new_spanned(
+                                attr,
+                                "only one #[watch] attribute per method — write one \
+                                 handler per watched field",
+                            ));
+                        }
+                    }
+                    Err(_) => {
+                        if marker_error.is_none() {
+                            marker_error = Some(syn::Error::new_spanned(
+                                attr,
+                                "#[watch] expects a field name: #[watch(field)]",
+                            ));
+                        }
+                    }
                 }
                 false // strip
             } else if attr.path().is_ident("computed") {
+                if !matches!(attr.meta, syn::Meta::Path(_)) && marker_error.is_none() {
+                    marker_error =
+                        Some(syn::Error::new_spanned(attr, "#[computed] takes no arguments"));
+                }
                 is_computed = true;
                 false
             } else {
                 true
             }
         });
+        if let Some(err) = marker_error {
+            return err.to_compile_error().into();
+        }
+        if watch_field.is_some() && is_computed {
+            return syn::Error::new_spanned(
+                &method.sig.ident,
+                "#[watch] and #[computed] cannot be combined on one method",
+            )
+            .to_compile_error()
+            .into();
+        }
         if let Some(field_ident) = watch_field {
-            // Extract V from the method's first typed arg.
-            let v_ty = method.sig.inputs.iter().find_map(|arg| match arg {
-                FnArg::Typed(PatType { ty, .. }) => Some((**ty).clone()),
-                _ => None,
-            });
-            let Some(v_ty) = v_ty else { continue };
+            // RFC-036 contract: the generated dispatch calls
+            // `s.<method>(new_v, prev_v)`, so only the
+            // `&mut self, (next: V, prev: Option<V>)` shape can ever be
+            // installed. Anything else is rejected here — before this
+            // check, a no-arg handler compiled green and the watch
+            // silently never fired.
+            let takes_ref_self = method
+                .sig
+                .receiver()
+                .is_some_and(|r| r.reference.is_some());
+            let typed_args: Vec<syn::Type> = method
+                .sig
+                .inputs
+                .iter()
+                .filter_map(|arg| match arg {
+                    FnArg::Typed(PatType { ty, .. }) => Some((**ty).clone()),
+                    _ => None,
+                })
+                .collect();
+            if !takes_ref_self || typed_args.len() != 2 {
+                let method_ident = &method.sig.ident;
+                return syn::Error::new_spanned(
+                    &method.sig,
+                    format!(
+                        "#[watch({field_ident})] handler must take `&mut self` and \
+                         `(next: V, prev: Option<V>)` — e.g. `fn {method_ident}(&mut self, \
+                         next: V, prev: Option<V>)`"
+                    ),
+                )
+                .to_compile_error()
+                .into();
+            }
+            let v_ty = typed_args
+                .into_iter()
+                .next()
+                .expect("arity checked to be exactly 2");
             methods_to_skip_in_arms.insert(method.sig.ident.to_string());
             watches.push((method.sig.ident.clone(), field_ident, v_ty));
         }
@@ -3980,6 +4045,23 @@ pub fn handlers(_attr: TokenStream, item: TokenStream) -> TokenStream {
     for item in &input.items {
         let ImplItem::Fn(method) = item else { continue };
         let Some(receiver) = method.sig.receiver() else {
+            // A lifecycle-named associated fn would fall out here before
+            // the name match — the hook would compile green and silently
+            // never fire. There is no template-path backstop for
+            // lifecycle names (they are auto-wired, never referenced
+            // from a template), so reject it.
+            let name = method.sig.ident.to_string();
+            if matches!(
+                name.as_str(),
+                "on_setup" | "on_mount" | "on_ready" | "on_unmount"
+            ) {
+                return syn::Error::new_spanned(
+                    &method.sig,
+                    format!("lifecycle method `{name}` must take `&mut self`"),
+                )
+                .to_compile_error()
+                .into();
+            }
             continue;
         };
         let ident = method.sig.ident.clone();

--- a/crates/pocopine-macros/src/template_plan.rs
+++ b/crates/pocopine-macros/src/template_plan.rs
@@ -1785,7 +1785,17 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
             // wrapping a `<slot>` outlet is the documented shape
             // (docs/guides/components/03-composition.md) — the slot
             // publication machinery owns that subtree, not the plan.
+            // The pp-for value itself is still validated; directives
+            // deeper in the exempt subtree stay slot-machinery-owned.
             if subtree_contains_slot(el) {
+                match parse_pp_for(&for_attr) {
+                    Some((_, items_expr)) => {
+                        let _ = check_template_expr(&items_expr, "pp-for", ctx);
+                    }
+                    None => ctx.diagnostics.push(format!(
+                        "`pp-for=\"{for_attr}\"` does not parse — expected `item in items`"
+                    )),
+                }
                 return;
             }
             ctx.diagnostics
@@ -1824,13 +1834,15 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
                 .find(|(n, _)| n == "pp-stagger")
                 .map(|(_, v)| v.trim().to_string())
             {
-                Some(v) if !v.is_empty() => v.parse::<u32>().unwrap_or_else(|_| {
+                // Empty is a truncation, not a request for 0ms —
+                // diagnosed like every other junk value.
+                Some(v) => v.parse::<u32>().unwrap_or_else(|_| {
                     ctx.diagnostics.push(format!(
                         "`pp-stagger=\"{v}\"` expects milliseconds, e.g. pp-stagger=\"40\""
                     ));
                     0
                 }),
-                _ => 0,
+                None => 0,
             };
             // RFC-058 Phase 4.2c — try to lift the row body
             // into a fragment fn. Skip when an RFC-054 row
@@ -2906,13 +2918,39 @@ fn is_keyboard_event(event: &str) -> bool {
     matches!(event, "keydown" | "keyup" | "keypress")
 }
 
+/// Named key modifiers the runtime normalizes (`on.rs named_key_for`).
+const NAMED_KEY_MODIFIERS: &[&str] = &[
+    "escape",
+    "esc",
+    "enter",
+    "tab",
+    "space",
+    "backspace",
+    "delete",
+    "del",
+    "arrow-up",
+    "up",
+    "arrow-down",
+    "down",
+    "arrow-left",
+    "left",
+    "arrow-right",
+    "right",
+    "home",
+    "end",
+    "page-up",
+    "page-down",
+];
+
 /// Event-aware compile-time mirror of the runtime listener modifier
-/// semantics. Control modifiers and `debounce[.ms]` work on any
-/// event; system keys (`ctrl`/`shift`/`alt`/`meta`) filter via the
-/// shared event modifier flags so they're valid anywhere; named /
-/// single-char / word KEY filters only ever match on keyboard
-/// events — anywhere else the listener would install but never
-/// fire. Pushes a diagnostic and returns `false` on the dead shapes.
+/// semantics (`pocopine-core/src/directives/on.rs`). Control
+/// modifiers work on any event; a number is a debounce delay only
+/// directly after `.debounce` (the runtime pairs them positionally);
+/// EVERYTHING else — system keys included — rides the RFC-013 key
+/// filter, which downcasts to `KeyboardEvent` and therefore never
+/// matches on any other event. Pushes a diagnostic and returns
+/// `false` for every shape that would install a listener that can
+/// never fire.
 fn validate_listener_modifiers(
     event: &str,
     modifiers: &[String],
@@ -2920,31 +2958,95 @@ fn validate_listener_modifiers(
     ctx: &mut AnalysisCtx,
 ) -> bool {
     let keyboard = is_keyboard_event(event);
-    let has_debounce = modifiers.iter().any(|m| m == "debounce");
-    for m in modifiers {
+    for (i, m) in modifiers.iter().enumerate() {
         let m = m.as_str();
-        let valid = LISTENER_CONTROL_MODIFIERS.contains(&m)
-            || m == "debounce"
-            || (has_debounce && is_debounce_ms(m))
-            || matches!(m, "ctrl" | "shift" | "alt" | "meta")
-            || (keyboard && is_supported_modifier(m));
-        if !valid {
+        if LISTENER_CONTROL_MODIFIERS.contains(&m) || m == "debounce" {
+            continue;
+        }
+        // Multi-digit numbers are debounce delays; the runtime pairs
+        // one only when it directly follows `.debounce` — anywhere
+        // else it installs as a key filter for a key named "300".
+        if is_debounce_ms(m) && m.len() > 1 {
+            if i > 0 && modifiers[i - 1] == "debounce" {
+                continue;
+            }
+            ctx.diagnostics.push(format!(
+                "`{display}`: `.{m}` only sets a debounce delay directly after \
+                 `.debounce` — write `.debounce.{m}`"
+            ));
+            return false;
+        }
+        if keyboard {
+            if matches!(m, "ctrl" | "shift" | "alt" | "meta")
+                || NAMED_KEY_MODIFIERS.contains(&m)
+                || m.len() == 1
+            {
+                continue;
+            }
+            if is_word_key(m) {
+                // Any word is a legal literal key filter, but a
+                // near-miss of a control modifier or named key is a
+                // typo filtering on a key that can't exist.
+                if let Some(s) = nearest_of(
+                    m,
+                    LISTENER_CONTROL_MODIFIERS
+                        .iter()
+                        .copied()
+                        .chain(NAMED_KEY_MODIFIERS.iter().copied()),
+                )
+                .filter(|s| m.len() >= 3 && strsim::levenshtein(m, s) <= 1)
+                {
+                    ctx.diagnostics.push(format!(
+                        "`{display}`: `.{m}` would install a key filter for a key \
+                         named \"{m}\", which looks like a typo — did you mean `.{s}`?"
+                    ));
+                    return false;
+                }
+                continue;
+            }
+            // Not word-shaped and not a named key (e.g. `arrow_up`) —
+            // it can never match a normalized key name.
+            let suggestion = nearest_of(
+                m,
+                NAMED_KEY_MODIFIERS
+                    .iter()
+                    .copied()
+                    .chain(LISTENER_CONTROL_MODIFIERS.iter().copied()),
+            )
+            .map(|s| format!(" — did you mean `.{s}`?"))
+            .unwrap_or_default();
+            ctx.diagnostics.push(format!(
+                "`{display}`: `.{m}` is not a control modifier or a recognized key \
+                 filter{suggestion}"
+            ));
+            return false;
+        }
+        // Non-keyboard event: everything below is a key filter, and
+        // the runtime key filter downcasts to KeyboardEvent — it can
+        // never match here, so the listener would never fire.
+        let message = if matches!(m, "ctrl" | "shift" | "alt" | "meta") {
+            format!(
+                "`{display}`: `.{m}` is a key filter and only matches keyboard events \
+                 (keydown/keyup/keypress) — on `{event}` the listener would never fire"
+            )
+        } else {
             let suggestion = nearest_of(
                 m,
                 LISTENER_CONTROL_MODIFIERS
                     .iter()
                     .copied()
-                    .chain(["debounce", "ctrl", "shift", "alt", "meta"]),
+                    .chain(["debounce"]),
             )
             .map(|s| format!(" — did you mean `.{s}`?"))
             .unwrap_or_default();
-            ctx.diagnostics.push(format!(
-                "`{display}`: modifier `.{m}` is not a control modifier, and `{event}` \
-                 is not a keyboard event, so a `.{m}` key filter can never match — the \
-                 listener would never fire{suggestion}"
-            ));
-            return false;
-        }
+            format!(
+                "`{display}`: `.{m}` is not a control modifier, and key filters only \
+                 match keyboard events — on `{event}` the listener would never \
+                 fire{suggestion}"
+            )
+        };
+        ctx.diagnostics.push(message);
+        return false;
     }
     true
 }
@@ -3116,11 +3218,19 @@ fn classify_attr(
                     }
                 }
             }
+            if value.trim().is_empty() {
+                ctx.diagnostics
+                    .push("`pp-model` requires a field expression: pp-model=\"field\"".to_string());
+                return ClassifyOutcome::Preserved;
+            }
+            let Some(expr_src) = check_template_expr(value, "pp-model", ctx) else {
+                return ClassifyOutcome::Preserved;
+            };
             let number = modifiers.contains(&"number");
             let lazy = modifiers.contains(&"lazy");
             ctx.native_models.push(NativeModelLite {
                 node_path: path.to_vec(),
-                expr_src: value.to_string(),
+                expr_src,
                 number,
                 lazy,
             });
@@ -3430,27 +3540,33 @@ fn classify_child_host_attr(
     }
     if rest == "model" || rest.starts_with("model.") || rest.starts_with("model:") {
         let (arg, modifiers) = parse_child_host_model(rest);
-        for m in &modifiers {
-            // Registry vocabulary for pp-model (`number`/`trim`/`lazy`).
-            if !matches!(m.as_str(), "number" | "trim" | "lazy") {
-                let suggestion = nearest_of(m, ["number", "trim", "lazy"].into_iter())
-                    .map(|s| format!(" — did you mean `.{s}`?"))
-                    .unwrap_or_default();
-                ctx.diagnostics.push(format!(
-                    "unknown `pp-model` modifier `.{m}` — supported: `.number`, \
-                     `.trim`, `.lazy`{suggestion}"
-                ));
-            }
+        // The component install path (`model::install_component`)
+        // takes no modifiers at all — `.number`/`.trim`/`.lazy` on a
+        // component host are silently dropped at runtime.
+        if let Some(m) = modifiers.first() {
+            let display = if modifiers.len() == 1 {
+                format!(".{m}")
+            } else {
+                format!(".{}", modifiers.join("."))
+            };
+            ctx.diagnostics.push(format!(
+                "component `pp-model` takes no `{display}` modifier — the component \
+                 install path ignores modifiers; coerce inside the child component"
+            ));
+            return ChildHostAttrOutcome::Preserved;
         }
         if value.trim().is_empty() {
             ctx.diagnostics
                 .push("`pp-model` requires a field expression: pp-model=\"field\"".to_string());
             return ChildHostAttrOutcome::Preserved;
         }
+        let Some(expr_src) = check_template_expr(value, "pp-model", ctx) else {
+            return ChildHostAttrOutcome::Preserved;
+        };
         return ChildHostAttrOutcome::Model(ChildHostModelLite {
             arg,
             modifiers,
-            expr_src: value.to_string(),
+            expr_src,
         });
     }
     if rest == "ref" {
@@ -3461,6 +3577,30 @@ fn classify_child_host_attr(
             return ChildHostAttrOutcome::Preserved;
         }
         return ChildHostAttrOutcome::Ref(trimmed.to_string());
+    }
+    // Same registry backstop as the native fall-through: an unknown
+    // pp-* head on a component host used to be preserved dead markup.
+    if let Some(parsed) = pocopine_directives::parse_directive_attr(name)
+        && pocopine_directives::removed_message(&parsed.head).is_none()
+    {
+        match pocopine_directives::lookup(&parsed.head) {
+            None => {
+                let suggestion = nearest_directive(&parsed.head)
+                    .map(|n| format!(" — did you mean `pp-{n}`?"))
+                    .unwrap_or_default();
+                ctx.diagnostics.push(format!(
+                    "unknown directive `pp-{}`{suggestion}",
+                    parsed.head
+                ));
+            }
+            Some(spec) if spec.host == pocopine_directives::Host::TemplateOnly => {
+                ctx.diagnostics.push(format!(
+                    "`pp-{}` is only valid on a `<template>`",
+                    spec.name
+                ));
+            }
+            Some(_) => {}
+        }
     }
     ChildHostAttrOutcome::Preserved
 }
@@ -3556,50 +3696,6 @@ fn parse_child_host_model(rest: &str) -> (Option<String>, Vec<String>) {
         return (None, modifiers);
     }
     (None, Vec::new())
-}
-
-fn is_supported_modifier(m: &str) -> bool {
-    matches!(
-        m,
-        "prevent" | "stop" | "self" | "once" | "window" | "document" | "outside" | "capture"
-    ) || is_key_modifier(m)
-        || is_debounce_modifier(m)
-        || is_debounce_ms(m)
-}
-
-fn is_key_modifier(m: &str) -> bool {
-    matches!(
-        m,
-        "ctrl"
-            | "shift"
-            | "alt"
-            | "meta"
-            | "enter"
-            | "escape"
-            | "esc"
-            | "tab"
-            | "space"
-            | "backspace"
-            | "delete"
-            | "del"
-            | "arrow-up"
-            | "arrow-down"
-            | "arrow-left"
-            | "arrow-right"
-            | "up"
-            | "down"
-            | "left"
-            | "right"
-            | "home"
-            | "end"
-            | "page-up"
-            | "page-down"
-    ) || m.len() == 1
-        || is_word_key(m)
-}
-
-fn is_debounce_modifier(m: &str) -> bool {
-    m == "debounce"
 }
 
 fn is_word_key(m: &str) -> bool {
@@ -4111,7 +4207,7 @@ fn escape_attr(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        emit_compiled_expr_option, is_lift_eligible_opaque, is_supported_modifier,
+        NAMED_KEY_MODIFIERS, emit_compiled_expr_option, is_lift_eligible_opaque,
         parse_pp_directive_name,
     };
 
@@ -4377,6 +4473,8 @@ mod tests {
 
     #[test]
     fn supported_listener_modifiers_include_runtime_named_keys() {
+        // Parity pin against `on.rs named_key_for` — every named key
+        // the runtime normalizes must be admitted at compile time.
         for modifier in [
             "backspace",
             "delete",
@@ -4392,7 +4490,7 @@ mod tests {
             "page-down",
         ] {
             assert!(
-                is_supported_modifier(modifier),
+                NAMED_KEY_MODIFIERS.contains(&modifier),
                 "{modifier} should compile instead of requiring mount fallback"
             );
         }
@@ -4442,6 +4540,14 @@ mod tests {
         let plan = analyze(r#"<ul><li pp-for="file in files"><slot name="row"></slot></li></ul>"#);
         assert!(
             !diagnostics(&plan).contains("compile_error"),
+            "{}",
+            diagnostics(&plan)
+        );
+
+        // …but the carve-out still validates the pp-for value itself.
+        let plan = analyze(r#"<ul><li pp-for="file of files"><slot name="row"></slot></li></ul>"#);
+        assert!(
+            diagnostics(&plan).contains("item in items"),
             "{}",
             diagnostics(&plan)
         );
@@ -4571,13 +4677,59 @@ mod tests {
             r#"<div>
                  <input @keydown.enter="submit()" />
                  <input @keyup.q="quick()" />
+                 <input @keydown.ctrl.enter="send()" />
                  <input @input.debounce.300="search()" />
-                 <button @click.ctrl="alt()">x</button>
                  <button @click.outside="close()">y</button>
                </div>"#,
         );
         let out = diagnostics(&plan);
         assert!(!out.contains("compile_error"), "{out}");
+    }
+
+    #[test]
+    fn runtime_dead_listener_shapes_are_compile_errors() {
+        // System keys ride the RFC-013 key filter, which bails on any
+        // non-KeyboardEvent — `@click.ctrl` never fires at runtime.
+        let plan = analyze(r#"<div><button @click.ctrl="save()">x</button></div>"#);
+        assert!(
+            diagnostics(&plan).contains("compile_error"),
+            "{}",
+            diagnostics(&plan)
+        );
+
+        // The debounce delay pairs positionally: a number anywhere
+        // else installs as a never-matching key filter.
+        let plan = analyze(r#"<div><input @input.300.debounce="search()" /></div>"#);
+        assert!(
+            diagnostics(&plan).contains("compile_error"),
+            "{}",
+            diagnostics(&plan)
+        );
+        let plan = analyze(r#"<div><input @keydown.enter.300="go()" /></div>"#);
+        assert!(
+            diagnostics(&plan).contains("compile_error"),
+            "{}",
+            diagnostics(&plan)
+        );
+
+        // Near-miss control modifiers on keyboard events are typos,
+        // not key filters.
+        let plan = analyze(r#"<div><input @keydown.prevnt="submit()" /></div>"#);
+        let out = diagnostics(&plan);
+        assert!(
+            out.contains("compile_error") && out.contains("prevent"),
+            "{out}"
+        );
+
+        // Misspelled named keys get a key-name suggestion, and the
+        // message must not claim keydown is not a keyboard event.
+        let plan = analyze(r#"<div><input @keydown.arrow_up="move()" /></div>"#);
+        let out = diagnostics(&plan);
+        assert!(
+            out.contains("compile_error") && out.contains("arrow-up"),
+            "{out}"
+        );
+        assert!(!out.contains("not a keyboard event"), "{out}");
     }
 
     #[test]
@@ -4600,6 +4752,13 @@ mod tests {
 
         let plan = analyze(r#"<div><input pp-model.number.lazy="age" /></div>"#);
         assert!(!diagnostics(&plan).contains("compile_error"));
+
+        // The model value itself is validated: empty or unparseable
+        // used to compile green as a dead two-way binding.
+        let plan = analyze(r#"<div><input pp-model="" /></div>"#);
+        assert!(diagnostics(&plan).contains("compile_error"));
+        let plan = analyze(r#"<div><input pp-model="1 +" /></div>"#);
+        assert!(diagnostics(&plan).contains("compile_error"));
     }
 
     #[test]
@@ -4632,6 +4791,22 @@ mod tests {
 
         let plan = analyze(r#"<div><x-input pp-model="">x</x-input></div>"#);
         assert!(diagnostics(&plan).contains("compile_error"));
+
+        // The component install path drops ALL pp-model modifiers —
+        // `.trim`/`.number`/`.lazy` on a component host are dead.
+        let plan = analyze(r#"<div><x-input pp-model:value.trim="v">x</x-input></div>"#);
+        assert!(diagnostics(&plan).contains("compile_error"));
+        let plan = analyze(r#"<div><x-input pp-model.number="v">x</x-input></div>"#);
+        assert!(diagnostics(&plan).contains("compile_error"));
+
+        // Unknown directive heads on component hosts get the same
+        // registry check + suggestion as native elements.
+        let plan = analyze(r#"<div><pine-button pp-shwo="is_open">x</pine-button></div>"#);
+        let out = diagnostics(&plan);
+        assert!(
+            out.contains("compile_error") && out.contains("pp-show"),
+            "{out}"
+        );
     }
 
     #[test]
@@ -4644,6 +4819,12 @@ mod tests {
             out.contains("compile_error") && out.contains("pp-stagger"),
             "{out}"
         );
+
+        // Empty is a truncation, not a request for 0ms.
+        let plan = analyze(
+            r#"<div><template pp-for="i in items" pp-stagger=""><span>r</span></template></div>"#,
+        );
+        assert!(diagnostics(&plan).contains("compile_error"));
     }
 
     #[test]

--- a/crates/pocopine-macros/src/template_plan.rs
+++ b/crates/pocopine-macros/src/template_plan.rs
@@ -83,6 +83,10 @@ pub(crate) struct EmittedTemplatePlan {
     /// can write `refs.body()` instead of
     /// `refs::get_component::<T>("body")`.
     pub ref_names: Vec<String>,
+    /// Build warnings the consuming macro should surface via the
+    /// `#[deprecated]`-const trick (RFC 045 §9.4) — non-fatal
+    /// authoring notes such as the JS-equality desugar.
+    pub warnings: Vec<String>,
 }
 
 #[derive(Clone)]
@@ -229,6 +233,7 @@ pub(crate) fn analyze_template_plan(
             specialized_mount_body: None,
             diagnostics,
             ref_names: ctx.ref_names_dedup(),
+            warnings: ctx.warnings.clone(),
         };
     }
     let cleaned_html = serialize_cleaned(&ast.roots, &ctx);
@@ -253,6 +258,7 @@ pub(crate) fn analyze_template_plan(
         specialized_mount_body,
         diagnostics,
         ref_names,
+        warnings: ctx.warnings.clone(),
     }
 }
 
@@ -333,6 +339,10 @@ struct AnalysisCtx {
     /// RFC-094 — chain build errors surfaced as compile_error!
     /// items (orphan/double/misplaced else, bad member shape).
     diagnostics: PlanDiagnostics,
+    /// Build warnings surfaced via the `#[deprecated]`-const trick
+    /// (RFC 045 §9.4) — currently the JS-equality desugar notes.
+    /// Unlike `diagnostics`, these don't stop the build.
+    warnings: Vec<String>,
     /// RFC-094 — node paths of consumed pp-else-if/pp-else
     /// member templates (kept in cleaned HTML until the
     /// controller detaches them; the serializer stamps them
@@ -701,6 +711,7 @@ impl AnalysisCtx {
             self.refs_from_lifted.push(name.clone());
         }
         self.diagnostics.extend(nested.diagnostics.iter().cloned());
+        self.warnings.extend(nested.warnings.iter().cloned());
     }
 
     fn emit_specialized_mount_body(&self) -> Option<TokenStream> {
@@ -1769,9 +1780,35 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
     }
 
     if let Some(for_attr) = pp_for_value(el) {
-        if el.tag == "template"
-            && !el.attrs.iter().any(|(n, _)| n == "pp-teleport")
-            && let Some((item_name, items_expr)) = parse_pp_for(&for_attr)
+        if el.tag != "template" {
+            // RFC-011 iterated slots: `<li pp-for="file in files">`
+            // wrapping a `<slot>` outlet is the documented shape
+            // (docs/guides/components/03-composition.md) — the slot
+            // publication machinery owns that subtree, not the plan.
+            if subtree_contains_slot(el) {
+                return;
+            }
+            ctx.diagnostics
+                .push("`pp-for` is only valid on a `<template>` (RFC-004)".to_string());
+            return;
+        }
+        if el.attrs.iter().any(|(n, _)| n == "pp-teleport") {
+            ctx.diagnostics.push(
+                "`pp-teleport` cannot be combined with `pp-for` on the same `<template>` \
+                 — teleport a wrapper around the list instead"
+                    .to_string(),
+            );
+            return;
+        }
+        let Some((item_name, items_expr)) = parse_pp_for(&for_attr) else {
+            ctx.diagnostics.push(format!(
+                "`pp-for=\"{for_attr}\"` does not parse — expected `item in items`"
+            ));
+            return;
+        };
+        let Some(items_expr) = check_template_expr(&items_expr, "pp-for", ctx) else {
+            return;
+        };
         {
             check_branch_body_roots("pp-for", el, ctx);
             let key_expr = el
@@ -1779,13 +1816,22 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
                 .iter()
                 .find(|(n, _)| n == "pp-key")
                 .map(|(_, v)| v.clone())
-                .filter(|s| !s.trim().is_empty());
-            let stagger_ms = el
+                .filter(|s| !s.trim().is_empty())
+                .and_then(|expr| check_template_expr(&expr, "pp-key", ctx));
+            let stagger_ms = match el
                 .attrs
                 .iter()
                 .find(|(n, _)| n == "pp-stagger")
-                .and_then(|(_, v)| v.trim().parse::<u32>().ok())
-                .unwrap_or(0);
+                .map(|(_, v)| v.trim().to_string())
+            {
+                Some(v) if !v.is_empty() => v.parse::<u32>().unwrap_or_else(|_| {
+                    ctx.diagnostics.push(format!(
+                        "`pp-stagger=\"{v}\"` expects milliseconds, e.g. pp-stagger=\"40\""
+                    ));
+                    0
+                }),
+                _ => 0,
+            };
             // RFC-058 Phase 4.2c — try to lift the row body
             // into a fragment fn. Skip when an RFC-054 row
             // plan claims this site (the row-plan fast path
@@ -1838,34 +1884,40 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
                 name: "pp-stagger".to_string(),
             });
             // Don't recurse — the row body is owned by the
-            // RFC-054 row plan (when present) or the mount
-            // (when absent). Either way the template-plan
-            // classifier doesn't follow `<template>` content.
+            // RFC-054 row plan (when present) or the lifted body
+            // fragment. Either way the template-plan classifier
+            // doesn't follow `<template>` content.
             return;
         }
-        // Ineligible (wrong host, has pp-teleport, or expr
-        // doesn't parse) — fall through to block-boundary skip
-        // so today's mount dispatch handles it.
-        return;
     }
 
     // RFC-058 Phase 4.3 — `pp-teleport` on a `<template>` host
     // graduates into a `StaticTeleportPlan` entry. Eligibility:
     // host is `<template>`, no co-occurring `pp-if` (pp-if owns
     // the mount cycle in that combo and reads pp-teleport
-    // itself), no co-occurring `pp-for` (pp-for graduated above
-    // and shouldn't be paired with pp-teleport on the same
-    // element — degenerate case, leave on mount).
+    // itself). A co-occurring `pp-for` was diagnosed above.
     if let Some(selector) = pp_teleport_value(el) {
         let has_if = el.attrs.iter().any(|(n, _)| n == "pp-if");
         let has_for = el.attrs.iter().any(|(n, _)| n == "pp-for");
+        if el.tag != "template" {
+            ctx.diagnostics
+                .push("`pp-teleport` is only valid on a `<template>` (RFC-006)".to_string());
+            return;
+        }
+        if selector.trim().is_empty() {
+            ctx.diagnostics.push(
+                "`pp-teleport` requires a CSS selector target: pp-teleport=\"#overlay\""
+                    .to_string(),
+            );
+            return;
+        }
         if has_if && !has_for {
             // The pp-if classifier below owns the combined
             // `pp-if` + `pp-teleport` site. It records the
             // selector on StaticIfPlan and strips both source
             // attrs so runtime discovery cannot double-install
             // either controller.
-        } else if el.tag == "template" && !has_if && !has_for && !selector.trim().is_empty() {
+        } else if !has_if && !has_for {
             // RFC-058 Phase 4.3c — try to lift the teleport
             // body into a fragment fn (same v1 envelope as
             // pp-if / pp-for body lifting).
@@ -1894,8 +1946,8 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
             });
             return;
         }
-        // Ineligible (wrong host, has pp-if/pp-for, empty
-        // selector) — leave the mount to dispatch.
+        // Only the `pp-if` combo continues past here — the pp-if
+        // classifier below owns that site.
         if !has_if {
             return;
         }
@@ -2085,13 +2137,21 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
     // `DocumentFragment` that doesn't appear in `el.children`),
     // body therefore needs its own compiled fragment function.
     if let Some(if_expr) = pp_if_value(el) {
+        if el.tag != "template" {
+            ctx.diagnostics
+                .push("`pp-if` is only valid on a `<template>` (RFC-094)".to_string());
+            return;
+        }
+        let Some(if_expr) = check_template_expr(&if_expr, "pp-if", ctx) else {
+            return;
+        };
         let teleport_selector = el
             .attrs
             .iter()
             .find(|(n, _)| n == "pp-teleport")
             .map(|(_, v)| v.clone())
             .filter(|s| !s.trim().is_empty());
-        if el.tag == "template" && pocopine_expr::parse(&if_expr).is_ok() {
+        {
             // Exactly one element root, enforced at compile time —
             // the runtime clone stamps only the FIRST root, so a
             // multi-root body used to silently drop its extra roots
@@ -2141,9 +2201,6 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
             }
             return;
         }
-        // Ineligible (wrong host, has pp-teleport, or expr
-        // doesn't parse) — fall through to mount as today.
-        return;
     }
 
     if el.tag == "pp-component" {
@@ -2180,7 +2237,7 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
         let has_pp_as = el.attrs.iter().any(|(name, _)| name == "pp-as");
         if !has_pp_as {
             for (name, value) in &el.attrs {
-                match classify_child_host_attr(name, value) {
+                match classify_child_host_attr(name, value, ctx) {
                     ChildHostAttrOutcome::Show(expr_src) => {
                         ctx.stripped.push(StrippedAttr {
                             node_path: path.clone(),
@@ -2345,13 +2402,16 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
         return;
     }
 
-    // Classify every attribute on this element. `pp-as` hosts
-    // (outside the template root) are skipped whole-subtree —
-    // the dynamic-component path owns them.
+    // Classify every attribute on this element. `pp-as` is
+    // component-only (RFC-019); component tags took the
+    // child-mount branch above, so a native element carrying it
+    // used to be skipped whole-subtree — every directive in the
+    // subtree died silently with it.
     if el.attrs.iter().any(|(name, _)| name == "pp-as") && el.tag != "root" {
+        ctx.diagnostics
+            .push("`pp-as` is only valid on a component tag (RFC-019)".to_string());
         return;
     }
-    let mut listener_unsupported_modifier = false;
     let host_is_native = is_plan_native(&el.tag);
     for (name, value) in &el.attrs {
         if el.tag == "root" && name == "pp-as" {
@@ -2359,16 +2419,8 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
         }
         // Outcome is recorded on `ctx` (stripped entries + plan
         // vecs); nothing branch-worthy remains at this call site.
-        let _ = classify_attr(
-            name,
-            value,
-            path,
-            ctx,
-            host_is_native,
-            &mut listener_unsupported_modifier,
-        );
+        let _ = classify_attr(name, value, path, ctx, &el.tag, host_is_native);
     }
-    let _ = listener_unsupported_modifier; // already handled per-attr
 
     // RFC-058 Phase 6.2 — scan direct text-node children for
     // `{{expr}}` interpolation and lift each into an
@@ -2389,7 +2441,26 @@ fn walk(el: &Element, ctx: &mut AnalysisCtx, emissions: &mut Emissions, path: &m
                 continue;
             }
             match parse_interp_segments(text) {
-                Ok(segments) if !segments.is_empty() => {
+                Ok(mut segments) if !segments.is_empty() => {
+                    // JS-equality desugar for `{{ a === b }}` — hard
+                    // parse failures stay on the emit path, which
+                    // already produces the teaching compile error.
+                    for segment in &mut segments {
+                        let InterpSegment::Dynamic(src) = segment else {
+                            continue;
+                        };
+                        if pocopine_expr::parse(src).is_err()
+                            && let Some(rewritten) = desugar_js_equality(src)
+                            && pocopine_expr::parse(&rewritten).is_ok()
+                        {
+                            ctx.warnings.push(format!(
+                                "pocopine: `{{{{ {src} }}}}` uses JavaScript equality \
+                                 (`===`/`!==`); pine-expr is Rust-style. Interpreted as \
+                                 `{rewritten}` — update the template to `==`/`!=`."
+                            ));
+                            *src = rewritten;
+                        }
+                    }
                     let any_dynamic = segments
                         .iter()
                         .any(|s| matches!(s, InterpSegment::Dynamic(_)));
@@ -2721,17 +2792,174 @@ enum ClassifyOutcome {
     Preserved,
 }
 
+/// Rewrite JS-style `===` / `!==` to `==` / `!=` outside string
+/// literals. Returns `Some(rewritten)` when at least one rewrite
+/// happened, `None` when the source has no JS equality operator.
+/// Byte-level splices are safe: the replacements are ASCII and
+/// never split a UTF-8 sequence.
+fn desugar_js_equality(src: &str) -> Option<String> {
+    let bytes = src.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    let mut changed = false;
+    let mut quote: Option<u8> = None;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if let Some(q) = quote {
+            if b == b'\\' && i + 1 < bytes.len() {
+                out.push(b);
+                out.push(bytes[i + 1]);
+                i += 2;
+                continue;
+            }
+            if b == q {
+                quote = None;
+            }
+            out.push(b);
+            i += 1;
+            continue;
+        }
+        match b {
+            b'\'' | b'"' => {
+                quote = Some(b);
+                out.push(b);
+                i += 1;
+            }
+            b'=' if bytes[i..].starts_with(b"===") => {
+                out.extend_from_slice(b"==");
+                i += 3;
+                changed = true;
+            }
+            b'!' if bytes[i..].starts_with(b"!==") => {
+                out.extend_from_slice(b"!=");
+                i += 3;
+                changed = true;
+            }
+            _ => {
+                out.push(b);
+                i += 1;
+            }
+        }
+    }
+    changed.then(|| String::from_utf8(out).expect("ASCII-only splices preserve UTF-8"))
+}
+
+/// Parse a directive expression the plan is about to install.
+///
+/// - Parses clean → `Some(source unchanged)`.
+/// - JS `===`/`!==` and otherwise clean → `Some(rewritten)` plus a
+///   build warning (the plan installs the Rust-style spelling).
+/// - Anything else → a compile diagnostic and `None`. Before this
+///   check, a parse failure left the attribute `Preserved` — dead
+///   markup since RFC-058 Phase 6.5 retired the runtime dispatch.
+fn check_template_expr(value: &str, directive: &str, ctx: &mut AnalysisCtx) -> Option<String> {
+    match pocopine_expr::parse(value) {
+        Ok(_) => Some(value.to_string()),
+        Err(err) => {
+            if let Some(rewritten) = desugar_js_equality(value)
+                && pocopine_expr::parse(&rewritten).is_ok()
+            {
+                ctx.warnings.push(format!(
+                    "pocopine: `{directive}=\"{value}\"` uses JavaScript equality \
+                     (`===`/`!==`); pine-expr is Rust-style. Interpreted as \
+                     `{rewritten}` — update the template to `==`/`!=`."
+                ));
+                return Some(rewritten);
+            }
+            let hint = err
+                .hint
+                .as_deref()
+                .map(|h| format!(" — {h}"))
+                .unwrap_or_default();
+            ctx.diagnostics.push(format!(
+                "`{directive}` expression `{value}` does not parse: {}{hint}",
+                err.message
+            ));
+            None
+        }
+    }
+}
+
+/// Closest live directive head for a did-you-mean suggestion, or
+/// `None` when nothing is within edit distance 2.
+fn nearest_directive(head: &str) -> Option<&'static str> {
+    nearest_of(head, pocopine_directives::DIRECTIVES.iter().map(|d| d.name))
+}
+
+fn nearest_of<'a>(input: &str, candidates: impl Iterator<Item = &'a str>) -> Option<&'a str> {
+    candidates
+        .map(|c| (strsim::levenshtein(input, c), c))
+        .min_by_key(|(d, _)| *d)
+        .filter(|(d, _)| *d <= 2)
+        .map(|(_, c)| c)
+}
+
+/// Listener control modifiers the applier implements
+/// (`pocopine-core/src/directives/on.rs`). Everything outside this
+/// set participates in the RFC-013 key filter, which only ever
+/// matches on keyboard events.
+const LISTENER_CONTROL_MODIFIERS: &[&str] = &[
+    "prevent", "stop", "self", "once", "window", "document", "outside", "capture",
+];
+
+fn is_keyboard_event(event: &str) -> bool {
+    matches!(event, "keydown" | "keyup" | "keypress")
+}
+
+/// Event-aware compile-time mirror of the runtime listener modifier
+/// semantics. Control modifiers and `debounce[.ms]` work on any
+/// event; system keys (`ctrl`/`shift`/`alt`/`meta`) filter via the
+/// shared event modifier flags so they're valid anywhere; named /
+/// single-char / word KEY filters only ever match on keyboard
+/// events — anywhere else the listener would install but never
+/// fire. Pushes a diagnostic and returns `false` on the dead shapes.
+fn validate_listener_modifiers(
+    event: &str,
+    modifiers: &[String],
+    display: &str,
+    ctx: &mut AnalysisCtx,
+) -> bool {
+    let keyboard = is_keyboard_event(event);
+    let has_debounce = modifiers.iter().any(|m| m == "debounce");
+    for m in modifiers {
+        let m = m.as_str();
+        let valid = LISTENER_CONTROL_MODIFIERS.contains(&m)
+            || m == "debounce"
+            || (has_debounce && is_debounce_ms(m))
+            || matches!(m, "ctrl" | "shift" | "alt" | "meta")
+            || (keyboard && is_supported_modifier(m));
+        if !valid {
+            let suggestion = nearest_of(
+                m,
+                LISTENER_CONTROL_MODIFIERS
+                    .iter()
+                    .copied()
+                    .chain(["debounce", "ctrl", "shift", "alt", "meta"]),
+            )
+            .map(|s| format!(" — did you mean `.{s}`?"))
+            .unwrap_or_default();
+            ctx.diagnostics.push(format!(
+                "`{display}`: modifier `.{m}` is not a control modifier, and `{event}` \
+                 is not a keyboard event, so a `.{m}` key filter can never match — the \
+                 listener would never fire{suggestion}"
+            ));
+            return false;
+        }
+    }
+    true
+}
+
 fn classify_attr(
     name: &str,
     value: &str,
     path: &[u16],
     ctx: &mut AnalysisCtx,
+    host_tag: &str,
     host_is_native: bool,
-    listener_unsupported_modifier: &mut bool,
 ) -> ClassifyOutcome {
     // RFC-020 listener shorthand: `@event[.mod]`.
     if let Some(rest) = name.strip_prefix('@') {
-        return classify_listener(rest, value, path, ctx, listener_unsupported_modifier);
+        return classify_listener(rest, value, path, ctx);
     }
     // RFC-020 bind shorthand: `:<arg>` (NOT `::` which is
     // illegal in HTML and therefore not a real attribute name).
@@ -2744,13 +2972,13 @@ fn classify_attr(
     if let Some(rest) = name.strip_prefix("pp-") {
         // pp-text="<expr>"
         if rest == "text" {
-            if pocopine_expr::parse(value).is_err() {
+            let Some(expr_src) = check_template_expr(value, "pp-text", ctx) else {
                 return ClassifyOutcome::Preserved;
-            }
+            };
             ctx.bindings.push(BindingLite {
                 node_path: path.to_vec(),
                 kind: BindingKindLite::Text,
-                expr_src: value.to_string(),
+                expr_src,
             });
             ctx.stripped.push(StrippedAttr {
                 node_path: path.to_vec(),
@@ -2760,13 +2988,13 @@ fn classify_attr(
         }
         // pp-html="<expr>"
         if rest == "html" {
-            if pocopine_expr::parse(value).is_err() {
+            let Some(expr_src) = check_template_expr(value, "pp-html", ctx) else {
                 return ClassifyOutcome::Preserved;
-            }
+            };
             ctx.bindings.push(BindingLite {
                 node_path: path.to_vec(),
                 kind: BindingKindLite::Html,
-                expr_src: value.to_string(),
+                expr_src,
             });
             ctx.stripped.push(StrippedAttr {
                 node_path: path.to_vec(),
@@ -2776,13 +3004,13 @@ fn classify_attr(
         }
         // pp-show="<expr>"
         if rest == "show" {
-            if pocopine_expr::parse(value).is_err() {
+            let Some(expr_src) = check_template_expr(value, "pp-show", ctx) else {
                 return ClassifyOutcome::Preserved;
-            }
+            };
             ctx.bindings.push(BindingLite {
                 node_path: path.to_vec(),
                 kind: BindingKindLite::Show,
-                expr_src: value.to_string(),
+                expr_src,
             });
             ctx.stripped.push(StrippedAttr {
                 node_path: path.to_vec(),
@@ -2796,15 +3024,15 @@ fn classify_attr(
         }
         // pp-on:<event>[.<mod>]="<expr>"
         if let Some(rest) = rest.strip_prefix("on:") {
-            return classify_listener(rest, value, path, ctx, listener_unsupported_modifier);
+            return classify_listener(rest, value, path, ctx);
         }
         // pp-ref="<name>"
         if rest == "ref" {
-            // `pp-ref` value is a static name, not an expression
-            // — empty / whitespace is an author bug; let the
-            // mount surface it.
+            // `pp-ref` value is a static name, not an expression.
             let trimmed = value.trim();
             if trimmed.is_empty() {
+                ctx.diagnostics
+                    .push("`pp-ref` requires a non-empty name: pp-ref=\"my_ref\"".to_string());
                 return ClassifyOutcome::Preserved;
             }
             ctx.refs.push(RefLite {
@@ -2854,11 +3082,40 @@ fn classify_attr(
         // native AND the directive has no `:arg` (the arg form
         // is for component target prop selection, not native
         // inputs).
+        if host_is_native && rest.starts_with("model:") {
+            // The `:arg` form selects a component prop; a native
+            // input has no props to select. Used to be preserved —
+            // dead markup since the runtime dispatch retired.
+            ctx.diagnostics.push(format!(
+                "`pp-{rest}`: the `pp-model:<prop>` form targets component models; \
+                 native inputs take bare `pp-model=\"field\"`"
+            ));
+            return ClassifyOutcome::Preserved;
+        }
         if host_is_native && (rest == "model" || rest.starts_with("model.")) {
-            // Parse modifiers (`.number`, `.lazy`). Accept any
-            // unknown modifier silently — runtime currently does
-            // the same; surfacing is a future enhancement.
             let modifiers: Vec<&str> = rest.split('.').skip(1).collect();
+            for m in &modifiers {
+                match *m {
+                    "number" | "lazy" => {}
+                    // Registry-documented, but `NativeModelLite` has no
+                    // trim lane and the applier never implemented one —
+                    // the modifier would be silently dropped.
+                    "trim" => ctx.diagnostics.push(
+                        "`pp-model.trim` is not supported by compiled templates — \
+                         trim in the handler instead"
+                            .to_string(),
+                    ),
+                    other => {
+                        let suggestion = nearest_of(other, ["number", "lazy"].into_iter())
+                            .map(|s| format!(" — did you mean `.{s}`?"))
+                            .unwrap_or_default();
+                        ctx.diagnostics.push(format!(
+                            "unknown `pp-model` modifier `.{other}` — supported: \
+                             `.number`, `.lazy`{suggestion}"
+                        ));
+                    }
+                }
+            }
             let number = modifiers.contains(&"number");
             let lazy = modifiers.contains(&"lazy");
             ctx.native_models.push(NativeModelLite {
@@ -2873,10 +3130,47 @@ fn classify_attr(
             });
             return ClassifyOutcome::Stripped;
         }
-        // Every other pp-* attribute (pp-cloak,
-        // pp-route, pp-transition:*, pp-stagger, etc.) —
-        // preserved on the cleaned HTML and handled by the
-        // runtime mount as today.
+        // Every other pp-* attribute. RFC-058 Phase 6.5 retired the
+        // runtime pp-* dispatch, so `Preserved` is dead markup unless
+        // something else (slot capture, the router's DOM queries, the
+        // plan applier) explicitly consumes the attribute. Check the
+        // shared directive registry: an unknown head is a typo, and a
+        // live head on the wrong host class can never activate.
+        if let Some(parsed) = pocopine_directives::parse_directive_attr(name) {
+            if pocopine_directives::removed_message(&parsed.head).is_some() {
+                // The RFC-063 forbidden-directives pass owns the
+                // migration error for these.
+                return ClassifyOutcome::Preserved;
+            }
+            match pocopine_directives::lookup(&parsed.head) {
+                None => {
+                    let suggestion = nearest_directive(&parsed.head)
+                        .map(|n| format!(" — did you mean `pp-{n}`?"))
+                        .unwrap_or_default();
+                    ctx.diagnostics.push(format!(
+                        "unknown directive `pp-{}`{suggestion}",
+                        parsed.head
+                    ));
+                }
+                Some(spec) => match spec.host {
+                    pocopine_directives::Host::TemplateOnly if host_tag != "template" => {
+                        ctx.diagnostics.push(format!(
+                            "`pp-{}` is only valid on a `<template>`",
+                            spec.name
+                        ));
+                    }
+                    pocopine_directives::Host::ComponentOnly => {
+                        // Component tags took the child-mount branch,
+                        // so this host is a native element.
+                        ctx.diagnostics.push(format!(
+                            "`pp-{}` is only valid on a component tag",
+                            spec.name
+                        ));
+                    }
+                    _ => {}
+                },
+            }
+        }
         return ClassifyOutcome::Preserved;
     }
     // Plain HTML attribute — preserved.
@@ -2976,6 +3270,15 @@ fn parse_interp_segments(input: &str) -> Result<Vec<InterpSegment>, String> {
     Ok(out)
 }
 
+/// Whether any descendant is a `<slot>` outlet — the marker for the
+/// RFC-011 iterated-slot shape (`pp-for` on a native element).
+fn subtree_contains_slot(el: &Element) -> bool {
+    el.children.iter().any(|n| match n {
+        Node::Element(c) => c.tag == "slot" || subtree_contains_slot(c),
+        _ => false,
+    })
+}
+
 /// Allowlist of runtime directives that are safe to lift into a
 /// compile-time `StaticOpaqueDirective` entry. Each entry is a
 /// pure DOM-side effect that installs once and self-manages —
@@ -2988,12 +3291,6 @@ fn is_lift_eligible_opaque(head: &str) -> bool {
 }
 
 fn classify_bind(arg: &str, value: &str, path: &[u16], ctx: &mut AnalysisCtx) -> ClassifyOutcome {
-    // `:<arg>` shorthand. Modifier suffix (`.<mod>`) is
-    // currently unsupported in the planned envelope; preserve
-    // the whole binding in that case.
-    if arg.contains('.') {
-        return ClassifyOutcome::Preserved;
-    }
     classify_bind_inner(&format!(":{arg}"), arg, value, path, ctx)
 }
 
@@ -3004,9 +3301,6 @@ fn classify_bind_full(
     path: &[u16],
     ctx: &mut AnalysisCtx,
 ) -> ClassifyOutcome {
-    if arg.contains('.') {
-        return ClassifyOutcome::Preserved;
-    }
     classify_bind_inner(full_name, arg, value, path, ctx)
 }
 
@@ -3020,15 +3314,24 @@ fn classify_bind_inner(
     if arg.is_empty() {
         return ClassifyOutcome::Preserved;
     }
-    if pocopine_expr::parse(value).is_err() {
+    // Bind takes no `.modifiers` (RFC-020) — a suffixed binding
+    // used to be preserved, i.e. dead markup.
+    if let Some((real_arg, mods)) = arg.split_once('.') {
+        ctx.diagnostics.push(format!(
+            "`{attr_to_strip}`: attribute bindings take no `.modifiers` \
+             (got `.{mods}`) — write `:{real_arg}=\"…\"`"
+        ));
         return ClassifyOutcome::Preserved;
     }
+    let Some(expr_src) = check_template_expr(value, attr_to_strip, ctx) else {
+        return ClassifyOutcome::Preserved;
+    };
     ctx.bindings.push(BindingLite {
         node_path: path.to_vec(),
         kind: BindingKindLite::Bind {
             arg: arg.to_string(),
         },
-        expr_src: value.to_string(),
+        expr_src,
     });
     ctx.stripped.push(StrippedAttr {
         node_path: path.to_vec(),
@@ -3042,41 +3345,30 @@ fn classify_listener(
     value: &str,
     path: &[u16],
     ctx: &mut AnalysisCtx,
-    unsupported: &mut bool,
 ) -> ClassifyOutcome {
     // `rest` is `event[.mod1.mod2…]`.
     let mut parts = rest.split('.');
     let event = match parts.next() {
         Some(e) if !e.is_empty() => e.to_string(),
-        _ => return ClassifyOutcome::Preserved,
+        _ => {
+            ctx.diagnostics
+                .push("`@` listener requires an event name: `@click=\"…\"`".to_string());
+            return ClassifyOutcome::Preserved;
+        }
     };
     let modifiers: Vec<String> = parts.map(|m| m.to_string()).collect();
-    if !modifiers.iter().all(|m| is_supported_modifier(m)) {
-        // RFC-057 §6.1 — unsupported modifier means the whole
-        // listener stays attribute-preserved so the runtime
-        // mount picks it up unchanged.
-        *unsupported = true;
+    if !validate_listener_modifiers(&event, &modifiers, &format!("@{rest}"), ctx) {
         return ClassifyOutcome::Preserved;
     }
-    if pocopine_expr::parse(value).is_err() {
+    let Some(expr_src) = check_listener_expr(value, rest, &modifiers, ctx) else {
         return ClassifyOutcome::Preserved;
-    }
-    let stripped_name = if rest.starts_with(|_: char| false) {
-        rest.to_string()
-    } else {
-        // We don't know whether the source attribute was
-        // `@event...` or `pp-on:event...` — caller passes the
-        // post-prefix `rest`. The full attribute name is
-        // reconstructed from the caller's match arm, but we
-        // need both shapes — stash both forms; the serializer
-        // checks both.
-        rest.to_string()
     };
+    let stripped_name = rest.to_string();
     ctx.listeners.push(ListenerLite {
         node_path: path.to_vec(),
         event,
         modifiers,
-        expr_src: value.to_string(),
+        expr_src,
     });
     // Strip both possible source spellings — the cleaned-HTML
     // serializer drops whichever the author wrote.
@@ -3110,43 +3402,49 @@ enum ChildHostAttrOutcome {
     Preserved,
 }
 
-fn classify_child_host_attr(name: &str, value: &str) -> ChildHostAttrOutcome {
+fn classify_child_host_attr(
+    name: &str,
+    value: &str,
+    ctx: &mut AnalysisCtx,
+) -> ChildHostAttrOutcome {
     if let Some(rest) = name.strip_prefix('@') {
-        return classify_child_host_listener(rest, value);
+        return classify_child_host_listener(rest, value, ctx);
     }
     if let Some(arg) = name.strip_prefix(':') {
-        if arg.is_empty() || arg.contains('.') || pocopine_expr::parse(value).is_err() {
-            return ChildHostAttrOutcome::Preserved;
-        }
-        return ChildHostAttrOutcome::Binding(ChildHostBindingLite {
-            arg: arg.to_string(),
-            expr_src: value.to_string(),
-        });
+        return classify_child_host_bind(name, arg, value, ctx);
     }
     let Some(rest) = name.strip_prefix("pp-") else {
         return ChildHostAttrOutcome::Preserved;
     };
     if rest == "show" {
-        if pocopine_expr::parse(value).is_err() {
+        let Some(expr_src) = check_template_expr(value, "pp-show", ctx) else {
             return ChildHostAttrOutcome::Preserved;
-        }
-        return ChildHostAttrOutcome::Show(value.to_string());
+        };
+        return ChildHostAttrOutcome::Show(expr_src);
     }
     if let Some(arg) = rest.strip_prefix("bind:") {
-        if arg.is_empty() || arg.contains('.') || pocopine_expr::parse(value).is_err() {
-            return ChildHostAttrOutcome::Preserved;
-        }
-        return ChildHostAttrOutcome::Binding(ChildHostBindingLite {
-            arg: arg.to_string(),
-            expr_src: value.to_string(),
-        });
+        return classify_child_host_bind(name, arg, value, ctx);
     }
     if let Some(rest) = rest.strip_prefix("on:") {
-        return classify_child_host_listener(rest, value);
+        return classify_child_host_listener(rest, value, ctx);
     }
     if rest == "model" || rest.starts_with("model.") || rest.starts_with("model:") {
         let (arg, modifiers) = parse_child_host_model(rest);
+        for m in &modifiers {
+            // Registry vocabulary for pp-model (`number`/`trim`/`lazy`).
+            if !matches!(m.as_str(), "number" | "trim" | "lazy") {
+                let suggestion = nearest_of(m, ["number", "trim", "lazy"].into_iter())
+                    .map(|s| format!(" — did you mean `.{s}`?"))
+                    .unwrap_or_default();
+                ctx.diagnostics.push(format!(
+                    "unknown `pp-model` modifier `.{m}` — supported: `.number`, \
+                     `.trim`, `.lazy`{suggestion}"
+                ));
+            }
+        }
         if value.trim().is_empty() {
+            ctx.diagnostics
+                .push("`pp-model` requires a field expression: pp-model=\"field\"".to_string());
             return ChildHostAttrOutcome::Preserved;
         }
         return ChildHostAttrOutcome::Model(ChildHostModelLite {
@@ -3158,6 +3456,8 @@ fn classify_child_host_attr(name: &str, value: &str) -> ChildHostAttrOutcome {
     if rest == "ref" {
         let trimmed = value.trim();
         if trimmed.is_empty() {
+            ctx.diagnostics
+                .push("`pp-ref` requires a non-empty name: pp-ref=\"my_ref\"".to_string());
             return ChildHostAttrOutcome::Preserved;
         }
         return ChildHostAttrOutcome::Ref(trimmed.to_string());
@@ -3165,20 +3465,78 @@ fn classify_child_host_attr(name: &str, value: &str) -> ChildHostAttrOutcome {
     ChildHostAttrOutcome::Preserved
 }
 
-fn classify_child_host_listener(rest: &str, value: &str) -> ChildHostAttrOutcome {
+fn classify_child_host_bind(
+    full_name: &str,
+    arg: &str,
+    value: &str,
+    ctx: &mut AnalysisCtx,
+) -> ChildHostAttrOutcome {
+    if arg.is_empty() {
+        return ChildHostAttrOutcome::Preserved;
+    }
+    if let Some((real_arg, mods)) = arg.split_once('.') {
+        ctx.diagnostics.push(format!(
+            "`{full_name}`: attribute bindings take no `.modifiers` \
+             (got `.{mods}`) — write `:{real_arg}=\"…\"`"
+        ));
+        return ChildHostAttrOutcome::Preserved;
+    }
+    let Some(expr_src) = check_template_expr(value, full_name, ctx) else {
+        return ChildHostAttrOutcome::Preserved;
+    };
+    ChildHostAttrOutcome::Binding(ChildHostBindingLite {
+        arg: arg.to_string(),
+        expr_src,
+    })
+}
+
+fn classify_child_host_listener(
+    rest: &str,
+    value: &str,
+    ctx: &mut AnalysisCtx,
+) -> ChildHostAttrOutcome {
     let mut parts = rest.split('.');
     let Some(event) = parts.next().filter(|s| !s.is_empty()) else {
+        ctx.diagnostics
+            .push("`@` listener requires an event name: `@click=\"…\"`".to_string());
         return ChildHostAttrOutcome::Preserved;
     };
     let modifiers: Vec<String> = parts.map(str::to_string).collect();
-    if !modifiers.iter().all(|m| is_supported_modifier(m)) || pocopine_expr::parse(value).is_err() {
+    if !validate_listener_modifiers(event, &modifiers, &format!("@{rest}"), ctx) {
         return ChildHostAttrOutcome::Preserved;
     }
+    let Some(expr_src) = check_listener_expr(value, rest, &modifiers, ctx) else {
+        return ChildHostAttrOutcome::Preserved;
+    };
     ChildHostAttrOutcome::Listener(ChildHostListenerLite {
         event: event.to_string(),
         modifiers,
-        expr_src: value.to_string(),
+        expr_src,
     })
+}
+
+/// Listener expression check with the effect-only carve-out: an empty
+/// value is valid when the modifier chain carries `.prevent`/`.stop`
+/// (the modifiers ARE the behavior — e.g. `@pointerdown.stop`). The
+/// plan stores an empty `expr_src`; the runtime installs the listener
+/// without an evaluation step.
+fn check_listener_expr(
+    value: &str,
+    rest: &str,
+    modifiers: &[String],
+    ctx: &mut AnalysisCtx,
+) -> Option<String> {
+    if value.trim().is_empty() {
+        if modifiers.iter().any(|m| m == "prevent" || m == "stop") {
+            return Some(String::new());
+        }
+        ctx.diagnostics.push(format!(
+            "`@{rest}` has no handler expression — an empty listener only makes sense \
+             with an effect modifier (`.prevent` / `.stop`)"
+        ));
+        return None;
+    }
+    check_template_expr(value, &format!("@{rest}"), ctx)
 }
 
 fn parse_child_host_model(rest: &str) -> (Option<String>, Vec<String>) {
@@ -4038,6 +4396,265 @@ mod tests {
                 "{modifier} should compile instead of requiring mount fallback"
             );
         }
+    }
+
+    // ─── silent-drop hardening ───────────────────────────────────
+    // RFC-058 Phase 6.5 retired the runtime pp-* dispatch, so a
+    // `Preserved` directive attribute is dead markup, not a fallback.
+    // Every directive the author wrote that the plan cannot install
+    // must surface as a diagnostic (or a build warning for the
+    // JS-equality desugar) — never a silent no-op.
+
+    fn warnings(plan: &super::EmittedTemplatePlan) -> String {
+        plan.warnings.join("\n")
+    }
+
+    #[test]
+    fn unknown_directive_head_is_a_compile_error_with_suggestion() {
+        let plan = analyze(r#"<div><button pp-shwo="isOpen">Toggle</button></div>"#);
+        let out = diagnostics(&plan);
+        assert!(out.contains("compile_error"), "{out}");
+        assert!(out.contains("pp-shwo"), "{out}");
+        assert!(out.contains("pp-show"), "suggestion expected: {out}");
+    }
+
+    #[test]
+    fn registry_live_preserved_directives_stay_clean() {
+        let plan =
+            analyze(r#"<div><a pp-route href="/x">x</a><span pp-transition="fade">y</span></div>"#);
+        let out = diagnostics(&plan);
+        assert!(!out.contains("compile_error"), "{out}");
+    }
+
+    #[test]
+    fn template_only_directives_on_a_native_host_are_compile_errors() {
+        let plan = analyze(r#"<div><div pp-if="open">body</div></div>"#);
+        let out = diagnostics(&plan);
+        assert!(out.contains("compile_error"), "{out}");
+        assert!(out.contains("pp-if") && out.contains("template"), "{out}");
+
+        let plan = analyze(r#"<div><div pp-for="item in items">row</div></div>"#);
+        let out = diagnostics(&plan);
+        assert!(out.contains("pp-for") && out.contains("template"), "{out}");
+
+        // RFC-011 iterated slots: pp-for on a native element wrapping
+        // a `<slot>` outlet is the documented shape — stays clean.
+        let plan = analyze(r#"<ul><li pp-for="file in files"><slot name="row"></slot></li></ul>"#);
+        assert!(
+            !diagnostics(&plan).contains("compile_error"),
+            "{}",
+            diagnostics(&plan)
+        );
+
+        let plan = analyze(r##"<div><div pp-teleport="#target">t</div></div>"##);
+        let out = diagnostics(&plan);
+        assert!(
+            out.contains("pp-teleport") && out.contains("template"),
+            "{out}"
+        );
+
+        // Orphan template-only helpers on native hosts die silently too.
+        let plan = analyze(r#"<div><div pp-slot="header">x</div></div>"#);
+        let out = diagnostics(&plan);
+        assert!(out.contains("pp-slot") && out.contains("template"), "{out}");
+    }
+
+    #[test]
+    fn malformed_pp_for_syntax_is_a_compile_error() {
+        let plan =
+            analyze(r#"<div><template pp-for="item of items"><span>r</span></template></div>"#);
+        let out = diagnostics(&plan);
+        assert!(out.contains("compile_error"), "{out}");
+        assert!(out.contains("item in items"), "{out}");
+    }
+
+    #[test]
+    fn unparseable_directive_expression_is_a_compile_error() {
+        let plan = analyze(r#"<div><span pp-show="(((">x</span></div>"#);
+        let out = diagnostics(&plan);
+        assert!(out.contains("compile_error"), "{out}");
+        assert!(out.contains("pp-show"), "{out}");
+
+        let plan = analyze(r#"<div><button :disabled="(((">x</button></div>"#);
+        assert!(diagnostics(&plan).contains("compile_error"));
+
+        let plan = analyze(r#"<div><button @click="(((">x</button></div>"#);
+        assert!(diagnostics(&plan).contains("compile_error"));
+    }
+
+    #[test]
+    fn js_triple_equality_desugars_with_a_build_warning() {
+        let plan = analyze(r#"<div><button :disabled="status === 'loading'">Save</button></div>"#);
+        let out = diagnostics(&plan);
+        assert!(!out.contains("compile_error"), "{out}");
+        let warns = warnings(&plan);
+        assert!(
+            warns.contains("==="),
+            "warning should name the JS operator: {warns}"
+        );
+        let tokens = plan
+            .plan_tokens
+            .expect("bind should still plan")
+            .to_string();
+        assert!(
+            tokens.contains("status == 'loading'"),
+            "expr_src should be rewritten to Rust-style equality: {tokens}"
+        );
+
+        let plan =
+            analyze(r#"<div><template pp-if="state !== 'done'"><span>x</span></template></div>"#);
+        assert!(!diagnostics(&plan).contains("compile_error"));
+        assert!(warnings(&plan).contains("!=="), "{}", warnings(&plan));
+    }
+
+    #[test]
+    fn interp_js_equality_desugars_with_a_build_warning() {
+        let plan = analyze("<div><span>{{ state === 'on' }}</span></div>");
+        assert!(!diagnostics(&plan).contains("compile_error"));
+        assert!(warnings(&plan).contains("==="), "{}", warnings(&plan));
+    }
+
+    #[test]
+    fn listener_modifier_that_can_never_fire_is_a_compile_error() {
+        // Misspelled control modifier: the runtime would treat it as a
+        // keyboard key filter, and a click never carries a key.
+        let plan = analyze(r#"<div><button @click.prevnt="save()">s</button></div>"#);
+        let out = diagnostics(&plan);
+        assert!(out.contains("compile_error"), "{out}");
+        assert!(out.contains("prevnt"), "{out}");
+        assert!(out.contains("prevent"), "suggestion expected: {out}");
+
+        // Named keys on non-keyboard events can never match.
+        let plan = analyze(r#"<div><button @click.enter="save()">s</button></div>"#);
+        assert!(diagnostics(&plan).contains("compile_error"));
+
+        // `.passive` is registry-documented but the applier never
+        // implemented it — the listener would install as a dead
+        // key filter.
+        let plan = analyze(r#"<div><div @scroll.passive="track()">s</div></div>"#);
+        assert!(diagnostics(&plan).contains("compile_error"));
+    }
+
+    #[test]
+    fn effect_only_listener_compiles_without_expression() {
+        // `@pointerdown.stop` with no handler is a real idiom (pine's
+        // own trigger components use it) — the modifiers ARE the
+        // behavior. It used to be preserved, i.e. silently dead.
+        let plan = analyze(r#"<div><button @pointerdown.stop="">x</button></div>"#);
+        assert!(
+            !diagnostics(&plan).contains("compile_error"),
+            "{}",
+            diagnostics(&plan)
+        );
+        let tokens = plan
+            .plan_tokens
+            .expect("effect-only listener should plan")
+            .to_string();
+        assert!(tokens.contains("pointerdown"), "{tokens}");
+
+        let plan = analyze(r#"<div><button @mousedown.prevent="">x</button></div>"#);
+        assert!(
+            !diagnostics(&plan).contains("compile_error"),
+            "{}",
+            diagnostics(&plan)
+        );
+
+        // Without an effect modifier an empty listener does nothing —
+        // that stays an error.
+        let plan = analyze(r#"<div><button @click="">x</button></div>"#);
+        assert!(diagnostics(&plan).contains("compile_error"));
+    }
+
+    #[test]
+    fn supported_listener_shapes_stay_clean() {
+        let plan = analyze(
+            r#"<div>
+                 <input @keydown.enter="submit()" />
+                 <input @keyup.q="quick()" />
+                 <input @input.debounce.300="search()" />
+                 <button @click.ctrl="alt()">x</button>
+                 <button @click.outside="close()">y</button>
+               </div>"#,
+        );
+        let out = diagnostics(&plan);
+        assert!(!out.contains("compile_error"), "{out}");
+    }
+
+    #[test]
+    fn native_model_bad_modifier_is_a_compile_error() {
+        let plan = analyze(r#"<div><input pp-model.numbr="age" /></div>"#);
+        let out = diagnostics(&plan);
+        assert!(
+            out.contains("compile_error") && out.contains("numbr"),
+            "{out}"
+        );
+        assert!(out.contains("number"), "suggestion expected: {out}");
+
+        // `.trim` is registry-documented but the compiled lift drops it.
+        let plan = analyze(r#"<div><input pp-model.trim="name" /></div>"#);
+        assert!(diagnostics(&plan).contains("compile_error"));
+
+        // The prop-selection arg form targets component models only.
+        let plan = analyze(r#"<div><input pp-model:value="age" /></div>"#);
+        assert!(diagnostics(&plan).contains("compile_error"));
+
+        let plan = analyze(r#"<div><input pp-model.number.lazy="age" /></div>"#);
+        assert!(!diagnostics(&plan).contains("compile_error"));
+    }
+
+    #[test]
+    fn empty_pp_ref_is_a_compile_error() {
+        let plan = analyze(r#"<div><span pp-ref=" ">x</span></div>"#);
+        assert!(diagnostics(&plan).contains("compile_error"));
+    }
+
+    #[test]
+    fn bind_arg_modifier_is_a_compile_error() {
+        let plan = analyze(r#"<div><span :class.once="cls">x</span></div>"#);
+        let out = diagnostics(&plan);
+        assert!(
+            out.contains("compile_error") && out.contains("once"),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn child_host_attrs_share_the_hardening() {
+        let plan = analyze(r#"<div><x-btn @click.prevnt="go()">x</x-btn></div>"#);
+        assert!(diagnostics(&plan).contains("prevnt"));
+
+        let plan = analyze(r#"<div><x-btn :disabled="a === 'b'">x</x-btn></div>"#);
+        assert!(!diagnostics(&plan).contains("compile_error"));
+        assert!(warnings(&plan).contains("==="), "{}", warnings(&plan));
+
+        let plan = analyze(r#"<div><x-input pp-model:value.numbr="v">x</x-input></div>"#);
+        assert!(diagnostics(&plan).contains("numbr"));
+
+        let plan = analyze(r#"<div><x-input pp-model="">x</x-input></div>"#);
+        assert!(diagnostics(&plan).contains("compile_error"));
+    }
+
+    #[test]
+    fn pp_stagger_junk_value_is_a_compile_error() {
+        let plan = analyze(
+            r#"<div><template pp-for="i in items" pp-stagger="fast"><span>r</span></template></div>"#,
+        );
+        let out = diagnostics(&plan);
+        assert!(
+            out.contains("compile_error") && out.contains("pp-stagger"),
+            "{out}"
+        );
+    }
+
+    #[test]
+    fn pp_teleport_misuse_is_a_compile_error() {
+        let plan = analyze(r#"<div><template pp-teleport=" "><span>b</span></template></div>"#);
+        assert!(diagnostics(&plan).contains("compile_error"));
+
+        let plan = analyze(
+            r##"<div><template pp-for="i in items" pp-teleport="#t"><span>r</span></template></div>"##,
+        );
+        assert!(diagnostics(&plan).contains("compile_error"));
     }
 
     /// `parse_pp_directive_name` mirrors the runtime

--- a/crates/pocopine/tests/handlers_contract_ui.rs
+++ b/crates/pocopine/tests/handlers_contract_ui.rs
@@ -1,0 +1,40 @@
+//! Compile-time contract for `#[handlers]` marker attributes.
+//!
+//! A `#[watch]`, lifecycle, or `#[computed]` method whose shape the macro
+//! cannot install must be a compile error, never a silent skip. Before
+//! this contract, a `#[watch(field)]` handler that omitted the
+//! `(next, prev)` args compiled green and was simply never installed —
+//! the watch never fired and the code read as a dead handler.
+//!
+//! Following the `store_computed_ui` convention: reject fixtures pin our
+//! own `compile_error!` text on bare `#[handlers]` impls so the snapshot
+//! stays stable across the CI and workspace nightlies. Regenerate with
+//! `TRYBUILD=overwrite` if rustc framing drifts.
+//!
+//! Host-only: trybuild shells out to cargo and isn't a wasm target.
+#![cfg(not(target_arch = "wasm32"))]
+
+#[test]
+fn handlers_marker_contract() {
+    let cases = trybuild::TestCases::new();
+    // The canonical `(next, prev)` shape compiles and installs.
+    cases.pass("tests/ui/watch_pass.rs");
+    // A handler that omits both value args is rejected, not skipped.
+    cases.compile_fail("tests/ui/watch_no_args.rs");
+    // A handler that omits `prev` is rejected with the same shape hint.
+    cases.compile_fail("tests/ui/watch_one_arg.rs");
+    // Bare `#[watch]` (no field) is rejected.
+    cases.compile_fail("tests/ui/watch_bare_attr.rs");
+    // `#[watch("field")]` (string literal, not an ident) is rejected.
+    cases.compile_fail("tests/ui/watch_nonident_attr.rs");
+    // Two `#[watch]` attributes on one method are rejected (previously
+    // last-one-won silently).
+    cases.compile_fail("tests/ui/watch_stacked.rs");
+    // A watch handler without a reference receiver is rejected.
+    cases.compile_fail("tests/ui/watch_no_receiver.rs");
+    // A lifecycle-named method without `self` is rejected (previously
+    // skipped before name matching — the hook silently never fired).
+    cases.compile_fail("tests/ui/lifecycle_no_receiver.rs");
+    // `#[computed]` takes no arguments (previously discarded silently).
+    cases.compile_fail("tests/ui/computed_with_args.rs");
+}

--- a/crates/pocopine/tests/macro_args_contract_ui.rs
+++ b/crates/pocopine/tests/macro_args_contract_ui.rs
@@ -1,0 +1,30 @@
+//! Compile-time contract for macro argument parsing — duplicate keys,
+//! ignored arguments, and dead flag combinations must be compile
+//! errors, never silent last-one-wins or discarded tokens.
+//!
+//! Reject fixtures pin our own `compile_error!` text; regenerate with
+//! `TRYBUILD=overwrite` if rustc framing drifts.
+//!
+//! Host-only: trybuild shells out to cargo and isn't a wasm target.
+#![cfg(not(target_arch = "wasm32"))]
+
+#[test]
+fn macro_args_contract() {
+    let cases = trybuild::TestCases::new();
+    // #[derive(Props)] fields take bare `#[prop]` — arguments used to
+    // be recognized, never parsed, and silently discarded.
+    cases.compile_fail("tests/ui/props_args_fail.rs");
+    // Duplicate #[component(...)] keys used to last-one-win silently.
+    cases.compile_fail("tests/ui/component_dup_key_fail.rs");
+    // `unchecked_paths` only accepts "true"/"false" — any other value
+    // used to silently disable the opt-out.
+    cases.compile_fail("tests/ui/component_unchecked_paths_fail.rs");
+    // Duplicate #[job] keys used to last-one-win silently.
+    cases.compile_fail("tests/ui/job_dup_queue_fail.rs");
+    // `retries` and `max_retries` are aliases — passing both silently
+    // kept the later one.
+    cases.compile_fail("tests/ui/job_retries_alias_fail.rs");
+    // `idempotent` is parsed, stored, and never consulted for
+    // streaming functions — the config was dead.
+    cases.compile_fail("tests/ui/server_idempotent_streaming_fail.rs");
+}

--- a/crates/pocopine/tests/template_plan_diagnostics_ui.rs
+++ b/crates/pocopine/tests/template_plan_diagnostics_ui.rs
@@ -6,4 +6,8 @@
 fn nested_template_plan_diagnostics() {
     let cases = trybuild::TestCases::new();
     cases.compile_fail("tests/ui/plan_nested_branch_roots.rs");
+    // Silent-drop hardening: a misspelled directive head and a dead
+    // listener modifier are compile errors, not preserved dead markup.
+    cases.compile_fail("tests/ui/plan_unknown_directive.rs");
+    cases.compile_fail("tests/ui/plan_dead_listener_modifier.rs");
 }

--- a/crates/pocopine/tests/ui/component_dup_key_fail.rs
+++ b/crates/pocopine/tests/ui/component_dup_key_fail.rs
@@ -1,0 +1,20 @@
+// Duplicate #[component(...)] keys used to last-one-win silently —
+// the earlier value vanished with no diagnostic.
+use pocopine::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "dup-key-fixture",
+    template_inline = "<div></div>",
+    role = "panel",
+    role = "toolbar"
+)]
+struct DupKeyFixture {
+    open: bool,
+}
+
+#[handlers]
+impl DupKeyFixture {}
+
+fn main() {}

--- a/crates/pocopine/tests/ui/component_dup_key_fail.stderr
+++ b/crates/pocopine/tests/ui/component_dup_key_fail.stderr
@@ -1,0 +1,5 @@
+error: duplicate `role` argument
+  --> tests/ui/component_dup_key_fail.rs:11:5
+   |
+11 |     role = "toolbar"
+   |     ^^^^

--- a/crates/pocopine/tests/ui/component_unchecked_paths_fail.rs
+++ b/crates/pocopine/tests/ui/component_unchecked_paths_fail.rs
@@ -1,0 +1,19 @@
+// `unchecked_paths` compared against the literal string "true" — any
+// other truthy spelling silently left path validation enabled.
+use pocopine::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "unchecked-paths-fixture",
+    template_inline = "<div></div>",
+    unchecked_paths = "yes"
+)]
+struct UncheckedPathsFixture {
+    open: bool,
+}
+
+#[handlers]
+impl UncheckedPathsFixture {}
+
+fn main() {}

--- a/crates/pocopine/tests/ui/component_unchecked_paths_fail.stderr
+++ b/crates/pocopine/tests/ui/component_unchecked_paths_fail.stderr
@@ -1,0 +1,5 @@
+error: `unchecked_paths` expects "true" or "false", got "yes"
+  --> tests/ui/component_unchecked_paths_fail.rs:10:23
+   |
+10 |     unchecked_paths = "yes"
+   |                       ^^^^^

--- a/crates/pocopine/tests/ui/computed_with_args.rs
+++ b/crates/pocopine/tests/ui/computed_with_args.rs
@@ -1,0 +1,17 @@
+// `#[computed(...)]` has no argument surface; extra tokens used to be
+// recognized, never parsed, and silently stripped.
+use pocopine::prelude::*;
+
+struct Derived {
+    items: Vec<String>,
+}
+
+#[handlers]
+impl Derived {
+    #[computed(cached)]
+    fn total(items: &Vec<String>) -> usize {
+        items.len()
+    }
+}
+
+fn main() {}

--- a/crates/pocopine/tests/ui/computed_with_args.stderr
+++ b/crates/pocopine/tests/ui/computed_with_args.stderr
@@ -1,0 +1,5 @@
+error: #[computed] takes no arguments
+  --> tests/ui/computed_with_args.rs:11:5
+   |
+11 |     #[computed(cached)]
+   |     ^^^^^^^^^^^^^^^^^^^

--- a/crates/pocopine/tests/ui/job_dup_queue_fail.rs
+++ b/crates/pocopine/tests/ui/job_dup_queue_fail.rs
@@ -1,0 +1,11 @@
+// Duplicate #[job] keys used to last-one-win silently — the job ran
+// on the wrong queue with no diagnostic.
+use pocopine::JobResult;
+
+#[pocopine::job(queue = "emails", queue = "reports")]
+async fn send(recipient: String) -> JobResult<()> {
+    let _ = recipient;
+    Ok(())
+}
+
+fn main() {}

--- a/crates/pocopine/tests/ui/job_dup_queue_fail.stderr
+++ b/crates/pocopine/tests/ui/job_dup_queue_fail.stderr
@@ -1,0 +1,13 @@
+error: duplicate `queue` argument
+ --> tests/ui/job_dup_queue_fail.rs:5:35
+  |
+5 | #[pocopine::job(queue = "emails", queue = "reports")]
+  |                                   ^^^^^
+
+warning: unused import: `pocopine::JobResult`
+ --> tests/ui/job_dup_queue_fail.rs:3:5
+  |
+3 | use pocopine::JobResult;
+  |     ^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

--- a/crates/pocopine/tests/ui/job_retries_alias_fail.rs
+++ b/crates/pocopine/tests/ui/job_retries_alias_fail.rs
@@ -1,0 +1,11 @@
+// `retries` and `max_retries` are aliases for the same knob — passing
+// both silently kept whichever came later.
+use pocopine::JobResult;
+
+#[pocopine::job(queue = "emails", retries = 3, max_retries = 9)]
+async fn send(recipient: String) -> JobResult<()> {
+    let _ = recipient;
+    Ok(())
+}
+
+fn main() {}

--- a/crates/pocopine/tests/ui/job_retries_alias_fail.stderr
+++ b/crates/pocopine/tests/ui/job_retries_alias_fail.stderr
@@ -1,0 +1,13 @@
+error: duplicate retry count — `retries` and `max_retries` are aliases; pass one of them once
+ --> tests/ui/job_retries_alias_fail.rs:5:48
+  |
+5 | #[pocopine::job(queue = "emails", retries = 3, max_retries = 9)]
+  |                                                ^^^^^^^^^^^
+
+warning: unused import: `pocopine::JobResult`
+ --> tests/ui/job_retries_alias_fail.rs:3:5
+  |
+3 | use pocopine::JobResult;
+  |     ^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

--- a/crates/pocopine/tests/ui/lifecycle_no_receiver.rs
+++ b/crates/pocopine/tests/ui/lifecycle_no_receiver.rs
@@ -1,0 +1,14 @@
+// A lifecycle-named method without `self` used to be skipped before
+// name matching — `on_ready` compiled green and silently never fired.
+use pocopine::prelude::*;
+
+struct Clock {
+    ticks: u32,
+}
+
+#[handlers]
+impl Clock {
+    fn on_ready() {}
+}
+
+fn main() {}

--- a/crates/pocopine/tests/ui/lifecycle_no_receiver.stderr
+++ b/crates/pocopine/tests/ui/lifecycle_no_receiver.stderr
@@ -1,0 +1,5 @@
+error: lifecycle method `on_ready` must take `&mut self`
+  --> tests/ui/lifecycle_no_receiver.rs:11:5
+   |
+11 |     fn on_ready() {}
+   |     ^^^^^^^^^^^^^

--- a/crates/pocopine/tests/ui/plan_dead_listener_modifier.poco
+++ b/crates/pocopine/tests/ui/plan_dead_listener_modifier.poco
@@ -1,0 +1,3 @@
+<div class="panel">
+  <button @click.prevnt="count = 1">Save</button>
+</div>

--- a/crates/pocopine/tests/ui/plan_dead_listener_modifier.rs
+++ b/crates/pocopine/tests/ui/plan_dead_listener_modifier.rs
@@ -1,0 +1,19 @@
+// A misspelled listener modifier used to install as a keyboard key
+// filter — on a click event the filter can never match, so the
+// handler silently never fired.
+use pocopine::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "plan-dead-listener-modifier",
+    template = "plan_dead_listener_modifier.poco"
+)]
+struct PlanDeadListenerModifier {
+    count: u32,
+}
+
+#[handlers]
+impl PlanDeadListenerModifier {}
+
+fn main() {}

--- a/crates/pocopine/tests/ui/plan_dead_listener_modifier.stderr
+++ b/crates/pocopine/tests/ui/plan_dead_listener_modifier.stderr
@@ -1,0 +1,10 @@
+error: pocopine: template plan error in component `plan-dead-listener-modifier` (`$DIR/tests/ui/plan_dead_listener_modifier.poco`): `@click.prevnt`: modifier `.prevnt` is not a control modifier, and `click` is not a keyboard event, so a `.prevnt` key filter can never match — the listener would never fire — did you mean `.prevent`?
+  --> tests/ui/plan_dead_listener_modifier.rs:8:1
+   |
+ 8 | / #[component(
+ 9 | |     name = "plan-dead-listener-modifier",
+10 | |     template = "plan_dead_listener_modifier.poco"
+11 | | )]
+   | |__^
+   |
+   = note: this error originates in the attribute macro `component` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/pocopine/tests/ui/plan_unknown_directive.poco
+++ b/crates/pocopine/tests/ui/plan_unknown_directive.poco
@@ -1,0 +1,3 @@
+<div class="panel">
+  <button pp-shwo="is_open">Toggle</button>
+</div>

--- a/crates/pocopine/tests/ui/plan_unknown_directive.rs
+++ b/crates/pocopine/tests/ui/plan_unknown_directive.rs
@@ -1,0 +1,19 @@
+// A misspelled directive head compiled green before the registry
+// check — the attribute was preserved on the cleaned HTML, which the
+// retired runtime dispatch never reads: dead markup.
+use pocopine::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Default, Serialize, Deserialize)]
+#[component(
+    name = "plan-unknown-directive",
+    template = "plan_unknown_directive.poco"
+)]
+struct PlanUnknownDirective {
+    is_open: bool,
+}
+
+#[handlers]
+impl PlanUnknownDirective {}
+
+fn main() {}

--- a/crates/pocopine/tests/ui/plan_unknown_directive.stderr
+++ b/crates/pocopine/tests/ui/plan_unknown_directive.stderr
@@ -1,0 +1,10 @@
+error: pocopine: template plan error in component `plan-unknown-directive` (`$DIR/tests/ui/plan_unknown_directive.poco`): unknown directive `pp-shwo` — did you mean `pp-show`?
+  --> tests/ui/plan_unknown_directive.rs:8:1
+   |
+ 8 | / #[component(
+ 9 | |     name = "plan-unknown-directive",
+10 | |     template = "plan_unknown_directive.poco"
+11 | | )]
+   | |__^
+   |
+   = note: this error originates in the attribute macro `component` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/crates/pocopine/tests/ui/props_args_fail.rs
+++ b/crates/pocopine/tests/ui/props_args_fail.rs
@@ -1,0 +1,14 @@
+// `#[prop(...)]` arguments in a #[derive(Props)] leaf struct used to
+// be silently discarded — `name`/`skip`-style intent evaporated.
+use pocopine::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Props, Default, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SeriesCommon {
+    #[prop(name = "series-key")]
+    pub key: String,
+    #[prop]
+    pub label: String,
+}
+
+fn main() {}

--- a/crates/pocopine/tests/ui/props_args_fail.stderr
+++ b/crates/pocopine/tests/ui/props_args_fail.stderr
@@ -1,0 +1,5 @@
+error: #[derive(Props)] fields take bare `#[prop]` — arguments are not supported here (the wire leaf name is always the field name)
+ --> tests/ui/props_args_fail.rs:8:5
+  |
+8 |     #[prop(name = "series-key")]
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/pocopine/tests/ui/server_idempotent_streaming_fail.rs
+++ b/crates/pocopine/tests/ui/server_idempotent_streaming_fail.rs
@@ -1,0 +1,10 @@
+// `#[server(idempotent)]` on a streaming function was parsed, stored,
+// and never consulted — the replay-safety intent was silently dead.
+use pocopine::StreamServerResult;
+
+#[pocopine::server(public, idempotent)]
+async fn feed() -> StreamServerResult<u32> {
+    todo!()
+}
+
+fn main() {}

--- a/crates/pocopine/tests/ui/server_idempotent_streaming_fail.stderr
+++ b/crates/pocopine/tests/ui/server_idempotent_streaming_fail.stderr
@@ -1,0 +1,13 @@
+error: #[server(idempotent)] has no effect on a streaming function — the stream transport has no replay envelope; remove `idempotent`
+ --> tests/ui/server_idempotent_streaming_fail.rs:6:17
+  |
+6 | async fn feed() -> StreamServerResult<u32> {
+  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: unused import: `pocopine::StreamServerResult`
+ --> tests/ui/server_idempotent_streaming_fail.rs:3:5
+  |
+3 | use pocopine::StreamServerResult;
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` (part of `#[warn(unused)]`) on by default

--- a/crates/pocopine/tests/ui/watch_bare_attr.rs
+++ b/crates/pocopine/tests/ui/watch_bare_attr.rs
@@ -1,0 +1,15 @@
+// Bare `#[watch]` (no field name) used to strip the attribute and
+// silently downgrade the method to an ordinary handler.
+use pocopine::prelude::*;
+
+struct Editor {
+    start_time: String,
+}
+
+#[handlers]
+impl Editor {
+    #[watch]
+    fn on_start_time(&mut self, _next: String, _prev: Option<String>) {}
+}
+
+fn main() {}

--- a/crates/pocopine/tests/ui/watch_bare_attr.stderr
+++ b/crates/pocopine/tests/ui/watch_bare_attr.stderr
@@ -1,0 +1,5 @@
+error: #[watch] expects a field name: #[watch(field)]
+  --> tests/ui/watch_bare_attr.rs:11:5
+   |
+11 |     #[watch]
+   |     ^^^^^^^^

--- a/crates/pocopine/tests/ui/watch_no_args.rs
+++ b/crates/pocopine/tests/ui/watch_no_args.rs
@@ -1,0 +1,15 @@
+// The reported bug shape: a `#[watch]` handler that takes only `&mut self`
+// used to compile green and silently never install — the watch never fired.
+use pocopine::prelude::*;
+
+struct Editor {
+    start_time: String,
+}
+
+#[handlers]
+impl Editor {
+    #[watch(start_time)]
+    fn on_start_time(&mut self) {}
+}
+
+fn main() {}

--- a/crates/pocopine/tests/ui/watch_no_args.stderr
+++ b/crates/pocopine/tests/ui/watch_no_args.stderr
@@ -1,0 +1,5 @@
+error: #[watch(start_time)] handler must take `&mut self` and `(next: V, prev: Option<V>)` — e.g. `fn on_start_time(&mut self, next: V, prev: Option<V>)`
+  --> tests/ui/watch_no_args.rs:12:5
+   |
+12 |     fn on_start_time(&mut self) {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/pocopine/tests/ui/watch_no_receiver.rs
+++ b/crates/pocopine/tests/ui/watch_no_receiver.rs
@@ -1,0 +1,15 @@
+// A `#[watch]` handler with no `self` receiver can never be installed —
+// the generated dispatch calls it as a method.
+use pocopine::prelude::*;
+
+struct Editor {
+    start_time: String,
+}
+
+#[handlers]
+impl Editor {
+    #[watch(start_time)]
+    fn on_start_time(_next: String, _prev: Option<String>) {}
+}
+
+fn main() {}

--- a/crates/pocopine/tests/ui/watch_no_receiver.stderr
+++ b/crates/pocopine/tests/ui/watch_no_receiver.stderr
@@ -1,0 +1,5 @@
+error: #[watch(start_time)] handler must take `&mut self` and `(next: V, prev: Option<V>)` — e.g. `fn on_start_time(&mut self, next: V, prev: Option<V>)`
+  --> tests/ui/watch_no_receiver.rs:12:5
+   |
+12 |     fn on_start_time(_next: String, _prev: Option<String>) {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/pocopine/tests/ui/watch_nonident_attr.rs
+++ b/crates/pocopine/tests/ui/watch_nonident_attr.rs
@@ -1,0 +1,15 @@
+// `#[watch("field")]` — a string literal instead of a field ident —
+// used to fail the ident parse and silently drop the watch.
+use pocopine::prelude::*;
+
+struct Editor {
+    start_time: String,
+}
+
+#[handlers]
+impl Editor {
+    #[watch("start_time")]
+    fn on_start_time(&mut self, _next: String, _prev: Option<String>) {}
+}
+
+fn main() {}

--- a/crates/pocopine/tests/ui/watch_nonident_attr.stderr
+++ b/crates/pocopine/tests/ui/watch_nonident_attr.stderr
@@ -1,0 +1,5 @@
+error: #[watch] expects a field name: #[watch(field)]
+  --> tests/ui/watch_nonident_attr.rs:11:5
+   |
+11 |     #[watch("start_time")]
+   |     ^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/pocopine/tests/ui/watch_one_arg.rs
+++ b/crates/pocopine/tests/ui/watch_one_arg.rs
@@ -1,0 +1,15 @@
+// A `#[watch]` handler missing `prev` used to slip past collection and
+// fail later inside generated code with a confusing arity error.
+use pocopine::prelude::*;
+
+struct Editor {
+    start_time: String,
+}
+
+#[handlers]
+impl Editor {
+    #[watch(start_time)]
+    fn on_start_time(&mut self, _next: String) {}
+}
+
+fn main() {}

--- a/crates/pocopine/tests/ui/watch_one_arg.stderr
+++ b/crates/pocopine/tests/ui/watch_one_arg.stderr
@@ -1,0 +1,5 @@
+error: #[watch(start_time)] handler must take `&mut self` and `(next: V, prev: Option<V>)` — e.g. `fn on_start_time(&mut self, next: V, prev: Option<V>)`
+  --> tests/ui/watch_one_arg.rs:12:5
+   |
+12 |     fn on_start_time(&mut self, _next: String) {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/pocopine/tests/ui/watch_pass.rs
+++ b/crates/pocopine/tests/ui/watch_pass.rs
@@ -1,0 +1,25 @@
+// The canonical `#[watch]` shape: `&mut self` + `(next: V, prev: Option<V>)`.
+// Hosted on a `#[store]` so the generated observe machinery exists.
+use pocopine::prelude::*;
+
+#[derive(Default, serde::Serialize, serde::Deserialize)]
+#[store(name = "editor")]
+struct EditorStore {
+    start_time: String,
+    count: i32,
+}
+
+#[handlers]
+impl EditorStore {
+    #[watch(start_time)]
+    fn on_start_time(&mut self, _next: String, _prev: Option<String>) {
+        self.count += 1;
+    }
+
+    #[watch(count)]
+    fn on_count(&mut self, next: i32, prev: Option<i32>) {
+        let _ = (next, prev);
+    }
+}
+
+fn main() {}

--- a/crates/pocopine/tests/ui/watch_stacked.rs
+++ b/crates/pocopine/tests/ui/watch_stacked.rs
@@ -1,0 +1,17 @@
+// Two `#[watch]` attributes on one method: the first used to be
+// silently discarded (last-one-wins). One handler per watched field.
+use pocopine::prelude::*;
+
+struct Editor {
+    start_time: String,
+    end_time: String,
+}
+
+#[handlers]
+impl Editor {
+    #[watch(start_time)]
+    #[watch(end_time)]
+    fn on_times(&mut self, _next: String, _prev: Option<String>) {}
+}
+
+fn main() {}

--- a/crates/pocopine/tests/ui/watch_stacked.stderr
+++ b/crates/pocopine/tests/ui/watch_stacked.stderr
@@ -1,0 +1,5 @@
+error: only one #[watch] attribute per method — write one handler per watched field
+  --> tests/ui/watch_stacked.rs:13:5
+   |
+13 |     #[watch(end_time)]
+   |     ^^^^^^^^^^^^^^^^^^

--- a/docs/guides/poco/04-expressions.md
+++ b/docs/guides/poco/04-expressions.md
@@ -46,7 +46,9 @@ in the template.
 ## What pine-expr does NOT support
 
 * Arithmetic beyond `+`: no `-`, `*`, `/`, `%`, `**`
-* JS-style strict equality: no `===`/`!==` — use `==`/`!=`
+* JS-style strict equality: `===`/`!==` in a directive or `{{ }}`
+  interpolation is desugared to `==`/`!=` with a build warning —
+  write `==`/`!=`; other contexts reject it outright
 * Method calls on objects: no `obj.method()`, no `.length`, no
   `.toFixed()`, no `.slice()`, no `.map()` / `.filter()`
 * Globals: no `Math.*`, no `Date.*`, no `console.*`, no `JSON.*`
@@ -160,8 +162,8 @@ points at the offending span in the `.poco` file:
 |---|---|
 | `progress * 100`, `a / b`, `i % 2` | `` arithmetic operator `*` is not supported in pine-expr `` |
 | `count - 1` | `arithmetic subtraction is not supported in pine-expr` |
-| `status === 'done'` | `` `===` is not supported in pine-expr `` |
-| `x !== 'y'` | `` `!==` is not supported in pine-expr `` |
+| `status === 'done'` | build warning; the template compiles as `status == 'done'` |
+| `x !== 'y'` | build warning; the template compiles as `x != 'y'` |
 | `files.filter(f)` | `method calls on objects are not supported in pine-expr` |
 | `x => x + 1` | `arrow functions are not supported in pine-expr` |
 | `a ?? b` | `` nullish coalescing `??` is not supported in pine-expr `` |

--- a/docs/guides/reactivity/01-essentials.md
+++ b/docs/guides/reactivity/01-essentials.md
@@ -113,6 +113,12 @@ field, kick off an animation, reset a buffer), use `#[watch(field)]`. The
 method takes `(new, prev)` where `prev` is `None` on the first call after
 mount, and runs whenever `field` changes.
 
+The signature is a contract: `&mut self` plus exactly
+`(new: V, prev: Option<V>)`. Any other shape — no args, a missing
+`prev`, no receiver, a bare `#[watch]` — is a compile error, as is
+stacking two `#[watch]` attributes on one method (write one handler per
+watched field).
+
 ```rust
 #[derive(Default, Serialize, Deserialize)]
 #[component(template = "PinCardDemo.poco")]

--- a/examples/website/src/components/showcase/calendar/CalendarDemo.poco
+++ b/examples/website/src/components/showcase/calendar/CalendarDemo.poco
@@ -34,11 +34,11 @@
           <div class="button-row">
             <button type="button"
                     class="seg-btn"
-                    :data-active="week_starts_on === 0"
+                    :data-active="week_starts_on == 0"
                     @click="week_start_sun">Sunday</button>
             <button type="button"
                     class="seg-btn"
-                    :data-active="week_starts_on === 1"
+                    :data-active="week_starts_on == 1"
                     @click="week_start_mon">Monday</button>
           </div>
         </div>
@@ -47,11 +47,11 @@
           <div class="control-title">Bounds</div>
           <label class="date-row">
             <span>Min</span>
-            <input type="date" pp-model:value="min_value">
+            <input type="date" pp-model="min_value">
           </label>
           <label class="date-row">
             <span>Max</span>
-            <input type="date" pp-model:value="max_value">
+            <input type="date" pp-model="max_value">
           </label>
         </div>
 

--- a/examples/website/src/components/showcase/field/FieldDemo.poco
+++ b/examples/website/src/components/showcase/field/FieldDemo.poco
@@ -16,7 +16,7 @@
                class="field-demo-input"
                placeholder="Required"
                required
-               pp-model:value="name">
+               pp-model="name">
       </pine-field-control>
       <pine-field-description>Visible on your profile.</pine-field-description>
       <pine-field-error>Please enter your name.</pine-field-error>

--- a/examples/website/src/components/showcase/fieldset/FieldsetDemo.poco
+++ b/examples/website/src/components/showcase/fieldset/FieldsetDemo.poco
@@ -14,11 +14,11 @@
       <pine-fieldset-legend>Account</pine-fieldset-legend>
       <label class="fieldset-demo-row">
         <span>First name</span>
-        <input type="text" class="fieldset-demo-input" pp-model:value="first_name">
+        <input type="text" class="fieldset-demo-input" pp-model="first_name">
       </label>
       <label class="fieldset-demo-row">
         <span>Last name</span>
-        <input type="text" class="fieldset-demo-input" pp-model:value="last_name">
+        <input type="text" class="fieldset-demo-input" pp-model="last_name">
       </label>
     </pine-fieldset-root>
     <pine-button variant="ghost" @click="toggle" style="margin-top:0.75rem">

--- a/examples/website/src/components/showcase/form/FormDemo.poco
+++ b/examples/website/src/components/showcase/form/FormDemo.poco
@@ -14,7 +14,7 @@
                class="form-demo-input"
                placeholder="Required"
                required
-               pp-model:value="username">
+               pp-model="username">
       </label>
       <button type="submit" class="form-demo-submit">Sign up</button>
     </pine-form-root>

--- a/rfcs/rfc-115-multi-field-watch.md
+++ b/rfcs/rfc-115-multi-field-watch.md
@@ -176,6 +176,28 @@ the documented alternative; the guide gets a "which one when" note.
   them off `self`; one that needs *which* field changed should use
   single-field watches — that need is the signal the fields have
   diverging behavior.
+- **Watch-all** — `#[watch(self)]` / bare `#[watch]` meaning "every
+  field". Rejected for three reasons:
+  1. *It's a loop generator.* Recompute handlers **write** derived
+     fields; a subscription that includes the handler's own outputs
+     re-triggers on them. Making that safe needs writer-suppression
+     machinery, and whether an unguarded version spins forever or
+     merely echoes depends on store equality short-circuiting. The
+     explicit list is loop-safe by construction: the author lists
+     inputs and omits outputs — a distinction the framework cannot
+     infer.
+  2. *`#[handlers]` cannot enumerate fields* — the struct lives under
+     `#[component]`; watch-all would need a runtime scope-level
+     any-change subscription with fuzzy scope questions (computed
+     fields? flattened leaves? parent prop writes?).
+  3. *The good argument for it — "I added a field and forgot to
+     extend the list" staleness — is better served by dependency
+     tracking*: run the method once as a tracked effect and subscribe
+     to exactly the fields it read (`watchEffect`-style,
+     `#[effect]`). That self-maintains the dependency set and cannot
+     loop on writes to unread fields, but read-tracking through
+     `&mut self` needs its own design (read-phase/write-phase split)
+     and is deferred to a future RFC.
 - **Watching computed fields or cross-scope fields** — same
   restrictions as single-field `#[watch]`.
 - **Predicates/filters** (`#[watch(a, if = ...)]`) — out of scope.
@@ -190,8 +212,14 @@ times per preset change.
 
 ## Open questions
 
-1. Should the coalesced handler also be the vehicle for a future
-   `#[watch(*)]`/whole-state watch? (Deliberately unanswered; the
-   list form neither enables nor blocks it.)
-2. Cap on list length? None proposed — the install cost is linear
+1. Cap on list length? None proposed — the install cost is linear
    and small.
+
+## The escalation ladder
+
+For documentation (`docs/guides/reactivity/`): explicit single-field
+watch when behavior diverges per field → `#[watch(a, b, c)]` for a
+shared recompute over a known set → flattened container watch
+(RFC-044 §5.10.5) when the set is a real domain object → a future
+dependency-tracked `#[effect]` if list maintenance ever becomes a
+genuine pain.

--- a/rfcs/rfc-115-multi-field-watch.md
+++ b/rfcs/rfc-115-multi-field-watch.md
@@ -191,13 +191,18 @@ the documented alternative; the guide gets a "which one when" note.
      any-change subscription with fuzzy scope questions (computed
      fields? flattened leaves? parent prop writes?).
   3. *The good argument for it — "I added a field and forgot to
-     extend the list" staleness — is better served by dependency
-     tracking*: run the method once as a tracked effect and subscribe
-     to exactly the fields it read (`watchEffect`-style,
-     `#[effect]`). That self-maintains the dependency set and cannot
-     loop on writes to unread fields, but read-tracking through
-     `&mut self` needs its own design (read-phase/write-phase split)
-     and is deferred to a future RFC.
+     extend the list" staleness — is already answered by the
+     container rung*: group the inputs into a struct and
+     `#[watch(container)]` (RFC-044 §5.10.5). A field added to the
+     struct is auto-included — exhaustiveness by construction, with
+     the dependency set still explicit and visible in the type.
+- **Dependency-tracked effects** (`watchEffect`-style implicit
+  subscription). Rejected as a direction, not just deferred: the
+  dependency set is invisible at the call site and *unstable across
+  runs* (a conditional read not taken this run silently drops the
+  subscription), which trades a visible, greppable list for
+  "why didn't this re-run" debugging. Explicit contracts are the
+  framework's position; do not re-propose implicit tracking.
 - **Watching computed fields or cross-scope fields** — same
   restrictions as single-field `#[watch]`.
 - **Predicates/filters** (`#[watch(a, if = ...)]`) — out of scope.
@@ -220,6 +225,7 @@ times per preset change.
 For documentation (`docs/guides/reactivity/`): explicit single-field
 watch when behavior diverges per field → `#[watch(a, b, c)]` for a
 shared recompute over a known set → flattened container watch
-(RFC-044 §5.10.5) when the set is a real domain object → a future
-dependency-tracked `#[effect]` if list maintenance ever becomes a
-genuine pain.
+(RFC-044 §5.10.5) when the set is a real domain object **or** when
+you want new fields auto-included without maintaining a list. Every
+rung keeps the dependency set explicit; there is no implicit-tracking
+rung by design.

--- a/rfcs/rfc-115-multi-field-watch.md
+++ b/rfcs/rfc-115-multi-field-watch.md
@@ -1,0 +1,197 @@
+# RFC-115: Multi-field watch — `#[watch(a, b, c)]`
+
+**Status:** Proposed
+**Crates:** `pocopine-macros` (`#[handlers]`), `pocopine-core` (reactive watch primitives)
+**Relates to:** RFC-026 (`#[watch(field)]` sugar), RFC-036 (watch install machinery), RFC-044 §5.10.5 (flattened-container watch), PR #279 (watch signature contract)
+
+## Summary
+
+Let one handler watch several fields:
+
+```rust
+#[watch(preset, mode, start_date, start_day, start_time, end_date, end_day, end_time)]
+fn on_when_changed(&mut self) {
+    self.recompute();
+}
+```
+
+- **One field** in the list keeps today's typed contract unchanged:
+  `&mut self, (next: V, prev: Option<V>)`.
+- **Two or more fields** require the payload-less shape: `&mut self`
+  and nothing else. With heterogeneous field types there is no
+  coherent single `(next, prev)`, and the dominant real-world use
+  (recompute/derive) never reads the payload.
+- **Coalesced dispatch:** when several watched fields change in the
+  same reactive flush, the handler runs **once**, deferred to the
+  tick boundary — not once per field.
+
+Both shapes are enforced with spanned compile errors, extending the
+PR #279 contract (a mismatched watch handler is never silently
+skipped).
+
+## Motivation
+
+The motivating shape appears verbatim in application code (the event
+editor's When control) — eight watch handlers, all identical:
+
+```rust
+#[watch(preset)]
+fn on_preset(&mut self, _next: WhenPreset, _prev: Option<WhenPreset>) {
+    self.recompute();
+}
+#[watch(mode)]
+fn on_mode(&mut self, _next: WhenMode, _prev: Option<WhenMode>) {
+    self.recompute();
+}
+#[watch(start_date)]
+fn on_start_date(&mut self, _next: Option<DateValue>, _prev: Option<Option<DateValue>>) {
+    self.recompute();
+}
+// … five more, byte-identical except the field name and types
+```
+
+Problems with the status quo:
+
+1. **Boilerplate scales linearly** with the field count, and every
+   handler's `(next, prev)` types must be kept in sync with the
+   struct — the payload is dead weight (`_next`, `_prev`) in every
+   one of them. This is also exactly the boilerplate that produced
+   the original no-arg-watch bug class PR #279 hardened against:
+   authors trimmed the unused args and the watch silently died.
+2. **Redundant recomputation.** A preset change that rewrites
+   `start_*` and `end_*` in one handler currently re-runs
+   `recompute()` up to eight times in a single flush — once per
+   per-field watch. The work is idempotent, so it's waste, not a
+   bug, but it's waste the author cannot avoid today.
+
+## Design
+
+### Attribute grammar
+
+`#[watch(...)]` takes a comma-separated list of **field idents** —
+the same tokens the single-field form takes today, one or more of
+them. No new vocabulary:
+
+- `#[watch(field)]` — unchanged, typed contract.
+- `#[watch(a, b, c)]` — multi-field, payload-less contract.
+
+The `Either::Of3(a, b, c)` spelling considered during design is
+rejected: it introduces arity-suffixed variants (`Of2`…`OfN`), it
+looks like a Rust path expression but is checked by nothing, and it
+expresses nothing a comma list doesn't.
+
+### Handler contracts (compile-enforced)
+
+| List arity | Required signature | Rationale |
+|---|---|---|
+| 1 | `fn f(&mut self, next: V, prev: Option<V>)` | unchanged (RFC-026 / PR #279) |
+| ≥ 2 | `fn f(&mut self)` | no single `(next, prev)` exists; the coalesced call has no one triggering value |
+
+Mismatches are spanned compile errors, symmetric with the PR #279
+messages:
+
+- `#[watch(a, b)]` on a handler with value args →
+  ``multi-field #[watch] handlers take `&mut self` only — the
+  coalesced call has no single (next, prev); read the fields off
+  self``
+- `#[watch(a)]` on a no-arg handler → the existing
+  ``#[watch(a)] handler must take `&mut self` and `(next: V,
+  prev: Option<V>)`…`` error, now with a trailing hint: ``…or list
+  every watched field: #[watch(a, b)] with a no-arg handler``.
+- Stacked `#[watch(a)] #[watch(b)]` attributes remain an error; the
+  message points at the list form.
+- Duplicate idents in one list (`#[watch(a, a)]`) are an error.
+
+### Dispatch semantics
+
+- **Coalescing:** the macro installs one subscription per listed
+  field, all sharing a pending cell + generation ticket (the same
+  mechanism the single-field install already uses for its initial
+  seed). The first triggering field in a flush schedules the handler
+  via `tick::next`; subsequent triggers in the same flush bump the
+  ticket and stay collapsed into that one scheduled call.
+- **Initial seed:** parity with single-field watch — one coalesced
+  initial invocation after `on_ready` wiring, regardless of how many
+  fields are listed. (For the motivating component this replaces the
+  manual `recompute()` seed in `on_mount`.)
+- **Ordering:** relative order between a multi-field handler and
+  single-field handlers on the same flush is unspecified, same as
+  between any two watches today.
+- **Reentrancy/borrow:** the handler is invoked through the same
+  `Handle::new(...).update(...)` path as single-field watches, so the
+  `&mut self` acquisition and the tick-deferred initial call keep the
+  RFC-026 guarantees.
+
+### Core primitive
+
+The typed install (`watch_scope_field_now::<V>`) needs `V`, which the
+`#[handlers]` macro cannot know for arbitrary fields (it sees only
+the impl block; the typed single-field form recovers `V` from the
+handler's own signature). Multi-field watch needs a **payload-less
+subscription**: `pocopine-core` grows a
+`watch_scope_field_changed(scope, name, cb)` primitive — same dirty
+propagation as the typed watch (including the RFC-044 dual-key
+container triggering), no value read, no downcast. Per the
+core-owns-engines rule this lands in `pocopine-core`;
+`pocopine-macros` stays a thin consumer.
+
+## Alternative considered: group the fields and watch the container
+
+RFC-044 §5.10.5 already supports this today:
+
+```rust
+#[prop(flatten)]
+common: WhenFields,        // one struct holding the eight fields
+
+#[watch(common)]
+fn on_common(&mut self, next: WhenFields, _prev: Option<WhenFields>) {
+    self.recompute();
+}
+```
+
+Dual-key triggering fires the container watch whenever any leaf
+changes, and this remains the **right answer when the group is a
+real domain object** — a value the component receives or exposes as
+a unit.
+
+It is the wrong general answer for the motivating case:
+
+- The eight fields are **internal editor state** bound via
+  `pp-model` — flatten is prop machinery; regrouping forces the
+  fields into the component's prop surface just to satisfy a watch.
+- Every template binding and every Rust access site churns
+  (`start_time` → `common.start_time`), i.e. the watch tail wags the
+  data-model dog.
+- The container watch delivers a cloned struct payload per leaf
+  change; the recompute pattern throws it away.
+
+The RFC therefore adds the list form and keeps container-watch as
+the documented alternative; the guide gets a "which one when" note.
+
+## Non-goals
+
+- **Per-field payloads in multi-watch** (an enum of
+  `WhichField(next, prev)` variants). Codegen-heavy, and every known
+  consumer ignores the payload. A handler that needs the values reads
+  them off `self`; one that needs *which* field changed should use
+  single-field watches — that need is the signal the fields have
+  diverging behavior.
+- **Watching computed fields or cross-scope fields** — same
+  restrictions as single-field `#[watch]`.
+- **Predicates/filters** (`#[watch(a, if = ...)]`) — out of scope.
+
+## Compatibility
+
+Purely additive. Every existing `#[watch(field)]` compiles
+unchanged. The PR #279 hardening errors gain one hint line. The
+motivating component collapses eight handlers plus a manual seed
+into one three-line handler, and stops running `recompute()` eight
+times per preset change.
+
+## Open questions
+
+1. Should the coalesced handler also be the vehicle for a future
+   `#[watch(*)]`/whole-state watch? (Deliberately unanswered; the
+   list form neither enables nor blocks it.)
+2. Cap on list length? None proposed — the install cost is linear
+   and small.


### PR DESCRIPTION
## Origin

A no-arg `#[watch]` handler compiled green but was never installed — the watch silently never fired (cost a long downstream debug session in AkDateRange, where all seven watch handlers were no-arg and the event editor ignored every edit). Auditing the macro crate for the same class found it everywhere: RFC-058 Phase 6.5 retired the runtime `pp-*` dispatch, but the template classifier still treated \"Preserved\" as a runtime fallback, so misspelled directives, unparseable expressions, wrong-host structural directives, dead listener modifiers, and ignored macro arguments all compiled green as dead markup/config.

## What this does

**`#[handlers]`** — malformed `#[watch]` (no args, missing `prev`, no receiver, bare/non-ident attr args, stacked attrs), receiver-less lifecycle-named methods, and `#[computed(args)]` are now spanned compile errors.

**Template plan** — registry-backed diagnostics (with did-you-mean suggestions, shared with the LSP registry) for: unknown `pp-*` heads on native and component hosts; template-only/component-only host violations (`<div pp-if>` rendered unconditionally before); `pp-for` syntax/expression errors; `pp-teleport` misuse; junk/empty `pp-stagger`; bind arg modifiers; empty `pp-ref`; empty/unparseable `pp-model` values; `pp-model:<prop>` on native inputs; `pp-model` modifiers on component hosts (the component install path drops them); and listener modifiers that install but can never fire — validation mirrors the runtime exactly (key filters require `KeyboardEvent`, so system keys/named keys/word keys are keyboard-only; debounce ms pairs positionally; near-miss typos like `.prevnt`/`.arrow_up` get suggestions).

**JS equality is lenient, per request**: `===`/`!==` outside string literals desugars to `==`/`!=` with a deprecated-const build warning, in directive expressions and `{{ }}` interpolations. Everything else is a hard error.

**Effect-only listeners are now a real feature**: `@pointerdown.stop` / `@mousedown.prevent` with no handler installs its modifiers with no evaluation step (`on::install` takes `Option<ast>`, with an install-time plan-failure backstop). Pine's own dropdown/popover triggers used this idiom — it had been silently dead.

**Macro args** — duplicate `#[component(...)]` keys, non-boolean `unchecked_paths`, duplicate `#[job]` queue/retries (incl. the `retries`/`max_retries` alias conflict), `#[prop(...)]` args in `#[derive(Props)]`, and `#[server(idempotent)]` on streaming fns are all errors now.

## Latent bugs the new errors flushed out (fixed here)

- 4 dead effect-only listeners: pine dropdown/popover triggers, richtext editor + task item
- 3 dead `===` bindings: PineUploadItem `aria-busy`, CalendarDemo `data-active` ×2
- 4 dead `pp-model:value` on native inputs: field/fieldset/form/calendar demos

## Tests

TDD throughout: three new trybuild harnesses (`handlers_contract_ui`, `macro_args_contract_ui`, extended `template_plan_diagnostics_ui`) with 17 fixtures pinning our `compile_error!` text, plus ~20 new unit tests in `template_plan.rs` covering every diagnostic and the desugar/warning paths. Gates: `cargo fmt --check`, CI's exact wasm+host clippy matrix (`-D warnings`), host suites, and the pocopine-core wasm battery — all green.

## Notes for reviewers

- `tests/ui/tp_pass.rs` (`template_paths_ui`) is red on main before this branch (pre-existing #277 fallout: the branch-roots check rejects that fixture's two-root `pp-for` body). Left untouched.
- `codex exec review` was quota-blocked mid-run; substituted with a multi-agent adversarial review (21 agents), whose 10 confirmed findings — mostly shapes the first validator draft blessed that the runtime still kills — are fixed in the final commit. Worth re-running Codex when credits reset.
- Known residual gap, documented in code: word-shaped key typos on keyboard events beyond edit-distance 1 (`@keydown.entr`) remain legal key filters — indistinguishable from genuine literal keys.