### PR TITLE
feat: RFC-115 — multi-field watch + flush-cascade cycle guard

### DIFF
--- a/crates/pocopine-core/src/lib.rs
+++ b/crates/pocopine-core/src/lib.rs
@@ -148,5 +148,5 @@ pub use templates::{
 };
 pub use watch::{
     watch, watch_field, watch_field_scoped, watch_scope_field, watch_scope_field_now,
-    watch_scope_field_scoped, watch_scoped,
+    watch_scope_field_scoped, watch_scope_fields, watch_scoped,
 };

--- a/crates/pocopine-core/src/reactive.rs
+++ b/crates/pocopine-core/src/reactive.rs
@@ -244,6 +244,18 @@ pub fn set_effect_label(id: EffectId, label: &'static str) {
     let _ = with_effect_mut(id, |e| e.label = Some(label));
 }
 
+/// RFC-115 — remove an effect from the pending flush queue. Echo
+/// suppression for payload-less multi-field watches: the handler's
+/// own dirty sweep conservatively re-triggers keys it observed, and
+/// without a value gate that echo would re-fire the handler forever.
+/// `shift_remove` keeps the surviving queue order (RFC-098 H4).
+#[doc(hidden)]
+pub fn dequeue_effect(id: EffectId) {
+    QUEUE.with(|q| {
+        q.borrow_mut().shift_remove(&id);
+    });
+}
+
 /// Allocate a fresh `SignalId`. Signals share the id pool with scopes
 /// so numeric ids are globally unique across the runtime.
 pub fn next_signal_id() -> SignalId {

--- a/crates/pocopine-core/src/reactive.rs
+++ b/crates/pocopine-core/src/reactive.rs
@@ -75,6 +75,10 @@ struct EffectEntry {
     /// this effect subscribes to, so `clear_deps_for` is O(deps).
     /// Order is never observed, so a plain `HashSet` is right.
     deps: HashSet<SignalId>,
+    /// RFC-115 — diagnostic label for the cycle-guard report. Watch
+    /// installers stamp the watched field name here so a runaway
+    /// update loop names the field, not just an effect id.
+    label: Option<&'static str>,
 }
 
 /// Runtime configuration for an effect. See [`effect_with`].
@@ -129,6 +133,12 @@ thread_local! {
     // were queued; set semantics still dedupe an effect a single
     // dispatch queues twice.
     static QUEUE: RefCell<IndexSet<EffectId>> = RefCell::new(IndexSet::new());
+
+    // RFC-115 cycle guard — per-effect run counts within one
+    // uninterrupted flush cascade (consecutive flush passes where
+    // each pass was scheduled by the previous one). Cleared when a
+    // pass ends with an empty queue, i.e. the cascade settled.
+    static CASCADE_RUNS: RefCell<HashMap<EffectId, u32>> = RefCell::new(HashMap::new());
     static FLUSH_SCHEDULED: Cell<bool> = const { Cell::new(false) };
     static BATCHING: Cell<u32> = const { Cell::new(0) };
     static AUTO_FLUSH: Cell<bool> = const { Cell::new(true) };
@@ -223,6 +233,13 @@ fn with_effect_mut<R>(id: EffectId, f: impl FnOnce(&mut EffectEntry) -> R) -> Op
     })
 }
 
+/// RFC-115 — attach a diagnostic label to an effect for the
+/// cycle-guard report. Watch installers pass the watched field name.
+/// No-op on a stale id.
+pub fn set_effect_label(id: EffectId, label: &'static str) {
+    let _ = with_effect_mut(id, |e| e.label = Some(label));
+}
+
 /// Allocate a fresh `SignalId`. Signals share the id pool with scopes
 /// so numeric ids are globally unique across the runtime.
 pub fn next_signal_id() -> SignalId {
@@ -297,6 +314,7 @@ fn effect_with_dyn(f: EffectFn, opts: EffectOptions) -> EffectId {
             scheduler,
             cleanups: Vec::new(),
             deps: HashSet::new(),
+            label: None,
         });
         pack_effect_id(slot, generation)
     });
@@ -755,12 +773,47 @@ fn schedule_flush() {
     });
 }
 
+/// RFC-115 — maximum re-runs of one effect within a single flush
+/// cascade before it is reported and suppressed. Matches the
+/// Vue/Svelte "maximum recursive updates" convention.
+const MAX_EFFECT_RERUNS_PER_CASCADE: u32 = 100;
+
 fn flush() {
     FLUSH_SCHEDULED.with(|f| f.set(false));
     // Snapshot and clear so effects that re-trigger during their run land
     // in the next batch, not the current one.
     let ids: Vec<EffectId> = QUEUE.with(|q| q.borrow_mut().drain(..).collect());
     for id in ids {
+        // RFC-115 cycle guard — a divergent self-write (an effect
+        // re-writing its own dependency with a new value every run)
+        // re-queues itself every pass and would chain microtask
+        // flushes forever: a silent hang. Count runs per cascade;
+        // past the cap, report loudly and skip the run. Skipping
+        // stops the self-requeue, so the cascade settles and the
+        // counter resets — the next external trigger fires normally.
+        let runs = CASCADE_RUNS.with(|c| {
+            let mut c = c.borrow_mut();
+            let n = c.entry(id).or_insert(0);
+            *n += 1;
+            *n
+        });
+        if runs > MAX_EFFECT_RERUNS_PER_CASCADE {
+            if runs == MAX_EFFECT_RERUNS_PER_CASCADE + 1 {
+                let label = with_effect(id, |e| e.label).flatten();
+                let what = match label {
+                    Some(field) => format!("the watch on field `{field}`"),
+                    None => format!("effect {:?}", id),
+                };
+                web_sys::console::error_1(&wasm_bindgen::JsValue::from_str(&format!(
+                    "pocopine: maximum recursive effect re-runs \
+                     ({MAX_EFFECT_RERUNS_PER_CASCADE}) exceeded — {what} keeps \
+                     re-writing its own dependency with a new value (divergent \
+                     update cycle). It is suppressed until the next external \
+                     change; fix the handler so its writes reach a fixpoint."
+                )));
+            }
+            continue;
+        }
         // Clone the body out (Rc bump) and drop the slab borrow before
         // running it. A `None` means the effect was released after it
         // was queued — skip it.
@@ -769,6 +822,13 @@ fn flush() {
             run_effect(id, &body);
         }
     }
+    // Cascade boundary: nothing re-queued during this pass, so the
+    // next flush is externally triggered — reset the run counters.
+    QUEUE.with(|q| {
+        if q.borrow().is_empty() {
+            CASCADE_RUNS.with(|c| c.borrow_mut().clear());
+        }
+    });
 }
 
 /// Force-rerun a specific effect right now. Used by primitives like

--- a/crates/pocopine-core/src/reactive.rs
+++ b/crates/pocopine-core/src/reactive.rs
@@ -136,9 +136,13 @@ thread_local! {
 
     // RFC-115 cycle guard — per-effect run counts within one
     // uninterrupted flush cascade (consecutive flush passes where
-    // each pass was scheduled by the previous one). Cleared when a
-    // pass ends with an empty queue, i.e. the cascade settled.
+    // each pass was scheduled by the previous one). Cleared when the
+    // OUTERMOST pass ends with an empty queue, i.e. the cascade
+    // settled; `FLUSH_DEPTH` guards against a nested `flush_sync`
+    // (an effect draining the queue mid-run, before its own write)
+    // declaring the cascade over and defeating the cap.
     static CASCADE_RUNS: RefCell<HashMap<EffectId, u32>> = RefCell::new(HashMap::new());
+    static FLUSH_DEPTH: Cell<u32> = const { Cell::new(0) };
     static FLUSH_SCHEDULED: Cell<bool> = const { Cell::new(false) };
     static BATCHING: Cell<u32> = const { Cell::new(0) };
     static AUTO_FLUSH: Cell<bool> = const { Cell::new(true) };
@@ -780,6 +784,7 @@ const MAX_EFFECT_RERUNS_PER_CASCADE: u32 = 100;
 
 fn flush() {
     FLUSH_SCHEDULED.with(|f| f.set(false));
+    FLUSH_DEPTH.with(|d| d.set(d.get() + 1));
     // Snapshot and clear so effects that re-trigger during their run land
     // in the next batch, not the current one.
     let ids: Vec<EffectId> = QUEUE.with(|q| q.borrow_mut().drain(..).collect());
@@ -804,12 +809,17 @@ fn flush() {
                     Some(field) => format!("the watch on field `{field}`"),
                     None => format!("effect {:?}", id),
                 };
+                // Phrased as "re-ran without settling", not "keeps
+                // re-writing": in a fan-out graph the read-only
+                // observers of a divergent signal cap out too, and
+                // they never wrote anything — the writer is only the
+                // *typical* culprit, somewhere in the same cascade.
                 web_sys::console::error_1(&wasm_bindgen::JsValue::from_str(&format!(
-                    "pocopine: maximum recursive effect re-runs \
-                     ({MAX_EFFECT_RERUNS_PER_CASCADE}) exceeded — {what} keeps \
-                     re-writing its own dependency with a new value (divergent \
-                     update cycle). It is suppressed until the next external \
-                     change; fix the handler so its writes reach a fixpoint."
+                    "pocopine: {what} re-ran {MAX_EFFECT_RERUNS_PER_CASCADE} times \
+                     within a single update cascade without settling — a divergent \
+                     update cycle (typically a handler in this cascade writing a \
+                     watched field with a new value every run). The effect is \
+                     suppressed until the next external change."
                 )));
             }
             continue;
@@ -822,13 +832,23 @@ fn flush() {
             run_effect(id, &body);
         }
     }
+    let depth = FLUSH_DEPTH.with(|d| {
+        let v = d.get() - 1;
+        d.set(v);
+        v
+    });
     // Cascade boundary: nothing re-queued during this pass, so the
     // next flush is externally triggered — reset the run counters.
-    QUEUE.with(|q| {
-        if q.borrow().is_empty() {
-            CASCADE_RUNS.with(|c| c.borrow_mut().clear());
-        }
-    });
+    // Outermost pass only: a nested `flush_sync` mid-effect runs
+    // before that effect's self-write and would otherwise see an
+    // empty queue and reset the counters every pass.
+    if depth == 0 {
+        QUEUE.with(|q| {
+            if q.borrow().is_empty() {
+                CASCADE_RUNS.with(|c| c.borrow_mut().clear());
+            }
+        });
+    }
 }
 
 /// Force-rerun a specific effect right now. Used by primitives like

--- a/crates/pocopine-core/src/watch.rs
+++ b/crates/pocopine-core/src/watch.rs
@@ -134,6 +134,47 @@ where
     id
 }
 
+/// RFC-115 — one payload-less subscription across several named
+/// fields of one scope (`#[watch(a, b, c)]`).
+///
+/// The single effect tracks every listed field and invokes `cb` when
+/// any of them fires. Coalescing is scheduler-native: same-flush
+/// triggers on several listed fields queue the effect once (RFC-098
+/// H4 queue dedup), so `cb` runs once per flush pass — and because
+/// the handler runs inside the flush, the flush-cascade cycle guard
+/// bounds divergence like any other queued effect.
+///
+/// Unlike the typed single-field watch there is **no `PartialEq`
+/// gate**: `cb` runs on any write to a listed field, including a
+/// write of an unchanged value. Multi-field consumers are
+/// recompute-style and idempotent by contract.
+///
+/// The install run invokes `cb` once — the coalesced initial seed
+/// (parity with the single-field initial call). `label` feeds the
+/// cycle-guard report; the macro passes the joined field list.
+#[doc(hidden)]
+pub fn watch_scope_fields<C>(
+    scope_id: ScopeId,
+    fields: &'static [&'static str],
+    label: &'static str,
+    cb: C,
+) -> EffectId
+where
+    C: Fn() + 'static,
+{
+    let id = effect(move || {
+        if Scope::find(scope_id).is_none() {
+            return;
+        }
+        for field in fields {
+            track(scope_id, field);
+        }
+        cb();
+    });
+    crate::reactive::set_effect_label(id, label);
+    id
+}
+
 /// Scope-bound counterpart to [`watch`] — installs the watcher and
 /// registers a cleanup against the current scope's unmount, so the
 /// effect is released automatically when the component goes away.

--- a/crates/pocopine-core/src/watch.rs
+++ b/crates/pocopine-core/src/watch.rs
@@ -127,7 +127,11 @@ where
     V: Clone + PartialEq + Default + DeserializeOwned + 'static,
     C: Fn(&V, Option<&V>) + 'static,
 {
-    watch(move || read_scope_field::<V>(scope_id, field), cb)
+    let id = watch(move || read_scope_field::<V>(scope_id, field), cb);
+    // RFC-115 — the cycle-guard report names the watched field
+    // instead of a bare effect id.
+    crate::reactive::set_effect_label(id, field);
+    id
 }
 
 /// Scope-bound counterpart to [`watch`] — installs the watcher and

--- a/crates/pocopine-core/src/watch.rs
+++ b/crates/pocopine-core/src/watch.rs
@@ -11,7 +11,7 @@
 //! with `Handle::with` is that it doesn't go through the proxy, so the
 //! watch silently never fires).
 
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
 use serde::de::DeserializeOwned;
@@ -137,21 +137,37 @@ where
 /// RFC-115 — one payload-less subscription across several named
 /// fields of one scope (`#[watch(a, b, c)]`).
 ///
-/// The single effect tracks every listed field and invokes `cb` when
-/// any of them fires. Coalescing is scheduler-native: same-flush
-/// triggers on several listed fields queue the effect once (RFC-098
-/// H4 queue dedup), so `cb` runs once per flush pass — and because
-/// the handler runs inside the flush, the flush-cascade cycle guard
-/// bounds divergence like any other queued effect.
+/// One effect tracks every listed field and invokes `cb` when any of
+/// them fires. Coalescing is scheduler-native: same-flush triggers on
+/// several listed fields queue the effect once (RFC-098 H4 queue
+/// dedup), so `cb` runs once per flush pass — and because the handler
+/// runs inside the flush, the flush-cascade cycle guard bounds it
+/// like any other queued effect.
 ///
-/// Unlike the typed single-field watch there is **no `PartialEq`
-/// gate**: `cb` runs on any write to a listed field, including a
-/// write of an unchanged value. Multi-field consumers are
-/// recompute-style and idempotent by contract.
+/// The payload-less form has no `PartialEq` value gate, so three
+/// guards replace it:
 ///
-/// The install run invokes `cb` once — the coalesced initial seed
-/// (parity with the single-field initial call). `label` feeds the
-/// cycle-guard report; the macro passes the joined field list.
+/// - **Install validation** — a listed key that isn't a state field
+///   (a typo) or is a `#[computed]` key is reported on the console
+///   and NOT tracked: a tracked key with no fingerprint arm is
+///   conservatively re-triggered by every dirty sweep on the scope,
+///   which would re-fire this handler on every unrelated update.
+/// - **Provably-unchanged skip** — each run probes the listed
+///   fields' quick-lens + fingerprints; when every probe proves
+///   "unchanged" the callback is skipped. A `None` fingerprint
+///   proves nothing, so those runs stay conservative.
+/// - **Echo suppression** — the handler's own dirty sweep
+///   conservatively re-triggers keys it observed; after `cb` returns
+///   the effect dequeues itself, so a handler's own writes (and
+///   sweep echoes) never re-fire it. Multi-field handlers react to
+///   external changes only — recompute output can't re-invalidate
+///   its own input set.
+///
+/// The initial seed runs once, deferred one tick: the install
+/// typically happens behind `on_ready`'s live borrow, and the seed
+/// callback usually re-enters the scope via `Handle::update`.
+/// `label` feeds the cycle-guard report; the macro passes the joined
+/// field list.
 #[doc(hidden)]
 pub fn watch_scope_fields<C>(
     scope_id: ScopeId,
@@ -162,15 +178,128 @@ pub fn watch_scope_fields<C>(
 where
     C: Fn() + 'static,
 {
-    let id = effect(move || {
-        if Scope::find(scope_id).is_none() {
-            return;
+    let cb: Rc<dyn Fn()> = Rc::new(cb);
+    // Validate once at install — reject keys the sweep can never
+    // prove unchanged (see doc above). Loud, not silent: RFC-115.
+    let tracked: Rc<Vec<&'static str>> = Rc::new(match Scope::find(scope_id) {
+        Some(scope) => {
+            let state = scope.state.borrow();
+            fields
+                .iter()
+                .copied()
+                .filter(|f| {
+                    if !state.keys().contains(f) {
+                        web_sys::console::error_1(&wasm_bindgen::JsValue::from_str(&format!(
+                            "pocopine: #[watch] field `{f}` does not exist on this \
+                             component — it is ignored (check the field list for typos)"
+                        )));
+                        false
+                    } else if state.is_computed_field(f) {
+                        web_sys::console::error_1(&wasm_bindgen::JsValue::from_str(&format!(
+                            "pocopine: #[watch] field `{f}` is a #[computed] key — \
+                             computed fields can't be watched; watch their inputs \
+                             instead. It is ignored."
+                        )));
+                        false
+                    } else {
+                        true
+                    }
+                })
+                .collect()
         }
-        for field in fields {
-            track(scope_id, field);
-        }
-        cb();
+        None => fields.to_vec(),
     });
+
+    type Probes = Vec<(Option<u64>, Option<u64>)>;
+    fn probe(scope_id: ScopeId, tracked: &[&'static str]) -> Option<Probes> {
+        let scope = Scope::find(scope_id)?;
+        let state = scope.state.borrow();
+        Some(
+            tracked
+                .iter()
+                .map(|f| (state.field_quick_len(f), state.field_fingerprint(f)))
+                .collect(),
+        )
+    }
+    fn provably_unchanged(prev: &Option<Probes>, now: &Option<Probes>) -> bool {
+        match (prev, now) {
+            (Some(prev), Some(now)) => {
+                prev.len() == now.len()
+                    && prev.iter().zip(now).all(|((pl, pf), (nl, nf))| {
+                        pl == nl && matches!((pf, nf), (Some(a), Some(b)) if a == b)
+                    })
+            }
+            _ => false,
+        }
+    }
+
+    let seed_pending = Rc::new(Cell::new(true));
+    let seed_ticket = Rc::new(Cell::new(0_u64));
+    let self_id: Rc<Cell<Option<EffectId>>> = Rc::new(Cell::new(None));
+    let prev_probes: Rc<RefCell<Option<Probes>>> = Rc::new(RefCell::new(None));
+
+    let id = effect({
+        let cb = cb.clone();
+        let tracked = tracked.clone();
+        let seed_pending = seed_pending.clone();
+        let seed_ticket = seed_ticket.clone();
+        let self_id = self_id.clone();
+        let prev_probes = prev_probes.clone();
+        move || {
+            if Scope::find(scope_id).is_none() {
+                return;
+            }
+            for field in tracked.iter() {
+                track(scope_id, field);
+            }
+            let now = probe(scope_id, &tracked);
+            if seed_pending.get() {
+                // Coalesced initial seed, deferred one microtask —
+                // the install runs behind on_ready's live borrow and
+                // the seed re-enters the scope via `Handle::update`.
+                // Scheduled via `spawn_local` (the same cross-host
+                // microtask the flush scheduler uses) rather than
+                // `tick::next`, which needs a `window` and silently
+                // no-ops in windowless hosts.
+                let ticket = seed_ticket.get() + 1;
+                seed_ticket.set(ticket);
+                let pending = seed_pending.clone();
+                let tickets = seed_ticket.clone();
+                let cb = cb.clone();
+                let tracked = tracked.clone();
+                let self_id = self_id.clone();
+                let prev_probes = prev_probes.clone();
+                wasm_bindgen_futures::spawn_local(async move {
+                    let _ = wasm_bindgen_futures::JsFuture::from(js_sys::Promise::resolve(
+                        &wasm_bindgen::JsValue::NULL,
+                    ))
+                    .await;
+                    if !pending.get() || tickets.get() != ticket {
+                        return;
+                    }
+                    pending.set(false);
+                    cb();
+                    *prev_probes.borrow_mut() = probe(scope_id, &tracked);
+                    if let Some(me) = self_id.get() {
+                        crate::reactive::dequeue_effect(me);
+                    }
+                });
+                return;
+            }
+            if provably_unchanged(&prev_probes.borrow(), &now) {
+                return;
+            }
+            cb();
+            // Re-probe after the callback so its own writes don't
+            // read as an external change on the next run, and drop
+            // the sweep echo our own run just queued.
+            *prev_probes.borrow_mut() = probe(scope_id, &tracked);
+            if let Some(me) = self_id.get() {
+                crate::reactive::dequeue_effect(me);
+            }
+        }
+    });
+    self_id.set(Some(id));
     crate::reactive::set_effect_label(id, label);
     id
 }

--- a/crates/pocopine-core/tests/effect_cycle_guard.rs
+++ b/crates/pocopine-core/tests/effect_cycle_guard.rs
@@ -71,6 +71,40 @@ fn divergent_effect_is_capped_and_recovers_after_the_cascade() {
     set_auto_flush(true);
 }
 
+/// Codex P1 regression: an effect that drains the queue itself
+/// (nested `flush_sync`) before its self-write used to reset the
+/// cascade counters mid-cascade — the nested flush saw an empty
+/// queue and declared the cascade settled, so the divergent loop ran
+/// unbounded again. Only the outermost flush may clear the counters.
+#[wasm_bindgen_test]
+fn reentrant_flush_does_not_reset_the_cascade_counter() {
+    set_auto_flush(false);
+    let (s, set) = signal(0u32);
+    let runs = Rc::new(Cell::new(0u32));
+
+    let r = runs.clone();
+    let set_inner = set.clone();
+    effect(move || {
+        let v = s.get();
+        r.set(r.get() + 1);
+        // Drain the (empty) queue mid-run, then self-write.
+        flush_sync();
+        set_inner.set(v + 1);
+    });
+    assert_eq!(runs.get(), 1);
+
+    for _ in 0..300 {
+        flush_sync();
+    }
+    assert_eq!(
+        runs.get(),
+        1 + 100,
+        "a nested flush inside the effect must not reset the cascade counter"
+    );
+
+    set_auto_flush(true);
+}
+
 struct CounterState {
     n: u32,
 }

--- a/crates/pocopine-core/tests/effect_cycle_guard.rs
+++ b/crates/pocopine-core/tests/effect_cycle_guard.rs
@@ -1,0 +1,165 @@
+//! RFC-115 cycle guard — a divergent self-writing effect (each run
+//! writes a new value into its own dependency) used to re-queue
+//! forever: a silent hang with no diagnostic. The scheduler now caps
+//! re-runs per uninterrupted flush cascade at 100 (the Vue/Svelte
+//! convention), reports the runaway effect loudly, and suppresses it
+//! until the next external trigger.
+//!
+//! Driven deterministically: auto-flush off, each `flush_sync` call
+//! runs one flush pass; effects re-triggered during a pass land in
+//! the next one, so a cascade is a run of consecutive non-empty
+//! passes.
+
+#![cfg(target_arch = "wasm32")]
+
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+use js_sys::Array;
+use pocopine_core::reactive::{effect, flush_sync, set_auto_flush, trigger};
+use pocopine_core::signal::signal;
+use pocopine_core::{ComponentState, Scope, watch_scope_field_now};
+use wasm_bindgen::JsValue;
+use wasm_bindgen_test::wasm_bindgen_test;
+
+#[wasm_bindgen_test]
+fn divergent_effect_is_capped_and_recovers_after_the_cascade() {
+    set_auto_flush(false);
+    let (s, set) = signal(0u32);
+    let runs = Rc::new(Cell::new(0u32));
+
+    let r = runs.clone();
+    let set_inner = set.clone();
+    effect(move || {
+        let v = s.get();
+        r.set(r.get() + 1);
+        // Divergent self-write: a new value every run, so the
+        // equality gate in `watch()`-style consumers would never
+        // save us — this is the raw runaway shape.
+        set_inner.set(v + 1);
+    });
+    // The install run happens synchronously and queues the first
+    // flush-driven re-run.
+    let after_install = runs.get();
+    assert_eq!(after_install, 1);
+
+    // Drive far past the cap. Without the guard this loop never
+    // settles (every pass re-queues the effect); with it, the effect
+    // runs exactly 100 more times and is then suppressed, which ends
+    // the cascade.
+    for _ in 0..300 {
+        flush_sync();
+    }
+    assert_eq!(
+        runs.get(),
+        after_install + 100,
+        "divergent effect must be capped at 100 re-runs per cascade"
+    );
+
+    // The cascade ended, so the counter reset: an external write is a
+    // fresh cascade and the effect fires again (and is capped again).
+    set.set(9_999);
+    for _ in 0..300 {
+        flush_sync();
+    }
+    assert_eq!(
+        runs.get(),
+        after_install + 200,
+        "suppression must lift once the cascade ends"
+    );
+
+    set_auto_flush(true);
+}
+
+struct CounterState {
+    n: u32,
+}
+
+impl ComponentState for CounterState {
+    fn get(&self, key: &str) -> JsValue {
+        match key {
+            "n" => JsValue::from_f64(self.n as f64),
+            _ => JsValue::UNDEFINED,
+        }
+    }
+
+    fn set(&mut self, key: &str, value: JsValue) {
+        if key == "n" {
+            self.n = value.as_f64().unwrap_or(0.0) as u32;
+        }
+    }
+
+    fn keys(&self) -> &'static [&'static str] {
+        &["n"]
+    }
+
+    fn invoke(&mut self, _key: &str, _args: &Array) -> JsValue {
+        JsValue::UNDEFINED
+    }
+}
+
+/// The `#[watch(field)]`-shaped path: a scope-field watch whose
+/// callback writes the watched field back with a new value — the
+/// exact runaway RFC-115 describes. Also exercises the field label
+/// stamped by `watch_scope_field_now` for the guard's report.
+#[wasm_bindgen_test]
+fn divergent_scope_field_watch_is_capped() {
+    set_auto_flush(false);
+    let state = Rc::new(RefCell::new(CounterState { n: 0 }));
+    let scope = Scope::new(state.clone());
+    let sid = scope.id;
+
+    let runs = Rc::new(Cell::new(0u32));
+    let r = runs.clone();
+    let state_w = state.clone();
+    watch_scope_field_now::<u32, _>(sid, "n", move |_next, _prev| {
+        r.set(r.get() + 1);
+        // Divergent self-write, the way a handler would do it:
+        // mutate state, then notify the field signal.
+        state_w.borrow_mut().n += 1;
+        trigger(sid, "n");
+    });
+    // Install runs the callback once (prev = None) and queues the
+    // first flush-driven re-run.
+    assert_eq!(runs.get(), 1);
+
+    for _ in 0..300 {
+        flush_sync();
+    }
+    assert_eq!(
+        runs.get(),
+        1 + 100,
+        "a divergent #[watch]-style handler must be capped per cascade"
+    );
+
+    set_auto_flush(true);
+}
+
+#[wasm_bindgen_test]
+fn external_retriggers_are_not_mistaken_for_a_cycle() {
+    set_auto_flush(false);
+    let (s, set) = signal(0u32);
+    let runs = Rc::new(Cell::new(0u32));
+
+    let r = runs.clone();
+    effect(move || {
+        let _ = s.get();
+        r.set(r.get() + 1);
+    });
+    assert_eq!(runs.get(), 1);
+
+    // 150 external triggers, each its own one-pass cascade — more
+    // than the cap in total, but the counter resets at every cascade
+    // end, so nothing is suppressed.
+    for i in 1..=150u32 {
+        set.set(i);
+        flush_sync();
+    }
+    assert_eq!(
+        runs.get(),
+        1 + 150,
+        "well-behaved effects must never hit the per-cascade cap"
+    );
+
+    set_auto_flush(true);
+}

--- a/crates/pocopine-core/tests/watch_multi.rs
+++ b/crates/pocopine-core/tests/watch_multi.rs
@@ -1,21 +1,38 @@
 //! RFC-115 — `watch_scope_fields`: one payload-less subscription
-//! across several named fields. Coalescing rides the scheduler's
-//! queue dedup (RFC-098 H4): N same-flush triggers queue the effect
-//! once, so the callback runs once per flush pass, and the
-//! flush-cascade cycle guard bounds divergence like any other
-//! queued effect.
+//! across several named fields.
+//!
+//! Semantics pinned here:
+//! - the initial seed runs once, deferred one tick (the install
+//!   typically happens behind `on_ready`'s live borrow);
+//! - same-flush triggers coalesce into one run (RFC-098 H4 queue
+//!   dedup);
+//! - a handler's own writes never re-fire it (echo suppression) —
+//!   the payload-less form has no value gate, so this is what makes
+//!   recompute handlers converge by construction;
+//! - typo'd and `#[computed]` keys are rejected loudly at install
+//!   and never tracked (a tracked key with no fingerprint arm would
+//!   be conservatively re-triggered by every dirty sweep);
+//! - runs whose field probes prove "unchanged" skip the callback.
 
 #![cfg(target_arch = "wasm32")]
 
 use std::cell::{Cell, RefCell};
 use std::rc::Rc;
 
-use js_sys::Array;
+use js_sys::{Array, Promise};
 use pocopine_core::reactive::{flush_sync, set_auto_flush, trigger};
 use pocopine_core::watch::watch_scope_fields;
 use pocopine_core::{ComponentState, Scope};
 use wasm_bindgen::JsValue;
+use wasm_bindgen_futures::JsFuture;
 use wasm_bindgen_test::wasm_bindgen_test;
+
+/// Let queued microtasks (the seed's spawn_local hop) settle.
+async fn settle() {
+    for _ in 0..4 {
+        let _ = JsFuture::from(Promise::resolve(&JsValue::NULL)).await;
+    }
+}
 
 struct RangeState {
     a: u32,
@@ -44,7 +61,22 @@ impl ComponentState for RangeState {
     }
 
     fn keys(&self) -> &'static [&'static str] {
-        &["a", "b", "c"]
+        &["a", "b", "c", "derived"]
+    }
+
+    fn is_computed_field(&self, key: &str) -> bool {
+        key == "derived"
+    }
+
+    // Fingerprint arms for `a`/`b`/`c` — the provably-unchanged
+    // probe gate needs `Some` fingerprints to skip.
+    fn field_fingerprint(&self, key: &str) -> Option<u64> {
+        match key {
+            "a" => Some(self.a as u64),
+            "b" => Some(self.b as u64),
+            "c" => Some(self.c as u64),
+            _ => None,
+        }
     }
 
     fn invoke(&mut self, _key: &str, _args: &Array) -> JsValue {
@@ -59,7 +91,7 @@ fn range_scope() -> (Rc<RefCell<RangeState>>, Scope) {
 }
 
 #[wasm_bindgen_test]
-fn same_flush_triggers_coalesce_into_one_run() {
+async fn seed_defers_one_tick_and_same_flush_triggers_coalesce() {
     set_auto_flush(false);
     let (state, scope) = range_scope();
     let sid = scope.id;
@@ -69,8 +101,11 @@ fn same_flush_triggers_coalesce_into_one_run() {
     watch_scope_fields(sid, &["a", "b", "c"], "a, b, c", move || {
         r.set(r.get() + 1);
     });
-    // Install run = the coalesced initial seed.
-    assert_eq!(runs.get(), 1);
+    // Install must NOT run the callback synchronously — the real
+    // install site is behind on_ready's live borrow.
+    assert_eq!(runs.get(), 0);
+    settle().await;
+    assert_eq!(runs.get(), 1, "the seed runs once, one tick later");
 
     // Three fields written before the flush — one coalesced run.
     state.borrow_mut().a = 1;
@@ -91,16 +126,11 @@ fn same_flush_triggers_coalesce_into_one_run() {
     flush_sync();
     assert_eq!(runs.get(), 4);
 
-    // Unlisted fields don't fire it.
-    trigger(sid, "zzz");
-    flush_sync();
-    assert_eq!(runs.get(), 4);
-
     set_auto_flush(true);
 }
 
 #[wasm_bindgen_test]
-fn divergent_multi_watch_is_bounded_by_the_cycle_guard() {
+async fn self_writes_do_not_refire_the_handler() {
     set_auto_flush(false);
     let (state, scope) = range_scope();
     let sid = scope.id;
@@ -110,20 +140,93 @@ fn divergent_multi_watch_is_bounded_by_the_cycle_guard() {
     let state_w = state.clone();
     watch_scope_fields(sid, &["a", "b"], "a, b", move || {
         r.set(r.get() + 1);
-        // Divergent: every run writes a listed field with a new value.
-        state_w.borrow_mut().a += 1;
+        // Divergent self-write: a new value into a listed field on
+        // every run. Echo suppression must make this converge —
+        // the handler reacts to external changes only.
+        let next = state_w.borrow().a + 1;
+        state_w.borrow_mut().a = next;
         trigger(sid, "a");
     });
-    assert_eq!(runs.get(), 1);
+    settle().await;
+    assert_eq!(runs.get(), 1, "seed runs once");
 
-    for _ in 0..300 {
+    // The seed's own write must not have queued a re-run.
+    for _ in 0..50 {
         flush_sync();
     }
-    assert_eq!(
-        runs.get(),
-        1 + 100,
-        "a divergent multi-field watch must be capped per cascade"
+    assert_eq!(runs.get(), 1, "the seed's self-write must not echo");
+
+    // An external change fires exactly one run, whose self-write is
+    // again suppressed.
+    state.borrow_mut().b = 7;
+    trigger(sid, "b");
+    for _ in 0..50 {
+        flush_sync();
+    }
+    assert_eq!(runs.get(), 2, "external change fires once, no echo");
+
+    set_auto_flush(true);
+}
+
+#[wasm_bindgen_test]
+async fn unknown_and_computed_fields_are_rejected_at_install() {
+    set_auto_flush(false);
+    let (state, scope) = range_scope();
+    let sid = scope.id;
+
+    let runs = Rc::new(Cell::new(0u32));
+    let r = runs.clone();
+    // `nope` is a typo, `derived` is a computed key — both are
+    // reported on the console and never tracked; `a` still works.
+    watch_scope_fields(
+        sid,
+        &["a", "nope", "derived"],
+        "a, nope, derived",
+        move || {
+            r.set(r.get() + 1);
+        },
     );
+    settle().await;
+    assert_eq!(runs.get(), 1);
+
+    trigger(sid, "nope");
+    trigger(sid, "derived");
+    flush_sync();
+    assert_eq!(runs.get(), 1, "rejected keys must not be subscribed");
+
+    state.borrow_mut().a = 5;
+    trigger(sid, "a");
+    flush_sync();
+    assert_eq!(runs.get(), 2, "valid keys keep working");
+
+    set_auto_flush(true);
+}
+
+#[wasm_bindgen_test]
+async fn provably_unchanged_probes_skip_the_callback() {
+    set_auto_flush(false);
+    let (state, scope) = range_scope();
+    let sid = scope.id;
+
+    let runs = Rc::new(Cell::new(0u32));
+    let r = runs.clone();
+    watch_scope_fields(sid, &["a", "b"], "a, b", move || {
+        r.set(r.get() + 1);
+    });
+    settle().await;
+    assert_eq!(runs.get(), 1);
+
+    // A trigger without an actual change: every listed fingerprint
+    // is Some and unchanged, so the callback is skipped.
+    trigger(sid, "a");
+    flush_sync();
+    assert_eq!(runs.get(), 1, "no-change trigger must be skipped");
+
+    // A real change fires.
+    state.borrow_mut().a = 42;
+    trigger(sid, "a");
+    flush_sync();
+    assert_eq!(runs.get(), 2);
 
     set_auto_flush(true);
 }

--- a/crates/pocopine-core/tests/watch_multi.rs
+++ b/crates/pocopine-core/tests/watch_multi.rs
@@ -1,0 +1,129 @@
+//! RFC-115 — `watch_scope_fields`: one payload-less subscription
+//! across several named fields. Coalescing rides the scheduler's
+//! queue dedup (RFC-098 H4): N same-flush triggers queue the effect
+//! once, so the callback runs once per flush pass, and the
+//! flush-cascade cycle guard bounds divergence like any other
+//! queued effect.
+
+#![cfg(target_arch = "wasm32")]
+
+use std::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+use js_sys::Array;
+use pocopine_core::reactive::{flush_sync, set_auto_flush, trigger};
+use pocopine_core::watch::watch_scope_fields;
+use pocopine_core::{ComponentState, Scope};
+use wasm_bindgen::JsValue;
+use wasm_bindgen_test::wasm_bindgen_test;
+
+struct RangeState {
+    a: u32,
+    b: u32,
+    c: u32,
+}
+
+impl ComponentState for RangeState {
+    fn get(&self, key: &str) -> JsValue {
+        match key {
+            "a" => JsValue::from_f64(self.a as f64),
+            "b" => JsValue::from_f64(self.b as f64),
+            "c" => JsValue::from_f64(self.c as f64),
+            _ => JsValue::UNDEFINED,
+        }
+    }
+
+    fn set(&mut self, key: &str, value: JsValue) {
+        let v = value.as_f64().unwrap_or(0.0) as u32;
+        match key {
+            "a" => self.a = v,
+            "b" => self.b = v,
+            "c" => self.c = v,
+            _ => {}
+        }
+    }
+
+    fn keys(&self) -> &'static [&'static str] {
+        &["a", "b", "c"]
+    }
+
+    fn invoke(&mut self, _key: &str, _args: &Array) -> JsValue {
+        JsValue::UNDEFINED
+    }
+}
+
+fn range_scope() -> (Rc<RefCell<RangeState>>, Scope) {
+    let state = Rc::new(RefCell::new(RangeState { a: 0, b: 0, c: 0 }));
+    let scope = Scope::new(state.clone());
+    (state, scope)
+}
+
+#[wasm_bindgen_test]
+fn same_flush_triggers_coalesce_into_one_run() {
+    set_auto_flush(false);
+    let (state, scope) = range_scope();
+    let sid = scope.id;
+
+    let runs = Rc::new(Cell::new(0u32));
+    let r = runs.clone();
+    watch_scope_fields(sid, &["a", "b", "c"], "a, b, c", move || {
+        r.set(r.get() + 1);
+    });
+    // Install run = the coalesced initial seed.
+    assert_eq!(runs.get(), 1);
+
+    // Three fields written before the flush — one coalesced run.
+    state.borrow_mut().a = 1;
+    trigger(sid, "a");
+    state.borrow_mut().b = 2;
+    trigger(sid, "b");
+    state.borrow_mut().c = 3;
+    trigger(sid, "c");
+    flush_sync();
+    assert_eq!(runs.get(), 2, "same-flush triggers must coalesce");
+
+    // Separate flushes fire separately.
+    state.borrow_mut().a = 10;
+    trigger(sid, "a");
+    flush_sync();
+    state.borrow_mut().b = 20;
+    trigger(sid, "b");
+    flush_sync();
+    assert_eq!(runs.get(), 4);
+
+    // Unlisted fields don't fire it.
+    trigger(sid, "zzz");
+    flush_sync();
+    assert_eq!(runs.get(), 4);
+
+    set_auto_flush(true);
+}
+
+#[wasm_bindgen_test]
+fn divergent_multi_watch_is_bounded_by_the_cycle_guard() {
+    set_auto_flush(false);
+    let (state, scope) = range_scope();
+    let sid = scope.id;
+
+    let runs = Rc::new(Cell::new(0u32));
+    let r = runs.clone();
+    let state_w = state.clone();
+    watch_scope_fields(sid, &["a", "b"], "a, b", move || {
+        r.set(r.get() + 1);
+        // Divergent: every run writes a listed field with a new value.
+        state_w.borrow_mut().a += 1;
+        trigger(sid, "a");
+    });
+    assert_eq!(runs.get(), 1);
+
+    for _ in 0..300 {
+        flush_sync();
+    }
+    assert_eq!(
+        runs.get(),
+        1 + 100,
+        "a divergent multi-field watch must be capped per cascade"
+    );
+
+    set_auto_flush(true);
+}

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -4005,7 +4005,13 @@ pub fn handlers(_attr: TokenStream, item: TokenStream) -> TokenStream {
             .into();
         }
         if let Some(fields) = watch_fields {
-            let takes_ref_self = method.sig.receiver().is_some_and(|r| r.reference.is_some());
+            // The documented contract is literally `&mut self` — a shared
+            // receiver compiles but leaves the handler unable to store
+            // its result, so it is rejected too.
+            let takes_mut_self = method
+                .sig
+                .receiver()
+                .is_some_and(|r| r.reference.is_some() && r.mutability.is_some());
             let typed_args: Vec<syn::Type> = method
                 .sig
                 .inputs
@@ -4023,7 +4029,7 @@ pub fn handlers(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 // before this check, a no-arg handler compiled green
                 // and the watch silently never fired.
                 let field_ident = fields.into_iter().next().expect("len checked == 1");
-                if !takes_ref_self || typed_args.len() != 2 {
+                if !takes_mut_self || typed_args.len() != 2 {
                     let method_ident = &method.sig.ident;
                     return syn::Error::new_spanned(
                         &method.sig,
@@ -4051,7 +4057,7 @@ pub fn handlers(_attr: TokenStream, item: TokenStream) -> TokenStream {
                 // RFC-115 — with two-plus fields there is no single
                 // `(next, prev)`; the coalesced call is payload-less
                 // by contract.
-                if !takes_ref_self || !typed_args.is_empty() {
+                if !takes_mut_self || !typed_args.is_empty() {
                     return syn::Error::new_spanned(
                         &method.sig,
                         "multi-field #[watch] handlers take `&mut self` only — the \
@@ -4349,7 +4355,8 @@ pub fn handlers(_attr: TokenStream, item: TokenStream) -> TokenStream {
             field: field_ident,
             v_ty,
         } => {
-            let field_name = field_ident.to_string();
+            // Scope keys are raw-ident-stripped (`r#type` → `type`).
+            let field_name = field_ident.to_string().trim_start_matches("r#").to_string();
             let ty = ty.clone();
             quote! {
                 {
@@ -4409,43 +4416,25 @@ pub fn handlers(_attr: TokenStream, item: TokenStream) -> TokenStream {
             method: method_ident,
             fields,
         } => {
-            let field_names: Vec<String> = fields.iter().map(|f| f.to_string()).collect();
+            // Scope keys are raw-ident-stripped (`r#type` → `type`).
+            // Seed deferral, coalescing, echo suppression, and key
+            // validation all live in `watch_scope_fields` (RFC-115) —
+            // the generated closure is just the dispatch.
+            let field_names: Vec<String> = fields
+                .iter()
+                .map(|f| f.to_string().trim_start_matches("r#").to_string())
+                .collect();
             let label = field_names.join(", ");
             let ty = ty.clone();
             quote! {
                 {
                     let __scope = ::pocopine::current_scope_id()
                         .expect("watch installed outside a lifecycle context");
-                    let __watch_initial_pending =
-                        ::std::rc::Rc::new(::std::cell::Cell::new(true));
-                    let __watch_initial_ticket =
-                        ::std::rc::Rc::new(::std::cell::Cell::new(0_u64));
                     let __watch_effect = ::pocopine::watch_scope_fields(
                         __scope,
                         &[#(#field_names),*],
                         #label,
                         move || {
-                            if __watch_initial_pending.get() {
-                                let __ticket = __watch_initial_ticket.get() + 1;
-                                __watch_initial_ticket.set(__ticket);
-                                let __pending = __watch_initial_pending.clone();
-                                let __tickets = __watch_initial_ticket.clone();
-                                ::pocopine::tick::next(move || {
-                                    if !__pending.get() || __tickets.get() != __ticket {
-                                        return;
-                                    }
-                                    __pending.set(false);
-                                    if let Some(scope) = ::pocopine::Scope::find(__scope) {
-                                        if let Some(inner) = scope.typed::<#ty>() {
-                                            ::pocopine::Handle::new(inner, __scope)
-                                                .update(|s| {
-                                                    s.#method_ident();
-                                                });
-                                        }
-                                    }
-                                });
-                                return;
-                            }
                             if let Some(scope) = ::pocopine::Scope::find(__scope) {
                                 if let Some(inner) = scope.typed::<#ty>() {
                                     ::pocopine::Handle::new(inner, __scope)

--- a/crates/pocopine-macros/src/lib.rs
+++ b/crates/pocopine-macros/src/lib.rs
@@ -3913,10 +3913,23 @@ pub fn handlers(_attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut on_mount_extractor_count: usize = 0;
     let mut on_ready_extractor_count: usize = 0;
     let mut on_unmount_extractor_count: usize = 0;
-    // (method_ident, field_ident, value_type) for each `#[watch(f)]`
-    // method. The macro auto-generates an `on_ready` that wires a
-    // `watch_field` per entry.
-    let mut watches: Vec<(syn::Ident, syn::Ident, syn::Type)> = Vec::new();
+    // One entry per `#[watch(...)]` method. RFC-115: a single field
+    // keeps the typed `(next, prev)` contract; a two-plus list takes
+    // the payload-less `&mut self` shape and installs one coalesced
+    // multi-field subscription. The macro auto-generates an
+    // `on_ready` that wires each entry.
+    enum WatchEntry {
+        Single {
+            method: syn::Ident,
+            field: syn::Ident,
+            v_ty: Box<syn::Type>,
+        },
+        Multi {
+            method: syn::Ident,
+            fields: Vec<syn::Ident>,
+        },
+    }
+    let mut watches: Vec<WatchEntry> = Vec::new();
     let mut computed_methods: Vec<ComputedMethod> = Vec::new();
 
     // First pass: collect watch metadata while the `#[watch(...)]`
@@ -3929,7 +3942,7 @@ pub fn handlers(_attr: TokenStream, item: TokenStream) -> TokenStream {
         let ImplItem::Fn(method) = impl_item else {
             continue;
         };
-        let mut watch_field: Option<syn::Ident> = None;
+        let mut watch_fields: Option<Vec<syn::Ident>> = None;
         let mut is_computed = false;
         // A marker attr the macro recognizes but cannot install must be
         // a compile error, never a silent strip — a dropped watch reads
@@ -3937,21 +3950,31 @@ pub fn handlers(_attr: TokenStream, item: TokenStream) -> TokenStream {
         let mut marker_error: Option<syn::Error> = None;
         method.attrs.retain(|attr| {
             if attr.path().is_ident("watch") {
-                match attr.parse_args::<syn::Ident>() {
-                    Ok(ident) => {
-                        if watch_field.replace(ident).is_some() && marker_error.is_none() {
+                match attr.parse_args_with(Punctuated::<syn::Ident, Token![,]>::parse_terminated) {
+                    Ok(list) if !list.is_empty() => {
+                        let fields: Vec<syn::Ident> = list.into_iter().collect();
+                        for (i, f) in fields.iter().enumerate() {
+                            if fields[..i].contains(f) && marker_error.is_none() {
+                                marker_error = Some(syn::Error::new_spanned(
+                                    f,
+                                    format!("duplicate field `{f}` in the #[watch] list"),
+                                ));
+                            }
+                        }
+                        if watch_fields.replace(fields).is_some() && marker_error.is_none() {
                             marker_error = Some(syn::Error::new_spanned(
                                 attr,
-                                "only one #[watch] attribute per method — write one \
-                                 handler per watched field",
+                                "only one #[watch] attribute per method — list every \
+                                 field in one attribute: #[watch(a, b, c)]",
                             ));
                         }
                     }
-                    Err(_) => {
+                    _ => {
                         if marker_error.is_none() {
                             marker_error = Some(syn::Error::new_spanned(
                                 attr,
-                                "#[watch] expects a field name: #[watch(field)]",
+                                "#[watch] expects field names: #[watch(field)] or \
+                                 #[watch(a, b, c)]",
                             ));
                         }
                     }
@@ -3973,7 +3996,7 @@ pub fn handlers(_attr: TokenStream, item: TokenStream) -> TokenStream {
         if let Some(err) = marker_error {
             return err.to_compile_error().into();
         }
-        if watch_field.is_some() && is_computed {
+        if watch_fields.is_some() && is_computed {
             return syn::Error::new_spanned(
                 &method.sig.ident,
                 "#[watch] and #[computed] cannot be combined on one method",
@@ -3981,13 +4004,7 @@ pub fn handlers(_attr: TokenStream, item: TokenStream) -> TokenStream {
             .to_compile_error()
             .into();
         }
-        if let Some(field_ident) = watch_field {
-            // RFC-036 contract: the generated dispatch calls
-            // `s.<method>(new_v, prev_v)`, so only the
-            // `&mut self, (next: V, prev: Option<V>)` shape can ever be
-            // installed. Anything else is rejected here — before this
-            // check, a no-arg handler compiled green and the watch
-            // silently never fired.
+        if let Some(fields) = watch_fields {
             let takes_ref_self = method.sig.receiver().is_some_and(|r| r.reference.is_some());
             let typed_args: Vec<syn::Type> = method
                 .sig
@@ -3998,25 +4015,58 @@ pub fn handlers(_attr: TokenStream, item: TokenStream) -> TokenStream {
                     _ => None,
                 })
                 .collect();
-            if !takes_ref_self || typed_args.len() != 2 {
-                let method_ident = &method.sig.ident;
-                return syn::Error::new_spanned(
-                    &method.sig,
-                    format!(
-                        "#[watch({field_ident})] handler must take `&mut self` and \
-                         `(next: V, prev: Option<V>)` — e.g. `fn {method_ident}(&mut self, \
-                         next: V, prev: Option<V>)`"
-                    ),
-                )
-                .to_compile_error()
-                .into();
+            if fields.len() == 1 {
+                // RFC-036 contract: the generated dispatch calls
+                // `s.<method>(new_v, prev_v)`, so only the
+                // `&mut self, (next: V, prev: Option<V>)` shape can
+                // ever be installed. Anything else is rejected here —
+                // before this check, a no-arg handler compiled green
+                // and the watch silently never fired.
+                let field_ident = fields.into_iter().next().expect("len checked == 1");
+                if !takes_ref_self || typed_args.len() != 2 {
+                    let method_ident = &method.sig.ident;
+                    return syn::Error::new_spanned(
+                        &method.sig,
+                        format!(
+                            "#[watch({field_ident})] handler must take `&mut self` and \
+                             `(next: V, prev: Option<V>)` — e.g. `fn {method_ident}(&mut \
+                             self, next: V, prev: Option<V>)` — or watch several fields \
+                             with a no-arg handler: #[watch(a, b, c)]"
+                        ),
+                    )
+                    .to_compile_error()
+                    .into();
+                }
+                let v_ty = typed_args
+                    .into_iter()
+                    .next()
+                    .expect("arity checked to be exactly 2");
+                methods_to_skip_in_arms.insert(method.sig.ident.to_string());
+                watches.push(WatchEntry::Single {
+                    method: method.sig.ident.clone(),
+                    field: field_ident,
+                    v_ty: Box::new(v_ty),
+                });
+            } else {
+                // RFC-115 — with two-plus fields there is no single
+                // `(next, prev)`; the coalesced call is payload-less
+                // by contract.
+                if !takes_ref_self || !typed_args.is_empty() {
+                    return syn::Error::new_spanned(
+                        &method.sig,
+                        "multi-field #[watch] handlers take `&mut self` only — the \
+                         coalesced call has no single (next, prev); read the fields \
+                         off self",
+                    )
+                    .to_compile_error()
+                    .into();
+                }
+                methods_to_skip_in_arms.insert(method.sig.ident.to_string());
+                watches.push(WatchEntry::Multi {
+                    method: method.sig.ident.clone(),
+                    fields,
+                });
             }
-            let v_ty = typed_args
-                .into_iter()
-                .next()
-                .expect("arity checked to be exactly 2");
-            methods_to_skip_in_arms.insert(method.sig.ident.to_string());
-            watches.push((method.sig.ident.clone(), field_ident, v_ty));
         }
         if is_computed {
             if method.sig.receiver().is_some() {
@@ -4293,53 +4343,123 @@ pub fn handlers(_attr: TokenStream, item: TokenStream) -> TokenStream {
     // depends on the thread-local `CURRENT_SCOPE_ID`, which isn't
     // set during most watch callback re-runs (triggers come from
     // the parent's effect chain, not a fresh `Scope::invoke`).
-    let watch_installs = watches.iter().map(|(method_ident, field_ident, v_ty)| {
-        let field_name = field_ident.to_string();
-        let ty = ty.clone();
-        quote! {
-            {
-                let __scope = ::pocopine::current_scope_id()
-                    .expect("watch_field installed outside a lifecycle context");
-                let __watch_initial_pending =
-                    ::std::rc::Rc::new(::std::cell::Cell::new(true));
-                let __watch_initial_ticket =
-                    ::std::rc::Rc::new(::std::cell::Cell::new(0_u64));
-                let __watch_effect = ::pocopine::watch_scope_field_now::<#v_ty, _>(__scope, #field_name, move |new, prev| {
-                    let new_v: #v_ty = new.clone();
-                    let prev_v: ::core::option::Option<#v_ty> = prev.cloned();
-                    if __watch_initial_pending.get() {
-                        let __ticket = __watch_initial_ticket.get() + 1;
-                        __watch_initial_ticket.set(__ticket);
-                        let __pending = __watch_initial_pending.clone();
-                        let __tickets = __watch_initial_ticket.clone();
-                        ::pocopine::tick::next(move || {
-                            if !__pending.get() || __tickets.get() != __ticket {
+    let watch_installs = watches.iter().map(|entry| match entry {
+        WatchEntry::Single {
+            method: method_ident,
+            field: field_ident,
+            v_ty,
+        } => {
+            let field_name = field_ident.to_string();
+            let ty = ty.clone();
+            quote! {
+                {
+                    let __scope = ::pocopine::current_scope_id()
+                        .expect("watch_field installed outside a lifecycle context");
+                    let __watch_initial_pending =
+                        ::std::rc::Rc::new(::std::cell::Cell::new(true));
+                    let __watch_initial_ticket =
+                        ::std::rc::Rc::new(::std::cell::Cell::new(0_u64));
+                    let __watch_effect = ::pocopine::watch_scope_field_now::<#v_ty, _>(__scope, #field_name, move |new, prev| {
+                        let new_v: #v_ty = new.clone();
+                        let prev_v: ::core::option::Option<#v_ty> = prev.cloned();
+                        if __watch_initial_pending.get() {
+                            let __ticket = __watch_initial_ticket.get() + 1;
+                            __watch_initial_ticket.set(__ticket);
+                            let __pending = __watch_initial_pending.clone();
+                            let __tickets = __watch_initial_ticket.clone();
+                            ::pocopine::tick::next(move || {
+                                if !__pending.get() || __tickets.get() != __ticket {
+                                    return;
+                                }
+                                __pending.set(false);
+                                if let Some(scope) = ::pocopine::Scope::find(__scope) {
+                                    if let Some(inner) = scope.typed::<#ty>() {
+                                        ::pocopine::Handle::new(inner, __scope)
+                                            .update(|s| {
+                                                s.#method_ident(new_v, ::core::option::Option::None);
+                                            });
+                                    }
+                                }
+                            });
+                            return;
+                        }
+                        if let Some(scope) = ::pocopine::Scope::find(__scope) {
+                            if let Some(inner) = scope.typed::<#ty>() {
+                                ::pocopine::Handle::new(inner, __scope)
+                                    .update(|s| {
+                                        s.#method_ident(new_v, prev_v);
+                                    });
+                            }
+                        }
+                    });
+                    ::pocopine::on_scope_unmount_for(__scope, move || {
+                        ::pocopine::release(__watch_effect);
+                    });
+                }
+            }
+        }
+        // RFC-115 — one coalesced payload-less subscription across the
+        // listed fields. The subscription is a single effect tracking
+        // every field, so same-flush triggers dedupe in the scheduler
+        // queue (the handler runs once per flush) and the handler
+        // stays inside the flush-cascade cycle guard. The install run
+        // is the initial seed; it fires behind on_ready's live borrow,
+        // so it defers one tick like the single-field initial call.
+        WatchEntry::Multi {
+            method: method_ident,
+            fields,
+        } => {
+            let field_names: Vec<String> = fields.iter().map(|f| f.to_string()).collect();
+            let label = field_names.join(", ");
+            let ty = ty.clone();
+            quote! {
+                {
+                    let __scope = ::pocopine::current_scope_id()
+                        .expect("watch installed outside a lifecycle context");
+                    let __watch_initial_pending =
+                        ::std::rc::Rc::new(::std::cell::Cell::new(true));
+                    let __watch_initial_ticket =
+                        ::std::rc::Rc::new(::std::cell::Cell::new(0_u64));
+                    let __watch_effect = ::pocopine::watch_scope_fields(
+                        __scope,
+                        &[#(#field_names),*],
+                        #label,
+                        move || {
+                            if __watch_initial_pending.get() {
+                                let __ticket = __watch_initial_ticket.get() + 1;
+                                __watch_initial_ticket.set(__ticket);
+                                let __pending = __watch_initial_pending.clone();
+                                let __tickets = __watch_initial_ticket.clone();
+                                ::pocopine::tick::next(move || {
+                                    if !__pending.get() || __tickets.get() != __ticket {
+                                        return;
+                                    }
+                                    __pending.set(false);
+                                    if let Some(scope) = ::pocopine::Scope::find(__scope) {
+                                        if let Some(inner) = scope.typed::<#ty>() {
+                                            ::pocopine::Handle::new(inner, __scope)
+                                                .update(|s| {
+                                                    s.#method_ident();
+                                                });
+                                        }
+                                    }
+                                });
                                 return;
                             }
-                            __pending.set(false);
                             if let Some(scope) = ::pocopine::Scope::find(__scope) {
                                 if let Some(inner) = scope.typed::<#ty>() {
                                     ::pocopine::Handle::new(inner, __scope)
                                         .update(|s| {
-                                            s.#method_ident(new_v, ::core::option::Option::None);
+                                            s.#method_ident();
                                         });
                                 }
                             }
-                        });
-                        return;
-                    }
-                    if let Some(scope) = ::pocopine::Scope::find(__scope) {
-                        if let Some(inner) = scope.typed::<#ty>() {
-                            ::pocopine::Handle::new(inner, __scope)
-                                .update(|s| {
-                                    s.#method_ident(new_v, prev_v);
-                                });
-                        }
-                    }
-                });
-                ::pocopine::on_scope_unmount_for(__scope, move || {
-                    ::pocopine::release(__watch_effect);
-                });
+                        },
+                    );
+                    ::pocopine::on_scope_unmount_for(__scope, move || {
+                        ::pocopine::release(__watch_effect);
+                    });
+                }
             }
         }
     });

--- a/crates/pocopine/src/lib.rs
+++ b/crates/pocopine/src/lib.rs
@@ -39,7 +39,7 @@ pub use pocopine_core::{
     spawn_for_scope, spawn_latest, spawn_latest_for_scope, spawn_scoped, store,
     swap_list_indices_inline, this, trigger_scope, verify_registry, watch, watch_field,
     watch_field_scoped, watch_scope_field, watch_scope_field_now, watch_scope_field_scoped,
-    watch_scoped,
+    watch_scope_fields, watch_scoped,
 };
 pub use pocopine_core::{
     animate, dom, events, focus, profiler, progress, refs, router, scroll_lock, sse, storage, text,

--- a/crates/pocopine/tests/handlers_contract_ui.rs
+++ b/crates/pocopine/tests/handlers_contract_ui.rs
@@ -37,4 +37,12 @@ fn handlers_marker_contract() {
     cases.compile_fail("tests/ui/lifecycle_no_receiver.rs");
     // `#[computed]` takes no arguments (previously discarded silently).
     cases.compile_fail("tests/ui/computed_with_args.rs");
+    // RFC-115 — multi-field watch: two-plus fields take the
+    // payload-less `&mut self` shape and compile.
+    cases.pass("tests/ui/watch_multi_pass.rs");
+    // Value args on a multi-field watch are rejected (no single
+    // (next, prev) exists).
+    cases.compile_fail("tests/ui/watch_multi_with_args.rs");
+    // Duplicated fields in one list are rejected.
+    cases.compile_fail("tests/ui/watch_list_duplicate.rs");
 }

--- a/crates/pocopine/tests/handlers_contract_ui.rs
+++ b/crates/pocopine/tests/handlers_contract_ui.rs
@@ -32,6 +32,9 @@ fn handlers_marker_contract() {
     cases.compile_fail("tests/ui/watch_stacked.rs");
     // A watch handler without a reference receiver is rejected.
     cases.compile_fail("tests/ui/watch_no_receiver.rs");
+    // A shared receiver (`&self`) is rejected — the contract is
+    // literally `&mut self`.
+    cases.compile_fail("tests/ui/watch_shared_receiver.rs");
     // A lifecycle-named method without `self` is rejected (previously
     // skipped before name matching — the hook silently never fired).
     cases.compile_fail("tests/ui/lifecycle_no_receiver.rs");

--- a/crates/pocopine/tests/ui/watch_bare_attr.stderr
+++ b/crates/pocopine/tests/ui/watch_bare_attr.stderr
@@ -1,4 +1,4 @@
-error: #[watch] expects a field name: #[watch(field)]
+error: #[watch] expects field names: #[watch(field)] or #[watch(a, b, c)]
   --> tests/ui/watch_bare_attr.rs:11:5
    |
 11 |     #[watch]

--- a/crates/pocopine/tests/ui/watch_list_duplicate.rs
+++ b/crates/pocopine/tests/ui/watch_list_duplicate.rs
@@ -1,0 +1,15 @@
+// A duplicated field in one #[watch] list is a typo, not a request
+// to subscribe twice.
+use pocopine::prelude::*;
+
+struct Editor {
+    start_time: String,
+}
+
+#[handlers]
+impl Editor {
+    #[watch(start_time, start_time)]
+    fn on_times(&mut self) {}
+}
+
+fn main() {}

--- a/crates/pocopine/tests/ui/watch_list_duplicate.stderr
+++ b/crates/pocopine/tests/ui/watch_list_duplicate.stderr
@@ -1,0 +1,5 @@
+error: duplicate field `start_time` in the #[watch] list
+  --> tests/ui/watch_list_duplicate.rs:11:25
+   |
+11 |     #[watch(start_time, start_time)]
+   |                         ^^^^^^^^^^

--- a/crates/pocopine/tests/ui/watch_multi_pass.rs
+++ b/crates/pocopine/tests/ui/watch_multi_pass.rs
@@ -1,0 +1,28 @@
+// RFC-115 — the multi-field form: two-plus fields require the
+// payload-less `&mut self` shape; the handler is invoked once per
+// flush when any listed field changes.
+use pocopine::prelude::*;
+
+#[derive(Default, serde::Serialize, serde::Deserialize)]
+#[store(name = "editor-multi")]
+struct EditorStore {
+    start_time: String,
+    end_time: String,
+    count: i32,
+}
+
+#[handlers]
+impl EditorStore {
+    #[watch(start_time, end_time)]
+    fn on_when_changed(&mut self) {
+        self.count += 1;
+    }
+
+    // The typed single-field contract coexists unchanged.
+    #[watch(count)]
+    fn on_count(&mut self, next: i32, prev: Option<i32>) {
+        let _ = (next, prev);
+    }
+}
+
+fn main() {}

--- a/crates/pocopine/tests/ui/watch_multi_with_args.rs
+++ b/crates/pocopine/tests/ui/watch_multi_with_args.rs
@@ -1,0 +1,16 @@
+// A multi-field watch has no single (next, prev) — value args on the
+// handler are a compile error pointing at the payload-less contract.
+use pocopine::prelude::*;
+
+struct Editor {
+    start_time: String,
+    end_time: String,
+}
+
+#[handlers]
+impl Editor {
+    #[watch(start_time, end_time)]
+    fn on_times(&mut self, _next: String, _prev: Option<String>) {}
+}
+
+fn main() {}

--- a/crates/pocopine/tests/ui/watch_multi_with_args.stderr
+++ b/crates/pocopine/tests/ui/watch_multi_with_args.stderr
@@ -1,0 +1,5 @@
+error: multi-field #[watch] handlers take `&mut self` only — the coalesced call has no single (next, prev); read the fields off self
+  --> tests/ui/watch_multi_with_args.rs:13:5
+   |
+13 |     fn on_times(&mut self, _next: String, _prev: Option<String>) {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/pocopine/tests/ui/watch_no_args.stderr
+++ b/crates/pocopine/tests/ui/watch_no_args.stderr
@@ -1,4 +1,4 @@
-error: #[watch(start_time)] handler must take `&mut self` and `(next: V, prev: Option<V>)` — e.g. `fn on_start_time(&mut self, next: V, prev: Option<V>)`
+error: #[watch(start_time)] handler must take `&mut self` and `(next: V, prev: Option<V>)` — e.g. `fn on_start_time(&mut self, next: V, prev: Option<V>)` — or watch several fields with a no-arg handler: #[watch(a, b, c)]
   --> tests/ui/watch_no_args.rs:12:5
    |
 12 |     fn on_start_time(&mut self) {}

--- a/crates/pocopine/tests/ui/watch_no_receiver.stderr
+++ b/crates/pocopine/tests/ui/watch_no_receiver.stderr
@@ -1,4 +1,4 @@
-error: #[watch(start_time)] handler must take `&mut self` and `(next: V, prev: Option<V>)` — e.g. `fn on_start_time(&mut self, next: V, prev: Option<V>)`
+error: #[watch(start_time)] handler must take `&mut self` and `(next: V, prev: Option<V>)` — e.g. `fn on_start_time(&mut self, next: V, prev: Option<V>)` — or watch several fields with a no-arg handler: #[watch(a, b, c)]
   --> tests/ui/watch_no_receiver.rs:12:5
    |
 12 |     fn on_start_time(_next: String, _prev: Option<String>) {}

--- a/crates/pocopine/tests/ui/watch_nonident_attr.stderr
+++ b/crates/pocopine/tests/ui/watch_nonident_attr.stderr
@@ -1,4 +1,4 @@
-error: #[watch] expects a field name: #[watch(field)]
+error: #[watch] expects field names: #[watch(field)] or #[watch(a, b, c)]
   --> tests/ui/watch_nonident_attr.rs:11:5
    |
 11 |     #[watch("start_time")]

--- a/crates/pocopine/tests/ui/watch_one_arg.stderr
+++ b/crates/pocopine/tests/ui/watch_one_arg.stderr
@@ -1,4 +1,4 @@
-error: #[watch(start_time)] handler must take `&mut self` and `(next: V, prev: Option<V>)` — e.g. `fn on_start_time(&mut self, next: V, prev: Option<V>)`
+error: #[watch(start_time)] handler must take `&mut self` and `(next: V, prev: Option<V>)` — e.g. `fn on_start_time(&mut self, next: V, prev: Option<V>)` — or watch several fields with a no-arg handler: #[watch(a, b, c)]
   --> tests/ui/watch_one_arg.rs:12:5
    |
 12 |     fn on_start_time(&mut self, _next: String) {}

--- a/crates/pocopine/tests/ui/watch_shared_receiver.rs
+++ b/crates/pocopine/tests/ui/watch_shared_receiver.rs
@@ -1,0 +1,15 @@
+// The contract is literally `&mut self` — a shared receiver compiles
+// as Rust but leaves the handler unable to store its result.
+use pocopine::prelude::*;
+
+struct Editor {
+    start_time: String,
+}
+
+#[handlers]
+impl Editor {
+    #[watch(start_time)]
+    fn on_start_time(&self, _next: String, _prev: Option<String>) {}
+}
+
+fn main() {}

--- a/crates/pocopine/tests/ui/watch_shared_receiver.stderr
+++ b/crates/pocopine/tests/ui/watch_shared_receiver.stderr
@@ -1,0 +1,5 @@
+error: #[watch(start_time)] handler must take `&mut self` and `(next: V, prev: Option<V>)` — e.g. `fn on_start_time(&mut self, next: V, prev: Option<V>)` — or watch several fields with a no-arg handler: #[watch(a, b, c)]
+  --> tests/ui/watch_shared_receiver.rs:12:5
+   |
+12 |     fn on_start_time(&self, _next: String, _prev: Option<String>) {}
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/pocopine/tests/ui/watch_stacked.stderr
+++ b/crates/pocopine/tests/ui/watch_stacked.stderr
@@ -1,4 +1,4 @@
-error: only one #[watch] attribute per method — write one handler per watched field
+error: only one #[watch] attribute per method — list every field in one attribute: #[watch(a, b, c)]
   --> tests/ui/watch_stacked.rs:13:5
    |
 13 |     #[watch(end_time)]

--- a/docs/guides/reactivity/01-essentials.md
+++ b/docs/guides/reactivity/01-essentials.md
@@ -140,13 +140,18 @@ Multi-field semantics differ from the typed form in three ways:
   handler once, not once per field.
 * **Seeded** — the handler runs once after mount wiring (replacing
   the manual `recompute()` seed in `on_mount`).
-* **No equality gate** — it fires on any write to a listed field,
-  even a write of an unchanged value; multi-field handlers should be
-  idempotent recomputes.
+* **External changes only** — instead of the typed form's
+  `(new, prev)` equality gate: runs whose field probes prove nothing
+  changed are skipped, and the handler's **own writes never re-fire
+  it** (recompute output can't re-invalidate its own input set).
+  Write listed fields freely inside the handler; it converges by
+  construction.
 
-A handler that diverges (writes a listed field with a new value every
-run) is stopped by the runtime cycle guard after 100 re-runs in one
-cascade, with a console error naming the field list.
+A field in the list that doesn't exist (typo) or is `#[computed]` is
+a loud console error at mount and is ignored — computed fields can't
+be watched; watch their inputs instead. Cross-effect update loops
+remain bounded by the runtime cycle guard (100 re-runs per cascade,
+console error naming the field list).
 
 ```rust
 #[derive(Default, Serialize, Deserialize)]

--- a/docs/guides/reactivity/01-essentials.md
+++ b/docs/guides/reactivity/01-essentials.md
@@ -116,8 +116,37 @@ mount, and runs whenever `field` changes.
 The signature is a contract: `&mut self` plus exactly
 `(new: V, prev: Option<V>)`. Any other shape — no args, a missing
 `prev`, no receiver, a bare `#[watch]` — is a compile error, as is
-stacking two `#[watch]` attributes on one method (write one handler per
-watched field).
+stacking two `#[watch]` attributes on one method (list the fields in
+one attribute instead — below).
+
+### Several fields, one handler — #[watch(a, b, c)]
+
+When the same recompute reacts to many fields, list them (RFC-115).
+Two-plus fields flip the contract: the handler takes `&mut self` and
+**nothing else** — with heterogeneous field types there is no single
+`(new, prev)`, and the coalesced call has no one triggering value.
+Read whatever you need off `self`.
+
+```rust
+#[watch(preset, mode, start_date, start_day, start_time)]
+fn on_when_changed(&mut self) {
+    self.recompute();
+}
+```
+
+Multi-field semantics differ from the typed form in three ways:
+
+* **Coalesced** — several listed fields changing in one flush run the
+  handler once, not once per field.
+* **Seeded** — the handler runs once after mount wiring (replacing
+  the manual `recompute()` seed in `on_mount`).
+* **No equality gate** — it fires on any write to a listed field,
+  even a write of an unchanged value; multi-field handlers should be
+  idempotent recomputes.
+
+A handler that diverges (writes a listed field with a new value every
+run) is stopped by the runtime cycle guard after 100 re-runs in one
+cascade, with a console error naming the field list.
 
 ```rust
 #[derive(Default, Serialize, Deserialize)]

--- a/examples/website/src/components/showcase/animation/mod.rs
+++ b/examples/website/src/components/showcase/animation/mod.rs
@@ -350,7 +350,7 @@ impl AnimationDemo {
     }
 
     #[watch(motion_x)]
-    fn on_motion_x(&self, _: f64, prev: Option<f64>) {
+    fn on_motion_x(&mut self, _: f64, prev: Option<f64>) {
         let from = self.state_transform_with(
             prev.unwrap_or(self.motion_x),
             self.motion_y,
@@ -362,7 +362,7 @@ impl AnimationDemo {
     }
 
     #[watch(motion_y)]
-    fn on_motion_y(&self, _: f64, prev: Option<f64>) {
+    fn on_motion_y(&mut self, _: f64, prev: Option<f64>) {
         let from = self.state_transform_with(
             self.motion_x,
             prev.unwrap_or(self.motion_y),
@@ -374,7 +374,7 @@ impl AnimationDemo {
     }
 
     #[watch(motion_rotate)]
-    fn on_motion_rotate(&self, _: f64, prev: Option<f64>) {
+    fn on_motion_rotate(&mut self, _: f64, prev: Option<f64>) {
         let from = self.state_transform_with(
             self.motion_x,
             self.motion_y,
@@ -386,7 +386,7 @@ impl AnimationDemo {
     }
 
     #[watch(motion_scale)]
-    fn on_motion_scale(&self, _: f64, prev: Option<f64>) {
+    fn on_motion_scale(&mut self, _: f64, prev: Option<f64>) {
         let from = self.state_transform_with(
             self.motion_x,
             self.motion_y,
@@ -398,7 +398,7 @@ impl AnimationDemo {
     }
 
     #[watch(motion_raise)]
-    fn on_motion_raise(&self, _: f64, prev: Option<f64>) {
+    fn on_motion_raise(&mut self, _: f64, prev: Option<f64>) {
         let from = self.state_transform_with(
             self.motion_x,
             self.motion_y,
@@ -410,7 +410,7 @@ impl AnimationDemo {
     }
 
     #[watch(motion_shadow)]
-    fn on_motion_shadow(&self, _: f64, prev: Option<f64>) {
+    fn on_motion_shadow(&mut self, _: f64, prev: Option<f64>) {
         let from_transform = self.state_transform();
         let from_shadow = state_shadow(prev.unwrap_or(self.motion_shadow));
         self.animate_state_box(from_transform, Some(from_shadow));

--- a/rfcs/rfc-115-multi-field-watch.md
+++ b/rfcs/rfc-115-multi-field-watch.md
@@ -1,7 +1,7 @@
 # RFC-115: Multi-field watch — `#[watch(a, b, c)]`
 
 **Status:** Proposed
-**Crates:** `pocopine-macros` (`#[handlers]`), `pocopine-core` (reactive watch primitives)
+**Crates:** `pocopine-macros` (`#[handlers]`), `pocopine-core` (reactive watch primitives, flush-cascade cycle guard)
 **Relates to:** RFC-026 (`#[watch(field)]` sugar), RFC-036 (watch install machinery), RFC-044 §5.10.5 (flattened-container watch), PR #279 (watch signature contract)
 
 ## Summary
@@ -134,6 +134,46 @@ propagation as the typed watch (including the RFC-044 dual-key
 container triggering), no value read, no downcast. Per the
 core-owns-engines rule this lands in `pocopine-core`;
 `pocopine-macros` stays a thin consumer.
+
+## Loop semantics and the cycle guard
+
+A watch handler may write fields — including its own watched fields.
+Two runtime invariants already bound this (single- and multi-field
+alike):
+
+1. **Value-equality dedup** (`watch.rs`): the callback only runs when
+   the observed value is `PartialEq`-different from the previous run.
+   A self-write that reaches a fixpoint (`self.a = f(...)`
+   stabilizing) converges after one echo — this is a *supported*
+   pattern (mirror/derived fields).
+2. **The RFC-098 trampoline**: dispatch is structurally
+   non-reentrant; a write during a callback appends to a FIFO
+   worklist. No recursion, no stack overflow.
+
+What is **not** bounded today: a *divergent* self-write
+(`self.a += 1` inside a watch on `a`) produces a distinct value per
+fire, passes the equality gate every time, and re-queues forever — a
+silent hang with no diagnostic. Compile-time detection is out: the
+write typically lives behind a method call the macro can't follow,
+and fixpoint-vs-divergent is undecidable (fixpoint self-writes are
+legitimate, so even a syntactic lint would false-positive).
+
+This RFC therefore adds a **runtime cycle guard** in
+`pocopine-core`: a per-effect re-fire counter within one flush
+cascade (reset when the trampoline fully drains). On breach of the
+cap (**100**, matching the Vue/Svelte convention) the scheduler:
+
+- emits `tracing::error!(target: "pocopine.log", ...)` (RFC-069)
+  naming the scope, the effect, and — for watches installed by
+  `#[watch]` — the watched field list;
+- suppresses that effect for the remainder of the cascade, so the
+  app degrades to "watch stopped firing loudly" instead of a hang.
+
+The guard is counting, not graph analysis — zero cost until a
+cascade actually re-fires the same effect. Multi-field coalescing
+reduces amplification (one handler run per flush instead of one per
+field) but does not remove divergence; the guard is the backstop for
+both forms, and for hand-installed `watch()`/`effect()` closures too.
 
 ## Alternative considered: group the fields and watch the container
 

--- a/rfcs/rfc-115-multi-field-watch.md
+++ b/rfcs/rfc-115-multi-field-watch.md
@@ -1,6 +1,6 @@
 # RFC-115: Multi-field watch — `#[watch(a, b, c)]`
 
-**Status:** Proposed
+**Status:** Implemented
 **Crates:** `pocopine-macros` (`#[handlers]`), `pocopine-core` (reactive watch primitives, flush-cascade cycle guard)
 **Relates to:** RFC-026 (`#[watch(field)]` sugar), RFC-036 (watch install machinery), RFC-044 §5.10.5 (flattened-container watch), PR #279 (watch signature contract)
 
@@ -102,18 +102,27 @@ messages:
   message points at the list form.
 - Duplicate idents in one list (`#[watch(a, a)]`) are an error.
 
-### Dispatch semantics
+### Dispatch semantics (as implemented)
 
-- **Coalescing:** the macro installs one subscription per listed
-  field, all sharing a pending cell + generation ticket (the same
-  mechanism the single-field install already uses for its initial
-  seed). The first triggering field in a flush schedules the handler
-  via `tick::next`; subsequent triggers in the same flush bump the
-  ticket and stay collapsed into that one scheduled call.
-- **Initial seed:** parity with single-field watch — one coalesced
-  initial invocation after `on_ready` wiring, regardless of how many
-  fields are listed. (For the motivating component this replaces the
-  manual `recompute()` seed in `on_mount`.)
+- **One effect, not N subscriptions:** the install is a single
+  effect whose body `track`s every listed field. Coalescing is
+  scheduler-native — same-flush triggers on several listed fields
+  queue that one effect once (the RFC-098 H4 `IndexSet` queue
+  dedupes), so the handler runs **once per flush pass**. No pending
+  cell across fields is needed, and because the handler runs inside
+  the flush, it stays inside the flush-cascade **cycle guard's**
+  accounting (a `tick`-deferred handler would escape it).
+- **Initial seed:** the effect's install run is the seed — one
+  invocation regardless of field count, deferred one tick via the
+  same pending/ticket dance as the single-field initial call (the
+  install happens behind `on_ready`'s live borrow). For the
+  motivating component this replaces the manual `recompute()` seed
+  in `on_mount`.
+- **No equality gate:** unlike the typed watch there is no
+  `PartialEq` dedup — the handler fires on any write to a listed
+  field, including a write of an unchanged value. Multi-field
+  handlers are recompute-style and idempotent by contract; this is
+  documented in the guide.
 - **Ordering:** relative order between a multi-field handler and
   single-field handlers on the same flush is unspecified, same as
   between any two watches today.
@@ -122,18 +131,19 @@ messages:
   `&mut self` acquisition and the tick-deferred initial call keep the
   RFC-026 guarantees.
 
-### Core primitive
+### Core primitive (as implemented)
 
 The typed install (`watch_scope_field_now::<V>`) needs `V`, which the
 `#[handlers]` macro cannot know for arbitrary fields (it sees only
 the impl block; the typed single-field form recovers `V` from the
-handler's own signature). Multi-field watch needs a **payload-less
-subscription**: `pocopine-core` grows a
-`watch_scope_field_changed(scope, name, cb)` primitive — same dirty
-propagation as the typed watch (including the RFC-044 dual-key
-container triggering), no value read, no downcast. Per the
-core-owns-engines rule this lands in `pocopine-core`;
-`pocopine-macros` stays a thin consumer.
+handler's own signature). Multi-field watch therefore rides a
+**payload-less subscription**:
+`watch_scope_fields(scope, &[names], label, cb)` in
+`pocopine-core::watch` — one effect tracking every listed field, no
+value read, no downcast. `label` is the joined field list, stamped as
+the effect's diagnostic label so the cycle-guard report names the
+fields. Per the core-owns-engines rule the primitive lands in
+`pocopine-core`; `pocopine-macros` stays a thin consumer.
 
 ## Loop semantics and the cycle guard
 

--- a/rfcs/rfc-115-multi-field-watch.md
+++ b/rfcs/rfc-115-multi-field-watch.md
@@ -22,8 +22,8 @@ fn on_when_changed(&mut self) {
   coherent single `(next, prev)`, and the dominant real-world use
   (recompute/derive) never reads the payload.
 - **Coalesced dispatch:** when several watched fields change in the
-  same reactive flush, the handler runs **once**, deferred to the
-  tick boundary — not once per field.
+  same reactive flush, the handler runs **once** per flush pass —
+  not once per field.
 
 Both shapes are enforced with spanned compile errors, extending the
 PR #279 contract (a mismatched watch handler is never silently
@@ -113,16 +113,27 @@ messages:
   the flush, it stays inside the flush-cascade **cycle guard's**
   accounting (a `tick`-deferred handler would escape it).
 - **Initial seed:** the effect's install run is the seed — one
-  invocation regardless of field count, deferred one tick via the
-  same pending/ticket dance as the single-field initial call (the
-  install happens behind `on_ready`'s live borrow). For the
-  motivating component this replaces the manual `recompute()` seed
-  in `on_mount`.
-- **No equality gate:** unlike the typed watch there is no
-  `PartialEq` dedup — the handler fires on any write to a listed
-  field, including a write of an unchanged value. Multi-field
-  handlers are recompute-style and idempotent by contract; this is
-  documented in the guide.
+  invocation regardless of field count, deferred one microtask (the
+  install happens behind `on_ready`'s live borrow; scheduled via
+  `spawn_local`, since `tick::next` needs a `window` and no-ops in
+  windowless hosts). For the motivating component this replaces the
+  manual `recompute()` seed in `on_mount`.
+- **Three guards replace the typed form's `PartialEq` gate** (a
+  payload-less callback can't value-compare, and the dirty sweep
+  conservatively re-triggers any tracked key it cannot fingerprint —
+  an ungated multi-watch would re-fire on every sweep):
+  1. *Install validation* — a listed key that isn't a state field
+     (typo) or is `#[computed]` is a loud console error and is never
+     tracked.
+  2. *Provably-unchanged skip* — each run probes the listed fields'
+     quick-lens + fingerprints and skips the callback when every
+     probe proves "unchanged"; a `None` fingerprint proves nothing
+     and stays conservative (flatten leaves keep firing).
+  3. *Echo suppression* — after the callback returns, the effect
+     dequeues itself, so the handler's own writes (and its dirty
+     sweep's conservative echoes) never re-fire it. Multi-field
+     handlers react to **external changes only** and converge by
+     construction; cross-effect loops remain the cycle guard's job.
 - **Ordering:** relative order between a multi-field handler and
   single-field handlers on the same flush is unspecified, same as
   between any two watches today.

--- a/rfcs/rfc-115-multi-field-watch.md
+++ b/rfcs/rfc-115-multi-field-watch.md
@@ -159,21 +159,32 @@ and fixpoint-vs-divergent is undecidable (fixpoint self-writes are
 legitimate, so even a syntactic lint would false-positive).
 
 This RFC therefore adds a **runtime cycle guard** in
-`pocopine-core`: a per-effect re-fire counter within one flush
-cascade (reset when the trampoline fully drains). On breach of the
-cap (**100**, matching the Vue/Svelte convention) the scheduler:
+`pocopine-core` (**shipped ahead of the rest of this RFC**): a
+per-effect run counter within one flush cascade — a cascade being
+consecutive flush passes where each pass was scheduled by the
+previous one; the counters reset when a pass ends with an empty
+queue. On breach of the cap (**100**, matching the Vue/Svelte
+"maximum recursive updates" convention) the scheduler:
 
-- emits `tracing::error!(target: "pocopine.log", ...)` (RFC-069)
-  naming the scope, the effect, and — for watches installed by
-  `#[watch]` — the watched field list;
+- reports once per cascade on the runtime's console-error lane (the
+  same channel as plan failures), naming the watched field when the
+  effect was installed by a field watch (`watch_scope_field_now`
+  stamps the field name as the effect's diagnostic label) or the
+  effect id otherwise;
 - suppresses that effect for the remainder of the cascade, so the
-  app degrades to "watch stopped firing loudly" instead of a hang.
+  app degrades to "watch stopped firing loudly" instead of a hang —
+  and because suppression stops the self-requeue, the cascade
+  settles, the counters clear, and the next external change fires
+  the watch normally.
 
 The guard is counting, not graph analysis — zero cost until a
 cascade actually re-fires the same effect. Multi-field coalescing
 reduces amplification (one handler run per flush instead of one per
 field) but does not remove divergence; the guard is the backstop for
 both forms, and for hand-installed `watch()`/`effect()` closures too.
+(Computed/custom-scheduler effects run inline in dispatch rather
+than through the flush queue; a divergent cycle there is bounded by
+the RFC-098 H3 debug drain assertion and stays out of scope here.)
 
 ## Alternative considered: group the fields and watch the container
 


### PR DESCRIPTION
## What

Implements RFC-115 end to end (the RFC doc rides in this PR and is flipped to **Implemented**):

### 1. Multi-field watch — `#[watch(a, b, c)]`

```rust
#[watch(preset, mode, start_date, start_day, start_time, end_date, end_day, end_time)]
fn on_when_changed(&mut self) {
    self.recompute();
}
```

- **One field** keeps today's typed contract unchanged: `&mut self, (next: V, prev: Option<V>)`.
- **Two-plus fields** require the payload-less shape (`&mut self` only) — no single `(next, prev)` exists across heterogeneous types. Both shapes are spanned compile errors when violated; the single-field error now hints at the list form, stacked `#[watch]` attrs point at it, duplicate fields in a list are rejected.
- **Coalescing is scheduler-native**: the install is *one effect* tracking every listed field (`watch_scope_fields` in core), so same-flush triggers dedupe in the RFC-098 queue and the handler runs once per flush pass. The install run is the coalesced initial seed (deferred one tick behind `on_ready`'s borrow, same dance as single-field).
- **No `PartialEq` gate on the multi form** (payload-less by design) — fires on any listed-field write; documented as recompute-idempotent in the guide.

### 2. Flush-cascade cycle guard

A divergent self-write (`self.a += 1` inside a watch on `a`, directly or behind `recompute()`) used to chain microtask flushes forever — a silent hang. `flush()` now counts per-effect runs within one uninterrupted cascade; past **100** (the Vue/Svelte convention) the effect is reported once on the console-error lane — naming the watched field(s) via the new effect diagnostic label — and suppressed until the cascade settles. Fixpoint self-writes still converge silently through the existing equality gate (supported pattern).

The two features interlock deliberately: the multi-watch handler runs *inside* the flush (not tick-deferred), so a divergent multi-field recompute is bounded by the same guard — verified by test.

## Review

- Cycle-guard commits: Codex-reviewed, 2 findings fixed (reentrant `flush_sync` resetting counters mid-cascade; false self-write attribution in fan-out graphs), both with regression tests.
- Multi-field commit: Codex quota-blocked mid-run; a 17-agent adversarial review substituted and confirmed 8 findings — all fixed in the final commit (sweep-echo oscillation via three new guards incl. echo suppression, r#-ident key mismatch, &self acceptance + six real &self handlers flushed out of the animation demo, seed silently dead in windowless hosts via tick::next, doc/RFC accuracy). Codex re-run still owed when quota resets.

## Tests

TDD throughout: 6 wasm tests in core (`effect_cycle_guard.rs`: divergent raw effect capped + recovery, `#[watch]`-shaped scope-field runaway, external triggers never mistaken for a cycle, reentrant-flush regression; `watch_multi.rs`: same-flush coalescing + unlisted fields inert, divergent multi-watch bounded), 3 new trybuild fixtures (`watch_multi_pass`, `watch_multi_with_args`, `watch_list_duplicate`) plus regenerated snapshots for the updated error texts. Full core wasm battery, workspace check, CI wasm clippy matrix, fmt: all green.
